### PR TITLE
raise `ArgumentError` when `SECRET_KEY_BASE` is an integer

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -167,6 +167,9 @@ module Rails
       # team. Details at https://github.com/rails/rails/pull/6952#issuecomment-7661220
       @caching_key_generator ||=
         if secrets.secret_key_base
+          unless secrets.secret_key_base.kind_of?(String)
+            raise ArgumentError, "`secret_key_base` for #{Rails.env} environment must be a type of String, change this value in `config/secrets.yml`"
+          end
           key_generator = ActiveSupport::KeyGenerator.new(secrets.secret_key_base, iterations: 1000)
           ActiveSupport::CachingKeyGenerator.new(key_generator)
         else

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -417,6 +417,19 @@ module ApplicationTests
       end
     end
 
+    test "raise when secrets.secret_key_base is not a type of string" do
+      app_file 'config/secrets.yml', <<-YAML
+        development:
+          secret_key_base: 123
+      YAML
+
+      app 'development'
+
+      assert_raise(ArgumentError) do
+        app.key_generator
+      end
+    end
+
     test "prefer secrets.secret_token over config.secret_token" do
       app_file 'config/initializers/secret_token.rb', <<-RUBY
         Rails.application.config.secret_token = ""


### PR DESCRIPTION
If `SECRET_KEY_BASE` or other `secret` gets passed as other then string
we need to raise `ArgumentError` to know that it's a wrong argument.

Closes #22072
