### PR TITLE
Clarifies db can be set up from structure.sql as well as from schema.rb

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -789,7 +789,7 @@ The `rake db:reset` task will drop the database and set it up again. This is
 functionally equivalent to `rake db:drop db:setup`.
 
 NOTE: This is not the same as running all the migrations. It will only use the
-contents of the current `schema.rb` or `structure.rb` file. If a migration can't be rolled back,
+contents of the current `db/schema.rb` or `db/structure.sql` file. If a migration can't be rolled back,
 `rake db:reset` may not help you. To find out more about dumping the schema see
 [Schema Dumping and You](#schema-dumping-and-you) section.
 

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -789,7 +789,7 @@ The `rake db:reset` task will drop the database and set it up again. This is
 functionally equivalent to `rake db:drop db:setup`.
 
 NOTE: This is not the same as running all the migrations. It will only use the
-contents of the current `schema.rb` file. If a migration can't be rolled back,
+contents of the current `schema.rb` or `structure.rb` file. If a migration can't be rolled back,
 `rake db:reset` may not help you. To find out more about dumping the schema see
 [Schema Dumping and You](#schema-dumping-and-you) section.
 


### PR DESCRIPTION
I added that 'structure.sql' file can be used when 'db:reset' is run.

'db:reset' task states 'db:reset' loads database from 'db/schema.rb'
or 'db/structure.sql' depending on the configuration (although
'db/schema.rb' is the default), hence the change.
