### PR TITLE
Ensure has many through to work even if `table_name` has schema name

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -63,12 +63,14 @@ module ActiveRecord
         key = join_keys.key
         foreign_key = join_keys.foreign_key
 
+        # we should pass only table name to #where
+        table_name = table.name.split(".").last
         value = transform_value(owner[foreign_key])
-        scope = scope.where(table.name => { key => value })
+        scope = scope.where(table_name => { key => value })
 
         if reflection.type
           polymorphic_type = transform_value(owner.class.base_class.name)
-          scope = scope.where(table.name => { reflection.type => polymorphic_type })
+          scope = scope.where(table_name => { reflection.type => polymorphic_type })
         end
 
         scope


### PR DESCRIPTION
This works on Rails 4.2, but 6a7ac40dabf4a8948418c61f307ffe52ddcb48f2
broke.
This commit fix it and add test cases to ensure future regression
will not occur.
