### PR TITLE
Correcting output of `number_to_percentage` example in `number_helper…

### DIFF
--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -139,7 +139,7 @@ module ActionView
       #   number_to_percentage(302.24398923423, precision: 5)              # => 302.24399%
       #   number_to_percentage(1000, locale: :fr)                          # => 1 000,000%
       #   number_to_percentage("98a")                                      # => 98a%
-      #   number_to_percentage(100, format: "%n  %")                       # => 100  %
+      #   number_to_percentage(100, format: "%n  %")                       # => 100.000  %
       #
       #   number_to_percentage("98a", raise: true)                         # => InvalidNumberError
       def number_to_percentage(number, options = {})

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -118,7 +118,7 @@ module ActiveSupport
     #   number_to_percentage(1000, locale: :fr)                    # => 1 000,000%
     #   number_to_percentage:(1000, precision: nil)                # => 1000%
     #   number_to_percentage('98a')                                # => 98a%
-    #   number_to_percentage(100, format: '%n  %')                 # => 100  %
+    #   number_to_percentage(100, format: '%n  %')                 # => 100.000  %
     def number_to_percentage(number, options = {})
       NumberToPercentageConverter.convert(number, options)
     end


### PR DESCRIPTION
Here is correct output of `number_to_percentage(100, format: "%n  %”)`

![screen shot 2015-09-22 at 7 15 09 am](https://cloud.githubusercontent.com/assets/2149795/10009417/0fc5fee4-60fa-11e5-8eed-809623b9040d.png)
