### PR TITLE
HashWithIndifferentAccess: Backport frozen? check from master into 4.2

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -269,7 +269,7 @@ module ActiveSupport
             value.nested_under_indifferent_access
           end
         elsif value.is_a?(Array)
-          unless options[:for] == :assignment
+          if options[:for] != :assignment || value.frozen?
             value = value.dup
           end
           value.map! { |e| convert_value(e, options) }

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -1,0 +1,11 @@
+require 'abstract_unit'
+require 'active_support/hash_with_indifferent_access'
+
+class HashWithIndifferentAccessTest < ActiveSupport::TestCase
+  def test_frozen_value
+    value = [1, 2, 3].freeze
+    hash = {}.with_indifferent_access
+    hash[:key] = value
+    assert_equal hash[:key], value
+  end
+end


### PR DESCRIPTION
Currently running into an error on `value.map!` when deep_merging frozen items.
