### PR TITLE
Fix ActiveRecord `instance_method_already_implemented` docs [ci skip]

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -96,7 +96,7 @@ module ActiveRecord
         end
       end
 
-      # Raises a <tt>ActiveRecord::DangerousAttributeError</tt> exception when an
+      # Raises an <tt>ActiveRecord::DangerousAttributeError</tt> exception when an
       # \Active \Record method is defined in the model, otherwise +false+.
       #
       #   class Person < ActiveRecord::Base


### PR DESCRIPTION
`Raises a ActiveRecord::DangerousAttributeError exception` should be `Raises an ActiveRecord::DangerousAttributeError exception`
