### PR TITLE
skipped assertion on datetime seconds precision as it is only valid for newer mysql verions        

### DIFF
--- a/activerecord/test/cases/type/date_time_test.rb
+++ b/activerecord/test/cases/type/date_time_test.rb
@@ -5,6 +5,7 @@ module ActiveRecord
   module Type
     class IntegerTest < ActiveRecord::TestCase
       def test_datetime_seconds_precision_applied_to_timestamp
+        skip "This test is invalid if subsecond precision isn't supported" unless subsecond_precision_supported?
         p = Task.create!(starting: ::Time.now)
         assert_equal p.starting.usec, p.reload.starting.usec
       end


### PR DESCRIPTION
versions

This should fix the test failures caused by #20317 
