### PR TITLE
Use sufficient a regexp anchor to check `@response.content_type.to_s`

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions.rb
@@ -12,7 +12,7 @@ module ActionDispatch
     include Rails::Dom::Testing::Assertions
 
     def html_document
-      @html_document ||= if @response.content_type.to_s =~ /xml$/
+      @html_document ||= if @response.content_type.to_s =~ /xml\z/
         Nokogiri::XML::Document.parse(@response.body)
       else
         Nokogiri::HTML::Document.parse(@response.body)


### PR DESCRIPTION
This commit follows up of ea9bc06c9a47b839d5e2db94ba6bf7e29c8f0ae9.
To check `@response.content_type.to_s` is ended with `"xml"`,
to use `\z` is sufficient.
