### PR TITLE
Fix a bug with returning_disabled when using the postgresql adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -761,7 +761,7 @@ module ActiveRecord
         end
 
         def extract_table_ref_from_insert_sql(sql) # :nodoc:
-          sql[/into\s+([^\(]*).*values\s*\(/im]
+          sql[/into\s("[A-Za-z0-9_."\[\]\s]+"|[A-Za-z0-9_."\[\]]+)\s*/im]
           $1.strip if $1
         end
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -123,6 +123,21 @@ module ActiveRecord
         assert_equal expect.to_i, result.rows.first.first
       end
 
+      def test_exec_insert_default_values_with_returning_disabled_and_no_sequence_name_given
+        connection = connection_without_insert_returning
+        result = connection.exec_insert("insert into postgresql_partitioned_table_parent DEFAULT VALUES", nil, [], 'id')
+        expect = connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
+        assert_equal expect.to_i, result.rows.first.first
+      end    
+
+      def test_exec_insert_default_values_quoted_schema_with_returning_disabled_and_no_sequence_name_given
+        connection = connection_without_insert_returning
+        result = connection.exec_insert('insert into "public"."postgresql_partitioned_table_parent" DEFAULT VALUES', nil, [], 'id')
+        expect = connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
+        assert_equal expect.to_i, result.rows.first.first
+      end      
+
+
       def test_sql_for_insert_with_returning_disabled
         connection = connection_without_insert_returning
         result = connection.sql_for_insert('sql', nil, nil, nil, 'binds')


### PR DESCRIPTION
The returning_disabled configuration option is required to make postgresql partitioning triggers work. This commit fixes a bug where an invalid query would be made in cases where returning_disabled was true and objects were created with no attributes defined.

This fixes one of the issues I identified in https://github.com/rails/rails/issues/21659
