### PR TITLE
Use #distinct instead of #uniq in the guides

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -80,7 +80,7 @@ The methods are:
 * `reorder`
 * `reverse_order`
 * `select`
-* `uniq`
+* `distinct`
 * `where`
 
 All of the above methods return an instance of `ActiveRecord::Relation`.
@@ -999,7 +999,7 @@ SELECT categories.* FROM categories
   INNER JOIN articles ON articles.category_id = categories.id
 ```
 
-Or, in English: "return a Category object for all categories with articles". Note that you will see duplicate categories if more than one article has the same category. If you want unique categories, you can use `Category.joins(:articles).uniq`.
+Or, in English: "return a Category object for all categories with articles". Note that you will see duplicate categories if more than one article has the same category. If you want unique categories, you can use `Category.joins(:articles).distinct`.
 
 #### Joining Multiple Associations
 

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -2163,7 +2163,7 @@ You can use any of the standard [querying methods](active_record_querying.html) 
 * `order`
 * `readonly`
 * `select`
-* `uniq`
+* `distinct`
 
 ##### `where`
 
@@ -2239,9 +2239,9 @@ If you use the `readonly` method, then the associated objects will be read-only 
 
 The `select` method lets you override the SQL `SELECT` clause that is used to retrieve data about the associated objects. By default, Rails retrieves all columns.
 
-##### `uniq`
+##### `distinct`
 
-Use the `uniq` method to remove duplicates from the collection.
+Use the `distinct` method to remove duplicates from the collection.
 
 #### When are Objects Saved?
 


### PR DESCRIPTION
Hello,

I was reading the Association Basics guide and since [#uniq is an alias for #distinct](https://github.com/rails/rails/blob/v4.2.4/activerecord/lib/active_record/relation/query_methods.rb#L779) I thought it'd be better to use only one of the methods in the associations scopes sections of the guide.

While deciding which one to use, I found out that `#uniq` will be deprecated in favor of `#distinct`:
rails/rails@adfab2dcf4003ca564d78d4425566dd2d9cd8b4f

So I changed the `#uniq` references to `#distinct`.
