### PR TITLE
where raises ArgumentError on unsupported argument types

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `where` raises ArgumentError on unsupported types.
+
+    Fixes #20473.
+
+    *Jake Worth*
+
 *   Add an immutable string type to help reduce memory usage for apps which do
     not need mutation detection on Strings.
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -552,6 +552,8 @@ module ActiveRecord
         WhereChain.new(spawn)
       elsif opts.blank?
         self
+      elsif !opts.is_a?(String) && !opts.respond_to?(:to_h)
+        raise ArgumentError, "Unsupported argument type: #{opts} (#{opts.class})"
       else
         spawn.where!(opts, *rest)
       end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -302,5 +302,11 @@ module ActiveRecord
       assert_raises(ActiveModel::ForbiddenAttributesError) { Author.where(params) }
       assert_equal author, Author.where(params.permit!).first
     end
+
+    def test_where_with_unsupported_arguments
+      author = authors(:david)
+
+      assert_raises(ArgumentError) { Author.where(42) }
+    end
   end
 end


### PR DESCRIPTION
This addresses the following issue:

'where doesn't warn for wrong values'
https://github.com/rails/rails/issues/20473
