### PR TITLE
Set standard_conforming_strings with SET

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,8 +1,11 @@
-*   Use `UPDATE` rather than `SET` when enabling the `standard_conforming_strings`
-    setting as this allows us to avoid disabling errors on the PostgreSQL connection.
-    The former behavior would cause problems when using a connection pooling tool like
-    PgBouncer because it's not guaranteed to have the same connection between calls to
-    `execute` and it could leave the connection with errors disabled.
+*   Avoid disabling errors on the PostgreSQL connection when enabling the
+    standard_conforming_strings setting. Errors were previously disabled because
+    the setting wasn't writable in Postgres 8.1 and didn't exist in earlier
+    versions. Now Rails only supports Postgres 8.2+ we're fine to assume the
+    setting exists. Disabling errors caused problems when using a connection
+    pooling tool like PgBouncer because it's not guaranteed to have the same
+    connection between calls to `execute` and it could leave the connection
+    with errors disabled.
 
     Fixes #22101.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -281,13 +281,8 @@ module ActiveRecord
         true
       end
 
-      # Enable standard-conforming strings if available.
       def set_standard_conforming_strings
-        execute(<<-SQL, 'SCHEMA')
-          UPDATE pg_settings
-          SET setting = 'on'
-          WHERE name = 'standard_conforming_strings' AND context = 'user'
-        SQL
+        execute('SET standard_conforming_strings = on', 'SCHEMA')
       end
 
       def supports_ddl_transactions?
@@ -652,7 +647,7 @@ module ActiveRecord
           self.client_min_messages = @config[:min_messages] || 'warning'
           self.schema_search_path = @config[:schema_search_path] || @config[:schema_order]
 
-          # Use standard-conforming strings if available so we don't have to do the E'...' dance.
+          # Use standard-conforming strings so we don't have to do the E'...' dance.
           set_standard_conforming_strings
 
           # If using Active Record's time zone support configure the connection to return


### PR DESCRIPTION
Follow up to #22101.

UPDATEs inside read only transactions result in errors, whereas SETs
don't.

This will break with Postgres 8.1, but Rails doesn't support it so
that's not a problem.

/cc @pixeltrix
