### PR TITLE
Clarify i18n active[model/record] key differences

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -805,6 +805,8 @@ en:
 
 Then `User.human_attribute_name("gender.female")` will return "Female".
 
+NOTE: If you are using a class which includes `ActiveModel` and does not inherit from `ActiveRecord::Base`, replace `activerecord` with `activemodel` in the above key paths.
+
 #### Error Message Scopes
 
 Active Record validation error messages can also be translated easily. Active Record gives you a couple of namespaces where you can place your message translations in order to provide different messages and translation for certain models, attributes, and/or validations. It also transparently takes single table inheritance into account.


### PR DESCRIPTION
I spent a decent amount of time the other day trying to figure out why my active model including class wasn't generating the properly localized validation messages, and a note like this would have saved me a lot of time.
