### PR TITLE
Explicitly define polymorphic_name

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -153,6 +153,26 @@ module ActiveRecord
     # :nodoc:
     attr_reader :association_cache
 
+    included do
+      # Set with a block to be executed in place of the ActiveRecord::AssociationReflection#derive_class_name.
+      # Used to change the default way the contents of a polymorphic type column is mapped into an ActiveRecord class.
+      #
+      # module ActiveRecord
+      #   class Railtie < Rails::Railtie # :nodoc:
+      #     config.active_record.derive_class_name_for_association_reflection = Proc.new do |name|
+      #       # Context is the instance of ActiveRecord::Reflection
+      #       # Default implementation is shown
+      #       class_name = name.to_s
+      #       class_name = class_name.singularize if collection?
+      #       class_name.camelize
+      #     end
+      #   end
+      # end
+      #
+      mattr_accessor :derive_class_name_for_association_reflection, instance_writer: false
+      self.derive_class_name_for_association_reflection = false
+    end
+
     # Returns the association instance for the given name, instantiating it if it doesn't already exist
     def association(name) #:nodoc:
       association = association_instance_get(name)
@@ -1720,6 +1740,12 @@ module ActiveRecord
         has_many name, scope, hm_options, &extension
         self._reflections[name.to_s].parent_reflection = [name.to_s, habtm_reflection]
       end
+
+      # By default, use the base class name for polymorphic identification.
+      def polymorphic_name
+        base_class.name
+      end
+
     end
   end
 end

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -49,12 +49,12 @@ module ActiveRecord
 
         binds << last_reflection.join_id_for(owner)
         if last_reflection.type
-          binds << owner.class.base_class.name
+          binds << owner.class.base_class.polymorphic_name
         end
 
         chain.each_cons(2).each do |reflection, next_reflection|
           if reflection.type
-            binds << next_reflection.klass.base_class.name
+            binds << next_reflection.klass.base_class.polymorphic_name
           end
         end
         binds
@@ -104,7 +104,7 @@ module ActiveRecord
         scope    = scope.where(table[key].eq(bind_val))
 
         if reflection.type
-          value    = owner.class.base_class.name
+          value    = owner.class.base_class.polymorphic_name
           bind_val = bind scope, table.table_name, reflection.type, value, tracker
           scope    = scope.where(table[reflection.type].eq(bind_val))
         else
@@ -120,7 +120,7 @@ module ActiveRecord
         constraint = table[key].eq(foreign_table[foreign_key])
 
         if reflection.type
-          value    = next_reflection.klass.base_class.name
+          value    = next_reflection.klass.base_class.polymorphic_name
           bind_val = bind scope, table.table_name, reflection.type, value, tracker
           scope    = scope.where(table[reflection.type].eq(bind_val))
         end

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -3,8 +3,7 @@ module ActiveRecord
   module Associations
     class BelongsToPolymorphicAssociation < BelongsToAssociation #:nodoc:
       def klass
-        type = owner[reflection.foreign_type]
-        type.presence && type.constantize
+        polymorphic_name(owner[reflection.foreign_type].presence)
       end
 
       private
@@ -35,6 +34,17 @@ module ActiveRecord
           foreign_key = super
           foreign_key && [foreign_key.to_s, owner[reflection.foreign_type].to_s]
         end
+
+        def polymorphic_name(type)
+          if type
+            blk = ActiveRecord::Base.derive_class_name_for_association_reflection
+            if blk
+              type = reflection.instance_exec(type, &blk)
+            end
+            type.constantize
+          end
+        end
+
     end
   end
 end

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -64,7 +64,7 @@ module ActiveRecord
             end
 
             if reflection.type
-              value = foreign_klass.base_class.name
+              value = foreign_klass.base_class.polymorphic_name
               column = klass.columns_hash[reflection.type.to_s]
 
               substitute = klass.connection.substitute_at(column)

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -548,9 +548,14 @@ module ActiveRecord
         end
 
         def derive_class_name
-          class_name = name.to_s
-          class_name = class_name.singularize if collection?
-          class_name.camelize
+          blk = ActiveRecord::Base.derive_class_name_for_association_reflection
+          if blk
+            instance_exec(name, &blk)
+          else
+            class_name = name.to_s
+            class_name = class_name.singularize if collection?
+            class_name.camelize
+          end
         end
 
         def derive_foreign_key

--- a/activerecord/test/cases/associations/polymorphic_name_test.rb
+++ b/activerecord/test/cases/associations/polymorphic_name_test.rb
@@ -1,0 +1,47 @@
+require 'cases/helper'
+require 'models/legacy_thing'
+require 'models/reference'
+
+class PolymorphicNameTest < ActiveRecord::TestCase
+  fixtures :legacy_things, :references
+
+  setup do
+    ActiveRecord::Base.derive_class_name_for_association_reflection = Proc.new do |name|
+      class_name = name.to_s
+      class_name = class_name.singularize if collection?
+      class_name.camelize
+    end
+  end
+
+  teardown do
+    ActiveRecord::Base.derive_class_name_for_association_reflection = false
+  end
+
+  def test_belongs_to
+    thing = LegacyThing.find(2)
+    assert_equal 'reference', thing.resource_type
+    assert_equal 1, thing.resource_id.to_i
+    resource = thing.resource
+    assert_equal 1, resource.id
+    assert_equal Reference, resource.class
+  end
+
+  def test_has_many
+    ref = Reference.find(1)
+    assert_equal 1, ref.legacy_things.count
+    assert_equal 2, ref.legacy_things.first.id
+  end
+
+  def test_joins
+    ref = Reference.joins(:legacy_things).select('legacy_things.id AS legacy_thing_id').where(id: 1).first
+    assert_equal 2, ref[:legacy_thing_id]
+  end
+
+  def test_replace
+    thing = LegacyThing.find(2)
+    ref = Reference.find(3)
+    thing.resource = ref
+    assert_equal 3, thing.resource.id
+  end
+
+end

--- a/activerecord/test/fixtures/legacy_things.yml
+++ b/activerecord/test/fixtures/legacy_things.yml
@@ -1,3 +1,8 @@
 obtuse:
   id: 1
   tps_report_number: 500
+
+polymorphic:
+  id: 2
+  resource_type: reference
+  resource_id: 1

--- a/activerecord/test/models/legacy_thing.rb
+++ b/activerecord/test/models/legacy_thing.rb
@@ -1,3 +1,4 @@
 class LegacyThing < ActiveRecord::Base
   self.locking_column = :version
+  belongs_to :resource, polymorphic: true
 end

--- a/activerecord/test/models/reference.rb
+++ b/activerecord/test/models/reference.rb
@@ -3,9 +3,14 @@ class Reference < ActiveRecord::Base
   belongs_to :job
 
   has_many :agents_posts_authors, :through => :person
+  has_many :legacy_things, as: :resource
 
   class << self; attr_accessor :make_comments; end
   self.make_comments = false
+
+  def self.polymorphic_name
+    'reference'
+  end
 
   before_destroy :make_comments
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -388,6 +388,8 @@ ActiveRecord::Schema.define do
   create_table :legacy_things, force: true do |t|
     t.integer :tps_report_number
     t.integer :version, null: false, default: 0
+    t.string  :resource_type
+    t.integer :resource_id
   end
 
   create_table :lessons, force: true do |t|


### PR DESCRIPTION
Allow override of default mapping of polymorphic type column into a class name. Arguably, coupling a DB column value to a ruby class name is questionable. An application may wish to use a symbolic or other means to map between a type column value and a class, either for philosophical reasons or to support a schema that is legacy or non-rails convention-based. In any event, the value for mapping this should be explicit by name, rather than using `base_class.name` in several different places.

This supersedes #17213
