### PR TITLE
Raise unless opts responds to `to_h`

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause_factory.rb
+++ b/activerecord/lib/active_record/relation/where_clause_factory.rb
@@ -21,7 +21,10 @@ module ActiveRecord
 
           parts = predicate_builder.build_from_hash(attributes)
         else
-          raise ArgumentError, "Unsupported argument type: #{opts} (#{opts.class})"
+          unless opts.respond_to?(:to_h)
+            raise ArgumentError, "Unsupported argument type: #{opts} (#{opts.class})"
+          end
+          parts = [opts]
         end
 
         WhereClause.new(parts, binds)


### PR DESCRIPTION
Tests such as test/cases/relation/where_test.rb
"test_where_with_strong_parameters" expect that `where` will accept
things that respond to `to_h` but are not Arrays, Strings, or Hashes.
