### PR TITLE
Delete needless `require 'active_support/deprecation'`

### DIFF
--- a/actionmailer/test/i18n_with_controller_test.rb
+++ b/actionmailer/test/i18n_with_controller_test.rb
@@ -1,7 +1,6 @@
 require 'abstract_unit'
 require 'action_view'
 require 'action_controller'
-require 'active_support/deprecation'
 
 class I18nTestMailer < ActionMailer::Base
   configure do |c|

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -1,6 +1,5 @@
 require 'active_support/core_ext/array/extract_options'
 require 'action_dispatch/middleware/stack'
-require 'active_support/deprecation'
 require 'action_dispatch/http/request'
 require 'action_dispatch/http/response'
 

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -1,4 +1,3 @@
-require 'active_support/deprecation'
 require 'active_support/core_ext/string/filters'
 
 module ActionController

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -1,7 +1,6 @@
 require 'singleton'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/string/starts_ends_with'
-require 'active_support/deprecation'
 
 module Mime
   class Mimes

--- a/actionpack/lib/action_dispatch/middleware/reloader.rb
+++ b/actionpack/lib/action_dispatch/middleware/reloader.rb
@@ -1,5 +1,3 @@
-require 'active_support/deprecation/reporting'
-
 module ActionDispatch
   # ActionDispatch::Reloader provides prepare and cleanup callbacks,
   # intended to assist with code reloading during development.

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -3,7 +3,6 @@ require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/enumerable'
 require 'active_support/core_ext/array/extract_options'
 require 'active_support/core_ext/regexp'
-require 'active_support/deprecation'
 require 'action_dispatch/routing/redirection'
 require 'action_dispatch/routing/endpoint'
 

--- a/actionpack/test/controller/new_base/render_text_test.rb
+++ b/actionpack/test/controller/new_base/render_text_test.rb
@@ -1,5 +1,4 @@
 require 'abstract_unit'
-require 'active_support/deprecation'
 
 module RenderText
   class MinimalController < ActionController::Metal

--- a/actionview/test/actionpack/abstract/render_test.rb
+++ b/actionview/test/actionpack/abstract/render_test.rb
@@ -1,5 +1,4 @@
 require 'abstract_unit'
-require 'active_support/deprecation'
 
 module AbstractController
   module Testing

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -1,5 +1,3 @@
-require "active_support/deprecation"
-
 module ActiveRecord
   module Associations
     # = Active Record Association Collection

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -1,5 +1,3 @@
-require "active_support/deprecation"
-
 module ActiveRecord
   module Associations
     class SingularAssociation < Association #:nodoc:


### PR DESCRIPTION
When `require 'active_support/rails'`, 'active_support/deprecation'
is automatically loaded.
