### PR TITLE
Continuing to try to backport #18228 to 4-2-stable

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add bigint primary key support for MySQL.
+
+    Example:
+
+        create_table :foos, id: :bigint do |t|
+        end
+
+    *Ryuta Kamizono*
+
 *   Support for any type primary key.
 
     Fixes #14194.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Improve a dump of the primary key support. If it is not a default primary key,
+    correctly dump the type and options.
+
+    Fixes #14169, #16599.
+
+    *Ryuta Kamizono*
+
 *   Add bigint primary key support for MySQL.
 
     Example:

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Support for any type primary key.
+
+    Fixes #14194.
+
+    *Ryuta Kamizono*
+
 *   Fix `rewhere` in a `has_many` association.
 
     Fixes #21955.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -65,6 +65,7 @@ module ActiveRecord
             column_options[:column] = o
             column_options[:first] = o.first
             column_options[:after] = o.after
+            column_options[:auto_increment] = o.auto_increment
             column_options[:primary_key] = o.primary_key
             column_options
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -30,7 +30,7 @@ module ActiveRecord
           def visit_ColumnDefinition(o)
             sql_type = type_to_sql(o.type, o.limit, o.precision, o.scale)
             column_sql = "#{quote_column_name(o.name)} #{sql_type}"
-            add_column_options!(column_sql, column_options(o)) unless o.primary_key?
+            add_column_options!(column_sql, column_options(o)) unless o.type == :primary_key
             column_sql
           end
 
@@ -65,6 +65,7 @@ module ActiveRecord
             column_options[:column] = o
             column_options[:first] = o.first
             column_options[:after] = o.after
+            column_options[:primary_key] = o.primary_key
             column_options
           end
 
@@ -88,6 +89,9 @@ module ActiveRecord
             end
             if options[:auto_increment] == true
               sql << " AUTO_INCREMENT"
+            end
+            if options[:primary_key] == true
+              sql << " PRIMARY KEY"
             end
             sql
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -83,7 +83,7 @@ module ActiveRecord
           end
 
           def add_column_options!(sql, options)
-            sql << " DEFAULT #{quote_value(options[:default], options[:column])}" if options_include_default?(options)
+            sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}" if options_include_default?(options)
             # must explicitly check for :null to allow change_column to work on migrations
             if options[:null] == false
               sql << " NOT NULL"
@@ -97,7 +97,7 @@ module ActiveRecord
             sql
           end
 
-          def quote_value(value, column)
+          def quote_default_expression(value, column)
             column.sql_type ||= type_to_sql(column.type, column.limit, column.precision, column.scale)
             column.cast_type ||= type_for_column(column)
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -15,7 +15,7 @@ module ActiveRecord
     # are typically created by methods in TableDefinition, and added to the
     # +columns+ attribute of said TableDefinition object, in order to be used
     # for generating a number of table creation or table changing SQL statements.
-    class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :primary_key, :sql_type, :cast_type) #:nodoc:
+    class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :auto_increment, :primary_key, :sql_type, :cast_type) #:nodoc:
 
       def primary_key?
         primary_key || type.to_sym == :primary_key
@@ -346,6 +346,7 @@ module ActiveRecord
         column.null        = options[:null]
         column.first       = options[:first]
         column.after       = options[:after]
+        column.auto_increment = options[:auto_increment]
         column.primary_key = type == :primary_key || options[:primary_key]
         column
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -12,6 +12,12 @@ module ActiveRecord
         spec
       end
 
+      def column_spec_for_primary_key(column)
+        return if column.type == :integer
+        spec = { id: column.type.inspect }
+        spec.merge!(prepare_column_options(column).delete_if { |key, _| [:name, :type].include?(key) })
+      end
+
       # This can be overridden on a Adapter level basis to support other
       # extended datatypes (Example: Adding an array option in the
       # PostgreSQLAdapter)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -12,10 +12,10 @@ module ActiveRecord
         spec
       end
 
-      def column_spec_for_primary_key(column)
+      def column_spec_for_primary_key(column, types)
         return if column.type == :integer
         spec = { id: column.type.inspect }
-        spec.merge!(prepare_column_options(column).delete_if { |key, _| [:name, :type].include?(key) })
+        spec.merge!(prepare_column_options(column, types).delete_if { |key, _| [:name, :type].include?(key) })
       end
 
       # This can be overridden on a Adapter level basis to support other

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -6,6 +6,13 @@ module ActiveRecord
     class AbstractMysqlAdapter < AbstractAdapter
       include Savepoints
 
+      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+        def primary_key(name, type = :primary_key, options = {})
+          options[:auto_increment] ||= type == :bigint
+          super
+        end
+      end
+
       class SchemaCreation < AbstractAdapter::SchemaCreation
         def visit_AddColumn(o)
           add_column_position!(super, column_options(o))
@@ -877,6 +884,10 @@ module ActiveRecord
           when 'SET NULL'; :nullify
           end
         end
+      end
+
+      def create_table_definition(name, temporary, options, as = nil) # :nodoc:
+        TableDefinition.new(native_database_types, name, temporary, options, as)
       end
 
       class MysqlDateTime < Type::DateTime # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -65,14 +65,14 @@ module ActiveRecord
         SchemaCreation.new self
       end
 
-      def column_spec_for_primary_key(column)
+      def column_spec_for_primary_key(column, types)
         spec = {}
         if column.extra == 'auto_increment'
           return unless column.limit == 8
           spec[:id] = ':bigint'
         else
           spec[:id] = column.type.inspect
-          spec.merge!(prepare_column_options(column).delete_if { |key, _| [:name, :type, :null].include?(key) })
+          spec.merge!(prepare_column_options(column, types).delete_if { |key, _| [:name, :type, :null].include?(key) })
         end
         spec
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -65,6 +65,18 @@ module ActiveRecord
         SchemaCreation.new self
       end
 
+      def column_spec_for_primary_key(column)
+        spec = {}
+        if column.extra == 'auto_increment'
+          return unless column.limit == 8
+          spec[:id] = ':bigint'
+        else
+          spec[:id] = column.type.inspect
+          spec.merge!(prepare_column_options(column).delete_if { |key, _| [:name, :type, :null].include?(key) })
+        end
+        spec
+      end
+
       def prepare_column_options(column, types) # :nodoc:
         spec = super
         spec.delete(:limit) if :boolean === column.type

--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -15,6 +15,10 @@ module ActiveRecord
 
         @default_function = default_function
       end
+
+      def serial?
+        default_function && default_function =~ /\Anextval\(.*\)\z/
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -4,14 +4,22 @@ module ActiveRecord
       class SchemaCreation < AbstractAdapter::SchemaCreation
         private
 
+        def column_options(o)
+          column_options = super
+          column_options[:array] = o.array
+          column_options
+        end
+
         def add_column_options!(sql, options)
-          if options[:array] || options[:column].try(:array)
+          if options[:array]
             sql << '[]'
           end
+          super
+        end
 
-          column = options.fetch(:column) { return super }
-          if column.type == :uuid && options[:default] =~ /\(\)/
-            sql << " DEFAULT #{options[:default]}"
+        def quote_value(value, column)
+          if column.type == :uuid && value =~ /\(\)/
+            value
           else
             super
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -17,7 +17,7 @@ module ActiveRecord
           super
         end
 
-        def quote_value(value, column)
+        def quote_default_expression(value, column)
           if column.type == :uuid && value =~ /\(\)/
             value
           else

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -4,15 +4,6 @@ module ActiveRecord
       class SchemaCreation < AbstractAdapter::SchemaCreation
         private
 
-        def visit_ColumnDefinition(o)
-          sql = super
-          if o.primary_key? && o.type != :primary_key
-            sql << " PRIMARY KEY "
-            add_column_options!(sql, column_options(o))
-          end
-          sql
-        end
-
         def add_column_options!(sql, options)
           if options[:array] || options[:column].try(:array)
             sql << '[]'

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -125,6 +125,21 @@ module ActiveRecord
         PostgreSQL::SchemaCreation.new self
       end
 
+      def column_spec_for_primary_key(column)
+        spec = {}
+        if column.serial?
+          return unless column.sql_type == 'bigint'
+          spec[:id] = ':bigserial'
+        elsif column.type == :uuid
+          spec[:id] = ':uuid'
+          spec[:default] = column.default_function.inspect
+        else
+          spec[:id] = column.type.inspect
+          spec.merge!(prepare_column_options(column).delete_if { |key, _| [:name, :type, :null].include?(key) })
+        end
+        spec
+      end
+
       # Adds +:array+ option to the default set provided by the
       # AbstractAdapter
       def prepare_column_options(column, types) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -125,7 +125,7 @@ module ActiveRecord
         PostgreSQL::SchemaCreation.new self
       end
 
-      def column_spec_for_primary_key(column)
+      def column_spec_for_primary_key(column, types)
         spec = {}
         if column.serial?
           return unless column.sql_type == 'bigint'
@@ -135,7 +135,7 @@ module ActiveRecord
           spec[:default] = column.default_function.inspect
         else
           spec[:id] = column.type.inspect
-          spec.merge!(prepare_column_options(column).delete_if { |key, _| [:name, :type, :null].include?(key) })
+          spec.merge!(prepare_column_options(column, types).delete_if { |key, _| [:name, :type, :null].include?(key) })
         end
         spec
       end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -118,11 +118,12 @@ HEADER
           if pkcol
             if pk != 'id'
               tbl.print %Q(, primary_key: "#{pk}")
-            elsif pkcol.sql_type == 'bigint'
-              tbl.print ", id: :bigserial"
-            elsif pkcol.sql_type == 'uuid'
-              tbl.print ", id: :uuid"
-              tbl.print %Q(, default: #{pkcol.default_function.inspect})
+            end
+            pkcolspec = @connection.column_spec_for_primary_key(pkcol)
+            if pkcolspec
+              pkcolspec.each do |key, value|
+                tbl.print ", #{key}: #{value}"
+              end
             end
           else
             tbl.print ", id: false"

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -119,7 +119,7 @@ HEADER
             if pk != 'id'
               tbl.print %Q(, primary_key: "#{pk}")
             end
-            pkcolspec = @connection.column_spec_for_primary_key(pkcol)
+            pkcolspec = @connection.column_spec_for_primary_key(pkcol, @types)
             if pkcolspec
               pkcolspec.each do |key, value|
                 tbl.print ", #{key}: #{value}"

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -195,6 +195,30 @@ class PrimaryKeyWithNoConnectionTest < ActiveRecord::TestCase
   end
 end
 
+class PrimaryKeyAnyTypeTest < ActiveRecord::TestCase
+  self.use_transactional_fixtures = false
+
+  class Barcode < ActiveRecord::Base
+  end
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table(:barcodes, primary_key: "code", id: :string, limit: 42, force: true)
+  end
+
+  teardown do
+    @connection.execute("DROP TABLE IF EXISTS barcodes")
+  end
+
+  def test_any_type_primary_key
+    assert_equal "code", Barcode.primary_key
+
+    column_type = Barcode.type_for_attribute(Barcode.primary_key)
+    assert_equal :string, column_type.type
+    assert_equal 42, column_type.limit
+  end
+end
+
 if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
   class PrimaryKeyWithAnsiQuotesTest < ActiveRecord::TestCase
     self.use_transactional_fixtures = false


### PR DESCRIPTION
LIke @joallard in #20425, I also could use the functionality in #18228 in Rails 4.2. I rebased joallard's branch on the current 4-2-stable and also backported 112706a, which should fix the test failures that #20425 is seeing since it removes the `types` argument that isn't really needed.

About to try this in our rails app while travis takes a look, will report back. I'll do my best to keep this up-to-date :)

:heart: :heart: :heart: :heart: 
