### PR TITLE
[WIP] Don't display HTML exceptions for API only.

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -47,11 +47,10 @@ module ActionDispatch
       request = ActionDispatch::Request.new env
       _, headers, body = response = @app.call(env)
 
-      if headers['X-Cascade'] == 'pass'
+      if headers['X-Cascade'] == 'pass' && !request.headers['CONTENT_TYPE'] == 'application/json'
         body.close if body.respond_to?(:close)
         raise ActionController::RoutingError, "No route matches [#{env['REQUEST_METHOD']}] #{env['PATH_INFO'].inspect}"
       end
-
       response
     rescue Exception => exception
       raise exception unless request.show_exceptions?


### PR DESCRIPTION
if you generate an API only app using

``` ruby
$ rails new my_api_only_app --api
```

it generates without any views or html. so you would expect that error messages would also not be in HTML. but it seems that's not the case. Rails still renders HTML for error 404 which is going to be nightmare for api client to parse & handle..

so if you invoke the API & it generates an error:

``` ruby
$ curl -vH 'Accept: application/json' localhost:3000/foo
<html> start here
</html>
```

I think we should return the error response in format based on clients says it can accept. so I tried to change that in this PR.

This is not finished(just POC to get conversation start). I want to know if its a good idea. Also, what approach do we want to follow for showing errors in JSON. could be simply

``` ruby
 body = '{"errors": "not found"}'
 format = "application/json"
```

good idea?
