### PR TITLE
Fix `static_cache_control` deprecation warning

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -56,9 +56,12 @@ module Rails
       end
 
       def static_cache_control=(value)
-        ActiveSupport::Deprecation.warn("static_cache_control is deprecated and will be removed in Rails 5.1. " \
-                                        "Please use `config.public_file_server.headers = {'Cache-Control' => #{value}} " \
-                                        "instead.")
+        ActiveSupport::Deprecation.warn <<-eow.strip_heredoc
+          `static_cache_control` is deprecated and will be removed in Rails 5.1.
+          Please use
+          `config.public_file_server.headers = { 'Cache-Control' => '#{value}' }`
+          instead.
+        eow
 
         @static_cache_control = value
       end


### PR DESCRIPTION
- Fix the warning message by wrapping the value in missing quotes and adding the missing backtick at the end. Finally, :lipstick: by adding a space inside the curly braces.

Before:

```
`config.public_file_server.headers = {'Cache-Control' => public, max-age=31536000}
```

Now:

```
`config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=31536000' }`
```
- Display `static_cache_control` instead of static_cache_control. This follows what the 2 neighboring methods are doing.
- Use strip_heredoc to improve the code formatting and readability like the 2 neighboring methods and wrap to 80 characters.
