### PR TITLE
Alias left_joins to left_outer_joins

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     delegate :find_by, :find_by!, to: :all
     delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, to: :all
     delegate :find_each, :find_in_batches, :in_batches, to: :all
-    delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins, :left_outer_joins, :or,
+    delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins, :left_joins, :left_outer_joins, :or,
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly,
              :having, :create_with, :uniq, :distinct, :references, :none, :unscope, to: :all
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, to: :all

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   # = Active Record \Relation
   class Relation
     MULTI_VALUE_METHODS  = [:includes, :eager_load, :preload, :select, :group,
-                            :order, :joins, :left_outer_joins, :references,
+                            :order, :joins, :left_joins, :left_outer_joins, :references,
                             :extending, :unscope]
 
     SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :reordering,

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -441,11 +441,13 @@ module ActiveRecord
 
       spawn.left_outer_joins!(*args)
     end
+    alias :left_joins :left_outer_joins
 
     def left_outer_joins!(*args) # :nodoc:
       self.left_outer_joins_values += args
       self
     end
+    alias :left_joins! :left_outer_joins!
 
     # Returns a new relation, which is the result of filtering the current relation
     # according to the conditions in the arguments.

--- a/activerecord/test/cases/associations/left_outer_join_association_test.rb
+++ b/activerecord/test/cases/associations/left_outer_join_association_test.rb
@@ -29,6 +29,11 @@ class LeftOuterJoinAssociationTest < ActiveRecord::TestCase
     assert_equal Author.count, Author.left_outer_joins(:posts).count
   end
 
+  def test_left_outer_join_by_left_joins
+    assert_not_equal Author.count, Author.joins(:posts).count
+    assert_equal Author.count, Author.left_joins(:posts).count
+  end
+
   def test_construct_finder_sql_ignores_empty_left_outer_joins_hash
     sql = capture_sql { Author.left_outer_joins({}) }.first
     assert_no_match(/LEFT OUTER JOIN/i, sql)

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -28,7 +28,7 @@ module ActiveRecord
       @relation ||= Relation.new FakeKlass.new('posts'), Post.arel_table, Post.predicate_builder
     end
 
-    (Relation::MULTI_VALUE_METHODS - [:references, :extending, :order, :unscope, :select]).each do |method|
+    (Relation::MULTI_VALUE_METHODS - [:references, :extending, :order, :unscope, :select, :left_joins]).each do |method|
       test "##{method}!" do
         assert relation.public_send("#{method}!", :foo).equal?(relation)
         assert_equal [:foo], relation.public_send("#{method}_values")


### PR DESCRIPTION
Related to https://github.com/rails/rails/pull/12071

As I said in https://github.com/rails/rails/pull/12071#issuecomment-64938682, `left_outer_joins` is slightly long. I really want to use this method with `left_joins`. Because OUTER keyword can be abbreviated in an actual query, I think aliasing `left_joins` to `left_outer_joins` is reasonable.
