### PR TITLE
Fix rake db:structure:dump on Postgres when multiple schemas are used

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `rake db:structure:dump` on Postgres when multiple schemas are used.
+
+    If postgresql is being used and there are multiple schemas listed on the
+    `schema_search_path`, then `structure.sql` dumps (triggered by `rake
+    db:structure:dump` or `config.active_record.schema_format = :sql`) began
+    failing in Rails 4.2.5.
+
+    *Nick Muerdter*
+
 *   Except keys of `build_record`'s argument from `create_scope` in `initialize_attributes`.
 
     Fixes #21893.

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -56,9 +56,9 @@ module ActiveRecord
 
         args = ['-s', '-x', '-O', '-f', filename]
         unless search_path.blank?
-          args << search_path.split(',').map do |part|
+          args += search_path.split(',').map do |part|
             "--schema=#{part.strip}"
-          end.join(' ')
+          end
         end
         args << configuration['database']
         run_cmd('pg_dump', args, 'dumping')

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -212,7 +212,7 @@ module ActiveRecord
     def test_structure_dump_with_schema_search_path
       @configuration['schema_search_path'] = 'foo,bar'
 
-      Kernel.expects(:system).with('pg_dump', '-s', '-x', '-O', '-f', @filename, '--schema=foo --schema=bar', 'my-app-db').returns(true)
+      Kernel.expects(:system).with('pg_dump', '-s', '-x', '-O', '-f', @filename, '--schema=foo', '--schema=bar', 'my-app-db').returns(true)
 
       ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
     end
@@ -228,7 +228,7 @@ module ActiveRecord
     end
 
     def test_structure_dump_with_dump_schemas_string
-      Kernel.expects(:system).with("pg_dump", '-s', '-x', '-O', '-f', @filename, '--schema=foo --schema=bar', "my-app-db").returns(true)
+      Kernel.expects(:system).with("pg_dump", '-s', '-x', '-O', '-f', @filename, '--schema=foo', '--schema=bar', "my-app-db").returns(true)
 
       with_dump_schemas('foo,bar') do
         ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)


### PR DESCRIPTION
If postgresql is being used and there are multiple schemas listed on the `schema_search_path`, then `structure.sql` dumps (triggered by `rake db:structure:dump` or `config.active_record.schema_format = :sql`) began failing in Rails 4.2.5.

This is due to the changes made in https://github.com/rails/rails/pull/17885 The problem is that multiple schemas were getting getting passed to `Kernel.system` as a single, space delimited string argument (for example, `"--schema=foo --schema=bar"`). However, with the updated array style of calling `Kernel.system`, these need to be passed as separate arguments (for example, `"--schema=foo", "--schema=bar"`). If they get passed as a single string, then the underlying pg_dump program isn't sure how to interpret that single argument and you'll get an error like:

```
pg_dump: No matching schemas were found
rake aborted!
failed to execute:
pg_dump -s -x -O -f structure.sql --schema=foo --schema=bar my-app-db


Please check the output above for any errors and make sure that `pg_dump` is installed in your PATH and has proper permissions.
```
