### PR TITLE
Add foreign key constraint support to SQLite3 adapter, fixed collation parsing

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for foreign key constraints to SQLite3 adapter
+
+    *David Mike Simon*
+
 *   Fix `rake db:structure:dump` on Postgres when multiple schemas are used.
 
     Fixes #22346.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -333,16 +333,16 @@ module ActiveRecord
       end
 
       def remove_foreign_key(options_or_to_table) # :nodoc:
-        if options_or_to_table.is_a?(Hash) and options_or_to_table.has_key?(:name)
-          foreign_keys.delete_if do |table_name, options|
-            options[:name].to_s == options_or_to_table[:name].to_s
+        if options_or_to_table.is_a?(Hash)
+          name_or_column = if options_or_to_table.has_key?(:name) then :name
+                           elsif options_or_to_table.has_key?(:column) then :column
+                           else raise ArgumentError, "options hash must have :name or :column"
+                           end
+          foreign_keys.delete_if do |_, options|
+            options[name_or_column].to_s == options_or_to_table[name_or_column].to_s
           end
-        elsif options_or_to_table.is_a?(Hash) and options_or_to_table.has_key?(:column)
-          foreign_keys.delete_if do |table_name, options|
-            options[:column].to_s == options_or_to_table[:column].to_s
-          end
-        elsif options_or_to_table.is_a?(String) or options_or_to_table.is_a?(Symbol)
-          foreign_keys.delete options_or_to_table.to_s
+        elsif options_or_to_table.is_a?(String) || options_or_to_table.is_a?(Symbol)
+          foreign_keys.delete(options_or_to_table.to_s)
         else
           raise ArgumentError, "remove_foreign_key needs either a table name or a foreign key options hash with :name or :column"
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -332,6 +332,22 @@ module ActiveRecord
         foreign_keys[table_name] = options
       end
 
+      def remove_foreign_key(options_or_to_table) # :nodoc:
+        if options_or_to_table.is_a?(Hash) and options_or_to_table.has_key?(:name)
+          foreign_keys.delete_if do |table_name, options|
+            options[:name].to_s == options_or_to_table[:name].to_s
+          end
+        elsif options_or_to_table.is_a?(Hash) and options_or_to_table.has_key?(:column)
+          foreign_keys.delete_if do |table_name, options|
+            options[:column].to_s == options_or_to_table[:column].to_s
+          end
+        elsif options_or_to_table.is_a?(String) or options_or_to_table.is_a?(Symbol)
+          foreign_keys.delete options_or_to_table.to_s
+        else
+          raise ArgumentError, "remove_foreign_key needs either a table name or a foreign key options hash with :name or :column"
+        end
+      end
+
       # Appends <tt>:datetime</tt> columns <tt>:created_at</tt> and
       # <tt>:updated_at</tt> to the table. See {connection.add_timestamps}[rdoc-ref:SchemaStatements#add_timestamps]
       #
@@ -429,6 +445,7 @@ module ActiveRecord
     #     t.change_default
     #     t.rename
     #     t.references
+    #     t.foreign_key
     #     t.belongs_to
     #     t.string
     #     t.text
@@ -444,6 +461,7 @@ module ActiveRecord
     #     t.boolean
     #     t.remove
     #     t.remove_references
+    #     t.remove_foreign_key
     #     t.remove_belongs_to
     #     t.remove_index
     #     t.remove_timestamps
@@ -613,6 +631,14 @@ module ActiveRecord
       # See {connection.add_foreign_key}[rdoc-ref:SchemaStatements#add_foreign_key]
       def foreign_key(*args) # :nodoc:
         @base.add_foreign_key(name, *args)
+      end
+
+      # Removes a foreign key.
+      # t.remove_foreign_key(:authors)
+      #
+      # See {connection.remove_foreign_key}[rdoc-ref:SchemaStatements#remove_foreign_key]
+      def remove_foreign_key(*args) # :nodoc:
+        @base.remove_foreign_key(name, *args)
       end
 
       # Checks to see if a foreign key exists.

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -165,51 +165,32 @@ module ActiveRecord
       assert_not_nil error.cause
     end
 
-    unless current_adapter?(:SQLite3Adapter)
-      def test_foreign_key_violations_are_translated_to_specific_exception
-        error = assert_raises(ActiveRecord::InvalidForeignKey) do
-          # Oracle adapter uses prefetched primary key values from sequence and passes them to connection adapter insert method
-          if @connection.prefetch_primary_key?
-            id_value = @connection.next_sequence_value(@connection.default_sequence_name("fk_test_has_fk", "id"))
-            @connection.execute "INSERT INTO fk_test_has_fk (id, fk_id) VALUES (#{id_value},0)"
-          else
-            @connection.execute "INSERT INTO fk_test_has_fk (fk_id) VALUES (0)"
-          end
+    def test_foreign_key_violations_are_translated_to_specific_exception
+      error = assert_raises(ActiveRecord::InvalidForeignKey) do
+        # Oracle adapter uses prefetched primary key values from sequence and passes them to connection adapter insert method
+        if @connection.prefetch_primary_key?
+          id_value = @connection.next_sequence_value(@connection.default_sequence_name("fk_test_has_fk", "id"))
+          @connection.execute "INSERT INTO fk_test_has_fk (id, fk_id) VALUES (#{id_value},0)"
+        else
+          @connection.execute "INSERT INTO fk_test_has_fk (fk_id) VALUES (0)"
         end
-
-        assert_not_nil error.cause
       end
 
-      def test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false
-        klass_has_fk = Class.new(ActiveRecord::Base) do
-          self.table_name = 'fk_test_has_fk'
-        end
-
-        error = assert_raises(ActiveRecord::InvalidForeignKey) do
-          has_fk = klass_has_fk.new
-          has_fk.fk_id = 1231231231
-          has_fk.save(validate: false)
-        end
-
-        assert_not_nil error.cause
-      end
+      assert_not_nil error.cause
     end
 
-    def test_disable_referential_integrity
-      assert_nothing_raised do
-        @connection.disable_referential_integrity do
-          # Oracle adapter uses prefetched primary key values from sequence and passes them to connection adapter insert method
-          if @connection.prefetch_primary_key?
-            id_value = @connection.next_sequence_value(@connection.default_sequence_name("fk_test_has_fk", "id"))
-            @connection.execute "INSERT INTO fk_test_has_fk (id, fk_id) VALUES (#{id_value},0)"
-          else
-            @connection.execute "INSERT INTO fk_test_has_fk (fk_id) VALUES (0)"
-          end
-          # should delete created record as otherwise disable_referential_integrity will try to enable constraints after executed block
-          # and will fail (at least on Oracle)
-          @connection.execute "DELETE FROM fk_test_has_fk"
-        end
+    def test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false
+      klass_has_fk = Class.new(ActiveRecord::Base) do
+        self.table_name = 'fk_test_has_fk'
       end
+
+      error = assert_raises(ActiveRecord::InvalidForeignKey) do
+        has_fk = klass_has_fk.new
+        has_fk.fk_id = 1231231231
+        has_fk.save(validate: false)
+      end
+
+      assert_not_nil error.cause
     end
 
     def test_select_all_always_return_activerecord_result
@@ -263,6 +244,34 @@ module ActiveRecord
     def test_passing_arguments_to_tables_is_deprecated
       assert_deprecated { @connection.tables(:books) }
     end
+  end
+
+  class AdapterTestDisableReferentialIntegrity < ActiveRecord::TestCase
+    def setup
+      @connection = ActiveRecord::Base.connection
+    end
+
+    # SQLite does not support disabling referential integrity within transactions,
+    # see https://www.sqlite.org/pragma.html#pragma_foreign_keys
+    self.use_transactional_tests = !current_adapter?(:SQLite3Adapter)
+
+    def test_disable_referential_integrity
+      assert_nothing_raised do
+        @connection.disable_referential_integrity do
+          # Oracle adapter uses prefetched primary key values from sequence and passes them to connection adapter insert method
+          if @connection.prefetch_primary_key?
+            id_value = @connection.next_sequence_value(@connection.default_sequence_name("fk_test_has_fk", "id"))
+            @connection.execute "INSERT INTO fk_test_has_fk (id, fk_id) VALUES (#{id_value},0)"
+          else
+            @connection.execute "INSERT INTO fk_test_has_fk (fk_id) VALUES (0)"
+          end
+          # should delete created record as otherwise disable_referential_integrity will try to enable constraints after executed block
+          # and will fail (at least on Oracle)
+          @connection.execute "DELETE FROM fk_test_has_fk"
+        end
+      end
+    end
+
   end
 
   class AdapterTestWithoutTransaction < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapters/sqlite3/collation_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/collation_test.rb
@@ -28,6 +28,20 @@ class SQLite3CollationTest < ActiveRecord::SQLite3TestCase
     assert_equal 'RTRIM', column.collation
   end
 
+  test "add column with escaped name with collation" do
+    @connection.add_column :collation_table_sqlite3, :"foo\"bar", :string, collation: 'RTRIM'
+
+    column = @connection.columns(:collation_table_sqlite3).find { |c| c.name == 'foo"bar' }
+    assert_equal :string, column.type
+    assert_equal 'RTRIM', column.collation
+
+    @connection.add_column :collation_table_sqlite3, :"foo,bar", :string, collation: 'RTRIM'
+
+    column = @connection.columns(:collation_table_sqlite3).find { |c| c.name == 'foo,bar' }
+    assert_equal :string, column.type
+    assert_equal 'RTRIM', column.collation
+  end
+
   test "add column with collation" do
     @connection.add_column :collation_table_sqlite3, :title, :string, collation: 'RTRIM'
 

--- a/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
@@ -75,9 +75,20 @@ class CopyTableTest < ActiveRecord::SQLite3TestCase
     test_copy_table 'binaries', 'binaries2'
   end
 
+  def test_copy_table_with_foreign_key_constraints
+    test_copy_table('authors', 'authors2') do
+      original_fk = @connection.foreign_keys('authors')
+      copied_fk = @connection.foreign_keys('authors2').each do |fkd|
+        # Prevent false negative due to changed name of copied table
+        fkd.from_table = 'authors'
+      end
+      assert_equal original_fk, copied_fk
+    end
+  end
+
 protected
   def copy_table(from, to, options = {})
-    @connection.copy_table(from, to, {:temporary => true}.merge(options))
+    @connection.copy_table(from, to, options)
   end
 
   def column_names(table)

--- a/activerecord/test/cases/adapters/sqlite3/foreign_key_parsing_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/foreign_key_parsing_test.rb
@@ -1,0 +1,169 @@
+require "cases/helper"
+
+class SQLite3ForeignKeyParsingTest < ActiveRecord::SQLite3TestCase
+  def setup
+    @connection = ActiveRecord::Base.connection
+  end
+
+  def teardown
+    @connection.drop_table :parsing_table_sqlite3, if_exists: true
+  end
+
+  test "nameless foreign keys defined as column constraints" do
+    sql = "CREATE TABLE parsing_table_sqlite3 (author_name text REFERENCES authors(name), author_id int REFERENCES authors(id))"
+    @connection.execute(sql)
+
+    keys = @connection.foreign_keys(:parsing_table_sqlite3)
+    assert_equal 2, keys.size
+    keys.each {|fk| assert_equal("authors", fk.to_table)}
+    keys.sort_by! {|fk| fk.column}
+
+    fk = keys.first
+    assert_equal nil, fk.name
+    assert_equal "author_id", fk.column
+    assert_equal "id", fk.primary_key
+
+    fk = keys.second
+    assert_equal nil, fk.name
+    assert_equal "author_name", fk.column
+    assert_equal "name", fk.primary_key
+  end
+
+  test "nameless foreign keys defined as table constraints" do
+    sql = "CREATE TABLE parsing_table_sqlite3 (author_name text, author_id int, FOREIGN KEY (author_name) REFERENCES authors(name), FOREIGN KEY (author_id) REFERENCES authors(id))"
+    @connection.execute(sql)
+
+    keys = @connection.foreign_keys(:parsing_table_sqlite3)
+    assert_equal 2, keys.size
+    keys.each {|fk| assert_equal("authors", fk.to_table)}
+    keys.sort_by! {|fk| fk.column}
+
+    fk = keys.first
+    assert_equal nil, fk.name
+    assert_equal "author_id", fk.column
+    assert_equal "id", fk.primary_key
+
+    fk = keys.second
+    assert_equal nil, fk.name
+    assert_equal "author_name", fk.column
+    assert_equal "name", fk.primary_key
+  end
+
+  test "named foreign keys defined as column constraints" do
+    sql = "CREATE TABLE parsing_table_sqlite3 (author_name text CONSTRAINT foo REFERENCES authors(name), author_id int CONSTRAINT bar REFERENCES authors(id))"
+    @connection.execute(sql)
+
+    keys = @connection.foreign_keys(:parsing_table_sqlite3)
+    assert_equal 2, keys.size
+    keys.each {|fk| assert_equal("authors", fk.to_table)}
+    keys.sort_by! {|fk| fk.column}
+
+    fk = keys.first
+    assert_equal "bar", fk.name
+    assert_equal "author_id", fk.column
+    assert_equal "id", fk.primary_key
+
+    fk = keys.second
+    assert_equal "foo", fk.name
+    assert_equal "author_name", fk.column
+    assert_equal "name", fk.primary_key
+  end
+
+  test "named foreign keys defined as table constraints" do
+    sql = "CREATE TABLE parsing_table_sqlite3 (author_name text, author_id int, CONSTRAINT foo FOREIGN KEY (author_name) REFERENCES authors(name), CONSTRAINT bar FOREIGN KEY (author_id) REFERENCES authors(id))"
+    @connection.execute(sql)
+
+    keys = @connection.foreign_keys(:parsing_table_sqlite3)
+    assert_equal 2, keys.size
+    keys.each {|fk| assert_equal("authors", fk.to_table)}
+    keys.sort_by! {|fk| fk.column}
+
+    fk = keys.first
+    assert_equal "bar", fk.name
+    assert_equal "author_id", fk.column
+    assert_equal "id", fk.primary_key
+
+    fk = keys.second
+    assert_equal "foo", fk.name
+    assert_equal "author_name", fk.column
+    assert_equal "name", fk.primary_key
+  end
+
+  test "foreign keys defined in both table and column constraints" do
+    sql = "CREATE TABLE parsing_table_sqlite3 (author_name text, author_id int REFERENCES authors(id), CONSTRAINT foo FOREIGN KEY (author_name) REFERENCES authors(name))"
+    @connection.execute(sql)
+
+    keys = @connection.foreign_keys(:parsing_table_sqlite3)
+    assert_equal 2, keys.size
+    keys.each {|fk| assert_equal("authors", fk.to_table)}
+    keys.sort_by! {|fk| fk.column}
+
+    fk = keys.first
+    assert_equal nil, fk.name
+    assert_equal "author_id", fk.column
+    assert_equal "id", fk.primary_key
+
+    fk = keys.second
+    assert_equal "foo", fk.name
+    assert_equal "author_name", fk.column
+    assert_equal "name", fk.primary_key
+  end
+
+  test "mixed foreign keys and collation setting on one column" do
+    sql = "CREATE TABLE parsing_table_sqlite3 (author_name text CONSTRAINT foo REFERENCES authors(name) COLLATE RTRIM REFERENCES people(name))"
+    @connection.execute(sql)
+
+    keys = @connection.foreign_keys(:parsing_table_sqlite3)
+    assert_equal 2, keys.size
+    keys.sort_by! {|fk| fk.to_table}
+
+    fk = keys.first
+    assert_equal "foo", fk.name
+    assert_equal "authors", fk.to_table
+    assert_equal "author_name", fk.column
+    assert_equal "name", fk.primary_key
+
+    fk = keys.second
+    assert_equal nil, fk.name
+    assert_equal "people", fk.to_table
+    assert_equal "author_name", fk.column
+    assert_equal "name", fk.primary_key
+
+    column = @connection.columns(:parsing_table_sqlite3).find { |c| c.name == 'author_name' }
+    assert_equal 'RTRIM', column.collation
+  end
+
+  test "foreign keys with implicit target column" do
+    sql = "CREATE TABLE parsing_table_sqlite3 (author_name text, author_id int REFERENCES authors, CONSTRAINT foo FOREIGN KEY (author_id) REFERENCES people)"
+    @connection.execute(sql)
+
+    keys = @connection.foreign_keys(:parsing_table_sqlite3)
+    assert_equal 2, keys.size
+    keys.sort_by! {|fk| fk.to_table}
+
+    fk = keys.first
+    assert_equal nil, fk.name
+    assert_equal "authors", fk.to_table
+    assert_equal "author_id", fk.column
+    assert_equal "id", fk.primary_key
+
+    fk = keys.second
+    assert_equal "foo", fk.name
+    assert_equal "people", fk.to_table
+    assert_equal "author_id", fk.column
+    assert_equal "id", fk.primary_key
+  end
+
+  test "foreign keys with escaped column names and escaped constraint names" do
+    sql = "CREATE TABLE parsing_table_sqlite3 (')author,''name''' text CONSTRAINT 'foo,''bar' REFERENCES authors(name))"
+    @connection.execute(sql)
+
+    keys = @connection.foreign_keys(:parsing_table_sqlite3)
+    assert_equal 1, keys.size
+
+    fk = keys.first
+    assert_equal "foo,'bar", fk.name
+    assert_equal ")author,'name'", fk.column
+    assert_equal "name", fk.primary_key
+  end
+end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -8,8 +8,6 @@ module ActiveRecord
     class SQLite3AdapterTest < ActiveRecord::SQLite3TestCase
       include DdlHelper
 
-      self.use_transactional_tests = false
-
       class DualEncoding < ActiveRecord::Base
       end
 

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -443,6 +443,8 @@ module ActiveRecord
 
         def test_create_table_with_force_cascade_drops_dependent_objects
           skip "MySQL > 5.5 does not drop dependent objects with DROP TABLE CASCADE" if current_adapter?(:MysqlAdapter, :Mysql2Adapter)
+          skip "SQLite does not drop dependent objects with DROP TABLE CASCADE" if current_adapter?(:SQLite3Adapter)
+
           # can't re-create table referenced by foreign key
           assert_raises(ActiveRecord::StatementInvalid) do
             @connection.create_table :trains, force: true

--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -76,9 +76,7 @@ module ActiveRecord
           assert_kind_of BigDecimal, row.wealth
 
           # If this assert fails, that means the SELECT is broken!
-          unless current_adapter?(:SQLite3Adapter)
-            assert_equal correct_value, row.wealth
-          end
+          assert_equal correct_value, row.wealth
 
           # Reset to old state
           TestModel.delete_all

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -47,7 +47,7 @@ module ActiveRecord
         assert_equal "fk_name", fk.name
       end
 
-      def test_add_foreign_key_inferes_column
+      def test_add_foreign_key_infers_column
         @connection.add_foreign_key :astronauts, :rockets
 
         foreign_keys = @connection.foreign_keys("astronauts")
@@ -168,7 +168,7 @@ module ActiveRecord
         assert_not @connection.foreign_key_exists?(:astronauts, name: "other_fancy_named_fk")
       end
 
-      def test_remove_foreign_key_inferes_column
+      def test_remove_foreign_key_infers_column
         @connection.add_foreign_key :astronauts, :rockets
 
         assert_equal 1, @connection.foreign_keys("astronauts").size

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -984,18 +984,16 @@ ActiveRecord::Schema.define do
   create_table :records, force: true do |t|
   end
 
-  except 'SQLite' do
-    # fk_test_has_fk should be before fk_test_has_pk
-    create_table :fk_test_has_fk, force: true do |t|
-      t.integer :fk_id, null: false
-    end
-
-    create_table :fk_test_has_pk, force: true, primary_key: "pk_id" do |t|
-    end
-
-    add_foreign_key :fk_test_has_fk, :fk_test_has_pk, column: "fk_id", name: "fk_name", primary_key: "pk_id"
-    add_foreign_key :lessons_students, :students
+  # fk_test_has_fk should be before fk_test_has_pk
+  create_table :fk_test_has_fk, force: true do |t|
+    t.integer :fk_id, null: false
   end
+
+  create_table :fk_test_has_pk, force: true, primary_key: "pk_id" do |t|
+  end
+
+  add_foreign_key :fk_test_has_fk, :fk_test_has_pk, column: "fk_id", name: "fk_name", primary_key: "pk_id"
+  add_foreign_key :lessons_students, :students
 
   create_table :overloaded_types, force: true do |t|
     t.float :overloaded_float, default: 500

--- a/activerecord/test/schema/sqlite_specific_schema.rb
+++ b/activerecord/test/schema/sqlite_specific_schema.rb
@@ -2,21 +2,4 @@ ActiveRecord::Schema.define do
   create_table :table_with_autoincrement, :force => true do |t|
     t.column :name, :string
   end
-
-  execute "DROP TABLE fk_test_has_fk" rescue nil
-  execute "DROP TABLE fk_test_has_pk" rescue nil
-  execute <<_SQL
-  CREATE TABLE 'fk_test_has_pk' (
-    'pk_id' INTEGER NOT NULL PRIMARY KEY
-  );
-_SQL
-
-  execute <<_SQL
-  CREATE TABLE 'fk_test_has_fk' (
-    'id'    INTEGER NOT NULL PRIMARY KEY,
-    'fk_id' INTEGER NOT NULL,
-
-    FOREIGN KEY ('fk_id') REFERENCES 'fk_test_has_pk'('pk_id')
-  );
-_SQL
 end


### PR DESCRIPTION
The biggest headache with this turned out to be getting the constraint's name. SQLite3 provides `PRAGMA foreign_key_list` for reflecting on the foreign keys defined in the database, but the information it returns does not include the names of the constraints! At least as of the current SQLite version, the only way to retrieve that name is to parse the recorded `CREATE TABLE` statement from `sqlite_master`.

This is similar to an older problem with the SQLite3 adapter, where it was necessary to parse the `CREATE TABLE` statement to retrieve information about text column collation. The current implementation uses a simple regex to retrieve the collation name. I wanted to follow the same pattern, but the existing code was very weak to unusual column names (e.g. those with escaped quotes) and to unexpected syntax (e.g. if the column names were **not** quoted). Therefore I replaced that code with the barest minimum of a tokenizer/parser system.

Then, I added to that the ability to parse the foreign key `REFERENCES` statements. SQLite3 annoyingly allows those be defined in two different places with slightly different syntax...

I also added some tests to exhibit the bug in the existing collation code, and some tests to make sure the new parser code worked correctly in various border cases.
