### PR TITLE
associate author to books, missing relation ship [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -11,6 +11,7 @@ module ActiveRecord
     #
     #   class Book < ActiveRecord::Base
     #     # columns: title, sales, author_id
+    #     belongs_to :author
     #   end
     #
     # When you load an author with all associated books Active Record will make


### PR DESCRIPTION
class Author < ActiveRecord::Base
   # columns: name, age
   has_many :books
 end

class Book < ActiveRecord::Base
   # columns: title, sales, author_id
   belongs_to :author    `# author need to belongs with book`
 end
