### PR TITLE
Remove outdated documentation regarding a bundled version of TZInfo

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -26,12 +26,6 @@ module ActiveSupport
   #   Time.zone      # => #<ActiveSupport::TimeZone:0x514834...>
   #   Time.zone.name # => "Eastern Time (US & Canada)"
   #   Time.zone.now  # => Sun, 18 May 2008 14:30:44 EDT -04:00
-  #
-  # The version of TZInfo bundled with Active Support only includes the
-  # definitions necessary to support the zones defined by the TimeZone class.
-  # If you need to use zones that aren't defined by TimeZone, you'll need to
-  # install the TZInfo gem (if a recent version of the gem is installed locally,
-  # this will be used instead of the bundled version.)
   class TimeZone
     # Keys are Rails TimeZone names, values are TZInfo identifiers.
     MAPPING = {


### PR DESCRIPTION
The documentation of `ActiveSupport::TimeZone` incorrectly refers to a 'version of TZInfo bundled with Active Support'. This bundled version was removed from Active Support in version 3.0, so the statement about installing the TZInfo gem is no longer needed.

This pull request removes this outdated and now misleading statement.
