### PR TITLE
Fix unnecessary variable assignment /associations/builder/association.rb#add_destroy_callbacks

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -136,8 +136,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.add_destroy_callbacks(model, reflection)
-      name = reflection.name
-      model.before_destroy lambda { |o| o.association(name).handle_dependency }
+      model.before_destroy lambda { |o| o.association(reflection.name).handle_dependency }
     end
   end
 end


### PR DESCRIPTION
There is no need to to assign reflection name to a variable, because it's called once.
