### PR TITLE
`ActiveRecord::Base#becomes` should retain the errors but use new base.

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -216,6 +216,7 @@ module ActiveRecord
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became.instance_variable_set("@errors", errors)
+      errors.instance_variable_set("@base", became)
       became
     end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -19,6 +19,8 @@ require 'models/person'
 require 'models/pet'
 require 'models/ship'
 require 'models/toy'
+require 'models/admin'
+require 'models/admin/user'
 require 'rexml/document'
 
 class PersistenceTest < ActiveRecord::TestCase
@@ -162,6 +164,21 @@ class PersistenceTest < ActiveRecord::TestCase
     original_errors = company.errors
     client = company.becomes(Client)
     assert_equal original_errors, client.errors
+  end
+
+  def test_becomes_errors_base
+    child_class = Class.new(Admin::User) do
+      store_accessor :settings, :foo
+
+      def self.name; 'Admin::ChildUser'; end
+    end
+
+    admin = Admin::User.new
+    cc = admin.becomes(child_class)
+    assert_equal cc.errors.instance_variable_get("@base"), cc
+    assert_nothing_raised do
+      cc.errors.add :foo, :invalid
+    end
   end
 
   def test_dupd_becomes_persists_changes_from_the_original


### PR DESCRIPTION
Upgrading of https://github.com/rails/rails/pull/3438

According to documentation of [ActiveModel::Errors#initialize](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/errors.rb#L65-L76)

> Pass in the instance of the object that is using the errors object.

Some subclass can have different validations and fields. And it is a place for potential errors. See new test for example.
