### PR TITLE
[ci skip] Fix ActiveRecord::Relation#update documentation

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -400,11 +400,11 @@ module ActiveRecord
     #   people = Person.where(group: 'expert')
     #   people.update(group: 'masters')
     #
-    #   Note: Updating a large number of records will run a
-    #   UPDATE query for each record, which may cause a performance
-    #   issue. So if it is not needed to run callbacks for each update, it is
-    #   preferred to use <tt>update_all</tt> for updating all records using
-    #   a single query.
+    # Note: Updating a large number of records will run an
+    # UPDATE query for each record, which may cause a performance
+    # issue. So if it is not needed to run callbacks for each update, it is
+    # preferred to use <tt>update_all</tt> for updating all records using
+    # a single query.
     def update(id = :all, attributes)
       if id.is_a?(Array)
         id.map.with_index { |one_id, idx| update(one_id, attributes[idx]) }


### PR DESCRIPTION
Fix indentation and minor typo.
- before

```
people = Person.where(group: 'expert')
people.update(group: 'masters')

Note: Updating a large number of records will run a
UPDATE query for each record, which may cause a performance
issue. So if it is not needed to run callbacks for each update, it is
preferred to use <tt>update_all</tt> for updating all records using
a single query.
```
- after

```
people = Person.where(group: 'expert')
people.update(group: 'masters')
```

Note: Updating a large number of records will run an
UPDATE query for each record, which may cause a performance
issue. So if it is not needed to run callbacks for each update, it is
preferred to use <tt>update_all</tt> for updating all records using
a single query.
