### PR TITLE
check if @rake_patterns is defined

### DIFF
--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -42,7 +42,8 @@ module Minitest
     ENV["RAILS_ENV"] = options[:environment] || "test"
 
     unless run_with_autorun
-      ::Rails::TestRequirer.require_files @rake_patterns || options[:patterns]
+      patterns = defined?(@rake_patterns) ? @rake_patterns : options[:patterns]
+      ::Rails::TestRequirer.require_files(patterns)
     end
 
     unless options[:full_backtrace] || ENV["BACKTRACE"]


### PR DESCRIPTION
This removes the following warning.

```
railties/lib/rails/test_unit/minitest_plugin.rb:45: warning: instance variable @rake_patterns not initialize
```
