### PR TITLE
add type option to create_join_table

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add `:primary_key_type` option to `#create_join_table`. This makes it
+    possible to use `#create_join_table` if you are using a non-integer type in
+    primary key.
+
+    Example:
+
+        create_join_table :foo, :bar, primary_key_type: :uuid do |t|
+        end
+
+    *Yuji Yaginuma*
+
 *   Introduce `connection.data_sources` and `connection.data_source_exists?`.
     These methods determine what relations can be used to back Active Record
     models (usually tables and views).

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -295,6 +295,8 @@ module ActiveRecord
       # [<tt>:force</tt>]
       #   Set to true to drop the table before creating it.
       #   Defaults to false.
+      # [<tt>:primary_key_type</tt>]
+      #   The type of primary key. Defaults to +:integer+.
       #
       # Note that +create_join_table+ does not create any indices by default; you can use
       # its block form to do so yourself:
@@ -318,14 +320,15 @@ module ActiveRecord
       def create_join_table(table_1, table_2, options = {})
         join_table_name = find_join_table_name(table_1, table_2, options)
 
+        primary_key_type = options.delete(:primary_key_type) || :integer
         column_options = options.delete(:column_options) || {}
         column_options.reverse_merge!(null: false)
 
         t1_column, t2_column = [table_1, table_2].map{ |t| t.to_s.singularize.foreign_key }
 
         create_table(join_table_name, options.merge!(id: false)) do |td|
-          td.integer t1_column, column_options
-          td.integer t2_column, column_options
+          td.send(primary_key_type, t1_column, column_options)
+          td.send(primary_key_type, t2_column, column_options)
           yield td if block_given?
         end
       end

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -20,6 +20,7 @@ module ActiveRecord
         connection.create_join_table :artists, :musics
 
         assert_equal %w(artist_id music_id), connection.columns(:artists_musics).map(&:name).sort
+        assert_equal %i(integer integer), connection.columns(:artists_musics).map(&:type).sort
       end
 
       def test_create_join_table_set_not_null_by_default
@@ -76,6 +77,11 @@ module ActiveRecord
         end
 
         assert_equal [%w(artist_id music_id)], connection.indexes(:artists_musics).map(&:columns)
+      end
+
+      def test_create_join_table_with_primary_key_type_options
+        connection.create_join_table :artists, :musics, primary_key_type: :string
+        assert_equal %i(string string), connection.columns(:artists_musics).map(&:type).sort
       end
 
       def test_drop_join_table


### PR DESCRIPTION
This makes it possible to use `#create_join_table` if you are using a non-integer type in primary key.
