### PR TITLE
Fix #21977: Removes memoization of helpers in Rails console

### DIFF
--- a/railties/lib/rails/console/helpers.rb
+++ b/railties/lib/rails/console/helpers.rb
@@ -4,7 +4,7 @@ module Rails
     #
     # This method assumes an +ApplicationController+ exists, and it extends +ActionController::Base+
     def helper
-      @helper ||= ApplicationController.helpers
+      ApplicationController.helpers
     end
 
     # Gets a new instance of a controller object.


### PR DESCRIPTION
In the Rails console, the `helper` function provides a shorthand for
working with application helpers.  However, `helper` memoizes the
value of `ApplicationController#helpers`. This means that if a user
subsequently changes helper code and calls `reload!` in the console,
their code changes will not be reflected by the `helper` function,
even though the helper was, in fact, reloaded.
