### PR TITLE
Respect value of `:object` if `:object` is false when rendering

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Respect value of `:object` if `:object` is false when rendering.
+
+    Fixes #22260.
+
+    *Yuichiro Kaneko*
+
 *   Generate `week_field` input values using a 1-based index and not a 0-based index
     as per the W3 spec: http://www.w3.org/TR/html-markup/datatypes.html#form.data.week
 

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -300,7 +300,7 @@ module ActionView
         layout = find_template(layout.to_s, @template_keys)
       end
 
-      object ||= locals[as]
+      object = locals[as] if object.nil? # Respect object when object is false
       locals[as] = object
 
       content = @template.render(view, locals) do |*name|

--- a/actionview/test/fixtures/test/_klass.erb
+++ b/actionview/test/fixtures/test/_klass.erb
@@ -1,0 +1,1 @@
+<%= klass.class.name %>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -250,6 +250,8 @@ module RenderTestCases
 
   def test_render_object
     assert_equal "Hello: david", @view.render(:partial => "test/customer", :object => Customer.new("david"))
+    assert_equal "FalseClass", @view.render(:partial => "test/klass", :object => false)
+    assert_equal "NilClass", @view.render(:partial => "test/klass", :object => nil)
   end
 
   def test_render_object_with_array


### PR DESCRIPTION
This commit fixes the bug convering `false` to `locals[as]` when
`options[:object]` is `false` (close #22260).

(cherry picked from commit 429bd260c1cca8af1aac0ec31b85e487dc14b123)
