### PR TITLE
Refactored preloading of a though assocations

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -17,7 +17,7 @@ module ActiveRecord
         end
 
         def run(preloader)
-          associated_records_by_owner(preloader).each do |owner, records|
+          associated_records_by_owner(preloader) do |owner, records|
             associate_records_to_owner(owner, records)
           end
         end
@@ -41,7 +41,7 @@ module ActiveRecord
             end
 
             owners.each_with_object({}) do |owner, result|
-              result[owner] = records[convert_key(owner[owner_key_name])] || []
+              yield(owner, records[convert_key(owner[owner_key_name])] || [])
             end
           end
 

--- a/activerecord/lib/active_record/associations/preloader/has_many_through.rb
+++ b/activerecord/lib/active_record/associations/preloader/has_many_through.rb
@@ -5,16 +5,6 @@ module ActiveRecord
     class Preloader
       class HasManyThrough < CollectionAssociation #:nodoc:
         include ThroughAssociation
-
-        def associated_records_by_owner(preloader)
-          records_by_owner = super
-
-          if reflection_scope.distinct_value
-            records_by_owner.each_value(&:uniq!)
-          end
-
-          records_by_owner
-        end
       end
     end
   end

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -13,86 +13,45 @@ module ActiveRecord
         end
 
         def associated_records_by_owner(preloader)
-          already_loaded = owners.first.association(through_reflection.name).loaded?
-          through_scope = through_scope()
-
-          unless already_loaded
-            preloader.preload(owners, through_reflection.name, through_scope)
-          end
-
-          through_records = owners.map do |owner|
-            center = owner.association(through_reflection.name).target
-            [owner, Array(center)]
-          end
-
-          if already_loaded
-            if source_type = reflection.options[:source_type]
-              through_records.map! do |owner, center|
-                center = center.select do |record|
-                  record[reflection.foreign_type] == source_type
-                end
-                [owner, center]
-              end
-            end
-          else
-            reset_association(owners, through_reflection.name, through_scope)
-          end
-
-          middle_records = through_records.flat_map(&:last)
-
-          if preload_scope
-            reflection_scope = reflection_scope().merge(preload_scope)
-          elsif reflection.scope
-            reflection_scope = reflection_scope()
-          end
-
-          preloaders = preloader.preload(middle_records,
-                                         source_reflection.name,
-                                         reflection_scope)
-
+          already_loaded     = owners.first.association(through_reflection.name).loaded?
+          through_scope      = through_scope()
+          reflection_scope   = target_reflection_scope
+          through_preloaders = preloader.preload(owners, through_reflection.name, through_scope)
+          middle_records     = through_preloaders.flat_map(&:preloaded_records)
+          preloaders         = preloader.preload(middle_records, source_reflection.name, reflection_scope)
           @preloaded_records = preloaders.flat_map(&:preloaded_records)
 
-          middle_to_pl = preloaders.each_with_object({}) do |pl, h|
-            pl.owners.each { |middle|
-              h[middle] = pl
-            }
-          end
-
-          through_records.each_with_object({}) do |(lhs, center), records_by_owner|
-            pl_to_middle = center.group_by { |record| middle_to_pl[record] }
-
-            records_by_owner[lhs] = pl_to_middle.flat_map do |pl, middles|
-              rhs_records = middles.flat_map { |r|
-                r.association(source_reflection.name).target
-              }.compact
-
-              # Respect the order on `reflection_scope` if it exists, else use the natural order.
-              if reflection_scope && !reflection_scope.order_values.empty?
-                @id_map ||= id_to_index_map @preloaded_records
-                rhs_records.sort_by { |rhs| @id_map[rhs] }
-              else
-                rhs_records
+          owners.each do |owner|
+            through_records = Array(owner.association(through_reflection.name).target)
+            if already_loaded
+              if source_type = reflection.options[:source_type]
+                through_records = through_records.select do |record|
+                  record[reflection.foreign_type] == source_type
+                end
               end
+            else
+              owner.association(through_reflection.name).reset if through_scope
             end
-          end.tap do
-            reset_association(middle_records, source_reflection.name, preload_scope)
+            result = through_records.flat_map do |record|
+              association = record.association(source_reflection.name)
+              target = association.target
+              association.reset if preload_scope
+              target
+            end
+            result.compact!
+            if reflection_scope
+              result.sort_by! { |rhs| preload_index[rhs] } if reflection_scope.order_values.any?
+              result.uniq! if reflection_scope.distinct_value
+            end
+            yield(owner, result)
           end
         end
 
         private
 
-          def id_to_index_map(ids)
-            id_map = {}
-            ids.each_with_index { |id, index| id_map[id] = index }
-            id_map
-          end
-
-          def reset_association(owners, association_name, should_reset)
-            # Don't cache the association - we would only be caching a subset
-            if should_reset
-              owners.each { |owner|
-                owner.association(association_name).reset
-              }
+          def preload_index
+            @preload_index ||= @preloaded_records.each_with_object({}).with_index do |(id, result), index|
+              result[id] = index
             end
           end
 
@@ -132,6 +91,16 @@ module ActiveRecord
             end
 
             scope unless scope.empty_scope?
+          end
+
+          def target_reflection_scope
+            if preload_scope
+              reflection_scope.merge(preload_scope)
+            elsif reflection.scope
+              reflection_scope
+            else
+              nil
+            end
           end
       end
     end


### PR DESCRIPTION
Removed all supportive structures
Reduced the theoretical complexity of the algorithm
No idea why all those things were in place.

Slight performance win... but more likely it is about code structure and memory usage.
https://gist.github.com/a956889b40c92f78bce5

```
Running benchmark with current working tree
Stashing changes
Running benchmark with clean working tree
Applying stashed changes back

                    user     system      total        real
-----preload though 10 iterations 1 associated for 10 given
After patch:    0.050000   0.010000   0.060000 (  0.047795)
Before patch:   0.050000   0.010000   0.060000 (  0.051627)
Improvement: 7%

----preload though 10 iterations 10 associated for 10 given
After patch:    0.060000   0.000000   0.060000 (  0.056658)
Before patch:   0.050000   0.000000   0.050000 (  0.058069)
Improvement: 2%

---preload though 10 iterations 100 associated for 10 given
After patch:    0.120000   0.010000   0.130000 (  0.127069)
Before patch:   0.130000   0.010000   0.140000 (  0.125798)
Improvement: -1%

----preload though 10 iterations 1 associated for 100 given
After patch:    0.400000   0.020000   0.420000 (  0.424181)
Before patch:   0.410000   0.020000   0.430000 (  0.439746)
Improvement: 4%

---preload though 10 iterations 10 associated for 100 given
After patch:    0.480000   0.020000   0.500000 (  0.504922)
Before patch:   0.490000   0.030000   0.520000 (  0.518169)
Improvement: 3%

--preload though 10 iterations 100 associated for 100 given
After patch:    1.240000   0.050000   1.290000 (  1.293026)
Before patch:   1.290000   0.050000   1.340000 (  1.334796)
Improvement: 3%
```

?r @sgrif 
