### PR TITLE
Don't render non-boolean false attribute

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -162,7 +162,7 @@ module ActionView
                 output << sep
                 output << boolean_tag_option(key)
               end
-            elsif !value.nil?
+            elsif value
               output << sep
               output << tag_option(key, value, escape)
             end

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -56,7 +56,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
     with_collection_radio_buttons :user, :active, collection, :last, :first, :disabled => [true, false]
 
     assert_select 'input[type=radio][value=true][disabled=disabled]'
-    assert_select 'input[type=radio][value=false][disabled=disabled]'
+    assert_select 'input[type=radio][disabled=disabled]'
     assert_no_select 'input[type=radio][value=other][disabled=disabled]'
   end
 
@@ -73,7 +73,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
     with_collection_radio_buttons :user, :active, collection, :last, :first, :readonly => [true, false]
 
     assert_select 'input[type=radio][value=true][readonly=readonly]'
-    assert_select 'input[type=radio][value=false][readonly=readonly]'
+    assert_select 'input[type=radio][readonly=readonly]'
     assert_no_select 'input[type=radio][value=other][readonly=readonly]'
   end
 
@@ -90,7 +90,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
     with_collection_radio_buttons :user, :active, collection, :last, :first, {}, :class => 'special-radio'
 
     assert_select 'input[type=radio][value=true].special-radio#user_active_true'
-    assert_select 'input[type=radio][value=false].special-radio#user_active_false'
+    assert_select 'input[type=radio].special-radio#user_active_false'
   end
 
   test 'collection radio accepts html options as the last element of array' do
@@ -98,7 +98,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
     with_collection_radio_buttons :user, :active, collection, :second, :first
 
     assert_select 'input[type=radio][value=true].foo#user_active_true'
-    assert_select 'input[type=radio][value=false].bar#user_active_false'
+    assert_select 'input[type=radio].bar#user_active_false'
   end
 
   test 'collection radio sets the label class defined inside the block' do
@@ -174,7 +174,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
     assert_select 'label.true[for=user_active_true]', 'true' do
       assert_select 'input#user_active_true[type=radio]'
     end
-    assert_select 'label.false[for=user_active_false]', 'false' do
+    assert_select 'label[for=user_active_false]', 'false' do
       assert_select 'input#user_active_false[type=radio]'
     end
   end
@@ -195,7 +195,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
   test 'collection radio accepts checked item which has a value of false' do
     with_collection_radio_buttons :user, :active, [[1, true], [0, false]], :last, :first, :checked => false
     assert_no_select 'input[type=radio][value=true][checked=checked]'
-    assert_select 'input[type=radio][value=false][checked=checked]'
+    assert_select 'input[type=radio][checked=checked]'
   end
 
   test 'collection radio buttons generates only one hidden field for the entire collection, to ensure something will be sent back to the server when posting an empty collection' do
@@ -505,7 +505,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
     assert_select 'label.true[for=user_active_true]', 'true' do
       assert_select 'input#user_active_true[type=checkbox]'
     end
-    assert_select 'label.false[for=user_active_false]', 'false' do
+    assert_select 'label[for=user_active_false]', 'false' do
       assert_select 'input#user_active_false[type=checkbox]'
     end
   end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -680,13 +680,13 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_boolean
     @post.secret = false
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="true" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="false" />',
+      '<input name="post[secret]" type="hidden" value="true" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" />',
       check_box("post", "secret", {}, false, true)
     )
 
     @post.secret = true
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="true" /><input id="post_secret" name="post[secret]" type="checkbox" value="false" />',
+      '<input name="post[secret]" type="hidden" value="true" /><input id="post_secret" name="post[secret]" type="checkbox" />',
       check_box("post", "secret", {}, false, true)
     )
   end
@@ -836,7 +836,7 @@ class FormHelperTest < ActionView::TestCase
       radio_button("post", "secret", true)
     )
 
-    assert_dom_equal('<input id="post_secret_false" name="post[secret]" type="radio" value="false" />',
+    assert_dom_equal('<input id="post_secret_false" name="post[secret]" type="radio" />',
       radio_button("post", "secret", false)
     )
   end

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -21,8 +21,8 @@ class TagHelperTest < ActionView::TestCase
     assert_equal "<p />", tag("p", :ignored => nil)
   end
 
-  def test_tag_options_accepts_false_option
-    assert_equal "<p value=\"false\" />", tag("p", :value => false)
+  def test_tag_options_rejects_false_option
+    assert_equal "<p />", tag("p", :value => false)
   end
 
   def test_tag_options_accepts_blank_option


### PR DESCRIPTION
## Problem

In both [Haml](https://github.com/haml/haml) and [Slim](https://github.com/slim-template/slim), following templates

``` haml
-# Haml
= content_tag(:div, 'text', foo: false)
= content_tag(:div, 'text', foo: nil)
%div{ foo: false } text
%div{ foo: nil } text
```

``` slim
-# Slim
= content_tag(:div, 'text', foo: false)
= content_tag(:div, 'text', foo: nil)
div foo=false text
div foo=nil text
```

are rendered to:

``` html
<div foo="false">text</div>
<div>text</div>
<div>text</div>
<div>text</div>
```

This behavior is inconsistent.
## Changes

 I think false value can be omitted too because `nil` is always treated as falsey value like boolean attributes. To unify the strange behavior of template rendered by template engines like Haml and Slim (which omit an attribute if its value is nil or false), I want to omit non-boolean attributes with false value.
