### PR TITLE
Fix instance variable not defined warning from Active Support test suite

### DIFF
--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -17,7 +17,7 @@ module FileUpdateCheckerSharedTests
   end
 
   def teardown
-    FileUtils.rm_rf(@tmpdir) if @tmpdir
+    FileUtils.rm_rf(@tmpdir) if defined? @tmpdir
   end
 
   test 'should not execute the block if no paths are given' do


### PR DESCRIPTION
Before

```
./Users/Juan/dev/rails/activesupport/test/file_update_checker_shared_tests.rb:20: warning: instance variable @tmpdir not initialized
```

After

No warnings
