### PR TITLE
Remove deprecated pg_dump -i flag

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -54,7 +54,7 @@ module ActiveRecord
           ActiveRecord::Base.dump_schemas
         end
 
-        args = ['-i', '-s', '-x', '-O', '-f', filename]
+        args = ['-s', '-x', '-O', '-f', filename]
         unless search_path.blank?
           args << search_path.split(',').map do |part|
             "--schema=#{part.strip}"


### PR DESCRIPTION
Using Rails 4.2.4 with the PostgreSQL 9.5.beta and `config.active_record.schema_format = :sql` with:

```
pg_dump: invalid option -- i
Try "pg_dump --help" for more information.
rake aborted!
Error dumping database
```

This is also an issue on current Rails master: https://github.com/rails/rails/blob/master/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb#L57

Per the Postgresql 9.4 pg_dump man page:

```
-i
--ignore-version

    A deprecated option that is now ignored.
```

Looks like it was removed in Postgres 9.5 and hasn't done anything for awhile (Even the 8.4 pg_dump man page says its ignored), even in unsupported postgres versions, so it's probably safe to remove from Rails, too.

This PR applies to master, should I also make a separate PR for 4.2.stable?
