### PR TITLE
Add `bin/test` script to rails plugin.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `bin/test` script to rails plugin.
+
+    `bin/test` can use the same API as `bin/rails test`.
+
+    *Yuji Yaginuma*
+
 *   Make `static_index` part of the `config.public_file_server` config and
     call it `public_file_server.index_name`.
 

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -148,9 +148,8 @@ task default: :test
     end
 
     def bin(force = false)
-      return unless engine?
-
-      directory "bin", force: force do |content|
+      bin_file = engine? ? 'bin/rails.tt' : 'bin/test.tt'
+      template bin_file, force: force do |content|
         "#{shebang}\n" + content
       end
       chmod "bin", 0755, verbose: false

--- a/railties/lib/rails/generators/rails/plugin/templates/bin/test.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/test.tt
@@ -1,0 +1,8 @@
+$: << File.expand_path(File.expand_path('../../test', __FILE__))
+
+require 'bundler/setup'
+require 'rails/test_unit/minitest_plugin'
+
+Rails::TestUnitReporter.executable = 'bin/test'
+
+exit Minitest.run(ARGV)

--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
@@ -14,6 +14,10 @@ require "rails/test_help"
 # to be shown.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
+<% unless engine? -%>
+Rails::TestUnitReporter.executable = 'bin/test'
+<% end -%>
+
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)

--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -14,15 +14,16 @@ module Minitest
   SummaryReporter.prepend AggregatedResultSuppresion
 
   def self.plugin_rails_options(opts, options)
+    executable = Rails::TestUnitReporter.executable
     opts.separator ""
-    opts.separator "Usage: bin/rails test [options] [files or directories]"
+    opts.separator "Usage: #{executable} [options] [files or directories]"
     opts.separator "You can run a single test by appending a line number to a filename:"
     opts.separator ""
-    opts.separator "    bin/rails test test/models/user_test.rb:27"
+    opts.separator "    #{executable} test/models/user_test.rb:27"
     opts.separator ""
     opts.separator "You can run multiple files and directories at the same time:"
     opts.separator ""
-    opts.separator "    bin/rails test test/controllers test/integration/login_test.rb"
+    opts.separator "    #{executable} test/controllers test/integration/login_test.rb"
     opts.separator ""
     opts.separator "By default test failures and errors are reported inline during a run."
     opts.separator ""

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -65,8 +65,11 @@ class PluginGeneratorTest < Rails::Generators::TestCase
       assert_match(/require.+test\/dummy\/config\/environment/, content)
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+test\/dummy\/db\/migrate/, content)
       assert_match(/Minitest\.backtrace_filter = Minitest::BacktraceFilter\.new/, content)
+      assert_match(/Rails::TestUnitReporter\.executable = 'bin\/test'/, content)
     end
     assert_file "test/bukkits_test.rb", /assert_kind_of Module, Bukkits/
+    assert_file 'bin/test'
+    assert_no_file 'bin/rails'
   end
 
   def test_generating_test_files_in_full_mode
@@ -223,7 +226,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     run_generator
     FileUtils.cd destination_root
     quietly { system 'bundle install' }
-    assert_match(/1 runs, 1 assertions, 0 failures, 0 errors/, `bundle exec rake test 2>&1`)
+    assert_match(/1 runs, 1 assertions, 0 failures, 0 errors/, `bin/test 2>&1`)
   end
 
   def test_ensure_that_tests_works_in_full_mode
@@ -315,7 +318,9 @@ class PluginGeneratorTest < Rails::Generators::TestCase
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+\.\.\/test\/dummy\/db\/migrate/, content)
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+<<.+\.\.\/db\/migrate/, content)
       assert_match(/ActionDispatch::IntegrationTest\.fixture_path = ActiveSupport::TestCase\.fixture_pat/, content)
+      assert_no_match(/Rails::TestUnitReporter\.executable = 'bin\/test'/, content)
     end
+    assert_no_file 'bin/test'
   end
 
   def test_create_mountable_application_with_mountable_option_and_hypenated_name

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -1,0 +1,123 @@
+require 'tmpdir'
+require 'abstract_unit'
+
+class PluginTestRunnerTest < ActiveSupport::TestCase
+  def setup
+    @destination_root = Dir.mktmpdir('bukkits')
+    Dir.chdir(@destination_root) { `bundle exec rails plugin new bukkits --skip-bundle` }
+    plugin_file 'test/dummy/db/schema.rb', ''
+  end
+
+  def teardown
+    FileUtils.rm_rf(@destination_root)
+  end
+
+  def test_run_single_file
+    create_test_file 'foo'
+    create_test_file 'bar'
+    assert_match "1 runs, 1 assertions, 0 failures", run_test_command("test/foo_test.rb")
+  end
+
+  def test_run_multiple_files
+    create_test_file 'foo'
+    create_test_file 'bar'
+    assert_match "2 runs, 2 assertions, 0 failures", run_test_command("test/foo_test.rb test/bar_test.rb")
+  end
+
+  def test_mix_files_and_line_filters
+    create_test_file 'account'
+    plugin_file 'test/post_test.rb', <<-RUBY
+      require 'test_helper'
+
+      class PostTest < ActiveSupport::TestCase
+        def test_post
+          puts 'PostTest'
+          assert true
+        end
+
+        def test_line_filter_does_not_run_this
+          assert true
+        end
+      end
+    RUBY
+
+    run_test_command('test/account_test.rb test/post_test.rb:4').tap do |output|
+      assert_match 'AccountTest', output
+      assert_match 'PostTest', output
+      assert_match '2 runs, 2 assertions', output
+    end
+  end
+
+  def test_multiple_line_filters
+    create_test_file 'account'
+    create_test_file 'post'
+
+    run_test_command('test/account_test.rb:4 test/post_test.rb:4').tap do |output|
+      assert_match 'AccountTest', output
+      assert_match 'PostTest', output
+    end
+  end
+
+  def test_line_filter_without_line_runs_all_tests
+    create_test_file 'account'
+
+    run_test_command('test/account_test.rb:').tap do |output|
+      assert_match 'AccountTest', output
+    end
+  end
+
+  def test_output_inline_by_default
+    create_test_file 'post', pass: false
+
+    output = run_test_command('test/post_test.rb')
+    assert_match %r{Running:\n\nPostTest\nF\n\nwups!\n\nbin/test #{plugin_path}/test/post_test.rb:6}, output
+  end
+
+  def test_only_inline_failure_output
+    create_test_file 'post', pass: false
+
+    output = run_test_command('test/post_test.rb')
+    assert_match %r{Finished in.*\n\n1 runs, 1 assertions}, output
+  end
+
+  def test_fail_fast
+    create_test_file 'post', pass: false
+
+    assert_match(/Interrupt/,
+      capture(:stderr) { run_test_command('test/post_test.rb --fail-fast') })
+  end
+
+  def test_raise_error_when_specified_file_does_not_exist
+    error = capture(:stderr) { run_test_command('test/not_exists.rb') }
+    assert_match(%r{cannot load such file.+test/not_exists\.rb}, error)
+  end
+
+  private
+    def plugin_path
+      "#{@destination_root}/bukkits"
+    end
+
+    def run_test_command(arguments)
+      Dir.chdir(plugin_path) { `bin/test #{arguments}` }
+    end
+
+    def create_test_file(name, pass: true)
+      plugin_file "test/#{name}_test.rb", <<-RUBY
+        require 'test_helper'
+
+        class #{name.camelize}Test < ActiveSupport::TestCase
+          def test_truth
+            puts "#{name.camelize}Test"
+            assert #{pass}, 'wups!'
+          end
+        end
+      RUBY
+    end
+
+    def plugin_file(path, contents, mode: 'w')
+      FileUtils.mkdir_p File.dirname("#{plugin_path}/#{path}")
+      File.open("#{plugin_path}/#{path}", mode) do |f|
+        f.puts contents
+      end
+    end
+end


### PR DESCRIPTION
rails minitest extension has become to use the `bin/rails`,  but `bin/rails` does not exist in rails plugin.
Therefore, it is displayed a snippet for rerun, that can not run,
I think it is better that had been disabled by default.
