### PR TITLE
Make `AR::SpawnMethods#merge!` to check an arg is a Proc

### DIFF
--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -12,6 +12,7 @@ module ActiveRecord
 
     # Merges in the conditions from <tt>other</tt>, if <tt>other</tt> is an ActiveRecord::Relation.
     # Returns an array representing the intersection of the resulting records with <tt>other</tt>, if <tt>other</tt> is an array.
+    #
     #   Post.where(published: true).joins(:comments).merge( Comment.where(spam: false) )
     #   # Performs a single join query with both where conditions.
     #
@@ -37,11 +38,12 @@ module ActiveRecord
     end
 
     def merge!(other) # :nodoc:
-      if !other.is_a?(Relation) && other.respond_to?(:to_proc)
+      if other.is_a?(Hash)
+        Relation::HashMerger.new(self, other).merge
+      elsif other.respond_to?(:to_proc)
         instance_exec(&other)
       else
-        klass = other.is_a?(Hash) ? Relation::HashMerger : Relation::Merger
-        klass.new(self, other).merge
+        Relation::Merger.new(self, other).merge
       end
     end
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -24,6 +24,10 @@ module ActiveRecord
       def self.sanitize_sql_for_order(sql)
         sql
       end
+
+      def self.arel_table
+        Post.arel_table
+      end
     end
 
     def test_construction


### PR DESCRIPTION
From Ruby ( 2.3.0dev trunk 52520), `Hash#to_proc` is defined
(https://github.com/ruby/ruby/commit/fbe967ec02cb65a7efa3fb8f3d747cf6f620dde1),
and many tests have been failed with
`ArgumentError: wrong number of arguments (given 0, expected 1)`.
Because we call `Hash#to_proc` with no args in `#merge!`.

In `#merge!` it is enough to check arg is a Proc or not.
