### PR TITLE
change `prepare_destination` to public API [ci skip]

### DIFF
--- a/railties/lib/rails/generators/testing/behaviour.rb
+++ b/railties/lib/rails/generators/testing/behaviour.rb
@@ -92,7 +92,8 @@ module Rails
             cd current_path
           end
 
-          def prepare_destination # :nodoc:
+          # Clears all files and directories in destination.
+          def prepare_destination
             rm_rf(destination_root)
             mkdir_p(destination_root)
           end


### PR DESCRIPTION
`prepare_destination` has been used in the template file for the generator,
I think it should be a public API

ref: https://github.com/rails/rails/blob/master/railties/lib/rails/generators/test_unit/generator/templates/generator_test.rb#L8
