### PR TITLE
Remove unused require

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -3,7 +3,6 @@ require "active_record/relation/query_attribute"
 require "active_record/relation/where_clause"
 require "active_record/relation/where_clause_factory"
 require 'active_model/forbidden_attributes_protection'
-require 'active_support/core_ext/string/filters'
 
 module ActiveRecord
   module QueryMethods


### PR DESCRIPTION
`require 'active_support/core_ext/string/filters'` was added in b3bfa36. However, it is no longer needed from 3ae981814 .
