### PR TITLE
activerecord: Apply associations to base class' descendants

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -34,6 +34,9 @@ module ActiveRecord
     def self.add_reflection(ar, name, reflection)
       ar.clear_reflections_cache
       ar._reflections = ar._reflections.merge(name.to_s => reflection)
+      ar.descendants.each do |k|
+        k._reflections.merge!(name.to_s => reflection)
+      end if ar.base_class == ar
     end
 
     def self.add_aggregate_reflection(ar, name, reflection)

--- a/activerecord/test/cases/associations/sti_descendants_test.rb
+++ b/activerecord/test/cases/associations/sti_descendants_test.rb
@@ -1,0 +1,12 @@
+require "cases/helper"
+require 'models/company'
+
+class Company
+  has_many :latest_contracts, -> { order('created_at DESC') }, foreign_key: :contract_id
+end
+
+class AlwaysReflectAssociationsOnSTIBaseClassDescendants < ActiveRecord::TestCase
+  def test_should_generate_valid_sql
+    assert Firm.reflections.keys.include? 'latest_contracts'
+  end
+end


### PR DESCRIPTION
currently, associations added later with freedom patching are not propagated into descendants.
