### PR TITLE
Change the order of association's adding constraints

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -147,9 +147,9 @@ module ActiveRecord
               scope.includes! item.includes_values
             end
 
+            scope.unscope!(*item.unscope_values)
             scope.where_clause += item.where_clause
             scope.order_values |= item.order_values
-            scope.unscope!(*item.unscope_values)
           end
 
           reflection = reflection.next

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2358,4 +2358,8 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal [bulb.id], car.bulb_ids
     assert_no_queries { car.bulb_ids }
   end
+
+    def test_rewhere
+      assert_equal 'SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = 99', posts(:welcome).comments_with_rewhere.to_sql
+    end
 end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2359,7 +2359,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_no_queries { car.bulb_ids }
   end
 
-    def test_rewhere
-      assert_equal 'SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = 99', posts(:welcome).comments_with_rewhere.to_sql
-    end
+  def test_has_many_association_with_rewhere
+    assert_equal 'Don\'t think too hard', posts(:welcome).comments_with_rewhere.first.body
+  end
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -67,6 +67,7 @@ class Post < ActiveRecord::Base
   end
 
   has_many :comments_with_extend_2, extend: [NamedExtension, NamedExtension2], class_name: "Comment", foreign_key: "post_id"
+  has_many :comments_with_rewhere, -> { rewhere(post_id: 99) }, class_name: "Comment"
 
   has_many :author_favorites, :through => :author
   has_many :author_categorizations, :through => :author, :source => :categorizations

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -67,7 +67,7 @@ class Post < ActiveRecord::Base
   end
 
   has_many :comments_with_extend_2, extend: [NamedExtension, NamedExtension2], class_name: "Comment", foreign_key: "post_id"
-  has_many :comments_with_rewhere, -> { rewhere(post_id: 99) }, class_name: "Comment"
+  has_many :comments_with_rewhere, -> { rewhere(post_id: 2) }, class_name: "Comment"
 
   has_many :author_favorites, :through => :author
   has_many :author_categorizations, :through => :author, :source => :categorizations


### PR DESCRIPTION
I think the order of constraint should be unscope -> where -> order.
The existing order causes this issue #21955.

Thanks.
