### PR TITLE
Fix to correctly schema dump the `tinyblob`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -7,6 +7,10 @@ module ActiveRecord
           super
         end
 
+        def blob(*args, **options)
+          args.each { |name| column(name, :blob, options) }
+        end
+
         def json(*args, **options)
           args.each { |name| column(name, :json, options) }
         end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -27,6 +27,14 @@ module ActiveRecord
 
         private
 
+        def schema_type(column)
+          if column.sql_type == 'tinyblob'
+            'blob'
+          else
+            super
+          end
+        end
+
         def schema_limit(column)
           super unless column.type == :boolean
         end

--- a/activerecord/test/cases/adapters/mysql/sql_types_test.rb
+++ b/activerecord/test/cases/adapters/mysql/sql_types_test.rb
@@ -4,7 +4,7 @@ class MysqlSqlTypesTest < ActiveRecord::MysqlTestCase
   def test_binary_types
     assert_equal 'varbinary(64)', type_to_sql(:binary, 64)
     assert_equal 'varbinary(4095)', type_to_sql(:binary, 4095)
-    assert_equal 'blob(4096)', type_to_sql(:binary, 4096)
+    assert_equal 'blob', type_to_sql(:binary, 4096)
     assert_equal 'blob', type_to_sql(:binary)
   end
 

--- a/activerecord/test/cases/adapters/mysql2/sql_types_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/sql_types_test.rb
@@ -4,7 +4,7 @@ class Mysql2SqlTypesTest < ActiveRecord::Mysql2TestCase
   def test_binary_types
     assert_equal 'varbinary(64)', type_to_sql(:binary, 64)
     assert_equal 'varbinary(4095)', type_to_sql(:binary, 4095)
-    assert_equal 'blob(4096)', type_to_sql(:binary, 4096)
+    assert_equal 'blob', type_to_sql(:binary, 4096)
     assert_equal 'blob', type_to_sql(:binary)
   end
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -215,7 +215,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
     def test_schema_dump_includes_length_for_mysql_blob_and_text_fields
       output = standard_dump
-      assert_match %r{t\.binary\s+"tiny_blob",\s+limit: 255$}, output
+      assert_match %r{t\.blob\s+"tiny_blob",\s+limit: 255$}, output
       assert_match %r{t\.binary\s+"normal_blob",\s+limit: 65535$}, output
       assert_match %r{t\.binary\s+"medium_blob",\s+limit: 16777215$}, output
       assert_match %r{t\.binary\s+"long_blob",\s+limit: 4294967295$}, output

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -2,7 +2,7 @@ ActiveRecord::Schema.define do
   create_table :binary_fields, force: true do |t|
     t.binary :var_binary, limit: 255
     t.binary :var_binary_large, limit: 4095
-    t.column :tiny_blob, 'tinyblob', limit: 255
+    t.blob   :tiny_blob, limit: 255
     t.binary :normal_blob, limit: 65535
     t.binary :medium_blob, limit: 16777215
     t.binary :long_blob, limit: 2147483647

--- a/activerecord/test/schema/mysql_specific_schema.rb
+++ b/activerecord/test/schema/mysql_specific_schema.rb
@@ -2,7 +2,7 @@ ActiveRecord::Schema.define do
   create_table :binary_fields, force: true do |t|
     t.binary :var_binary, limit: 255
     t.binary :var_binary_large, limit: 4095
-    t.column :tiny_blob, 'tinyblob', limit: 255
+    t.blob   :tiny_blob, limit: 255
     t.binary :normal_blob, limit: 65535
     t.binary :medium_blob, limit: 16777215
     t.binary :long_blob, limit: 2147483647


### PR DESCRIPTION
Currently `tinyblob` is dumped to `t.binary "tiny_blob", limit: 255`.
But `t.binary ... limit: 255` is generating SQL to `varchar(255)`.
It is incorrect. This PR fixes this problem.
