### PR TITLE
Fix Mutating ActiveSupport::TimeZone object while calling to_s method on it

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,8 +1,10 @@
 *   Fix `ActiveSupport::TimeZone#to_s` to not mutate  frozen
     `ActiveSupport::TimeZone` object.
-        ActiveSupport::TimeZone['Hawaii'].freeze
-        ActiveSupport::TimeZone['Hawaii'].to_s => does not raise RuntimeError 
 
+    Example:
+
+      ActiveSupport::TimeZone['Hawaii'].freeze
+      ActiveSupport::TimeZone['Hawaii'].to_s => does not raise RuntimeError
 
     *Pema Geyleg*
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix `ActiveSupport::TimeZone#to_s` to not mutate  frozen
+    `ActiveSupport::TimeZone` object.
+        ActiveSupport::TimeZone['Hawaii'].freeze
+        ActiveSupport::TimeZone['Hawaii'].to_s => does not raise RuntimeError 
+
+
+    *Pema Geyleg*
+
 *   `assert_difference` and `assert_no_difference` now returns the result of the
     yielded block.
 

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -270,19 +270,14 @@ module ActiveSupport
     # that Ruby uses to represent time zone offsets (see Time#utc_offset).
     def initialize(name, utc_offset = nil, tzinfo = nil)
       @name = name
-      @utc_offset = utc_offset
       @tzinfo = tzinfo || TimeZone.find_tzinfo(name)
-      @current_period = nil
+      @current_period = @tzinfo.current_period
+      @utc_offset = utc_offset || @current_period.try!(:utc_offset)
     end
 
     # Returns the offset of this time zone from UTC in seconds.
     def utc_offset
-      if @utc_offset
-        @utc_offset
-      else
-        @current_period ||= tzinfo.current_period if tzinfo
-        @current_period.utc_offset if @current_period
-      end
+      @utc_offset || @current_period.try!(:utc_offset)
     end
 
     # Returns a formatted string of the offset from UTC, or an alternative

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -388,10 +388,9 @@ class TimeZoneTest < ActiveSupport::TestCase
     end
   end
 
-  def test_utc_offset_lazy_loaded_from_tzinfo_when_not_passed_in_to_initialize
+  def test_utc_offset_loaded_from_tzinfo_when_not_passed_in_to_initialize
     tzinfo = TZInfo::Timezone.get('America/New_York')
     zone = ActiveSupport::TimeZone.create(tzinfo.name, nil, tzinfo)
-    assert_equal nil, zone.instance_variable_get('@utc_offset')
     assert_equal(-18_000, zone.utc_offset)
   end
 
@@ -452,6 +451,12 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert zone =~ /Eastern/
     assert zone =~ /New_York/
     assert zone !~ /Nonexistent_Place/
+  end
+
+  def test_frozen_object_and_to_s
+    ActiveSupport::TimeZone.instance_variable_get(:@lazy_zones_map).delete('Tokelau Is.')
+    ActiveSupport::TimeZone['Tokelau Is.'].freeze
+    assert_nothing_raised(RuntimeError) { ActiveSupport::TimeZone['Tokelau Is.'].to_s }
   end
 
   def test_to_s

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -388,9 +388,10 @@ class TimeZoneTest < ActiveSupport::TestCase
     end
   end
 
-  def test_utc_offset_loaded_from_tzinfo_when_not_passed_in_to_initialize
+  def test_utc_offset_lazy_loaded_from_tzinfo_when_not_passed_in_to_initialize
     tzinfo = TZInfo::Timezone.get('America/New_York')
     zone = ActiveSupport::TimeZone.create(tzinfo.name, nil, tzinfo)
+    assert_equal(nil, zone.instance_variable_get('@utc_offset'))
     assert_equal(-18_000, zone.utc_offset)
   end
 


### PR DESCRIPTION
Fixed the issue of ActiveSupport::TimeZone#to_s mutating @current_period when that instance of ActiveSupport::TimeZone object is frozen.

Currently we use rails 4.0 where our application lets each user to set their preferred time zone and we were using ActiveSupport::TimeZone for that. One of the requirement was to let the user select from the GMT#{formatted_offset} timezone name. 

However, we found that calling to_s instance method on frozen ActiveSupport::TimeZone object will raise RuntimeError. That instance of ActiveSupport::TImeZone (for given name) object with instance variable @current_period set to nil could be frozen in any part of the app and if we ended up calling to_s on new instance of the ActiveSupport::TimeZone (for given name) object could led to RuntimeError. This error happens intermittently and is very difficult to debug.

This bug was fixed in Rails version 4.2 by calling utc_offset method right after creating ActiveSupport::TimeZone object. I believe that calling utc_offset by using tap right after creating an instance of ActiveSupport::TimeZone was not the ideal fix the issue. 
Currently the refactored code from this commit https://github.com/rails/rails/commit/ab4c900656db249caa6ff363a932168695b9021e removed that fix.

I could also provide benchmark result for my fix. Please guide me if there is anything else I can do better here.
