### PR TITLE
used predicate methods to avoid is_a? checks

### DIFF
--- a/actionpack/lib/action_dispatch/journey/nodes/node.rb
+++ b/actionpack/lib/action_dispatch/journey/nodes/node.rb
@@ -42,6 +42,7 @@ module ActionDispatch
         def terminal?; false; end
         def star?; false; end
         def cat?; false; end
+        def group?; false; end
       end
 
       class Terminal < Node # :nodoc:
@@ -95,6 +96,7 @@ module ActionDispatch
 
       class Group < Unary # :nodoc:
         def type; :GROUP; end
+        def group?; true; end
       end
 
       class Star < Unary # :nodoc:

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -46,7 +46,7 @@ module ActionDispatch
         end
 
         def names
-          @names ||= spec.grep(Nodes::Symbol).map(&:name)
+          @names ||= spec.find_all(&:symbol?).map(&:name)
         end
 
         def required_names
@@ -54,8 +54,8 @@ module ActionDispatch
         end
 
         def optional_names
-          @optional_names ||= spec.grep(Nodes::Group).flat_map { |group|
-            group.grep(Nodes::Symbol)
+          @optional_names ||= spec.find_all(&:group?).flat_map { |group|
+            group.find_all(&:symbol?)
           }.map(&:name).uniq
         end
 


### PR DESCRIPTION
Following 8d7b883f33034732996f80f73f46d050c7dc9210 & d12ff4fa50719e5282cb2a357968b9532ddce683
