### PR TITLE
Move the methods for schema dumping into `{mysql,postgresql}/schema_dumper.rb`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -20,7 +20,7 @@ module ActiveRecord
 
       # This can be overridden on an Adapter level basis to support other
       # extended datatypes (Example: Adding an array option in the
-      # PostgreSQLAdapter)
+      # PostgreSQL::ColumnDumper)
       def prepare_column_options(column)
         spec = {}
         spec[:name]      = column.name.inspect

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -1,0 +1,48 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      module ColumnDumper
+        def column_spec_for_primary_key(column)
+          spec = {}
+          if column.auto_increment?
+            spec[:id] = ':bigint' if column.bigint?
+            spec[:unsigned] = 'true' if column.unsigned?
+            return if spec.empty?
+          else
+            spec[:id] = column.type.inspect
+            spec.merge!(prepare_column_options(column).delete_if { |key, _| [:name, :type, :null].include?(key) })
+          end
+          spec
+        end
+
+        def prepare_column_options(column)
+          spec = super
+          spec[:unsigned] = 'true' if column.unsigned?
+          spec
+        end
+
+        def migration_keys
+          super + [:unsigned]
+        end
+
+        private
+
+        def schema_limit(column)
+          super unless column.type == :boolean
+        end
+
+        def schema_precision(column)
+          super unless /time/ === column.sql_type && column.precision == 0
+        end
+
+        def schema_collation(column)
+          if column.collation && table_name = column.instance_variable_get(:@table_name)
+            @table_collation_cache ||= {}
+            @table_collation_cache[table_name] ||= select_one("SHOW TABLE STATUS LIKE '#{table_name}'")["Collation"]
+            column.collation.inspect if column.collation != @table_collation_cache[table_name]
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -1,0 +1,54 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module ColumnDumper
+        def column_spec_for_primary_key(column)
+          spec = {}
+          if column.serial?
+            return unless column.bigint?
+            spec[:id] = ':bigserial'
+          elsif column.type == :uuid
+            spec[:id] = ':uuid'
+            spec[:default] = column.default_function.inspect
+          else
+            spec[:id] = column.type.inspect
+            spec.merge!(prepare_column_options(column).delete_if { |key, _| [:name, :type, :null].include?(key) })
+          end
+          spec
+        end
+
+        # Adds +:array+ option to the default set
+        def prepare_column_options(column)
+          spec = super
+          spec[:array] = 'true' if column.array?
+          spec
+        end
+
+        # Adds +:array+ as a valid migration key
+        def migration_keys
+          super + [:array]
+        end
+
+        private
+
+        def schema_type(column)
+          return super unless column.serial?
+
+          if column.bigint?
+            'bigserial'
+          else
+            'serial'
+          end
+        end
+
+        def schema_default(column)
+          if column.default_function
+            column.default_function.inspect unless column.serial?
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Current master branch includes many schema dumping improvements.
It extract these features to the appropriate files.
