### PR TITLE
Add :nodoc: directive to foo

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/method_transplanting.rb
+++ b/activesupport/lib/active_support/core_ext/module/method_transplanting.rb
@@ -2,7 +2,9 @@ class Module
   ###
   # TODO: remove this after 1.9 support is dropped
   def methods_transplantable? # :nodoc:
-    x = Module.new { def foo; end }
+    x = Module.new {
+      def foo; end # :nodoc:
+    }
     Module.new { define_method :bar, x.instance_method(:foo) }
     true
   rescue TypeError


### PR DESCRIPTION
I wonder if this damned method is intentionally kept for the sake of humor or whatever, if once accidentally appeared in [the API reference](http://api.rubyonrails.org/classes/Module.html#method-i-foo), but I bother to add the directive, as otherwise this is likely to stay there until Rails 5.1 where the entire module is supposed to be removed.
