### PR TITLE
Refactor preloader: avoid passing extra preloader object argument  

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -143,7 +143,7 @@ module ActiveRecord
         grouped_records(association, records).flat_map do |reflection, klasses|
           klasses.map do |rhs_klass, rs|
             loader = preloader_for(reflection, rs, rhs_klass).new(rhs_klass, rs, reflection, scope)
-            loader.run self
+            loader.run
             loader
           end
         end
@@ -168,7 +168,7 @@ module ActiveRecord
           @reflection = reflection
         end
 
-        def run(preloader); end
+        def run; end
 
         def preloaded_records
           owners.flat_map { |owner| owner.association(reflection.name).target }
@@ -177,7 +177,7 @@ module ActiveRecord
 
       class NullPreloader # :nodoc:
         def self.new(klass, owners, reflection, preload_scope); self; end
-        def self.run(preloader); end
+        def self.run; end
         def self.preloaded_records; []; end
       end
 

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -15,11 +15,11 @@ module ActiveRecord
           @preloaded_records = []
         end
 
-        def run(preloader)
-          preload(preloader)
+        def run
+          preload
         end
 
-        def preload(preloader)
+        def preload
           raise NotImplementedError
         end
 
@@ -61,7 +61,7 @@ module ActiveRecord
 
         private
 
-        def associated_records_by_owner(preloader)
+        def associated_records_by_owner
           records = load_records
           owners.each_with_object({}) do |owner, result|
             result[owner] = records[convert_key(owner[owner_key_name])] || []

--- a/activerecord/lib/active_record/associations/preloader/collection_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/collection_association.rb
@@ -9,8 +9,8 @@ module ActiveRecord
           super.order(preload_scope.values[:order] || reflection_scope.values[:order])
         end
 
-        def preload(preloader)
-          associated_records_by_owner(preloader).each do |owner, records|
+        def preload
+          associated_records_by_owner.each do |owner, records|
             association = owner.association(reflection.name)
             association.loaded!
             association.target.concat(records)

--- a/activerecord/lib/active_record/associations/preloader/has_many_through.rb
+++ b/activerecord/lib/active_record/associations/preloader/has_many_through.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       class HasManyThrough < CollectionAssociation #:nodoc:
         include ThroughAssociation
 
-        def associated_records_by_owner(preloader)
+        def associated_records_by_owner
           records_by_owner = super
 
           if reflection_scope.distinct_value

--- a/activerecord/lib/active_record/associations/preloader/singular_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/singular_association.rb
@@ -5,8 +5,8 @@ module ActiveRecord
 
         private
 
-        def preload(preloader)
-          associated_records_by_owner(preloader).each do |owner, associated_records|
+        def preload
+          associated_records_by_owner.each do |owner, associated_records|
             record = associated_records.first
 
             association = owner.association(reflection.name)

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -10,8 +10,8 @@ module ActiveRecord
           reflection.source_reflection
         end
 
-        def associated_records_by_owner(preloader)
-          preloader.preload(owners,
+        def associated_records_by_owner
+          Preloader.new.preload(owners,
                             through_reflection.name,
                             through_scope)
 
@@ -25,7 +25,7 @@ module ActiveRecord
 
           middle_records = through_records.flat_map { |(_,rec)| rec }
 
-          preloaders = preloader.preload(middle_records,
+          preloaders = Preloader.new.preload(middle_records,
                                          source_reflection.name,
                                          reflection_scope)
 


### PR DESCRIPTION
`AR::Assns::Preloader` is pretty light object that doesn't require any argument to construct and doesn't hold any data. I don't know why we have to pass it as argument.

``` ruby
amount = 1000000
Benchmark.bmbm do |x|
  x.report do
    amount.times do
      Object.new 
    end
  end
  x.report do
    amount.times do
      ActiveRecord::Associations::Preloader.new
    end
  end
end
```

```
Rehearsal ------------------------------------
   0.150000   0.000000   0.150000 (  0.152009)
   0.160000   0.000000   0.160000 (  0.162004)
--------------------------- total: 0.310000sec

       user     system      total        real
   0.120000   0.000000   0.120000 (  0.126182)
   0.130000   0.000000   0.130000 (  0.134619)
```

r? @sgrif 
