### PR TITLE
Fix test_database_created_by_root of mysql

### DIFF
--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -104,7 +104,7 @@ module ActiveRecord
       def test_database_created_by_root
         assert_permissions_granted_for "pat"
         @connection.expects(:create_database).
-          with('my-app-db', :charset => 'utf8', :collation => 'utf8_unicode_ci')
+          with('my-app-db', {})
 
         ActiveRecord::Tasks::DatabaseTasks.create @configuration
       end


### PR DESCRIPTION
`DEFAULT_CHARSET` and `DEFAULT_COLLATION` in `MySQLDatabaseTasks`
was changed by 322068fe85278ea26e26da6dfd7c5612dab15a72.
This test case also should be changed.
