### PR TITLE
Changed version specification for rack-cache dependency

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activesupport', version)
   s.add_dependency('activemodel',   version)
-  s.add_dependency('rack-cache',    '~> 1.2')
+  s.add_dependency('rack-cache',    '~> 1.2.0')
   s.add_dependency('builder',       '~> 3.0.0')
   s.add_dependency('rack',          '~> 1.4.5')
   s.add_dependency('rack-test',     '~> 0.6.1')


### PR DESCRIPTION
See #21889 
- Used to have "~> 1.2" which allows version 1.3
- Version 1.3, released recently, requires ruby >= 2.0.0

This means makes action_pack 3.2 incompatible with ruby 1.9.3 if version 1.3 of rack-cache is resolved.
