### PR TITLE
Properly indent '<head>' and '<body>' within '<html>'

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -1,23 +1,24 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title><%= camelized %></title>
-  <%- if options[:skip_javascript] -%>
-  <%%= stylesheet_link_tag    'application', media: 'all' %>
-  <%- else -%>
-    <%- if gemfile_entries.any? { |m| m.name == 'turbolinks' } -%>
-  <%%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <head>
+    <title><%= camelized %></title>
+    <%- if options[:skip_javascript] -%>
+    <%%= stylesheet_link_tag    'application', media: 'all' %>
     <%- else -%>
-  <%%= stylesheet_link_tag    'application', media: 'all' %>
-  <%%= javascript_include_tag 'application' %>
+      <%- if gemfile_entries.any? { |m| m.name == 'turbolinks' } -%>
+    <%%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
+    <%%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+      <%- else -%>
+    <%%= stylesheet_link_tag    'application', media: 'all' %>
+    <%%= javascript_include_tag 'application' %>
+      <%- end -%>
     <%- end -%>
-  <%- end -%>
-  <%%= csrf_meta_tags %>
-</head>
-<body>
+    <%%= csrf_meta_tags %>
+  </head>
 
-<%%= yield %>
+  <body>
 
-</body>
+    <%%= yield %>
+
+  </body>
 </html>


### PR DESCRIPTION
Both `<head>` and `<body>` aren't indented at all, though they have a parent `<html>` element.

This PR indents those elements properly (and everything within them).

I find myself fixing this in every new app 
