### PR TITLE
Fixed serializing `:at` option for `assert_eqnueued_with` and `assert_performed_with`

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixed serializing `:at` option for `assert_enqueued_with`
+    and `assert_performed_with`
+
+    *Wojciech Wnętrzak*
+
 *   Support passing array to `assert_enqueued_jobs` in `:only` option.
 
     *Wojciech Wnętrzak*

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -218,6 +218,12 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_enqueued_job_with_at_option
+    assert_enqueued_with(job: HelloJob, at: Date.tomorrow.noon) do
+      HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
+    end
+  end
+
   def test_assert_enqueued_job_with_global_id_args
     ricardo = Person.new(9)
     assert_enqueued_with(job: HelloJob, args: [ricardo]) do
@@ -439,15 +445,21 @@ class PerformedJobsTest < ActiveJob::TestCase
 
   def test_assert_performed_job_failure
     assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_with(job: LoggingJob, at: Date.tomorrow.noon, queue: 'default') do
-        NestedJob.set(wait_until: Date.tomorrow.noon).perform_later
+      assert_performed_with(job: LoggingJob) do
+        HelloJob.perform_later
       end
     end
 
     assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_with(job: NestedJob, at: Date.tomorrow.noon, queue: 'low') do
-        NestedJob.set(queue: 'low', wait_until: Date.tomorrow.noon).perform_later
+      assert_performed_with(job: HelloJob, queue: 'low') do
+        HelloJob.set(queue: 'important').perform_later
       end
+    end
+  end
+
+  def test_assert_performed_job_with_at_option
+    assert_performed_with(job: HelloJob, at: Date.tomorrow.noon) do
+      HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
     end
   end
 


### PR DESCRIPTION
`scheduled_at` is casted to float https://github.com/rails/rails/blob/b081edaf20fd828b5246239bcaaec35802558f21/activejob/lib/active_job/enqueuing.rb#L64-L65
so it also has to be float here.
