### PR TITLE
remove warning from Calculations#sum

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -71,7 +71,7 @@ module ActiveRecord
     #
     #   Person.sum(:age) # => 4562
     def sum(column_name = nil, &block)
-      return super &block if block_given?
+      return super(&block) if block_given?
       calculate(:sum, column_name)
     end
 


### PR DESCRIPTION
This removes the following warning.

```
activerecord/lib/active_record/relation/calculations.rb:74: warning: `&' interpreted as argument prefix
```
