### PR TITLE
Remove meaningless `|| native_database_types[column.type][:limit]`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -62,7 +62,7 @@ module ActiveRecord
 
       def schema_limit(column)
         limit = column.limit
-        limit.inspect if limit && limit != native_database_types[column.type][:limit]
+        limit.inspect if limit
       end
 
       def schema_precision(column)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -127,7 +127,7 @@ module ActiveRecord
         primary_key: "int auto_increment PRIMARY KEY",
         string:      { name: "varchar", limit: 255 },
         text:        { name: "text" },
-        integer:     { name: "int", limit: 4 },
+        integer:     { name: "int" },
         float:       { name: "float" },
         decimal:     { name: "decimal" },
         datetime:    { name: "datetime" },

--- a/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
@@ -48,7 +48,7 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
 
   test "schema dump includes collation" do
     output = dump_table_schema("charset_collations")
-    assert_match %r{t.string\s+"string_ascii_bin",\s+collation: "ascii_bin"$}, output
+    assert_match %r{t.string\s+"string_ascii_bin",\s+limit: 255,\s+collation: "ascii_bin"$}, output
     assert_match %r{t.text\s+"text_ucs2_unicode_ci",\s+limit: 65535,\s+collation: "ucs2_unicode_ci"$}, output
   end
 end

--- a/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
@@ -57,7 +57,7 @@ class Mysql2UnsignedTypeTest < ActiveRecord::Mysql2TestCase
 
   test "schema dump includes unsigned option" do
     schema = dump_table_schema "unsigned_types"
-    assert_match %r{t.integer\s+"unsigned_integer",\s+unsigned: true$}, schema
+    assert_match %r{t.integer\s+"unsigned_integer",\s+limit: 4,\s+unsigned: true$}, schema
     assert_match %r{t.integer\s+"unsigned_bigint",\s+limit: 8,\s+unsigned: true$}, schema
     assert_match %r{t.float\s+"unsigned_float",\s+limit: 24,\s+unsigned: true$}, schema
     assert_match %r{t.decimal\s+"unsigned_decimal",\s+precision: 10,\s+scale: 2,\s+unsigned: true$}, schema

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -118,7 +118,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
       assert_match %r{c_int_4.*}, output
       assert_no_match %r{c_int_4.*limit:}, output
     elsif current_adapter?(:Mysql2Adapter)
-      assert_match %r{c_int_without_limit"$}, output
+      assert_match %r{c_int_without_limit.*limit: 4$}, output
 
       assert_match %r{c_int_1.*limit: 1}, output
       assert_match %r{c_int_2.*limit: 2}, output


### PR DESCRIPTION
This line was introduced by 2c76793f087e212ff4c6d835656a9a95c8bfeaa5.
Originally the line was `if column.limit != types[column.type][:limit]`.
Simply it is only remove this condition for dumping column limit.
