### PR TITLE
Don’t allow arbitrary data in back urls

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Restrict `url_for :back` to valid, non-JavaScript URLs. GH#14444
+
+    *Damien Burke*
+
 *   Allow `date_select` helper selected option to accept hash like the default options.
 
     *Lecky Lao*

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -41,10 +41,20 @@ module ActionView
       end
 
       def _back_url # :nodoc:
-        referrer = controller.respond_to?(:request) && controller.request.env["HTTP_REFERER"]
-        referrer || 'javascript:history.back()'
+        _filtered_referrer || 'javascript:history.back()'
       end
       protected :_back_url
+
+      def _filtered_referrer # :nodoc:
+        if controller.respond_to?(:request)
+          referrer = controller.request.env["HTTP_REFERER"]
+          if referrer && URI(referrer).scheme != 'javascript'
+            referrer
+          end
+        end
+      rescue URI::InvalidURIError
+      end
+      protected :_filtered_referrer
 
       # Creates an anchor element of the given +name+ using a URL created by the set of +options+.
       # See the valid options in the documentation for +url_for+. It's also possible to

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -50,6 +50,23 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_equal 'javascript:history.back()', url_for(:back)
   end
 
+  def test_url_for_with_back_and_no_controller
+    @controller = nil
+    assert_equal 'javascript:history.back()', url_for(:back)
+  end
+
+  def test_url_for_with_back_and_javascript_referer
+    referer = 'javascript:alert(document.cookie)'
+    @controller = Struct.new(:request).new(Struct.new(:env).new("HTTP_REFERER" => referer))
+    assert_equal 'javascript:history.back()', url_for(:back)
+  end
+
+  def test_url_for_with_invalid_referer
+    referer = 'THIS IS NOT A URL'
+    @controller = Struct.new(:request).new(Struct.new(:env).new("HTTP_REFERER" => referer))
+    assert_equal 'javascript:history.back()', url_for(:back)
+  end
+
   def test_button_to_with_straight_url
     assert_dom_equal %{<form method="post" action="http://www.example.com" class="button_to"><input type="submit" value="Hello" /></form>}, button_to("Hello", "http://www.example.com")
   end


### PR DESCRIPTION
`link_to :back` creates a link to whatever was
passed in via the referer header. If an attacker
can alter the referer header, that would create
a cross-site scripting vulnerability on every
page that uses `link_to :back`

This commit restricts the back URL to valid
non-javascript URLs.

https://github.com/rails/rails/issues/14444
