### PR TITLE
no more class methods for JoinDependency [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations/alias_tracker.rb
+++ b/activerecord/lib/active_record/associations/alias_tracker.rb
@@ -2,8 +2,7 @@ require 'active_support/core_ext/string/conversions'
 
 module ActiveRecord
   module Associations
-    # Keeps track of table aliases for ActiveRecord::Associations::ClassMethods::JoinDependency and
-    # ActiveRecord::Associations::ThroughAssociationScope
+    # Keeps track of table aliases for ActiveRecord::Associations::JoinDependency
     class AliasTracker # :nodoc:
       attr_reader :aliases
 


### PR DESCRIPTION
`ActiveRecord::Associations::JoinDependency` now it’s own class and `ActiveRecord::Associations::ThroughAssociationScope` doesn’t exists
