### PR TITLE
Make migrations concurrent-safe

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -272,6 +272,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support locking of an entire table?
+      def supports_table_locking?
+        false
+      end
+
       # This is meant to be implemented by the adapters that support extensions
       def disable_extension(name)
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -159,6 +159,10 @@ module ActiveRecord
         postgresql_version >= 90200
       end
 
+      def supports_table_locking?
+        true
+      end
+
       def index_algorithms
         { concurrently: 'CONCURRENTLY' }
       end


### PR DESCRIPTION
- Addresses issue #22092
- Makes it safe to run multiple migrations on a database simultaneously from different machines or threads.
- Currently dependent on adapter, only postgresql supports it because
  it's the only one that supports DDL transactions
