### PR TITLE
remove useless method

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -237,10 +237,6 @@ task default: :test
         build(:javascripts) unless api?
       end
 
-      def create_images_directory
-        build(:images) unless api?
-      end
-
       def create_bin_files
         build(:bin)
       end


### PR DESCRIPTION
`images` method has been deleted in 2bc4856, `create_images_directory` does nothing.
