### PR TITLE
Set active_record config for always creating uuids in generators

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add ability to default to `uuid` as primary key when generating database migrations
+
+    Set `Rails.application.config.active_record.primary_key = :uuid`
+    or `config.active_record.primary_key = :uuid` in config/application.rb
+
+    *Jon McCartie*
+
 *   Qualify column name inserted by `group` in calculation
 
     Giving `group` an unqualified column name now works, even if the relation

--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
@@ -1,6 +1,6 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
   def change
-    create_table :<%= table_name %> do |t|
+    create_table :<%= table_name %><%= id_kind %> do |t|
 <% attributes.each do |attribute| -%>
 <% if attribute.password_digest? -%>
       t.string :password_digest<%= attribute.inject_options %>

--- a/railties/lib/rails/generators/migration.rb
+++ b/railties/lib/rails/generators/migration.rb
@@ -30,6 +30,11 @@ module Rails
         end
       end
 
+      def id_kind
+        kind = Rails.application.config.active_record.primary_key rescue nil
+        ", id: :#{kind}" if kind
+      end
+
       def create_migration(destination, data, config = {}, &block)
         action Rails::Generators::Actions::CreateMigration.new(self, destination, block || data.to_s, config)
       end

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -221,6 +221,19 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_add_uuid_to_create_table_migration
+    previous_value = Rails.application.config.active_record.primary_key
+    Rails.application.config.active_record.primary_key = :uuid
+    run_generator ["create_books"]
+    assert_migration "db/migrate/create_books.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/create_table :books, id: :uuid/, change)
+      end
+    end
+
+    Rails.application.config.active_record.primary_key = previous_value
+  end
+
   def test_should_create_empty_migrations_if_name_not_start_with_add_or_remove_or_create
     migration = "delete_books"
     run_generator [migration, "title:string", "content:text"]


### PR DESCRIPTION
UUID's are awesome (and they improve performance). I want them everywhere, but it's annoying to have to modify my DB migrations every time.  I wish I could make an application config to force the generators to always add `id: :uuid` whenever I create a table.

Throw this in your `application.rb` file...

```
config.active_record.primary_key = :uuid
```

...and `id: :uuid` will be added to every `create_table` generation:
