### PR TITLE
Suppress warnings (warnings about AD::IntegrationTest HTTP request)

### DIFF
--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -463,7 +463,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
   def test_get_xml_rss_atom
     %w[ application/xml application/rss+xml application/atom+xml ].each do |mime_string|
       with_test_route_set do
-        get "/get", {}, {"HTTP_ACCEPT" => mime_string}
+        get "/get", headers: {"HTTP_ACCEPT" => mime_string}
         assert_equal 200, status
         assert_equal "OK", status_message
         assert_response 200


### PR DESCRIPTION
These warings have been appeared from
ea9bc06c9a47b839d5e2db94ba6bf7e29c8f0ae9.
