### PR TITLE
Fix documentation for has_many dependant options.

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -932,8 +932,11 @@ If you set the `:dependent` option to:
 
 * `:destroy`, when the object is destroyed, `destroy` will be called on its
 associated objects.
-* `:delete`, when the object is destroyed, all its associated objects will be
+* `:delete_all`, when the object is destroyed, all its associated objects will be
 deleted directly from the database without calling their `destroy` method.
+* `:nullify`, causes the foreign key to be set to `NULL`. Callbacks are not executed.
+* `:restrict_with_exception`, causes an exception to be raised if there is an associated record
+* `:restrict_with_error`, causes an error to be added to the owner if there is an associated object
 
 WARNING: You should not specify this option on a `belongs_to` association that is connected with a `has_many` association on the other class. Doing so can lead to orphaned records in your database.
 


### PR DESCRIPTION
- A `has_many` dependant association accepts `[:destroy, :delete_all, :nullify,
  :restrict_with_error, :restrict_with_exception]` as [dependant options](https://github.com/rails/rails/blob/3e36db4406beea32772b1db1e9a16cc1e8aea14c/activerecord/lib/active_record/associations/builder/has_many.rb#L11). Currently the documentation references `delete` instead of `delete_all`
- Adds documentation for other options
- Fixes #21803 
