### PR TITLE
Add support for using nested travel method

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,34 @@
+*   Added support for using nested travel methods to use different mock values
+    in nested scopes. Before this change, if you use nested travel methods,
+    Rails will automatically reset all mock values after deepest scope so
+    you can't keep using same mock value in same scope level.
+
+    Old behaviour in example:
+      Time.now.day # => 7
+      travel 1.day do
+        Time.now.day # => 8
+
+        travel 1.day do
+          Time.now.day # => 9
+        end
+
+        Time.now.day # => This will return 7 because all mock values reset
+      end
+
+    New behaviour in example:
+      Time.now.day # => 7
+      travel 1.day do
+        Time.now.day # => 8
+
+        travel 1.day do
+          Time.now.day # => 9
+        end
+
+        Time.now.day # => This will return 8 like first call in this scope
+      end
+
+    *Mehmet Emin İNAÇ*
+
 *  Fix regression in `Hash#dig` for HashWithIndifferentAccess.
    *Jon Moss*
 

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -87,4 +87,36 @@ class TimeTravelTest < ActiveSupport::TestCase
       end
     end
   end
+
+  def test_nested_travel
+    travel 1.day do
+      time_1 = Time.current
+      date_1 = Date.today
+      d_time_1 = DateTime.now
+
+      travel 1.day do
+        time_2 = Time.current
+        date_2 = Date.today
+        d_time_2 = DateTime.now
+
+        travel 1.day do
+          time_3 = Time.current
+          date_3 = Date.today
+          d_time_3 = DateTime.now
+
+          assert_equal time_3, Time.current
+          assert_equal date_3, Date.today
+          assert_equal d_time_3, DateTime.now
+        end
+
+        assert_equal time_2, Time.current
+        assert_equal date_2, Date.today
+        assert_equal d_time_2, DateTime.now
+      end
+
+      assert_equal time_1, Time.current
+      assert_equal date_1, Date.today
+      assert_equal d_time_1, DateTime.now
+    end
+  end
 end


### PR DESCRIPTION
One of my friend saw that while working on an issue about rubygems, it would be great if we can use nested `travel` methods and asked me to implement this.
By this way we can use nested `travel` methods in our tests. For example;

``` ruby
travel 1.day do
  Foo.do_something #This method depends on Time.now and it has mock value lets say A

  travel 1.day do
    Bar.do_another_thing #This method depends on Time.now and it has mock value lets say B
  end

  Zoo.do_yet_another_thing #This method depends on Time.now and it has mock value as A
end
```

In current implementation we can't use nested `travel` methods because when the execution of deepest `travel` method finishes `Time.now` returns back to original `Time.now`.
Lets see this in an example like above;

``` ruby
travel 1.day do
  Foo.do_something #This method depends on Time.now and it has mock value lets say A

  travel 1.day do
    Bar.do_another_thing #This method depends on Time.now and it has mock value lets say B
  end

  Zoo.do_yet_another_thing #This method depends on Time.now and it returns the original Time.now
end
```

As you can see we've expected that `Time.now` will return `A` but it returns original `Time.now`.
