### PR TITLE
Added missing specs for not modifying queues when using AJ test helpers

### DIFF
--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -242,6 +242,15 @@ class EnqueuedJobsTest < ActiveJob::TestCase
 
     assert_equal "No enqueued job found with {:job=>HelloJob, :args=>[#{wilma.inspect}]}", error.message
   end
+
+  def test_assert_enqueued_job_does_not_change_jobs_count
+    HelloJob.perform_later
+    assert_enqueued_with(job: HelloJob) do
+      HelloJob.perform_later
+    end
+
+    assert_equal 2, ActiveJob::Base.queue_adapter.enqueued_jobs.count
+  end
 end
 
 class PerformedJobsTest < ActiveJob::TestCase
@@ -486,5 +495,17 @@ class PerformedJobsTest < ActiveJob::TestCase
     end
 
     assert_equal "No performed job found with {:job=>HelloJob, :args=>[#{wilma.inspect}]}", error.message
+  end
+
+  def test_assert_performed_job_does_not_change_jobs_count
+    assert_performed_with(job: HelloJob) do
+      HelloJob.perform_later
+    end
+
+    assert_performed_with(job: HelloJob) do
+      HelloJob.perform_later
+    end
+
+    assert_equal 2, ActiveJob::Base.queue_adapter.performed_jobs.count
   end
 end


### PR DESCRIPTION
I was wondering why `ensure` statements were needed here https://github.com/rails/rails/blob/e70ec9e91cb63fd63cfc0a285e5d2268a0297e46/activejob/lib/active_job/test_helper.rb#L245-L247 as when I removed them, tests were still passing.

I added missing test for this case and also changed implementation to little more readable (in my opinion at least ;-)) as it's not messing with clearing/restoring the queue
