### PR TITLE
remove unnecessary forwardable require

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -1,5 +1,4 @@
 require 'action_dispatch/journey'
-require 'forwardable'
 require 'active_support/concern'
 require 'active_support/core_ext/object/to_query'
 require 'active_support/core_ext/hash/slice'


### PR DESCRIPTION
`Forwardable` has been used in the past
