### PR TITLE
Edits default `config/boot.rb` to match what's generated by Rails 4.2.

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -86,10 +86,9 @@ The `APP_PATH` constant will be used later in `rails/commands`. The `config/boot
 `config/boot.rb` contains:
 
 ```ruby
-# Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' # Set up gems listed in the Gemfile.
 ```
 
 In a standard Rails application, there's a `Gemfile` which declares all


### PR DESCRIPTION
Changes contents of `config/boot.rb` to match what Rails 4.2 now generates (see [here](https://github.com/rails/rails/blob/4-2-stable/railties/lib/rails/generators/rails/app/templates/config/boot.rb) ).
