### PR TITLE
Use #current instead of #now to prevent zone issues and use new ruby …

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -18,7 +18,7 @@ class Time
 
     # Return the number of days in the given month.
     # If no year is specified, it will use the current year.
-    def days_in_month(month, year = now.year)
+    def days_in_month(month, year = current.year)
       if month == 2 && ::Date.gregorian_leap?(year)
         29
       else


### PR DESCRIPTION
…hash syntax

Rails uses config.time_zone to set time zone for the application, but Time.now uses server time zone instead of using set config.time_zone. So, in order to use application time zone we need to use Time.current/Time.zone.now.
