### PR TITLE
Make `assert_difference` return the result of the yielded block.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   `assert_difference` and `assert_no_difference` now returns the result of the
+    yielded block.
+
+    Example:
+
+      post = assert_difference -> { Post.count }, 1 do
+        Post.create
+      end
+
+    *Lucas Mazza*
+
 *   Short-circuit `blank?` on date and time values since they are never blank.
 
     Fixes #21657
@@ -12,7 +23,7 @@
 *   Updated Unicode version to 8.0.0
 
     *Anshul Sharma*
-    
+
 *   `number_to_currency` and `number_with_delimiter` now accept custom `delimiter_pattern` option
      to handle placement of delimiter, to support currency formats like INR
 

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -68,13 +68,15 @@ module ActiveSupport
         }
         before = exps.map(&:call)
 
-        yield
+        retval = yield
 
         expressions.zip(exps).each_with_index do |(code, e), i|
           error  = "#{code.inspect} didn't change by #{difference}"
           error  = "#{message}.\n#{error}" if message
           assert_equal(before[i] + difference, e.call, error)
         end
+
+        retval
       end
 
       # Assertion that the numeric result of evaluating an expression is not

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -56,6 +56,14 @@ class AssertDifferenceTest < ActiveSupport::TestCase
     end
   end
 
+  def test_assert_difference_retval
+    incremented = assert_difference '@object.num', +1 do
+      @object.increment
+    end
+
+    assert_equal incremented, 1
+  end
+
   def test_assert_difference_with_implicit_difference
     assert_difference '@object.num' do
       @object.increment


### PR DESCRIPTION
With this we can perform new assertions on the returned value without having
to cache it with an outer variable or wrapping all subsequent assertions inside
the `assert_difference` block.

Before:

```
post = nil
assert_difference -> { Post.count }, 1 do
  Post.create
end

assert_predicate post, :persisted?
```

Now:

```
post = assert_difference -> { Post.count } do
  Post.create
end

assert_predicate post, :persisted?
```
