### PR TITLE
Eliminate overlapping `app/assets` load path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ gemspec
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem 'rake', '>= 10.3'
 
+# Active Support depends on a prerelease concurrent-ruby 1.0.0, so track
+# latest master as it approaches release.
+gem 'concurrent-ruby', '~> 1.0.0.pre2', github: 'ruby-concurrency/concurrent-ruby'
+
 # Active Job depends on the URI::GID::MissingModelIDError, which isn't released yet.
 gem 'globalid', github: 'rails/globalid', branch: 'master'
 gem 'rack', github: 'rack/rack', branch: 'master'
@@ -21,8 +25,8 @@ gem 'turbolinks', github: 'rails/turbolinks', branch: 'master'
 gem 'arel', github: 'rails/arel', branch: 'master'
 gem 'mail', github: 'mikel/mail', branch: 'master'
 
-gem 'sprockets', github: 'rails/sprockets', branch: 'master'
-gem 'sprockets-rails', github: 'rails/sprockets-rails', branch: 'master'
+gem 'sprockets', '~> 4.0', github: 'rails/sprockets', branch: 'master'
+gem 'sprockets-rails', '~> 3.0.0.beta3', github: 'rails/sprockets-rails', branch: 'master'
 gem 'sass-rails', github: 'rails/sass-rails', branch: 'master'
 
 # require: false so bcrypt is loaded only when has_secure_password is used.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,10 +73,10 @@ GIT
 
 GIT
   remote: git://github.com/rails/sprockets-rails.git
-  revision: 600f981fe79ff2d4179baf84bd18fac5acb58b5e
+  revision: 77098c5acd9f27613875097ce6587aff9d871d7f
   branch: master
   specs:
-    sprockets-rails (3.0.0.beta2)
+    sprockets-rails (3.0.0.beta3)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -96,6 +96,12 @@ GIT
   specs:
     turbolinks (3.0.0)
       coffee-rails
+
+GIT
+  remote: git://github.com/ruby-concurrency/concurrent-ruby.git
+  revision: d15c5d624612c07dc6d2bf4af27b5c00eb6ae12b
+  specs:
+    concurrent-ruby (1.0.0.pre2)
 
 PATH
   remote: .
@@ -179,7 +185,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
-    concurrent-ruby (1.0.0.pre2)
     connection_pool (2.2.0)
     dalli (2.7.4)
     dante (0.2.0)
@@ -309,6 +314,7 @@ DEPENDENCIES
   benchmark-ips
   byebug
   coffee-rails (~> 4.1.0)
+  concurrent-ruby (~> 1.0.0.pre2)!
   dalli (>= 2.2.1)
   delayed_job
   delayed_job_active_record
@@ -342,8 +348,8 @@ DEPENDENCIES
   sequel
   sidekiq
   sneakers
-  sprockets!
-  sprockets-rails!
+  sprockets (~> 4.0)!
+  sprockets-rails (~> 3.0.0.beta3)!
   sqlite3 (~> 1.3.6)
   stackprof
   sucker_punch

--- a/railties/lib/rails/generators/rails/app/templates/app/assets/config/manifest.js.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/config/manifest.js.tt
@@ -1,11 +1,8 @@
 
-<% unless api? -%>
+<% unless options.api? -%>
 //= link_tree ../images
 <% end -%>
 <% unless options.skip_javascript -%>
 //= link_directory ../javascripts .js
 <% end -%>
 //= link_directory ../stylesheets .css
-<% if mountable? && !api? -%>
-//= link <%= underscored_name %>_manifest.js
-<% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/app/assets/manifest.js.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/manifest.js.tt
@@ -1,8 +1,0 @@
-
-<% unless options.api? -%>
-//= link_tree ./images
-<% end -%>
-<% unless options.skip_javascript -%>
-//= link ./javascripts/application.js
-<% end -%>
-//= link ./stylesheets/application.css

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -106,7 +106,7 @@ task default: :test
     def test_dummy_assets
       template "rails/javascripts.js",    "#{dummy_path}/app/assets/javascripts/application.js", force: true
       template "rails/stylesheets.css",   "#{dummy_path}/app/assets/stylesheets/application.css", force: true
-      template "rails/dummy_manifest.js", "#{dummy_path}/app/assets/manifest.js", force: true
+      template "rails/dummy_manifest.js", "#{dummy_path}/app/assets/config/manifest.js", force: true
     end
 
     def test_dummy_clean
@@ -124,7 +124,7 @@ task default: :test
     end
 
     def assets_manifest
-      template "rails/engine_manifest.js", "app/assets/#{underscored_name}_manifest.js"
+      template "rails/engine_manifest.js", "app/assets/config/#{underscored_name}_manifest.js"
     end
 
     def stylesheets

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/engine_manifest.js
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/engine_manifest.js
@@ -1,6 +1,6 @@
 <% if mountable? -%>
-<% unless options.skip_javascript -%>
-//= link ./javascripts/<%= namespaced_name %>/application.js
+<% if !options.skip_javascript -%>
+//= link_directory ../javascripts/<%= namespaced_name %> .js
 <% end -%>
-//= link ./stylesheets/<%= namespaced_name %>/application.css
+//= link_directory ../stylesheets/<%= namespaced_name %> .css
 <% end -%>

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -51,7 +51,12 @@ module TestHelpers
       old_env = ENV["RAILS_ENV"]
       @app ||= begin
         ENV["RAILS_ENV"] = env
-        require "#{app_path}/config/environment"
+
+        # FIXME: shush Sass warning spam, not relevant to testing Railties
+        Kernel.silence_warnings do
+          require "#{app_path}/config/environment"
+        end
+
         Rails.application
       end
     ensure
@@ -161,18 +166,18 @@ module TestHelpers
       require "action_view/railtie"
       require 'action_dispatch/middleware/flash'
 
-      app = Class.new(Rails::Application)
-      app.config.eager_load = false
-      app.secrets.secret_key_base = "3b7cd727ee24e8444053437c36cc66c4"
-      app.config.session_store :cookie_store, key: "_myapp_session"
-      app.config.active_support.deprecation = :log
-      app.config.active_support.test_order = :random
-      app.config.log_level = :info
+      @app = Class.new(Rails::Application)
+      @app.config.eager_load = false
+      @app.secrets.secret_key_base = "3b7cd727ee24e8444053437c36cc66c4"
+      @app.config.session_store :cookie_store, key: "_myapp_session"
+      @app.config.active_support.deprecation = :log
+      @app.config.active_support.test_order = :random
+      @app.config.log_level = :info
 
-      yield app if block_given?
-      app.initialize!
+      yield @app if block_given?
+      @app.initialize!
 
-      app.routes.draw do
+      @app.routes.draw do
         get "/" => "omg#index"
       end
 
@@ -297,7 +302,10 @@ module TestHelpers
     end
 
     def boot_rails
-      require File.expand_path('../../../../load_paths', __FILE__)
+      # FIXME: shush Sass warning spam, not relevant to testing Railties
+      Kernel.silence_warnings do
+        require File.expand_path('../../../../load_paths', __FILE__)
+      end
     end
   end
 end
@@ -327,5 +335,9 @@ Module.new do
   File.open("#{app_template_path}/config/boot.rb", 'w') do |f|
     f.puts "require '#{environment}'"
     f.puts "require 'rails/all'"
+
+    # Preempt the Bundler.require in config/application.rb and silence warning
+    # spam from our gem dependencies (👋 hello Sass 😁)
+    f.puts "Kernel.silence_warnings { Bundler.require(*Rails.groups) }"
   end
 end unless defined?(RAILS_ISOLATED_ENGINE)


### PR DESCRIPTION
- Move `app/assets/manifest.js` to `app/assets/config/manifest.js`. Avoid the suggestion that you can/should deep-link `stylesheets/foo`.
- Pull in all toplevel stylesheets and JavaScripts, not just `application.js` and `.css`. Demonstrate how to use `link_directory` with a specified `.js`/`.css` type.
- Fix `RAILS_ENV` handling in assets tests.
- Shush warnings spam from third-party libs that distract from tests.
- Remove the `app/assets` toplevel path in https://github.com/rails/sprockets-rails/pull/277
