### PR TITLE
don't package test files in plugin gemspec

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
@@ -15,9 +15,6 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
-<% unless options.skip_test? -%>
-  s.test_files = Dir["test/**/*"]
-<% end -%>
 
   <%= '# ' if options.dev? || options.edge? -%>s.add_dependency "rails", "~> <%= Rails::VERSION::STRING %>"
 <% unless options[:skip_active_record] -%>


### PR DESCRIPTION
In rails engine, there is a dummy application under test,
the size of the test file is increased.

However, there is no need test files for most users,
I think it good to have so as not included by default.
