### PR TITLE
Update timestamp in AR#increment!

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -161,7 +161,7 @@ module ActiveRecord
 
         # Make sure the lock version column gets updated when counters are
         # updated.
-        def update_counters(id, counters)
+        def update_counters(id, counters, touch = false)
           counters = counters.merge(locking_column => 1) if locking_enabled?
           super
         end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -334,7 +334,7 @@ module ActiveRecord
     def increment!(attribute, by = 1)
       increment(attribute, by)
       change = public_send(attribute) - (attribute_was(attribute.to_s) || 0)
-      self.class.update_counters(id, attribute => change)
+      self.class.update_counters(id, { attribute => change }, true)
       clear_attribute_change(attribute) # eww
       self
     end

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -37,6 +37,9 @@ module ActiveRecord
   module Timestamp
     extend ActiveSupport::Concern
 
+    TIMESTAMP_ATTRIBUTES_FOR_CREATE = [:created_at, :created_on]
+    TIMESTAMP_ATTRIBUTES_FOR_UPDATE = [:updated_at, :updated_on]
+
     included do
       class_attribute :record_timestamps
       self.record_timestamps = true
@@ -94,11 +97,11 @@ module ActiveRecord
     end
 
     def timestamp_attributes_for_update
-      [:updated_at, :updated_on]
+      TIMESTAMP_ATTRIBUTES_FOR_UPDATE
     end
 
     def timestamp_attributes_for_create
-      [:created_at, :created_on]
+      TIMESTAMP_ATTRIBUTES_FOR_CREATE
     end
 
     def all_timestamp_attributes

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -129,6 +129,15 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal initial_credit + 2, a1.reload.credit_limit
   end
 
+  def test_increment_updates_timestamps
+    topic = topics(:first)
+    topic.update_columns(updated_at: Time.now.prev_month)
+    previously_updated_at = topic.updated_at
+
+    topic.increment!(:replies_count)
+    assert_not_equal previously_updated_at, topic.reload.updated_at
+  end
+
   def test_destroy_all
     conditions = "author_name = 'Mary'"
     topics_by_mary = Topic.all.merge!(:where => conditions, :order => 'id').to_a


### PR DESCRIPTION
Now, AR#increment! is concurrent safe(https://github.com/rails/rails/pull/11410). However, this commit breaks backward compatability because `.update_counters` doesn't update timestamp.

Here is a reproduction script for this issue.
https://gist.github.com/akihiro17/aa08276f5d0f72d9869b

In this commit, `.update_counters` updates timestamp if both `touch` and `record_time_stamp` are true.
