### PR TITLE
Remove leading slash from path

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -639,7 +639,7 @@ However, because you are developing the `blorgh` engine on your local machine,
 you will need to specify the `:path` option in your `Gemfile`:
 
 ```ruby
-gem 'blorgh', path: "/path/to/blorgh"
+gem 'blorgh', path: "path/to/blorgh"
 ```
 
 Then run `bundle` to install the gem.


### PR DESCRIPTION
The leading slash denotes an absolute path, rather than a relative one (which is significantly more popular).

I considered changing it to `vendor/engines/blorgh`, which occurs later in the document, in the 'Critical Files' section. I decided against it because engines are frequently internal, and therefore not appropriate for `/vendor`. 

I prefer just `engines/blorg` and would be willing to change the path in 'Critical Files' to make them both match.

Thoughts?
