### PR TITLE
Fix subsecond precision supported version

### DIFF
--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -47,9 +47,7 @@ def in_memory_db?
 end
 
 def subsecond_precision_supported?
-  !current_adapter?(:MysqlAdapter, :Mysql2Adapter) ||
-    (ActiveRecord::Base.connection.send(:version) >= '5.6.0' &&
-    ActiveRecord::Base.connection.send(:version) < '5.7.0')
+  !current_adapter?(:MysqlAdapter, :Mysql2Adapter) || ActiveRecord::Base.connection.send(:version) >= '5.6.4'
 end
 
 def mysql_enforcing_gtid_consistency?


### PR DESCRIPTION
Fractional Seconds supported version is 5.6.4 or higher.

http://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html
