### PR TITLE
Add `columns_for_distinct` for MySQL 5.7 with ONLY_FULL_GROUP_BY

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1028,11 +1028,12 @@ module ActiveRecord
       end
 
       # Given a set of columns and an ORDER BY clause, returns the columns for a SELECT DISTINCT.
-      # Both PostgreSQL and Oracle overrides this for custom DISTINCT syntax - they
+      # PostgreSQL, MySQL, and Oracle overrides this for custom DISTINCT syntax - they
       # require the order columns appear in the SELECT.
       #
       #   columns_for_distinct("posts.id", ["posts.created_at desc"])
-      def columns_for_distinct(columns, orders) #:nodoc:
+      #
+      def columns_for_distinct(columns, orders) # :nodoc:
         columns
       end
 

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -1,0 +1,44 @@
+require "cases/helper"
+
+class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
+  def setup
+    @conn = ActiveRecord::Base.connection
+  end
+
+  def test_columns_for_distinct_zero_orders
+    assert_equal "posts.id",
+      @conn.columns_for_distinct("posts.id", [])
+  end
+
+  def test_columns_for_distinct_one_order
+    assert_equal "posts.id, posts.created_at AS alias_0",
+      @conn.columns_for_distinct("posts.id", ["posts.created_at desc"])
+  end
+
+  def test_columns_for_distinct_few_orders
+    assert_equal "posts.id, posts.created_at AS alias_0, posts.position AS alias_1",
+      @conn.columns_for_distinct("posts.id", ["posts.created_at desc", "posts.position asc"])
+  end
+
+  def test_columns_for_distinct_with_case
+    assert_equal(
+      'posts.id, CASE WHEN author.is_active THEN UPPER(author.name) ELSE UPPER(author.email) END AS alias_0',
+      @conn.columns_for_distinct('posts.id',
+        ["CASE WHEN author.is_active THEN UPPER(author.name) ELSE UPPER(author.email) END"])
+    )
+  end
+
+  def test_columns_for_distinct_blank_not_nil_orders
+    assert_equal "posts.id, posts.created_at AS alias_0",
+      @conn.columns_for_distinct("posts.id", ["posts.created_at desc", "", "   "])
+  end
+
+  def test_columns_for_distinct_with_arel_order
+    order = Object.new
+    def order.to_sql
+      "posts.created_at desc"
+    end
+    assert_equal "posts.id, posts.created_at AS alias_0",
+      @conn.columns_for_distinct("posts.id", [order])
+  end
+end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -19,7 +19,7 @@ require 'models/car'
 require 'models/tyre'
 
 class FinderTest < ActiveRecord::TestCase
-  fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :customers, :categories, :categorizations, :cars
+  fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :author_addresses, :customers, :categories, :categorizations, :cars
 
   def test_find_by_id_with_hash
     assert_raises(ActiveRecord::StatementInvalid) do
@@ -993,10 +993,13 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_find_with_order_on_included_associations_with_construct_finder_sql_for_association_limiting_and_is_distinct
-    assert_equal 2, Post.includes(authors: :author_address).order('author_addresses.id DESC ').limit(2).to_a.size
+    assert_equal 2, Post.includes(authors: :author_address).
+      where.not(author_addresses: { id: nil }).
+      order('author_addresses.id DESC').limit(2).to_a.size
 
     assert_equal 3, Post.includes(author: :author_address, authors: :author_address).
-                              order('author_addresses_authors.id DESC ').limit(3).to_a.size
+      where.not(author_addresses_authors: { id: nil }).
+      order('author_addresses_authors.id DESC').limit(3).to_a.size
   end
 
   def test_find_with_nil_inside_set_passed_for_one_attribute

--- a/activerecord/test/fixtures/author_addresses.yml
+++ b/activerecord/test/fixtures/author_addresses.yml
@@ -3,3 +3,9 @@ david_address:
 
 david_address_extra:
   id: 2
+
+mary_address:
+  id: 3
+
+bob_address:
+  id: 4

--- a/activerecord/test/fixtures/authors.yml
+++ b/activerecord/test/fixtures/authors.yml
@@ -9,7 +9,9 @@ david:
 mary:
   id: 2
   name: Mary
+  author_address_id: 3
 
 bob:
   id: 3
   name: Bob
+  author_address_id: 4


### PR DESCRIPTION
In MySQL 5.7.5 and up, ONLY_FULL_GROUP_BY affects handling of queries
that use DISTINCT and ORDER BY. It requires the ORDER BY columns in the
select list for distinct queries, and requires that the ORDER BY include
the distinct column.

See https://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html
