### PR TITLE
Allow singular controller mapping in routes

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Allow `singular: true` to map singular resources to singular controllers.
+    For example,
+
+    ```ruby
+    resource :profile, singular: true
+    ```
+
+    will map to `ProfileController`.
+
+    *Jerome Dalbert*
+
 *   Catch invalid UTF-8 querystring values and respond with BadRequest
 
     Check querystring params for invalid UTF-8 characters, and raise an

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -384,6 +384,7 @@ class ReviewsController < ResourcesController; end
 class AccountsController <  ResourcesController; end
 class AdminController   <  ResourcesController; end
 class ProductsController < ResourcesController; end
+class ProductController < ResourcesController; end
 class ImagesController < ResourcesController; end
 
 module Backoffice

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -1075,6 +1075,16 @@ class ResourcesTest < ActionController::TestCase
     end
   end
 
+  def test_singular_singleton_resource_maps_to_singular_controller
+    with_routing do |set|
+      set.draw do
+        resource :product, singular: true
+      end
+
+      assert_routing '/product', controller: 'product', action: 'show'
+    end
+  end
+
   protected
     def with_restful_routing(*args)
       options = args.extract_options!

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -165,7 +165,7 @@ creates six different routes in your application, all mapping to the `Geocoders`
 | PATCH/PUT | /geocoder      | geocoders#update  | update the one and only geocoder resource     |
 | DELETE    | /geocoder      | geocoders#destroy | delete the geocoder resource                  |
 
-NOTE: Because you might want to use the same controller for a singular route (`/account`) and a plural route (`/accounts/45`), singular resources map to plural controllers. So that, for example, `resource :photo` and `resources :photos` creates both singular and plural routes that map to the same controller (`PhotosController`).
+NOTE: Because you might want to use the same controller for a singular route (`/account`) and a plural route (`/accounts/45`), singular resources map to plural controllers by default. So that, for example, `resource :photo` and `resources :photos` creates both singular and plural routes that map to the same controller (`PhotosController`). If you just want to use a singular controller, add `singular: true` to the resource declaration.
 
 A singular resourceful route generates these helpers:
 


### PR DESCRIPTION
Allow singular REST resources to map to singular controller names with the
`singular: true` option.

Examples:

``` ruby
resource :profile, singular: true # maps to ProfileController

resource :dashboard, singular: true, only: :show # maps to DashboardController

namespace :user
  resource :basic_info, singular: true, only: :show # maps to BasicInfoController
end
```

A more opinionated alternative to this PR is PR #22168. I figured I would post both just in case.
