### PR TITLE
Fix double word 'string' [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -18,7 +18,7 @@ module ActionDispatch
       #   assert_recognizes({controller: 'items', action: 'create'}, {path: 'items', method: :post})
       #
       # You can also pass in +extras+ with a hash containing URL parameters that would normally be in the query string. This can be used
-      # to assert that values in the query string string will end up in the params hash correctly. To test query strings you must use the
+      # to assert that values in the query string will end up in the params hash correctly. To test query strings you must use the
       # extras argument, appending the query string on the path directly will not work. For example:
       #
       #   # Asserts that a path of '/items/list/1?view=print' returns the correct options


### PR DESCRIPTION
Fixes double word 'string string'.
