### PR TITLE
[Action View Overview Guide] Add note about Jbuilder

### DIFF
--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -147,6 +147,39 @@ xml.rss("version" => "2.0", "xmlns:dc" => "http://purl.org/dc/elements/1.1/") do
 end
 ```
 
+#### Jbuilder
+<a href="https://github.com/rails/jbuilder">Jbuilder</a> is a gem that's
+maintained by the Rails team and included in the default Rails Gemfile.
+It's similar to Builder, but is used to generate JSON, instead of XML.
+
+If you don't have it, you can add the following to your Gemfile:
+
+```ruby
+gem 'jbuilder'
+```
+
+A Jbuilder object named `json` is automatically made available to templates with
+a `.jbuilder` extension.
+
+Here is a basic example:
+
+```ruby
+json.name("Alex")
+json.email("alex@example.com")
+```
+
+would produce:
+
+```json
+{
+  "name": "Alex",
+  "email: "alex@example.com"
+}
+```
+
+See the <a href="https://github.com/rails/jbuilder#jbuilder">
+Jbuilder documention</a> for more examples and information.
+
 #### Template Caching
 
 By default, Rails will compile each template to a method in order to render it. When you alter a template, Rails will check the file's modification time and recompile it in development mode.


### PR DESCRIPTION
Currently, the **Action View Overview** talks about Builder, but doesn't mention Jbuilder.

Jbuilder is included in the default Gemfile (when running `rails new app_name`), so I think it deserves some mention in the guides. It's one of the only gems in there that doesn't get mentioned (the other s `sdoc`).

My impression is that JBuilder is currently used to render views more often than Builder.

Would be willing to expand this a little bit, but also reduce it to an `INFO` or `TIP` box.

Thoughts?
