### PR TITLE
Fixed deprecated string to specify the middleware [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -244,7 +244,7 @@ config.middleware.swap ActionController::Failsafe, Lifo::Failsafe
 They can also be removed from the stack completely:
 
 ```ruby
-config.middleware.delete "Rack::MethodOverride"
+config.middleware.delete Rack::MethodOverride
 ```
 
 ### Configuring i18n


### PR DESCRIPTION
Using string for middleware class names is deprecated in  https://github.com/rails/rails/commit/83b767cef90abfc4c2ee9f4b451b0215501fae9a . Fixed for this is missing in PR https://github.com/rails/rails/pull/21851
