### PR TITLE
Set-Cookie values must be strings according to rack spec

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -396,7 +396,8 @@ module ActionDispatch
       end
 
       def write(headers)
-        headers[HTTP_HEADER] = make_set_cookie_header headers[HTTP_HEADER]
+        hv = make_set_cookie_header headers[HTTP_HEADER]
+        headers[HTTP_HEADER] = hv if hv
       end
 
       mattr_accessor :always_write_cookie


### PR DESCRIPTION
But it's still possible, make_set_cookie_header return nil in a [empty rails 5 app](https://github.com/cloud-mes/demo).

Once I think it should be handle [via rack#955](https://github.com/rack/rack/pull/955), but according to the [rack SPEC](https://github.com/rack/rack/blob/master/SPEC#L234-L236), seems this is a better place.

Notice it's still not perfect way to fix, because if I add `Rack::Lint` to application.rb, still `ActionDispatch::Request::Session:0x6c5d108 not yet loaded` error happen.

``` ruby
# ActionDispatch::Session::CookieStore can not pass Rack::Lint and report below error.
# session #<ActionDispatch::Request::Session not yet loaded> must respond to store and []=
config.middleware.insert_after ActionDispatch::Session::CookieStore, Rack::Lint
```
