### PR TITLE
Add days_in_year method to Time class

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+* Added `Time#days_in_year` to return the number of days in the given year, or the
+  current year if no argument is provided.
+
+  *Jon Pascoe*
+
 * Updated `parameterize` to preserve the case of a string, optionally.
 
     Example:

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -26,6 +26,12 @@ class Time
       end
     end
 
+    # Returns the number of days in the given year.
+    # If no year is specified, it will use the current year.
+    def days_in_year(year = current.year)
+      days_in_month(2, year) + 337
+    end
+
     # Returns <tt>Time.zone.now</tt> when <tt>Time.zone</tt> or <tt>config.time_zone</tt> are set, otherwise just returns <tt>Time.now</tt>.
     def current
       ::Time.zone ? ::Time.zone.now : ::Time.now

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -617,6 +617,25 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_days_in_year_with_year
+    assert_equal 365, Time.days_in_year(2005)
+    assert_equal 366, Time.days_in_year(2004)
+    assert_equal 366, Time.days_in_year(2000)
+    assert_equal 365, Time.days_in_year(1900)
+  end
+
+  def test_days_in_year_in_common_year_without_year_arg
+    Time.stub(:now, Time.utc(2007)) do
+      assert_equal 365, Time.days_in_year
+    end
+  end
+
+  def test_days_in_year_in_leap_year_without_year_arg
+    Time.stub(:now, Time.utc(2008)) do
+      assert_equal 366, Time.days_in_year
+    end
+  end
+
   def test_last_month_on_31st
     assert_equal Time.local(2004, 2, 29), Time.local(2004, 3, 31).last_month
   end


### PR DESCRIPTION
Adds a `days_in_year` method to the `Time` class.

Returns `365` for common years and `366` for leap years.
