### PR TITLE
Don't set a nil Set-Cookie header when there aren't any cookies

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -396,7 +396,9 @@ module ActionDispatch
       end
 
       def write(headers)
-        headers[HTTP_HEADER] = make_set_cookie_header headers[HTTP_HEADER]
+        if header = make_set_cookie_header(headers[HTTP_HEADER])
+          headers[HTTP_HEADER] = header
+        end
       end
 
       mattr_accessor :always_write_cookie


### PR DESCRIPTION
Omit the header entirely when there aren't any cookies to write. Throws a wrench in `Rack::Lint` and confuses some Rack handlers (like [Nack](https://github.com/josh/nack))

Related: https://github.com/rack/rack/pull/956
