### PR TITLE
Update docs/comments to use setup/teardown blocks vs. methods.

### DIFF
--- a/activesupport/lib/active_support/log_subscriber/test_helper.rb
+++ b/activesupport/lib/active_support/log_subscriber/test_helper.rb
@@ -11,7 +11,6 @@ module ActiveSupport
     #     include ActiveSupport::LogSubscriber::TestHelper
     #
     #     setup do
-    #       super
     #       ActiveRecord::LogSubscriber.attach_to(:active_record)
     #     end
     #

--- a/activesupport/lib/active_support/log_subscriber/test_helper.rb
+++ b/activesupport/lib/active_support/log_subscriber/test_helper.rb
@@ -10,7 +10,7 @@ module ActiveSupport
     #   class SyncLogSubscriberTest < ActiveSupport::TestCase
     #     include ActiveSupport::LogSubscriber::TestHelper
     #
-    #     def setup
+    #     setup do
     #       super
     #       ActiveRecord::LogSubscriber.attach_to(:active_record)
     #     end

--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -8,10 +8,10 @@ classes. Active Model allows for Action Pack helpers to interact with
 plain Ruby objects. Active Model also helps build custom ORMs for use
 outside of the Rails framework.
 
-After reading this guide, you will know: 
+After reading this guide, you will know:
 
 * How an Active Record model behaves.
-* How Callbacks and validations work. 
+* How Callbacks and validations work.
 * How serializers work.
 * The Rails internationalization (i18n) framework.
 
@@ -428,7 +428,7 @@ the Active Model API.
     class PersonTest < ActiveSupport::TestCase
       include ActiveModel::Lint::Tests
 
-      def setup
+      setup do
         @model = Person.new
       end
     end

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -908,12 +908,12 @@ require 'test_helper'
 
 class ArticlesControllerTest < ActionController::TestCase
   # called before every single test
-  def setup
+  setup do
     @article = articles(:one)
   end
 
   # called after every single test
-  def teardown
+  teardown do
     # when controller is using cache it may be a good idea to reset it afterwards
     Rails.cache.clear
   end


### PR DESCRIPTION
As discussed in the minitest-spec-rails issue (http://git.io/vlHxx) Rails uses setup/teardown callbacks. Defining `setup` or `teardown` methods vs. blocks will yield inconsistent behavior in the callback chain.
