### PR TITLE
Fix engine named routes regression

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -632,7 +632,7 @@ module ActionDispatch
                   super(options)
                 else
                   prefix_options = options.slice(*_route.segment_keys)
-                  prefix_options[:script_name] = ''
+                  prefix_options[:script_name] ||= _routes.default_url_options.fetch(:script_name) { '' }
                   # we must actually delete prefix segment keys to avoid passing them to next url_for
                   _route.segment_keys.each { |k| options.delete(k) }
                   _routes.url_helpers.send("#{name}_path", prefix_options)

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -632,6 +632,7 @@ module ActionDispatch
                   super(options)
                 else
                   prefix_options = options.slice(*_route.segment_keys)
+                  prefix_options[:script_name] = ''
                   # we must actually delete prefix segment keys to avoid passing them to next url_for
                   _route.segment_keys.each { |k| options.delete(k) }
                   _routes.url_helpers.send("#{name}_path", prefix_options)

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1309,6 +1309,56 @@ YAML
       assert_equal '/foo/bukkits/bukkit', last_response.body
     end
 
+    test "paths are properly generated when application is mounted at sub-path and relative_url_root is set" do
+      add_to_config "config.relative_url_root = '/foo'"
+
+      @plugin.write "lib/bukkits.rb", <<-RUBY
+        module Bukkits
+          class Engine < ::Rails::Engine
+            isolate_namespace Bukkits
+          end
+        end
+      RUBY
+
+      app_file "app/controllers/bar_controller.rb", <<-RUBY
+        class BarController < ApplicationController
+          def index
+            render text: bukkits.bukkit_path
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get '/bar' => 'bar#index', :as => 'bar'
+          mount Bukkits::Engine => "/bukkits", :as => "bukkits"
+        end
+      RUBY
+
+      @plugin.write "config/routes.rb", <<-RUBY
+        Bukkits::Engine.routes.draw do
+          get '/bukkit' => 'bukkit#index'
+        end
+      RUBY
+
+
+      @plugin.write "app/controllers/bukkits/bukkit_controller.rb", <<-RUBY
+        class Bukkits::BukkitController < ActionController::Base
+          def index
+            render text: main_app.bar_path
+          end
+        end
+      RUBY
+
+      boot_rails
+
+      get("/bukkits/bukkit", {}, {'SCRIPT_NAME' => '/foo'})
+      assert_equal '/foo/bar', last_response.body
+
+      get("/bar", {}, {'SCRIPT_NAME' => '/foo'})
+      assert_equal '/foo/bukkits/bukkit', last_response.body
+    end
+
   private
     def app
       Rails.application


### PR DESCRIPTION
This pull request aims to fix a regression that has been present in Rails since v4.2.2

When generating the url for a mounted engine through its proxy, the path should be the sum of three parts:
1. Any `SCRIPT_NAME` request header or the value of `relative_url_root`.
2. A prefix (the engine's mounted path).
3. The path of the named route inside the engine.

Since commit 0703453, this has been broken. Instead, the path is the sum of four parts:
1. Any `SCRIPT_NAME` request header or the value of `relative_url_root`.
2. The value of `relative_url_root`.
3. A prefix (the engine's mounted path).
4. The path of the named route inside the engine.

This commit fixes the regression by using the value of `default_url_options[:script_name]` or an empty string as a benign truthy value for `options[:script_name]` when the prefix is being generated, avoiding the duplicate `relative_url_root` value in the final result.

This resolves issues #20920 and #21459.
This is an alternative pull request to #20958.
