### PR TITLE
Add missing env & config dependency to `rake db:seed`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add environment & load_config dependency to `bin/rake db:seed` to enable
+    seed load in environments without Rails and custom DB configuration
+
+    *Tobias Bielohlawek*
+
 *   MariaDB 5.3+ supports microsecond datetime precision.
 
     *Jeremy Daer*

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -191,7 +191,7 @@ db_namespace = namespace :db do
   task :setup => ['db:schema:load_if_ruby', 'db:structure:load_if_sql', :seed]
 
   desc 'Loads the seed data from db/seeds.rb'
-  task :seed do
+  task :seed  => [:environment, :load_config] do
     db_namespace['abort_if_pending_migrations'].invoke
     ActiveRecord::Tasks::DatabaseTasks.load_seed
   end


### PR DESCRIPTION
Fixes loading Seeds in a custom, non-rails environment. This failed due to missing dependencies on `rake db:seed` - added with this PR.

I couldn't find a proper way to test this, or an existing test to re-use. pls advise.
