### PR TITLE
fix NoMethodError being raised when action is empty

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -311,6 +311,11 @@ module ActionDispatch
           def check_part(name, part, path_params, hash)
             if part
               hash[name] = yield(part)
+
+              if hash[name].blank?
+                message = ":#{name} can't be blank, please check your routes."
+                raise ArgumentError, message
+              end
             else
               unless path_params.include?(name)
                 message = "Missing :#{name} key on routes definition, please check your routes."

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3818,6 +3818,15 @@ class TestNamespaceWithControllerOption < ActionDispatch::IntegrationTest
 
     assert_match "'Admin' is not a supported controller name", e.message
   end
+
+  def test_action_is_empty
+    ex = assert_raises(ArgumentError) {
+      draw do
+        get '/foo/bar', controller: :foo, action: ''
+      end
+    }
+    assert_match(/:action can't be blank/, ex.message)
+  end
 end
 
 class TestDefaultScope < ActionDispatch::IntegrationTest

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -174,7 +174,7 @@ module ActionView
       def normalize_name(name, prefixes) #:nodoc:
         prefixes = prefixes.presence
         parts    = name.to_s.split('/'.freeze)
-        parts.shift if parts.first.empty?
+        parts.shift if !parts.empty? && parts.first.empty?
         name     = parts.pop
 
         return name, prefixes || [""] if parts.empty?

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -16,7 +16,7 @@ module ActionView
       def self.build(name, prefix, partial)
         virtual = ""
         virtual << "#{prefix}/" unless prefix.empty?
-        virtual << (partial ? "_#{name}" : name)
+        virtual << (partial ? "_#{name}" : name.to_s)
         new name, prefix, partial, virtual
       end
 

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -869,6 +869,10 @@ class RenderTest < ActionController::TestCase
     assert_raise(AbstractController::ActionNotFound) { get :determine_layout }
   end
 
+  def test_action_is_empty
+    assert_raise(AbstractController::ActionNotFound, "No action responded to []") { get '' }
+  end
+
   # :ported:
   def test_access_to_request_in_view
     get :accessing_request_in_template

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -206,6 +206,12 @@ class LookupContextTest < ActiveSupport::TestCase
     @lookup_context.prefixes = ["foo"]
     assert_equal ["foo"], @lookup_context.prefixes
   end
+
+  test "if given view paths is empty, raise error" do
+    assert_raise ActionView::MissingTemplate do
+      @lookup_context.find("")
+    end
+  end
 end
 
 class LookupContextWithFalseCaching < ActiveSupport::TestCase


### PR DESCRIPTION
(This is a continuation of #18810. Since have deleted the original branch by mistake, making a new PR)

When action set in routes is empty, raised unexpeted `NoMethodError`.

``` ruby
Rails.application.routes.draw do
  get 'users/profile', controller: 'users', action: ''
end 
```

stacktrace is as follows:

``` ruby
NoMethodError (undefined method `empty?' for nil:NilClass):
  actionview (4.2.0) lib/action_view/lookup_context.rb:176:in `normalize_name'
  actionview (4.2.0) lib/action_view/lookup_context.rb:151:in `args_for_lookup'
  actionview (4.2.0) lib/action_view/lookup_context.rb:130:in `exists?'
  actionview (4.2.0) lib/action_view/view_paths.rb:13:in `template_exists?'
  actionpack (4.2.0) lib/action_controller/metal/implicit_render.rb:14:in `method_for_action'
  actionpack (4.2.0) lib/abstract_controller/base.rb:230:in `_find_action_name'
  actionpack (4.2.0) lib/abstract_controller/base.rb:131:in `process'
  actionview (4.2.0) lib/action_view/rendering.rb:30:in `process'
  actionpack (4.2.0) lib/action_controller/metal.rb:195:in `dispatch'
  actionpack (4.2.0) lib/action_controller/metal/rack_delegation.rb:13:in `dispatch'
  actionpack (4.2.0) lib/action_controller/metal.rb:236:in `block in action'
  actionpack (4.2.0) lib/action_dispatch/routing/route_set.rb:73:in `call'
  actionpack (4.2.0) lib/action_dispatch/routing/route_set.rb:73:in `dispatch'
  actionpack (4.2.0) lib/action_dispatch/routing/route_set.rb:42:in `serve'
  actionpack (4.2.0) lib/action_dispatch/journey/router.rb:43:in `block in serve'
  actionpack (4.2.0) lib/action_dispatch/journey/router.rb:30:in `each'
  actionpack (4.2.0) lib/action_dispatch/journey/router.rb:30:in `serve'
  actionpack (4.2.0) lib/action_dispatch/routing/route_set.rb:802:in `call'
```

This PR fix it.
