### PR TITLE
Refactored association preloader for performance

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -12,7 +12,6 @@ module ActiveRecord
           @preload_scope = preload_scope
           @model         = owners.first && owners.first.class
           @scope         = nil
-          @owners_by_key = nil
           @preloaded_records = []
         end
 
@@ -56,18 +55,6 @@ module ActiveRecord
           raise NotImplementedError
         end
 
-        def owners_by_key
-          @owners_by_key ||= if key_conversion_required?
-                               owners.group_by do |owner|
-                                 owner[owner_key_name].to_s
-                               end
-                             else
-                               owners.group_by do |owner|
-                                 owner[owner_key_name]
-                               end
-                             end
-        end
-
         def options
           reflection.options
         end
@@ -75,32 +62,33 @@ module ActiveRecord
         private
 
         def associated_records_by_owner(preloader)
-          owners_map = owners_by_key
-          owner_keys = owners_map.keys.compact
-
-          # Each record may have multiple owners, and vice-versa
-          records_by_owner = owners.each_with_object({}) do |owner,h|
-            h[owner] = []
+          records = load_records
+          owners.each_with_object({}) do |owner, result|
+            result[owner] = records[convert_key(owner[owner_key_name])] || []
           end
+        end
 
-          if owner_keys.any?
-            # Some databases impose a limit on the number of ids in a list (in Oracle it's 1000)
-            # Make several smaller queries if necessary or make one query if the adapter supports it
-            sliced  = owner_keys.each_slice(klass.connection.in_clause_length || owner_keys.size)
-
-            records = load_slices sliced
-            records.each do |record, owner_key|
-              owners_map[owner_key].each do |owner|
-                records_by_owner[owner] << record
-              end
+        def owner_keys
+          unless defined?(@owner_keys)
+            @owner_keys = owners.map do |owner|
+              owner[owner_key_name]
             end
+            @owner_keys.uniq!
+            @owner_keys.compact!
           end
-
-          records_by_owner
+          @owner_keys
         end
 
         def key_conversion_required?
-          association_key_type != owner_key_type
+          @key_conversion_required ||= association_key_type != owner_key_type
+        end
+
+        def convert_key(key)
+          if key_conversion_required?
+            key.to_s
+          else
+            key
+          end
         end
 
         def association_key_type
@@ -111,17 +99,17 @@ module ActiveRecord
           @model.type_for_attribute(owner_key_name.to_s).type
         end
 
-        def load_slices(slices)
-          @preloaded_records = slices.flat_map { |slice|
+        def load_records
+          return {} if owner_keys.empty?
+          # Some databases impose a limit on the number of ids in a list (in Oracle it's 1000)
+          # Make several smaller queries if necessary or make one query if the adapter supports it
+          slices  = owner_keys.each_slice(klass.connection.in_clause_length || owner_keys.size)
+          @preloaded_records = slices.flat_map do |slice|
             records_for(slice)
-          }
-
-          @preloaded_records.map { |record|
-            key = record[association_key_name]
-            key = key.to_s if key_conversion_required?
-
-            [record, key]
-          }
+          end
+          @preloaded_records.group_by do |record| 
+            convert_key(record[association_key_name])
+          end
         end
 
         def reflection_scope


### PR DESCRIPTION
- less arrays created: using `group_by` instead of array of arrays of two elements

From:
https://github.com/rails/rails/pull/21918/files#diff-83ce56e0f856f2c8d7ceb7fab4eb4c2bL92
To:
https://github.com/rails/rails/pull/21918/files#diff-83ce56e0f856f2c8d7ceb7fab4eb4c2bR66
- less complexity with only one level of nesting in loop

https://github.com/rails/rails/pull/21918/files#diff-83ce56e0f856f2c8d7ceb7fab4eb4c2bR101

Benchmark:
https://gist.github.com/7b486f5852f4f833ce37

```
                    user     system      total        real
------------------1000 iterations 1 associated for 10 given
After patch:    0.710000   0.050000   0.760000 (  0.757919)
Before patch:   0.720000   0.050000   0.770000 (  0.768007)
Improvement: 1%

-----------------1000 iterations 10 associated for 10 given
After patch:    2.270000   0.120000   2.390000 (  2.387669)
Before patch:   2.450000   0.120000   2.570000 (  2.568925)
Improvement: 7%

-----------------100 iterations 100 associated for 10 given
After patch:    1.770000   0.070000   1.840000 (  1.845977)
Before patch:   1.990000   0.080000   2.070000 (  2.067470)
Improvement: 11%

------------------100 iterations 1 associated for 100 given
After patch:    0.370000   0.010000   0.380000 (  0.378398)
Before patch:   0.360000   0.010000   0.370000 (  0.370559)
Improvement: -2%

-----------------100 iterations 10 associated for 100 given
After patch:    1.930000   0.080000   2.010000 (  2.013075)
Before patch:   2.140000   0.080000   2.220000 (  2.224573)
Improvement: 10%

-----------------10 iterations 100 associated for 100 given
After patch:    1.840000   0.080000   1.920000 (  1.928696)
Before patch:   2.040000   0.090000   2.130000 (  2.132890)
Improvement: 10%

```

Slight performance present when loading only one associated record, but I think this is kind of ok.
