### PR TITLE
Use `Mime[:foo]` instead of `Mime::Type[:FOO]` for back compat

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -10,11 +10,15 @@
 
     To this:
 
-      Mime::Type[:HTML]
+      Mime[:html]
 
     This change is so that Rails will not manage a list of constants, and fixes
     an issue where if a type isn't registered you could possibly get the wrong
     object.
+
+    `Mime[:html]` is available in older versions of Rails, too, so you can
+    safely change libraries and plugins and maintain compatibility with
+    multiple versions of Rails.
 
 *   `url_for` does not modify its arguments when generating polymorphic URLs.
 

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -55,7 +55,7 @@ module AbstractController
     # Returns Content-Type of rendered content
     # :api: public
     def rendered_format
-      Mime::Type[:TEXT]
+      Mime[:text]
     end
 
     DEFAULT_PROTECTED_INSTANCE_VARIABLES = Set.new %i(

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -34,7 +34,7 @@ module ActionController
     #
     #       def authenticate
     #         case request.format
-    #         when Mime::Type[:XML], Mime::Type[:ATOM]
+    #         when Mime[:xml], Mime[:atom]
     #           if user = authenticate_with_http_basic { |u, p| @account.users.authenticate(u, p) }
     #             @current_user = user
     #           else
@@ -361,7 +361,7 @@ module ActionController
     #
     #       def authenticate
     #         case request.format
-    #         when Mime::Type[:XML], Mime::Type[:ATOM]
+    #         when Mime[:xml], Mime[:atom]
     #           if user = authenticate_with_http_token { |t, o| @account.users.authenticate(t, o) }
     #             @current_user = user
     #           else

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -229,14 +229,14 @@ module ActionController #:nodoc:
         @responses = {}
         @variant = variant
 
-        mimes.each { |mime| @responses[Mime::Type[mime.upcase.to_sym]] = nil }
+        mimes.each { |mime| @responses[Mime[mime]] = nil }
       end
 
       def any(*args, &block)
         if args.any?
           args.each { |type| send(type, &block) }
         else
-          custom(Mime::Type[:ALL], &block)
+          custom(Mime::ALL, &block)
         end
       end
       alias :all :any
@@ -251,7 +251,7 @@ module ActionController #:nodoc:
       end
 
       def response
-        response = @responses.fetch(format, @responses[Mime::Type[:ALL]])
+        response = @responses.fetch(format, @responses[Mime::ALL])
         if response.is_a?(VariantCollector) # `format.html.phone` - variant inline syntax
           response.variant
         elsif response.nil? || response.arity == 0 # `format.html` - just a format, call its block

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -68,11 +68,11 @@ module ActionController
     #   ActionController::Renderers.add :csv do |obj, options|
     #     filename = options[:filename] || 'data'
     #     str = obj.respond_to?(:to_csv) ? obj.to_csv : obj.to_s
-    #     send_data str, type: Mime::Type[:CSV],
+    #     send_data str, type: Mime[:csv],
     #       disposition: "attachment; filename=#{filename}.csv"
     #   end
     #
-    # Note that we used Mime::Type[:CSV] for the csv mime type as it comes with Rails.
+    # Note that we used Mime[:csv] for the csv mime type as it comes with Rails.
     # For a custom renderer, you'll need to register a mime type with
     # <tt>Mime::Type.register</tt>.
     #
@@ -116,24 +116,24 @@ module ActionController
       json = json.to_json(options) unless json.kind_of?(String)
 
       if options[:callback].present?
-        if content_type.nil? || content_type == Mime::Type[:JSON]
-          self.content_type = Mime::Type[:JS]
+        if content_type.nil? || content_type == Mime[:json]
+          self.content_type = Mime[:js]
         end
 
         "/**/#{options[:callback]}(#{json})"
       else
-        self.content_type ||= Mime::Type[:JSON]
+        self.content_type ||= Mime[:json]
         json
       end
     end
 
     add :js do |js, options|
-      self.content_type ||= Mime::Type[:JS]
+      self.content_type ||= Mime[:js]
       js.respond_to?(:to_js) ? js.to_js(options) : js
     end
 
     add :xml do |xml, options|
-      self.content_type ||= Mime::Type[:XML]
+      self.content_type ||= Mime[:xml]
       xml.respond_to?(:to_xml) ? xml.to_xml(options) : xml
     end
   end

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -64,7 +64,7 @@ module ActionController
     end
 
     def _set_html_content_type
-      self.content_type = Mime::Type[:HTML].to_s
+      self.content_type = Mime[:html].to_s
     end
 
     def _set_rendered_content_type(format)

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -34,7 +34,7 @@ module ActionController
       self.session = session
       self.session_options = TestSession::DEFAULT_OPTIONS
       @custom_param_parsers = {
-        Mime::Type[:XML] => lambda { |raw_post| Hash.from_xml(raw_post)['hash'] }
+        Mime[:xml] => lambda { |raw_post| Hash.from_xml(raw_post)['hash'] }
       }
     end
 
@@ -402,7 +402,7 @@ module ActionController
         MSG
 
         @request.env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
-        @request.env['HTTP_ACCEPT'] ||= [Mime::Type[:JS], Mime::Type[:HTML], Mime::Type[:XML], 'text/xml', Mime::Type[:ALL]].join(', ')
+        @request.env['HTTP_ACCEPT'] ||= [Mime[:js], Mime[:html], Mime[:xml], 'text/xml', '*/*'].join(', ')
         __send__(*args).tap do
           @request.env.delete 'HTTP_X_REQUESTED_WITH'
           @request.env.delete 'HTTP_ACCEPT'
@@ -505,7 +505,7 @@ module ActionController
         if xhr
           @request.set_header 'HTTP_X_REQUESTED_WITH', 'XMLHttpRequest'
           @request.fetch_header('HTTP_ACCEPT') do |k|
-            @request.set_header k, [Mime::Type[:JS], Mime::Type[:HTML], Mime::Type[:XML], 'text/xml', Mime::Type[:ALL]].join(', ')
+            @request.set_header k, [Mime[:js], Mime[:html], Mime[:xml], 'text/xml', '*/*'].join(', ')
           end
         end
 

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -10,7 +10,7 @@ module ActionDispatch
         self.ignore_accept_header = false
       end
 
-      # The MIME type of the HTTP request, such as Mime::Type[:XML].
+      # The MIME type of the HTTP request, such as Mime[:xml].
       #
       # For backward compatibility, the post \format is extracted from the
       # X-Post-Data-Format HTTP header if present.
@@ -49,9 +49,9 @@ module ActionDispatch
 
       # Returns the MIME type for the \format used in the request.
       #
-      #   GET /posts/5.xml   | request.format => Mime::Type[:XML]
-      #   GET /posts/5.xhtml | request.format => Mime::Type[:HTML]
-      #   GET /posts/5       | request.format => Mime::Type[:HTML] or Mime::Type[:JS], or request.accepts.first
+      #   GET /posts/5.xml   | request.format => Mime[:xml]
+      #   GET /posts/5.xhtml | request.format => Mime[:html]
+      #   GET /posts/5       | request.format => Mime[:html] or Mime[:js], or request.accepts.first
       #
       def format(view_path = [])
         formats.first || Mime::NullType.instance
@@ -70,9 +70,9 @@ module ActionDispatch
           elsif use_accept_header && valid_accept_header
             accepts
           elsif xhr?
-            [Mime::Type[:JS]]
+            [Mime[:js]]
           else
-            [Mime::Type[:HTML]]
+            [Mime[:html]]
           end
           set_header k, v
         end
@@ -138,14 +138,14 @@ module ActionDispatch
       #
       def negotiate_mime(order)
         formats.each do |priority|
-          if priority == Mime::Type[:ALL]
+          if priority == Mime::ALL
             return order.first
           elsif order.include?(priority)
             return priority
           end
         end
 
-        order.include?(Mime::Type[:ALL]) ? format : nil
+        order.include?(Mime::ALL) ? format : nil
       end
 
       protected

--- a/actionpack/lib/action_dispatch/http/mime_types.rb
+++ b/actionpack/lib/action_dispatch/http/mime_types.rb
@@ -31,6 +31,3 @@ Mime::Type.register "application/json", :json, %w( text/x-json application/jsonr
 
 Mime::Type.register "application/pdf", :pdf, [], %w(pdf)
 Mime::Type.register "application/zip", :zip, [], %w(zip)
-
-# Create Mime::Type[:ALL] but do not add it to the SET.
-Mime::Type.add_type :ALL, Mime::Type::All.new("*/*", :all, [])

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -4,7 +4,7 @@ module ActionDispatch
       PARAMETERS_KEY = 'action_dispatch.request.path_parameters'
 
       DEFAULT_PARSERS = {
-        Mime::Type[:JSON] => lambda { |raw_post|
+        Mime[:json] => lambda { |raw_post|
           data = ActiveSupport::JSON.decode(raw_post)
           data.is_a?(Hash) ? data : {:_json => data}
         }

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -427,7 +427,7 @@ module ActionDispatch # :nodoc:
       return if content_type
 
       ct = parse_content_type
-      set_content_type(ct.mime_type || Mime::Type[:HTML].to_s,
+      set_content_type(ct.mime_type || Mime[:html].to_s,
                        ct.charset || self.class.default_charset)
     end
 

--- a/actionpack/lib/action_dispatch/testing/assertions.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions.rb
@@ -12,7 +12,7 @@ module ActionDispatch
     include Rails::Dom::Testing::Assertions
 
     def html_document
-      @html_document ||= if @response.content_type === Mime::Type[:XML]
+      @html_document ||= if @response.content_type === Mime[:xml]
         Nokogiri::XML::Document.parse(@response.body)
       else
         Nokogiri::HTML::Document.parse(@response.body)

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -354,7 +354,7 @@ module ActionDispatch
           if xhr
             headers ||= {}
             headers['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
-            headers['HTTP_ACCEPT'] ||= [Mime::Type[:JS], Mime::Type[:HTML], Mime::Type[:XML], 'text/xml', Mime::Type[:ALL]].join(', ')
+            headers['HTTP_ACCEPT'] ||= [Mime[:js], Mime[:html], Mime[:xml], 'text/xml', '*/*'].join(', ')
           end
 
           # this modifies the passed request_env directly

--- a/actionpack/test/abstract/collector_test.rb
+++ b/actionpack/test/abstract/collector_test.rb
@@ -53,9 +53,9 @@ module AbstractController
         collector.html
         collector.text(:foo)
         collector.js(:bar) { :baz }
-        assert_equal [Mime::Type[:HTML], [], nil], collector.responses[0]
-        assert_equal [Mime::Type[:TEXT], [:foo], nil], collector.responses[1]
-        assert_equal [Mime::Type[:JS], [:bar]], collector.responses[2][0,2]
+        assert_equal [Mime[:html], [], nil], collector.responses[0]
+        assert_equal [Mime[:text], [:foo], nil], collector.responses[1]
+        assert_equal [Mime[:js], [:bar]], collector.responses[2][0,2]
         assert_equal :baz, collector.responses[2][2].call
       end
     end

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -65,7 +65,7 @@ class ActionPackAssertionsController < ActionController::Base
   end
 
   def render_text_with_custom_content_type
-    render body: "Hello!", content_type: Mime::Type[:RSS]
+    render body: "Hello!", content_type: Mime[:rss]
   end
 
   def session_stuffing

--- a/actionpack/test/controller/content_type_test.rb
+++ b/actionpack/test/controller/content_type_test.rb
@@ -3,7 +3,7 @@ require 'abstract_unit'
 class OldContentTypeController < ActionController::Base
   # :ported:
   def render_content_type_from_body
-    response.content_type = Mime::Type[:RSS]
+    response.content_type = Mime[:rss]
     render body: "hello world!"
   end
 
@@ -14,7 +14,7 @@ class OldContentTypeController < ActionController::Base
 
   # :ported:
   def render_content_type_from_render
-    render body: "hello world!", :content_type => Mime::Type[:RSS]
+    render body: "hello world!", :content_type => Mime[:rss]
   end
 
   # :ported:
@@ -36,7 +36,7 @@ class OldContentTypeController < ActionController::Base
   end
 
   def render_change_for_builder
-    response.content_type = Mime::Type[:HTML]
+    response.content_type = Mime[:html]
     render :action => "render_default_for_builder"
   end
 
@@ -45,7 +45,7 @@ class OldContentTypeController < ActionController::Base
       format.html { render body: "hello world!" }
       format.xml  { render action: "render_default_content_types_for_respond_to" }
       format.js   { render body: "hello world!" }
-      format.rss  { render body: "hello world!", content_type: Mime::Type[:XML] }
+      format.rss  { render body: "hello world!", content_type: Mime[:xml] }
     end
   end
 end
@@ -64,68 +64,68 @@ class ContentTypeTest < ActionController::TestCase
   def test_render_defaults
     get :render_defaults
     assert_equal "utf-8", @response.charset
-    assert_equal Mime::Type[:TEXT], @response.content_type
+    assert_equal Mime[:text], @response.content_type
   end
 
   def test_render_changed_charset_default
     with_default_charset "utf-16" do
       get :render_defaults
       assert_equal "utf-16", @response.charset
-      assert_equal Mime::Type[:TEXT], @response.content_type
+      assert_equal Mime[:text], @response.content_type
     end
   end
 
   # :ported:
   def test_content_type_from_body
     get :render_content_type_from_body
-    assert_equal Mime::Type[:RSS], @response.content_type
+    assert_equal Mime[:rss], @response.content_type
     assert_equal "utf-8", @response.charset
   end
 
   # :ported:
   def test_content_type_from_render
     get :render_content_type_from_render
-    assert_equal Mime::Type[:RSS], @response.content_type
+    assert_equal Mime[:rss], @response.content_type
     assert_equal "utf-8", @response.charset
   end
 
   # :ported:
   def test_charset_from_body
     get :render_charset_from_body
-    assert_equal Mime::Type[:TEXT], @response.content_type
+    assert_equal Mime[:text], @response.content_type
     assert_equal "utf-16", @response.charset
   end
 
   # :ported:
   def test_nil_charset_from_body
     get :render_nil_charset_from_body
-    assert_equal Mime::Type[:TEXT], @response.content_type
+    assert_equal Mime[:text], @response.content_type
     assert_equal "utf-8", @response.charset, @response.headers.inspect
   end
 
   def test_nil_default_for_erb
     with_default_charset nil do
       get :render_default_for_erb
-      assert_equal Mime::Type[:HTML], @response.content_type
+      assert_equal Mime[:html], @response.content_type
       assert_nil @response.charset, @response.headers.inspect
     end
   end
 
   def test_default_for_erb
     get :render_default_for_erb
-    assert_equal Mime::Type[:HTML], @response.content_type
+    assert_equal Mime[:html], @response.content_type
     assert_equal "utf-8", @response.charset
   end
 
   def test_default_for_builder
     get :render_default_for_builder
-    assert_equal Mime::Type[:XML], @response.content_type
+    assert_equal Mime[:xml], @response.content_type
     assert_equal "utf-8", @response.charset
   end
 
   def test_change_for_builder
     get :render_change_for_builder
-    assert_equal Mime::Type[:HTML], @response.content_type
+    assert_equal Mime[:html], @response.content_type
     assert_equal "utf-8", @response.charset
   end
 
@@ -144,24 +144,24 @@ class AcceptBasedContentTypeTest < ActionController::TestCase
   tests OldContentTypeController
 
   def test_render_default_content_types_for_respond_to
-    @request.accept = Mime::Type[:HTML].to_s
+    @request.accept = Mime[:html].to_s
     get :render_default_content_types_for_respond_to
-    assert_equal Mime::Type[:HTML], @response.content_type
+    assert_equal Mime[:html], @response.content_type
 
-    @request.accept = Mime::Type[:JS].to_s
+    @request.accept = Mime[:js].to_s
     get :render_default_content_types_for_respond_to
-    assert_equal Mime::Type[:JS], @response.content_type
+    assert_equal Mime[:js], @response.content_type
   end
 
   def test_render_default_content_types_for_respond_to_with_template
-    @request.accept = Mime::Type[:XML].to_s
+    @request.accept = Mime[:xml].to_s
     get :render_default_content_types_for_respond_to
-    assert_equal Mime::Type[:XML], @response.content_type
+    assert_equal Mime[:xml], @response.content_type
   end
 
   def test_render_default_content_types_for_respond_to_with_overwrite
-    @request.accept = Mime::Type[:RSS].to_s
+    @request.accept = Mime[:rss].to_s
     get :render_default_content_types_for_respond_to
-    assert_equal Mime::Type[:XML], @response.content_type
+    assert_equal Mime[:xml], @response.content_type
   end
 end

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -81,7 +81,7 @@ class RespondToController < ActionController::Base
   def using_defaults_with_all
     respond_to do |type|
       type.html
-      type.all{ render body: "ALL" }
+      type.all { render body: "ALL" }
     end
   end
 

--- a/actionpack/test/controller/new_base/content_type_test.rb
+++ b/actionpack/test/controller/new_base/content_type_test.rb
@@ -7,12 +7,12 @@ module ContentType
     end
 
     def set_on_response_obj
-      response.content_type = Mime::Type[:RSS]
+      response.content_type = Mime[:rss]
       render body: "Hello world!"
     end
 
     def set_on_render
-      render body: "Hello world!", content_type: Mime::Type[:RSS]
+      render body: "Hello world!", content_type: Mime[:rss]
     end
   end
 

--- a/actionpack/test/controller/render_other_test.rb
+++ b/actionpack/test/controller/render_other_test.rb
@@ -12,7 +12,7 @@ class RenderOtherTest < ActionController::TestCase
 
   def test_using_custom_render_option
     ActionController.add_renderer :simon do |says, options|
-      self.content_type  = Mime::Type[:TEXT]
+      self.content_type  = Mime[:text]
       self.response_body = "Simon says: #{says}"
     end
 

--- a/actionpack/test/controller/render_xml_test.rb
+++ b/actionpack/test/controller/render_xml_test.rb
@@ -92,6 +92,6 @@ class RenderXmlTest < ActionController::TestCase
 
   def test_should_use_implicit_content_type
     get :implicit_content_type, format: 'atom'
-    assert_equal Mime::Type[:ATOM], @response.content_type
+    assert_equal Mime[:atom], @response.content_type
   end
 end

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -22,7 +22,7 @@ class SendFileController < ActionController::Base
 
   def test_send_file_headers_bang
     options = {
-      :type => Mime::Type[:PNG],
+      :type => Mime[:png],
       :disposition => 'disposition',
       :filename => 'filename'
     }
@@ -32,7 +32,7 @@ class SendFileController < ActionController::Base
 
   def test_send_file_headers_with_disposition_as_a_symbol
     options = {
-      :type => Mime::Type[:PNG],
+      :type => Mime[:png],
       :disposition => :disposition,
       :filename => 'filename'
     }

--- a/actionpack/test/controller/webservice_test.rb
+++ b/actionpack/test/controller/webservice_test.rb
@@ -65,7 +65,7 @@ class WebServiceTest < ActionDispatch::IntegrationTest
 
   def test_register_and_use_json_simple
     with_test_route_set do
-      with_params_parsers Mime::Type[:JSON] => Proc.new { |data| ActiveSupport::JSON.decode(data)['request'].with_indifferent_access } do
+      with_params_parsers Mime[:json] => Proc.new { |data| ActiveSupport::JSON.decode(data)['request'].with_indifferent_access } do
         post "/",
           params: '{"request":{"summary":"content...","title":"JSON"}}',
           headers: { 'CONTENT_TYPE' => 'application/json' }
@@ -99,7 +99,7 @@ class WebServiceTest < ActionDispatch::IntegrationTest
   def test_parsing_json_doesnot_rescue_exception
     req = Class.new(ActionDispatch::Request) do
       def params_parsers
-        { Mime::Type[:JSON] => Proc.new { |data| raise Interrupt } }
+        { Mime[:json] => Proc.new { |data| raise Interrupt } }
       end
 
       def content_length; get_header('rack.input').length; end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -750,33 +750,33 @@ class RequestFormat < BaseRequestTest
   test "xml format" do
     request = stub_request
     assert_called(request, :parameters, times: 2, returns: {format: :xml}) do
-      assert_equal Mime::Type[:XML], request.format
+      assert_equal Mime[:xml], request.format
     end
   end
 
   test "xhtml format" do
     request = stub_request
     assert_called(request, :parameters, times: 2, returns: {format: :xhtml}) do
-      assert_equal Mime::Type[:HTML], request.format
+      assert_equal Mime[:html], request.format
     end
   end
 
   test "txt format" do
     request = stub_request
     assert_called(request, :parameters, times: 2, returns: {format: :txt}) do
-      assert_equal Mime::Type[:TEXT], request.format
+      assert_equal Mime[:text], request.format
     end
   end
 
   test "XMLHttpRequest" do
     request = stub_request(
       'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest',
-      'HTTP_ACCEPT' => [Mime::Type[:JS], Mime::Type[:HTML], Mime::Type[:XML], "text/xml", Mime::Type[:ALL]].join(",")
+      'HTTP_ACCEPT' => [Mime[:js], Mime[:html], Mime[:xml], "text/xml", "*/*"].join(",")
     )
 
     assert_called(request, :parameters, times: 1, returns: {}) do
       assert request.xhr?
-      assert_equal Mime::Type[:JS], request.format
+      assert_equal Mime[:js], request.format
     end
   end
 
@@ -796,29 +796,29 @@ class RequestFormat < BaseRequestTest
 
   test "formats text/html with accept header" do
     request = stub_request 'HTTP_ACCEPT' => 'text/html'
-    assert_equal [Mime::Type[:HTML]], request.formats
+    assert_equal [Mime[:html]], request.formats
   end
 
   test "formats blank with accept header" do
     request = stub_request 'HTTP_ACCEPT' => ''
-    assert_equal [Mime::Type[:HTML]], request.formats
+    assert_equal [Mime[:html]], request.formats
   end
 
   test "formats XMLHttpRequest with accept header" do
     request = stub_request 'HTTP_X_REQUESTED_WITH' => "XMLHttpRequest"
-    assert_equal [Mime::Type[:JS]], request.formats
+    assert_equal [Mime[:js]], request.formats
   end
 
   test "formats application/xml with accept header" do
     request = stub_request('CONTENT_TYPE' => 'application/xml; charset=UTF-8',
                            'HTTP_X_REQUESTED_WITH' => "XMLHttpRequest")
-    assert_equal [Mime::Type[:XML]], request.formats
+    assert_equal [Mime[:xml]], request.formats
   end
 
   test "formats format:text with accept header" do
     request = stub_request
     assert_called(request, :parameters, times: 2, returns: {format: :txt}) do
-      assert_equal [Mime::Type[:TEXT]], request.formats
+      assert_equal [Mime[:text]], request.formats
     end
   end
 
@@ -848,7 +848,7 @@ class RequestFormat < BaseRequestTest
   test "formats with xhr request" do
     request = stub_request 'HTTP_X_REQUESTED_WITH' => "XMLHttpRequest"
     assert_called(request, :parameters, times: 1, returns: {}) do
-      assert_equal [Mime::Type[:JS]], request.formats
+      assert_equal [Mime[:js]], request.formats
     end
   end
 
@@ -859,35 +859,35 @@ class RequestFormat < BaseRequestTest
     begin
       request = stub_request 'HTTP_ACCEPT' => 'application/xml'
       assert_called(request, :parameters, times: 1, returns: {}) do
-        assert_equal [ Mime::Type[:HTML] ], request.formats
+        assert_equal [ Mime[:html] ], request.formats
       end
 
       request = stub_request 'HTTP_ACCEPT' => 'koz-asked/something-crazy'
       assert_called(request, :parameters, times: 1, returns: {}) do
-        assert_equal [ Mime::Type[:HTML] ], request.formats
+        assert_equal [ Mime[:html] ], request.formats
       end
 
       request = stub_request 'HTTP_ACCEPT' => '*/*;q=0.1'
       assert_called(request, :parameters, times: 1, returns: {}) do
-        assert_equal [ Mime::Type[:HTML] ], request.formats
+        assert_equal [ Mime[:html] ], request.formats
       end
 
       request = stub_request 'HTTP_ACCEPT' => 'application/jxw'
       assert_called(request, :parameters, times: 1, returns: {}) do
-        assert_equal [ Mime::Type[:HTML] ], request.formats
+        assert_equal [ Mime[:html] ], request.formats
       end
 
       request = stub_request 'HTTP_ACCEPT' => 'application/xml',
                              'HTTP_X_REQUESTED_WITH' => "XMLHttpRequest"
 
       assert_called(request, :parameters, times: 1, returns: {}) do
-        assert_equal [ Mime::Type[:JS] ], request.formats
+        assert_equal [ Mime[:js] ], request.formats
       end
 
       request = stub_request 'HTTP_ACCEPT' => 'application/xml',
                              'HTTP_X_REQUESTED_WITH' => "XMLHttpRequest"
       assert_called(request, :parameters, times: 2, returns: {format: :json}) do
-        assert_equal [ Mime::Type[:JSON] ], request.formats
+        assert_equal [ Mime[:json] ], request.formats
       end
     ensure
       ActionDispatch::Request.ignore_accept_header = old_ignore_accept_header
@@ -897,7 +897,7 @@ end
 
 class RequestMimeType < BaseRequestTest
   test "content type" do
-    assert_equal Mime::Type[:HTML], stub_request('CONTENT_TYPE' => 'text/html').content_mime_type
+    assert_equal Mime[:html], stub_request('CONTENT_TYPE' => 'text/html').content_mime_type
   end
 
   test "no content type" do
@@ -905,11 +905,11 @@ class RequestMimeType < BaseRequestTest
   end
 
   test "content type is XML" do
-    assert_equal Mime::Type[:XML], stub_request('CONTENT_TYPE' => 'application/xml').content_mime_type
+    assert_equal Mime[:xml], stub_request('CONTENT_TYPE' => 'application/xml').content_mime_type
   end
 
   test "content type with charset" do
-    assert_equal Mime::Type[:XML], stub_request('CONTENT_TYPE' => 'application/xml; charset=UTF-8').content_mime_type
+    assert_equal Mime[:xml], stub_request('CONTENT_TYPE' => 'application/xml; charset=UTF-8').content_mime_type
   end
 
   test "user agent" do
@@ -922,9 +922,9 @@ class RequestMimeType < BaseRequestTest
       'HTTP_X_REQUESTED_WITH' => "XMLHttpRequest"
     )
 
-    assert_equal nil, request.negotiate_mime([Mime::Type[:XML], Mime::Type[:JSON]])
-    assert_equal Mime::Type[:HTML], request.negotiate_mime([Mime::Type[:XML], Mime::Type[:HTML]])
-    assert_equal Mime::Type[:HTML], request.negotiate_mime([Mime::Type[:XML], Mime::Type[:ALL]])
+    assert_equal nil, request.negotiate_mime([Mime[:xml], Mime[:json]])
+    assert_equal Mime[:html], request.negotiate_mime([Mime[:xml], Mime[:html]])
+    assert_equal Mime[:html], request.negotiate_mime([Mime[:xml], Mime::ALL])
   end
 
   test "negotiate_mime with content_type" do
@@ -933,7 +933,7 @@ class RequestMimeType < BaseRequestTest
       'HTTP_X_REQUESTED_WITH' => "XMLHttpRequest"
     )
 
-    assert_equal Mime::Type[:XML], request.negotiate_mime([Mime::Type[:XML], Mime::Type[:CSV]])
+    assert_equal Mime[:xml], request.negotiate_mime([Mime[:xml], Mime[:csv]])
   end
 end
 

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -184,13 +184,13 @@ class ResponseTest < ActiveSupport::TestCase
   test "read charset and content type" do
     resp = ActionDispatch::Response.new.tap { |response|
       response.charset = 'utf-16'
-      response.content_type = Mime::Type[:XML]
+      response.content_type = Mime[:xml]
       response.body = 'Hello'
     }
     resp.to_a
 
     assert_equal('utf-16', resp.charset)
-    assert_equal(Mime::Type[:XML], resp.content_type)
+    assert_equal(Mime[:xml], resp.content_type)
 
     assert_equal('application/xml; charset=utf-16', resp.headers['Content-Type'])
   end
@@ -392,7 +392,7 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
     @app = lambda { |env|
       ActionDispatch::Response.new.tap { |resp|
         resp.charset = 'utf-16'
-        resp.content_type = Mime::Type[:XML]
+        resp.content_type = Mime[:xml]
         resp.body = 'Hello'
       }.to_a
     }
@@ -401,7 +401,7 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_equal('utf-16', @response.charset)
-    assert_equal(Mime::Type[:XML], @response.content_type)
+    assert_equal(Mime[:xml], @response.content_type)
 
     assert_equal('application/xml; charset=utf-16', @response.headers['Content-Type'])
   end
@@ -417,7 +417,7 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_equal('utf-16', @response.charset)
-    assert_equal(Mime::Type[:XML], @response.content_type)
+    assert_equal(Mime[:xml], @response.content_type)
 
     assert_equal('application/xml; charset=utf-16', @response.headers['Content-Type'])
   end

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -136,7 +136,7 @@ module ActionView
         tag(
           "link",
           "rel"   => tag_options[:rel] || "alternate",
-          "type"  => tag_options[:type] || Mime::Type.lookup_by_extension(type.to_s).to_s,
+          "type"  => tag_options[:type] || Mime[type].to_s,
           "title" => tag_options[:title] || type.to_s.upcase,
           "href"  => url_options.is_a?(Hash) ? url_for(url_options.merge(:only_path => false)) : url_options
         )

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -466,7 +466,7 @@ class TestController < ApplicationController
   end
 
   def render_content_type_from_body
-    response.content_type = Mime::RSS
+    response.content_type = Mime[:rss]
     render body: "hello world!"
   end
 

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -52,7 +52,7 @@ class LookupContextTest < ActiveSupport::TestCase
   end
 
   test "handles explicitly defined */* formats fallback to :js" do
-    @lookup_context.formats = [:js, Mime::Type[:ALL]]
+    @lookup_context.formats = [:js, Mime::ALL]
     assert_equal [:js, *Mime::SET.symbols], @lookup_context.formats
   end
 

--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -31,7 +31,7 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
             raise AbstractController::ActionNotFound, "Email part '#{part_type}' not found in #{@preview.name}##{@email_action}"
           end
         else
-          @part = find_preferred_part(request.format, Mime::Type[:HTML], Mime::Type[:TEXT])
+          @part = find_preferred_part(request.format, Mime[:html], Mime[:text])
           render action: 'email', layout: false, formats: %w[html]
         end
       else

--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -95,8 +95,8 @@
     <% if @email.multipart? %>
       <dd>
         <select onchange="document.getElementsByName('messageBody')[0].src=this.options[this.selectedIndex].value;">
-          <option <%= request.format == Mime::Type[:HTML] ? 'selected' : '' %> value="?part=text%2Fhtml">View as HTML email</option>
-          <option <%= request.format == Mime::Type[:TEXT] ? 'selected' : '' %> value="?part=text%2Fplain">View as plain-text email</option>
+          <option <%= request.format == Mime[:html] ? 'selected' : '' %> value="?part=text%2Fhtml">View as HTML email</option>
+          <option <%= request.format == Mime[:text] ? 'selected' : '' %> value="?part=text%2Fplain">View as plain-text email</option>
         </select>
       </dd>
     <% end %>


### PR DESCRIPTION
Rails 4.x and earlier didn't support `Mime::Type[:FOO]`, so libraries that support multiple Rails versions would've had to feature-detect whether to use `Mime::Type[:FOO]` or `Mime::FOO`.

`Mime[:foo]` has been around for ages to look up registered MIME types by symbol / extension, though, so libraries and plugins can safely switch to that without breaking backward- or forward-compatibility.

Note: `Mime::ALL` isn't a real MIME type and isn't registered for lookup by type or extension, so it's not available as `Mime[:all]`. We use it internally as a wildcard for `respond_to` negotiation. If you use this internal constant, continue to reference it with `Mime::ALL`.

Ref. efc6dd550ee49e7e443f9d72785caa0f240def53

cc @tenderlove 
