### PR TITLE
alias any? to exists? in the finder methods

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -296,6 +296,7 @@ module ActiveRecord
 
       connection.select_value(relation, "#{name} Exists", relation.bound_attributes) ? true : false
     end
+    alias :any? :exists?
 
     # This method is called whenever no records are found with either a single
     # id or multiple ids and raises a ActiveRecord::RecordNotFound exception.


### PR DESCRIPTION
Hey everyone!

I'm putting this PR out there for a quick question first - is there a reason why `any?` wasn't aliased to `exists?`? I'm wondering if this has been decided upon already. If not, I'm happy to add tests to this and whatnot to keep it up to standard.

Thanks
