### PR TITLE
Update docs to suggest safe json api check

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -35,7 +35,7 @@ module ActionController #:nodoc:
   # <tt>ApplicationController</tt> (by default: <tt>:exception</tt>):
   #
   #   class ApplicationController < ActionController::Base
-  #     protect_from_forgery unless: -> { request.format.json? }
+  #     protect_from_forgery unless: -> { request.content_type == 'application/json' }
   #   end
   #
   # CSRF protection is turned on with the <tt>protect_from_forgery</tt> method.


### PR DESCRIPTION
Checking `request.format.json?` is not secure, since someone could simply append `.json` to the end of a form POST. You should check the content_type to be sure.
