### PR TITLE
Fix a faulty form_for test

### DIFF
--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1539,9 +1539,10 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_requires_block
-    assert_raises(ArgumentError) do
-      form_for(:post, @post, html: { id: 'create-post' })
+    error = assert_raises(ArgumentError) do
+      form_for(@post, html: { id: 'create-post' })
     end
+    assert_equal "Missing block", error.message
   end
 
   def test_form_for_requires_arguments


### PR DESCRIPTION
Stumbled upon this one while trying to deprecate the String/Symbol
passing to `form_for`.

This test passed on an accident, because the signature of `form_for`
currently accepts 2 positional arguments and a block. Calling it with
the wrong number of arguments caused:

``` ruby
(byebug) form_for(:post, @post, html: { id: 'create-post' })
*** ArgumentError Exception: wrong number of arguments (3 for 1..2)
```

This made the test pass, because it was still an `ArgumentError`. :-)
