### PR TITLE
added missing instructions for `rack-cors`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb
@@ -1,5 +1,7 @@
-# Avoid CORS issues when API is called from the frontend app
-# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests
+# Be sure to restart your server when you modify this file.
+
+# Avoid CORS issues when API is called from the frontend app.
+# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
 
 # Read more: https://github.com/cyu/rack-cors
 


### PR DESCRIPTION
`config.middleware.insert_before` changes require to restart the server 

Also added missing `.` at the EOL.
