### PR TITLE
Remove `DEFAULT_CHARSET` and `DEFAULT_COLLATION`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Remove `DEFAULT_CHARSET` and `DEFAULT_COLLATION` in `MySQLDatabaseTasks`.
+
+    We should omit the collation entirely rather than providing a default.
+    Then the choice is the responsibility of the server and MySQL distribution.
+
+    *Ryuta Kamizono*
+
 *   Alias `ActiveRecord::Relation#left_joins` to
     `ActiveRecord::Relation#left_outer_joins`.
 

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -1,8 +1,6 @@
 module ActiveRecord
   module Tasks # :nodoc:
     class MySQLDatabaseTasks # :nodoc:
-      DEFAULT_CHARSET     = ENV['CHARSET']   || 'utf8'
-      DEFAULT_COLLATION   = ENV['COLLATION'] || 'utf8_unicode_ci'
       ACCESS_DENIED_ERROR = 1045
 
       delegate :connection, :establish_connection, to: ActiveRecord::Base
@@ -87,12 +85,6 @@ module ActiveRecord
         Hash.new.tap do |options|
           options[:charset]     = configuration['encoding']   if configuration.include? 'encoding'
           options[:collation]   = configuration['collation']  if configuration.include? 'collation'
-
-          # Set default charset only when collation isn't set.
-          options[:charset]   ||= DEFAULT_CHARSET unless options[:collation]
-
-          # Set default collation only when charset is also default.
-          options[:collation] ||= DEFAULT_COLLATION if options[:charset] == DEFAULT_CHARSET
         end
       end
 

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -21,28 +21,21 @@ module ActiveRecord
       ActiveRecord::Tasks::DatabaseTasks.create @configuration
     end
 
-    def test_creates_database_with_default_encoding_and_collation
+    def test_creates_database_with_no_default_options
       @connection.expects(:create_database).
-        with('my-app-db', charset: 'utf8', collation: 'utf8_unicode_ci')
+        with('my-app-db', {})
 
       ActiveRecord::Tasks::DatabaseTasks.create @configuration
     end
 
-    def test_creates_database_with_given_encoding_and_default_collation
-      @connection.expects(:create_database).
-        with('my-app-db', charset: 'utf8', collation: 'utf8_unicode_ci')
-
-      ActiveRecord::Tasks::DatabaseTasks.create @configuration.merge('encoding' => 'utf8')
-    end
-
-    def test_creates_database_with_given_encoding_and_no_collation
+    def test_creates_database_with_given_encoding
       @connection.expects(:create_database).
         with('my-app-db', charset: 'latin1')
 
       ActiveRecord::Tasks::DatabaseTasks.create @configuration.merge('encoding' => 'latin1')
     end
 
-    def test_creates_database_with_given_collation_and_no_encoding
+    def test_creates_database_with_given_collation
       @connection.expects(:create_database).
         with('my-app-db', collation: 'latin1_swedish_ci')
 
@@ -203,9 +196,9 @@ module ActiveRecord
       ActiveRecord::Tasks::DatabaseTasks.purge @configuration
     end
 
-    def test_recreates_database_with_the_default_options
+    def test_recreates_database_with_no_default_options
       @connection.expects(:recreate_database).
-        with('test-db', charset: 'utf8', collation: 'utf8_unicode_ci')
+        with('test-db', {})
 
       ActiveRecord::Tasks::DatabaseTasks.purge @configuration
     end


### PR DESCRIPTION
Related with #20000.

We should omit the collation entirely rather than providing a default.
Then the choice is the responsibility of the server and MySQL distribution.
