### PR TITLE
Fix precision on cache_key

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -10,9 +10,9 @@ module ActiveRecord
       # Indicates the format used to generate the timestamp in the cache key.
       # Accepts any of the symbols in <tt>Time::DATE_FORMATS</tt>.
       #
-      # This is +:nsec+, by default.
+      # This is +:usec+, by default.
       class_attribute :cache_timestamp_format, :instance_writer => false
-      self.cache_timestamp_format = :nsec
+      self.cache_timestamp_format = :usec
     end
 
     # Returns a String, which Action Pack uses for constructing a URL to this

--- a/activerecord/test/cases/cache_key_test.rb
+++ b/activerecord/test/cases/cache_key_test.rb
@@ -1,0 +1,25 @@
+require "cases/helper"
+
+module ActiveRecord
+  class CacheKeyTest < ActiveRecord::TestCase
+    self.use_transactional_tests = false
+
+    class CacheMe < ActiveRecord::Base; end
+
+    setup do
+      @connection = ActiveRecord::Base.connection
+      @connection.create_table(:cache_mes) { |t| t.timestamps }
+    end
+
+    teardown do
+      @connection.drop_table :cache_mes, if_exists: true
+    end
+
+    test "test_cache_key_format_is_not_too_precise" do
+      record = CacheMe.create
+      key = record.cache_key
+
+      assert_equal key, record.reload.cache_key
+    end
+  end
+end

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -53,7 +53,7 @@ module ActiveRecord
 
     test "cache_key with custom timestamp column" do
       topics = Topic.where("title like ?", "%Topic%")
-      last_topic_timestamp = topics(:fifth).written_on.utc.to_s(:nsec)
+      last_topic_timestamp = topics(:fifth).written_on.utc.to_s(:usec)
       assert_match(last_topic_timestamp, topics.cache_key(:written_on))
     end
 

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -81,7 +81,7 @@ class IntegrationTest < ActiveRecord::TestCase
 
   def test_cache_key_format_for_existing_record_with_updated_at
     dev = Developer.first
-    assert_equal "developers/#{dev.id}-#{dev.updated_at.utc.to_s(:nsec)}", dev.cache_key
+    assert_equal "developers/#{dev.id}-#{dev.updated_at.utc.to_s(:usec)}", dev.cache_key
   end
 
   def test_cache_key_format_for_existing_record_with_updated_at_and_custom_cache_timestamp_format
@@ -111,19 +111,19 @@ class IntegrationTest < ActiveRecord::TestCase
   def test_cache_key_for_updated_on
     dev = Developer.first
     dev.updated_at = nil
-    assert_equal "developers/#{dev.id}-#{dev.updated_on.utc.to_s(:nsec)}", dev.cache_key
+    assert_equal "developers/#{dev.id}-#{dev.updated_on.utc.to_s(:usec)}", dev.cache_key
   end
 
   def test_cache_key_for_newer_updated_at
     dev = Developer.first
     dev.updated_at += 3600
-    assert_equal "developers/#{dev.id}-#{dev.updated_at.utc.to_s(:nsec)}", dev.cache_key
+    assert_equal "developers/#{dev.id}-#{dev.updated_at.utc.to_s(:usec)}", dev.cache_key
   end
 
   def test_cache_key_for_newer_updated_on
     dev = Developer.first
     dev.updated_on += 3600
-    assert_equal "developers/#{dev.id}-#{dev.updated_on.utc.to_s(:nsec)}", dev.cache_key
+    assert_equal "developers/#{dev.id}-#{dev.updated_on.utc.to_s(:usec)}", dev.cache_key
   end
 
   def test_cache_key_format_is_precise_enough
@@ -134,8 +134,16 @@ class IntegrationTest < ActiveRecord::TestCase
     assert_not_equal key, dev.cache_key
   end
 
+  def test_cache_key_format_is_not_too_precise
+    skip("Subsecond precision is not supported") unless subsecond_precision_supported?
+    dev = Developer.first
+    dev.touch
+    key = dev.cache_key
+    assert_equal key, dev.reload.cache_key
+  end
+
   def test_named_timestamps_for_cache_key
     owner = owners(:blackbeard)
-    assert_equal "owners/#{owner.id}-#{owner.happy_at.utc.to_s(:nsec)}", owner.cache_key(:updated_at, :happy_at)
+    assert_equal "owners/#{owner.id}-#{owner.happy_at.utc.to_s(:usec)}", owner.cache_key(:updated_at, :happy_at)
   end
 end

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -6,6 +6,7 @@ class Time
     :db           => '%Y-%m-%d %H:%M:%S',
     :number       => '%Y%m%d%H%M%S',
     :nsec         => '%Y%m%d%H%M%S%9N',
+    :usec         => '%Y%m%d%H%M%S%6N',
     :time         => '%H:%M',
     :short        => '%d %b %H:%M',
     :long         => '%B %d, %Y %H:%M',

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -534,6 +534,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal "17:44",                           time.to_s(:time)
     assert_equal "20050221174430",                  time.to_s(:number)
     assert_equal "20050221174430123456789",         time.to_s(:nsec)
+    assert_equal "20050221174430123456",            time.to_s(:usec)
     assert_equal "February 21, 2005 17:44",         time.to_s(:long)
     assert_equal "February 21st, 2005 17:44",       time.to_s(:long_ordinal)
     with_env_tz "UTC" do


### PR DESCRIPTION
this addresses #21815 

The `cache_key` is set at nanoseconds precision, while timestamps in the database only have microseconds precision at best. This will result in in-memory objects having different `cache_key`s than objects retrieved from the database. I wrote and added a test to demonstrate the issue.

Two things that I stumbled upon that might have some implications: 
- I had to remove the `precision: 6` modifier on the timestamped columns in the schema in order to reproduce the 'bug'. Apparantly, this precision modifier doesn't only apply to the column in the DB but also put a precision limitation on the Model attribute. Does that make sense? Does it have to do with #20317?
- I added `:usec` as a DATE_FORMAT, but left `:nsec` alone. Personally, I think it makes more sense to use microseconds everywhere instead of nanoseconds. First of all, not all platforms support nanoseconds (OS X being the major one) and platforms that do support it only estimate it with CPU-clockcycles. Nanoseconds seem pretty unreliable to me and I can think of no reason why you'd want them, but maybe I'm not getting something here?

Let me know what you guys think!
