### PR TITLE
Show middleware classes on /rails/info/properties

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -15,7 +15,11 @@ module ActionDispatch
       def name; klass.name; end
 
       def inspect
-        klass.to_s
+        if klass.is_a?(Class)
+          klass.to_s
+        else
+          klass.class.to_s
+        end
       end
 
       def build(app)


### PR DESCRIPTION
Closes #21230 by following the indication of @rafaelfranca:

> I think the output change would be simpler.
> What is really important to show is the class of the middleware, so we should change the output to show that.

This is the result:
<img width="1552" alt="screen shot 2015-11-11 at 9 47 57 am" src="https://cloud.githubusercontent.com/assets/10076/11098361/5675c4b0-8859-11e5-9fa7-bdec74892928.png">
