### PR TITLE
Require correctly when requiring core_ext

### DIFF
--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -1,3 +1,4 @@
+require 'active_support/deprecation'
 require 'active_support/deprecation/proxy_wrappers'
 
 class LoadError

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -1,3 +1,5 @@
+require 'active_support/dependencies/autoload'
+
 module ActiveSupport
   module NumberHelper
     extend ActiveSupport::Autoload


### PR DESCRIPTION
This is a followup on #22137 

In addition to the described problem the proxy_wrappers.rb has to load deprecation therefore the extra commit. But for backporting in 4.2.5 only e1c7809 has to be cherry-picked.
