### PR TITLE
update to ruby-oci8 - 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,7 @@ end
 # gems that are necessary for ActiveRecord tests with Oracle database
 if ENV['ORACLE_ENHANCED']
   platforms :ruby do
-    gem 'ruby-oci8', '~> 2.1'
+    gem 'ruby-oci8', '~> 2.2'
   end
   gem 'activerecord-oracle_enhanced-adapter', github: 'rsim/oracle-enhanced', branch: 'master'
 end


### PR DESCRIPTION
It stopped `ruby 1.8` support and more feature with security fix, Support `OS X 10.11 El Capitan`, we already switched to `ruby >= 2.2.2`
