### PR TITLE
add deprecations for a smooth transition after #22215

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `ActiveSupport::Cache::Store#namespaced_key`, 
+    `ActiveSupport::Cache::MemCachedStore#escape_key`, and 
+    `ActiveSupport::Cache::FileStore#key_file_path` 
+    are deprecated and replaced with `normalize_key` that now calls `super`.
+    
+    `ActiveSupport::Cache::LocaleCache#set_cache_value` is deprecated and replaced with `write_cache_value`.
+    
+    *Michael Grosser*
+
 *   Implements an evented file system monitor to asynchronously detect changes
     in the application source code, routes, locales, etc.
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -8,6 +8,7 @@ require 'active_support/core_ext/numeric/bytes'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/object/to_param'
 require 'active_support/core_ext/string/inflections'
+require 'active_support/core_ext/string/strip'
 
 module ActiveSupport
   # See ActiveSupport::Cache::Store for documentation.
@@ -536,7 +537,14 @@ module ActiveSupport
           key = "#{prefix}:#{key}" if prefix
           key
         end
-        alias namespaced_key normalize_key
+
+        def namespaced_key(*args)
+          ActiveSupport::Deprecation.warn(<<-MESSAGE.strip_heredoc)
+            `namespaced_key` is deprecated and will be removed from Rails 5.1.
+            Please use `normalize_key` which will return a fully resolved key.
+          MESSAGE
+          normalize_key(*args)
+        end
 
         def instrument(operation, key, options = nil)
           log { "Cache #{operation}: #{normalize_key(key, options)}#{options.blank? ? "" : " (#{options.inspect})"}" }

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -137,6 +137,14 @@ module ActiveSupport
           File.join(cache_path, DIR_FORMATTER % dir_1, DIR_FORMATTER % dir_2, *fname_paths)
         end
 
+        def key_file_path(key)
+          ActiveSupport::Deprecation.warn(<<-MESSAGE.strip_heredoc)
+            `key_file_path` is deprecated and will be removed from Rails 5.1.
+            Please use `normalize_key` which will return a fully resolved key or nothing.
+          MESSAGE
+          key
+        end
+
         # Translate a file path into a key.
         def file_path_key(path)
           fname = path[cache_path.to_s.size..-1].split(File::SEPARATOR, 4).last

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -195,6 +195,14 @@ module ActiveSupport
           key
         end
 
+        def escape_key(key)
+          ActiveSupport::Deprecation.warn(<<-MESSAGE.strip_heredoc)
+            `escape_key` is deprecated and will be removed from Rails 5.1.
+            Please use `normalize_key` which will return a fully resolved key or nothing.
+          MESSAGE
+          key
+        end
+
         def deserialize_entry(raw_value)
           if raw_value
             entry = Marshal.load(raw_value) rescue raw_value

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -93,14 +93,14 @@ module ActiveSupport
         def increment(name, amount = 1, options = nil) # :nodoc:
           return super unless local_cache
           value = bypass_local_cache{super}
-          set_cache_value(name, value, options)
+          write_cache_value(name, value, options)
           value
         end
 
         def decrement(name, amount = 1, options = nil) # :nodoc:
           return super unless local_cache
           value = bypass_local_cache{super}
-          set_cache_value(name, value, options)
+          write_cache_value(name, value, options)
           value
         end
 
@@ -123,7 +123,15 @@ module ActiveSupport
             super
           end
 
-          def set_cache_value(name, value, options) # :nodoc:
+          def set_cache_value(value, name, amount, options) # :nodoc:
+            ActiveSupport::Deprecation.warn(<<-MESSAGE.strip_heredoc)
+              `set_cache_value` is deprecated and will be removed from Rails 5.1.
+              Please use `write_cache_value`
+            MESSAGE
+            write_cache_value name, value, options
+          end
+
+          def write_cache_value(name, value, options) # :nodoc:
             name = normalize_key(name, options)
             cache = local_cache
             cache.mute do

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -518,6 +518,12 @@ module CacheStoreBehavior
   ensure
     ActiveSupport::Notifications.unsubscribe "cache_read.active_support"
   end
+
+  def test_can_call_deprecated_namesaced_key
+    assert_deprecated "`namespaced_key` is deprecated" do
+      @cache.send(:namespaced_key, 111, {})
+    end
+  end
 end
 
 # https://rails.lighthouseapp.com/projects/8994/tickets/6225-memcachestore-cant-deal-with-umlauts-and-special-characters
@@ -693,6 +699,15 @@ module LocalCacheBehavior
     app = @cache.middleware.new(app)
     app.call({})
   end
+
+  def test_can_call_deprecated_set_cache_value
+    @cache.with_local_cache do
+      assert_deprecated "`set_cache_value` is deprecated" do
+        @cache.send(:set_cache_value, 1, 'foo', :ignored, {})
+      end
+      assert_equal 1, @cache.read('foo')
+    end
+  end
 end
 
 module AutoloadingCacheBehavior
@@ -857,6 +872,12 @@ class FileStoreTest < ActiveSupport::TestCase
     assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
     @cache.write(1, nil)
     assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
+  end
+
+  def test_can_call_deprecated_key_file_path
+    assert_deprecated "`key_file_path` is deprecated" do
+      assert_equal 111, @cache.send(:key_file_path, 111)
+    end
   end
 end
 
@@ -1031,6 +1052,12 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     assert_not_equal value.object_id, @cache.read('foo').object_id
     value << 'bingo'
     assert_not_equal value, @cache.read('foo')
+  end
+
+  def test_can_call_deprecated_escape_key
+    assert_deprecated "`escape_key` is deprecated" do
+      assert_equal 111, @cache.send(:escape_key, 111)
+    end
   end
 end
 


### PR DESCRIPTION
@jeremy @rafaelfranca @kaspth 

see discussion in https://github.com/rails/rails/pull/22215 and https://github.com/rails/rails/pull/22205#issuecomment-157834280

now subclasses that call it will get a nice warning and still work

``` Ruby
def foobar(key, options)
  File.read(key_file_path(namespaced_key(key, options)))
end
```
