### PR TITLE
Implement ActiveRecord::Base.ignored_columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -32,6 +32,11 @@
 
     *Yves Senn*, *Matthew Draper*
 
+*   Add `ActiveRecord::Base.ignored_columns` to make some columns
+    invisible from ActiveRecord.
+
+    *Jean Boussier*
+
 *   `ActiveRecord::Tasks::MySQLDatabaseTasks` fails if shellout to
     mysql commands (like `mysqldump`) is not successful.
 

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -50,6 +50,13 @@ module ActiveRecord
       class_attribute :pluralize_table_names, instance_writer: false
       self.pluralize_table_names = true
 
+      ##
+      # :singleton-method:
+      # Accessor for the list of columns names the model should ignore. Ignored columns won't have attribute
+      # accessors defined, and won't be referenced in SQL queries.
+      class_attribute :ignored_columns, instance_accessor: false
+      self.ignored_columns = [].freeze
+
       self.inheritance_column = 'type'
 
       delegate :type_for_attribute, to: :class
@@ -308,7 +315,7 @@ module ActiveRecord
       end
 
       def load_schema!
-        @columns_hash = connection.schema_cache.columns_hash(table_name)
+        @columns_hash = connection.schema_cache.columns_hash(table_name).except(*ignored_columns)
         @columns_hash.each do |name, column|
           warn_if_deprecated_type(column)
           define_attribute(

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1571,4 +1571,22 @@ class BasicsTest < ActiveRecord::TestCase
 
     assert_not topic.id_changed?
   end
+
+  test "ignored columns are not present in columns_hash" do
+    cache_columns = Developer.connection.schema_cache.columns_hash(Developer.table_name)
+    assert_includes cache_columns.keys, 'first_name'
+    refute_includes Developer.columns_hash.keys, 'first_name'
+  end
+
+  test "ignored columns have no attirbute methods" do
+    refute Developer.new.respond_to?(:first_name)
+    refute Developer.new.respond_to?(:first_name=)
+    refute Developer.new.respond_to?(:first_name?)
+  end
+
+  test "ignored columns don't prevent explicit declaration of attribute methods" do
+    assert Developer.new.respond_to?(:last_name)
+    assert Developer.new.respond_to?(:last_name=)
+    assert Developer.new.respond_to?(:last_name?)
+  end
 end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -7,6 +7,8 @@ module DeveloperProjectsAssociationExtension2
 end
 
 class Developer < ActiveRecord::Base
+  self.ignored_columns = %w(first_name last_name)
+
   has_and_belongs_to_many :projects do
     def find_most_recent
       order("id DESC").first
@@ -60,6 +62,9 @@ class Developer < ActiveRecord::Base
   before_create do |developer|
     developer.audit_logs.build :message => "Computer created"
   end
+
+  attr_accessor :last_name
+  define_attribute_method 'last_name'
 
   def log=(message)
     audit_logs.build :message => message

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -250,6 +250,7 @@ ActiveRecord::Schema.define do
 
   create_table :developers, force: true do |t|
     t.string   :name
+    t.string   :first_name
     t.integer  :salary, default: 70000
     if subsecond_precision_supported?
       t.datetime :created_at, precision: 6


### PR DESCRIPTION
### Use cases

This is useful when you use online schema change tools like https://github.com/soundcloud/lhm or [pt-online-schema-change](https://www.percona.com/doc/percona-toolkit/2.1/pt-online-schema-change.html).

Since some columns will appear or disappear at any moment, you want to make those columns invisible to AR for a while. Otherwise you could have some processes knowing about the columns and others who don't.

Another use case could be to prevent the use of a column in one class that share a table via STI.
### Unanswered questions

There is a couple edge cases I'd like thoughts on:
- [ ] The current implementation doesn't allow to change the list of `ignored_columns` after the columns have been loaded. Should we allow it? If so it mean we need to undefine methods which not great. Maybe just a warning?
- [ ] Quid of inheritance? Should those be inherited or not? FWIW I think they should.

@matthewd @sgrif @rafaelfranca for review please.
