### PR TITLE
Set `scope.reordering_value` to `true` if :reordering values aren't nil

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Set `scope.reordering_value` to `true` if :reordering values are specified.
+
+    Fixes #21886.
+
+    *Hiroaki Izu*
+
 *   Add support for bidirectional destroy dependencies.
 
     Fixes #13609.

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -136,6 +136,10 @@ module ActiveRecord
           end
           scope.order! preload_values[:order] || values[:order]
 
+          if preload_values[:reordering] || values[:reordering]
+            scope.reordering_value = true
+          end
+
           if preload_values[:readonly] || values[:readonly]
             scope.readonly!
           end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1179,6 +1179,24 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal 1, mary.unique_categorized_post_ids.length
   end
 
+  def test_preloading_has_one_using_reorder
+    klass = Class.new(ActiveRecord::Base) do
+      def self.name; "TempAuthor"; end
+      self.table_name = "authors"
+      has_one :post, class_name: "PostWithDefaultScope", foreign_key: :author_id
+      has_one :reorderd_post, -> { reorder(title: :desc) }, class_name: "PostWithDefaultScope", foreign_key: :author_id
+    end
+
+    author = klass.first
+    # PRECONDITION: make sure ordering results in different results
+    assert_not_equal author.post, author.reorderd_post
+
+    preloaded_reorderd_post = klass.preload(:reorderd_post).first.reorderd_post
+
+    assert_equal author.reorderd_post, preloaded_reorderd_post
+    assert_equal posts(:sti_post_and_comments).title, preloaded_reorderd_post.title
+  end
+
   def test_preloading_polymorphic_with_custom_foreign_type
     sponsor = sponsors(:moustache_club_sponsor_for_groucho)
     groucho = members(:groucho)


### PR DESCRIPTION
We should call `scope.order!` and set `scope.reordering_value` to `true` if :reordering values are specified

Fixes #21886
