### PR TITLE
do not show Active Job test generator

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -208,6 +208,7 @@ module Rails
           "#{test}:model",
           "#{test}:scaffold",
           "#{test}:view",
+          "#{test}:job",
           "#{template}:controller",
           "#{template}:scaffold",
           "#{template}:mailer",


### PR DESCRIPTION
Like the other generator, for also Active Job, I think that there is no need to
display for test generator.
