### PR TITLE
Error when setting the default value to a db function. 

### DIFF
--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -70,6 +70,16 @@ module ActiveRecord
         ensure
           rename_column "test_models", "id_test", "id"
         end
+
+        def test_mysql_rename_column_preserves_default_options
+          TestModel.reset_column_information
+          assert_nothing_raised(StatementInvalid) do
+            add_column "test_models", "mysql_tested_at", :datetime, null: false, default: 'CURRENT_TIMESTAMP'
+            rename_column "test_models", "mysql_tested_at", "should_not_fail_at"
+            remove_column "test_models", "should_not_fail_at"
+          end
+        end
+
       end
 
       def test_rename_nonexistent_column

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -676,7 +676,8 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       # One query for columns (delete_me table)
       # One query for primary key (delete_me table)
       # One query to do the bulk change
-      assert_queries(3, :ignore_none => true) do
+      # One query to test for function check on default column values.
+      assert_queries(4, :ignore_none => true) do
         with_bulk_change_table do |t|
           t.change :name, :string, :default => 'NONAME'
           t.change :birthdate, :datetime


### PR DESCRIPTION
In Rails v4.2.2, I've added tests for underlying support for the passed in default function (if it is a function) then bypasses quoting out the default value as necessary.
