### PR TITLE
Change configuration-guide example

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -35,7 +35,7 @@ In general, the work of configuring Rails means configuring the components of Ra
 For example, the `config/application.rb` file includes this setting:
 
 ```ruby
-config.autoload_paths += %W(#{config.root}/extras)
+config.time_zone = 'Central Time (US & Canada)'
 ```
 
 This is a setting for Rails itself. If you want to pass settings to individual Rails components, you can do so via the same `config` object in `config/application.rb`:


### PR DESCRIPTION
Use an example from a default Rails app (4.2.5) rather than an outdated one in the Configuring Rails Components section.
I picked config.time_zone as it currently is the only 'setting for Rails' left in a default config/application.rb.

I stumbled upon this with investigating autoloading in a legacy app, which still included the example comment "# config.autoload_paths += %W(#{config.root}/extras)". Usually adding app/\* directories to autoload_paths isn't necessary, so also finding this example within the current docs was a bit confusing initially.

[ci skip]
