### PR TITLE
Change `Journey::Route#verb` to return string instead of regexp.

### DIFF
--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -163,7 +163,7 @@ module ActionDispatch
       end
 
       def verb
-        %r[^#{verbs.join('|')}$]
+        verbs.join('|')
       end
 
       private

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -16,10 +16,6 @@ module ActionDispatch
         app.app
       end
 
-      def verb
-        super.source.gsub(/[$^]/, '')
-      end
-
       def path
         super.spec.to_s
       end

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -82,7 +82,7 @@ module ActionDispatch
         end
         assert_equal({:omg=>:awesome, :controller=>"posts", :action=>"index"},
                      fakeset.defaults.first)
-        assert_equal(/^GET$/, fakeset.routes.first.verb)
+        assert_equal("GET", fakeset.routes.first.verb)
       end
 
       def test_mapping_requirements
@@ -99,7 +99,7 @@ module ActionDispatch
         mapper.scope(via: :put) do
           mapper.match '/', :to => 'posts#index', :as => :main
         end
-        assert_equal(/^PUT$/, fakeset.routes.first.verb)
+        assert_equal("PUT", fakeset.routes.first.verb)
       end
 
       def test_map_slash

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -77,6 +77,17 @@ module ActionDispatch
         ], output
       end
 
+      def test_articles_inspect_with_multiple_verbs
+        output = draw do
+          match 'articles/:id', to: 'articles#update', via: [:put, :patch]
+        end
+
+        assert_equal [
+          "Prefix Verb      URI Pattern             Controller#Action",
+          "       PUT|PATCH /articles/:id(.:format) articles#update"
+        ], output
+      end
+
       def test_inspect_shows_custom_assets
         output = draw do
           get '/custom/assets', :to => 'custom_assets#show'


### PR DESCRIPTION
By [this commit](https://github.com/rails/rails/commit/0b476de445faf330c58255e2ec3eea0f3a7c1bfc)
`Journey::Route#verb` need not to return verb as regexp.
The returned value is used by inspector, so change it to be a string.

Add inspect_with_multiple_verbs test case to keep the behavior of
inspector correctly.
