### PR TITLE
Require only necessary concurrent-ruby classes.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ PATH
       activesupport (= 5.0.0.alpha)
       arel (= 7.0.0.alpha)
     activesupport (5.0.0.alpha)
-      concurrent-ruby (~> 1.0.0.pre3, < 2.0.0)
+      concurrent-ruby (~> 1.0.0.pre5, < 2.0.0)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       method_source
@@ -201,7 +201,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
-    concurrent-ruby (1.0.0.pre4)
+    concurrent-ruby (1.0.0.pre5)
     connection_pool (2.2.0)
     dalli (2.7.4)
     dante (0.2.0)

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -1,5 +1,5 @@
 require 'abstract_unit'
-require 'concurrent/atomics'
+require 'concurrent/atomic/count_down_latch'
 Thread.abort_on_exception = true
 
 module ActionController

--- a/actionpack/test/dispatch/live_response_test.rb
+++ b/actionpack/test/dispatch/live_response_test.rb
@@ -1,5 +1,5 @@
 require 'abstract_unit'
-require 'concurrent/atomics'
+require 'concurrent/atomic/count_down_latch'
 
 module ActionController
   module Live

--- a/actionview/lib/action_view/dependency_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker.rb
@@ -1,4 +1,4 @@
-require 'concurrent'
+require 'concurrent/map'
 require 'action_view/path_set'
 
 module ActionView

--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -1,4 +1,4 @@
-require 'concurrent'
+require 'concurrent/map'
 require 'action_view/dependency_tracker'
 require 'monitor'
 

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -1,4 +1,4 @@
-require 'concurrent'
+require 'concurrent/map'
 require 'active_support/core_ext/module/remove_method'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'action_view/template/resolver'

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -1,5 +1,5 @@
 require 'action_view/renderer/partial_renderer/collection_caching'
-require 'concurrent'
+require 'concurrent/map'
 
 module ActionView
   class PartialIteration

--- a/activejob/lib/active_job/async_job.rb
+++ b/activejob/lib/active_job/async_job.rb
@@ -1,4 +1,7 @@
-require 'concurrent'
+require 'concurrent/map'
+require 'concurrent/scheduled_task'
+require 'concurrent/executor/thread_pool_executor'
+require 'concurrent/utility/processor_counter'
 
 module ActiveJob
   # == Active Job Async Job

--- a/activejob/test/adapters/async.rb
+++ b/activejob/test/adapters/async.rb
@@ -1,4 +1,3 @@
-require 'concurrent'
 require 'active_job/async_job'
 
 ActiveJob::Base.queue_adapter = :async

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -1,4 +1,4 @@
-require 'concurrent'
+require 'concurrent/map'
 require 'mutex_m'
 
 module ActiveModel

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -1,7 +1,7 @@
 require 'active_support/core_ext/enumerable'
 require 'active_support/core_ext/string/filters'
 require 'mutex_m'
-require 'concurrent'
+require 'concurrent/map'
 
 module ActiveRecord
   # = Active Record Attribute Methods

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1,5 +1,5 @@
 require 'thread'
-require 'concurrent'
+require 'concurrent/map'
 require 'monitor'
 
 module ActiveRecord

--- a/activerecord/lib/active_record/type/type_map.rb
+++ b/activerecord/lib/active_record/type/type_map.rb
@@ -1,4 +1,4 @@
-require 'concurrent'
+require 'concurrent/map'
 
 module ActiveRecord
   module Type

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -26,7 +26,7 @@ require 'models/bird'
 require 'models/car'
 require 'models/bulb'
 require 'rexml/document'
-require 'concurrent/atomics'
+require 'concurrent/atomic/count_down_latch'
 
 class FirstAbstractClass < ActiveRecord::Base
   self.abstract_class = true

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -1,5 +1,5 @@
 require "cases/helper"
-require 'concurrent/atomics'
+require 'concurrent/atomic/count_down_latch'
 
 module ActiveRecord
   module ConnectionAdapters

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'json',       '~> 1.7', '>= 1.7.7'
   s.add_dependency 'tzinfo',     '~> 1.1'
   s.add_dependency 'minitest',   '~> 5.1'
-  s.add_dependency 'concurrent-ruby', '~> 1.0.0.pre3', '< 2.0.0'
+  s.add_dependency 'concurrent-ruby', '~> 1.0.0.pre5', '< 2.0.0'
   s.add_dependency 'method_source'
 end

--- a/activesupport/lib/active_support/concurrency/latch.rb
+++ b/activesupport/lib/active_support/concurrency/latch.rb
@@ -1,4 +1,4 @@
-require 'concurrent/atomics'
+require 'concurrent/atomic/count_down_latch'
 
 module ActiveSupport
   module Concurrency
@@ -8,7 +8,7 @@ module ActiveSupport
         ActiveSupport::Deprecation.warn("ActiveSupport::Concurrency::Latch is deprecated. Please use Concurrent::CountDownLatch instead.")
         super(count)
       end
-      
+
       alias_method :release, :count_down
 
       def await

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -1,6 +1,6 @@
 require 'set'
 require 'thread'
-require 'concurrent'
+require 'concurrent/map'
 require 'pathname'
 require 'active_support/core_ext/module/aliasing'
 require 'active_support/core_ext/module/attribute_accessors'

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -1,4 +1,4 @@
-require 'concurrent'
+require 'concurrent/map'
 require 'active_support/core_ext/array/prepend_and_append'
 require 'active_support/i18n'
 

--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -1,4 +1,4 @@
-require 'concurrent'
+require 'concurrent/map'
 require 'openssl'
 
 module ActiveSupport

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -1,5 +1,5 @@
 require 'mutex_m'
-require 'concurrent'
+require 'concurrent/map'
 
 module ActiveSupport
   module Notifications

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -1,5 +1,5 @@
 require 'tzinfo'
-require 'concurrent'
+require 'concurrent/map'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/try'
 

--- a/activesupport/test/share_lock_test.rb
+++ b/activesupport/test/share_lock_test.rb
@@ -1,5 +1,5 @@
 require 'abstract_unit'
-require 'concurrent/atomics'
+require 'concurrent/atomic/count_down_latch'
 require 'active_support/concurrency/share_lock'
 
 class ShareLockTest < ActiveSupport::TestCase


### PR DESCRIPTION
This PR has two changes, which I will happily separate into two PRs if that would be preferred. The two changes are:
- Using concurrent-ruby v1.0.0.pre5 (upgraded from pre3)
- Limiting `require` statements to only load necessary files from concurrent-ruby

**1.0.0.pre5**

This is the last planned pre-release of concurrent-ruby. There are no new features, just performance improvements and a few refinements to the internal synchronization layer and associated memory model. We hope to release 1.0.0 fairly soon, once our biggest users have upgraded to pre5.

**Updated require statements**

Based on a recommendation by @jeremy in a concurrent-ruby [issue](https://github.com/ruby-concurrency/concurrent-ruby/issues/395#issuecomment-153138030).

For historical reasons, most of c-r doesn't use `autoload` (though we plan to change this in 2.0). By requiring the entire gem we unintentionally added unnecessary delay to Rails loading. Internally we have been very judicious in using explicit requires in all files. This makes it possible to include only the required c-r components. This update narrows all require statements to the minimum necessary. This should improve load time for all users.
