### PR TITLE
Reorder application of has_many association constraints.

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -147,9 +147,9 @@ module ActiveRecord
               scope.includes! item.includes_values
             end
 
+            scope.unscope!(*item.unscope_values)
             scope.where_clause += item.where_clause
             scope.order_values |= item.order_values
-            scope.unscope!(*item.unscope_values)
           end
 
           reflection = reflection.next

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2181,6 +2181,26 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal [bulb1, bulb2], car.all_bulbs.sort_by(&:id)
   end
 
+  test "can unscope and where the default scope of the associated model" do
+    Car.has_many :other_bulbs, -> { unscope(where: [:name]).where(name: 'other') }, class_name: "Bulb"
+    car = Car.create!
+    bulb1 = Bulb.create! name: "defaulty", car: car
+    bulb2 = Bulb.create! name: "other",    car: car
+
+    assert_equal [bulb1], car.bulbs
+    assert_equal [bulb2], car.other_bulbs
+  end
+
+  test "can rewhere the default scope of the associated model" do
+    Car.has_many :old_bulbs, -> { rewhere(name: 'old') }, class_name: "Bulb"
+    car = Car.create!
+    bulb1 = Bulb.create! name: "defaulty", car: car
+    bulb2 = Bulb.create! name: "old",      car: car
+
+    assert_equal [bulb1], car.bulbs
+    assert_equal [bulb2], car.old_bulbs
+  end
+
   test 'unscopes the default scope of associated model when used with include' do
     car = Car.create!
     bulb = Bulb.create! name: "other", car: car


### PR DESCRIPTION
With `unscope!` called last, it undoes `where` constraints of the same
value when the `where` is chained after the `unscope`. This is what a
`rewhere` does. This is undesirable behavior.

The included tests demonstrate both the `unscope(...).where(...)`
behavior as well as the direct use of `rewhere(...)`.

This is in reference to #21955.
