### PR TITLE
Fix `transaction` reverting in migration

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Made the commands inside a `transaction` in a reverted migration also
+    run reverted.
+
+    Fixes #21484.
+
+    *David Verhasselt*
+
 *   Added `ActiveRecord::Relation#left_outer_joins`.
 
     Example:

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -616,9 +616,7 @@ module ActiveRecord
             connection.revert { yield }
           end
           @connection = recorder.delegate
-          recorder.commands.each do |cmd, args, block|
-            send(cmd, *args, &block)
-          end
+          recorder.replay(self)
         end
       end
     end

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -345,6 +345,17 @@ module ActiveRecord
           @recorder.inverse_of :remove_foreign_key, [:dogs]
         end
       end
+
+      def test_invert_transaction_with_irreversible_inside_is_irreversible
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.revert do
+            @recorder.transaction do
+              @recorder.execute 'some sql'
+            end
+          end
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
It used to be that commands run inside a `transaction` in a reverted migration ran uninverted, which was counter-intuitive.

To fix this, I had to move the logic of running the recorded commands from Migration into CommandRecorder so as to not duplicate that logic. We could not just postpone execution of the block in a `transaction` until the commands were replayed, since we need to know if there are any irreversible commands inside that transaction before we execute it for real.

Fixes #21484
