### PR TITLE
Fixes an issue with render partial not raising when custom collection…

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Changed render partial with a collection to check that the collection supports to_ary, if not
+    a 'NoMethodError' exception will be thrown.
+
+    *Jason Clark*
+    
 *   Collection input propagates input's `id` to the label's `for` attribute when
     using html options as the last element of collection.
 

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -403,7 +403,7 @@ module ActionView
     def collection_from_options
       if @options.key?(:collection)
         collection = @options[:collection]
-        collection.respond_to?(:to_ary) ? collection.to_ary : []
+        collection.try!(:to_ary) ? collection.to_ary : []
       end
     end
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -272,6 +272,24 @@ module RenderTestCases
       @view.render(:partial => "test/local_inspector", :collection => [ Customer.new("mary") ])
   end
 
+  class CustomCustomerCollection
+    include Enumerable
+    attr_reader :instances
+
+    def initialize(instances)
+      @instances = instances
+    end
+
+    delegate :each, :size, :length, to: :@instances
+  end
+
+  def test_render_partial_collection_should_raise_if_missing_to_ary 
+    custom_collection = CustomCustomerCollection.new([Customer.new("david"), Customer.new("scott")])
+    assert_raises NoMethodError do
+      @view.render(partial: "test/customer", collection: custom_collection)
+    end
+  end
+
   def test_render_partial_with_empty_collection_should_return_nil
     assert_nil @view.render(:partial => "test/customer", :collection => [])
   end


### PR DESCRIPTION
This PR deals with an issue I ran into recently, where we use a custom collection and pass that to render partial.  When we did this, we noticed nothing was being outputted from the partial and this is because render partial with a collection looks does a responds_with?(:to_ary) on the collection.  If nothing responds, then it just passes an empty array and nothing happens...   

I feel that we should get a NoMethodError back if the collection doesn't support to_ary, so the developer has some idea what is going on...
