### PR TITLE
Remove JRUBY_OPTS from .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ before_script:
   - bundle update
 cache: bundler
 env:
-  global:
-    - JRUBY_OPTS='-J-Xmx1024M'
   matrix:
     - "GEM=railties"
     - "GEM=ap"


### PR DESCRIPTION
As we are not running tests for JRuby on travis this option is not
needed.

For more details check 0e8c04529159522aadbfe4fe71ea3d326df07d52
