### PR TITLE
Do not allow HTTP Basic Auth with Base64 encrypted blank credentials.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   In HTTP Basic Authentication, do not continue to login procedure with Base64 encrypted
+    blank credentials.
+    Fixes #9172
+
+    *Lau Taarnskov*
+
 *   ActionDispatch::Response#new no longer applies default headers.  If you want
     default headers applied to the response object, then call
     `ActionDispatch::Response.create`.  This change only impacts people who are

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -94,11 +94,15 @@ module ActionController
       end
 
       def has_basic_credentials?(request)
-        request.authorization.present? && (auth_scheme(request).downcase == 'basic')
+        request.authorization.present? && (auth_scheme(request).downcase == 'basic') && !user_name_or_password_blank?(request)
       end
 
       def user_name_and_password(request)
         decode_credentials(request).split(':', 2)
+      end
+
+      def user_name_or_password_blank?(request)
+        user_name_and_password(request).all?(&:blank?)
       end
 
       def decode_credentials(request)

--- a/actionpack/test/controller/http_basic_authentication_test.rb
+++ b/actionpack/test/controller/http_basic_authentication_test.rb
@@ -35,6 +35,8 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     def authenticate_with_request
       if authenticate_with_http_basic { |username, password| username == 'pretty' && password == 'please' }
         @logged_in = true
+      elsif authenticate_with_http_basic { |username, password| username.blank? && password.blank? }
+        @logged_in = true
       else
         request_http_basic_authentication("SuperSecret", "Authentication Failed\n")
       end
@@ -116,6 +118,24 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     assert_equal 'Basic realm="SuperSecret"', @response.headers['WWW-Authenticate']
   end
 
+  test "authentication request with encoded blank credentials" do
+    @request.env['HTTP_AUTHORIZATION'] = "Basic "
+    get :display
+    assert_response :unauthorized
+
+    @request.env['HTTP_AUTHORIZATION'] = " "
+    get :display
+    assert_response :unauthorized
+
+    @request.env['HTTP_AUTHORIZATION'] = encode_credentials('', '')
+    get :display
+    assert_response :unauthorized
+
+    @request.env['HTTP_AUTHORIZATION'] = encode_credentials('  ', '  ')
+    get :display
+    assert_response :unauthorized
+  end
+  
   test "authentication request with invalid credential" do
     @request.env['HTTP_AUTHORIZATION'] = encode_credentials('pretty', 'foo')
     get :display


### PR DESCRIPTION
This is a rebase of #9951
