### PR TITLE
update docs for MessageEncryptor#new to recommend a KDF [ci skip]

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -34,8 +34,8 @@ module ActiveSupport
     # Initialize a new MessageEncryptor. +secret+ must be at least as long as
     # the cipher key size. For the default 'aes-256-cbc' cipher, this is 256
     # bits. If you are using a user-entered secret, you can generate a suitable
-    # key with <tt>OpenSSL::Digest::SHA256.new(user_secret).digest</tt> or
-    # similar.
+    # key by using <tt>ActiveSupport::KeyGenerator</tt> or a similar key
+    # derivation function.
     #
     # Options:
     # * <tt>:cipher</tt>     - Cipher to use. Can be any cipher returned by


### PR DESCRIPTION
The class docs for ActiveSupport::MessageEncryptor already demonstrate the use of ActiveSupport::KeyGenerator to derive a key from a user passphrase. This PR simply updates the initialize docs to avoid recommending an unsafe behavior.

I marked this as CI skip as the contributor guide recommended for docs only PRs, but let me know if I've made any mistakes!
