### PR TITLE
Support passing array to `assert_enqueued_jobs` in `:only` option

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support passing array to `assert_enqueued_jobs` in `:only` option.
+
+    *Wojciech Wnętrzak*
+
 *   Add job priorities to Active Job.
 
     *wvengen*

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -300,7 +300,7 @@ module ActiveJob
 
         def enqueued_jobs_size(only: nil) # :nodoc:
           if only
-            enqueued_jobs.select { |job| job.fetch(:job) == only }.size
+            enqueued_jobs.select { |job| Array(only).include?(job.fetch(:job)) }.size
           else
             enqueued_jobs.size
           end

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -140,6 +140,16 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     assert_match(/1 .* but 2/, error.message)
   end
 
+  def test_assert_enqueued_jobs_with_only_option_as_array
+    assert_nothing_raised do
+      assert_enqueued_jobs 2, only: [HelloJob, LoggingJob] do
+        HelloJob.perform_later('jeremy')
+        LoggingJob.perform_later('stewie')
+        RescueJob.perform_later('david')
+      end
+    end
+  end
+
   def test_assert_no_enqueued_jobs_with_only_option
     assert_nothing_raised do
       assert_no_enqueued_jobs only: HelloJob do
@@ -157,6 +167,14 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
 
     assert_match(/0 .* but 1/, error.message)
+  end
+
+  def test_assert_no_enqueued_jobs_with_only_option_as_array
+    assert_nothing_raised do
+      assert_no_enqueued_jobs only: [HelloJob, RescueJob] do
+        LoggingJob.perform_later
+      end
+    end
   end
 
   def test_assert_enqueued_job


### PR DESCRIPTION
To be consistent with `assert_performed_jobs` that accepts array in `:only` option
