### PR TITLE
Use `partition` instead of `split` in ActiveSupport::Subscriber#finish

### DIFF
--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -91,7 +91,7 @@ module ActiveSupport
       event.end = finished
       event.payload.merge!(payload)
 
-      method = name.split('.'.freeze).first
+      method = name.partition('.'.freeze).first
       send(method, event)
     end
 


### PR DESCRIPTION
`split` is about 1.15x slower than `partition`.

I think this commit is useful because we call `ActiveSupport::Subscriber#finish` many times although the performance improvement is relatively small when calling the method only once.
- benchmark script

``` ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  name = 'sql.activerecord'

  x.report('split') do
    name.split('.'.freeze).first
  end

  x.report('partition') do
    name.partition('.'.freeze).first
  end

  x.compare!
end
```
- output

```
Calculating -------------------------------------
               split    72.310k i/100ms
           partition    81.414k i/100ms
-------------------------------------------------
               split      2.052M (± 2.3%) i/s -     10.268M
           partition      2.393M (± 3.1%) i/s -     11.968M

Comparison:
           partition:  2393252.5 i/s
               split:  2051642.2 i/s - 1.17x slower
```
