### PR TITLE
Fix proper fonts in `change_column_null` method docs. [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -507,7 +507,7 @@ module ActiveRecord
         raise NotImplementedError, "change_column_default is not implemented"
       end
 
-      # Sets or removes a +NOT NULL+ constraint on a column. The +null+ flag
+      # Sets or removes a <tt>NOT NULL</tt> constraint on a column. The +null+ flag
       # indicates whether the value can be +NULL+. For example
       #
       #   change_column_null(:users, :nickname, false)
@@ -519,7 +519,7 @@ module ActiveRecord
       # allows them to be +NULL+ (drops the constraint).
       #
       # The method accepts an optional fourth argument to replace existing
-      # +NULL+s with some other value. Use that one when enabling the
+      # <tt>NULL</tt>s with some other value. Use that one when enabling the
       # constraint if needed, since otherwise those rows would not be valid.
       #
       # Please note the fourth argument does not set a column's default.


### PR DESCRIPTION
Right now, `change_column_null` method docs showing `+NOT NULL+` and  `+NULL+s`. See - 
![screen shot 2015-09-27 at 2 50 36 pm](https://cloud.githubusercontent.com/assets/2149795/10122083/7953a0fa-6528-11e5-9549-d84aee119595.png)
After this change, `change_column_null` method docs will show proper fonts. See -
![screen shot 2015-09-27 at 3 13 43 pm](https://cloud.githubusercontent.com/assets/2149795/10122121/6e6fc482-652a-11e5-91c5-964be8e9ffe5.png)
