### PR TITLE
Schema migrations by invocation time

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1284,4 +1284,24 @@
 
     *Yves Senn*
 
+*   Schema Migrations now contain time of creation information to track when
+    migrations were run.
+    ```
+	  database: vagrant_development
+
+	  Status   Migration ID    Migration Run             Migration Name
+	  ---------------------------------------------------------------------------
+	  up       20150918171109  2015-09-18 17:20:22 UTC   ********** NO FILE **********
+	  up       20150918210543  2015-09-18 21:07:10 UTC   Bar
+	  down     20150918210806                            Baz
+    ```
+
+*   In the environmnet file, you can now request that schema migrations be ordered by invocatio
+    time:
+
+      config.active_record.schema_migrations_by_invocation_time = true
+
+    When you use `rake db:migrate:status` the output will be ordered by the Migration Run column
+    When you use `rake db:rollback` migrations will be rolled back in the order they were inovoked!
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -882,9 +882,17 @@ module ActiveRecord
       def dump_schema_information #:nodoc:
         sm_table = ActiveRecord::Migrator.schema_migrations_table_name
 
-        ActiveRecord::SchemaMigration.order('version').map { |sm|
-          "INSERT INTO #{sm_table} (version) VALUES ('#{sm.version}');"
-        }.join "\n\n"
+        column_names = ActiveRecord::SchemaMigration.column_names
+        column_names_cs = column_names.join(', ')
+
+        ActiveRecord::SchemaMigration.all.sort do |a, b|
+          ActiveRecord::SchemaMigration.sorter(a, b)
+        end.map do |sm|
+          quoted_values_cs = column_names.map do |column_name|
+            ActiveRecord::SchemaMigration.connection.quote(sm.attributes[column_name])
+          end.join(', ')
+          "INSERT INTO #{sm_table} (#{column_names_cs}) VALUES (#{quoted_values_cs});"
+        end.join "\n\n"
       end
 
       # Should not be called normally, but this operation is non-destructive.
@@ -905,7 +913,7 @@ module ActiveRecord
         end
 
         unless migrated.include?(version)
-          execute "INSERT INTO #{sm_table} (version) VALUES ('#{version}')"
+          ActiveRecord::SchemaMigration.create!(version: version)
         end
 
         inserted = Set.new
@@ -913,7 +921,7 @@ module ActiveRecord
           if inserted.include?(v)
             raise "Duplicate migration #{v}. Please renumber your migrations to resolve the conflict."
           elsif v < version
-            execute "INSERT INTO #{sm_table} (version) VALUES ('#{v}')"
+            ActiveRecord::SchemaMigration.create!(version: v)
             inserted << v
           end
         end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -78,6 +78,12 @@ module ActiveRecord
 
       ##
       # :singleton-method:
+      # Should migrations be managed by invocation time
+      mattr_accessor :schema_migrations_by_invocation_time, instance_writer: false
+      self.schema_migrations_by_invocation_time = false
+
+      ##
+      # :singleton-method:
       # Specify whether schema dump should happen at the end of the
       # db:migrate rake task. This is true by default, which is useful for the
       # development environment. This should ideally be false in the production

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -94,30 +94,44 @@ db_namespace = namespace :db do
     desc 'Display status of migrations'
     task :status => [:environment, :load_config] do
       unless ActiveRecord::SchemaMigration.table_exists?
-        abort 'Schema migrations table does not exist yet.'
+        puts 'Schema migrations table does not exist yet.'
+        next  # means "return" for rake task
       end
-      db_list = ActiveRecord::SchemaMigration.normalized_versions
+      MigrationStatus = Struct.new(:status, :version, :created_at, :name)
 
-      file_list =
-          ActiveRecord::Tasks::DatabaseTasks.migrations_paths.flat_map do |path|
-            # match "20091231235959_some_name.rb" and "001_some_name.rb" pattern
-            Dir.foreach(path).grep(/^(\d{3,})_(.+)\.rb$/) do
-              version = ActiveRecord::SchemaMigration.normalize_migration_number($1)
-              status = db_list.delete(version) ? 'up' : 'down'
-              [status, version, $2.humanize]
+      all_migrations_by_version = ActiveRecord::SchemaMigration.all.map do |schema_migration|
+        MigrationStatus.new(:up, schema_migration.normalized_version, schema_migration.created_at, nil)
+      end.index_by(&:version)
+
+      ActiveRecord::Migrator.migrations_paths.each do |path|
+        Dir.foreach(path) do |file|
+          # match "20091231235959_some_name.rb" and "001_some_name.rb" pattern
+          if match_data = /^(\d{3,})_(.+)\.rb$/.match(file)
+            if all_migrations_by_version.has_key?(match_data[1])
+              all_migrations_by_version[match_data[1]].name = match_data[2].humanize
+            else
+              all_migrations_by_version[match_data[1]] = MigrationStatus.new(
+                :down,
+                ActiveRecord::SchemaMigration.normalize_migration_number(match_data[1]),
+                nil,
+                match_data[2].humanize
+              )
             end
           end
+        end
+      end
 
-      db_list.map! do |version|
-        ['up', version, '********** NO FILE **********']
-      end
-      # output
       puts "\ndatabase: #{ActiveRecord::Base.connection_config[:database]}\n\n"
-      puts "#{'Status'.center(8)}  #{'Migration ID'.ljust(14)}  Migration Name"
-      puts "-" * 50
-      (db_list + file_list).sort_by { |_, version, _| version }.each do |status, version, name|
-        puts "#{status.center(8)}  #{version.ljust(14)}  #{name}"
+      header = "#{'Status'.center(8)}  #{'Migration ID'.ljust(14)}  #{'Migration Run'.ljust(24)}  Migration Name"
+      puts header
+      puts "-" * header.length
+
+      all_migrations_by_version.values.sort do |a, b|
+        ActiveRecord::SchemaMigration.sorter(a, b)
+      end.each do |migration|
+        puts "#{migration.status.to_s.center(8)}  #{migration.version.ljust(14)}  #{migration.created_at.to_s.ljust(24)}  #{migration.name.present? ? migration.name : '********** NO FILE **********'}"
       end
+
       puts
     end
   end

--- a/activerecord/test/cases/migration/table_and_index_test.rb
+++ b/activerecord/test/cases/migration/table_and_index_test.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
         conn.initialize_schema_migrations_table
 
-        assert_equal "p_unique_schema_migrations_s", conn.indexes(ActiveRecord::Migrator.schema_migrations_table_name)[0][:name]
+        assert_equal ["p_created_at_schema_migrations_s", "p_unique_schema_migrations_s"], conn.indexes(ActiveRecord::Migrator.schema_migrations_table_name).map(&:name).sort
       ensure
         ActiveRecord::Base.table_name_prefix = ""
         ActiveRecord::Base.table_name_suffix = ""

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -55,7 +55,7 @@ module ApplicationTests
            bin/rake db:migrate`
           output = `bin/rake db:migrate:status`
           assert_match(%r{database:\s+\S*#{Regexp.escape(expected_database)}}, output)
-          assert_match(/up\s+\d{14}\s+Create books/, output)
+          assert_match(/up\s+\d{14}\s+.{24}\s+Create books/, output)
         end
       end
 


### PR DESCRIPTION
this depends on a previous pull: [https://github.com/rails/rails/pull/21670]
I didn't want this code, which is a little more invasive causing concern with the base code.

In the environment file, you can now request that schema migrations be ordered by invocation time:

```
config.active_record.schema_migrations_by_invocation_time = true
```
- When you use `rake db:migrate:status` the output will be ordered by the Migration Run column.
- When you use `rake db:rollback` migrations will be rolled back in the order they were invoked!
