### PR TITLE
Wrong usage of 'a' in docs fixed [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -458,7 +458,7 @@ module ActiveRecord
       end
 
       class ExplainPrettyPrinter # :nodoc:
-        # Pretty prints the result of a EXPLAIN in a way that resembles the output of the
+        # Pretty prints the result of an EXPLAIN in a way that resembles the output of the
         # MySQL shell:
         #
         #   +----+-------------+-------+-------+---------------+---------+---------+-------+------+-------------+

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -8,7 +8,7 @@ module ActiveRecord
         end
 
         class ExplainPrettyPrinter # :nodoc:
-          # Pretty prints the result of a EXPLAIN in a way that resembles the output of the
+          # Pretty prints the result of an EXPLAIN in a way that resembles the output of the
           # PostgreSQL shell:
           #
           #                                     QUERY PLAN

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -218,7 +218,7 @@ module ActiveRecord
       end
 
       class ExplainPrettyPrinter
-        # Pretty prints the result of a EXPLAIN QUERY PLAN in a way that resembles
+        # Pretty prints the result of an EXPLAIN QUERY PLAN in a way that resembles
         # the output of the SQLite shell:
         #
         #   0|0|0|SEARCH TABLE users USING INTEGER PRIMARY KEY (rowid=?) (~1 rows)

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -62,7 +62,7 @@ module ActiveRecord
         aggregate_reflections[aggregation.to_s]
       end
 
-      # Returns a Hash of name of the reflection as the key and a AssociationReflection as the value.
+      # Returns a Hash of name of the reflection as the key and an AssociationReflection as the value.
       #
       #   Account.reflections # => {"balance" => AggregateReflection}
       #

--- a/activesupport/lib/active_support/core_ext/marshal.rb
+++ b/activesupport/lib/active_support/core_ext/marshal.rb
@@ -6,7 +6,7 @@ module ActiveSupport
       if exc.message.match(%r|undefined class/module (.+)|)
         # try loading the class/module
         $1.constantize
-        # if it is a IO we need to go back to read the object
+        # if it is an IO we need to go back to read the object
         source.rewind if source.respond_to?(:rewind)
         retry
       else


### PR DESCRIPTION
This is all I've found in docs.
