### PR TITLE
Do not merge already merged joins [22022 fix]

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -122,9 +122,21 @@ module ActiveRecord
           join_dependency = ActiveRecord::Associations::JoinDependency.new(other.klass,
                                                                            joins_dependency,
                                                                            [])
-          relation.joins! rest
 
-          @relation = relation.joins join_dependency
+          unless join_already_merged?(join_dependency)
+            relation.joins! rest
+            @relation = relation.joins join_dependency
+          end
+        end
+      end
+
+      def join_already_merged?(to_merge)
+        relation.joins_values.select do |joins_value|
+          joins_value.is_a? ActiveRecord::Associations::JoinDependency
+        end.each do |merged|
+          if merged.tree == to_merge.tree && merged.base == to_merge.tree && merged.joins.empty?
+            return true
+          end
         end
       end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -203,6 +203,14 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal Topic.order(:id).to_sql, Topic.order(:id => :asc).to_sql
   end
 
+  def test_repeated_merge_does_not_generate_duplicated_sql
+    relation = Post.joins(:comments)
+    relation_to_merge = Comment.joins(:post)
+    single_merge = relation.merge(relation_to_merge)
+    double_merge = relation.merge(relation_to_merge).merge(relation_to_merge)
+    assert_equal single_merge.to_sql, double_merge.to_sql
+  end
+
   def test_finding_with_desc_order_with_string
     topics = Topic.order(id: "desc")
     assert_equal 5, topics.to_a.size


### PR DESCRIPTION
Hi!
I would like to start contributing to Rails. I thought this [issue](https://github.com/rails/rails/issues/22022) could be a good start.

I was looking at `ActiveRecord::Relation::Merger` code, especially [`#merge_joins`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation/merger.rb#L107-L129) method. I realised that if you merge the same relation more than once, sql is simply duplicated (see [test](https://github.com/rails/rails/commit/550bfb88e201af6403c88e264d1b44d33c23a7f6)).
Probably there are few solutions to this problem. One of them would be not to merge relation if it's already merged. I've tried this approach. I would love to hear if a) it's a good approach at all, and b) if I identified problem correctly.

PS. Please show mercy, it's my first time :)
