### PR TITLE
Added assertion for error messages for nil and unknown delivery methods

### DIFF
--- a/actionmailer/test/delivery_methods_test.rb
+++ b/actionmailer/test/delivery_methods_test.rb
@@ -165,16 +165,18 @@ class MailDeliveryTest < ActiveSupport::TestCase
 
   test "non registered delivery methods raises errors" do
     DeliveryMailer.delivery_method = :unknown
-    assert_raise RuntimeError do
+    error = assert_raise RuntimeError do
       DeliveryMailer.welcome.deliver_now
     end
+    assert_equal "Invalid delivery method :unknown", error.message
   end
 
   test "undefined delivery methods raises errors" do
     DeliveryMailer.delivery_method = nil
-    assert_raise RuntimeError do
+    error = assert_raise RuntimeError do
       DeliveryMailer.welcome.deliver_now
     end
+    assert_equal "Delivery method cannot be nil", error.message
   end
 
   test "does not perform deliveries if requested" do


### PR DESCRIPTION
As `deliver_now` raises `RuntimeError` for both nil & unknown delivery method so it’s good to have assertion for error messages as well
