### PR TITLE
even if a write fails, store the raw value

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -36,13 +36,13 @@ module ActiveSupport
         end
 
         def write_entry(key, entry, options) # :nodoc:
-          retval = super
-          if options[:raw] && local_cache && retval
+          if options[:raw] && local_cache
             raw_entry = Entry.new(entry.value.to_s)
             raw_entry.expires_at = entry.expires_at
-            local_cache.write_entry(key, raw_entry, options)
+            super(key, raw_entry, options)
+          else
+            super
           end
-          retval
         end
       end
 

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -655,6 +655,14 @@ module LocalCacheBehavior
     end
   end
 
+  def test_local_cache_of_read_nil
+    @cache.with_local_cache do
+      assert_equal nil, @cache.read('foo')
+      @cache.send(:bypass_local_cache) { @cache.write 'foo', 'bar' }
+      assert_equal nil, @cache.read('foo')
+    end
+  end
+
   def test_local_cache_of_delete
     @cache.with_local_cache do
       @cache.write('foo', 'bar')


### PR DESCRIPTION
given a memcached store with raw true, atm
- if a value is written it comes back from the local_cache as raw
- if a value is NOT written it comes back from the local_cache as NOT raw (because super still writes to local cache)

tiny bug I found while strolling through this file for some other PRs ...
