### PR TITLE
Changed ActiveModel::Validations::LengthValidator to take lambda as a value for dynamic validation

### DIFF
--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -50,7 +50,7 @@ module ActiveModel
         end
 
         keys.each do |key|
-          value = options[key]
+          value = options[key].is_a?(Proc) ? options[key].call : options[key]
 
           unless (value.is_a?(Integer) && value >= 0) || value == Float::INFINITY
             raise ArgumentError, ":#{key} must be a nonnegative Integer or Infinity"
@@ -64,7 +64,7 @@ module ActiveModel
         errors_options = options.except(*RESERVED_OPTIONS)
 
         CHECKS.each do |key, validity_check|
-          next unless check_value = options[key]
+          next unless check_value = options[key].is_a?(Proc) ? options[key].call : options[key]
 
           if !value.nil? || skip_nil_check?(key)
             next if value_length.send(validity_check, check_value)


### PR DESCRIPTION
Here is a suggesting change for the ActiveModel::Validations::LengthValidator to take lambda as a value for dynamic validation. 
This commit is related to the requirements below: 
http://stackoverflow.com/questions/32714439/dynamic-minimum-maximum-values-for-rails-mode-validates

In practice, there are some requirements to change min/max values in runtime however current length validator cannot support it because the option values are determined in class loading time.
To take dynamic change in validation, the options can take lambda to call the value dynamically.

I hope this change can be helpful. :)
