### PR TITLE
No need to declare ActiveRecord::Attributes::Type

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -5,9 +5,6 @@ module ActiveRecord
   module Attributes
     extend ActiveSupport::Concern
 
-    # :nodoc:
-    Type = ActiveRecord::Type
-
     included do
       class_attribute :attributes_to_define_after_schema_loads, instance_accessor: false # :internal:
       self.attributes_to_define_after_schema_loads = {}


### PR DESCRIPTION
/cc @sgrif 
