### PR TITLE
Fixed concurrent-ruby warnings.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rake', '>= 10.3'
 
 # Active Support depends on a prerelease concurrent-ruby 1.0.0, so track
 # latest master as it approaches release.
-gem 'concurrent-ruby', '~> 1.0.0.pre2', github: 'ruby-concurrency/concurrent-ruby'
+gem 'concurrent-ruby', '~> 1.0.0.pre3', github: 'ruby-concurrency/concurrent-ruby'
 
 # Active Job depends on the URI::GID::MissingModelIDError, which isn't released yet.
 gem 'globalid', github: 'rails/globalid', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,9 +99,9 @@ GIT
 
 GIT
   remote: git://github.com/ruby-concurrency/concurrent-ruby.git
-  revision: c0e52022e5388ed984935bbd59f281c501071760
+  revision: 10ceb96c146d2937b66e7a444445e5ab9edbeb7c
   specs:
-    concurrent-ruby (1.0.0.pre2)
+    concurrent-ruby (1.0.0.pre3)
 
 PATH
   remote: .
@@ -136,7 +136,7 @@ PATH
       activesupport (= 5.0.0.alpha)
       arel (= 7.0.0.alpha)
     activesupport (5.0.0.alpha)
-      concurrent-ruby (~> 1.0.0.pre2, < 2.0.0)
+      concurrent-ruby (~> 1.0.0.pre3, < 2.0.0)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       method_source
@@ -314,7 +314,7 @@ DEPENDENCIES
   benchmark-ips
   byebug
   coffee-rails (~> 4.1.0)
-  concurrent-ruby (~> 1.0.0.pre2)!
+  concurrent-ruby (~> 1.0.0.pre3)!
   dalli (>= 2.2.1)
   delayed_job
   delayed_job_active_record

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'json',       '~> 1.7', '>= 1.7.7'
   s.add_dependency 'tzinfo',     '~> 1.1'
   s.add_dependency 'minitest',   '~> 5.1'
-  s.add_dependency 'concurrent-ruby', '~> 1.0.0.pre2', '< 2.0.0'
+  s.add_dependency 'concurrent-ruby', '~> 1.0.0.pre3', '< 2.0.0'
   s.add_dependency 'method_source'
 end


### PR DESCRIPTION
Bumped version of concurrent-ruby to 1.0.0.pre3, which fixes all interpreter warnings.

Since two members of the concurrent-ruby team are speaking at RubyConf this year I plan to release 1.0.0 before November 15th (the first day of the conference).
