### PR TITLE
Updated Mime Negotiations docs [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -34,7 +34,7 @@ module ActionController
     #
     #       def authenticate
     #         case request.format
-    #         when Mime::XML, Mime::ATOM
+    #         when Mime::Type[:XML], Mime::Type[:ATOM]
     #           if user = authenticate_with_http_basic { |u, p| @account.users.authenticate(u, p) }
     #             @current_user = user
     #           else
@@ -361,7 +361,7 @@ module ActionController
     #
     #       def authenticate
     #         case request.format
-    #         when Mime::XML, Mime::ATOM
+    #         when Mime::Type[:XML], Mime::Type[:ATOM]
     #           if user = authenticate_with_http_token { |t, o| @account.users.authenticate(t, o) }
     #             @current_user = user
     #           else

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -10,7 +10,7 @@ module ActionDispatch
         self.ignore_accept_header = false
       end
 
-      # The MIME type of the HTTP request, such as Mime::XML.
+      # The MIME type of the HTTP request, such as Mime::Type[:XML].
       #
       # For backward compatibility, the post \format is extracted from the
       # X-Post-Data-Format HTTP header if present.
@@ -49,9 +49,9 @@ module ActionDispatch
 
       # Returns the MIME type for the \format used in the request.
       #
-      #   GET /posts/5.xml   | request.format => Mime::XML
-      #   GET /posts/5.xhtml | request.format => Mime::HTML
-      #   GET /posts/5       | request.format => Mime::HTML or MIME::JS, or request.accepts.first
+      #   GET /posts/5.xml   | request.format => Mime::Type[:XML]
+      #   GET /posts/5.xhtml | request.format => Mime::Type[:HTML]
+      #   GET /posts/5       | request.format => Mime::Type[:HTML] or Mime::Type[:JS], or request.accepts.first
       #
       def format(view_path = [])
         formats.first || Mime::NullType.instance


### PR DESCRIPTION
As we all know that Accessing mime types via constants is deprecated. Now, we are using `Mime::Type[:JSON]` instead of `Mime::JSON`
