### PR TITLE
Map singular resources to singular controllers by default

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Map singular resources to singular controllers by default.
+    
+    For example,
+
+    ```ruby
+    resource :profile
+    ```
+
+    will map to `ProfileController`. Adding `plural_controller: true` to the
+    resource declaration will map to `ProfilesController`.
+
+    *Jerome Dalbert*
+
 *   Catch invalid UTF-8 querystring values and respond with BadRequest
 
     Check querystring params for invalid UTF-8 characters, and raise an

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1111,7 +1111,7 @@ module ActionDispatch
         # CANONICAL_ACTIONS holds all actions that does not need a prefix or
         # a path appended since they fit properly in their scope level.
         VALID_ON_OPTIONS  = [:new, :collection, :member]
-        RESOURCE_OPTIONS  = [:as, :controller, :path, :only, :except, :param, :concerns]
+        RESOURCE_OPTIONS  = [:as, :controller, :path, :only, :except, :param, :concerns, :plural_controller]
         CANONICAL_ACTIONS = %w(index create new show update destroy)
 
         class Resource #:nodoc:
@@ -1201,9 +1201,10 @@ module ActionDispatch
 
         class SingletonResource < Resource #:nodoc:
           def initialize(entities, api_only, shallow, options)
+            @plural_controller = options[:plural_controller]
             super
             @as         = nil
-            @controller = (options[:controller] || plural).to_s
+            @controller = (options[:controller] || suffixed_name).to_s
             @as         = options[:as]
           end
 
@@ -1213,6 +1214,10 @@ module ActionDispatch
             else
               [:show, :create, :update, :destroy, :new, :edit]
             end
+          end
+
+          def suffixed_name
+            @plural_controller ? plural : name.to_s
           end
 
           def plural

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -382,8 +382,10 @@ class CommentsController < ResourcesController; end
 class ReviewsController < ResourcesController; end
 
 class AccountsController <  ResourcesController; end
+class ProfileController <  ResourcesController; end
 class AdminController   <  ResourcesController; end
 class ProductsController < ResourcesController; end
+class ProductController < ResourcesController; end
 class ImagesController < ResourcesController; end
 
 module Backoffice

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -513,14 +513,14 @@ class ResourcesTest < ActionController::TestCase
   end
 
   def test_should_create_singleton_resource_routes
-    with_singleton_resources :account do
-      assert_singleton_restful_for :account
+    with_singleton_resources :profile do
+      assert_singleton_restful_for :profile
     end
   end
 
   def test_should_create_multiple_singleton_resource_routes
-    with_singleton_resources :account, :product do
-      assert_singleton_restful_for :account
+    with_singleton_resources :profile, :product do
+      assert_singleton_restful_for :profile
       assert_singleton_restful_for :product
     end
   end
@@ -529,12 +529,12 @@ class ResourcesTest < ActionController::TestCase
     with_routing do |set|
       set.draw do
         resource :admin, :controller => 'admin' do
-          resource :account
+          resource :profile
         end
       end
 
       assert_singleton_restful_for :admin, :controller => 'admin'
-      assert_singleton_restful_for :account, :name_prefix => "admin_", :path_prefix => 'admin/'
+      assert_singleton_restful_for :profile, :name_prefix => "admin_", :path_prefix => 'admin/'
     end
   end
 
@@ -542,18 +542,18 @@ class ResourcesTest < ActionController::TestCase
     [:patch, :put, :post].each do |method|
       with_routing do |set|
         set.draw do
-          resource :account do
+          resource :profile do
             match :reset, :on => :member, :via => method
           end
         end
 
         reset_options = {:action => 'reset'}
-        reset_path    = "/account/reset"
-        assert_singleton_routes_for :account do |options|
+        reset_path    = "/profile/reset"
+        assert_singleton_routes_for :profile do |options|
           assert_recognizes(options.merge(reset_options), :path => reset_path, :method => method)
         end
 
-        assert_singleton_named_routes_for :account do
+        assert_singleton_named_routes_for :profile do
           assert_named_route reset_path, :reset_account_path, reset_options
         end
       end
@@ -564,7 +564,7 @@ class ResourcesTest < ActionController::TestCase
     [:patch, :put, :post].each do |method|
       with_routing do |set|
         set.draw do
-          resource :account do
+          resource :profile do
             match :reset, :on => :member, :via => method
             match :disable, :on => :member, :via => method
           end
@@ -572,13 +572,13 @@ class ResourcesTest < ActionController::TestCase
 
         %w(reset disable).each do |action|
           action_options = {:action => action}
-          action_path    = "/account/#{action}"
-          assert_singleton_routes_for :account do |options|
+          action_path    = "/profile/#{action}"
+          assert_singleton_routes_for :profile do |options|
             assert_recognizes(options.merge(action_options), :path => action_path, :method => method)
           end
 
-          assert_singleton_named_routes_for :account do
-            assert_named_route action_path, "#{action}_account_path".to_sym, action_options
+          assert_singleton_named_routes_for :profile do
+            assert_named_route action_path, "#{action}_profile_path".to_sym, action_options
           end
         end
       end
@@ -588,13 +588,13 @@ class ResourcesTest < ActionController::TestCase
   def test_should_nest_resources_in_singleton_resource
     with_routing do |set|
       set.draw do
-        resource :account do
+        resource :profile do
           resources :messages
         end
       end
 
-      assert_singleton_restful_for :account
-      assert_simply_restful_for :messages, :name_prefix => "account_", :path_prefix => 'account/'
+      assert_singleton_restful_for :profile
+      assert_simply_restful_for :messages, :name_prefix => "profile_", :path_prefix => 'profile/'
     end
   end
 
@@ -602,14 +602,14 @@ class ResourcesTest < ActionController::TestCase
     with_routing do |set|
       set.draw do
         scope ':site_id' do
-          resource(:account) do
+          resource(:profile) do
             resources :messages
           end
         end
       end
 
-      assert_singleton_restful_for :account, :path_prefix => '7/', :options => { :site_id => '7' }
-      assert_simply_restful_for :messages, :name_prefix => "account_", :path_prefix => '7/account/', :options => { :site_id => '7' }
+      assert_singleton_restful_for :profile, :path_prefix => '7/', :options => { :site_id => '7' }
+      assert_simply_restful_for :messages, :name_prefix => "profile_", :path_prefix => '7/profile/', :options => { :site_id => '7' }
     end
   end
 
@@ -668,16 +668,16 @@ class ResourcesTest < ActionController::TestCase
     with_routing do |set|
       set.draw do
         scope '/admin' do
-          resource :account, :as => :admin_account do
+          resource :profile, :as => :admin_profile do
             get :login, :on => :member
             get :preview, :on => :new
           end
         end
       end
-      assert_singleton_restful_for :account, :name_prefix => 'admin_', :path_prefix => 'admin/'
-      assert_named_route "/admin/account/login", "login_admin_account_path", {}
-      assert_named_route "/admin/account/new", "new_admin_account_path", {}
-      assert_named_route "/admin/account/new/preview", "preview_new_admin_account_path", {}
+      assert_singleton_restful_for :profile, :name_prefix => 'admin_', :path_prefix => 'admin/'
+      assert_named_route "/admin/profile/login", "login_admin_profile_path", {}
+      assert_named_route "/admin/profile/new", "new_admin_profile_path", {}
+      assert_named_route "/admin/profile/new/preview", "preview_new_admin_profile_path", {}
     end
   end
 
@@ -808,11 +808,11 @@ class ResourcesTest < ActionController::TestCase
   def test_singleton_resource_has_only_show_action
     with_routing do |set|
       set.draw do
-        resource :account, :only => :show
+        resource :profile, :only => :show
       end
 
-      assert_singleton_resource_allowed_routes('accounts', {},                    :show, [:index, :new, :create, :edit, :update, :destroy])
-      assert_singleton_resource_allowed_routes('accounts', { :format => 'xml' },  :show, [:index, :new, :create, :edit, :update, :destroy])
+      assert_singleton_resource_allowed_routes('profile', {},                    :show, [:index, :new, :create, :edit, :update, :destroy])
+      assert_singleton_resource_allowed_routes('profile', { :format => 'xml' },  :show, [:index, :new, :create, :edit, :update, :destroy])
     end
   end
 
@@ -830,11 +830,11 @@ class ResourcesTest < ActionController::TestCase
   def test_singleton_resource_does_not_have_destroy_action
     with_routing do |set|
       set.draw do
-        resource :account, :except => :destroy
+        resource :profile, :except => :destroy
       end
 
-      assert_singleton_resource_allowed_routes('accounts', {},                    [:new, :create, :show, :edit, :update], :destroy)
-      assert_singleton_resource_allowed_routes('accounts', { :format => 'xml' },  [:new, :create, :show, :edit, :update], :destroy)
+      assert_singleton_resource_allowed_routes('profile', {},                    [:new, :create, :show, :edit, :update], :destroy)
+      assert_singleton_resource_allowed_routes('profile', { :format => 'xml' },  [:new, :create, :show, :edit, :update], :destroy)
     end
   end
 
@@ -880,39 +880,39 @@ class ResourcesTest < ActionController::TestCase
   def test_singleton_resource_has_only_create_action_and_named_route
     with_routing do |set|
       set.draw do
-        resource :account, :only => :create
+        resource :profile, :only => :create
       end
 
-      assert_singleton_resource_allowed_routes('accounts', {},                    :create, [:new, :show, :edit, :update, :destroy])
-      assert_singleton_resource_allowed_routes('accounts', { :format => 'xml' },  :create, [:new, :show, :edit, :update, :destroy])
+      assert_singleton_resource_allowed_routes('profile', {},                    :create, [:new, :show, :edit, :update, :destroy])
+      assert_singleton_resource_allowed_routes('profile', { :format => 'xml' },  :create, [:new, :show, :edit, :update, :destroy])
 
-      assert_not_nil set.named_routes[:account]
+      assert_not_nil set.named_routes[:profile]
     end
   end
 
   def test_singleton_resource_has_only_update_action_and_named_route
     with_routing do |set|
       set.draw do
-        resource :account, :only => :update
+        resource :profile, :only => :update
       end
 
-      assert_singleton_resource_allowed_routes('accounts', {},                    :update, [:new, :create, :show, :edit, :destroy])
-      assert_singleton_resource_allowed_routes('accounts', { :format => 'xml' },  :update, [:new, :create, :show, :edit, :destroy])
+      assert_singleton_resource_allowed_routes('profile', {},                    :update, [:new, :create, :show, :edit, :destroy])
+      assert_singleton_resource_allowed_routes('profile', { :format => 'xml' },  :update, [:new, :create, :show, :edit, :destroy])
 
-      assert_not_nil set.named_routes[:account]
+      assert_not_nil set.named_routes[:profile]
     end
   end
 
   def test_singleton_resource_has_only_destroy_action_and_named_route
     with_routing do |set|
       set.draw do
-        resource :account, :only => :destroy
+        resource :profile, :only => :destroy
       end
 
-      assert_singleton_resource_allowed_routes('accounts', {},                    :destroy, [:new, :create, :show, :edit, :update])
-      assert_singleton_resource_allowed_routes('accounts', { :format => 'xml' },  :destroy, [:new, :create, :show, :edit, :update])
+      assert_singleton_resource_allowed_routes('profile', {},                    :destroy, [:new, :create, :show, :edit, :update])
+      assert_singleton_resource_allowed_routes('profile', { :format => 'xml' },  :destroy, [:new, :create, :show, :edit, :update])
 
-      assert_not_nil set.named_routes[:account]
+      assert_not_nil set.named_routes[:profile]
     end
   end
 
@@ -951,18 +951,18 @@ class ResourcesTest < ActionController::TestCase
   def test_singleton_resource_has_only_member_action
     with_routing do |set|
       set.draw do
-        resource :account, :only => [] do
+        resource :profile, :only => [] do
           member do
             get :signup
           end
         end
       end
 
-      assert_singleton_resource_allowed_routes('accounts', {},                    [], [:new, :create, :show, :edit, :update, :destroy])
-      assert_singleton_resource_allowed_routes('accounts', { :format => 'xml' },  [], [:new, :create, :show, :edit, :update, :destroy])
+      assert_singleton_resource_allowed_routes('profile', {},                    [], [:new, :create, :show, :edit, :update, :destroy])
+      assert_singleton_resource_allowed_routes('profile', { :format => 'xml' },  [], [:new, :create, :show, :edit, :update, :destroy])
 
-      assert_recognizes({ :controller => 'accounts', :action => 'signup' },                   :path => 'account/signup',      :method => :get)
-      assert_recognizes({ :controller => 'accounts', :action => 'signup', :format => 'xml' }, :path => 'account/signup.xml',  :method => :get)
+      assert_recognizes({ :controller => 'profile', :action => 'signup' },                   :path => 'profile/signup',      :method => :get)
+      assert_recognizes({ :controller => 'profile', :action => 'signup', :format => 'xml' }, :path => 'profile/signup.xml',  :method => :get)
     end
   end
 
@@ -1042,7 +1042,7 @@ class ResourcesTest < ActionController::TestCase
         resource :product
       end
 
-      assert_routing '/product', :controller => 'products', :action => 'show'
+      assert_routing '/product', :controller => 'product', :action => 'show'
       assert set.recognize_path("/product", :method => :get)
     end
   end
@@ -1072,6 +1072,16 @@ class ResourcesTest < ActionController::TestCase
   def test_singleton_resource_name_is_not_singularized
     with_singleton_resources(:products) do
       assert_singleton_restful_for :products
+    end
+  end
+
+  def test_singleton_resource_with_plural_option_maps_to_plural_controller
+    with_routing do |set|
+      set.draw do
+        resource :product, plural_controller: true
+      end
+
+      assert_routing '/product', controller: 'products', action: 'show'
     end
   end
 
@@ -1238,7 +1248,7 @@ class ResourcesTest < ActionController::TestCase
 
     def assert_singleton_routes_for(singleton_name, options = {})
       route_options = (options[:options] ||= {}).dup
-      route_options[:controller] = options[:controller] || singleton_name.to_s.pluralize
+      route_options[:controller] = options[:controller] || singleton_name.to_s
 
       full_path           = "/#{options[:path_prefix]}#{options[:as] || singleton_name}"
       new_path            = "#{full_path}/new"
@@ -1273,7 +1283,7 @@ class ResourcesTest < ActionController::TestCase
 
     def assert_singleton_named_routes_for(singleton_name, options = {})
       route_options = (options[:options] ||= {}).dup
-      controller_name = route_options[:controller] || options[:controller] || singleton_name.to_s.pluralize
+      controller_name = route_options[:controller] || options[:controller] || singleton_name.to_s
       @controller = "#{controller_name.camelize}Controller".constantize.new
       @controller.singleton_class.include(@routes.url_helpers)
       get :show, params: route_options

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -141,28 +141,28 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     get '/session'
-    assert_equal 'sessions#create', @response.body
+    assert_equal 'session#create', @response.body
     assert_equal '/session', session_path
 
     post '/session'
-    assert_equal 'sessions#create', @response.body
+    assert_equal 'session#create', @response.body
 
     put '/session'
-    assert_equal 'sessions#update', @response.body
+    assert_equal 'session#update', @response.body
 
     delete '/session'
-    assert_equal 'sessions#destroy', @response.body
+    assert_equal 'session#destroy', @response.body
 
     get '/session/new'
-    assert_equal 'sessions#new', @response.body
+    assert_equal 'session#new', @response.body
     assert_equal '/session/new', new_session_path
 
     get '/session/edit'
-    assert_equal 'sessions#edit', @response.body
+    assert_equal 'session#edit', @response.body
     assert_equal '/session/edit', edit_session_path
 
     post '/session/reset'
-    assert_equal 'sessions#reset', @response.body
+    assert_equal 'session#reset', @response.body
     assert_equal '/session/reset', reset_session_path
   end
 
@@ -181,20 +181,20 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     get '/session'
-    assert_equal 'sessions#create', @response.body
+    assert_equal 'session#create', @response.body
     assert_equal '/session', session_path
 
     post '/session'
-    assert_equal 'sessions#create', @response.body
+    assert_equal 'session#create', @response.body
 
     put '/session'
-    assert_equal 'sessions#update', @response.body
+    assert_equal 'session#update', @response.body
 
     delete '/session'
-    assert_equal 'sessions#destroy', @response.body
+    assert_equal 'session#destroy', @response.body
 
     post '/session/reset'
-    assert_equal 'sessions#reset', @response.body
+    assert_equal 'session#reset', @response.body
     assert_equal '/session/reset', reset_session_path
 
     get '/session/new'
@@ -212,7 +212,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     get '/session/info'
-    assert_equal 'infos#show', @response.body
+    assert_equal 'info#show', @response.body
     assert_equal '/session/info', session_info_path
   end
 
@@ -226,7 +226,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     get '/session/crush'
-    assert_equal 'sessions#crush', @response.body
+    assert_equal 'session#crush', @response.body
     assert_equal '/session/crush', crush_session_path
   end
 
@@ -688,15 +688,15 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     get '/projects/1/manager'
-    assert_equal 'managers#show', @response.body
+    assert_equal 'manager#show', @response.body
     assert_equal '/projects/1/manager', project_super_manager_path(:project_id => '1')
 
     get '/projects/1/manager/new'
-    assert_equal 'managers#new', @response.body
+    assert_equal 'manager#new', @response.body
     assert_equal '/projects/1/manager/new', new_project_super_manager_path(:project_id => '1')
 
     post '/projects/1/manager/fire'
-    assert_equal 'managers#fire', @response.body
+    assert_equal 'manager#fire', @response.body
     assert_equal '/projects/1/manager/fire', fire_project_super_manager_path(:project_id => '1')
   end
 
@@ -749,7 +749,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/projects/1/people/1', project_person_path(:project_id => '1', :id => '1')
 
     get '/projects/1/people/1/7a2dec8/avatar'
-    assert_equal 'avatars#show', @response.body
+    assert_equal 'avatar#show', @response.body
     assert_equal '/projects/1/people/1/7a2dec8/avatar', project_person_avatar_path(:project_id => '1', :person_id => '1', :access_token => '7a2dec8')
 
     put '/projects/1/people/1/accessible_projects'
@@ -812,7 +812,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/projects/1/posts/1/preview', preview_project_post_path(:project_id => '1', :id => '1')
 
     get '/projects/1/posts/1/subscription'
-    assert_equal 'subscriptions#show', @response.body
+    assert_equal 'subscription#show', @response.body
     assert_equal '/projects/1/posts/1/subscription', project_post_subscription_path(:project_id => '1', :post_id => '1')
 
     get '/projects/1/posts/1/comments'
@@ -878,19 +878,19 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     delete '/past'
-    assert_equal 'pasts#destroy', @response.body
+    assert_equal 'past#destroy', @response.body
     assert_equal '/past', past_path
 
     patch '/present'
-    assert_equal 'presents#update', @response.body
+    assert_equal 'present#update', @response.body
     assert_equal '/present', present_path
 
     put '/present'
-    assert_equal 'presents#update', @response.body
+    assert_equal 'present#update', @response.body
     assert_equal '/present', present_path
 
     post '/future'
-    assert_equal 'futures#create', @response.body
+    assert_equal 'future#create', @response.body
     assert_equal '/future', future_path
   end
 
@@ -972,15 +972,15 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/pt/projetos/1/editar', edit_pt_project_path(1)
 
     get '/pt/administrador'
-    assert_equal 'admins#show', @response.body
+    assert_equal 'admin#show', @response.body
     assert_equal '/pt/administrador', pt_admin_path
 
     get '/pt/administrador/novo'
-    assert_equal 'admins#new', @response.body
+    assert_equal 'admin#new', @response.body
     assert_equal '/pt/administrador/novo', new_pt_admin_path
 
     put '/pt/administrador/ativar'
-    assert_equal 'admins#activate', @response.body
+    assert_equal 'admin#activate', @response.body
     assert_equal '/pt/administrador/ativar', activate_pt_admin_path
   end
 
@@ -1079,15 +1079,15 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     get '/account/subscription'
-    assert_equal 'account/subscriptions#show', @response.body
+    assert_equal 'account/subscription#show', @response.body
     assert_equal '/account/subscription', account_subscription_path
 
     get '/account/credit'
-    assert_equal 'account/credits#show', @response.body
+    assert_equal 'account/credit#show', @response.body
     assert_equal '/account/credit', account_credit_path
 
     get '/account/credit_card'
-    assert_equal 'account/credit_cards#show', @response.body
+    assert_equal 'account/credit_card#show', @response.body
     assert_equal '/account/credit_card', account_credit_card_path
   end
 
@@ -1101,7 +1101,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     get '/account/admin/subscription'
-    assert_equal 'account/admin/subscriptions#show', @response.body
+    assert_equal 'account/admin/subscription#show', @response.body
     assert_equal '/account/admin/subscription', account_admin_subscription_path
   end
 
@@ -1120,11 +1120,11 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
     get '/clients/1/google/account'
     assert_equal '/clients/1/google/account', client_google_account_path(1)
-    assert_equal 'google/accounts#show', @response.body
+    assert_equal 'google/account#show', @response.body
 
     get '/clients/1/google/account/secret/info'
     assert_equal '/clients/1/google/account/secret/info', client_google_account_secret_info_path(1)
-    assert_equal 'google/secret/infos#show', @response.body
+    assert_equal 'google/secret/info#show', @response.body
   end
 
   def test_namespace_with_options
@@ -1395,7 +1395,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
     get "/user"
     assert_response :success
-    assert_equal "users#show", @response.body
+    assert_equal "user#show", @response.body
     assert_equal "/user", user_path
 
     get "/user.html"
@@ -1769,7 +1769,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     get '/dashboard', headers: { 'REMOTE_ADDR' => '10.0.0.100' }
     assert_equal 'pass', @response.headers['X-Cascade']
     get '/dashboard', headers: { 'REMOTE_ADDR' => '192.168.1.100' }
-    assert_equal 'dashboards#show', @response.body
+    assert_equal 'dashboard#show', @response.body
   end
 
   def test_root_works_in_the_resources_scope
@@ -1790,7 +1790,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     get '/token'
-    assert_equal 'api/tokens#show', @response.body
+    assert_equal 'api/token#show', @response.body
     assert_equal '/token', token_path
   end
 
@@ -1798,16 +1798,16 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     draw do
       scope :path => 'api' do
         resource :me
-        get '/' => 'mes#index'
+        get '/' => 'me#index'
       end
     end
 
     get '/api/me'
-    assert_equal 'mes#show', @response.body
+    assert_equal 'me#show', @response.body
     assert_equal '/api/me', me_path
 
     get '/api'
-    assert_equal 'mes#index', @response.body
+    assert_equal 'me#index', @response.body
   end
 
   def test_symbol_scope
@@ -1815,7 +1815,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       scope :path => 'api' do
         scope :v2 do
           resource :me, as: 'v2_me'
-          get '/' => 'mes#index'
+          get '/' => 'me#index'
         end
 
         scope :v3, :admin do
@@ -1825,14 +1825,14 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     get '/api/v2/me'
-    assert_equal 'mes#show', @response.body
+    assert_equal 'me#show', @response.body
     assert_equal '/api/v2/me', v2_me_path
 
     get '/api/v2'
-    assert_equal 'mes#index', @response.body
+    assert_equal 'me#index', @response.body
 
     get '/api/v3/admin/me'
-    assert_equal 'mes#show', @response.body
+    assert_equal 'me#show', @response.body
   end
 
   def test_url_generator_for_generic_route
@@ -1909,13 +1909,13 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal 'projects#preview', @response.body
 
     post '/pt/administrador/novo/preview'
-    assert_equal 'admins#preview', @response.body
+    assert_equal 'admin#preview', @response.body
 
     post '/pt/products/novo/preview'
     assert_equal 'products#preview', @response.body
 
     post '/profile/new/preview'
-    assert_equal 'profiles#preview', @response.body
+    assert_equal 'profile#preview', @response.body
   end
 
   def test_resource_merges_options_from_scope
@@ -2007,15 +2007,15 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/api/players/2/edit', edit_api_player_path(:id => '2')
 
     get '/api/teams/1/captain'
-    assert_equal 'api/captains#show', @response.body
+    assert_equal 'api/captain#show', @response.body
     assert_equal '/api/teams/1/captain', api_team_captain_path(:team_id => '1')
 
     get '/api/teams/1/captain/new'
-    assert_equal 'api/captains#new', @response.body
+    assert_equal 'api/captain#new', @response.body
     assert_equal '/api/teams/1/captain/new', new_api_team_captain_path(:team_id => '1')
 
     get '/api/teams/1/captain/edit'
-    assert_equal 'api/captains#edit', @response.body
+    assert_equal 'api/captain#edit', @response.body
     assert_equal '/api/teams/1/captain/edit', edit_api_team_captain_path(:team_id => '1')
 
     get '/threads'
@@ -2035,7 +2035,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/threads/1/edit', edit_thread_path(:id => '1')
 
     get '/threads/1/owner'
-    assert_equal 'owners#show', @response.body
+    assert_equal 'owner#show', @response.body
     assert_equal '/threads/1/owner', thread_owner_path(:thread_id => '1')
 
     get '/threads/1/messages'
@@ -2279,7 +2279,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
         get "secret/profile" => "customers#secret", :on => :member
         post "preview" => "customers#preview", :as => :another_preview, :on => :new
         resource :avatar do
-          get "thumbnail" => "avatars#thumbnail", :as => :thumbnail, :on => :member
+          get "thumbnail" => "avatar#thumbnail", :as => :thumbnail, :on => :member
         end
         resources :invoices do
           get "outstanding" => "invoices#outstanding", :on => :collection
@@ -2534,7 +2534,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_raises(ActionController::UrlGenerationError){ movie_path(:movie_id => '00001', :id => '00001') }
 
     get '/movies/0001/trailer'
-    assert_equal 'trailers#show', @response.body
+    assert_equal 'trailer#show', @response.body
     assert_equal '/movies/0001/trailer', movie_trailer_path(:movie_id => '0001')
 
     get '/movies/00001/trailer'
@@ -2571,7 +2571,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_raise(NoMethodError) { edit_only_club_player_path(:club_id => '1', :id => '2') }
 
     get '/only/clubs/1/chairman'
-    assert_equal 'only/chairmen#show', @response.body
+    assert_equal 'only/chairman#show', @response.body
     assert_equal '/only/clubs/1/chairman', only_club_chairman_path(:club_id => '1')
 
     get '/only/clubs/1/chairman/edit'
@@ -2608,7 +2608,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_raise(NoMethodError) { edit_except_club_player_path(:club_id => '1', :id => '2') }
 
     get '/except/clubs/1/chairman'
-    assert_equal 'except/chairmen#show', @response.body
+    assert_equal 'except/chairman#show', @response.body
     assert_equal '/except/clubs/1/chairman', except_club_chairman_path(:club_id => '1')
 
     get '/except/clubs/1/chairman/edit'
@@ -2651,7 +2651,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/only/sectors/1/companies/2', only_sector_company_path(:sector_id => '1', :id => '2')
 
     get '/only/sectors/1/leader'
-    assert_equal 'only/leaders#show', @response.body
+    assert_equal 'only/leader#show', @response.body
     assert_equal '/only/sectors/1/leader', only_sector_leader_path(:sector_id => '1')
   end
 
@@ -2690,7 +2690,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/except/sectors/1/companies/2', except_sector_company_path(:sector_id => '1', :id => '2')
 
     get '/except/sectors/1/leader'
-    assert_equal 'except/leaders#show', @response.body
+    assert_equal 'except/leader#show', @response.body
     assert_equal '/except/sectors/1/leader', except_sector_leader_path(:sector_id => '1')
   end
 
@@ -2945,7 +2945,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal '/pages/Ruby_on_Rails', wiki_page_path(:id => 'Ruby_on_Rails')
 
     get '/my_account'
-    assert_equal 'wiki_accounts#show', @response.body
+    assert_equal 'wiki_account#show', @response.body
     assert_equal '/my_account', wiki_account_path
   end
 

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -154,18 +154,18 @@ This resourceful route:
 resource :geocoder
 ```
 
-creates six different routes in your application, all mapping to the `Geocoders` controller:
+creates six different routes in your application, all mapping to the `Geocoder` controller:
 
 | HTTP Verb | Path           | Controller#Action | Used for                                      |
 | --------- | -------------- | ----------------- | --------------------------------------------- |
-| GET       | /geocoder/new  | geocoders#new     | return an HTML form for creating the geocoder |
-| POST      | /geocoder      | geocoders#create  | create the new geocoder                       |
-| GET       | /geocoder      | geocoders#show    | display the one and only geocoder resource    |
-| GET       | /geocoder/edit | geocoders#edit    | return an HTML form for editing the geocoder  |
-| PATCH/PUT | /geocoder      | geocoders#update  | update the one and only geocoder resource     |
-| DELETE    | /geocoder      | geocoders#destroy | delete the geocoder resource                  |
+| GET       | /geocoder/new  | geocoder#new     | return an HTML form for creating the geocoder |
+| POST      | /geocoder      | geocoder#create  | create the new geocoder                       |
+| GET       | /geocoder      | geocoder#show    | display the one and only geocoder resource    |
+| GET       | /geocoder/edit | geocoder#edit    | return an HTML form for editing the geocoder  |
+| PATCH/PUT | /geocoder      | geocoder#update  | update the one and only geocoder resource     |
+| DELETE    | /geocoder      | geocoder#destroy | delete the geocoder resource                  |
 
-NOTE: Because you might want to use the same controller for a singular route (`/account`) and a plural route (`/accounts/45`), singular resources map to plural controllers. So that, for example, `resource :photo` and `resources :photos` creates both singular and plural routes that map to the same controller (`PhotosController`).
+TIP: If you want to use the same controller for a singular route (`/account`) and a plural route (`/accounts/45`), use the `plural_controller: true` option to map both routes to `AccountsController`.
 
 A singular resourceful route generates these helpers:
 


### PR DESCRIPTION
Make singular resources map to singular controller names by default.

Examples:

``` ruby
resource :profile # maps to ProfileController

resource :profile, plural_controller: true # maps to ProfilesController (old behavior)
```

A less opinionated alternative to this PR is PR #22167. I figured I would post both just in case.
