### PR TITLE
use ActiveModel::Naming module instead of Model [ci skip]

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -226,7 +226,7 @@ module ActiveModel
     # (See ActiveModel::Name for more information).
     #
     #   class Person
-    #     include ActiveModel::Model
+    #     extend ActiveModel::Naming
     #   end
     #
     #   Person.model_name.name     # => "Person"


### PR DESCRIPTION
Use the documented module instead of ActiveModel::Model.
This makes the example more focused.

?r @senny
