### PR TITLE
Make the `config.static_index` option part of the `config.public_server` option

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -199,7 +199,7 @@ The full set of methods that can be used in this block are as follows:
 Every Rails application comes with a standard set of middleware which it uses in this order in the development environment:
 
 * `ActionDispatch::SSL` forces every request to be under HTTPS protocol. Will be available if `config.force_ssl` is set to `true`. Options passed to this can be configured by using `config.ssl_options`.
-* `ActionDispatch::Static` is used to serve static assets. Disabled if `config.public_file_server.enabled` is `false`. Set `config.static_index` if you need to serve a static directory index file that is not named `index`. For example, to serve `main.html` instead of `index.html` for directory requests, set `config.static_index` to `"main"`.
+* `ActionDispatch::Static` is used to serve static assets. Disabled if `config.public_file_server.enabled` is `false`. Set `config.public_file_server.index_name` if you need to serve a static directory index file that is not named `index`. For example, to serve `main.html` instead of `index.html` for directory requests, set `config.public_file_server.index_name` to `"main"`.
 * `Rack::Lock` wraps the app in mutex so it can only be called by a single thread at a time. Only enabled when `config.cache_classes` is `false`.
 * `ActiveSupport::Cache::Strategy::LocalCache` serves as a basic memory backed cache. This cache is not thread safe and is intended only for serving as a temporary memory cache for a single thread.
 * `Rack::Runtime` sets an `X-Runtime` header, containing the time (in seconds) taken to execute the request.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Make `static_index` part of the `config.public_file_server` config and
+    call it `public_file_server.index_name`.
+
+    *Yuki Nishijima*
+
 *   Generated `Gemfile`s for new applications include a new dependency on
     [listen](https://github.com/guard/listen) commented out.
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -14,7 +14,7 @@ module Rails
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters,
                     :force_ssl, :helpers_paths, :logger, :log_formatter, :log_tags,
                     :railties_order, :relative_url_root, :secret_key_base, :secret_token,
-                    :ssl_options, :static_index, :public_file_server,
+                    :ssl_options, :public_file_server,
                     :session_options, :time_zone, :reload_classes_only_on_change,
                     :beginning_of_week, :filter_redirect, :x
 
@@ -29,9 +29,9 @@ module Rails
         @filter_parameters             = []
         @filter_redirect               = []
         @helpers_paths                 = []
-        @static_index                  = "index"
         @public_file_server            = ActiveSupport::OrderedOptions.new
         @public_file_server.enabled    = true
+        @public_file_server.index_name = "index"
         @force_ssl                     = false
         @ssl_options                   = {}
         @session_store                 = :cookie_store

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -21,7 +21,7 @@ module Rails
             headers = config.public_file_server.headers || {}
             headers['Cache-Control'.freeze] = config.static_cache_control if config.static_cache_control
 
-            middleware.use ::ActionDispatch::Static, paths["public"].first, index: config.static_index, headers: headers
+            middleware.use ::ActionDispatch::Static, paths["public"].first, index: config.public_file_server.index_name, headers: headers
           end
 
           if rack_cache = load_rack_cache

--- a/railties/test/application/middleware/static_test.rb
+++ b/railties/test/application/middleware/static_test.rb
@@ -44,7 +44,7 @@ module ApplicationTests
       assert_equal 'public, max-age=60',     last_response.headers["Cache-Control"]
     end
 
-    test "static_index defaults to 'index'" do
+    test "public_file_server.index_name defaults to 'index'" do
       app_file "public/index.html", "/index.html"
       
       require "#{app_path}/config/environment"
@@ -54,10 +54,10 @@ module ApplicationTests
       assert_equal "/index.html\n", last_response.body
     end
 
-    test "static_index configurable" do
+    test "public_file_server.index_name configurable" do
       app_file "public/other-index.html", "/other-index.html"
-      add_to_config "config.static_index = 'other-index'"
-      
+      add_to_config "config.public_file_server.index_name = 'other-index'"
+
       require "#{app_path}/config/environment"
 
       get '/'


### PR DESCRIPTION
Now that we have the `config.public_file_server` option, and I think it makes more sense to make [the `config.static_index` option](https://github.com/rails/rails/pull/20017) part of the `config.public_file_server` option. I'm not sure if it has to go through a deprecation cycle since it's a new feature of Rails 5.0, but let me know if it still has to.

cc/ @eliotsykes
