### PR TITLE
consistent and efficient decement and increment behavior

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,9 +1,19 @@
+*   `ActiveSupport::Cache::Store` now uses `increment_entry` and `decrement_entry` internally, 
+     overwrite these in your subclasses to not duplicate instrumentation logic and use LocalCache
+     for increment and decrement.
+     
+    `ActiveSupport::Cache::MemoryStore#modify_value`, and 
+    `ActiveSupport::Cache::FileStore#modify_value` 
+    are deprecated and replaced with `modify_entry` which takes a fully resolved key. 
+    
+    *Michael Grosser*
+
 *   `ActiveSupport::Cache::Store#namespaced_key`, 
     `ActiveSupport::Cache::MemCachedStore#escape_key`, and 
     `ActiveSupport::Cache::FileStore#key_file_path` 
     are deprecated and replaced with `normalize_key` that now calls `super`.
     
-    `ActiveSupport::Cache::LocaleCache#set_cache_value` is deprecated and replaced with `write_cache_value`.
+    `ActiveSupport::Cache::LocaleCache#set_cache_value` is deprecated and replaced with `local_cache.write`.
     
     *Michael Grosser*
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -428,8 +428,11 @@ module ActiveSupport
       # Options are passed to the underlying cache implementation.
       #
       # All implementations may not support this method.
-      def increment(name, amount = 1, options = nil)
-        raise NotImplementedError.new("#{self.class.name} does not support increment")
+      def increment(name, amount = 1, options = {})
+        options = merged_options(options)
+        instrument(:increment, name, :amount => amount) do
+          increment_entry(normalize_key(name, options), amount, options)
+        end
       end
 
       # Decrement an integer value in the cache.
@@ -437,8 +440,11 @@ module ActiveSupport
       # Options are passed to the underlying cache implementation.
       #
       # All implementations may not support this method.
-      def decrement(name, amount = 1, options = nil)
-        raise NotImplementedError.new("#{self.class.name} does not support decrement")
+      def decrement(name, amount = 1, options = {})
+        options = merged_options(options)
+        instrument(:increment, name, :amount => amount) do
+          decrement_entry(normalize_key(name, options), amount, options)
+        end
       end
 
       # Cleanup the cache by removing expired entries.
@@ -496,6 +502,14 @@ module ActiveSupport
         # implement this method.
         def delete_entry(key, options) # :nodoc:
           raise NotImplementedError.new
+        end
+
+        def increment_entry(key, amount)
+          raise NotImplementedError.new("#{self.class.name} does not support increment_entry")
+        end
+
+        def decrement_entry(key, amount)
+          raise NotImplementedError.new("#{self.class.name} does not support decrement_entry")
         end
 
       private

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -108,34 +108,6 @@ module ActiveSupport
         end
       end
 
-      # Increment a cached value. This method uses the memcached incr atomic
-      # operator and can only be used on values written with the :raw option.
-      # Calling it on a value not stored with :raw will initialize that value
-      # to zero.
-      def increment(name, amount = 1, options = nil) # :nodoc:
-        options = merged_options(options)
-        instrument(:increment, name, :amount => amount) do
-          @data.incr(normalize_key(name, options), amount)
-        end
-      rescue Dalli::DalliError => e
-        logger.error("DalliError (#{e}): #{e.message}") if logger
-        nil
-      end
-
-      # Decrement a cached value. This method uses the memcached decr atomic
-      # operator and can only be used on values written with the :raw option.
-      # Calling it on a value not stored with :raw will initialize that value
-      # to zero.
-      def decrement(name, amount = 1, options = nil) # :nodoc:
-        options = merged_options(options)
-        instrument(:decrement, name, :amount => amount) do
-          @data.decr(normalize_key(name, options), amount)
-        end
-      rescue Dalli::DalliError => e
-        logger.error("DalliError (#{e}): #{e.message}") if logger
-        nil
-      end
-
       # Clear the entire cache on all memcached servers. This method should
       # be used with care when shared cache is being used.
       def clear(options = nil)
@@ -180,6 +152,28 @@ module ActiveSupport
         rescue Dalli::DalliError => e
           logger.error("DalliError (#{e}): #{e.message}") if logger
           false
+        end
+
+        # Increment a cached value. This method uses the memcached incr atomic
+        # operator and can only be used on values written with the :raw option.
+        # Calling it on a value not stored with :raw will initialize that value
+        # to zero.
+        def increment_entry(key, amount, options)
+          @data.incr(key, amount)
+        rescue Dalli::DalliError => e
+          logger.error("DalliError (#{e}): #{e.message}") if logger
+          nil
+        end
+
+        # Decrement a cached value. This method uses the memcached decr atomic
+        # operator and can only be used on values written with the :raw option.
+        # Calling it on a value not stored with :raw will initialize that value
+        # to zero.
+        def decrement_entry(key, amount, options)
+          @data.decr(key, amount)
+        rescue Dalli::DalliError => e
+          logger.error("DalliError (#{e}): #{e.message}") if logger
+          nil
         end
 
       private

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -879,6 +879,14 @@ class FileStoreTest < ActiveSupport::TestCase
       assert_equal 111, @cache.send(:key_file_path, 111)
     end
   end
+
+  def test_can_call_deprecated_modify_value
+    assert_deprecated "`modify_value` is deprecated" do
+      @cache.write('foo', 1)
+      @cache.send(:modify_value, 'foo', 1, {})
+    end
+    assert_equal 2, @cache.read('foo')
+  end
 end
 
 class MemoryStoreTest < ActiveSupport::TestCase
@@ -981,6 +989,14 @@ class MemoryStoreTest < ActiveSupport::TestCase
     assert_equal false, @cache.write(1, "aaaaaaaaaa", :unless_exist => true)
     @cache.write(1, nil)
     assert_equal false, @cache.write(1, "aaaaaaaaaa", :unless_exist => true)
+  end
+
+  def test_can_call_deprecated_modify_value
+    assert_deprecated "`modify_value` is deprecated" do
+      @cache.write('foo', 1)
+      @cache.send(:modify_value, 'foo', 1, {})
+    end
+    assert_equal 2, @cache.read('foo')
   end
 end
 


### PR DESCRIPTION
currently
- decement/increment behavior is copy-pasted throughout file/memory/memcache store
- increment/decrement logs a read/write operation

so fix it to:
- reuse increment/decrement logging logic for all stores
