### PR TITLE
make local read multi look into local cache first

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -332,19 +332,16 @@ module ActiveSupport
         options = merged_options(options)
 
         instrument_multi(:read, names, options) do |payload|
-          results = {}
-          names.each do |name|
-            key = normalize_key(name, options)
-            entry = read_entry(key, options)
+          keys_to_names = Hash[names.map { |name| [normalize_key(name, options), name] }]
+          read_multi_entry(keys_to_names.keys, options).each_with_object({}) do |(key, entry), results|
             if entry
               if entry.expired?
                 delete_entry(key, options)
               else
-                results[name] = entry.value
+                results[keys_to_names[key]] = entry.value
               end
             end
           end
-          results
         end
       end
 
@@ -483,6 +480,13 @@ module ActiveSupport
         # this method.
         def read_entry(key, options) # :nodoc:
           raise NotImplementedError.new
+        end
+
+        # Read multiple entries from the cache implementation.
+        def read_multi_entry(keys, options)
+          keys.each_with_object({}) do |key, values|
+            values[key] = read_entry(key, options)
+          end
         end
 
         # Write an entry to the cache implementation. Subclasses must implement


### PR DESCRIPTION
atm it always goes straight to the backend if the backend has implemented a read_multi as mem_cached / dalli etc do
