### PR TITLE
Added options for rails update task

### DIFF
--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -45,7 +45,8 @@ namespace :rails do
         @app_generator ||= begin
           require 'rails/generators'
           require 'rails/generators/rails/app/app_generator'
-          gen = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true },
+          skip_options = { skip_active_record: true } if ENV['skip_active_record']
+          gen = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }.merge(skip_options || {}),
             destination_root: Rails.root
           File.exist?(Rails.root.join("config", "application.rb")) ?
             gen.send(:app_const) : gen.send(:valid_const?)

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -4,6 +4,8 @@ namespace :rails do
     o = OptionParser.new
     o.banner = "Usage: rake rails:update -- [options]"
     o.on("-o", "--skip-active-record") { options[:skip_active_record] = true }
+    o.on("-T", "--skip-test") { options[:skip_test] = true }
+    o.on("-M", "--skip-action-mailer") { options[:skip_action_mailer] = true }
     args = o.order!(ARGV) {}
     o.parse!(args)
     options


### PR DESCRIPTION
@carlosantoniodasilva Added options for `rails:update` rake task. If user executes `bundle exec rails:update skip_active_record=true` then it automatically comments active record related configuration while updating.

Ref discussion thread: https://groups.google.com/forum/#!topic/rubyonrails-core/VuC8ht0kaA8 
