### PR TITLE
default value for FixtureSet.fixture_class_names ought to be a Class

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -875,9 +875,7 @@ module ActiveRecord
       self.pre_loaded_fixtures = false
       self.config = ActiveRecord::Base
 
-      self.fixture_class_names = Hash.new do |h, fixture_set_name|
-        h[fixture_set_name] = ActiveRecord::FixtureSet.default_fixture_model_name(fixture_set_name, self.config)
-      end
+      self.fixture_class_names = {}
 
       silence_warnings do
         define_singleton_method :use_transactional_tests do

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -955,3 +955,17 @@ class FixturesWithAbstractBelongsTo < ActiveRecord::TestCase
     assert_equal pirates(:blackbeard), doubloons(:blackbeards_doubloon).pirate
   end
 end
+
+class FixtureClassNamesTest < ActiveRecord::TestCase
+  def setup
+    @saved_cache = self.fixture_class_names.dup
+  end
+
+  def teardown
+    self.fixture_class_names.replace(@saved_cache)
+  end
+
+  test "fixture_class_names returns nil for unregistered identifier" do
+    assert_nil self.fixture_class_names['unregistered_identifier']
+  end
+end


### PR DESCRIPTION
While working on a plugin involving fixtures, I found that if I accessed `TestFixtures.fixture_class_names` with a fixture identifier that didn't exist in the mapping yet, it would conveniently be added as the estimated name of the class corresponding to that fixture. This was fine, until the tests actually ran, at which point very obscure errors popped up, saying that "comparison of String with Class failed". I was able to work around this by using `TestFixtures::ClassCache` instead, but it seemed like this little inconsistency ought to be cleaned up.

A more detailed explanation follows, telling why I think this is a bug, and how I think it ought to be fixed.

Look at `TestFixtures.set_fixture_class`. As documented, it accepts a mapping of fixture identifiers (string or symbol) to Classes (the model classes that implement the named fixture).

Look now at the initialization of `TestFixtures.fixture_class_names`. It defines a Hash, which will return a string by default (where the string is the estimated class name of the given fixture identifier).

Now look at TestFixtures.load_fixtures. It calls `FixtureSet.create_fixtures`, passing in the mapping of `fixture_class_names`.

Following this on to `FixtureSet.create_fixtures`, this instantiates a `FixtureSet::ClassCache`, passing in the map of class names.

`ClassCache`, in turn, calls `insert_class` for each value in the cache. (Recall that `set_fixture_class` puts Class objects in there, while the default proc for the mapping puts String objects.)

Look finally at `insert_class`. If the value is present, it checks to see if the value is a subclass of `AR::Base`. Fair enough...but wait! What if the value is a String? You get an exception, because a String
instance cannot be compared with a Class.

Judging from the implementation, it seems like the expected behavior here is for the default proc of the `fixture_class_names` mapping ought to return a Class, and not a String.

That is what this change does.
