### PR TITLE
shorten module inclusion in actioncontroller

### DIFF
--- a/actionpack/lib/action_controller/api.rb
+++ b/actionpack/lib/action_controller/api.rb
@@ -135,7 +135,7 @@ module ActionController
       ParamsWrapper
     ]
 
-    include *MODULES
+    include *MODULES.reverse
 
     ActiveSupport.run_load_hooks(:action_controller, self)
   end

--- a/actionpack/lib/action_controller/api.rb
+++ b/actionpack/lib/action_controller/api.rb
@@ -91,9 +91,7 @@ module ActionController
     # the ones passed as arguments:
     #
     #   class MyAPIBaseController < ActionController::Metal
-    #     ActionController::API.without_modules(:ForceSSL, :UrlFor).each do |left|
-    #       include left
-    #     end
+    #     include *ActionController::API.without_modules(:ForceSSL, :UrlFor)
     #   end
     #
     # This gives better control over what you want to exclude and makes it easier
@@ -137,9 +135,7 @@ module ActionController
       ParamsWrapper
     ]
 
-    MODULES.each do |mod|
-      include mod
-    end
+    include *MODULES
 
     ActiveSupport.run_load_hooks(:action_controller, self)
   end

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -243,7 +243,7 @@ module ActionController
       ParamsWrapper
     ]
 
-    include *MODULES
+    include *MODULES.reverse
     setup_renderer!
 
     # Define some internal variables that should not be propagated to the view.

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -184,9 +184,7 @@ module ActionController
     # ActionController::Base except the ones passed as arguments:
     #
     #   class MyBaseController < ActionController::Metal
-    #     ActionController::Base.without_modules(:ParamsWrapper, :Streaming).each do |left|
-    #       include left
-    #     end
+    #     include *ActionController::Base.without_modules(:ParamsWrapper, :Streaming)
     #   end
     #
     # This gives better control over what you want to exclude and makes it
@@ -245,9 +243,7 @@ module ActionController
       ParamsWrapper
     ]
 
-    MODULES.each do |mod|
-      include mod
-    end
+    include *MODULES
     setup_renderer!
 
     # Define some internal variables that should not be propagated to the view.


### PR DESCRIPTION
This will save a few lines and is slightly faster. There should be no functionality changes.

edit: include actually goes from last arg to first, so I need to reverse the array

``` ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  x.warmup = 2

  modules = 100.times.map{ Module.new }

  x.report("each") do
    Class.new do
      modules.each{|m| include m}
    end
  end

  x.report("reversed splat") do
    Class.new do
      include *modules.reverse
    end
  end
end

```

```
Calculating -------------------------------------
                each   932.000  i/100ms
      reversed splat     1.071k i/100ms
-------------------------------------------------
                each      9.713k (± 8.1%) i/s -     48.464k
      reversed splat     10.654k (± 8.2%) i/s -     53.550k
```
