### PR TITLE
[ci skip] add `controller:` argument to routing.md

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -142,10 +142,10 @@ Sometimes, you have a resource that clients always look up without referencing a
 get 'profile', to: 'users#show'
 ```
 
-Passing a `String` to `get` will expect a `controller#action` format, while passing a `Symbol` will map directly to an action:
+Passing a `String` to `get` will expect a `controller#action` format, while passing a `Symbol` will map directly to an action but you must also specify the `controller:` to use:
 
 ```ruby
-get 'profile', to: :show
+get 'profile', to: :show, controller: 'users'
 ```
 
 This resourceful route:


### PR DESCRIPTION
This is a small amendment to the routing guide. There is an example in the guide that will raise an exception when used:

``` ruby
get 'profile', to: :show
```

Passing a `Symbol` to the `to:` argument for a `get` route method requires a `controller:` argument to also be defined. The documentation is missing the `controller:` argument, which leaving out raises:

```
$ rake routes
ArgumentError: Missing :controller key on routes definition, please check your routes.
```

Adding the `controller:` argument will map the route correctly without raising an exception:

``` ruby
get 'profile', to: :show, controller: 'users'
```

```
$ rake routes
profile GET    /profile(.:format)  users#show
```

This commit updates the example in the documentation to avoid the exception being raised.

<hr />

Examples run on Rails version: 4.2.4.
