### PR TITLE
Fix: SystemStackError when `large_hash.slice!`

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -30,12 +30,12 @@ class Hash
   #   # => {:c=>3, :d=>4}
   def slice!(*keys)
     keys.map! { |key| convert_key(key) } if respond_to?(:convert_key, true)
-    omit = slice(*self.keys - keys)
-    hash = slice(*keys)
-    hash.default      = default
-    hash.default_proc = default_proc if default_proc
-    replace(hash)
-    omit
+    self.each_with_object(self.class.new) do|(key, value), omit|
+      unless keys.include? key
+        self.delete key
+        omit[key] = value
+      end
+    end
   end
 
   # Removes and returns the key/value pairs matching the given keys.

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -913,6 +913,13 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal [], hash[:c]
   end
 
+  def test_slice_bang_does_not_crash_large_hash
+    original = (1..200_000).map {|i| [i, i] }.to_h
+    expected = { 1 => 1 }
+    original.slice!(1)
+    assert_equal expected, original
+  end
+
   def test_extract
     original = {:a => 1, :b => 2, :c => 3, :d => 4}
     expected = {:a => 1, :b => 2}


### PR DESCRIPTION
# Problem

Calling `slice!` method of a very large hash causes a
`SystemStackError` unexpectedly:

``` ruby
> (1..200_000).map {|i| [i, i] }.to_h.slice!(1) ; print
SystemStackError: stack level too deep
```

This is because splat operator `*` for a large enumerable uses up the
VM's stack.
# Solution

Rewrite `Hash#slice!` method not to use the splat operator `*`.
# NOTE

This problem causes only in Ruby 2.1 or lower, according to [this issue](https://redmine.ruby-lang.org/issues/10440).
And Rails 5 doesn't support the versions.
So this patch might not make anything better,
but don't you feel my version looks simpler?
