### PR TITLE
Add comma to to make the information clear

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -657,7 +657,7 @@ NOTE: If the user has not selected a file the corresponding parameter will be an
 
 ### Dealing with Ajax
 
-Unlike other forms making an asynchronous file upload form is not as simple as providing `form_for` with `remote: true`. With an Ajax form the serialization is done by JavaScript running inside the browser and since JavaScript cannot read files from your hard drive the file cannot be uploaded. The most common workaround is to use an invisible iframe that serves as the target for the form submission.
+Unlike other forms, making an asynchronous file upload form is not as simple as providing `form_for` with `remote: true`. With an Ajax form the serialization is done by JavaScript running inside the browser and since JavaScript cannot read files from your hard drive the file cannot be uploaded. The most common workaround is to use an invisible iframe that serves as the target for the form submission.
 
 Customizing Form Builders
 -------------------------


### PR DESCRIPTION
http://guides.rubyonrails.org/form_helpers.html

5.2 Dealing with Ajax
Unlike other forms making an asynchronous file upload form is not as simple as providing form_for with remote: true.

Insert comma after 'Unlike other forms.' as shown below
Unlike other forms, making an asynchronous file upload form is not as simple as providing form_for with remote: true.
