### PR TITLE
Avoid disabling postgres errors

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -283,10 +283,11 @@ module ActiveRecord
 
       # Enable standard-conforming strings if available.
       def set_standard_conforming_strings
-        old, self.client_min_messages = client_min_messages, 'panic'
-        execute('SET standard_conforming_strings = on', 'SCHEMA') rescue nil
-      ensure
-        self.client_min_messages = old
+        execute(<<-SQL, 'SCHEMA')
+          UPDATE pg_settings
+          SET setting = 'on'
+          WHERE name = 'standard_conforming_strings'
+        SQL
       end
 
       def supports_ddl_transactions?

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -286,7 +286,7 @@ module ActiveRecord
         execute(<<-SQL, 'SCHEMA')
           UPDATE pg_settings
           SET setting = 'on'
-          WHERE name = 'standard_conforming_strings'
+          WHERE name = 'standard_conforming_strings' AND context = 'user'
         SQL
       end
 


### PR DESCRIPTION
The standard_conforming_strings setting doesn't exist on all versions of
Postgres, but if it does exist, Rails turns it on. Previously this was done by
effectively disabling errors on the Postgres connection, issuing a SET to turn
the setting on, then re-enabling errors on the connection. However, if you're
running pgbouncer in transaction-pooling mode, you can't guarantee that
successive calls to `#execute` will be sent to the same pgbouncer-postgres
connection, so you can end up disabling errors on a different postgres
connection, and never re-enabling them. Future queries on that connection that
result in errors (e.g. violating unique constraints) will leave the connection
in a bad state where successive queries will fail.

This commit sets standard_conforming_strings by issuing an UPDATE to
pg_settings, which will update the setting if it exists, and do nothing if it
doesn't (rather than erroring out like SET would), which means we can remove
the error-disabling code.

It's also worth noting that Postgres has allowed standard_conforming_strings to
be updated since 8.2 (which is the oldest version Rails supports), so
technically we probably don't even need to be defensive here.

This is related to a larger issue about Rails' use of connection-level
features, which we're writing up and will open an issue for soon.
