### PR TITLE
Always use `replace_named_bind_variables` when Hash is given

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -144,7 +144,7 @@ module ActiveRecord
       #   # => "name='foo''bar' and group_id='4'"
       def sanitize_sql_array(ary)
         statement, *values = ary
-        if values.first.is_a?(Hash) && statement =~ /:\w+/
+        if values.first.is_a?(Hash)
           replace_named_bind_variables(statement, values.first)
         elsif statement.include?('?')
           replace_bind_variables(statement, values)

--- a/activerecord/test/cases/sanitize_test.rb
+++ b/activerecord/test/cases/sanitize_test.rb
@@ -58,6 +58,11 @@ class SanitizeTest < ActiveRecord::TestCase
     assert_equal 'normal string 42', Binary.send(:sanitize_sql_like, 'normal string 42', '!')
   end
 
+  def test_sanitize_sql_array_handles_named_bind_variables
+    assert_equal "name='%s'", Binary.send(:sanitize_sql_array, ["name='%s'", name: "Bambi"])
+    assert_equal "name=?", Binary.send(:sanitize_sql_array, ["name=?", name: "Bambi"])
+  end
+
   def test_sanitize_sql_like_example_use_case
     searchable_post = Class.new(Post) do
       def self.search(term)


### PR DESCRIPTION
Change to use `replace_named_bind_variables` always if second args
of `sanitize_sql_array` is a Hash.
This commit make it easy to check arity mismatch between statement
and hash.

Before:

```
sanitize_sql_array(["name='%s'", name: "Bambi"])
\# => "name='{:name=>\\\"Bambi\\\"}'"
```

After:

```
sanitize_sql_array(["name='%s'", name: "Bambi"])
\# => "name='%s'"
```
