### PR TITLE
Remove newlines from start of logs

### DIFF
--- a/actionmailer/lib/action_mailer/log_subscriber.rb
+++ b/actionmailer/lib/action_mailer/log_subscriber.rb
@@ -8,7 +8,7 @@ module ActionMailer
     def deliver(event)
       info do
         recipients = Array(event.payload[:to]).join(', ')
-        "\nSent mail to #{recipients} (#{event.duration.round(1)}ms)"
+        "Sent mail to #{recipients} (#{event.duration.round(1)}ms)"
       end
 
       debug { event.payload[:mail] }
@@ -16,7 +16,7 @@ module ActionMailer
 
     # An email was received.
     def receive(event)
-      info { "\nReceived mail (#{event.duration.round(1)}ms)" }
+      info { "Received mail (#{event.duration.round(1)}ms)" }
       debug { event.payload[:mail] }
     end
 
@@ -25,7 +25,7 @@ module ActionMailer
       debug do
         mailer = event.payload[:mailer]
         action = event.payload[:action]
-        "\n#{mailer}##{action}: processed outbound mail in #{event.duration.round(1)}ms"
+        "#{mailer}##{action}: processed outbound mail in #{event.duration.round(1)}ms"
       end
     end
 


### PR DESCRIPTION
Currently if using a single line logger, this causes the time stamp and
log message to be on separate lines which is not common to how most
other logging works.
