### PR TITLE
Remove unnecessary line break in csrf helper

### DIFF
--- a/actionview/lib/action_view/helpers/csrf_helper.rb
+++ b/actionview/lib/action_view/helpers/csrf_helper.rb
@@ -22,7 +22,7 @@ module ActionView
           [
             tag('meta', :name => 'csrf-param', :content => request_forgery_protection_token),
             tag('meta', :name => 'csrf-token', :content => form_authenticity_token)
-          ].join("\n").html_safe
+          ].join.html_safe
         end
       end
 


### PR DESCRIPTION
It will allow to generate resulted html with such lib as slim just in one line instead of two.
