### PR TITLE
Make `db:migrate:status` to render `1_some.rb` format migrate files.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,44 @@
+*   Make `db:migrate:status` to render `1_some.rb` format migrate files.
+
+    These files are in `db/migrate`:
+
+        * 1_valid_people_have_last_names.rb
+        * 20150819202140_irreversible_migration.rb
+        * 20150823202140_add_admin_flag_to_users.rb
+        * 20150823202141_migration_tests.rb
+        * 2_we_need_reminders.rb
+        * 3_innocent_jointable.rb
+
+    Before:
+
+        $ bundle exec rake db:migrate:status
+        ...
+
+         Status   Migration ID    Migration Name
+        --------------------------------------------------
+           up     001             ********** NO FILE **********
+           up     002             ********** NO FILE **********
+           up     003             ********** NO FILE **********
+           up     20150819202140  Irreversible migration
+           up     20150823202140  Add admin flag to users
+           up     20150823202141  Migration tests
+
+    After:
+
+        $ bundle exec rake db:migrate:status
+        ...
+
+         Status   Migration ID    Migration Name
+        --------------------------------------------------
+           up     001             Valid people have last names
+           up     002             We need reminders
+           up     003             Innocent jointable
+           up     20150819202140  Irreversible migration
+           up     20150823202140  Add admin flag to users
+           up     20150823202141  Migration tests
+
+    *Yuichiro Kaneko*
+
 *   Define `ActiveRecord::Sanitization.sanitize_sql_for_order` and use it inside
     `preprocess_order_args`.
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -100,12 +100,14 @@ db_namespace = namespace :db do
 
       file_list =
           ActiveRecord::Tasks::DatabaseTasks.migrations_paths.flat_map do |path|
-            # match "20091231235959_some_name.rb" and "001_some_name.rb" pattern
-            Dir.foreach(path).grep(/^(\d{3,})_(.+)\.rb$/) do
-              version = ActiveRecord::SchemaMigration.normalize_migration_number($1)
+            Dir.foreach(path).map do |file|
+              next unless ActiveRecord::Migrator.match_to_migration_filename?(file)
+
+              version, name, scope = ActiveRecord::Migrator.parse_migration_filename(file)
+              version = ActiveRecord::SchemaMigration.normalize_migration_number(version)
               status = db_list.delete(version) ? 'up' : 'down'
-              [status, version, $2.humanize]
-            end
+              [status, version, (name + scope).humanize]
+            end.compact
           end
 
       db_list.map! do |version|

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -154,6 +154,28 @@ module ApplicationTests
         end
       end
 
+      test 'running migrations with not timestamp head migration files' do
+        Dir.chdir(app_path) do
+
+          app_file "db/migrate/1_one_migration.rb", <<-MIGRATION
+            class OneMigration < ActiveRecord::Migration
+            end
+          MIGRATION
+
+          app_file "db/migrate/02_two_migration.rb", <<-MIGRATION
+            class TwoMigration < ActiveRecord::Migration
+            end
+          MIGRATION
+
+          `bin/rake db:migrate`
+
+           output = `bin/rake db:migrate:status`
+
+           assert_match(/up\s+001\s+One migration/, output)
+           assert_match(/up\s+002\s+Two migration/, output)
+        end
+      end
+
       test 'schema generation when dump_schema_after_migration is set' do
         add_to_config('config.active_record.dump_schema_after_migration = false')
 


### PR DESCRIPTION
`1_valid_people_have_last_names.rb` and
`20150823202140_create_users.rb` are valid migration file name.
But `1_valid_people_have_last_names.rb` is rendered as
`********** NO FILE **********` when `rake db:migrate:status`.

Fix to this bug, this commit includes
- define some API private methdos and a Constant
  `match_to_migration_filename?`, `parse_migration_filename`, and
  `MigrationFilenameRegexp`
- use these methods in `db:migrate:status` task

Example:

These files are in `db/migrate`
- 1_valid_people_have_last_names.rb
- 20150819202140_irreversible_migration.rb
- 20150823202140_add_admin_flag_to_users.rb
- 20150823202141_migration_tests.rb
- 2_we_need_reminders.rb
- 3_innocent_jointable.rb

we can migrate all of them.

Before

``` shell
$ bundle exec rake db:migrate:status

...

 Status   Migration ID    Migration Name
--------------------------------------------------
   up     001             ********** NO FILE **********
   up     002             ********** NO FILE **********
   up     003             ********** NO FILE **********
   up     20150819202140  Irreversible migration
   up     20150823202140  Add admin flag to users
   up     20150823202141  Migration tests
```

After

``` shell
$ bundle exec rake db:migrate:status

...

 Status   Migration ID    Migration Name
--------------------------------------------------
   up     001             Valid people have last names
   up     002             We need reminders
   up     003             Innocent jointable
   up     20150819202140  Irreversible migration
   up     20150823202140  Add admin flag to users
   up     20150823202141  Migration tests
```
