### PR TITLE
Add enabled flag to the public file server settings.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -17,11 +17,6 @@
 
     *Agis Anastasopoulos*
 
-*   Deprecate `config.static_cache_control` in favor of
-    `config.public_file_server.headers`
-
-    *Yuki Nishijima*
-
 *   Add the ability of returning arbitrary headers to ActionDispatch::Static
 
     Now ActionDispatch::Static can accept HTTP headers so that developers

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,7 +1,26 @@
+*   Deprecate `serve_static_files` in favor of `public_file_server.enabled`.
+
+    Unifies the static asset options under `public_file_server`.
+
+    To upgrade, replace occurrences of:
+
+    ```
+    config.serve_static_files = # false or true
+    ```
+
+    in your environment files, with:
+
+    ```
+    config.public_file_server.enabled = # false or true
+    ```
+
+    *Kasper Timm Hansen*
+
 *   Route generator should be idempotent
     running generators several times no longer require you to cleanup routes.rb
 
     *Thiago Pinto*
+
 *   Allow passing an environment to `config_for`.
 
     *Simon Eskildsen*

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -16,6 +16,28 @@
 
     *Kasper Timm Hansen*
 
+*   Deprecate `config.static_cache_control` in favor of
+    `config.public_file_server.headers`.
+
+    To upgrade, replace occurrences of:
+
+    ```
+    config.static_cache_control = 'public, max-age=60'
+    ```
+
+    in your environment files, with:
+
+    ```
+    config.public_file_server.headers = {
+      'Cache-Control' => 'public, max-age=60'
+    }
+    ```
+
+    `config.public_file_server.headers` can set arbitrary headers, sent along when
+    a response is delivered.
+
+    *Yuki Nishijima*
+
 *   Route generator should be idempotent
     running generators several times no longer require you to cleanup routes.rb
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -3,6 +3,9 @@ require 'active_support/file_update_checker'
 require 'rails/engine/configuration'
 require 'rails/source_annotation_extractor'
 
+require 'active_support/deprecation'
+require 'active_support/core_ext/string/strip' # for strip_heredoc
+
 module Rails
   class Application
     class Configuration < ::Rails::Engine::Configuration
@@ -11,7 +14,7 @@ module Rails
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters,
                     :force_ssl, :helpers_paths, :logger, :log_formatter, :log_tags,
                     :railties_order, :relative_url_root, :secret_key_base, :secret_token,
-                    :serve_static_files, :ssl_options, :static_index, :public_file_server,
+                    :ssl_options, :static_index, :public_file_server,
                     :session_options, :time_zone, :reload_classes_only_on_change,
                     :beginning_of_week, :filter_redirect, :x
 
@@ -26,9 +29,9 @@ module Rails
         @filter_parameters             = []
         @filter_redirect               = []
         @helpers_paths                 = []
-        @serve_static_files            = true
         @static_index                  = "index"
         @public_file_server            = ActiveSupport::OrderedOptions.new
+        @public_file_server.enabled    = true
         @force_ssl                     = false
         @ssl_options                   = {}
         @session_store                 = :cookie_store
@@ -58,6 +61,24 @@ module Rails
                                         "instead.")
 
         @static_cache_control = value
+      end
+
+      def serve_static_files
+        ActiveSupport::Deprecation.warn <<-eow.strip_heredoc
+          `serve_static_files` is deprecated and will be removed in Rails 5.1.
+          Please use `public_file_server.enabled` instead.
+        eow
+
+        @public_file_server.enabled
+      end
+
+      def serve_static_files=(value)
+        ActiveSupport::Deprecation.warn <<-eow.strip_heredoc
+          `serve_static_files` is deprecated and will be removed in Rails 5.1.
+          Please use `public_file_server.enabled = #{value}` instead.
+        eow
+
+        @public_file_server.enabled = value
       end
 
       def encoding=(value)

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -17,7 +17,7 @@ module Rails
 
           middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header
 
-          if config.serve_static_files
+          if config.public_file_server.enabled
             headers = config.public_file_server.headers || {}
             headers['Cache-Control'.freeze] = config.static_cache_control if config.static_cache_control
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -16,7 +16,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   <%- unless options.skip_sprockets? -%>
   # Compress JavaScripts and CSS.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -12,8 +12,8 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
 
-  # Configure static file server for tests with Cache-Control for performance.
-  config.serve_static_files         = true
+  # Configure public file server for tests with Cache-Control for performance.
+  config.public_file_server.enabled = true
   config.public_file_server.headers = {
     'Cache-Control' => 'public, max-age=3600'
   }

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -308,34 +308,44 @@ module ApplicationTests
       assert_equal Pathname.new(app_path).join("somewhere"), Rails.public_path
     end
 
-    test "In production mode, config.serve_static_files is off by default" do
+    test "In production mode, config.public_file_server.enabled is off by default" do
       restore_default_config
 
       with_rails_env "production" do
         app 'production'
-        assert_not app.config.serve_static_files
+        assert_not app.config.public_file_server.enabled
       end
     end
 
-    test "In production mode, config.serve_static_files is enabled when RAILS_SERVE_STATIC_FILES is set" do
+    test "In production mode, config.public_file_server.enabled is enabled when RAILS_SERVE_STATIC_FILES is set" do
       restore_default_config
 
       with_rails_env "production" do
         switch_env "RAILS_SERVE_STATIC_FILES", "1" do
           app 'production'
-          assert app.config.serve_static_files
+          assert app.config.public_file_server.enabled
         end
       end
     end
 
-    test "In production mode, config.serve_static_files is disabled when RAILS_SERVE_STATIC_FILES is blank" do
+    test "In production mode, config.public_file_server.enabled is disabled when RAILS_SERVE_STATIC_FILES is blank" do
       restore_default_config
 
       with_rails_env "production" do
         switch_env "RAILS_SERVE_STATIC_FILES", " " do
           app 'production'
-          assert_not app.config.serve_static_files
+          assert_not app.config.public_file_server.enabled
         end
+      end
+    end
+
+    test "config.serve_static_files is deprecated" do
+      make_basic_app do |application|
+        assert_deprecated do
+          application.config.serve_static_files = true
+        end
+
+        assert application.config.public_file_server.enabled
       end
     end
 


### PR DESCRIPTION
As discussed in https://github.com/rails/rails/pull/19135#issuecomment-153385986.

Replaces `serve_static_files` to unify the static options under the `public_file_server` wing.

Deprecates `serve_static_files` accessors, but make them use the newer config internally.
