### PR TITLE
use class to specify the middleware [ci skip]

### DIFF
--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -171,7 +171,7 @@ Add the following lines to your application configuration:
 
 ```ruby
 # config/application.rb
-config.middleware.delete "Rack::Lock"
+config.middleware.delete Rack::Lock
 ```
 
 And now if you inspect the middleware stack, you'll find that `Rack::Lock` is
@@ -191,16 +191,16 @@ If you want to remove session related middleware, do the following:
 
 ```ruby
 # config/application.rb
-config.middleware.delete "ActionDispatch::Cookies"
-config.middleware.delete "ActionDispatch::Session::CookieStore"
-config.middleware.delete "ActionDispatch::Flash"
+config.middleware.delete ActionDispatch::Cookies
+config.middleware.delete ActionDispatch::Session::CookieStore
+config.middleware.delete ActionDispatch::Flash
 ```
 
 And to remove browser related middleware,
 
 ```ruby
 # config/application.rb
-config.middleware.delete "Rack::MethodOverride"
+config.middleware.delete Rack::MethodOverride
 ```
 
 ### Internal Middleware Stack

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb
@@ -3,7 +3,7 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, "Rack::Cors" do
+# Rails.application.config.middleware.insert_before 0, Rack::Cors do
 #   allow do
 #     origins 'example.com'
 #


### PR DESCRIPTION
using string for middleware class names is deprecated in 83b767cef90abfc4c2ee9f4b451b0215501fae9a
