### PR TITLE
remove unnecessary readme in dummy application

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -117,7 +117,7 @@ task default: :test
         remove_file "Gemfile"
         remove_file "lib/tasks"
         remove_file "public/robots.txt"
-        remove_file "README"
+        remove_file "README.md"
         remove_file "test"
         remove_file "vendor"
       end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -440,6 +440,19 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_unnecessary_files_are_not_generated_in_dummy_application
+    run_generator
+    assert_no_file 'test/dummy/.gitignore'
+    assert_no_file 'test/dummy/db/seeds.rb'
+    assert_no_file 'test/dummy/Gemfile'
+    assert_no_file 'test/dummy/public/robots.txt'
+    assert_no_file 'test/dummy/README.md'
+    assert_no_directory 'test/dummy/lib/tasks'
+    assert_no_directory 'test/dummy/doc'
+    assert_no_directory 'test/dummy/test'
+    assert_no_directory 'test/dummy/vendor'
+  end
+
   def test_skipping_test_files
     run_generator [destination_root, "--skip-test"]
     assert_no_file "test"


### PR DESCRIPTION
`README` it is changed to `README.rdoc` in 6b126e2, it has been changed to`README.md` further 89a12c9.
