### PR TITLE
Use "rake time:zones:all" in description instead of "rake -D time"

### DIFF
--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -26,7 +26,7 @@ module ActiveSupport
 
       unless zone_default
         raise 'Value assigned to config.time_zone not recognized. ' \
-          'Run "rake -D time" for a list of tasks for finding appropriate time zone names.'
+          'Run "rake time:zones:all" for a time zone names list.'
       end
 
       Time.zone_default = zone_default

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -26,7 +26,7 @@ module <%= app_const_base %>
     # -- all .rb files in that directory are automatically loaded.
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
+    # Run "rake time:zones:all" for a time zone names list. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.


### PR DESCRIPTION
Running "rake -D time" causes "invalid option: -D" warning.
