### PR TITLE
use prepend instead of extending every instance

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -10,6 +10,7 @@ module ActiveSupport
     # FileStore implements the Strategy::LocalCache strategy which implements
     # an in-memory cache inside of a block.
     class FileStore < Store
+      prepend Strategy::LocalCache
       attr_reader :cache_path
 
       DIR_FORMATTER = "%03X"
@@ -20,7 +21,6 @@ module ActiveSupport
       def initialize(cache_path, options = nil)
         super(options)
         @cache_path = cache_path.to_s
-        extend Strategy::LocalCache
       end
 
       # Deletes all items from the cache. In this case it deletes all the entries in the specified

--- a/activesupport/lib/active_support/cache/null_store.rb
+++ b/activesupport/lib/active_support/cache/null_store.rb
@@ -8,10 +8,7 @@ module ActiveSupport
     # be cached inside blocks that utilize this strategy. See
     # ActiveSupport::Cache::Strategy::LocalCache for more details.
     class NullStore < Store
-      def initialize(options = nil)
-        super(options)
-        extend Strategy::LocalCache
-      end
+      prepend Strategy::LocalCache
 
       def clear(options = nil)
       end


### PR DESCRIPTION
initialize with prepend seems like a hack that was added before prepend was supported,
let's stop doing that ...
