### PR TITLE
Only prepend a single module when defining deprecation wrappers.

### DIFF
--- a/activesupport/lib/active_support/deprecation/method_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/method_wrappers.rb
@@ -30,16 +30,16 @@ module ActiveSupport
         deprecator = options.delete(:deprecator) || ActiveSupport::Deprecation.instance
         method_names += options.keys
 
-        method_names.each do |method_name|
-          mod = Module.new do
+        mod = Module.new do
+          method_names.each do |method_name|
             define_method(method_name) do |*args, &block|
               deprecator.deprecation_warning(method_name, options[method_name])
               super(*args, &block)
             end
           end
-
-          target_module.prepend(mod)
         end
+
+        target_module.prepend(mod)
       end
     end
   end


### PR DESCRIPTION
I could not find any reason why each method got its own prepended
module here, and all tests appear to pass with my change.
