### PR TITLE
[ci skip] fix inconsistent indentation

### DIFF
--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -294,7 +294,7 @@ Getting closer... Now we will implement the code of the `acts_as_yaffle` method 
 
 module Yaffle
   module ActsAsYaffle
-   extend ActiveSupport::Concern
+    extend ActiveSupport::Concern
 
     included do
     end


### PR DESCRIPTION
Example code was incorrectly indented in the `plugins` guide
