### PR TITLE
Fix deprecation warning messages on deprecate_methods

### DIFF
--- a/activesupport/lib/active_support/deprecation/method_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/method_wrappers.rb
@@ -9,25 +9,49 @@ module ActiveSupport
       #   module Fred
       #     extend self
       #
-      #     def foo; end
-      #     def bar; end
-      #     def baz; end
+      #     def aaa; end
+      #     def bbb; end
+      #     def ccc; end
+      #     def ddd; end
+      #     def eee; end
       #   end
       #
-      #   ActiveSupport::Deprecation.deprecate_methods(Fred, :foo, bar: :qux, baz: 'use Bar#baz instead')
-      #   # => [:foo, :bar, :baz]
+      # Using the default deprecator:
+      #   ActiveSupport::Deprecation.deprecate_methods(Fred, :aaa, bbb: :zzz, ccc: 'use Bar#ccc instead')
+      #   # => [:aaa, :bbb, :ccc]
       #
-      #   Fred.foo
-      #   # => "DEPRECATION WARNING: foo is deprecated and will be removed from Rails 4.1."
+      #   Fred.aaa
+      #   # DEPRECATION WARNING: aaa is deprecated and will be removed from Rails 5.0. (called from irb_binding at (irb):10)
+      #   # => nil
       #
-      #   Fred.bar
-      #   # => "DEPRECATION WARNING: bar is deprecated and will be removed from Rails 4.1 (use qux instead)."
+      #   Fred.bbb
+      #   # DEPRECATION WARNING: bbb is deprecated and will be removed from Rails 5.0 (use zzz instead). (called from irb_binding at (irb):11)
+      #   # => nil
       #
-      #   Fred.baz
-      #   # => "DEPRECATION WARNING: baz is deprecated and will be removed from Rails 4.1 (use Bar#baz instead)."
+      #   Fred.ccc
+      #   # DEPRECATION WARNING: ccc is deprecated and will be removed from Rails 5.0 (use Bar#ccc instead). (called from irb_binding at (irb):12)
+      #   # => nil
+      #
+      # Passing in a custom deprecator:
+      #   custom_deprecator = ActiveSupport::Deprecation.new('next-release', 'MyGem')
+      #   ActiveSupport::Deprecation.deprecate_methods(Fred, ddd: :zzz, deprecator: custom_deprecator)
+      #   # => [:ddd]
+      #
+      #   Fred.ddd
+      #   DEPRECATION WARNING: ddd is deprecated and will be removed from MyGem next-release (use zzz instead). (called from irb_binding at (irb):15)
+      #   # => nil
+      #
+      # Using a custom deprecator directly:
+      #   custom_deprecator = ActiveSupport::Deprecation.new('next-release', 'MyGem')
+      #   custom_deprecator.deprecate_methods(Fred, eee: :zzz)
+      #   # => [:eee]
+      #
+      #   Fred.eee
+      #   DEPRECATION WARNING: eee is deprecated and will be removed from MyGem next-release (use zzz instead). (called from irb_binding at (irb):18)
+      #   # => nil
       def deprecate_methods(target_module, *method_names)
         options = method_names.extract_options!
-        deprecator = options.delete(:deprecator) || ActiveSupport::Deprecation.instance
+        deprecator = options.delete(:deprecator) || self
         method_names += options.keys
 
         mod = Module.new do

--- a/activesupport/lib/active_support/testing/deprecation.rb
+++ b/activesupport/lib/active_support/testing/deprecation.rb
@@ -3,8 +3,8 @@ require 'active_support/deprecation'
 module ActiveSupport
   module Testing
     module Deprecation #:nodoc:
-      def assert_deprecated(match = nil, &block)
-        result, warnings = collect_deprecations(&block)
+      def assert_deprecated(match = nil, deprecator = nil, &block)
+        result, warnings = collect_deprecations(deprecator, &block)
         assert !warnings.empty?, "Expected a deprecation warning within the block but received none"
         if match
           match = Regexp.new(Regexp.escape(match)) unless match.is_a?(Regexp)
@@ -13,22 +13,23 @@ module ActiveSupport
         result
       end
 
-      def assert_not_deprecated(&block)
-        result, deprecations = collect_deprecations(&block)
+      def assert_not_deprecated(deprecator = nil, &block)
+        result, deprecations = collect_deprecations(deprecator, &block)
         assert deprecations.empty?, "Expected no deprecation warning within the block but received #{deprecations.size}: \n  #{deprecations * "\n  "}"
         result
       end
 
-      def collect_deprecations
-        old_behavior = ActiveSupport::Deprecation.behavior
+      def collect_deprecations(deprecator = nil)
+        deprecator ||= ActiveSupport::Deprecation
+        old_behavior = deprecator.behavior
         deprecations = []
-        ActiveSupport::Deprecation.behavior = Proc.new do |message, callstack|
+        deprecator.behavior = Proc.new do |message, callstack|
           deprecations << message
         end
         result = yield
         [result, deprecations]
       ensure
-        ActiveSupport::Deprecation.behavior = old_behavior
+        deprecator.behavior = old_behavior
       end
     end
   end

--- a/activesupport/test/deprecation/method_wrappers_test.rb
+++ b/activesupport/test/deprecation/method_wrappers_test.rb
@@ -1,0 +1,34 @@
+require 'abstract_unit'
+require 'active_support/deprecation'
+
+class MethodWrappersTest < ActiveSupport::TestCase
+  def setup
+    @klass = Class.new do
+      def new_method; "abc" end
+      alias_method :old_method, :new_method
+    end
+  end
+
+  def test_deprecate_methods_warning_default
+    warning = /old_method is deprecated and will be removed from Rails \d.\d \(use new_method instead\)/
+    ActiveSupport::Deprecation.deprecate_methods(@klass, :old_method => :new_method)
+
+    assert_deprecated(warning) { assert_equal "abc", @klass.new.old_method }
+  end
+
+  def test_deprecate_methods_warning_with_optional_deprecator
+    warning = /old_method is deprecated and will be removed from MyGem next-release \(use new_method instead\)/
+    deprecator = ActiveSupport::Deprecation.new("next-release", "MyGem")
+    ActiveSupport::Deprecation.deprecate_methods(@klass, :old_method => :new_method, :deprecator => deprecator)
+
+    assert_deprecated(warning, deprecator) { assert_equal "abc", @klass.new.old_method }
+  end
+
+  def test_deprecate_methods_warning_when_deprecated_with_custom_deprecator
+    warning = /old_method is deprecated and will be removed from MyGem next-release \(use new_method instead\)/
+    deprecator = ActiveSupport::Deprecation.new("next-release", "MyGem")
+    deprecator.deprecate_methods(@klass, :old_method => :new_method)
+
+    assert_deprecated(warning, deprecator) { assert_equal "abc", @klass.new.old_method }
+  end
+end

--- a/activesupport/test/testing/deprecation_test.rb
+++ b/activesupport/test/testing/deprecation_test.rb
@@ -1,0 +1,21 @@
+require 'abstract_unit'
+require 'active_support/deprecation'
+
+class DeprecationTestingTest < ActiveSupport::TestCase
+  def setup
+    @klass = Class.new do
+      def new_method; "abc" end
+      alias_method :old_method, :new_method
+    end
+  end
+
+  def test_assert_deprecated_raises_when_method_not_deprecated
+    assert_raises(Minitest::Assertion) { assert_deprecated { @klass.new.old_method } }
+  end
+
+  def test_assert_not_deprecated
+    ActiveSupport::Deprecation.deprecate_methods(@klass, :old_method => :new_method)
+
+    assert_raises(Minitest::Assertion) { assert_not_deprecated { @klass.new.old_method } }
+  end
+end


### PR DESCRIPTION
``` ruby
module MyModule
  extend self
  def aaa; end
end

ActiveSupport::Deprecation.new("next-release", "MyGem").deprecate_methods(MyModule, :aaa)
=> [:aaa]

### Previously
MyModule.aaa
DEPRECATION WARNING: aaa is deprecated and will be removed from Rails 5.0. (called from irb_binding at (irb):7)
=> nil

### Now
MyModule.aaa
DEPRECATION WARNING: aaa is deprecated and will be removed from MyGem next-release. (called from irb_binding at (irb):7)
=> nil
```
