### PR TITLE
Fix generated projection fields in group by query

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Queries such as `Computer.joins(:monitor).group(:status).count` will now be
+    interpreted as  `Computer.joins(:monitor).group('computers.status').count`
+    so that when `Computer` and `Monitor` have both `status` columns we don't
+    have conflicts in projection.
+
+    *Rafael Sales*
+
 *   Add ability to default to `uuid` as primary key when generating database migrations
 
     Set `Rails.application.config.active_record.primary_key = :uuid`

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -275,6 +275,7 @@ module ActiveRecord
       else
         group_fields = group_attrs
       end
+      group_fields = arel_columns(group_fields)
 
       group_aliases = group_fields.map { |field|
         column_alias_for(field)
@@ -299,7 +300,7 @@ module ActiveRecord
       ]
       select_values += select_values unless having_clause.empty?
 
-      select_values.concat arel_columns(group_fields).zip(group_aliases).map { |field,aliaz|
+      select_values.concat group_fields.zip(group_aliases).map { |field,aliaz|
         if field.respond_to?(:as)
           field.as(aliaz)
         else

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -277,14 +277,8 @@ module ActiveRecord
       end
       group_fields = arel_columns(group_fields)
 
-      group_aliases = group_fields.map { |field|
-        column_alias_for(field)
-      }
-      group_columns = group_aliases.zip(group_fields).map { |aliaz,field|
-        [aliaz, field]
-      }
-
-      group = group_fields
+      group_aliases = group_fields.map { |field| column_alias_for(field) }
+      group_columns = group_aliases.zip(group_fields)
 
       if operation == 'count' && column_name == :all
         aggregate_alias = 'count_all'
@@ -300,7 +294,7 @@ module ActiveRecord
       ]
       select_values += select_values unless having_clause.empty?
 
-      select_values.concat group_fields.zip(group_aliases).map { |field,aliaz|
+      select_values.concat group_columns.map { |aliaz, field|
         if field.respond_to?(:as)
           field.as(aliaz)
         else
@@ -309,7 +303,7 @@ module ActiveRecord
       }
 
       relation = except(:group)
-      relation.group_values  = group
+      relation.group_values  = group_fields
       relation.select_values = select_values
 
       calculated_data = @klass.connection.select_all(relation, nil, relation.bound_attributes)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -455,6 +455,11 @@ class CalculationsTest < ActiveRecord::TestCase
     [1,6,2,9].each { |firm_id| assert c.keys.include?(firm_id) }
   end
 
+  def test_should_count_field_of_root_table_with_conflicting_group_by_column
+    assert_equal({ 1 => 1 }, Firm.joins(:accounts).group(:firm_id).count)
+    assert_equal({ 1 => 1 }, Firm.joins(:accounts).group('accounts.firm_id').count)
+  end
+
   def test_count_with_no_parameters_isnt_deprecated
     assert_not_deprecated { Account.count }
   end

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -10,7 +10,6 @@ class Company < AbstractCompany
   has_one :dummy_account, :foreign_key => "firm_id", :class_name => "Account"
   has_many :contracts
   has_many :developers, :through => :contracts
-  has_many :accounts
 
   scope :of_first_firm, lambda {
     joins(:account => :firm).


### PR DESCRIPTION
1. 1st commit: Fix generated projection fields in group by query (closes #21922)
   
   Let `Book(id, author_id)`, `Photo(id, book_id, author_id)` and `Author(id)`
   
   Running `Book.group(:author_id).joins(:photos).count` will produce:
   - Rails 4.2 - conflicts `author_id` in both projection and group by:
   
   ``` sql
   SELECT COUNT(*) AS count_all, author_id AS author_id
     FROM "books" INNER JOIN "photos" ON "photos"."book_id" = "books"."id"
    GROUP BY author_id
   ```
   - Master (9d02a25) - conflicts `author_id` only in projection:
   
   ``` sql
   SELECT COUNT(*) AS count_all, author_id AS author_id
     FROM "books" INNER JOIN "photos" ON "photos"."book_id" = "books"."id"
    GROUP BY "books"."author_id"
   ```
   - With this fix:
   
   ``` sql
   SELECT COUNT(*) AS count_all, "books"."author_id" AS books_author_id
     FROM "books" INNER JOIN "photos" ON "photos"."book_id" = "books"."id"
    GROUP BY "books"."author_id"
   ```
2. 2nd commit: Refactor Calculations#execute_grouped_calculation and clean AR test case
   - Removing "Company has_many :accounts" test/models/company.rb because:
   
   ``` sql
   ActiveRecord::StatementInvalid: SQLite3::SQLException: no such column: accounts.company_id:
    SELECT COUNT(*) AS count_all, "companies"."firm_id" AS companies_firm_id
       FROM "companies" INNER JOIN "accounts" ON "accounts"."company_id" = "companies"."id"
   GROUP BY "companies"."firm_id"
   ```
   - The refactor on Calculations class was just to simplify the code
