### PR TITLE
remove unnecessary `.sass-cache` from plugin's gitignore template

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/gitignore
+++ b/railties/lib/rails/generators/rails/plugin/templates/gitignore
@@ -6,5 +6,4 @@ pkg/
 <%= dummy_path %>/db/*.sqlite3-journal
 <%= dummy_path %>/log/*.log
 <%= dummy_path %>/tmp/
-<%= dummy_path %>/.sass-cache
 <% end -%>


### PR DESCRIPTION
Since the sass cache is output to the `tmp/cache/sass`.
