### PR TITLE
Decrease string allocations in AbstractAdapter#log

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -506,7 +506,7 @@ module ActiveRecord
 
       def log(sql, name = "SQL", binds = [], statement_name = nil)
         @instrumenter.instrument(
-          "sql.active_record",
+          "sql.active_record".freeze,
           :sql            => sql,
           :name           => name,
           :connection_id  => object_id,


### PR DESCRIPTION
Freezing `"sql.active_record"` slightly decreases string allocations.

I used the following benchmark script.

``` ruby
require 'active_record'
require 'allocation_tracer'
require 'pp'

ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
ActiveRecord::Base.logger = Logger.new(STDOUT)

class CreateModels < ActiveRecord::Migration
  def change
    create_table :posts do |t|
      t.string :name,:email
    end
  end
end

CreateModels.new.change

class Post < ActiveRecord::Base
end

ObjectSpace::AllocationTracer.setup(%i{path line type})

result = ObjectSpace::AllocationTracer.trace do
  1000.times do
    post = Post.new(name: 'test', email: 'dummy')
    post.save
  end
end

pp allocated: ObjectSpace::AllocationTracer.allocated_count_table
```
- before

```
allocated: :T_STRING=>130119
```
- after

```
allocated: :T_STRING=>127113
```
