### PR TITLE
validate proper options passed to add_foreign_key

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -950,6 +950,7 @@ module ActiveRecord
 
       def foreign_key_options(from_table, to_table, options) # :nodoc:
         options = options.dup
+        validate_foreign_key_options(options)
         options[:column] ||= foreign_key_column_for(to_table)
         options[:name]   ||= foreign_key_name(from_table, options)
         options
@@ -1195,6 +1196,15 @@ module ActiveRecord
         else
           default_or_changes
         end
+      end
+
+      def validate_foreign_key_options(options) # :nodoc:
+        valid_options = [:column, :primary_key, :name, :on_delete, :on_update]
+        return true if options.blank?
+        options.each do |option, value|
+          raise ArgumentError, "'#{option}' is not a valid option. Valid options are: '#{valid_options.join(", ")}'" unless valid_options.include?(option)
+        end
+        true
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1199,7 +1199,7 @@ module ActiveRecord
       end
 
       def validate_foreign_key_options(options) # :nodoc:
-        valid_options = [:column, :primary_key, :name, :on_delete, :on_update]
+        valid_options = [:column, :primary_key, :name, :on_delete, :on_update, :to_table]
         return true if options.blank?
         options.each do |option, value|
           raise ArgumentError, "'#{option}' is not a valid option. Valid options are: '#{valid_options.join(", ")}'" unless valid_options.include?(option)

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -127,7 +127,7 @@ module ActiveRecord
         assert_raises ArgumentError do
           @connection.add_foreign_key :astronauts, :rockets, nullify: true
         end
-        valid_options = [:column, :primary_key, :name, :on_delete, :on_update]
+        valid_options = [:column, :primary_key, :name, :on_delete, :on_update, :to_table]
         begin
           @connection.add_foreign_key :astronauts, :rockets, nullify: true
         rescue => e

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -117,6 +117,25 @@ module ActiveRecord
         assert_equal :cascade, fk.on_delete
       end
 
+      def test_only_valid_options_can_be_provided
+        assert_raises ArgumentError do
+          @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", on_cascade: :delete
+        end
+        assert_raises ArgumentError do
+          @connection.add_foreign_key :astronauts, :rockets, columns: "rocket_id"
+        end
+        assert_raises ArgumentError do
+          @connection.add_foreign_key :astronauts, :rockets, nullify: true
+        end
+        valid_options = [:column, :primary_key, :name, :on_delete, :on_update]
+        begin
+          @connection.add_foreign_key :astronauts, :rockets, nullify: true
+        rescue => e
+          assert_equal true, e.message.include?("nullify")
+          assert_equal true, e.message.include?(valid_options.join(", "))
+        end
+      end
+
       def test_add_on_delete_nullify_foreign_key
         @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", on_delete: :nullify
 


### PR DESCRIPTION
Just a quick helper when adding foreign keys during the migration. I used the wrong options i.e. `on_cascade: :delete`. But that never rose an exception. A month later I wondered why some records were not deleted properly from our production database.

This raises an exception whenever invalid options are passed.

Comments/feedback appreciated.
