### PR TITLE
Remove required `sdoc` from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require 'sdoc'
 require 'net/http'
 
 $:.unshift File.expand_path('..', __FILE__)


### PR DESCRIPTION
This is required inside `api/task`
