### PR TITLE
Raise error when adding unreachable included blocks to concerns

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Raise error when adding unreachable included blocks to concerns.
+
+    *David Verhasselt*
+
 *   `HashWithIndifferentAccess.new` respects the default value or proc on objects
     that respond to `#to_hash`. `.new_from_hash_copying_default` simply invokes `.new`.
     All calls to `.new_from_hash_copying_default` are replaced with `.new`.

--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -126,4 +126,16 @@ class ConcernTest < ActiveSupport::TestCase
       end
     end
   end
+
+  def test_raise_when_included_block_unreacable
+    test_module = Module.new do
+      extend ActiveSupport::Concern
+    end
+
+    @klass.include(test_module)
+
+    assert_raises(ActiveSupport::Concern::UnreachableIncludedBlock) do
+      test_module.included {}
+    end
+  end
 end


### PR DESCRIPTION
Unreachable included blocks happen in the edge case where the Concern references the Class that includes it, and this Concern is loaded before the Class. Before this patch, the `included` block would just silently never be called, making it hard to debug what or where it went wrong. By explicitly not allowing an `included` block to be defined after the Concern was already included somewhere we make sure that the developer is aware of the problem and can search for the circular reference that causes it.

I've created a more expanded test version that explains when this happens in real life usage:

https://gist.github.com/dv/523e5358d434df0b3b51

This can happen if the concern is defined in a directory that is autoloaded before the class is loaded.
