### PR TITLE
send normalized keys to the cache backends so they do not need to man…

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -536,6 +536,7 @@ module ActiveSupport
           key = "#{prefix}:#{key}" if prefix
           key
         end
+        alias namespaced_key normalize_key
 
         def instrument(operation, key, options = nil)
           log { "Cache #{operation}: #{normalize_key(key, options)}#{options.blank? ? "" : " (#{options.inspect})"}" }

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -275,7 +275,7 @@ module ActiveSupport
       def fetch(name, options = nil)
         if block_given?
           options = merged_options(options)
-          key = namespaced_key(name, options)
+          key = normalize_key(name, options)
 
           instrument(:read, name, options) do |payload|
             cached_entry = read_entry(key, options) unless options[:force]
@@ -302,7 +302,7 @@ module ActiveSupport
       # Options are passed to the underlying cache implementation.
       def read(name, options = nil)
         options = merged_options(options)
-        key = namespaced_key(name, options)
+        key = normalize_key(name, options)
         instrument(:read, name, options) do |payload|
           entry = read_entry(key, options)
           if entry
@@ -334,7 +334,7 @@ module ActiveSupport
         instrument_multi(:read, names, options) do |payload|
           results = {}
           names.each do |name|
-            key = namespaced_key(name, options)
+            key = normalize_key(name, options)
             entry = read_entry(key, options)
             if entry
               if entry.expired?
@@ -386,7 +386,7 @@ module ActiveSupport
 
         instrument(:write, name, options) do
           entry = Entry.new(value, options)
-          write_entry(namespaced_key(name, options), entry, options)
+          write_entry(normalize_key(name, options), entry, options)
         end
       end
 
@@ -397,7 +397,7 @@ module ActiveSupport
         options = merged_options(options)
 
         instrument(:delete, name) do
-          delete_entry(namespaced_key(name, options), options)
+          delete_entry(normalize_key(name, options), options)
         end
       end
 
@@ -408,7 +408,7 @@ module ActiveSupport
         options = merged_options(options)
 
         instrument(:exist?, name) do
-          entry = read_entry(namespaced_key(name, options), options)
+          entry = read_entry(normalize_key(name, options), options)
           (entry && !entry.expired?) || false
         end
       end
@@ -529,7 +529,7 @@ module ActiveSupport
 
         # Prefix a key with the namespace. Namespace and key will be delimited
         # with a colon.
-        def namespaced_key(key, options)
+        def normalize_key(key, options)
           key = expanded_key(key)
           namespace = options[:namespace] if options
           prefix = namespace.is_a?(Proc) ? namespace.call : namespace
@@ -538,7 +538,7 @@ module ActiveSupport
         end
 
         def instrument(operation, key, options = nil)
-          log { "Cache #{operation}: #{namespaced_key(key, options)}#{options.blank? ? "" : " (#{options.inspect})"}" }
+          log { "Cache #{operation}: #{normalize_key(key, options)}#{options.blank? ? "" : " (#{options.inspect})"}" }
 
           payload = { :key => key }
           payload.merge!(options) if options.is_a?(Hash)

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -60,7 +60,7 @@ module ActiveSupport
           matcher = key_matcher(matcher, options)
           search_dir(cache_path) do |path|
             key = file_path_key(path)
-            delete_entry(normalize_key(key, options), options) if key.match(matcher)
+            delete_entry(path, options) if key.match(matcher)
           end
         end
       end

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -60,7 +60,7 @@ module ActiveSupport
           matcher = key_matcher(matcher, options)
           search_dir(cache_path) do |path|
             key = file_path_key(path)
-            delete_entry(key, options) if key.match(matcher)
+            delete_entry(normalize_key(key, options), options) if key.match(matcher)
           end
         end
       end
@@ -68,9 +68,8 @@ module ActiveSupport
       protected
 
         def read_entry(key, options)
-          file_name = key_file_path(key)
-          if File.exist?(file_name)
-            File.open(file_name) { |f| Marshal.load(f) }
+          if File.exist?(key)
+            File.open(key) { |f| Marshal.load(f) }
           end
         rescue => e
           logger.error("FileStoreError (#{e}): #{e.message}") if logger
@@ -78,23 +77,21 @@ module ActiveSupport
         end
 
         def write_entry(key, entry, options)
-          file_name = key_file_path(key)
-          return false if options[:unless_exist] && File.exist?(file_name)
-          ensure_cache_path(File.dirname(file_name))
-          File.atomic_write(file_name, cache_path) {|f| Marshal.dump(entry, f)}
+          return false if options[:unless_exist] && File.exist?(key)
+          ensure_cache_path(File.dirname(key))
+          File.atomic_write(key, cache_path) {|f| Marshal.dump(entry, f)}
           true
         end
 
         def delete_entry(key, options)
-          file_name = key_file_path(key)
-          if File.exist?(file_name)
+          if File.exist?(key)
             begin
-              File.delete(file_name)
-              delete_empty_directories(File.dirname(file_name))
+              File.delete(key)
+              delete_empty_directories(File.dirname(key))
               true
             rescue => e
               # Just in case the error was caused by another process deleting the file first.
-              raise e if File.exist?(file_name)
+              raise e if File.exist?(key)
               false
             end
           end
@@ -118,7 +115,8 @@ module ActiveSupport
         end
 
         # Translate a key into a file path.
-        def key_file_path(key)
+        def normalize_key(key, options)
+          key = super
           fname = URI.encode_www_form_component(key)
 
           if fname.size > FILEPATH_MAX_SIZE
@@ -175,7 +173,7 @@ module ActiveSupport
         # Modifies the amount of an already existing integer value that is stored in the cache.
         # If the key is not found nothing is done.
         def modify_value(name, amount, options)
-          file_name = key_file_path(namespaced_key(name, options))
+          file_name = normalize_key(name, options)
 
           lock_file(file_name) do
             options = merged_options(options)

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -93,14 +93,14 @@ module ActiveSupport
         def increment(name, amount = 1, options = nil) # :nodoc:
           return super unless local_cache
           value = bypass_local_cache{super}
-          set_cache_value(value, name, amount, options)
+          set_cache_value(name, value, options)
           value
         end
 
         def decrement(name, amount = 1, options = nil) # :nodoc:
           return super unless local_cache
           value = bypass_local_cache{super}
-          set_cache_value(value, name, amount, options)
+          set_cache_value(name, value, options)
           value
         end
 
@@ -124,6 +124,7 @@ module ActiveSupport
           end
 
           def set_cache_value(value, name, amount, options) # :nodoc:
+            name = normalize_key(name, options)
             cache = local_cache
             cache.mute do
               if value

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -123,7 +123,7 @@ module ActiveSupport
             super
           end
 
-          def set_cache_value(value, name, amount, options) # :nodoc:
+          def set_cache_value(name, value, options) # :nodoc:
             name = normalize_key(name, options)
             cache = local_cache
             cache.mute do

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -416,7 +416,7 @@ module CacheStoreBehavior
 
   def test_race_condition_protection_skipped_if_not_defined
     @cache.write('foo', 'bar')
-    time = @cache.send(:read_entry, 'foo', {}).expires_at
+    time = @cache.send(:read_entry, @cache.send(:normalize_key, 'foo', {}), {}).expires_at
 
     Time.stub(:now, Time.at(time)) do
       result = @cache.fetch('foo') do
@@ -783,13 +783,13 @@ class FileStoreTest < ActiveSupport::TestCase
   end
 
   def test_key_transformation
-    key = @cache.send(:key_file_path, "views/index?id=1")
+    key = @cache.send(:normalize_key, "views/index?id=1", {})
     assert_equal "views/index?id=1", @cache.send(:file_path_key, key)
   end
 
   def test_key_transformation_with_pathname
     FileUtils.touch(File.join(cache_dir, "foo"))
-    key = @cache_with_pathname.send(:key_file_path, "views/index?id=1")
+    key = @cache_with_pathname.send(:normalize_key, "views/index?id=1", {})
     assert_equal "views/index?id=1", @cache_with_pathname.send(:file_path_key, key)
   end
 
@@ -797,7 +797,7 @@ class FileStoreTest < ActiveSupport::TestCase
   # remain valid
   def test_filename_max_size
     key = "#{'A' * ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}"
-    path = @cache.send(:key_file_path, key)
+    path = @cache.send(:normalize_key, key, {})
     Dir::Tmpname.create(path) do |tmpname, n, opts|
       assert File.basename(tmpname+'.lock').length <= 255, "Temp filename too long: #{File.basename(tmpname+'.lock').length}"
     end
@@ -807,7 +807,7 @@ class FileStoreTest < ActiveSupport::TestCase
   # If filename is 'AAAAB', where max size is 4, the returned path should be AAAA/B
   def test_key_transformation_max_filename_size
     key = "#{'A' * ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}B"
-    path = @cache.send(:key_file_path, key)
+    path = @cache.send(:normalize_key, key, {})
     assert path.split('/').all? { |dir_name| dir_name.size <= ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}
     assert_equal 'B', File.basename(path)
   end


### PR DESCRIPTION
…age this themselves

key manipulation is a recurring pattern in the cache stores (base + file + mem_cached) which makes the code less readable and mixes concerns

this moves all the key manipulation into a single method normalize_key and reuses that, which will also enable users to inherit or share logic better via modules since they no longer have to modify the key (escape_key or key_file_path or namespaced_key)
