### PR TITLE
Refactor ActionMailer::Base

### DIFF
--- a/actionmailer/lib/action_mailer/late_attachments_proxy.rb
+++ b/actionmailer/lib/action_mailer/late_attachments_proxy.rb
@@ -1,0 +1,14 @@
+module ActionMailer
+  class LateAttachmentsProxy < SimpleDelegator #:nodoc:
+    def inline; _raise_error end
+
+    def []=(_name, _content); _raise_error end
+
+    private
+
+      def _raise_error
+        fail "Can't add attachments after `mail` was called.\n" \
+             "Make sure to use `attachments[]=` before calling `mail`."
+      end
+  end
+end

--- a/actionmailer/lib/action_mailer/null_mail.rb
+++ b/actionmailer/lib/action_mailer/null_mail.rb
@@ -1,0 +1,15 @@
+module ActionMailer
+  class NullMail #:nodoc:
+    def body; '' end
+
+    def header; {} end
+
+    def respond_to?(_string, _include_all = false)
+      true
+    end
+
+    def method_missing(*)
+      nil
+    end
+  end
+end


### PR DESCRIPTION
An attempt at implementing recommendations from the book "Clean Code" by Robert C. Martin on the ActionMailer::Base class to make it more maintainable.
- replaced code comments with meaningful method names;
- reduced length of methods to 10 and less LOC;
- reduced cyclomatic complexity and assignment-branch-condition metrics
  to satisfy Rubocop's default configuration;
- fixed some punctuation issues.

I did not change number or signatures of public or protected methods. All new methods are private.

I did not change the funky way private/protected modifiers are indented (outdented?) although it seems that [Contributing to RoR](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions) page meant something different.
