### PR TITLE
Better deprecation warning for `ActiveRecord::Relation#update`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Give `AcriveRecord::Relation#update` its own deprecation warning when
+    passed an `ActiveRecord::Base` instance.
+
+    Fixes #21945.
+
+    *Ted Johansson*
+
 *   Make it possible to pass `:to_table` when adding a foreign key through
     `add_reference`.
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -417,6 +417,13 @@ module ActiveRecord
       elsif id == :all
         to_a.each { |record| record.update(attributes) }
       else
+        if ActiveRecord::Base === id
+          id = id.id
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            You are passing an instance of ActiveRecord::Base to `update`.
+            Please pass the id of the object by calling `.id`
+          MSG
+        end
         object = find(id)
         object.update(attributes)
         object

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1541,6 +1541,13 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 'David', topic2.reload.author_name
   end
 
+  def test_update_on_relation_passing_active_record_object_is_deprecated
+    topic = Topic.create!(title: 'Foo', author_name: nil)
+    assert_deprecated(/update/) do
+      Topic.where(id: topic.id).update(topic, title: 'Bar')
+    end
+  end
+
   def test_distinct
     tag1 = Tag.create(:name => 'Foo')
     tag2 = Tag.create(:name => 'Foo')


### PR DESCRIPTION
When passing an instance of `ActiveRecord::Base` to `#update`, it would internally delegate to the class method `#find`, resulting in a misleading deprecation warning, like:

```
DEPRECATION WARNING: You are passing an instance of ActiveRecord::Base to `find`.
Please pass the id of the object by calling `.id`.
(called from index at /home/vagrant/my-test-app/app/controllers/users_controller.rb:4)
```

This change gives this deprecated use of `#update` its own warning:

```
DEPRECATION WARNING: You are passing an instance of ActiveRecord::Base to `update`.
Please pass the id of the object by calling `.id`.
(called from index at /home/vagrant/my-test-app/app/controllers/users_controller.rb:4)
```

Full issue is outlined here: [Misleading deprecation warning when calling update with an instance](https://github.com/rails/rails/issues/21945)
