### PR TITLE
Requesting documentation update

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -300,10 +300,10 @@ module ActiveRecord
     #
     # === A word of warning
     #
-    # Don't create associations that have the same name as instance methods of
-    # ActiveRecord::Base. Since the association adds a method with that name to
-    # its model, it will override the inherited method and break things.
-    # For instance, +attributes+ and +connection+ would be bad choices for association names.
+    # Don't create associations that have the same name as [instance methods](http://api.rubyonrails.org/classes/ActiveRecord/Core.html) of
+    # <tt>ActiveRecord::Base</tt>. Since the association adds a method with that name to
+    # its model, using an association with the same name as one provided by <tt>ActiveRecord::Base</tt> will override the method inherited through <tt>ActiveRecord::Base</tt> and will break things.
+    # For instance, +attributes+ and +connection+ would be bad choices for association names, because those names already exist in the list of <tt>ActiveRecord::Base</tt> instance methods.
     #
     # == Auto-generated methods
     # See also Instance Public methods below for more details.


### PR DESCRIPTION
Hi there!

I made a suggested edit to the section that gives a 'word of warning' with respect to creating associations with the same name as ActiveRecord::Base instance methods. It'd be great to have a hyperlink to the list of ActiveRecord::Base instance methods so we can more easily know which association names we should avoid to minimize conflicts.

*\* I originally made this pull request on an incorrect branch, so I'm resubmitting now, comparing against the master branch.

Also, it was requested in the last pull request that I don't link to APIdock--since it is not the official documentation site-- and to use Rdoc to link internally. I'd be happy to link internally if I could find the _actual_ location of where one can find the list of ActiveRecord::Base instance methods elsewhere within the documentation site. Can someone point me to that? It really would help provide clarification for the new-to-RoR crowd...

Thanks!
