### PR TITLE
ActionDispatch::RemoteIp middleware should come before Rails::Rack::Logger

### DIFF
--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -50,12 +50,13 @@ module Rails
           middleware.use ::Rack::Runtime
           middleware.use ::Rack::MethodOverride unless config.api_only
           middleware.use ::ActionDispatch::RequestId
+          # Must come before Rails::Rack::Logger otherwise wrong IP is logged when :remote_ip is used as log tag
+          middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
 
           # Must come after Rack::MethodOverride to properly log overridden methods
           middleware.use ::Rails::Rack::Logger, config.log_tags
           middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
           middleware.use ::ActionDispatch::DebugExceptions, app
-          middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
 
           unless config.cache_classes
             middleware.use ::ActionDispatch::Reloader, lambda { reload_dependencies? }


### PR DESCRIPTION
Default [middleware stack](https://github.com/rails/rails/blob/master/railties/lib/rails/application/default_middleware_stack.rb#L54) puts `Rails::Rack::Logger` before `ActionDispatch::RemoteIp`. In this way one of the most useful `log_tags` (`:remote_ip`) won't work when application is behind a trusted reverse proxy.

I solved this in my application by using these lines in `config/application.rb`

``` ruby
config.middleware.delete 'ActionDispatch::RemoteIp'
config.middleware.insert_before Rails::Rack::Logger, ActionDispatch::RemoteIp, true, Regexp.new(ENV['TRUSTED_PROXIES'])
```

However I don't see any drawback in having `ActionDispatch::RemoteIp` before `Rails::Rack::Logger` in the middleware stack thus the PR, otherwise `config.log_tags = [:remote_ip]` will always report the wrong address in logs.

For the same reason it would be nice to also have these two middlewares to be present in the stack **before** `Rails::Rack::Logger` to allow better logging context

``` ruby
use ActionDispatch::Cookies
use ActionDispatch::Session::CookieStore
# If moved down in the stack one can do this
config.log_tags = [->(req) { "UID: #{req.session[:user_id] }", ->(req) { "Some cookie: #{request.cookies[:some_cookie]}" }]
```

But I don't know if moving them could cause potential issues in other parts of Rails.

I think this is also related to #5223 as pointed out in [this comment](https://github.com/rails/rails/issues/5223#issuecomment-91239443)

I don't know how to test this, if you point me in the right direction I'll try to write a test for this change.
