### PR TITLE
Show helpful messages on invalid param. encodings

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Show helpful message in `BadRequest` exceptions due to invalid path
+    parameter encodings.
+
+    Fixes #21923.
+
+    *Agis Anastasopoulos*
+
 *   Deprecate `config.static_cache_control` in favor of
     `config.public_file_server.headers`
 

--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -5,12 +5,10 @@ module ActionController
   class BadRequest < ActionControllerError #:nodoc:
     attr_reader :original_exception
 
-    def initialize(type = nil, e = nil)
-      return super() unless type && e
-
-      super("Invalid #{type} parameters: #{e.message}")
+    def initialize(msg = nil, e = nil)
+      super(msg)
       @original_exception = e
-      set_backtrace e.backtrace
+      set_backtrace e.backtrace if e
     end
   end
 

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -65,7 +65,7 @@ module ActionDispatch
       path_parameters.each do |key, value|
         next unless value.respond_to?(:valid_encoding?)
         unless value.valid_encoding?
-          raise ActionController::BadRequest, "Invalid parameter: #{key} => #{value}"
+          raise ActionController::BadRequest, "Invalid parameter encoding: #{key} => #{value.inspect}"
         end
       end
     end
@@ -341,7 +341,7 @@ module ActionDispatch
         set_header k, Request::Utils.normalize_encode_params(super || {})
       end
     rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e
-      raise ActionController::BadRequest.new(:query, e)
+      raise ActionController::BadRequest.new("Invalid query parameters: #{e.message}", e)
     end
     alias :query_parameters :GET
 
@@ -357,7 +357,7 @@ module ActionDispatch
       self.request_parameters = Request::Utils.normalize_encode_params(super || {})
       raise
     rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e
-      raise ActionController::BadRequest.new(:request, e)
+      raise ActionController::BadRequest.new("Invalid request parameters: #{e.message}", e)
     end
     alias :request_parameters :POST
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -961,6 +961,20 @@ class RequestParameters < BaseRequestTest
     end
   end
 
+  test "path parameters with invalid UTF8 encoding" do
+    request = stub_request(
+      "action_dispatch.request.path_parameters" => { foo: "\xBE" }
+    )
+
+    err = assert_raises(ActionController::BadRequest) do
+      request.check_path_parameters!
+    end
+
+    assert_match "Invalid parameter encoding", err.message
+    assert_match "foo", err.message
+    assert_match "\\xBE", err.message
+  end
+
   test "parameters not accessible after rack parse error of invalid UTF8 character" do
     request = stub_request("QUERY_STRING" => "foo%81E=1")
 


### PR DESCRIPTION
Prior to this change, given a route:

```
# config/routes.rb
get ':a' => "foo#bar"
```

If one pointed to http://example.com/%BE (param `a` has invalid encoding),
a `BadRequest` would be raised with the following non-informative message:

```
ActionController::BadRequest
```

From now on the message displayed is:

```
Invalid parameter encoding: hi => "\xBE"
```

Fixes #21923.
