### PR TITLE
Fix for #20602 - adjust association query for tables without primary keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Subqueries such as the following example (`Group` has no primary key)
+    now work without having to specify `item_id` in the query:
+
+    `Group.where(item: Groups.all.select(:item_id))`
+
+    Fixes #20602
+
+    *Tim Breitkreutz*
+
 *   Improve support for non Active Record objects on `validates_associated`
 
     Skipping `marked_for_destruction?` when the associated object does not responds

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
@@ -33,7 +33,7 @@ module ActiveRecord
       def ids
         case value
         when Relation
-          value.select(primary_key)
+          value.primary_key.blank? ? value : value.select(primary_key)
         when Array
           value.map { |v| convert_to_id(v) }
         else

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -23,6 +23,8 @@ require 'models/admin/user'
 require 'models/ship'
 require 'models/treasure'
 require 'models/parrot'
+require 'models/snip'
+require 'models/snap'
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
@@ -1095,6 +1097,17 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     client = Client.find(3)
 
     assert_deprecated { client.firm(true) }
+  end
+
+  # See https://github.com/rails/rails/issues/20602
+  def test_belongs_to_without_primary_key
+    snip = Snip.create!
+    snap = snip.snaps.create!
+    snap2 = snip.snaps.create!
+
+    snaps = Snap.where(snip: Snap.all.select(:snip_id))
+    assert_equal [snap.id, snap2.id], snaps.map(&:id) # nils because there's no primary key
+    assert_equal [snap.snip_id, snap2.snip_id], snaps.map(&:snip_id)
   end
 end
 

--- a/activerecord/test/models/snap.rb
+++ b/activerecord/test/models/snap.rb
@@ -1,0 +1,3 @@
+class Snap < ActiveRecord::Base
+  belongs_to :snip
+end

--- a/activerecord/test/models/snip.rb
+++ b/activerecord/test/models/snip.rb
@@ -1,0 +1,3 @@
+class Snip < ActiveRecord::Base
+  has_many :snaps
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -744,6 +744,14 @@ ActiveRecord::Schema.define do
     end
   end
 
+  create_table :snaps, id: false, force: true do |t|
+    t.integer :snip_id
+  end
+
+  create_table :snips, force: true do |t|
+    t.integer :post_id
+  end
+
   create_table :prisoners, force: true do |t|
     t.belongs_to :ship
   end


### PR DESCRIPTION
Re: #20602 

Sometime after 4.0 a query against a model without a primary key, that belongs_to another record, would no longer respond correctly to an inner selection of ids.  This PR may fix it.

See the Issue for examples and details, thanks.
