### PR TITLE
[ci skip] Replace "destroy` method" with `destroy` action`

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -79,7 +79,7 @@ it asks the router to map it to a controller action. If the first matching route
 resources :photos
 ```
 
-Rails would dispatch that request to the `destroy` method on the `photos` controller with `{ id: '17' }` in `params`.
+Rails would dispatch that request to the `destroy` action on the `photos` controller with `{ id: '17' }` in `params`.
 
 ### CRUD, Verbs, and Actions
 


### PR DESCRIPTION
Sure this is `destroy` method of PhotosController, but in this chapter
these methods which mapped by the router are called "action".
For example:

``` ruby
get '/patients/:id', to: 'patients#show'
```

is described to dispatch "controller's `show` action".
