### PR TITLE
Fix usage of word alternatively in docs [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -53,7 +53,7 @@ module ActionDispatch
   #     resources :posts, :comments
   #   end
   #
-  # Alternately, you can add prefixes to your path without using a separate
+  # Alternatively, you can add prefixes to your path without using a separate
   # directory by using +scope+. +scope+ takes additional options which
   # apply to all enclosed routes.
   #

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -75,7 +75,7 @@ module ActionView #:nodoc:
   #
   #   Headline: <%= local_assigns[:headline] %>
   #
-  # This is useful in cases where you aren't sure if the local variable has been assigned. Alternately, you could also use
+  # This is useful in cases where you aren't sure if the local variable has been assigned. Alternatively, you could also use
   # <tt>defined? headline</tt> to first check if the variable has been assigned before using it.
   #
   # === Template caching


### PR DESCRIPTION
Alternately means switching between two alternatives, alternatively means doing something different.
