### PR TITLE
Devide `PartialRenderer` into `CollectionRenderer` and `MemberR…

### DIFF
--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -387,7 +387,7 @@ class AutomaticCollectionCacheTest < ActionController::TestCase
     @controller.perform_caching = true
     @controller.partial_rendered_times = 0
     @controller.cache_store = ActiveSupport::Cache::MemoryStore.new
-    ActionView::PartialRenderer.collection_cache = @controller.cache_store
+    ActionView::PartialRenderer::CollectionRenderer.collection_cache = @controller.cache_store
   end
 
   def test_collection_fetches_cached_views

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -281,269 +281,326 @@ module ActionView
   #     <%- end -%>
   #   <% end %>
   class PartialRenderer < AbstractRenderer
-    include CollectionCaching
-
     PREFIXED_PARTIAL_NAMES = Concurrent::Map.new do |h, k|
       h[k] = Concurrent::Map.new
     end
 
-    def initialize(*)
-      super
-      @context_prefix = @lookup_context.prefixes.first
-    end
+    class Base < AbstractRenderer # :nodoc:
+      IDENTIFIER_ERROR_MESSAGE = "The partial name (%s) is not a valid Ruby identifier; " +
+                                 "make sure your partial name starts with underscore."
 
-    def render(context, options, block)
-      setup(context, options, block)
-      identifier = (@template = find_partial) ? @template.identifier : @path
+      OPTION_AS_ERROR_MESSAGE  = "The value (%s) of the option `as` is not a valid Ruby identifier; " +
+                                 "make sure it starts with lowercase letter, " +
+                                 "and is followed by any combination of letters, numbers and underscores."
 
-      @lookup_context.rendered_format ||= begin
-        if @template && @template.formats.present?
-          @template.formats.first
+      def self.build(lookup_context, context, options, block)
+        partial = options[:partial]
+
+        if String === partial
+          options.merge!(has_object: options.key?(:object), collection: collection_from_options(options), path: partial)
         else
-          formats.first
+          options.merge!(has_object: true, object: partial, collection: collection_from_object(partial) || collection_from_options(options), path: nil)
+        end
+
+        klass = options[:collection] ? CollectionRenderer : MemberRenderer
+        klass.new(lookup_context).setup(context, options, block)
+      end
+
+      def self.collection_from_options(options)
+        if options.key?(:collection)
+          collection = options[:collection]
+          collection.respond_to?(:to_ary) ? collection.to_ary : []
+        end
+      end
+      private_class_method :collection_from_options
+
+      def self.collection_from_object(object)
+        object.to_ary if object.respond_to?(:to_ary)
+      end
+      private_class_method :collection_from_object
+
+      def initialize(*)
+        super
+        @context_prefix = @lookup_context.prefixes.first
+      end
+
+      # Sets up instance variables needed for rendering a partial. This method
+      # finds the options and details and extracts them. The method also contains
+      # logic that handles the type of object passed in as the partial.
+      #
+      # If +options[:partial]+ is a string, then the +@path+ instance variable is
+      # set to that string. Otherwise, the +options[:partial]+ object must
+      # respond to +to_partial_path+ in order to setup the path.
+      def setup(context, options, block)
+        @view   = context
+        @options = options
+        @block   = block
+
+        @locals  = options[:locals] || {}
+        @has_object = options[:has_object]
+        @object     = options[:object]
+        @collection = options[:collection]
+        @details = extract_details(options)
+
+        prepend_formats(options[:formats])
+
+        setup_path
+
+        if as = options[:as]
+          raise_invalid_option_as(as) unless as.to_s =~ /\A[a-z_]\w*\z/
+          as = as.to_sym
+        end
+
+        if @path
+          @variable, @variable_counter, @variable_iteration = retrieve_variable(@path, as)
+          @template_keys = retrieve_template_keys
+        else
+          # We only need this when entering +collection_without_template+
+          @collection_data.map! { |path| retrieve_variable(path, as).unshift(path) }
+        end
+
+        self
+      end
+
+      def render
+        @template = find_partial
+
+        @lookup_context.rendered_format ||= begin
+          if @template && @template.formats.present?
+            @template.formats.first
+          else
+            formats.first
+          end
         end
       end
 
-      if @collection
-        instrument(:collection, :identifier => identifier || "collection", :count => @collection.size) do
-          render_collection
+      private
+        def setup_path
+          raise NotImplementedError, "Subclasses must implement a #setup_path"
         end
-      else
+
+        def identifier
+          @template ? @template.identifier : @path
+        end
+
+        def find_partial
+          find_template(@path, @template_keys) if @path
+        end
+
+        def find_template(path, locals)
+          prefixes = path.include?(?/) ? [] : @lookup_context.prefixes
+          @lookup_context.find_template(path, prefixes, true, locals, @details)
+        end
+
+        # Obtains the path to where the object's partial is located. If the object
+        # responds to +to_partial_path+, then +to_partial_path+ will be called and
+        # will provide the path. If the object does not respond to +to_partial_path+,
+        # then an +ArgumentError+ is raised.
+        #
+        # If +prefix_partial_path_with_controller_namespace+ is true, then this
+        # method will prefix the partial paths with a namespace.
+        def partial_path(object = @object)
+          object = object.to_model if object.respond_to?(:to_model)
+
+          path = if object.respond_to?(:to_partial_path)
+            object.to_partial_path
+          else
+            raise ArgumentError.new("'#{object.inspect}' is not an ActiveModel-compatible object. It must implement :to_partial_path.")
+          end
+
+          if @view.prefix_partial_path_with_controller_namespace
+            prefixed_partial_names[path] ||= merge_prefix_into_object_path(@context_prefix, path.dup)
+          else
+            path
+          end
+        end
+
+        def prefixed_partial_names
+          @prefixed_partial_names ||= PREFIXED_PARTIAL_NAMES[@context_prefix]
+        end
+
+        def merge_prefix_into_object_path(prefix, object_path)
+          if prefix.include?(?/) && object_path.include?(?/)
+            prefixes = []
+            prefix_array = File.dirname(prefix).split('/')
+            object_path_array = object_path.split('/')[0..-3] # skip model dir & partial
+
+            prefix_array.each_with_index do |dir, index|
+              break if dir == object_path_array[index]
+              prefixes << dir
+            end
+
+            (prefixes << object_path).join("/")
+          else
+            object_path
+          end
+        end
+
+        def raise_invalid_identifier(path)
+          raise ArgumentError.new(IDENTIFIER_ERROR_MESSAGE % (path))
+        end
+
+        def raise_invalid_option_as(as)
+          raise ArgumentError.new(OPTION_AS_ERROR_MESSAGE % (as))
+        end
+    end
+
+    class MemberRenderer < Base # :nodoc:
+      def setup(*)
+        super
+      end
+
+      def render
+        super
         instrument(:partial, :identifier => identifier) do
           render_partial
         end
       end
+
+      private
+        def setup_path
+          @path = @options[:path] ? @options[:path] : partial_path
+        end
+
+        def render_partial
+          view, locals, block = @view, @locals, @block
+          object, as = @object, @variable
+
+          if !block && (layout = @options[:layout])
+            layout = find_template(layout.to_s, @template_keys)
+          end
+
+          object = locals[as] if object.nil? # Respect object when object is false
+          locals[as] = object if @has_object
+
+          content = @template.render(view, locals) do |*name|
+            view._layout_for(*name, &block)
+          end
+
+          content = layout.render(view, locals){ content } if layout
+          content
+        end
+
+        def retrieve_template_keys
+          keys = @locals.keys
+          keys << @variable if @has_object || @collection
+          keys
+        end
+
+        def retrieve_variable(path, as)
+          variable = as || begin
+            base = path[-1] == "/".freeze ? "".freeze : File.basename(path)
+            raise_invalid_identifier(path) unless base =~ /\A_?(.*)(?:\.\w+)*\z/
+            $1.to_sym
+          end
+          variable_counter = nil
+          variable_iteration = nil
+          [variable, variable_counter, variable_iteration]
+        end
     end
 
-    private
+    class CollectionRenderer < Base # :nodoc:
+      include CollectionCaching
 
-    def render_collection
-      return nil if @collection.blank?
-
-      if @options.key?(:spacer_template)
-        spacer = find_template(@options[:spacer_template], @locals.keys).render(@view, @locals)
+      def setup(*)
+        super
       end
 
-      cache_collection_render do
-        @template ? collection_with_template : collection_without_template
-      end.join(spacer).html_safe
-    end
-
-    def render_partial
-      view, locals, block = @view, @locals, @block
-      object, as = @object, @variable
-
-      if !block && (layout = @options[:layout])
-        layout = find_template(layout.to_s, @template_keys)
-      end
-
-      object = locals[as] if object.nil? # Respect object when object is false
-      locals[as] = object if @has_object
-
-      content = @template.render(view, locals) do |*name|
-        view._layout_for(*name, &block)
-      end
-
-      content = layout.render(view, locals){ content } if layout
-      content
-    end
-
-    # Sets up instance variables needed for rendering a partial. This method
-    # finds the options and details and extracts them. The method also contains
-    # logic that handles the type of object passed in as the partial.
-    #
-    # If +options[:partial]+ is a string, then the +@path+ instance variable is
-    # set to that string. Otherwise, the +options[:partial]+ object must
-    # respond to +to_partial_path+ in order to setup the path.
-    def setup(context, options, block)
-      @view   = context
-      @options = options
-      @block   = block
-
-      @locals  = options[:locals] || {}
-      @details = extract_details(options)
-
-      prepend_formats(options[:formats])
-
-      partial = options[:partial]
-
-      if String === partial
-        @has_object = options.key?(:object)
-        @object     = options[:object]
-        @collection = collection_from_options
-        @path       = partial
-      else
-        @has_object = true
-        @object = partial
-        @collection = collection_from_object || collection_from_options
-
-        if @collection
-          paths = @collection_data = @collection.map { |o| partial_path(o) }
-          @path = paths.uniq.one? ? paths.first : nil
-        else
-          @path = partial_path
+      def render
+        super
+        instrument(:collection, :identifier => identifier || "collection", :count => @collection.size) do
+          render_collection
         end
       end
 
-      if as = options[:as]
-        raise_invalid_option_as(as) unless as.to_s =~ /\A[a-z_]\w*\z/
-        as = as.to_sym
-      end
-
-      if @path
-        @variable, @variable_counter, @variable_iteration = retrieve_variable(@path, as)
-        @template_keys = retrieve_template_keys
-      else
-        paths.map! { |path| retrieve_variable(path, as).unshift(path) }
-      end
-
-      self
-    end
-
-    def collection_from_options
-      if @options.key?(:collection)
-        collection = @options[:collection]
-        collection.respond_to?(:to_ary) ? collection.to_ary : []
-      end
-    end
-
-    def collection_from_object
-      @object.to_ary if @object.respond_to?(:to_ary)
-    end
-
-    def find_partial
-      find_template(@path, @template_keys) if @path
-    end
-
-    def find_template(path, locals)
-      prefixes = path.include?(?/) ? [] : @lookup_context.prefixes
-      @lookup_context.find_template(path, prefixes, true, locals, @details)
-    end
-
-    def collection_with_template
-      view, locals, template = @view, @locals, @template
-      as, counter, iteration = @variable, @variable_counter, @variable_iteration
-
-      if layout = @options[:layout]
-        layout = find_template(layout, @template_keys)
-      end
-
-      partial_iteration = PartialIteration.new(@collection.size)
-      locals[iteration] = partial_iteration
-
-      @collection.map do |object|
-        locals[as]        = object
-        locals[counter]   = partial_iteration.index
-
-        content = template.render(view, locals)
-        content = layout.render(view, locals) { content } if layout
-        partial_iteration.iterate!
-        content
-      end
-    end
-
-    def collection_without_template
-      view, locals, collection_data = @view, @locals, @collection_data
-      cache = {}
-      keys  = @locals.keys
-
-      partial_iteration = PartialIteration.new(@collection.size)
-
-      @collection.map do |object|
-        index = partial_iteration.index
-        path, as, counter, iteration = collection_data[index]
-
-        locals[as]        = object
-        locals[counter]   = index
-        locals[iteration] = partial_iteration
-
-        template = (cache[path] ||= find_template(path, keys + [as, counter]))
-        content = template.render(view, locals)
-        partial_iteration.iterate!
-        content
-      end
-    end
-
-    # Obtains the path to where the object's partial is located. If the object
-    # responds to +to_partial_path+, then +to_partial_path+ will be called and
-    # will provide the path. If the object does not respond to +to_partial_path+,
-    # then an +ArgumentError+ is raised.
-    #
-    # If +prefix_partial_path_with_controller_namespace+ is true, then this
-    # method will prefix the partial paths with a namespace.
-    def partial_path(object = @object)
-      object = object.to_model if object.respond_to?(:to_model)
-
-      path = if object.respond_to?(:to_partial_path)
-        object.to_partial_path
-      else
-        raise ArgumentError.new("'#{object.inspect}' is not an ActiveModel-compatible object. It must implement :to_partial_path.")
-      end
-
-      if @view.prefix_partial_path_with_controller_namespace
-        prefixed_partial_names[path] ||= merge_prefix_into_object_path(@context_prefix, path.dup)
-      else
-        path
-      end
-    end
-
-    def prefixed_partial_names
-      @prefixed_partial_names ||= PREFIXED_PARTIAL_NAMES[@context_prefix]
-    end
-
-    def merge_prefix_into_object_path(prefix, object_path)
-      if prefix.include?(?/) && object_path.include?(?/)
-        prefixes = []
-        prefix_array = File.dirname(prefix).split('/')
-        object_path_array = object_path.split('/')[0..-3] # skip model dir & partial
-
-        prefix_array.each_with_index do |dir, index|
-          break if dir == object_path_array[index]
-          prefixes << dir
+      private
+        def setup_path
+          if @options[:path]
+            @path = @options[:path]
+          else
+            @collection_data = @collection.map { |o| partial_path(o) }
+            @path = @collection_data.uniq.one? ? @collection_data.first : nil
+          end
         end
 
-        (prefixes << object_path).join("/")
-      else
-        object_path
-      end
+        def render_collection
+          return nil if @collection.blank?
+
+          if @options.key?(:spacer_template)
+            spacer = find_template(@options[:spacer_template], @locals.keys).render(@view, @locals)
+          end
+
+          cache_collection_render do
+            @template ? collection_with_template : collection_without_template
+          end.join(spacer).html_safe
+        end
+
+        def collection_with_template
+          view, locals, template = @view, @locals, @template
+          as, counter, iteration = @variable, @variable_counter, @variable_iteration
+
+          if layout = @options[:layout]
+            layout = find_template(layout, @template_keys)
+          end
+
+          partial_iteration = PartialIteration.new(@collection.size)
+          locals[iteration] = partial_iteration
+
+          @collection.map do |object|
+            locals[as]        = object
+            locals[counter]   = partial_iteration.index
+
+            content = template.render(view, locals)
+            content = layout.render(view, locals) { content } if layout
+            partial_iteration.iterate!
+            content
+          end
+        end
+
+        def collection_without_template
+          view, locals, collection_data = @view, @locals, @collection_data
+          cache = {}
+          keys  = @locals.keys
+
+          partial_iteration = PartialIteration.new(@collection.size)
+
+          @collection.map do |object|
+            index = partial_iteration.index
+            path, as, counter, iteration = collection_data[index]
+
+            locals[as]        = object
+            locals[counter]   = index
+            locals[iteration] = partial_iteration
+
+            template = (cache[path] ||= find_template(path, keys + [as, counter]))
+            content = template.render(view, locals)
+            partial_iteration.iterate!
+            content
+          end
+        end
+
+        def retrieve_template_keys
+          keys = @locals.keys
+          keys << @variable if @has_object || @collection
+          keys << @variable_counter
+          keys << @variable_iteration
+          keys
+        end
+
+        def retrieve_variable(path, as)
+          variable = as || begin
+            base = path[-1] == "/".freeze ? "".freeze : File.basename(path)
+            raise_invalid_identifier(path) unless base =~ /\A_?(.*)(?:\.\w+)*\z/
+            $1.to_sym
+          end
+          variable_counter = :"#{variable}_counter"
+          variable_iteration = :"#{variable}_iteration"
+          [variable, variable_counter, variable_iteration]
+        end
     end
 
-    def retrieve_template_keys
-      keys = @locals.keys
-      keys << @variable if @has_object || @collection
-      if @collection
-        keys << @variable_counter
-        keys << @variable_iteration
-      end
-      keys
-    end
-
-    def retrieve_variable(path, as)
-      variable = as || begin
-        base = path[-1] == "/".freeze ? "".freeze : File.basename(path)
-        raise_invalid_identifier(path) unless base =~ /\A_?(.*)(?:\.\w+)*\z/
-        $1.to_sym
-      end
-      if @collection
-        variable_counter = :"#{variable}_counter"
-        variable_iteration = :"#{variable}_iteration"
-      end
-      [variable, variable_counter, variable_iteration]
-    end
-
-    IDENTIFIER_ERROR_MESSAGE = "The partial name (%s) is not a valid Ruby identifier; " +
-                               "make sure your partial name starts with underscore."
-
-    OPTION_AS_ERROR_MESSAGE  = "The value (%s) of the option `as` is not a valid Ruby identifier; " +
-                               "make sure it starts with lowercase letter, " +
-                               "and is followed by any combination of letters, numbers and underscores."
-
-    def raise_invalid_identifier(path)
-      raise ArgumentError.new(IDENTIFIER_ERROR_MESSAGE % (path))
-    end
-
-    def raise_invalid_option_as(as)
-      raise ArgumentError.new(OPTION_AS_ERROR_MESSAGE % (as))
+    def render(context, options, block)
+      Base.build(@lookup_context, context, options, block).render
     end
   end
 end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -616,14 +616,14 @@ class CachedCollectionViewRenderTest < CachedViewRenderTest
   class CachedCustomer < Customer; end
 
   teardown do
-    ActionView::PartialRenderer.collection_cache.clear
+    ActionView::PartialRenderer::CollectionRenderer.collection_cache.clear
   end
 
   test "with custom key" do
     customer = Customer.new("david")
     key = cache_key([customer, 'key'], "test/_customer")
 
-    ActionView::PartialRenderer.collection_cache.write(key, 'Hello')
+    ActionView::PartialRenderer::CollectionRenderer.collection_cache.write(key, 'Hello')
 
     assert_equal "Hello",
       @view.render(partial: "test/customer", collection: [customer], cache: ->(item) { [item, 'key'] })
@@ -633,7 +633,7 @@ class CachedCollectionViewRenderTest < CachedViewRenderTest
     customer = Customer.new("david")
     key = cache_key([customer, 'key'], "test/_customer")
 
-    ActionView::PartialRenderer.collection_cache.write(key, 'Hello')
+    ActionView::PartialRenderer::CollectionRenderer.collection_cache.write(key, 'Hello')
 
     assert_equal "Hello: david",
       @view.render(partial: "test/customer", collection: [customer], cache: ->(item) { [item, 'another_key'] })
@@ -643,7 +643,7 @@ class CachedCollectionViewRenderTest < CachedViewRenderTest
     customer = CachedCustomer.new("david")
     key = cache_key(customer, "test/_cached_customer")
 
-    ActionView::PartialRenderer.collection_cache.write(key, 'Cached')
+    ActionView::PartialRenderer::CollectionRenderer.collection_cache.write(key, 'Cached')
 
     assert_equal "Cached",
       @view.render(partial: "test/cached_customer", collection: [customer])
@@ -653,7 +653,7 @@ class CachedCollectionViewRenderTest < CachedViewRenderTest
     customer = CachedCustomer.new("david")
     key = cache_key(customer, "test/_cached_customer_as")
 
-    ActionView::PartialRenderer.collection_cache.write(key, 'Cached')
+    ActionView::PartialRenderer::CollectionRenderer.collection_cache.write(key, 'Cached')
 
     assert_equal "Cached",
       @view.render(partial: "test/cached_customer_as", collection: [customer], as: :buyer)


### PR DESCRIPTION
…enderer`

`PartialRenderer` handling both collection and member makes
`PartialRenderer` be complex:
- branching with `if @collection` in some methods
- instance variables only used by collection logic are definded
  (e.g. `@collection_data`)

This commit devides it into `CollectionRenderer` and `MemberRenderer`.
Removing `if @collection` and some instance variables.
