### PR TITLE
Remove UUID formatting protections

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb
@@ -3,16 +3,12 @@ module ActiveRecord
     module PostgreSQL
       module OID # :nodoc:
         class Uuid < Type::Value # :nodoc:
-          ACCEPTABLE_UUID = %r{\A\{?([a-fA-F0-9]{4}-?){8}\}?\z}x
-
-          alias_method :serialize, :deserialize
-
           def type
             :uuid
           end
 
           def cast(value)
-            value.to_s[ACCEPTABLE_UUID, 0]
+            value.presence
           end
         end
       end


### PR DESCRIPTION
This essentially reverts https://github.com/rails/rails/pull/15944 and https://github.com/rails/rails/pull/15932.

Currently, assigning invalid UUIDs to non-primary key columns fails silently and prevents validations where nil values are allowed.
