### PR TITLE
Fix `ActiveRecord::PredicateBuilder` docs. as `register_handler` no m…

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -67,7 +67,7 @@ module ActiveRecord
     #         Arel::Nodes::And.new([range.start, range.end])
     #       )
     #     end
-    #     ActiveRecord::PredicateBuilder.register_handler(MyCustomDateRange, handler)
+    #     ActiveRecord::PredicateBuilder.new("users").register_handler(MyCustomDateRange, handler)
     def register_handler(klass, handler)
       @handlers.unshift([klass, handler])
     end


### PR DESCRIPTION
As `register_handler` no more `Class Method` since commit https://github.com/rails/rails/commit/a3936bbe21f4bff8247f890cacfd0fc882921003. See -

![screen shot 2015-09-26 at 9 10 36 am](https://cloud.githubusercontent.com/assets/2149795/10115671/90d0f08e-642e-11e5-90fe-746dc26d854e.png)
