### PR TITLE
Fix Unnecessary variable assignment /associations/builder/belongs_to.rb#add_destroy_callbacks

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -116,8 +116,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.add_destroy_callbacks(model, reflection)
-      name = reflection.name
-      model.after_destroy lambda { |o| o.association(name).handle_dependency }
+      model.after_destroy lambda { |o| o.association(reflection.name).handle_dependency }
     end
 
     def self.define_validations(model, reflection)


### PR DESCRIPTION
There is no need to to assign reflection name to a variable, because it's called once.
