### PR TITLE
Change "parse_query" to "parse_nested_query"

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -711,13 +711,6 @@ action for a Person model, `params[:person]` would usually be a hash of all the 
 
 Fundamentally HTML forms don't know about any sort of structured data, all they generate is name-value pairs, where pairs are just plain strings. The arrays and hashes you see in your application are the result of some parameter naming conventions that Rails uses.
 
-TIP: You may find you can try out examples in this section faster by using the console to directly invoke Rack's parameter parser. For example,
-
-```ruby
-Rack::Utils.parse_query "name=fred&phone=0123456789"
-# => {"name"=>"fred", "phone"=>"0123456789"}
-```
-
 ### Basic Structures
 
 The two basic structures are arrays and hashes. Hashes mirror the syntax used for accessing the value in `params`. For example, if a form contains:


### PR DESCRIPTION
`parse_query` doesn't parse complex nested forms, while `parse_nested_query` does. Here's an example of the difference:

``` ruby
>> Rack::Utils.parse_query "filters[][a]=1&filters[][b]=11&filters[][a]=2&filters[][b]=22"
=> {"filters[][a]"=>["1", "2"], "filters[][b]"=>["11", "22"]}
>> Rack::Utils.parse_nested_query "filters[][a]=1&filters[][b]=11&filters[][a]=2&filters[][b]=22"
=> {"filters"=>[{"a"=>"1", "b"=>"11"}, {"a"=>"2", "b"=>"22"}]}
```

I believe it would be better to point to `parse_nested_query` in the documentation, so that users would not be confused about why their nested params aren't being converted correctly, which is the case for some of the examples in the guide.
