### PR TITLE
Additional math operations for enumerable.rb

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -21,9 +21,51 @@ module Enumerable
     if block_given?
       map(&block).sum(identity)
     else
-      inject { |sum, element| sum + element } || identity
+      inject(:+) || identity
     end
   end
+
+  
+  # Calculates a product by multiplying numeric elements
+  # [5, 15, 10].mult # => 750
+  #
+  # returns nil if blank or any element is nil
+  def mult(identity = 1, &block)
+    return nil if (self.blank? || self.include?(nil))
+    raise "All elements must be numeric" if self.any? { |x| x.is_a? String }
+
+    if block_given?
+      map(&block).mult(identity)
+    else
+      inject(:*) || identity
+    end
+  end 
+   
+
+  # Calculates a mean average of the elements
+  def avg(identity = 0, &block)
+    return nil if (self.blank? || self.include?(nil))
+    raise "All elements must be numeric" if self.any? { |x| x.is_a? String }
+
+    if block_given?
+      map(&block).avg(identity)
+    else
+      (inject(:+).to_f / self.count) || identity
+    end
+  end 
+
+
+  # Calculates a median average of the elements
+  def median(identity = 0, &block)
+    return nil if (self.blank? || self.include?(nil))
+    raise "All elements must be numeric" if self.any? { |x| x.is_a? String }
+
+    if block_given?
+      map(&block).median(identity)
+    else
+      (self.sort[(self.length - 1) / 2] + self.sort[self.length / 2]) / 2.0 || identity
+    end
+  end   
 
   # Convert an enumerable to a hash.
   #


### PR DESCRIPTION
- add <code>mult</code>, <code>avg</code>, and <code>median</code> methods to enumerable module in activesupport with comment documentation
- refactor <code>sum</code> method
- add corresponding test methods to <code>enumerable_test.rb</code> 

example usage:

``` ruby
payments = GenericEnumerable.new([ Payment.new(5), Payment.new(15), Payment.new(10), Payment.new(75), Payment.new(45) ])

#sum
payments.sum(&:price) #=> 150

#product
payments.mult(&:price) #=> 2531250

#mean
payments.avg(&:price) #=> 30.0

#median
payments.median(&:price) #=> 15.0
```
- these methods would be very useful for the rails console and would allow quicker retrieval of statistical information on object and/or object attributes
