### PR TITLE
Not passing `native_database_types` to `TableDefinition`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -206,14 +206,13 @@ module ActiveRecord
       include ColumnMethods
 
       attr_accessor :indexes
-      attr_reader :name, :temporary, :options, :as, :foreign_keys, :native
+      attr_reader :name, :temporary, :options, :as, :foreign_keys
 
-      def initialize(types, name, temporary, options, as = nil)
+      def initialize(name, temporary, options, as = nil)
         @columns_hash = {}
         @indexes = {}
         @foreign_keys = {}
         @primary_keys = nil
-        @native = types
         @temporary = temporary
         @options = options
         @as = as
@@ -362,11 +361,8 @@ module ActiveRecord
       def new_column_definition(name, type, options) # :nodoc:
         type = aliased_types(type.to_s, type)
         column = create_column_definition name, type
-        limit = options.fetch(:limit) do
-          native[type][:limit] if native[type].is_a?(Hash)
-        end
 
-        column.limit       = limit
+        column.limit       = options[:limit]
         column.precision   = options[:precision]
         column.scale       = options[:scale]
         column.default     = options[:default]
@@ -627,11 +623,6 @@ module ActiveRecord
       def foreign_key_exists?(*args) # :nodoc:
         @base.foreign_key_exists?(name, *args)
       end
-
-      private
-        def native
-          @base.native_database_types
-        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1168,7 +1168,7 @@ module ActiveRecord
 
       private
       def create_table_definition(name, temporary = false, options = nil, as = nil)
-        TableDefinition.new native_database_types, name, temporary, options, as
+        TableDefinition.new(name, temporary, options, as)
       end
 
       def create_alter_table(name)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -1019,7 +1019,7 @@ module ActiveRecord
       end
 
       def create_table_definition(name, temporary = false, options = nil, as = nil) # :nodoc:
-        MySQL::TableDefinition.new(native_database_types, name, temporary, options, as)
+        MySQL::TableDefinition.new(name, temporary, options, as)
       end
 
       def integer_to_sql(limit) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -736,7 +736,7 @@ module ActiveRecord
         end
 
         def create_table_definition(name, temporary = false, options = nil, as = nil) # :nodoc:
-          PostgreSQL::TableDefinition.new native_database_types, name, temporary, options, as
+          PostgreSQL::TableDefinition.new(name, temporary, options, as)
         end
 
         def can_perform_case_insensitive_comparison_for?(column)


### PR DESCRIPTION
The `native_database_types` only used in `TableDefinition` for look up
the default `:limit` option. But this is duplicated process with
`type_to_sql`. Passing `native_database_types` is not needed.
