### PR TITLE
[ci skip] Fix <tt> in doc around +maximum(:updated_at)

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -66,7 +66,7 @@ module ActionController
     #
     # You can also pass an object that responds to +maximum+, such as a
     # collection of active records. In this case +last_modified+ will be set by
-    # calling +maximum(:updated_at)+ on the collection (the timestamp of the
+    # calling <tt>maximum(:updated_at)</tt> on the collection (the timestamp of the
     # most recently updated record) and the +etag+ by passing the object itself.
     #
     #   def index


### PR DESCRIPTION
Before

<img width="660" alt="screen shot 2015-11-15 at 2 43 28 am" src="https://cloud.githubusercontent.com/assets/10076/11168405/ac6cb2c0-8b42-11e5-8339-3c7ade9f515b.png">

After

<img width="589" alt="screen shot 2015-11-15 at 2 45 31 am" src="https://cloud.githubusercontent.com/assets/10076/11168416/f5eed108-8b42-11e5-8a75-30b845305e12.png">
