### PR TITLE
Avoid mutating original response in connection management middleware

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Change connection management middleware to return a new response with
+    a body proxy, rather than mutating the original.
+
+    *Kevin Buchanan*
+
 *   Make `db:migrate:status` to render `1_some.rb` format migrate files.
 
     These files are in `db/migrate`:

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -960,12 +960,11 @@ module ActiveRecord
       def call(env)
         testing = env['rack.test']
 
-        response = @app.call(env)
-        response[2] = ::Rack::BodyProxy.new(response[2]) do
+        status, headers, body = @app.call(env)
+        proxy = ::Rack::BodyProxy.new(body) do
           ActiveRecord::Base.clear_active_connections! unless testing
         end
-
-        response
+        [status, headers, proxy]
       rescue Exception
         ActiveRecord::Base.clear_active_connections! unless testing
         raise

--- a/activerecord/test/cases/connection_management_test.rb
+++ b/activerecord/test/cases/connection_management_test.rb
@@ -94,6 +94,13 @@ module ActiveRecord
         assert response_body.respond_to?(:to_path)
         assert_equal response_body.to_path, "/path"
       end
+
+      test "doesn't mutate the original response" do
+        original_response = [200, {}, 'hi']
+        app = lambda { |_| original_response }
+        response_body = ConnectionManagement.new(app).call(@env)[2]
+        assert_equal original_response.last, 'hi'
+      end
     end
   end
 end


### PR DESCRIPTION
Mutating the original response causes problems when the response is a constant. For example, I might want to return a constant from a health endpoint, without worrying about where the connection management middleware is:

``` ruby
class Health
  OK = [200, {}, ["OK"]]
  NOT_OK = [503, {}, ["NOT_OK"]]

  def initialize(app)
    @app = app
  end

  def call(env)
    if env["PATH_INFO"] == "/health"
      ActiveRecord::Base.connected? ? OK : NOT_OK
    else
      @app.call(env)
    end
  end
end
```

Currently, this will either lead to a memory leak due to re-wrapping the body in a new `Rack::BodyProxy` which will never be garbage collected, or raise an exception if the constant is frozen.

This change just returns a new response instead of mutating the original.
