### PR TITLE
Convert (usec / 1.0e+6) to integer inorder to get a integerin return …

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -55,7 +55,7 @@ class Time
   #   Time.new(2012, 8, 29, 12, 34, 56).seconds_since_midnight # => 45296
   #   Time.new(2012, 8, 29, 23, 59, 59).seconds_since_midnight # => 86399
   def seconds_since_midnight
-    to_i - change(:hour => 0).to_i + (usec / 1.0e+6)
+    to_i - change(hour: 0).to_i + (usec / 1.0e+6).to_i
   end
 
   # Returns the number of seconds until 23:59:59.

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -16,7 +16,8 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal 60,Time.local(2005,1,1,0,1,0).seconds_since_midnight
     assert_equal 3660,Time.local(2005,1,1,1,1,0).seconds_since_midnight
     assert_equal 86399,Time.local(2005,1,1,23,59,59).seconds_since_midnight
-    assert_equal 60.00001,Time.local(2005,1,1,0,1,0,10).seconds_since_midnight
+    assert_equal 60,Time.local(2005,1,1,0,1,0,10).seconds_since_midnight
+    assert_not_equal 60.00001,Time.local(2005,1,1,0,1,0,10).seconds_since_midnight
   end
 
   def test_seconds_since_midnight_at_daylight_savings_time_start


### PR DESCRIPTION
…instead of decimal from #seconds_since_midnight
