### PR TITLE
Add each schema parameter as its own argument.

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -47,9 +47,9 @@ module ActiveRecord
         args = ['-s', '-x', '-O', '-f', filename]
         search_path = configuration['schema_search_path']
         unless search_path.blank?
-          args << search_path.split(',').map do |part|
+          args += search_path.split(',').map do |part|
             "--schema=#{part.strip}"
-          end.join(' ')
+          end
         end
         args << configuration['database']
         run_cmd('pg_dump', args, 'dumping')

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -211,6 +211,19 @@ module ActiveRecord
     ensure
       FileUtils.rm(filename) if File.exist?(filename)
     end
+
+    def test_structure_dump_with_schema_search_path
+      filename = "awesome-file.sql"
+      schema_search_path = 'foo, bar'
+      @configuration['schema_search_path'] = schema_search_path
+      Kernel.expects(:system).with('pg_dump', '-s', '-x', '-O', '-f', filename, '--schema=foo', '--schema=bar', 'my-app-db').returns(true)
+      @connection.expects(:schema_search_path).returns(schema_search_path)
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+      assert File.exist?(filename)
+    ensure
+      FileUtils.rm(filename) if File.exist?(filename)
+    end
   end
 
   class PostgreSQLStructureLoadTest < ActiveRecord::TestCase


### PR DESCRIPTION
At least on my machine the existing code fails, if there is more than
one schema in the search path, with the following error message:

```
pg_dump: No matching schemas were found
```

Passing each schema parameter as its own argument fixes the problem.
