### PR TITLE
Fix #22232: rake test tasks exit status code

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix setting exit status code for rake test tasks. The exit status code
+    was not set when tests were fired with `rake`. Now, it is being set and it matches
+    behavior of running tests via `rails` command (`rails test`), so no matter if
+    `rake test` or `rails test` command is used the exit code will be set.
+
+    *Arkadiusz Fal*
+
 *   Add Command infrastructure to replace rake.
 
     Also move `rake dev:cache` to new infrastructure. You'll need to use

--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -57,7 +57,9 @@ module Minitest
   # as the patterns would also contain the other Rake tasks.
   def self.rake_run(patterns) # :nodoc:
     @rake_patterns = patterns
-    run
+    passed = run
+    exit passed unless passed
+    passed
   end
 
   def self.plugin_rails_init(options)


### PR DESCRIPTION
Rake test task sets exit status code, so the behavior
is matching rails test command.
