### PR TITLE
Remove not used argument `table_name` of `sanitize_sql_for_conditions`

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -15,7 +15,7 @@ module ActiveRecord
       # them into a valid SQL fragment for a WHERE clause.
       #   ["name='%s' and group_id='%s'", "foo'bar", 4]  returns  "name='foo''bar' and group_id='4'"
       #   "name='foo''bar' and group_id='4'" returns "name='foo''bar' and group_id='4'"
-      def sanitize_sql_for_conditions(condition, table_name = self.table_name)
+      def sanitize_sql_for_conditions(condition)
         return nil if condition.blank?
 
         case condition


### PR DESCRIPTION
This argument was needen when `sanitize_sql_for_conditions` internally
called `sanitize_sql_hash_for_conditions`.
But `sanitize_sql_hash_for_conditions` was deprecated
(https://github.com/rails/rails/commit/eb921000a11bc87a3b001164fc367b84aee584c5)
and deleted
(https://github.com/rails/rails/commit/3a59dd212315ebb9bae8338b98af259ac00bbef3)
(https://github.com/rails/rails/commit/4bd089f1d93fa168b0ae17dd8c92a5157a2537d7).
