### PR TITLE
Fix rack-cache version for ruby < 2.0

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activesupport', version)
   s.add_dependency('activemodel',   version)
-  s.add_dependency('rack-cache',    '~> 1.2')
+  s.add_dependency('rack-cache',    '~> 1.2.0')
   s.add_dependency('builder',       '~> 3.0.0')
   s.add_dependency('rack',          '~> 1.4.5')
   s.add_dependency('rack-test',     '~> 0.6.1')


### PR DESCRIPTION
rack-cache in 1.3.0 required ruby version >= 2.0.0. That mean all
clean installation rails 3.2 on ruby < 2.0 should fail.
