### PR TITLE
Fix arguments of `AR::Calculations#sum`

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -70,9 +70,9 @@ module ActiveRecord
     # +calculate+ for examples with options.
     #
     #   Person.sum(:age) # => 4562
-    def sum(*args)
-      return super if block_given?
-      calculate(:sum, *args)
+    def sum(column_name = nil, &block)
+      return super &block if block_given?
+      calculate(:sum, column_name)
     end
 
     # This calculates aggregate values in the given column. Methods for count, sum, average,


### PR DESCRIPTION
Arguments of `#sum` does not match with other shortcuts methods
(count, average, minimum, and maximum).
This commit fix these two points:
- call `super` with only block arguments
  First argument of `super` method, `Enumerable#sum`, is `identity`
  and first argument of `AR::Calculations#sum` is `column_name`.
  `Enumerable#sum` does not expect `column_name` to be passed.
- Change first argument of `sum` from array arguemnt to single
  argument to match other shortcuts methods. When `sum` accept
  array arguemnt, user can pass multi arguments and an exception is
  raised from `calculate`.
