### PR TITLE
monitor is require for SneakersAdapter

### DIFF
--- a/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
@@ -1,5 +1,5 @@
 require 'sneakers'
-require 'thread'
+require 'monitor'
 
 module ActiveJob
   module QueueAdapters


### PR DESCRIPTION
we are using `@monitor = Monitor.new` that inherit from `Monitor` class, we leave behind this commit https://github.com/rails/rails/commit/cbfc8b36
