### PR TITLE
Raise informative exceptions on invalid encodings

### DIFF
--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -14,6 +14,12 @@ module ActionController
     end
   end
 
+  class InvalidParameterEncoding < ActionControllerError
+    def initialize(param, value)
+      super("Invalid parameter encoding: #{param} => #{value.inspect}")
+    end
+  end
+
   class RenderError < ActionControllerError #:nodoc:
   end
 

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -59,7 +59,7 @@ module ActionDispatch
       path_parameters.each do |key, value|
         next unless value.respond_to?(:valid_encoding?)
         unless value.valid_encoding?
-          raise ActionController::BadRequest, "Invalid parameter: #{key} => #{value}"
+          raise ActionController::InvalidParameterEncoding.new(key, value)
         end
       end
     end

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -16,7 +16,8 @@ module ActionDispatch
       'ActionController::InvalidCrossOriginRequest'   => :unprocessable_entity,
       'ActionDispatch::ParamsParser::ParseError'      => :bad_request,
       'ActionController::BadRequest'                  => :bad_request,
-      'ActionController::ParameterMissing'            => :bad_request
+      'ActionController::ParameterMissing'            => :bad_request,
+      'ActionController::InvalidParameterEncoding'    => :bad_request
     )
 
     cattr_accessor :rescue_templates


### PR DESCRIPTION
Prior to this change, given a route:

```
get ':a' => "foo#bar"
```

If one pointed to http://example.com/%BE (param `a` has invalid encoding),
a `BadRequest` would be raised with the following non-informative message:

```
ActionController::BadRequest
```

From now on, `ActionController::InvalidParameterEncoding` is raised instead
and the message displayed is:

```
Invalid parameter encoding: hi => "\xBE
```

Fixes #21923.
