### PR TITLE
[ci skip] Change `via: [:get, :post]` to `via: [:put, :patch]`

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -642,7 +642,7 @@ This will define a `user_path` method that will be available in controllers, hel
 In general, you should use the `get`, `post`, `put`, `patch`  and `delete` methods to constrain a route to a particular verb. You can use the `match` method with the `:via` option to match multiple verbs at once:
 
 ```ruby
-match 'photos', to: 'photos#show', via: [:get, :post]
+match 'photos/:id', to: 'photos#update', via: [:put, :patch]
 ```
 
 You can match all verbs to a particular route using `via: :all`:


### PR DESCRIPTION
I think `via: [:put, :patch]` is more natural use case than
`via: [:get, :post]`.
