### PR TITLE
fix method name typo [ci skip]

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Allow `host` option in `javascript_include_tag` and `stylesheet_tag` helpers
+*   Allow `host` option in `javascript_include_tag` and `stylesheet_link_tag` helpers
 
     *Grzegorz Witek*
 


### PR DESCRIPTION
ref: https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/asset_tag_helper.rb#L92
