### PR TITLE
Qualify column names in calculation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Qualify column name inserted by `group` in calculation
+
+    Giving `group` an unqualified column name now works, even if the relation
+    has `JOIN` with another table which also has a column of the name.
+
+    *Soutaro Matsumoto*
+
 *   Don't require a database connection to load a class which uses acceptance
     validations.
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -296,9 +296,7 @@ module ActiveRecord
       ]
       select_values += select_values unless having_clause.empty?
 
-      select_values.concat group_fields.zip(group_aliases).map { |field,aliaz|
-        field = arel_columns([field]).first
-        
+      select_values.concat arel_columns(group_fields).zip(group_aliases).map { |field,aliaz|
         if field.respond_to?(:as)
           field.as(aliaz)
         else

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -297,10 +297,11 @@ module ActiveRecord
       select_values += select_values unless having_clause.empty?
 
       select_values.concat group_fields.zip(group_aliases).map { |field,aliaz|
+        field = arel_columns([field]).first
+        
         if field.respond_to?(:as)
           field.as(aliaz)
         else
-          field = "#{table_name}.#{field}" if columns_hash.key?(field.to_s)
           "#{field} AS #{aliaz}"
         end
       }

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -300,6 +300,7 @@ module ActiveRecord
         if field.respond_to?(:as)
           field.as(aliaz)
         else
+          field = "#{table_name}.#{field}" if columns_hash.key?(field.to_s)
           "#{field} AS #{aliaz}"
         end
       }

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -102,6 +102,12 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 60,   c[2]
   end
 
+  def test_should_qualify_fields_by_group
+    assert_nothing_raised do
+      AuditLog.joins(:developer).group(:id).count
+    end
+  end
+
   def test_should_order_by_grouped_field
     c = Account.group(:firm_id).order("firm_id").sum(:credit_limit)
     assert_equal [1, 2, 6, 9], c.keys.compact

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -102,9 +102,22 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 60,   c[2]
   end
 
-  def test_should_qualify_fields_by_group
-    assert_nothing_raised do
+  def test_should_generate_valid_sql_with_joins_and_group
+    assert_nothing_raised ActiveRecord::StatementInvalid do
       AuditLog.joins(:developer).group(:id).count
+    end
+  end
+
+  def test_should_calculate_against_given_relation
+    developer = Developer.create!(name: "developer")
+    developer.audit_logs.create!(message: "first log")
+    developer.audit_logs.create!(message: "second log")
+
+    c = developer.audit_logs.joins(:developer).group(:id).count
+
+    assert_equal developer.audit_logs.count, c.size
+    developer.audit_logs.each do |log|
+      assert_equal 1, c[log.id]
     end
   end
 


### PR DESCRIPTION
This is to qualify column names inserted by `group` in calculation query.

A calculation including `joins` and `group` like the following may cause a SQL error.

``` rb
AuditLogs.joins(:developer).group(:id).count
```

Here, column name given to `group` call also exists in the joined table. The column name given via `group` will not qualified with table names, and the result is an error.

```
ActiveRecord::StatementInvalid: SQLite3::SQLException: ambiguous column name: id: SELECT COUNT(*) AS count_all, id AS id FROM "audit_logs" INNER JOIN "developers" ON "developers"."id" = "audit_logs"."developer_id" GROUP BY "audit_logs"."id"
```

This patch is to fix this by qualifying the column names with table name.
