### PR TITLE
Implements an evented file system monitor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ end
 
 # Active Support.
 gem 'dalli', '>= 2.2.1'
+gem 'listen', '~> 3.0.3'
 
 # Active Job.
 group :job do

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ end
 
 # Active Support.
 gem 'dalli', '>= 2.2.1'
-gem 'listen', '~> 3.0.3'
+gem 'listen', '~> 3.0.4'
 
 # Active Job.
 group :job do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,9 @@ GEM
       delayed_job (>= 3.0, < 5)
     erubis (2.7.0)
     execjs (2.6.0)
+    ffi (1.9.10)
+    ffi (1.9.10-x64-mingw32)
+    ffi (1.9.10-x86-mingw32)
     hitimes (1.2.3)
     hitimes (1.2.3-x86-mingw32)
     i18n (0.7.0)
@@ -219,6 +222,9 @@ GEM
     kindlerb (0.1.1)
       mustache
       nokogiri
+    listen (3.0.3)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     metaclass (0.0.4)
@@ -252,6 +258,9 @@ GEM
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
     rake (10.4.2)
+    rb-fsevent (0.9.6)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
     rdoc (4.2.0)
     redcarpet (3.2.3)
     redis (3.2.1)
@@ -333,6 +342,7 @@ DEPENDENCIES
   jquery-rails!
   json
   kindlerb (= 0.1.1)
+  listen (~> 3.0.3)
   mail!
   minitest (< 5.3.4)
   mocha (~> 0.14)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
     kindlerb (0.1.1)
       mustache
       nokogiri
-    listen (3.0.3)
+    listen (3.0.4)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     loofah (2.0.3)
@@ -342,7 +342,7 @@ DEPENDENCIES
   jquery-rails!
   json
   kindlerb (= 0.1.1)
-  listen (~> 3.0.3)
+  listen (~> 3.0.4)
   mail!
   minitest (< 5.3.4)
   mocha (~> 0.14)

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Implements an evented file system monitor to asynchronously detect changes
+    in the application source code, routes, locales, etc.
+
+    To opt-in load the [listen](https://github.com/guard/listen) gem in `Gemfile`:
+
+      group :development do
+        gem 'listen', '~> 3.0.4'
+      end
+
+    *Puneet Agarwal* and *Xavier Noria*
+
 * Updated `parameterize` to preserve the case of a string, optionally.
 
     Example:

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -34,6 +34,7 @@ module ActiveSupport
   autoload :Dependencies
   autoload :DescendantsTracker
   autoload :FileUpdateChecker
+  autoload :FileEventedUpdateChecker
   autoload :LogSubscriber
   autoload :Notifications
 

--- a/activesupport/lib/active_support/file_evented_update_checker.rb
+++ b/activesupport/lib/active_support/file_evented_update_checker.rb
@@ -84,7 +84,7 @@ module ActiveSupport
     end
 
     def existing_parent(dir)
-      dir = Pathname.new(File.expand_path(dir))
+      dir = Pathname.new(expand_path(dir))
 
       loop do
         if dir.directory?

--- a/activesupport/lib/active_support/file_evented_update_checker.rb
+++ b/activesupport/lib/active_support/file_evented_update_checker.rb
@@ -107,9 +107,7 @@ module ActiveSupport
         lcsp = Pathname.new(paths[0])
 
         paths[1..-1].each do |path|
-          loop do
-            break if lcsp.ascendant_of?(path)
-
+          until lcsp.ascendant_of?(path)
             if lcsp.root?
               # If we get here a root directory is not an ascendant of path.
               # This may happen if there are paths in different drives on

--- a/activesupport/lib/active_support/file_evented_update_checker.rb
+++ b/activesupport/lib/active_support/file_evented_update_checker.rb
@@ -13,9 +13,9 @@ module ActiveSupport
         @dirs[@ph.xpath(dir)] = Array(exts).map {|ext| @ph.normalize_extension(ext)}
       end
 
-      @block    = block
-      @modified = false
-      @lcsp     = @ph.longest_common_subpath(@dirs.keys)
+      @block   = block
+      @updated = false
+      @lcsp    = @ph.longest_common_subpath(@dirs.keys)
 
       if (watch_dirs = base_directories).any?
         Listen.to(*watch_dirs, &method(:changed)).start
@@ -23,13 +23,13 @@ module ActiveSupport
     end
 
     def updated?
-      @modified
+      @updated
     end
 
     def execute
       @block.call
     ensure
-      @modified = false
+      @updated = false
     end
 
     def execute_if_updated
@@ -43,7 +43,7 @@ module ActiveSupport
 
     def changed(modified, added, removed)
       unless updated?
-        @modified = (modified + added + removed).any? {|f| watching?(f)}
+        @updated = (modified + added + removed).any? {|f| watching?(f)}
       end
     end
 

--- a/activesupport/lib/active_support/file_evented_update_checker.rb
+++ b/activesupport/lib/active_support/file_evented_update_checker.rb
@@ -4,8 +4,6 @@ require 'pathname'
 
 module ActiveSupport
   class FileEventedUpdateChecker
-    attr_reader :listener
-
     def initialize(files, dirs={}, &block)
       @files = files.map {|f| expand_path(f)}.to_set
 
@@ -18,8 +16,7 @@ module ActiveSupport
       @modified = false
 
       if (watch_dirs = base_directories).any?
-        @listener = Listen.to(*watch_dirs, &method(:changed))
-        @listener.start
+        Listen.to(*watch_dirs, &method(:changed)).start
       end
     end
 

--- a/activesupport/lib/active_support/file_evented_update_checker.rb
+++ b/activesupport/lib/active_support/file_evented_update_checker.rb
@@ -72,14 +72,11 @@ module ActiveSupport
       end
 
       def directories_to_watch
-        bd = []
+        dtw = (@files + @dirs.keys).map {|f| @ph.existing_parent(f)}
+        dtw.compact!
+        dtw.uniq!
 
-        bd.concat @files.map {|f| @ph.existing_parent(f.dirname)}
-        bd.concat @dirs.keys.map {|dir| @ph.existing_parent(dir)}
-        bd.compact!
-        bd.uniq!
-
-        @ph.filter_out_descendants(bd)
+        @ph.filter_out_descendants(dtw)
       end
 
     class PathHelper

--- a/activesupport/lib/active_support/file_evented_update_checker.rb
+++ b/activesupport/lib/active_support/file_evented_update_checker.rb
@@ -144,6 +144,7 @@ module ActiveSupport
           }
         end
 
+        # Array#- preserves order.
         directories - descendants
       end
     end

--- a/activesupport/lib/active_support/file_evented_update_checker.rb
+++ b/activesupport/lib/active_support/file_evented_update_checker.rb
@@ -1,0 +1,67 @@
+require 'listen'
+
+module ActiveSupport
+  class FileEventedUpdateChecker
+    attr_reader :listener
+    def initialize(files, directories={}, &block)
+      @files = files.map { |f| File.expand_path(f)}.to_set
+      @dirs = Hash.new
+      directories.each do |key,value|
+        @dirs[File.expand_path(key)] = Array(value) if !Array(value).empty?
+      end
+      @block = block
+      @modified = false
+      watch_dirs = base_directories
+      @listener = Listen.to(*watch_dirs,&method(:changed)) if !watch_dirs.empty?
+      @listener.start if @listener
+    end
+
+    def updated?
+      @modified
+    end
+
+    def execute
+      @block.call
+    ensure
+      @modified = false
+    end
+
+    def execute_if_updated
+      if updated?
+        execute
+        true
+      else
+        false
+      end
+    end
+
+    private
+
+    def watching?(file)
+      return true if @files.include?(file)
+      cfile = file
+      while !cfile.eql? "/"
+        cfile = File.expand_path("#{cfile}/..")
+        if !@dirs[cfile].nil? and file.end_with?(*(@dirs[cfile].map {|ext| ".#{ext.to_s}"}))
+          return true
+        end
+      end
+      false
+    end
+
+    def changed(modified, added, removed)
+      return if updated?
+      if (modified + added + removed).any? { |f| watching? f }
+        @modified = true
+      end
+    end
+
+    def base_directories
+      (@files.map { |f| existing_parent(File.expand_path("#{f}/..")) } + @dirs.keys.map {|dir| existing_parent(dir)}).uniq
+    end
+
+    def existing_parent(path)
+      File.exist?(path) ? path : existing_parent(File.expand_path("#{path}/.."))
+    end
+  end
+end

--- a/activesupport/lib/active_support/file_evented_update_checker.rb
+++ b/activesupport/lib/active_support/file_evented_update_checker.rb
@@ -41,46 +41,46 @@ module ActiveSupport
 
     private
 
-    def changed(modified, added, removed)
-      unless updated?
-        @updated = (modified + added + removed).any? {|f| watching?(f)}
-      end
-    end
-
-    def watching?(file)
-      file = @ph.xpath(file)
-
-      return true  if @files.member?(file)
-      return false if file.directory?
-
-      ext = @ph.normalize_extension(file.extname)
-      dir = file.dirname
-
-      loop do
-        if @dirs.fetch(dir, []).include?(ext)
-          break true
-        else
-          if @lcsp
-            break false if dir == @lcsp
-          else
-            break false if dir.root?
-          end
-
-          dir = dir.parent
+      def changed(modified, added, removed)
+        unless updated?
+          @updated = (modified + added + removed).any? {|f| watching?(f)}
         end
       end
-    end
 
-    def directories_to_watch
-      bd = []
+      def watching?(file)
+        file = @ph.xpath(file)
 
-      bd.concat @files.map {|f| @ph.existing_parent(f.dirname)}
-      bd.concat @dirs.keys.map {|dir| @ph.existing_parent(dir)}
-      bd.compact!
-      bd.uniq!
+        return true  if @files.member?(file)
+        return false if file.directory?
 
-      @ph.filter_out_descendants(bd)
-    end
+        ext = @ph.normalize_extension(file.extname)
+        dir = file.dirname
+
+        loop do
+          if @dirs.fetch(dir, []).include?(ext)
+            break true
+          else
+            if @lcsp
+              break false if dir == @lcsp
+            else
+              break false if dir.root?
+            end
+
+            dir = dir.parent
+          end
+        end
+      end
+
+      def directories_to_watch
+        bd = []
+
+        bd.concat @files.map {|f| @ph.existing_parent(f.dirname)}
+        bd.concat @dirs.keys.map {|dir| @ph.existing_parent(dir)}
+        bd.compact!
+        bd.uniq!
+
+        @ph.filter_out_descendants(bd)
+      end
 
     class PathHelper
       using Module.new {

--- a/activesupport/lib/active_support/file_evented_update_checker.rb
+++ b/activesupport/lib/active_support/file_evented_update_checker.rb
@@ -126,19 +126,8 @@ module ActiveSupport
 
       # Returns the deepest existing ascendant, which could be the argument itself.
       def existing_parent(dir)
-        loop do
-          if dir.directory?
-            break dir
-          else
-            if dir.root?
-              # Edge case in which not even the root exists. For example, Windows
-              # paths could have a non-existing drive letter. Since the parent of
-              # root is root, we need to break to prevent an infinite loop.
-              break
-            else
-              dir = dir.parent
-            end
-          end
+        dir.ascend do |ascendant|
+          break ascendant if ascendant.directory?
         end
       end
 

--- a/activesupport/lib/active_support/file_evented_update_checker.rb
+++ b/activesupport/lib/active_support/file_evented_update_checker.rb
@@ -50,23 +50,19 @@ module ActiveSupport
       def watching?(file)
         file = @ph.xpath(file)
 
-        return true  if @files.member?(file)
-        return false if file.directory?
+        if @files.member?(file)
+          true
+        elsif file.directory?
+          false
+        else
+          ext = @ph.normalize_extension(file.extname)
 
-        ext = @ph.normalize_extension(file.extname)
-        dir = file.dirname
-
-        loop do
-          if @dirs.fetch(dir, []).include?(ext)
-            break true
-          else
-            if @lcsp
-              break false if dir == @lcsp
-            else
-              break false if dir.root?
+          file.dirname.ascend do |dir|
+            if @dirs.fetch(dir, []).include?(ext)
+              break true
+            elsif dir == @lcsp || dir.root?
+              break false
             end
-
-            dir = dir.parent
           end
         end
       end

--- a/activesupport/lib/active_support/file_evented_update_checker.rb
+++ b/activesupport/lib/active_support/file_evented_update_checker.rb
@@ -4,13 +4,13 @@ require 'pathname'
 
 module ActiveSupport
   class FileEventedUpdateChecker #:nodoc: all
-    def initialize(files, dirs={}, &block)
+    def initialize(files, dirs = {}, &block)
       @ph    = PathHelper.new
-      @files = files.map {|f| @ph.xpath(f)}.to_set
+      @files = files.map { |f| @ph.xpath(f) }.to_set
 
       @dirs = {}
       dirs.each do |dir, exts|
-        @dirs[@ph.xpath(dir)] = Array(exts).map {|ext| @ph.normalize_extension(ext)}
+        @dirs[@ph.xpath(dir)] = Array(exts).map { |ext| @ph.normalize_extension(ext) }
       end
 
       @block   = block
@@ -43,7 +43,7 @@ module ActiveSupport
 
       def changed(modified, added, removed)
         unless updated?
-          @updated = (modified + added + removed).any? {|f| watching?(f)}
+          @updated = (modified + added + removed).any? { |f| watching?(f) }
         end
       end
 
@@ -68,7 +68,7 @@ module ActiveSupport
       end
 
       def directories_to_watch
-        dtw = (@files + @dirs.keys).map {|f| @ph.existing_parent(f)}
+        dtw = (@files + @dirs.keys).map { |f| @ph.existing_parent(f) }
         dtw.compact!
         dtw.uniq!
 
@@ -126,7 +126,7 @@ module ActiveSupport
       def filter_out_descendants(directories)
         return directories if directories.length < 2
 
-        sorted_by_nparts = directories.sort_by {|dir| dir.each_filename.to_a.length}
+        sorted_by_nparts = directories.sort_by { |dir| dir.each_filename.to_a.length }
         descendants = []
 
         until sorted_by_nparts.empty?

--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -35,7 +35,7 @@ module ActiveSupport
     # This method must also receive a block that will be called once a path
     # changes. The array of files and list of directories cannot be changed
     # after FileUpdateChecker has been initialized.
-    def initialize(files, dirs={}, &block)
+    def initialize(files, dirs = {}, &block)
       @files = files.freeze
       @glob  = compile_glob(dirs)
       @block = block

--- a/activesupport/test/file_evented_update_checker_test.rb
+++ b/activesupport/test/file_evented_update_checker_test.rb
@@ -3,8 +3,6 @@ require 'fileutils'
 require 'thread'
 require 'file_update_checker_with_enumerable_test_cases'
 
-MTIME_FIXTURES_PATH = File.expand_path('fixtures', __dir__)
-
 class FileEventedUpdateCheckerTest < ActiveSupport::TestCase
   include FileUpdateCheckerWithEnumerableTestCases
 

--- a/activesupport/test/file_evented_update_checker_test.rb
+++ b/activesupport/test/file_evented_update_checker_test.rb
@@ -1,6 +1,7 @@
 require 'abstract_unit'
 require 'fileutils'
 require 'thread'
+require 'pathname'
 require 'file_update_checker_with_enumerable_test_cases'
 
 class FileEventedUpdateCheckerTest < ActiveSupport::TestCase
@@ -8,5 +9,64 @@ class FileEventedUpdateCheckerTest < ActiveSupport::TestCase
 
   def build_new_watcher(files, dirs={}, &block)
     ActiveSupport::FileEventedUpdateChecker.new(files, dirs, &block)
+  end
+end
+
+class FileEventedUpdateCheckerPathHelperTest < ActiveSupport::TestCase
+  def pn(path)
+    Pathname.new(path)
+  end
+
+  setup do
+    @ph = ActiveSupport::FileEventedUpdateChecker::PathHelper.new
+  end
+
+  test '#xpath returns the expanded path as a Pathname object' do
+    assert_equal pn(__FILE__).expand_path, @ph.xpath(__FILE__)
+  end
+
+  test '#normalize_extension returns a bare extension as is' do
+    assert_equal 'rb', @ph.normalize_extension('rb')
+  end
+
+  test '#normalize_extension removes a leading dot' do
+    assert_equal 'rb', @ph.normalize_extension('.rb')
+  end
+
+  test '#normalize_extension supports symbols' do
+    assert_equal 'rb', @ph.normalize_extension(:rb)
+  end
+
+  test '#longest_common_subpath finds the longest common subpath, if there is one' do
+    paths = %w(
+      /foo/bar
+      /foo/baz
+      /foo/bar/baz/woo/zoo
+    ).map {|path| pn(path)}
+
+    assert_equal pn('/foo'), @ph.longest_common_subpath(paths)
+  end
+
+  test '#longest_common_subpath returns the root directory as an edge case' do
+    paths = %w(
+      /foo/bar
+      /foo/baz
+      /foo/bar/baz/woo/zoo
+      /wadus
+    ).map {|path| pn(path)}
+
+    assert_equal pn('/'), @ph.longest_common_subpath(paths)
+  end
+
+  test '#longest_common_subpath returns nil for an empty collection' do
+    assert_nil @ph.longest_common_subpath([])
+  end
+
+  test '#existing_parent returns the most specific existing ascendant' do
+    wd = Pathname.getwd
+
+    assert_equal wd, @ph.existing_parent(wd)
+    assert_equal wd, @ph.existing_parent(wd.join('non-existing/directory'))
+    assert_equal pn('/'), @ph.existing_parent(pn('/non-existing/directory'))
   end
 end

--- a/activesupport/test/file_evented_update_checker_test.rb
+++ b/activesupport/test/file_evented_update_checker_test.rb
@@ -1,19 +1,21 @@
 require 'abstract_unit'
-require 'fileutils'
-require 'thread'
 require 'pathname'
 require 'file_update_checker_with_enumerable_test_cases'
 
 class FileEventedUpdateCheckerTest < ActiveSupport::TestCase
   include FileUpdateCheckerWithEnumerableTestCases
 
-  def build_new_watcher(files, dirs={}, &block)
+  def build_new_watcher(files=[], dirs={}, &block)
     ActiveSupport::FileEventedUpdateChecker.new(files, dirs, &block)
   end
 
   def teardown
     super
     Listen.stop
+  end
+
+  def wait
+    sleep 0.5
   end
 end
 

--- a/activesupport/test/file_evented_update_checker_test.rb
+++ b/activesupport/test/file_evented_update_checker_test.rb
@@ -10,6 +10,11 @@ class FileEventedUpdateCheckerTest < ActiveSupport::TestCase
   def build_new_watcher(files, dirs={}, &block)
     ActiveSupport::FileEventedUpdateChecker.new(files, dirs, &block)
   end
+
+  def teardown
+    super
+    Listen.stop
+  end
 end
 
 class FileEventedUpdateCheckerPathHelperTest < ActiveSupport::TestCase

--- a/activesupport/test/file_evented_update_checker_test.rb
+++ b/activesupport/test/file_evented_update_checker_test.rb
@@ -88,4 +88,34 @@ class FileEventedUpdateCheckerPathHelperTest < ActiveSupport::TestCase
     assert_equal wd, @ph.existing_parent(wd.join('non-existing/directory'))
     assert_equal pn('/'), @ph.existing_parent(pn('/non-existing/directory'))
   end
+
+  test '#filter_out_descendants returns the same collection if there are no descendants (empty)' do
+    assert_equal [], @ph.filter_out_descendants([])
+  end
+
+  test '#filter_out_descendants returns the same collection if there are no descendants (one)' do
+    assert_equal ['/foo'], @ph.filter_out_descendants(['/foo'])
+  end
+
+  test '#filter_out_descendants returns the same collection if there are no descendants (several)' do
+    paths = %w(
+      /Rails.root/app/controllers
+      /Rails.root/app/models
+      /Rails.root/app/helpers
+    ).map {|path| pn(path)}
+
+    assert_equal paths, @ph.filter_out_descendants(paths)
+  end
+
+  test '#filter_out_descendants filters out descendants preserving order' do
+    paths = %w(
+      /Rails.root/app/controllers
+      /Rails.root/app/controllers/concerns
+      /Rails.root/app/models
+      /Rails.root/app/models/concerns
+      /Rails.root/app/helpers
+    ).map {|path| pn(path)}
+
+    assert_equal paths.values_at(0, 2, 4), @ph.filter_out_descendants(paths)
+  end
 end

--- a/activesupport/test/file_evented_update_checker_test.rb
+++ b/activesupport/test/file_evented_update_checker_test.rb
@@ -1,0 +1,21 @@
+require 'abstract_unit'
+require 'fileutils'
+require 'thread'
+require 'file_update_checker_with_enumerable_test_cases'
+
+MTIME_FIXTURES_PATH = File.expand_path("../fixtures", __FILE__)
+
+class FileEventedUpdateCheckerWithEnumerableTest < ActiveSupport::TestCase
+	include FileUpdateCheckerWithEnumerableTestCases
+  def build_new_watcher(files, dirs={}, &block)
+    ActiveSupport::FileEventedUpdateChecker.new(files, dirs, &block)
+  end
+
+  def test_modified_should_become_true_when_watched_file_is_updated
+  	watcher = ActiveSupport::FileEventedUpdateChecker.new(FILES){ i += 1 }
+  	assert_equal watcher.updated?, false
+  	FileUtils.rm(FILES)
+  	sleep 1
+  	assert_equal watcher.updated?, true
+  end
+end

--- a/activesupport/test/file_evented_update_checker_test.rb
+++ b/activesupport/test/file_evented_update_checker_test.rb
@@ -6,7 +6,9 @@ class FileEventedUpdateCheckerTest < ActiveSupport::TestCase
   include FileUpdateCheckerWithEnumerableTestCases
 
   def new_checker(files=[], dirs={}, &block)
-    ActiveSupport::FileEventedUpdateChecker.new(files, dirs, &block)
+    ActiveSupport::FileEventedUpdateChecker.new(files, dirs, &block).tap do
+      wait
+    end
   end
 
   def teardown
@@ -15,7 +17,7 @@ class FileEventedUpdateCheckerTest < ActiveSupport::TestCase
   end
 
   def wait
-    sleep 0.5
+    sleep 1
   end
 end
 

--- a/activesupport/test/file_evented_update_checker_test.rb
+++ b/activesupport/test/file_evented_update_checker_test.rb
@@ -5,7 +5,7 @@ require 'file_update_checker_with_enumerable_test_cases'
 class FileEventedUpdateCheckerTest < ActiveSupport::TestCase
   include FileUpdateCheckerWithEnumerableTestCases
 
-  def build_new_watcher(files=[], dirs={}, &block)
+  def new_checker(files=[], dirs={}, &block)
     ActiveSupport::FileEventedUpdateChecker.new(files, dirs, &block)
   end
 

--- a/activesupport/test/file_evented_update_checker_test.rb
+++ b/activesupport/test/file_evented_update_checker_test.rb
@@ -1,9 +1,9 @@
 require 'abstract_unit'
 require 'pathname'
-require 'file_update_checker_with_enumerable_test_cases'
+require 'file_update_checker_shared_tests'
 
 class FileEventedUpdateCheckerTest < ActiveSupport::TestCase
-  include FileUpdateCheckerWithEnumerableTestCases
+  include FileUpdateCheckerSharedTests
 
   def new_checker(files=[], dirs={}, &block)
     ActiveSupport::FileEventedUpdateChecker.new(files, dirs, &block).tap do

--- a/activesupport/test/file_evented_update_checker_test.rb
+++ b/activesupport/test/file_evented_update_checker_test.rb
@@ -3,19 +3,12 @@ require 'fileutils'
 require 'thread'
 require 'file_update_checker_with_enumerable_test_cases'
 
-MTIME_FIXTURES_PATH = File.expand_path("../fixtures", __FILE__)
+MTIME_FIXTURES_PATH = File.expand_path('fixtures', __dir__)
 
-class FileEventedUpdateCheckerWithEnumerableTest < ActiveSupport::TestCase
-	include FileUpdateCheckerWithEnumerableTestCases
+class FileEventedUpdateCheckerTest < ActiveSupport::TestCase
+  include FileUpdateCheckerWithEnumerableTestCases
+
   def build_new_watcher(files, dirs={}, &block)
     ActiveSupport::FileEventedUpdateChecker.new(files, dirs, &block)
-  end
-
-  def test_modified_should_become_true_when_watched_file_is_updated
-  	watcher = ActiveSupport::FileEventedUpdateChecker.new(FILES){ i += 1 }
-  	assert_equal watcher.updated?, false
-  	FileUtils.rm(FILES)
-  	sleep 1
-  	assert_equal watcher.updated?, true
   end
 end

--- a/activesupport/test/file_evented_update_checker_test.rb
+++ b/activesupport/test/file_evented_update_checker_test.rb
@@ -19,6 +19,16 @@ class FileEventedUpdateCheckerTest < ActiveSupport::TestCase
   def wait
     sleep 1
   end
+
+  def touch(files)
+    super
+    wait # wait for the events to fire
+  end
+
+  def rm_f(files)
+    super
+    wait
+  end
 end
 
 class FileEventedUpdateCheckerPathHelperTest < ActiveSupport::TestCase

--- a/activesupport/test/file_evented_update_checker_test.rb
+++ b/activesupport/test/file_evented_update_checker_test.rb
@@ -5,7 +5,7 @@ require 'file_update_checker_shared_tests'
 class FileEventedUpdateCheckerTest < ActiveSupport::TestCase
   include FileUpdateCheckerSharedTests
 
-  def new_checker(files=[], dirs={}, &block)
+  def new_checker(files = [], dirs = {}, &block)
     ActiveSupport::FileEventedUpdateChecker.new(files, dirs, &block).tap do
       wait
     end
@@ -61,7 +61,7 @@ class FileEventedUpdateCheckerPathHelperTest < ActiveSupport::TestCase
       /foo/bar
       /foo/baz
       /foo/bar/baz/woo/zoo
-    ).map {|path| pn(path)}
+    ).map { |path| pn(path) }
 
     assert_equal pn('/foo'), @ph.longest_common_subpath(paths)
   end
@@ -72,7 +72,7 @@ class FileEventedUpdateCheckerPathHelperTest < ActiveSupport::TestCase
       /foo/baz
       /foo/bar/baz/woo/zoo
       /wadus
-    ).map {|path| pn(path)}
+    ).map { |path| pn(path) }
 
     assert_equal pn('/'), @ph.longest_common_subpath(paths)
   end
@@ -102,7 +102,7 @@ class FileEventedUpdateCheckerPathHelperTest < ActiveSupport::TestCase
       /Rails.root/app/controllers
       /Rails.root/app/models
       /Rails.root/app/helpers
-    ).map {|path| pn(path)}
+    ).map { |path| pn(path) }
 
     assert_equal paths, @ph.filter_out_descendants(paths)
   end
@@ -114,7 +114,7 @@ class FileEventedUpdateCheckerPathHelperTest < ActiveSupport::TestCase
       /Rails.root/app/models
       /Rails.root/app/models/concerns
       /Rails.root/app/helpers
-    ).map {|path| pn(path)}
+    ).map { |path| pn(path) }
 
     assert_equal paths.values_at(0, 2, 4), @ph.filter_out_descendants(paths)
   end

--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -12,7 +12,7 @@ module FileUpdateCheckerSharedTests
   end
 
   def tmpfiles
-    @tmpfiles ||= %w(foo.rb bar.rb baz.rb).map {|f| tmpfile(f)}
+    @tmpfiles ||= %w(foo.rb bar.rb baz.rb).map { |f| tmpfile(f) }
   end
 
   def teardown

--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-module FileUpdateCheckerWithEnumerableTestCases
+module FileUpdateCheckerSharedTests
   include FileUtils
 
   def tmpdir

--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -1,6 +1,7 @@
 require 'fileutils'
 
 module FileUpdateCheckerSharedTests
+  extend ActiveSupport::Testing::Declarative
   include FileUtils
 
   def tmpdir
@@ -19,7 +20,7 @@ module FileUpdateCheckerSharedTests
     FileUtils.rm_rf(@tmpdir) if @tmpdir
   end
 
-  def test_should_not_execute_the_block_if_no_paths_are_given
+  test 'should not execute the block if no paths are given' do
     i = 0
 
     checker = new_checker { i += 1 }
@@ -28,7 +29,7 @@ module FileUpdateCheckerSharedTests
     assert_equal 0, i
   end
 
-  def test_should_not_execute_the_block_if_no_files_change
+  test 'should not execute the block if no files change' do
     i = 0
 
     FileUtils.touch(tmpfiles)
@@ -39,7 +40,7 @@ module FileUpdateCheckerSharedTests
     assert_equal 0, i
   end
 
-  def test_should_execute_the_block_once_when_files_are_created
+  test 'should execute the block once when files are created' do
     i = 0
 
     checker = new_checker(tmpfiles) { i += 1 }
@@ -50,7 +51,7 @@ module FileUpdateCheckerSharedTests
     assert_equal 1, i
   end
 
-  def test_should_execute_the_block_once_when_files_are_modified
+  test 'should execute the block once when files are modified' do
     i = 0
 
     FileUtils.touch(tmpfiles)
@@ -63,7 +64,7 @@ module FileUpdateCheckerSharedTests
     assert_equal 1, i
   end
 
-  def test_should_execute_the_block_once_when_files_are_deleted
+  test 'should execute the block once when files are deleted' do
     i = 0
 
     FileUtils.touch(tmpfiles)
@@ -77,7 +78,7 @@ module FileUpdateCheckerSharedTests
   end
 
 
-  def test_updated_should_become_true_when_watched_files_are_created
+  test 'updated should become true when watched files are created' do
     i = 0
 
     checker = new_checker(tmpfiles) { i += 1 }
@@ -89,7 +90,7 @@ module FileUpdateCheckerSharedTests
   end
 
 
-  def test_updated_should_become_true_when_watched_files_are_modified
+  test 'updated should become true when watched files are modified' do
     i = 0
 
     FileUtils.touch(tmpfiles)
@@ -102,7 +103,7 @@ module FileUpdateCheckerSharedTests
     assert checker.updated?
   end
 
-  def test_updated_should_become_true_when_watched_files_are_deleted
+  test 'updated should become true when watched files are deleted' do
     i = 0
 
     FileUtils.touch(tmpfiles)
@@ -115,7 +116,7 @@ module FileUpdateCheckerSharedTests
     assert checker.updated?
   end
 
-  def test_should_be_robust_to_handle_files_with_wrong_modified_time
+  test 'should be robust to handle files with wrong modified time' do
     i = 0
 
     FileUtils.touch(tmpfiles)
@@ -132,7 +133,7 @@ module FileUpdateCheckerSharedTests
     assert_equal 1, i
   end
 
-  def test_should_cache_updated_result_until_execute
+  test 'should cache updated result until execute' do
     i = 0
 
     checker = new_checker(tmpfiles) { i += 1 }
@@ -145,7 +146,7 @@ module FileUpdateCheckerSharedTests
     assert !checker.updated?
   end
 
-  def test_should_execute_the_block_if_files_change_in_a_watched_directory_one_extension
+  test 'should execute the block if files change in a watched directory one extension' do
     i = 0
 
     checker = new_checker([], tmpdir => :rb) { i += 1 }
@@ -156,7 +157,7 @@ module FileUpdateCheckerSharedTests
     assert_equal 1, i
   end
 
-  def test_should_execute_the_block_if_files_change_in_a_watched_directory_several_extensions
+  test 'should execute the block if files change in a watched directory several extensions' do
     i = 0
 
     checker = new_checker([], tmpdir => [:rb, :txt]) { i += 1 }
@@ -172,7 +173,7 @@ module FileUpdateCheckerSharedTests
     assert_equal 2, i
   end
 
-  def test_should_not_execute_the_block_if_the_file_extension_is_not_watched
+  test 'should not execute the block if the file extension is not watched' do
     i = 0
 
     checker = new_checker([], tmpdir => :txt) { i += 1 }
@@ -183,7 +184,7 @@ module FileUpdateCheckerSharedTests
     assert_equal 0, i
   end
 
-  def test_does_not_assume_files_exist_on_instantiation
+  test 'does not assume files exist on instantiation' do
     i = 0
 
     non_existing = tmpfile('non_existing.rb')
@@ -195,7 +196,7 @@ module FileUpdateCheckerSharedTests
     assert_equal 1, i
   end
 
-  def test_detects_files_in_new_subdirectories
+  test 'detects files in new subdirectories' do
     i = 0
 
     checker = new_checker([], tmpdir => :rb) { i += 1 }
@@ -213,7 +214,7 @@ module FileUpdateCheckerSharedTests
     assert_equal 1, i
   end
 
-  def test_looked_up_extensions_are_inherited_in_subdirectories_not_listening_to_them
+  test 'looked up extensions are inherited in subdirectories not listening to them' do
     i = 0
 
     subdir = tmpfile('subdir')

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -4,7 +4,7 @@ require 'file_update_checker_shared_tests'
 class FileUpdateCheckerTest < ActiveSupport::TestCase
   include FileUpdateCheckerSharedTests
 
-  def new_checker(files=[], dirs={}, &block)
+  def new_checker(files = [], dirs = {}, &block)
     ActiveSupport::FileUpdateChecker.new(files, dirs, &block)
   end
 

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -4,7 +4,7 @@ require 'file_update_checker_with_enumerable_test_cases'
 class FileUpdateCheckerTest < ActiveSupport::TestCase
   include FileUpdateCheckerWithEnumerableTestCases
 
-  def build_new_watcher(files=[], dirs={}, &block)
+  def new_checker(files=[], dirs={}, &block)
     ActiveSupport::FileUpdateChecker.new(files, dirs, &block)
   end
 end

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -7,4 +7,13 @@ class FileUpdateCheckerTest < ActiveSupport::TestCase
   def new_checker(files=[], dirs={}, &block)
     ActiveSupport::FileUpdateChecker.new(files, dirs, &block)
   end
+
+  def wait
+    # noop
+  end
+
+  def touch(files)
+    sleep 1 # let's wait a bit to ensure there's a new mtime
+    super
+  end
 end

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -3,8 +3,6 @@ require 'fileutils'
 require 'thread'
 require 'file_update_checker_with_enumerable_test_cases'
 
-MTIME_FIXTURES_PATH = File.expand_path('fixtures', __dir__)
-
 class FileUpdateCheckerTest < ActiveSupport::TestCase
   include FileUpdateCheckerWithEnumerableTestCases
 

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -3,10 +3,11 @@ require 'fileutils'
 require 'thread'
 require 'file_update_checker_with_enumerable_test_cases'
 
-MTIME_FIXTURES_PATH = File.expand_path("../fixtures", __FILE__)
+MTIME_FIXTURES_PATH = File.expand_path('fixtures', __dir__)
 
-class FileUpdateCheckerWithEnumerableTest < ActiveSupport::TestCase
+class FileUpdateCheckerTest < ActiveSupport::TestCase
   include FileUpdateCheckerWithEnumerableTestCases
+
   def build_new_watcher(files, dirs={}, &block)
     ActiveSupport::FileUpdateChecker.new(files, dirs, &block)
   end

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -1,112 +1,13 @@
 require 'abstract_unit'
 require 'fileutils'
 require 'thread'
+require 'file_update_checker_with_enumerable_test_cases'
 
 MTIME_FIXTURES_PATH = File.expand_path("../fixtures", __FILE__)
 
 class FileUpdateCheckerWithEnumerableTest < ActiveSupport::TestCase
-  FILES = %w(1.txt 2.txt 3.txt)
-
-  def setup
-    FileUtils.mkdir_p("tmp_watcher")
-    FileUtils.touch(FILES)
-  end
-
-  def teardown
-    FileUtils.rm_rf("tmp_watcher")
-    FileUtils.rm_rf(FILES)
-  end
-
-  def test_should_not_execute_the_block_if_no_paths_are_given
-    i = 0
-    checker = ActiveSupport::FileUpdateChecker.new([]){ i += 1 }
-    checker.execute_if_updated
-    assert_equal 0, i
-  end
-
-  def test_should_not_invoke_the_block_if_no_file_has_changed
-    i = 0
-    checker = ActiveSupport::FileUpdateChecker.new(FILES){ i += 1 }
-    5.times { assert !checker.execute_if_updated }
-    assert_equal 0, i
-  end
-
-  def test_should_invoke_the_block_if_a_file_has_changed
-    i = 0
-    checker = ActiveSupport::FileUpdateChecker.new(FILES){ i += 1 }
-    sleep(1)
-    FileUtils.touch(FILES)
-    assert checker.execute_if_updated
-    assert_equal 1, i
-  end
-
-  def test_should_be_robust_enough_to_handle_deleted_files
-    i = 0
-    checker = ActiveSupport::FileUpdateChecker.new(FILES){ i += 1 }
-    FileUtils.rm(FILES)
-    assert checker.execute_if_updated
-    assert_equal 1, i
-  end
-
-  def test_should_be_robust_to_handle_files_with_wrong_modified_time
-    i = 0
-    now = Time.now
-    time = Time.mktime(now.year + 1, now.month, now.day) # wrong mtime from the future
-    File.utime time, time, FILES[2]
-
-    checker = ActiveSupport::FileUpdateChecker.new(FILES){ i += 1 }
-
-    sleep(1)
-    FileUtils.touch(FILES[0..1])
-
-    assert checker.execute_if_updated
-    assert_equal 1, i
-  end
-
-  def test_should_cache_updated_result_until_execute
-    i = 0
-    checker = ActiveSupport::FileUpdateChecker.new(FILES){ i += 1 }
-    assert !checker.updated?
-
-    sleep(1)
-    FileUtils.touch(FILES)
-
-    assert checker.updated?
-    checker.execute
-    assert !checker.updated?
-  end
-
-  def test_should_invoke_the_block_if_a_watched_dir_changed_its_glob
-    i = 0
-    checker = ActiveSupport::FileUpdateChecker.new([], "tmp_watcher" => [:txt]){ i += 1 }
-    FileUtils.cd "tmp_watcher" do
-      FileUtils.touch(FILES)
-    end
-    assert checker.execute_if_updated
-    assert_equal 1, i
-  end
-
-  def test_should_not_invoke_the_block_if_a_watched_dir_changed_its_glob
-    i = 0
-    checker = ActiveSupport::FileUpdateChecker.new([], "tmp_watcher" => :rb){ i += 1 }
-    FileUtils.cd "tmp_watcher" do
-      FileUtils.touch(FILES)
-    end
-    assert !checker.execute_if_updated
-    assert_equal 0, i
-  end
-
-  def test_should_not_block_if_a_strange_filename_used
-    FileUtils.mkdir_p("tmp_watcher/valid,yetstrange,path,")
-    FileUtils.touch(FILES.map { |file_name| "tmp_watcher/valid,yetstrange,path,/#{file_name}" })
-
-    test = Thread.new do
-      ActiveSupport::FileUpdateChecker.new([],"tmp_watcher/valid,yetstrange,path," => :txt) { i += 1 }
-      Thread.exit
-    end
-    test.priority = -1
-    test.join(5)
-
-    assert !test.alive?
+  include FileUpdateCheckerWithEnumerableTestCases
+  def build_new_watcher(files, dirs={}, &block)
+    ActiveSupport::FileUpdateChecker.new(files, dirs, &block)
   end
 end

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -1,12 +1,10 @@
 require 'abstract_unit'
-require 'fileutils'
-require 'thread'
 require 'file_update_checker_with_enumerable_test_cases'
 
 class FileUpdateCheckerTest < ActiveSupport::TestCase
   include FileUpdateCheckerWithEnumerableTestCases
 
-  def build_new_watcher(files, dirs={}, &block)
+  def build_new_watcher(files=[], dirs={}, &block)
     ActiveSupport::FileUpdateChecker.new(files, dirs, &block)
   end
 end

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -1,8 +1,8 @@
 require 'abstract_unit'
-require 'file_update_checker_with_enumerable_test_cases'
+require 'file_update_checker_shared_tests'
 
 class FileUpdateCheckerTest < ActiveSupport::TestCase
-  include FileUpdateCheckerWithEnumerableTestCases
+  include FileUpdateCheckerSharedTests
 
   def new_checker(files=[], dirs={}, &block)
     ActiveSupport::FileUpdateChecker.new(files, dirs, &block)

--- a/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
+++ b/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
@@ -7,11 +7,16 @@ module FileUpdateCheckerWithEnumerableTestCases
     # noop
   end
 
+  def touch(files)
+    sleep 1
+    super
+  end
+
   def setup
     @tmpdir = Dir.mktmpdir
 
     @files = %w(foo.rb bar.rb baz.rb).map {|f| "#{@tmpdir}/#{f}"}
-    touch(@files)
+    FileUtils.touch(@files)
   end
 
   def teardown
@@ -41,7 +46,6 @@ module FileUpdateCheckerWithEnumerableTestCases
 
     checker = new_checker(@files) { i += 1 }
 
-    sleep 1
     touch(@files)
     wait
 
@@ -82,7 +86,6 @@ module FileUpdateCheckerWithEnumerableTestCases
 
     checker = new_checker(@files) { i += 1 }
 
-    sleep 1
     touch(@files[1..-1])
     wait
 
@@ -96,7 +99,6 @@ module FileUpdateCheckerWithEnumerableTestCases
     checker = new_checker(@files) { i += 1 }
     assert !checker.updated?
 
-    sleep 1
     touch(@files)
     wait
 
@@ -110,7 +112,6 @@ module FileUpdateCheckerWithEnumerableTestCases
 
     checker = new_checker([], @tmpdir => :rb) { i += 1 }
 
-    sleep 1
     touch(@files)
     wait
 

--- a/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
+++ b/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
@@ -93,7 +93,7 @@ module FileUpdateCheckerWithEnumerableTestCases
     assert !checker.updated?
   end
 
-  def test_should_execute_the_block_if_files_change_in_a_watched_directory
+  def test_should_execute_the_block_if_files_change_in_a_watched_directory_one_extension
     i = 0
 
     checker = new_checker([], @tmpdir => :rb) { i += 1 }
@@ -102,6 +102,22 @@ module FileUpdateCheckerWithEnumerableTestCases
 
     assert checker.execute_if_updated
     assert_equal 1, i
+  end
+
+  def test_should_execute_the_block_if_files_change_in_a_watched_directory_several_extensions
+    i = 0
+
+    checker = new_checker([], @tmpdir => [:rb, :txt]) { i += 1 }
+
+    touch("#{@tmpdir}/foo.rb")
+
+    assert checker.execute_if_updated
+    assert_equal 1, i
+
+    touch("#{@tmpdir}/foo.rb")
+
+    assert checker.execute_if_updated
+    assert_equal 2, i
   end
 
   def test_should_not_execute_the_block_if_the_file_extension_is_not_watched

--- a/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
+++ b/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
@@ -13,7 +13,7 @@ module FileUpdateCheckerWithEnumerableTestCases
   end
 
   def setup
-    @tmpdir = Dir.mktmpdir
+    @tmpdir = Dir.mktmpdir(nil, __dir__)
 
     @files = %w(foo.rb bar.rb baz.rb).map {|f| "#{@tmpdir}/#{f}"}
     FileUtils.touch(@files)

--- a/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
+++ b/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
@@ -56,13 +56,13 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_updated_should_become_true_when_watched_files_are_deleted
     i = 0
 
-    watcher = new_checker(@files) { i += 1 }
-    assert !watcher.updated?
+    checker = new_checker(@files) { i += 1 }
+    assert !checker.updated?
 
     rm_f(@files)
     wait
 
-    assert watcher.updated?
+    assert checker.updated?
   end
 
   def test_should_be_robust_enough_to_handle_deleted_files

--- a/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
+++ b/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
@@ -23,7 +23,7 @@ module FileUpdateCheckerWithEnumerableTestCases
     assert_equal 0, i
   end
 
-  def test_should_not_invoke_the_block_if_no_file_has_changed
+  def test_should_not_execute_the_block_if_no_files_change
     i = 0
 
     checker = new_checker(@files) { i += 1 }
@@ -32,7 +32,7 @@ module FileUpdateCheckerWithEnumerableTestCases
     assert_equal 0, i
   end
 
-  def test_should_invoke_the_block_if_a_file_has_changed
+  def test_should_execute_the_block_once_when_files_change
     i = 0
 
     checker = new_checker(@files) { i += 1 }
@@ -54,7 +54,7 @@ module FileUpdateCheckerWithEnumerableTestCases
     assert checker.updated?
   end
 
-  def test_should_detect_deleted_files
+  def test_should_execute_the_block_once_when_files_are_deleted
     i = 0
 
     checker = new_checker(@files) { i += 1 }
@@ -93,7 +93,7 @@ module FileUpdateCheckerWithEnumerableTestCases
     assert !checker.updated?
   end
 
-  def test_should_invoke_the_block_if_a_watched_dir_changes
+  def test_should_execute_the_block_if_files_change_in_a_watched_directory
     i = 0
 
     checker = new_checker([], @tmpdir => :rb) { i += 1 }
@@ -104,7 +104,7 @@ module FileUpdateCheckerWithEnumerableTestCases
     assert_equal 1, i
   end
 
-  def test_should_not_invoke_the_block_if_a_watched_dir_does_not_change
+  def test_should_not_execute_the_block_if_the_file_extension_is_not_watched
     i = 0
 
     checker = new_checker([], @tmpdir => :txt) { i += 1 }

--- a/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
+++ b/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
@@ -1,0 +1,110 @@
+module FileUpdateCheckerWithEnumerableTestCases
+  FILES = %w(1.txt 2.txt 3.txt)
+
+  def setup
+    FileUtils.mkdir_p("tmp_watcher")
+    FileUtils.touch(FILES)
+  end
+
+  def teardown
+    FileUtils.rm_rf("tmp_watcher")
+    FileUtils.rm_rf(FILES)
+  end
+
+  def test_should_not_execute_the_block_if_no_paths_are_given
+    i = 0
+    checker = build_new_watcher([]){ i += 1}
+    checker.execute_if_updated
+    assert_equal 0, i
+  end
+
+  def test_should_not_invoke_the_block_if_no_file_has_changed
+    i = 0
+    checker = build_new_watcher(FILES){ i += 1 }
+    5.times { assert !checker.execute_if_updated }
+    assert_equal 0, i
+  end
+
+  def test_should_invoke_the_block_if_a_file_has_changed
+    i = 0
+    checker = build_new_watcher(FILES){ i += 1 }
+    sleep(1)
+    FileUtils.touch(FILES)
+    sleep(1) #extra
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
+
+  def test_should_be_robust_enough_to_handle_deleted_files
+    i = 0
+    checker = build_new_watcher(FILES){ i += 1 }
+    FileUtils.rm(FILES)
+    sleep(1) #extra
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
+
+  def test_should_be_robust_to_handle_files_with_wrong_modified_time
+    i = 0
+    now = Time.now
+    time = Time.mktime(now.year + 1, now.month, now.day) # wrong mtime from the future
+    File.utime time, time, FILES[2]
+
+    checker = build_new_watcher(FILES){ i += 1 }
+
+    sleep(1)
+    FileUtils.touch(FILES[0..1])
+    sleep(1) #extra
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
+
+  def test_should_cache_updated_result_until_execute
+    i = 0
+    checker = build_new_watcher(FILES){ i += 1 }
+    assert !checker.updated?
+
+    sleep(1)
+    FileUtils.touch(FILES)
+    sleep(1) #extra
+    assert checker.updated?
+    checker.execute
+    assert !checker.updated?
+  end
+
+  def test_should_invoke_the_block_if_a_watched_dir_changed_its_glob
+    i = 0
+    checker = build_new_watcher([], "tmp_watcher" => [:txt]){ i += 1 }
+    FileUtils.cd "tmp_watcher" do
+      FileUtils.touch(FILES)
+    end
+    sleep(1) #extra
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
+
+  def test_should_not_invoke_the_block_if_a_watched_dir_changed_its_glob
+    i = 0
+    checker = build_new_watcher([], "tmp_watcher" => :rb){ i += 1 }
+    FileUtils.cd "tmp_watcher" do
+      FileUtils.touch(FILES)
+    end
+    sleep(1) #extra
+    assert !checker.execute_if_updated
+    assert_equal 0, i
+  end
+
+  def test_should_not_block_if_a_strange_filename_used
+    FileUtils.mkdir_p("tmp_watcher/valid,yetstrange,path,")
+    FileUtils.touch(FILES.map { |file_name| "tmp_watcher/valid,yetstrange,path,/#{file_name}" })
+
+    test = Thread.new do
+      build_new_watcher([],"tmp_watcher/valid,yetstrange,path," => :txt) { i += 1 }
+      Thread.exit
+    end
+    test.priority = -1
+    test.join(5)
+
+    assert !test.alive?
+  end
+end

--- a/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
+++ b/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
@@ -2,71 +2,95 @@ module FileUpdateCheckerWithEnumerableTestCases
   FILES = %w(1.txt 2.txt 3.txt)
 
   def setup
-    FileUtils.mkdir_p("tmp_watcher")
+    FileUtils.mkdir_p('tmp_watcher')
     FileUtils.touch(FILES)
   end
 
   def teardown
-    FileUtils.rm_rf("tmp_watcher")
+    FileUtils.rm_rf('tmp_watcher')
     FileUtils.rm_rf(FILES)
   end
 
   def test_should_not_execute_the_block_if_no_paths_are_given
     i = 0
-    checker = build_new_watcher([]){ i += 1}
+
+    checker = build_new_watcher([]) { i += 1 }
     checker.execute_if_updated
+
     assert_equal 0, i
   end
 
   def test_should_not_invoke_the_block_if_no_file_has_changed
     i = 0
-    checker = build_new_watcher(FILES){ i += 1 }
-    5.times { assert !checker.execute_if_updated }
+
+    checker = build_new_watcher(FILES) { i += 1 }
+
+    assert !checker.execute_if_updated
     assert_equal 0, i
   end
 
   def test_should_invoke_the_block_if_a_file_has_changed
     i = 0
-    checker = build_new_watcher(FILES){ i += 1 }
-    sleep(1)
+
+    checker = build_new_watcher(FILES) { i += 1 }
+    sleep 1
+
     FileUtils.touch(FILES)
-    sleep(1) #extra
+    sleep 1
+
     assert checker.execute_if_updated
     assert_equal 1, i
   end
 
+  def test_updated_should_become_true_when_watched_files_are_deleted
+    watcher = build_new_watcher(FILES) { i += 1 }
+    assert !watcher.updated?
+
+    FileUtils.rm(FILES)
+    sleep 1
+
+    assert watcher.updated?
+  end
+
   def test_should_be_robust_enough_to_handle_deleted_files
     i = 0
-    checker = build_new_watcher(FILES){ i += 1 }
-    FileUtils.rm(FILES)
-    sleep(1) #extra
+
+    checker = build_new_watcher(FILES) { i += 1 }
+    FileUtils.rm_f(FILES)
+
+    sleep 1
+
     assert checker.execute_if_updated
     assert_equal 1, i
   end
 
   def test_should_be_robust_to_handle_files_with_wrong_modified_time
     i = 0
+
     now = Time.now
     time = Time.mktime(now.year + 1, now.month, now.day) # wrong mtime from the future
-    File.utime time, time, FILES[2]
+    File.utime(time, time, FILES[2])
 
-    checker = build_new_watcher(FILES){ i += 1 }
+    checker = build_new_watcher(FILES) { i += 1 }
+    sleep 1
 
-    sleep(1)
     FileUtils.touch(FILES[0..1])
-    sleep(1) #extra
+    sleep 1
+
     assert checker.execute_if_updated
     assert_equal 1, i
   end
 
   def test_should_cache_updated_result_until_execute
     i = 0
-    checker = build_new_watcher(FILES){ i += 1 }
-    assert !checker.updated?
 
-    sleep(1)
+    checker = build_new_watcher(FILES) { i += 1 }
+    assert !checker.updated?
+    sleep 1
+
     FileUtils.touch(FILES)
-    sleep(1) #extra
+    sleep 1
+
     assert checker.updated?
     checker.execute
     assert !checker.updated?
@@ -74,34 +98,42 @@ module FileUpdateCheckerWithEnumerableTestCases
 
   def test_should_invoke_the_block_if_a_watched_dir_changed_its_glob
     i = 0
-    checker = build_new_watcher([], "tmp_watcher" => [:txt]){ i += 1 }
-    FileUtils.cd "tmp_watcher" do
+
+    checker = build_new_watcher([], 'tmp_watcher' => [:txt]) { i += 1 }
+
+    FileUtils.cd 'tmp_watcher' do
       FileUtils.touch(FILES)
     end
-    sleep(1) #extra
+    sleep 1
+
     assert checker.execute_if_updated
     assert_equal 1, i
   end
 
   def test_should_not_invoke_the_block_if_a_watched_dir_changed_its_glob
     i = 0
-    checker = build_new_watcher([], "tmp_watcher" => :rb){ i += 1 }
-    FileUtils.cd "tmp_watcher" do
+
+    checker = build_new_watcher([], 'tmp_watcher' => :rb) { i += 1 }
+
+    FileUtils.cd 'tmp_watcher' do
       FileUtils.touch(FILES)
     end
-    sleep(1) #extra
+    sleep 1
+
     assert !checker.execute_if_updated
     assert_equal 0, i
   end
 
-  def test_should_not_block_if_a_strange_filename_used
-    FileUtils.mkdir_p("tmp_watcher/valid,yetstrange,path,")
-    FileUtils.touch(FILES.map { |file_name| "tmp_watcher/valid,yetstrange,path,/#{file_name}" })
+  def test_should_not_block_with_unusual_file_names
+    unusual_dirname = 'tmp_watcher/valid,yetstrange,path,'
+    FileUtils.mkdir_p(unusual_dirname)
+    FileUtils.touch(FILES.map { |file_name| "#{unusual_dirname}/#{file_name}" })
 
     test = Thread.new do
-      build_new_watcher([],"tmp_watcher/valid,yetstrange,path," => :txt) { i += 1 }
+      build_new_watcher([], unusual_dirname => :txt) { i += 1 }
       Thread.exit
     end
+
     test.priority = -1
     test.join(5)
 

--- a/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
+++ b/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
@@ -3,15 +3,20 @@ require 'fileutils'
 module FileUpdateCheckerWithEnumerableTestCases
   include FileUtils
 
-  def setup
-    @tmpdir = Dir.mktmpdir(nil, __dir__)
+  def tmpdir
+    @tmpdir ||= Dir.mktmpdir(nil, __dir__)
+  end
 
-    @files = %w(foo.rb bar.rb baz.rb).map {|f| "#{@tmpdir}/#{f}"}
-    FileUtils.touch(@files)
+  def tmpfile(name)
+    "#{tmpdir}/#{name}"
+  end
+
+  def tmpfiles
+    @tmpfiles ||= %w(foo.rb bar.rb baz.rb).map {|f| tmpfile(f)}
   end
 
   def teardown
-    FileUtils.rm_rf(@tmpdir)
+    FileUtils.rm_rf(@tmpdir) if @tmpdir
   end
 
   def test_should_not_execute_the_block_if_no_paths_are_given
@@ -26,55 +31,102 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_not_execute_the_block_if_no_files_change
     i = 0
 
-    checker = new_checker(@files) { i += 1 }
+    FileUtils.touch(tmpfiles)
+
+    checker = new_checker(tmpfiles) { i += 1 }
 
     assert !checker.execute_if_updated
     assert_equal 0, i
   end
 
-  def test_should_execute_the_block_once_when_files_change
+  def test_should_execute_the_block_once_when_files_are_created
     i = 0
 
-    checker = new_checker(@files) { i += 1 }
+    checker = new_checker(tmpfiles) { i += 1 }
 
-    touch(@files)
+    touch(tmpfiles)
 
     assert checker.execute_if_updated
     assert_equal 1, i
   end
 
-  def test_updated_should_become_true_when_watched_files_are_deleted
+  def test_should_execute_the_block_once_when_files_are_modified
     i = 0
 
-    checker = new_checker(@files) { i += 1 }
-    assert !checker.updated?
+    FileUtils.touch(tmpfiles)
 
-    rm_f(@files)
+    checker = new_checker(tmpfiles) { i += 1 }
 
-    assert checker.updated?
+    touch(tmpfiles)
+
+    assert checker.execute_if_updated
+    assert_equal 1, i
   end
 
   def test_should_execute_the_block_once_when_files_are_deleted
     i = 0
 
-    checker = new_checker(@files) { i += 1 }
+    FileUtils.touch(tmpfiles)
 
-    rm_f(@files)
+    checker = new_checker(tmpfiles) { i += 1 }
+
+    rm_f(tmpfiles)
 
     assert checker.execute_if_updated
     assert_equal 1, i
   end
 
+
+  def test_updated_should_become_true_when_watched_files_are_created
+    i = 0
+
+    checker = new_checker(tmpfiles) { i += 1 }
+    assert !checker.updated?
+
+    touch(tmpfiles)
+
+    assert checker.updated?
+  end
+
+
+  def test_updated_should_become_true_when_watched_files_are_modified
+    i = 0
+
+    FileUtils.touch(tmpfiles)
+
+    checker = new_checker(tmpfiles) { i += 1 }
+    assert !checker.updated?
+
+    touch(tmpfiles)
+
+    assert checker.updated?
+  end
+
+  def test_updated_should_become_true_when_watched_files_are_deleted
+    i = 0
+
+    FileUtils.touch(tmpfiles)
+
+    checker = new_checker(tmpfiles) { i += 1 }
+    assert !checker.updated?
+
+    rm_f(tmpfiles)
+
+    assert checker.updated?
+  end
+
   def test_should_be_robust_to_handle_files_with_wrong_modified_time
     i = 0
 
-    now = Time.now
+    FileUtils.touch(tmpfiles)
+
+    now  = Time.now
     time = Time.mktime(now.year + 1, now.month, now.day) # wrong mtime from the future
-    File.utime(time, time, @files[0])
+    File.utime(time, time, tmpfiles[0])
 
-    checker = new_checker(@files) { i += 1 }
+    checker = new_checker(tmpfiles) { i += 1 }
 
-    touch(@files[1..-1])
+    touch(tmpfiles[1..-1])
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -83,10 +135,10 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_cache_updated_result_until_execute
     i = 0
 
-    checker = new_checker(@files) { i += 1 }
+    checker = new_checker(tmpfiles) { i += 1 }
     assert !checker.updated?
 
-    touch(@files)
+    touch(tmpfiles)
 
     assert checker.updated?
     checker.execute
@@ -96,9 +148,9 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_execute_the_block_if_files_change_in_a_watched_directory_one_extension
     i = 0
 
-    checker = new_checker([], @tmpdir => :rb) { i += 1 }
+    checker = new_checker([], tmpdir => :rb) { i += 1 }
 
-    touch(@files)
+    touch(tmpfile('foo.rb'))
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -107,14 +159,14 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_execute_the_block_if_files_change_in_a_watched_directory_several_extensions
     i = 0
 
-    checker = new_checker([], @tmpdir => [:rb, :txt]) { i += 1 }
+    checker = new_checker([], tmpdir => [:rb, :txt]) { i += 1 }
 
-    touch("#{@tmpdir}/foo.rb")
+    touch(tmpfile('foo.rb'))
 
     assert checker.execute_if_updated
     assert_equal 1, i
 
-    touch("#{@tmpdir}/foo.rb")
+    touch(tmpfile('foo.txt'))
 
     assert checker.execute_if_updated
     assert_equal 2, i
@@ -123,9 +175,9 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_not_execute_the_block_if_the_file_extension_is_not_watched
     i = 0
 
-    checker = new_checker([], @tmpdir => :txt) { i += 1 }
+    checker = new_checker([], tmpdir => :txt) { i += 1 }
 
-    touch(@files)
+    touch(tmpfile('foo.rb'))
 
     assert !checker.execute_if_updated
     assert_equal 0, i
@@ -134,7 +186,7 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_does_not_assume_files_exist_on_instantiation
     i = 0
 
-    non_existing = "#{@tmpdir}/non_existing.rb"
+    non_existing = tmpfile('non_existing.rb')
     checker = new_checker([non_existing]) { i += 1 }
 
     touch(non_existing)
@@ -146,9 +198,9 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_detects_files_in_new_subdirectories
     i = 0
 
-    checker = new_checker([], @tmpdir => :rb) { i += 1 }
+    checker = new_checker([], tmpdir => :rb) { i += 1 }
 
-    subdir = "#{@tmpdir}/subdir"
+    subdir = tmpfile('subdir')
     mkdir(subdir)
     wait
 
@@ -164,17 +216,17 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_looked_up_extensions_are_inherited_in_subdirectories_not_listening_to_them
     i = 0
 
-    subdir = "#{@tmpdir}/subdir"
+    subdir = tmpfile('subdir')
     mkdir(subdir)
 
-    checker = new_checker([], @tmpdir => :rb, subdir => :txt) { i += 1 }
+    checker = new_checker([], tmpdir => :rb, subdir => :txt) { i += 1 }
 
-    touch("#{@tmpdir}/new.txt")
+    touch(tmpfile('new.txt'))
 
     assert !checker.execute_if_updated
     assert_equal 0, i
 
-    # subdir does not look for Ruby files, but its parent @tmpdir does.
+    # subdir does not look for Ruby files, but its parent tmpdir does.
     touch("#{subdir}/nested.rb")
 
     assert checker.execute_if_updated

--- a/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
+++ b/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
@@ -3,15 +3,6 @@ require 'fileutils'
 module FileUpdateCheckerWithEnumerableTestCases
   include FileUtils
 
-  def wait
-    # noop
-  end
-
-  def touch(files)
-    sleep 1
-    super
-  end
-
   def setup
     @tmpdir = Dir.mktmpdir(nil, __dir__)
 
@@ -20,7 +11,7 @@ module FileUpdateCheckerWithEnumerableTestCases
   end
 
   def teardown
-    rm_rf(@tmpdir)
+    FileUtils.rm_rf(@tmpdir)
   end
 
   def test_should_not_execute_the_block_if_no_paths_are_given
@@ -47,7 +38,6 @@ module FileUpdateCheckerWithEnumerableTestCases
     checker = new_checker(@files) { i += 1 }
 
     touch(@files)
-    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -60,18 +50,16 @@ module FileUpdateCheckerWithEnumerableTestCases
     assert !checker.updated?
 
     rm_f(@files)
-    wait
 
     assert checker.updated?
   end
 
-  def test_should_be_robust_enough_to_handle_deleted_files
+  def test_should_detect_deleted_files
     i = 0
 
     checker = new_checker(@files) { i += 1 }
 
     rm_f(@files)
-    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -87,7 +75,6 @@ module FileUpdateCheckerWithEnumerableTestCases
     checker = new_checker(@files) { i += 1 }
 
     touch(@files[1..-1])
-    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -100,7 +87,6 @@ module FileUpdateCheckerWithEnumerableTestCases
     assert !checker.updated?
 
     touch(@files)
-    wait
 
     assert checker.updated?
     checker.execute
@@ -113,7 +99,6 @@ module FileUpdateCheckerWithEnumerableTestCases
     checker = new_checker([], @tmpdir => :rb) { i += 1 }
 
     touch(@files)
-    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -125,7 +110,6 @@ module FileUpdateCheckerWithEnumerableTestCases
     checker = new_checker([], @tmpdir => :txt) { i += 1 }
 
     touch(@files)
-    wait
 
     assert !checker.execute_if_updated
     assert_equal 0, i
@@ -138,7 +122,6 @@ module FileUpdateCheckerWithEnumerableTestCases
     checker = new_checker([non_existing]) { i += 1 }
 
     touch(non_existing)
-    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -157,7 +140,6 @@ module FileUpdateCheckerWithEnumerableTestCases
     assert_equal 0, i
 
     touch("#{subdir}/nested.rb")
-    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -172,20 +154,17 @@ module FileUpdateCheckerWithEnumerableTestCases
     checker = new_checker([], @tmpdir => :rb, subdir => :txt) { i += 1 }
 
     touch("#{@tmpdir}/new.txt")
-    wait
 
     assert !checker.execute_if_updated
     assert_equal 0, i
 
     # subdir does not look for Ruby files, but its parent @tmpdir does.
     touch("#{subdir}/nested.rb")
-    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
 
     touch("#{subdir}/nested.txt")
-    wait
 
     assert checker.execute_if_updated
     assert_equal 2, i

--- a/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
+++ b/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
@@ -1,29 +1,36 @@
+require 'fileutils'
+
 module FileUpdateCheckerWithEnumerableTestCases
-  FILES = %w(1.txt 2.txt 3.txt)
+  include FileUtils
+
+  def wait
+    # noop
+  end
 
   def setup
-    FileUtils.mkdir_p('tmp_watcher')
-    FileUtils.touch(FILES)
+    @tmpdir = Dir.mktmpdir
+
+    @files = %w(foo.rb bar.rb baz.rb).map {|f| "#{@tmpdir}/#{f}"}
+    touch(@files)
   end
 
   def teardown
-    FileUtils.rm_rf('tmp_watcher')
-    FileUtils.rm_rf(FILES)
+    rm_rf(@tmpdir)
   end
 
   def test_should_not_execute_the_block_if_no_paths_are_given
     i = 0
 
-    checker = build_new_watcher([]) { i += 1 }
-    checker.execute_if_updated
+    checker = build_new_watcher { i += 1 }
 
+    assert !checker.execute_if_updated
     assert_equal 0, i
   end
 
   def test_should_not_invoke_the_block_if_no_file_has_changed
     i = 0
 
-    checker = build_new_watcher(FILES) { i += 1 }
+    checker = build_new_watcher(@files) { i += 1 }
 
     assert !checker.execute_if_updated
     assert_equal 0, i
@@ -32,22 +39,24 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_invoke_the_block_if_a_file_has_changed
     i = 0
 
-    checker = build_new_watcher(FILES) { i += 1 }
-    sleep 1
+    checker = build_new_watcher(@files) { i += 1 }
 
-    FileUtils.touch(FILES)
     sleep 1
+    touch(@files)
+    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
   end
 
   def test_updated_should_become_true_when_watched_files_are_deleted
-    watcher = build_new_watcher(FILES) { i += 1 }
+    i = 0
+
+    watcher = build_new_watcher(@files) { i += 1 }
     assert !watcher.updated?
 
-    FileUtils.rm(FILES)
-    sleep 1
+    rm_f(@files)
+    wait
 
     assert watcher.updated?
   end
@@ -55,10 +64,10 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_be_robust_enough_to_handle_deleted_files
     i = 0
 
-    checker = build_new_watcher(FILES) { i += 1 }
-    FileUtils.rm_f(FILES)
+    checker = build_new_watcher(@files) { i += 1 }
 
-    sleep 1
+    rm_f(@files)
+    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -69,13 +78,13 @@ module FileUpdateCheckerWithEnumerableTestCases
 
     now = Time.now
     time = Time.mktime(now.year + 1, now.month, now.day) # wrong mtime from the future
-    File.utime(time, time, FILES[2])
+    File.utime(time, time, @files[0])
 
-    checker = build_new_watcher(FILES) { i += 1 }
-    sleep 1
+    checker = build_new_watcher(@files) { i += 1 }
 
-    FileUtils.touch(FILES[0..1])
     sleep 1
+    touch(@files[1..-1])
+    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -84,59 +93,40 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_cache_updated_result_until_execute
     i = 0
 
-    checker = build_new_watcher(FILES) { i += 1 }
+    checker = build_new_watcher(@files) { i += 1 }
     assert !checker.updated?
-    sleep 1
 
-    FileUtils.touch(FILES)
     sleep 1
+    touch(@files)
+    wait
 
     assert checker.updated?
     checker.execute
     assert !checker.updated?
   end
 
-  def test_should_invoke_the_block_if_a_watched_dir_changed_its_glob
+  def test_should_invoke_the_block_if_a_watched_dir_changes
     i = 0
 
-    checker = build_new_watcher([], 'tmp_watcher' => [:txt]) { i += 1 }
+    checker = build_new_watcher([], @tmpdir => :rb) { i += 1 }
 
-    FileUtils.cd 'tmp_watcher' do
-      FileUtils.touch(FILES)
-    end
     sleep 1
+    touch(@files)
+    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
   end
 
-  def test_should_not_invoke_the_block_if_a_watched_dir_changed_its_glob
+  def test_should_not_invoke_the_block_if_a_watched_dir_does_not_change
     i = 0
 
-    checker = build_new_watcher([], 'tmp_watcher' => :rb) { i += 1 }
+    checker = build_new_watcher([], @tmpdir => :txt) { i += 1 }
 
-    FileUtils.cd 'tmp_watcher' do
-      FileUtils.touch(FILES)
-    end
-    sleep 1
+    touch(@files)
+    wait
 
     assert !checker.execute_if_updated
     assert_equal 0, i
-  end
-
-  def test_should_not_block_with_unusual_file_names
-    unusual_dirname = 'tmp_watcher/valid,yetstrange,path,'
-    FileUtils.mkdir_p(unusual_dirname)
-    FileUtils.touch(FILES.map { |file_name| "#{unusual_dirname}/#{file_name}" })
-
-    test = Thread.new do
-      build_new_watcher([], unusual_dirname => :txt) { i += 1 }
-      Thread.exit
-    end
-
-    test.priority = -1
-    test.join(5)
-
-    assert !test.alive?
   end
 end

--- a/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
+++ b/activesupport/test/file_update_checker_with_enumerable_test_cases.rb
@@ -21,7 +21,7 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_not_execute_the_block_if_no_paths_are_given
     i = 0
 
-    checker = build_new_watcher { i += 1 }
+    checker = new_checker { i += 1 }
 
     assert !checker.execute_if_updated
     assert_equal 0, i
@@ -30,7 +30,7 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_not_invoke_the_block_if_no_file_has_changed
     i = 0
 
-    checker = build_new_watcher(@files) { i += 1 }
+    checker = new_checker(@files) { i += 1 }
 
     assert !checker.execute_if_updated
     assert_equal 0, i
@@ -39,7 +39,7 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_invoke_the_block_if_a_file_has_changed
     i = 0
 
-    checker = build_new_watcher(@files) { i += 1 }
+    checker = new_checker(@files) { i += 1 }
 
     sleep 1
     touch(@files)
@@ -52,7 +52,7 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_updated_should_become_true_when_watched_files_are_deleted
     i = 0
 
-    watcher = build_new_watcher(@files) { i += 1 }
+    watcher = new_checker(@files) { i += 1 }
     assert !watcher.updated?
 
     rm_f(@files)
@@ -64,7 +64,7 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_be_robust_enough_to_handle_deleted_files
     i = 0
 
-    checker = build_new_watcher(@files) { i += 1 }
+    checker = new_checker(@files) { i += 1 }
 
     rm_f(@files)
     wait
@@ -80,7 +80,7 @@ module FileUpdateCheckerWithEnumerableTestCases
     time = Time.mktime(now.year + 1, now.month, now.day) # wrong mtime from the future
     File.utime(time, time, @files[0])
 
-    checker = build_new_watcher(@files) { i += 1 }
+    checker = new_checker(@files) { i += 1 }
 
     sleep 1
     touch(@files[1..-1])
@@ -93,7 +93,7 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_cache_updated_result_until_execute
     i = 0
 
-    checker = build_new_watcher(@files) { i += 1 }
+    checker = new_checker(@files) { i += 1 }
     assert !checker.updated?
 
     sleep 1
@@ -108,7 +108,7 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_invoke_the_block_if_a_watched_dir_changes
     i = 0
 
-    checker = build_new_watcher([], @tmpdir => :rb) { i += 1 }
+    checker = new_checker([], @tmpdir => :rb) { i += 1 }
 
     sleep 1
     touch(@files)
@@ -121,7 +121,7 @@ module FileUpdateCheckerWithEnumerableTestCases
   def test_should_not_invoke_the_block_if_a_watched_dir_does_not_change
     i = 0
 
-    checker = build_new_watcher([], @tmpdir => :txt) { i += 1 }
+    checker = new_checker([], @tmpdir => :txt) { i += 1 }
 
     touch(@files)
     wait

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1159,7 +1159,7 @@ false:
 
 ```ruby
 group :development do
-  gem 'listen'
+  gem 'listen', '~> 3.0.4'
 end
 ```
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1149,3 +1149,25 @@ Disallow: /
 
 To block just specific pages, it's necessary to use a more complex syntax. Learn
 it on the [official documentation](http://www.robotstxt.org/robotstxt.html).
+
+Evented File System Monitor
+---------------------------
+
+If the [listen gem](https://github.com/guard/listen) is loaded Rails uses an
+evented file system monitor to detect changes when `config.cache_classes` is
+false:
+
+```ruby
+group :development do
+  gem 'listen'
+end
+```
+
+Otherwise, in every request Rails walks the application tree to check if
+anything has changed.
+
+On Linux and Mac OS X no additional gems are needed, but some are required
+[for *BSD](https://github.com/guard/listen#on-bsd) and
+[for Windows](https://github.com/guard/listen#on-windows).
+
+Note that [some setups are unsupported](https://github.com/guard/listen#issues--limitations).

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Generated `Gemfile`s for new applications include a new dependency on
+    [listen](https://github.com/guard/listen) commented out.
+
+    *Puneet Agarwal* and *Xavier Noria*
+
 *   Deprecate `serve_static_files` in favor of `public_file_server.enabled`.
 
     Unifies the static asset options under `public_file_server`.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -44,7 +44,7 @@ module Rails
         @railties_order                = [:all]
         @relative_url_root             = ENV["RAILS_RELATIVE_URL_ROOT"]
         @reload_classes_only_on_change = true
-        @file_watcher                  = ActiveSupport::FileUpdateChecker
+        @file_watcher                  = (defined?(Listen) && Listen::Adapter.select()!=Listen::Adapter::Polling)? ActiveSupport::FileEventedUpdateChecker : ActiveSupport::FileUpdateChecker
         @exceptions_app                = nil
         @autoflush_log                 = true
         @log_formatter                 = ActiveSupport::Logger::SimpleFormatter.new

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -44,7 +44,7 @@ module Rails
         @railties_order                = [:all]
         @relative_url_root             = ENV["RAILS_RELATIVE_URL_ROOT"]
         @reload_classes_only_on_change = true
-        @file_watcher                  = (defined?(Listen) && Listen::Adapter.select()!=Listen::Adapter::Polling)? ActiveSupport::FileEventedUpdateChecker : ActiveSupport::FileUpdateChecker
+        @file_watcher                  = file_update_checker
         @exceptions_app                = nil
         @autoflush_log                 = true
         @log_formatter                 = ActiveSupport::Logger::SimpleFormatter.new
@@ -181,6 +181,14 @@ module Rails
       end
 
       private
+        def file_update_checker
+          if defined?(Listen) && Listen::Adapter.select() != Listen::Adapter::Polling
+            ActiveSupport::FileEventedUpdateChecker
+          else
+            ActiveSupport::FileUpdateChecker
+          end
+        end
+
         class Custom #:nodoc:
           def initialize
             @configurations = Hash.new

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -53,3 +53,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+# Uncomment this, to increase the performance
+# gem 'listen', '~> 3.0.3'

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -48,11 +48,12 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 <% end -%>
+
+  # Loading the listen gem enables an evented file system monitor. Check
+  # https://github.com/guard/listen#listen-adapters if on Windows or *BSD.
+  # gem 'listen', '~> 3.0.3'
 end
 <% end -%>
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
-# Uncomment this, to increase the performance
-# gem 'listen', '~> 3.0.3'

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -51,7 +51,7 @@ group :development do
 
   # Loading the listen gem enables an evented file system monitor. Check
   # https://github.com/guard/listen#listen-adapters if on Windows or *BSD.
-  # gem 'listen', '~> 3.0.3'
+  # gem 'listen', '~> 3.0.4'
 end
 <% end -%>
 


### PR DESCRIPTION
Implements an evented file system monitor to asynchronously detect changes in the application source code, routes, locales, etc.

To opt-in load the [listen](https://github.com/guard/listen) gem in `Gemfile`:

``` ruby
group :development do
  gem 'listen', '~> 3.0.4'
end
```

[Original work](https://github.com/rails/rails/pull/20785) by @puneet24 for [GSoC 2015](http://weblog.rubyonrails.org/2015/9/25/gsoc-2015-wrapping-up/), later iterated by yours truly.
