### PR TITLE
Update all ActiveRecord referencing links

### DIFF
--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -20,7 +20,7 @@ A short rundown of some of the major features:
    class Product < ActiveRecord::Base
    end
 
-  {Learn more}[link:classes/ActiveRecord/Base.html]
+  {Learn more}[link:lib/active_record/base.rb]
 
 The Product class is automatically mapped to the table named "products",
 which might look like this:
@@ -43,7 +43,7 @@ This would also define the following accessors: <tt>Product#name</tt> and
      belongs_to :conglomerate
    end
 
-  {Learn more}[link:classes/ActiveRecord/Associations/ClassMethods.html]
+  {Learn more}[link:lib/active_record/associations/builder/association.rb]
 
 
 * Aggregations of value objects.
@@ -55,7 +55,7 @@ This would also define the following accessors: <tt>Product#name</tt> and
                  mapping: [%w(address_street street), %w(address_city city)]
    end
 
-  {Learn more}[link:classes/ActiveRecord/Aggregations/ClassMethods.html]
+  {Learn more}[link:lib/active_record/aggregations.rb]
 
 
 * Validation rules that can differ for new or existing objects.
@@ -67,7 +67,7 @@ This would also define the following accessors: <tt>Product#name</tt> and
       validates :password, :email_address, confirmation: true, on: :create
     end
 
-  {Learn more}[link:classes/ActiveRecord/Validations.html]
+  {Learn more}[link:lib/active_record/validations.rb]
 
 
 * Callbacks available for the entire life cycle (instantiation, saving, destroying, validating, etc.).
@@ -77,7 +77,7 @@ This would also define the following accessors: <tt>Product#name</tt> and
      # the `invalidate_payment_plan` method gets called just before Person#destroy
    end
 
-  {Learn more}[link:classes/ActiveRecord/Callbacks.html]
+  {Learn more}[link:lib/active_record/callbacks.rb]
 
 
 * Inheritance hierarchies.
@@ -87,7 +87,7 @@ This would also define the following accessors: <tt>Product#name</tt> and
    class Client < Company; end
    class PriorityClient < Client; end
 
-  {Learn more}[link:classes/ActiveRecord/Base.html]
+  {Learn more}[link:lib/active_record/inheritance.rb]
 
 
 * Transactions.
@@ -98,7 +98,7 @@ This would also define the following accessors: <tt>Product#name</tt> and
       mary.deposit(100)
     end
 
-  {Learn more}[link:classes/ActiveRecord/Transactions/ClassMethods.html]
+  {Learn more}[link:lib/active_record/transactions.rb]
 
 
 * Reflections on columns, associations, and aggregations.
@@ -107,7 +107,7 @@ This would also define the following accessors: <tt>Product#name</tt> and
     reflection.klass # => Client (class)
     Firm.columns # Returns an array of column descriptors for the firms table
 
-  {Learn more}[link:classes/ActiveRecord/Reflection/ClassMethods.html]
+  {Learn more}[link:lib/active_record/reflection.rb]
 
 
 * Database abstraction through simple adapters.
@@ -124,10 +124,11 @@ This would also define the following accessors: <tt>Product#name</tt> and
       database: 'activerecord'
     )
 
-  {Learn more}[link:classes/ActiveRecord/Base.html] and read about the built-in support for
-  MySQL[link:classes/ActiveRecord/ConnectionAdapters/MysqlAdapter.html],
-  PostgreSQL[link:classes/ActiveRecord/ConnectionAdapters/PostgreSQLAdapter.html], and
-  SQLite3[link:classes/ActiveRecord/ConnectionAdapters/SQLite3Adapter.html].
+  {Learn more}[link:lib/active_record/connection_handling.rb] and read about the built-in support for
+  MySQL[link:lib/active_record/connection_adapters/mysql_adapter.rb],
+  MySQL2[link:lib/active_record/connection_adapters/mysql2_adapter.rb],
+  PostgreSQL[link:lib/active_record/connection_adapters/postgresql_adapter.rb], and
+  SQLite3[link:lib/active_record/connection_adapters/sqlite3_adapter.rb].
 
 
 * Logging support for Log4r[https://github.com/colbygk/log4r] and Logger[http://www.ruby-doc.org/stdlib/libdoc/logger/rdoc].
@@ -156,7 +157,7 @@ This would also define the following accessors: <tt>Product#name</tt> and
       end
     end
 
-  {Learn more}[link:classes/ActiveRecord/Migration.html]
+  {Learn more}[link:lib/active_record/migration.rb]
 
 
 == Philosophy


### PR DESCRIPTION
I noticed that most of the links in the `ActiveRecord` specific `README.rdoc` were rendering a 404. I made some assumptions, namely that the links were supposed to point toward the files inside this repo that they reference. I also used the `.../active_record/associations/builder/association.rb` for associations as it is the parent `Association` class. If these assumptions were incorrect, please point me in the right direction and I will update the links accordingly. 

correct links in `ActiveRecord` specific `README.rdoc` for `Base`, `Associations`, `Aggregations`,
`Validations`, `Callbacks`, `Inheritance`, `Transaction`,
`Reflection`, `ConnectionHandling`, and `Migrations`, as well
as the links to adapters for `MySQL`, `MySQL2`,
`PostgreSQL`, and `SQLite3`.

This is my first real PR against an OSS repo. Any and all feedback is appreciated.
