### PR TITLE
Update docs for `formatted_offset`

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -40,6 +40,8 @@ class DateTime
   alias_method :to_default_s, :to_s if instance_methods(false).include?(:to_s)
   alias_method :to_s, :to_formatted_s
 
+  # Returns a formatted string of the offset from UTC, or an alternative
+  # string if the time zone is already UTC.
   #
   #   datetime = DateTime.civil(2000, 1, 1, 0, 0, 0, Rational(-6, 24))
   #   datetime.formatted_offset         # => "-06:00"

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -55,7 +55,8 @@ class Time
   alias_method :to_default_s, :to_s
   alias_method :to_s, :to_formatted_s
 
-  # Returns the UTC offset as an +HH:MM formatted string.
+  # Returns a formatted string of the offset from UTC, or an alternative
+  # string if the time zone is already UTC.
   #
   #   Time.local(2000).formatted_offset        # => "-06:00"
   #   Time.local(2000).formatted_offset(false) # => "-0600"

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -285,8 +285,12 @@ module ActiveSupport
       end
     end
 
-    # Returns the offset of this time zone as a formatted string, of the
-    # format "+HH:MM".
+    # Returns a formatted string of the offset from UTC, or an alternative
+    # string if the time zone is already UTC.
+    #
+    #   zone = ActiveSupport::TimeZone['Central Time (US & Canada)']
+    #   zone.formatted_offset        # => "-06:00"
+    #   zone.formatted_offset(false) # => "-0600"
     def formatted_offset(colon=true, alternate_utc_string = nil)
       utc_offset == 0 && alternate_utc_string || self.class.seconds_to_utc_offset(utc_offset, colon)
     end


### PR DESCRIPTION
Output of `formatted_offset` is depends on input so it’s not always in +HH:MM format. Possible outputs are “+5:30”, “+530” or provided alternate UTC string.

[Another place](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/time_with_zone.rb#L113) with same documentation 
