### PR TITLE
`column_alias_for` method is no more supporting *keys [ci skip]

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -338,7 +338,6 @@ module ActiveRecord
     #   column_alias_for("sum(id)")                  # => "sum_id"
     #   column_alias_for("count(distinct users.id)") # => "count_distinct_users_id"
     #   column_alias_for("count(*)")                 # => "count_all"
-    #   column_alias_for("count", "id")              # => "count_id"
     def column_alias_for(keys)
       if keys.respond_to? :name
         keys = "#{keys.relation.name}.#{keys.name}"


### PR DESCRIPTION
since https://github.com/rails/rails/commit/f77beac8a66a15b1e6f100e4134c79338ee9756b, `column_alias_for` method is no more supporting *keys
