### PR TITLE
fix application_controller require_dependency path generated by api scaffold generator

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb
@@ -1,5 +1,5 @@
 <% if namespaced? -%>
-require_dependency "<%= namespaced_file_path %>/application_controller"
+require_dependency "<%= namespaced_path %>/application_controller"
 
 <% end -%>
 <% module_namespacing do -%>


### PR DESCRIPTION
In the app generator, regardless of the namespace, it is adapted to read the same `application_controller.rb`, modified to api generator also be the same behavior.

ref 686966a1861e6761021d45f6795de753e8a62216, 06ac63b4c602e4b26cb3bfbf0dfd2bed8b00e786
