### PR TITLE
Except keys of `build_record`'s argument from `create_scope` in initi…

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Except keys of `build_record`'s argument from `create_scope` in `initialize_attributes`.
+
+    Fixes #21893.
+
+    *Yuichiro Kaneko*
+
 *   No longer pass deprecated option `-i` to `pg_dump`.
 
     *Paul Sadauskas*

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -163,9 +163,12 @@ module ActiveRecord
         @reflection = @owner.class._reflect_on_association(reflection_name)
       end
 
-      def initialize_attributes(record) #:nodoc:
+      def initialize_attributes(record, except_from_scope_attributes = nil) #:nodoc:
+        except_from_scope_attributes ||= {}
         skip_assign = [reflection.foreign_key, reflection.type].compact
-        attributes = create_scope.except(*(record.changed - skip_assign))
+        assigned_keys = record.changed
+        assigned_keys += except_from_scope_attributes.keys.map(&:to_s)
+        attributes = create_scope.except(*(assigned_keys - skip_assign))
         record.assign_attributes(attributes)
         set_inverse_instance(record)
       end
@@ -245,7 +248,7 @@ module ActiveRecord
 
         def build_record(attributes)
           reflection.build_association(attributes) do |record|
-            initialize_attributes(record)
+            initialize_attributes(record, attributes)
           end
         end
     end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -89,9 +89,22 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     bulb = car.bulbs.create
     assert_equal 'defaulty', bulb.name
+  end
 
-    bulb = car.bulbs.create(:name => 'exotic')
+  def test_build_and_create_from_association_should_respect_passed_attributes_over_default_scope
+    car = Car.create(name: 'honda')
+
+    bulb = car.bulbs.build(name: 'exotic')
     assert_equal 'exotic', bulb.name
+
+    bulb = car.bulbs.create(name: 'exotic')
+    assert_equal 'exotic', bulb.name
+
+    bulb = car.awesome_bulbs.build(frickinawesome: false)
+    assert_equal false, bulb.frickinawesome
+
+    bulb = car.awesome_bulbs.create(frickinawesome: false)
+    assert_equal false, bulb.frickinawesome
   end
 
   def test_build_from_association_should_respect_scope

--- a/activerecord/test/models/bulb.rb
+++ b/activerecord/test/models/bulb.rb
@@ -1,6 +1,7 @@
 class Bulb < ActiveRecord::Base
   default_scope { where(:name => 'defaulty') }
   belongs_to :car, :touch => true
+  scope :awesome, -> { where(frickinawesome: true) }
 
   attr_reader :scope_after_initialize, :attributes_after_initialize
 

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -4,6 +4,7 @@ class Car < ActiveRecord::Base
   has_many :funky_bulbs, class_name: 'FunkyBulb', dependent: :destroy
   has_many :failed_bulbs, class_name: 'FailedBulb', dependent: :destroy
   has_many :foo_bulbs, -> { where(:name => 'foo') }, :class_name => "Bulb"
+  has_many :awesome_bulbs, -> { awesome }, class_name: "Bulb"
 
   has_one :bulb
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -122,7 +122,7 @@ ActiveRecord::Schema.define do
   create_table :bulbs, force: true do |t|
     t.integer :car_id
     t.string  :name
-    t.boolean :frickinawesome
+    t.boolean :frickinawesome, default: false
     t.string :color
   end
 


### PR DESCRIPTION
…alize_attributes

If argument of `build_record` has key and value which is same as
default value of database, we should also except the key from
`create_scope` in `initialize_attributes`.
Because at first `build_record` initialize record object with argument
of `build_record`, then assign attributes derived from Association's scope.
In this case `record.changed` does not include the key, which value is
same as default value of database, so we should add the key to except list.

Fix #21893.

(cherry picked from commit 817c1825c15013fd0180762ac5c05a2e024a640d)
