### PR TITLE
MySQL 5.6.5 and greater supports functions as column default values.

### DIFF
--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -52,6 +52,11 @@ def subsecond_precision_supported?
     ActiveRecord::Base.connection.send(:version) < '5.7.0')
 end
 
+def mysql_function_defaults_supported?
+  !current_adapter?(:MysqlAdapter, :Mysql2Adapter) ||
+    ActiveRecord::Base.connection.send(:version) >= '5.6.5'
+end
+
 def mysql_enforcing_gtid_consistency?
   current_adapter?(:MysqlAdapter, :Mysql2Adapter) && 'ON' == ActiveRecord::Base.connection.show_variable('enforce_gtid_consistency')
 end

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -72,6 +72,17 @@ module ActiveRecord
         end
       end
 
+      if mysql_function_defaults_supported?
+        def test_mysql_rename_column_preserves_default_options
+          TestModel.reset_column_information
+          assert_nothing_raised(StatementInvalid) do
+            add_column "test_models", "mysql_tested_at", :datetime, null: false, default: 'CURRENT_TIMESTAMP'
+            rename_column "test_models", "mysql_tested_at", "should_not_fail_at"
+            remove_column "test_models", "should_not_fail_at"
+          end
+        end
+      end
+
       def test_rename_nonexistent_column
         exception = if current_adapter?(:PostgreSQLAdapter, :OracleAdapter)
                       ActiveRecord::StatementInvalid

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -669,7 +669,14 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       # One query for columns (delete_me table)
       # One query for primary key (delete_me table)
       # One query to do the bulk change
-      assert_queries(3, :ignore_none => true) do
+      if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
+        # One query to do function support check on mysql
+        query_count = 4
+      else
+        query_count = 3
+      end
+
+      assert_queries(query_count, :ignore_none => true) do
         with_bulk_change_table do |t|
           t.change :name, :string, :default => 'NONAME'
           t.change :birthdate, :datetime


### PR DESCRIPTION
However in AR, default options are quoted which doesn't allow for
passing in these functions.

For example, attempting to rename a column with a default value
that is function would result in this sql being generated and thro
an error:

  ALTER TABLE `test_models` ADD `mysql_tested_at` datetime DEFAULT
  'CURRENT_TIMESTAMP' NOT NULL

There are various workarounds for column creation seen here:
http://www.mikeperham.com/2014/05/17/setting-mysql-datetime-column-defaults-in-rails/
but not for renaming and again those are hacks.

This commit tests underlying support for
the function (if it is a function) then bypasses quoting the
default value.

https://dev.mysql.com/doc/refman/5.6/en/timestamp-initialization.html
http://optimize-this.blogspot.com/2012/04/datetime-default-now-finally-available.html
