### PR TITLE
Change the paths for both Gemfile lines to be 'engines/blorgh'

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -150,7 +150,7 @@ When you include the engine into an application later on, you will do so with
 this line in the Rails application's `Gemfile`:
 
 ```ruby
-gem 'blorgh', path: "vendor/engines/blorgh"
+gem 'blorgh', path: 'engines/blorgh'
 ```
 
 Don't forget to run `bundle install` as usual. By specifying it as a gem within
@@ -639,7 +639,7 @@ However, because you are developing the `blorgh` engine on your local machine,
 you will need to specify the `:path` option in your `Gemfile`:
 
 ```ruby
-gem 'blorgh', path: "path/to/blorgh"
+gem 'blorgh', path: 'engines/blorgh'
 ```
 
 Then run `bundle` to install the gem.


### PR DESCRIPTION
They'd now be consistent.

I don't think `vendor/engines` makes much sense, since it's likely not vendor code.

This also changes the quotes to be single, so we only have one type of quote within each line.
