### PR TITLE
Fix equality check on instances of Hash and HashWithIndifferentAccess

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix equality check on instances of `Hash` and
+    `ActiveSupport::HashWithIndifferentAccess`.
+
+    *Ali Ismayilov*
+
 *   Implements an evented file system monitor to asynchronously detect changes
     in the application source code, routes, locales, etc.
 

--- a/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb
+++ b/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb
@@ -20,4 +20,14 @@ class Hash
   #   { a: b }.with_indifferent_access['a'] # calls b.nested_under_indifferent_access
   #   # => {"b"=>1}
   alias nested_under_indifferent_access with_indifferent_access
+
+  alias_method :original_eql?, :==
+  def ==(other)
+    if other.is_a?(HashWithIndifferentAccess)
+      with_indifferent_access.original_eql?(other)
+    else
+      original_eql?(other)
+    end
+  end
+  alias_method :eql?, :==
 end

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -263,6 +263,11 @@ module ActiveSupport
       _new_hash
     end
 
+    def ==(other)
+      super(other.try(:with_indifferent_access))
+    end
+    alias_method :eql?, :==
+
     protected
       def convert_key(key)
         key.kind_of?(Symbol) ? key.to_s : key

--- a/activesupport/test/indifferent_hash_equality_test.rb
+++ b/activesupport/test/indifferent_hash_equality_test.rb
@@ -1,0 +1,21 @@
+class IndifferentHashEqualityTest < ActiveSupport::TestCase
+  def setup
+    @regular_hash = {foo: :bar}
+    @indifferent_hash = ActiveSupport::HashWithIndifferentAccess.new(@regular_hash)
+  end
+
+  def test_equal
+    assert @indifferent_hash.eql?(@regular_hash)
+    assert_equal @indifferent_hash, @regular_hash
+  end
+
+  def test_equal_to_other_classes
+    @indifferent_hash = ActiveSupport::HashWithIndifferentAccess.new(foo: :bar)
+    assert_not_equal @indifferent_hash, 1
+  end
+
+  def test_hash_equal
+    assert @regular_hash.eql?(@indifferent_hash)
+    assert_equal @regular_hash, @indifferent_hash
+  end
+end


### PR DESCRIPTION
Fixes rails/rails#21032

So that,

```
{foo: 'bar'}.with_indifferent_access == {foo: 'bar'}
=> true
```
