### PR TITLE
fix Mime type in doc since mime types via constants is deprecated [ci…

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_types.rb
+++ b/actionpack/lib/action_dispatch/http/mime_types.rb
@@ -32,5 +32,5 @@ Mime::Type.register "application/json", :json, %w( text/x-json application/jsonr
 Mime::Type.register "application/pdf", :pdf, [], %w(pdf)
 Mime::Type.register "application/zip", :zip, [], %w(zip)
 
-# Create Mime::ALL but do not add it to the SET.
+# Create Mime::Type[:ALL] but do not add it to the SET.
 Mime::Type.add_type :ALL, Mime::Type::All.new("*/*", :all, [])

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -154,10 +154,10 @@ class MimeTypeTest < ActiveSupport::TestCase
   end
 
   test "type convenience methods" do
-    # Don't test Mime::ALL, since it Mime::ALL#html? == true
+    # Don't test Mime::Type[:ALL], since it Mime::Type[:ALL].html? == true
     types = Mime::SET.symbols.uniq - [:all, :iphone]
 
-    # Remove custom Mime::Type instances set in other tests, like Mime::GIF and Mime::IPHONE
+    # Remove custom Mime::Type instances set in other tests, like Mime::Type[:GIF] and Mime::Type[:IPHONE]
     types.delete_if { |type| !Mime::Type.registered?(type.upcase) }
 
     types.each do |type|
@@ -186,7 +186,7 @@ class MimeTypeTest < ActiveSupport::TestCase
   test "verifiable mime types" do
     all_types = Mime::SET.symbols
     all_types.uniq!
-    # Remove custom Mime::Type instances set in other tests, like Mime::GIF and Mime::IPHONE
+    # Remove custom Mime::Type instances set in other tests, like Mime::Type[:GIF] and Mime::Type[:IPHONE]
     all_types.delete_if { |type| !Mime::Type.registered?(type.upcase) }
   end
 


### PR DESCRIPTION
… skip]
