### PR TITLE
Added context for running engine:migrations:install task.

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -670,7 +670,7 @@ pre-defined path which may be customizable.
 The engine contains migrations for the `blorgh_articles` and `blorgh_comments`
 table which need to be created in the application's database so that the
 engine's models can query them correctly. To copy these migrations into the
-application use this command:
+application run the following command from the `test/dummy` directory of your Rails engine:
 
 ```bash
 $ rake blorgh:install:migrations


### PR DESCRIPTION
Existing documentation does not note that rake 'blorgh:install:migrations' must be run from engine/test/dummy context. Otherwise, 'Don't know how to build task engine:install:migrations' is returned (checked edge documentation also).
