### PR TITLE
`WhereClauseFactory` should accept `Arel::Nodes::Node` and `Symbol`

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause_factory.rb
+++ b/activerecord/lib/active_record/relation/where_clause_factory.rb
@@ -20,6 +20,8 @@ module ActiveRecord
           attributes, binds = predicate_builder.create_binds(attributes)
 
           parts = predicate_builder.build_from_hash(attributes)
+        when Arel::Nodes::Node, Symbol
+          parts = [opts]
         else
           raise ArgumentError, "Unsupported argument type: #{opts} (#{opts.class})"
         end


### PR DESCRIPTION
This commit follow up of 4d8f62d.
`Arel::Nodes::Node` and `Symbol` are passed through `where!` method,
we should change `WhereClauseFactory` to accept these class.
