### PR TITLE
Allow unloadable classes to be... loaded

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -771,6 +771,8 @@ module ActiveSupport #:nodoc:
         parent.instance_eval { remove_const to_remove }
       rescue NameError
         log "the constant #{const} is not reachable anymore, skipping"
+      ensure
+        loaded.delete(expanded)
       end
     end
 

--- a/activesupport/test/autoloading_fixtures/something_unloadable.rb
+++ b/activesupport/test/autoloading_fixtures/something_unloadable.rb
@@ -1,0 +1,3 @@
+class SomethingUnloadable
+  unloadable
+end

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -732,6 +732,16 @@ class DependenciesTest < ActiveSupport::TestCase
     remove_constants(:C)
   end
 
+  def test_unloadable_constants_should_be_loadable_after_being_cleared
+    with_autoloading_fixtures do
+      assert_kind_of Class, SomethingUnloadable
+      assert ActiveSupport::Dependencies.explicitly_unloadable_constants.include?(SomethingUnloadable.name)
+      ActiveSupport::Dependencies.clear
+      assert ! defined?(SomethingUnloadable)
+      assert_kind_of Class, SomethingUnloadable
+    end
+  end
+
   def test_new_contants_in_without_constants
     assert_equal [], (ActiveSupport::Dependencies.new_constants_in(Object) { })
     assert ActiveSupport::Dependencies.constant_watch_stack.all? {|k,v| v.empty? }


### PR DESCRIPTION
Fix #21198

That sounds wrong

To be honest, I don't really understand what unloadable means.

But if #21198 is a bug, I think this fixes it.
