### PR TITLE
Fix `Post` has_many `:categorizations` association

### DIFF
--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -118,7 +118,7 @@ class Post < ActiveRecord::Base
   has_many :invalid_taggings, -> { where 'taggings.id < 0' }, :as => :taggable, :class_name => "Tagging"
   has_many :invalid_tags, :through => :invalid_taggings, :source => :tag
 
-  has_many :categorizations, :foreign_key => :category_id
+  has_many :categorizations
   has_many :authors, :through => :categorizations
 
   has_many :categorizations_using_author_id, :primary_key => :author_id, :foreign_key => :post_id, :class_name => 'Categorization'


### PR DESCRIPTION
Before:

``` sql
SELECT "posts".* FROM "posts" INNER JOIN "categorizations" ON "categorizations"."category_id" = "posts"."id"
```

After:

``` sql
SELECT "posts".* FROM "posts" INNER JOIN "categorizations" ON "categorizations"."post_id" = "posts"."id"
```
