### PR TITLE
Use latest byebug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     builder (3.2.2)
     bunny (2.2.0)
       amq-protocol (>= 2.0.0)
-    byebug (6.0.2)
+    byebug (8.2.0)
     celluloid (0.17.2)
       celluloid-essentials
       celluloid-extras


### PR DESCRIPTION
Since my patch for byebug https://github.com/deivid-rodriguez/byebug/pull/160 which is released in byebug 7.0 improved the debugging performance about 10x faster, I want Rails maintainers to use the latest byebug for debugging Rails and save your time.
