### PR TITLE
Fix InheritanceTest#test_scope_inherited_properly implementation bugs

### DIFF
--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -353,7 +353,7 @@ class InheritanceTest < ActiveRecord::TestCase
 
   def test_scope_inherited_properly
     assert_nothing_raised { Company.of_first_firm.to_sql }
-    assert_nothing_raised { Client.of_first_firm }
+    assert_nothing_raised { Client.of_first_firm.to_sql }
   end
 end
 

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -352,7 +352,7 @@ class InheritanceTest < ActiveRecord::TestCase
   end
 
   def test_scope_inherited_properly
-    assert_nothing_raised { Company.of_first_firm }
+    assert_nothing_raised { Company.of_first_firm.to_sql }
     assert_nothing_raised { Client.of_first_firm }
   end
 end

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -13,7 +13,7 @@ class Company < AbstractCompany
   has_many :accounts
 
   scope :of_first_firm, lambda {
-    joins(:account => :firm).
+    joins(:accounts => :firm).
     where('firms.id' => 1)
   }
 


### PR DESCRIPTION
I've updated the `InheritanceTest#test_scope_inherited_properly` test to trigger a reflection on the associations (which `ActiveRecord::Relation` does lazily). This causes the following error to be raised, indicating the test is not properly testing scope inheritance:

```
ActiveRecord::ConfigurationError: Association named 'account' was not found on Company; perhaps you misspelled it?
```

This PR fixes https://github.com/rails/rails/issues/21993 by fixing the pluralization of the `joins` clause on the `Company.of_first_firm` scope.

Inheritance is indeed properly working, just improperly tested. :smile: 
