### PR TITLE
Document how scope inheritance is being tested

### DIFF
--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -351,6 +351,9 @@ class InheritanceTest < ActiveRecord::TestCase
     assert_nothing_raised { s = SpecialSubscriber.new("name" => "And breaaaaathe!"); s.id = 'roger'; s.save }
   end
 
+  # NOTE: this test only cares that `Client` responds to `of_first_firm`,
+  # indicating that it inherited the scope from `Company`. It does not care
+  # if the scope and its joins and conditions are valid.
   def test_scope_inherited_properly
     assert_nothing_raised { Company.of_first_firm }
     assert_nothing_raised { Client.of_first_firm }


### PR DESCRIPTION
The test wants to make sure that `Client`, which is a subclass of `Company`, responds to `of_first_firm`, which `Company` defines. That's it.

Also explains that the scope itself doesn't need to be valid (because it isn't valid and doesn't matter to the inheritance of the scope itself).

This is to follow up on https://github.com/rails/rails/pull/21994 which was reverted because it was failing once merged. Upon further investigation, I realized that I was confused about the intent of the test (sorry, I'm an outsider, it wasn't obvious on first pass). So I think the real problem here is lack of clarity for what is being tested, specifically for the uninitiated.

Feel free to close this or write docs however preferred, just thought I'd follow up with an alternative "solution".

cc @arthurnn @rafaelfranca 
