### PR TITLE
Do not document private methods in AJ::TestHelper

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -290,15 +290,15 @@ module ActiveJob
                to: :queue_adapter
 
       private
-        def clear_enqueued_jobs
+        def clear_enqueued_jobs # :nodoc:
           enqueued_jobs.clear
         end
 
-        def clear_performed_jobs
+        def clear_performed_jobs # :nodoc:
           performed_jobs.clear
         end
 
-        def enqueued_jobs_size(only: nil)
+        def enqueued_jobs_size(only: nil) # :nodoc:
           if only
             enqueued_jobs.select { |job| job.fetch(:job) == only }.size
           else
@@ -306,7 +306,7 @@ module ActiveJob
           end
         end
 
-        def serialize_args_for_assertion(args)
+        def serialize_args_for_assertion(args) # :nodoc:
           serialized_args = args.dup
           if job_args = serialized_args.delete(:args)
             serialized_args[:args] = ActiveJob::Arguments.serialize(job_args)
@@ -314,7 +314,7 @@ module ActiveJob
           serialized_args
         end
 
-        def instantiate_job(payload)
+        def instantiate_job(payload) # :nodoc:
           job = payload[:job].new(*payload[:args])
           job.scheduled_at = Time.at(payload[:at]) if payload.key?(:at)
           job.queue_name = payload[:queue]


### PR DESCRIPTION
I found that this methods are documented at http://edgeapi.rubyonrails.org/classes/ActiveJob/TestHelper.html#method-i-clear_enqueued_jobs

I don't know why they are not automatically hidden from generating docs, like other private methods in module, in example at https://github.com/rails/rails/blob/b081edaf20fd828b5246239bcaaec35802558f21/activesupport/lib/active_support/testing/time_helpers.rb#L126-L128
