### PR TITLE
Fix a typo: Mime::Types should be Mime::Type [ci skip]

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -5,7 +5,7 @@
 
     To this:
 
-      Mime::Types[:HTML]
+      Mime::Type[:HTML]
 
     This change is so that Rails will not manage a list of constants, and fixes
     an issue where if a type isn't registered you could possibly get the wrong


### PR DESCRIPTION
From [these commits](https://github.com/rails/rails/compare/ad1d0b8408f08bc08d54adfd66040bea14b44fe4...6486c7ac94268728c4255b420d36cb859cd3ea20) I think this is a typo. :sweat_smile: 
