### PR TITLE
remove unused require

### DIFF
--- a/railties/lib/rails/generators/testing/assertions.rb
+++ b/railties/lib/rails/generators/testing/assertions.rb
@@ -1,5 +1,3 @@
-require 'shellwords'
-
 module Rails
   module Generators
     module Testing


### PR DESCRIPTION
`shellwords` is no longer needed from #20605.
