### PR TITLE
ActiveSupport::Autoload unset when only requiring core_ext

### DIFF
--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -1,3 +1,5 @@
+require 'active_support/dependencies/autoload'
+
 module ActiveSupport
   module NumberHelper
     extend ActiveSupport::Autoload


### PR DESCRIPTION
When only requiring `active_support/core_ext` number helper is loaded
without before requiring autoload therefore the ActiveSupport::Autoload
constant/module is unset and requiring fails.

How to reproduce in ActiveSupport v4.2.4 using Ruby 2.2.3

```
$ gem install activesupport -v '4.2.4'
$ ruby -v
ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-darwin14]
$ irb
2.2.3 :001 > require 'active_support/core_ext'
NameError: uninitialized constant ActiveSupport::Autoload
  from /Users/fredericbranczyk/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/number_helper.rb:3:in `<module:NumberHelper>'
  from /Users/fredericbranczyk/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/number_helper.rb:2:in `<module:ActiveSupport>'
  from /Users/fredericbranczyk/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/number_helper.rb:1:in `<top (required)>'
  from /Users/fredericbranczyk/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:69:in `require'
  from /Users/fredericbranczyk/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:69:in `require'
  from /Users/fredericbranczyk/.rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/core_ext/numeric/conversions.rb:2:in `<top (required)>'
  from /Users/fredericbranczyk/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:69:in `require'
  from /Users/fredericbranczyk/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:69:in `require'
...
```

I hope I opened the PR against the correct branch. I thought it's a regression for 4.2.5 so I chose this branch. Please correct me when I'm wrong and I'll just cherry-pick it to where it belongs.
