### PR TITLE
Make `Module#redefine_method` to keep method visibility

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/remove_method.rb
+++ b/activesupport/lib/active_support/core_ext/module/remove_method.rb
@@ -16,7 +16,20 @@ class Module
   # Replaces the existing method definition, if there is one, with the passed
   # block as its body.
   def redefine_method(method, &block)
+    visibility = method_visibility(method)
     remove_possible_method(method)
     define_method(method, &block)
+    send(visibility, method)
+  end
+
+  def method_visibility(method) # :nodoc:
+    case
+    when private_method_defined?(method)
+      :private
+    when protected_method_defined?(method)
+      :protected
+    else
+      :public
+    end
   end
 end

--- a/activesupport/test/core_ext/module/remove_method_test.rb
+++ b/activesupport/test/core_ext/module/remove_method_test.rb
@@ -7,6 +7,16 @@ module RemoveMethodTests
       return 1
     end
 
+    def do_something_protected
+      return 1
+    end
+    protected :do_something_protected
+
+    def do_something_private
+      return 1
+    end
+    private :do_something_private
+
     class << self
       def do_something_else
         return 2
@@ -34,8 +44,16 @@ class RemoveMethodTest < ActiveSupport::TestCase
   def test_redefine_method_in_an_object
     RemoveMethodTests::A.class_eval{
       self.redefine_method(:do_something) { return 100 }
+      self.redefine_method(:do_something_protected) { return 100 }
+      self.redefine_method(:do_something_private) { return 100 }
     }
     assert_equal 100, RemoveMethodTests::A.new.do_something
+    assert_equal 100, RemoveMethodTests::A.new.send(:do_something_protected)
+    assert_equal 100, RemoveMethodTests::A.new.send(:do_something_private)
+
+    assert RemoveMethodTests::A.public_method_defined? :do_something
+    assert RemoveMethodTests::A.protected_method_defined? :do_something_protected
+    assert RemoveMethodTests::A.private_method_defined? :do_something_private
   end
 
 end


### PR DESCRIPTION
Before this commit `Module#redefine_method` always changes
visibility of redefined method to `public`.
This commit changes behavior of Module#redefine_method` to
keep method visibility.
