### PR TITLE
do not generate manifest.js in plugins

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -226,7 +226,7 @@ task default: :test
       end
 
       def create_assets_manifest_file
-        build(:assets_manifest) unless api?
+        build(:assets_manifest) if !api? && engine?
       end
 
       def create_public_stylesheets_files

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -60,6 +60,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "README.rdoc", /Bukkits/
     assert_no_file "config/routes.rb"
+    assert_no_file "app/assets/config/bukkits_manifest.js"
     assert_file "test/test_helper.rb" do |content|
       assert_match(/require.+test\/dummy\/config\/environment/, content)
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+test\/dummy\/db\/migrate/, content)


### PR DESCRIPTION
Since the plugin generator do not generate assets, I think manifest.js also that it unnecessary.
