### PR TITLE
Avoid loading all records in Relation#inspect

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Avoid loading an unbound number of records in Relation#inspect.
+
+    *Amir Yalon*
+
 *   Option to remove standardized column types/arguments spaces in schema dump
     with `ActiveRecord::SchemaDumper.standardized_argument_widths` and
     `ActiveRecord::SchemaDumper.standardized_type_widths` methods.

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1917,6 +1917,12 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
+  test "unloaded relations add a LIMIT in #inspect but not in #to_a" do
+    relation = Post.all
+    assert_sql(/LIMIT/) { relation.inspect }
+    assert_sql(/\A(?!.*LIMIT)/m) { relation.to_a }
+  end
+
   test "using a custom table affects the wheres" do
     table_alias = Post.arel_table.alias("omg_posts")
 


### PR DESCRIPTION
Calling `#records` without a `#limit` can potentially put a lot of pressure on resources of the running machine, as seen in charliesome/better_errors#72.  Instead, I apply the same limit here in a way that avoids unnecessary loading of all records.
