### PR TITLE
Backport: Cache url_helpers instead of creating each time

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -471,9 +471,11 @@ module ActionDispatch
         return if MountedHelpers.method_defined?(name)
 
         routes = self
+        helpers = routes.url_helpers
+
         MountedHelpers.class_eval do
           define_method "_#{name}" do
-            RoutesProxy.new(routes, _routes_context)
+            RoutesProxy.new(routes, _routes_context, helpers)
           end
         end
 

--- a/actionpack/lib/action_dispatch/routing/routes_proxy.rb
+++ b/actionpack/lib/action_dispatch/routing/routes_proxy.rb
@@ -8,9 +8,9 @@ module ActionDispatch
       attr_accessor :scope, :routes
       alias :_routes :routes
 
-      def initialize(routes, scope, helpers=nil)
+      def initialize(routes, scope, helpers)
         @routes, @scope = routes, scope
-        @helpers = helpers || routes.url_helpers
+        @helpers = helpers
       end
 
       def url_options

--- a/actionpack/lib/action_dispatch/routing/routes_proxy.rb
+++ b/actionpack/lib/action_dispatch/routing/routes_proxy.rb
@@ -8,8 +8,9 @@ module ActionDispatch
       attr_accessor :scope, :routes
       alias :_routes :routes
 
-      def initialize(routes, scope)
+      def initialize(routes, scope, helpers=nil)
         @routes, @scope = routes, scope
+        @helpers = helpers || routes.url_helpers
       end
 
       def url_options
@@ -19,16 +20,16 @@ module ActionDispatch
       end
 
       def respond_to?(method, include_private = false)
-        super || routes.url_helpers.respond_to?(method)
+        super || @helpers.respond_to?(method)
       end
 
       def method_missing(method, *args)
-        if routes.url_helpers.respond_to?(method)
+        if @helpers.respond_to?(method)
           self.class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{method}(*args)
               options = args.extract_options!
               args << url_options.merge((options || {}).symbolize_keys)
-              routes.url_helpers.#{method}(*args)
+              @helpers.#{method}(*args)
             end
           RUBY
           send(method, *args)

--- a/actionview/test/activerecord/polymorphic_routes_test.rb
+++ b/actionview/test/activerecord/polymorphic_routes_test.rb
@@ -113,7 +113,7 @@ class PolymorphicRoutesTest < ActionController::TestCase
 
   def test_passing_routes_proxy
     with_namespaced_routes(:blog) do
-      proxy = ActionDispatch::Routing::RoutesProxy.new(_routes, self)
+      proxy = ActionDispatch::Routing::RoutesProxy.new(_routes, self, _routes.url_helpers)
       @blog_post.save
       assert_url "http://example.com/posts/#{@blog_post.id}", [proxy, @blog_post]
     end


### PR DESCRIPTION
This is a backport of #19007 from `master` to `4-2-stable`. It fixes #22320 
