### PR TITLE
adding test for content type with default charset

### DIFF
--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -196,7 +196,17 @@ class ResponseTest < ActiveSupport::TestCase
     assert_equal('application/xml; charset=utf-16', resp.headers['Content-Type'])
   end
 
-  test "read content type without charset" do
+  test "read content type with default charset utf-8" do
+    original = ActionDispatch::Response.default_charset
+    begin
+      resp = ActionDispatch::Response.new(200, { "Content-Type" => "text/xml" })
+      assert_equal('utf-8', resp.charset)
+    ensure
+      ActionDispatch::Response.default_charset = original
+    end
+  end
+
+  test "read content type with charset utf-16" do
     jruby_skip "https://github.com/jruby/jruby/issues/3138"
 
     original = ActionDispatch::Response.default_charset


### PR DESCRIPTION
- first test is for `default_charset` i.e `ActionDispatch::Response.default_charset = “utf-8”` 
- In below test we are passing `ActionDispatch::Response.default_charset = 'utf-16’` so name of the test is irrelevant — “read content type without charset”
