### PR TITLE
rails/application: allow passing an env to config_for

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow passing an environment to `config_for`.
+
+    *Simon Eskildsen*
+
 *   Allow rake:stats to account for rake tasks in lib/tasks
 
     *Kevin Deisz*

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -218,12 +218,12 @@ module Rails
     #     Rails.application.configure do
     #       config.middleware.use ExceptionNotifier, config_for(:exception_notification)
     #     end
-    def config_for(name)
+    def config_for(name, env: Rails.env)
       yaml = Pathname.new("#{paths["config"].existent.first}/#{name}.yml")
 
       if yaml.exist?
         require "erb"
-        (YAML.load(ERB.new(yaml.read).result) || {})[Rails.env] || {}
+        (YAML.load(ERB.new(yaml.read).result) || {})[env] || {}
       else
         raise "Could not load configuration. No such file - #{yaml}"
       end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1367,5 +1367,21 @@ module ApplicationTests
 
       assert_match 'YAML syntax error occurred while parsing', exception.message
     end
+
+    test "config_for allows overriding the environment" do
+      app_file 'config/custom.yml', <<-RUBY
+        test:
+          key: 'walrus'
+        production:
+            key: 'unicorn'
+      RUBY
+
+      add_to_config <<-RUBY
+          config.my_custom_config = config_for('custom', env: 'production')
+      RUBY
+      require "#{app_path}/config/environment"
+
+      assert_equal 'unicorn', Rails.application.config.my_custom_config['key']
+    end
   end
 end


### PR DESCRIPTION
Would make it easier to write tests to sanity check configuration files for other environments.

@rafaelfranca @byroot 
