### PR TITLE
Remove skipped JRuby tests that are passing on 9.0.3.0.

### DIFF
--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -206,8 +206,6 @@ class ResponseTest < ActiveSupport::TestCase
   end
 
   test "read content type with charset utf-16" do
-    jruby_skip "https://github.com/jruby/jruby/issues/3138"
-
     original = ActionDispatch::Response.default_charset
     begin
       ActionDispatch::Response.default_charset = 'utf-16'

--- a/actionpack/test/dispatch/routing/concerns_test.rb
+++ b/actionpack/test/dispatch/routing/concerns_test.rb
@@ -109,8 +109,6 @@ class RoutingConcernsTest < ActionDispatch::IntegrationTest
   end
 
   def test_concerns_executes_block_in_context_of_current_mapper
-    jruby_skip "https://github.com/jruby/jruby/issues/3143"
-
     mapper = ActionDispatch::Routing::Mapper.new(ActionDispatch::Routing::RouteSet.new)
     mapper.concern :test_concern do
       resources :things

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -75,8 +75,6 @@ module StaticTests
   end
 
   def test_served_static_file_with_non_english_filename
-    jruby_skip "Stop skipping if following bug gets fixed: " \
-      "http://jira.codehaus.org/browse/JRUBY-7192"
     assert_html "means hello in Japanese\n", get("/foo/#{Rack::Utils.escape("こんにちは.html")}")
   end
 


### PR DESCRIPTION
@rafaelfranca The tests are passing on my local machine I'll try this on travis
