### PR TITLE
ActionMailer: Add fallback to template lookup

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add support for absolute paths in :template_path option.
+
+    Example:
+
+        mail(to: recipients,
+             template_path: '/custom/template/path')
+
+    Fixes #22047.
+
+    *Yuichi Takeuchi*
+
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
 *   `config.force_ssl = true` will set

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -920,7 +920,7 @@ module ActionMailer
     end
 
     def each_template(paths, name, &block)
-      templates = lookup_context.find_all(name, paths)
+      templates = lookup_context.with_fallbacks { lookup_context.find_all(name, paths) }
       if templates.empty?
         raise ActionView::MissingTemplate.new(paths, name, paths, false, 'mailer')
       else

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -564,6 +564,9 @@ class BaseTest < ActiveSupport::TestCase
 
     mail = BaseMailer.welcome_from_another_path(['unknown/invalid', 'another.path/base_mailer']).deliver_now
     assert_equal("Welcome from another path", mail.body.encoded)
+
+    mail = BaseMailer.welcome_from_another_path(File.expand_path('another.path/base_mailer', FIXTURE_LOAD_PATH)).deliver_now
+    assert_equal("Welcome from another path", mail.body.encoded)
   end
 
   test "assets tags should use ActionMailer's asset_host settings" do


### PR DESCRIPTION
Fix of #22047 
Add fallback to template lookup

```
mail(to: recipients,
     template_path: '/custom/template/path')
```
