### PR TITLE
Deprecate passing strings or symbols to form_for

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,7 +1,8 @@
+*   Deprecate passing strings or symbols to form_for.
+
+    *Genadi Samokovarov*
+
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
-
-*   No changes.
-
 
 *   `I18n.translate` helper will wrap the missing translation keys
      in a <span> tag only if `debug_missing_translation` configuration

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -121,11 +121,9 @@ module ActionView
       #
       # The method can be used in several slightly different ways, depending on
       # how much you wish to rely on Rails to infer automatically from the model
-      # how the form should be constructed. For a generic model object, a form
-      # can be created by passing +form_for+ a string or symbol representing
-      # the object we are concerned with:
+      # how the form should be constructed.
       #
-      #   <%= form_for :person do |f| %>
+      #   <%= form_for @person do |f| %>
       #     First name: <%= f.text_field :first_name %><br />
       #     Last name : <%= f.text_field :last_name %><br />
       #     Biography : <%= f.text_area :biography %><br />
@@ -149,13 +147,6 @@ module ActionView
       # the value entered by the user will be available in the controller as
       # <tt>params[:person][:first_name]</tt>.
       #
-      # For fields generated in this way using the FormBuilder,
-      # if <tt>:person</tt> also happens to be the name of an instance variable
-      # <tt>@person</tt>, the default value of the field shown when the form is
-      # initially displayed (e.g. in the situation where you are editing an
-      # existing record) will be the value of the corresponding attribute of
-      # <tt>@person</tt>.
-      #
       # The rightmost argument to +form_for+ is an
       # optional hash of options -
       #
@@ -174,6 +165,10 @@ module ActionView
       #   either "get" or "post". If "patch", "put", "delete", or another verb
       #   is used, a hidden input with name <tt>_method</tt> is added to
       #   simulate the verb over post.
+      # * <tt>:as</tt> - Specifies the prefix used to name the input elements
+      #   within the form (hence the key that denotes them in the +params+ hash).
+      #   By default it is derived from the object's _class_, e.g.
+      #   <tt>params[:post]</tt>, if the object's class is +Post+.
       # * <tt>:authenticity_token</tt> - Authenticity token to use in the form.
       #   Use only if you need to pass custom authenticity token string, or to
       #   not add authenticity_token field at all (by passing <tt>false</tt>).
@@ -193,7 +188,7 @@ module ActionView
       # possible to use both the stand-alone FormHelper methods and methods
       # from FormTagHelper. For example:
       #
-      #   <%= form_for :person do |f| %>
+      #   <%= form_for @person do |f| %>
       #     First name: <%= f.text_field :first_name %>
       #     Last name : <%= f.text_field :last_name %>
       #     Biography : <%= text_area :person, :biography %>
@@ -205,32 +200,7 @@ module ActionView
       # are designed to work with an object as base, like
       # FormOptionHelper#collection_select and DateHelper#datetime_select.
       #
-      # === #form_for with a model object
-      #
-      # In the examples above, the object to be created or edited was
-      # represented by a symbol passed to +form_for+, and we noted that
-      # a string can also be used equivalently. It is also possible, however,
-      # to pass a model object itself to +form_for+. For example, if <tt>@post</tt>
-      # is an existing record you wish to edit, you can create the form using
-      #
-      #   <%= form_for @post do |f| %>
-      #     ...
-      #   <% end %>
-      #
-      # This behaves in almost the same way as outlined previously, with a
-      # couple of small exceptions. First, the prefix used to name the input
-      # elements within the form (hence the key that denotes them in the +params+
-      # hash) is actually derived from the object's _class_, e.g. <tt>params[:post]</tt>
-      # if the object's class is +Post+. However, this can be overwritten using
-      # the <tt>:as</tt> option, e.g. -
-      #
-      #   <%= form_for(@person, as: :client) do |f| %>
-      #     ...
-      #   <% end %>
-      #
-      # would result in <tt>params[:client]</tt>.
-      #
-      # Secondly, the field values shown when the form is initially displayed
+      # The field values shown when the form is initially displayed
       # are taken from the attributes of the object passed to +form_for+,
       # regardless of whether the object is an instance
       # variable. So, for example, if we had a _local_ variable +post+
@@ -431,6 +401,10 @@ module ActionView
 
         case record
         when String, Symbol
+          ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)
+            Passing a string or a symbol is deprecated and will be removed in
+            Rails 5.1. To avoid this warning, pass a model instead.
+          MESSAGE
           object_name = record
           object      = nil
         else

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1973,11 +1973,12 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_enforce_utf8_true
-    form_for(:post, enforce_utf8: true) do |f|
+    form_for(@post, enforce_utf8: true) do |f|
       concat f.text_field(:title)
     end
 
-    expected = whole_form("/", nil, nil, enforce_utf8: true) do
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "post", enforce_utf8: true) do
+      "<input type='hidden' name='_method' value='patch' />" +
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
     end
 
@@ -1985,11 +1986,12 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_enforce_utf8_false
-    form_for(:post, enforce_utf8: false) do |f|
+    form_for(@post, enforce_utf8: false) do |f|
       concat f.text_field(:title)
     end
 
-    expected = whole_form("/", nil, nil, enforce_utf8: false) do
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "post", enforce_utf8: false) do
+      "<input type='hidden' name='_method' value='patch' />" +
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
     end
 
@@ -2033,11 +2035,13 @@ class FormHelperTest < ActionView::TestCase
     end
   end
 
-  def test_form_for_without_object
-    form_for(:post, html: { id: 'create-post' }) do |f|
-      concat f.text_field(:title)
-      concat f.text_area(:body)
-      concat f.check_box(:secret)
+  def test_form_for_without_object_deprecation
+    assert_deprecated do
+      form_for(:post, html: { id: 'create-post' }) do |f|
+        concat f.text_field(:title)
+        concat f.text_area(:body)
+        concat f.check_box(:secret)
+      end
     end
 
     expected = whole_form("/", "create-post") do
@@ -2261,10 +2265,12 @@ class FormHelperTest < ActionView::TestCase
     end
   end
 
-  def test_submit_without_object_and_locale_strings
+  def test_submit_without_object_and_locale_strings_deprecation
     with_locale :submit do
-      form_for(:post) do |f|
-        concat f.submit class: "extra"
+      assert_deprecated do
+        form_for(:post) do |f|
+          concat f.submit class: "extra"
+        end
       end
 
       expected = whole_form do
@@ -2306,7 +2312,7 @@ class FormHelperTest < ActionView::TestCase
 
   def test_deep_nested_fields_for
     @comment.save
-    form_for(:posts) do |f|
+    form_for([@post], as: :posts) do |f|
       f.fields_for('post[]', @post) do |f2|
         f2.text_field(:id)
         @post.comments.each do |comment|
@@ -2317,7 +2323,8 @@ class FormHelperTest < ActionView::TestCase
       end
     end
 
-    expected = whole_form do
+    expected = whole_form("/posts/123", "edit_posts", "edit_posts", method: "post") do
+      "<input type='hidden' name='_method' value='patch' />" +
       "<input name='posts[post][0][comment][1][name]' type='text' id='posts_post_0_comment_1_name' value='comment #1' />"
     end
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -511,7 +511,7 @@ method called `form_for`. To use this method, add this code into
 `app/views/articles/new.html.erb`:
 
 ```html+erb
-<%= form_for :article do |f| %>
+<%= form_for @article do |f| %>
   <p>
     <%= f.label :title %><br>
     <%= f.text_field :title %>
@@ -553,7 +553,7 @@ Edit the `form_for` line inside `app/views/articles/new.html.erb` to look like
 this:
 
 ```html+erb
-<%= form_for :article, url: articles_path do |f| %>
+<%= form_for @article, url: articles_path do |f| %>
 ```
 
 In this example, the `articles_path` helper is passed to the `:url` option.
@@ -952,7 +952,7 @@ Now, add another link in `app/views/articles/new.html.erb`, underneath the
 form, to go back to the `index` action:
 
 ```erb
-<%= form_for :article, url: articles_path do |f| %>
+<%= form_for @article, url: articles_path do |f| %>
   ...
 <% end %>
 
@@ -1063,7 +1063,7 @@ something went wrong. To do that, you'll modify
 `app/views/articles/new.html.erb` to check for error messages:
 
 ```html+erb
-<%= form_for :article, url: articles_path do |f| %>
+<%= form_for @article, url: articles_path do |f| %>
 
   <% if @article.errors.any? %>
     <div id="error_explanation">
@@ -1155,7 +1155,7 @@ it look as follows:
 ```html+erb
 <h1>Editing article</h1>
 
-<%= form_for :article, url: article_path(@article), method: :patch do |f| %>
+<%= form_for @article, url: article_path(@article), method: :patch do |f| %>
 
   <% if @article.errors.any? %>
     <div id="error_explanation">


### PR DESCRIPTION
This has been agreed on in #19699. This issues a  deprecation warning in
5.0 and we can remove the functionality in 5.1.

I have dropped all the examples we had with symbol/string syntax as
well, so we don't advertise it anymore. I have also tweaked most of the
tests, so we don't issue deprecation warnings during test runs.
