### PR TITLE
do not override fetch on local cache

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -48,10 +48,6 @@ module ActiveSupport
             @data.clear
           end
 
-          def fetch(*args, &block)
-            @data.fetch(*args, &block)
-          end
-
           def read_entry(key, options)
             @data[key]
           end
@@ -63,6 +59,10 @@ module ActiveSupport
 
           def delete_entry(key, options)
             !!@data.delete(key)
+          end
+
+          def fetch_entry(key, options = nil) # :nodoc:
+            @data.fetch(key) { @data[key] = yield }
           end
         end
 
@@ -103,11 +103,7 @@ module ActiveSupport
         protected
           def read_entry(key, options) # :nodoc:
             if cache = local_cache
-              cache.fetch(key) do
-                entry = super
-                cache.write_entry(key, entry, options)
-                entry
-              end
+              cache.fetch_entry(key) { super }
             else
               super
             end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -633,6 +633,13 @@ module LocalCacheBehavior
     end
   end
 
+  def test_local_cache_fetch
+    @cache.with_local_cache do
+      @cache.send(:local_cache).write 'foo', 'bar'
+      assert_equal 'bar', @cache.send(:local_cache).fetch('foo')
+    end
+  end
+
   def test_local_cache_of_write_nil
     @cache.with_local_cache do
       assert @cache.write('foo', nil)
@@ -1102,11 +1109,11 @@ class CacheStoreLoggerTest < ActiveSupport::TestCase
   def test_log_with_proc_namespace
     proc = Proc.new do
       "proc_namespace"
-    end    
+    end
     @cache.fetch('foo', {:namespace => proc}) { 'bar' }
     assert_match %r{proc_namespace:foo}, @buffer.string
   end
-  
+
   def test_mute_logging
     @cache.mute { @cache.fetch('foo') { 'bar' } }
     assert @buffer.string.blank?


### PR DESCRIPTION
just realized that my last PR overwrote fetch on the local_cache with an unexpected behavior ... it is still supposed to behave like a cache and not return the raw entry ...

https://github.com/rails/rails/pull/22194

@sgrif 
