### PR TITLE
Suppress warning (warning about assigned but unused variable)

### DIFF
--- a/activerecord/test/cases/connection_management_test.rb
+++ b/activerecord/test/cases/connection_management_test.rb
@@ -98,7 +98,7 @@ module ActiveRecord
       test "doesn't mutate the original response" do
         original_response = [200, {}, 'hi']
         app = lambda { |_| original_response }
-        response_body = ConnectionManagement.new(app).call(@env)[2]
+        ConnectionManagement.new(app).call(@env)[2]
         assert_equal original_response.last, 'hi'
       end
     end


### PR DESCRIPTION
These warings have been appeared from
https://github.com/rails/rails/commit/92bc8cdb0771bf6ffcfb31ef58dba529527b514c
