### PR TITLE
Let enqueue options[:wait] be competible with string

### DIFF
--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -65,7 +65,7 @@ module ActiveJob
     #    my_job_instance.enqueue wait_until: Date.tomorrow.midnight
     #    my_job_instance.enqueue priority: 10
     def enqueue(options={})
-      self.scheduled_at = options[:wait].seconds.from_now.to_f if options[:wait]
+      self.scheduled_at = options[:wait].to_f.seconds.from_now.to_f if options[:wait]
       self.scheduled_at = options[:wait_until].to_f if options[:wait_until]
       self.queue_name   = self.class.queue_name_from_part(options[:queue]) if options[:queue]
       self.priority     = options[:priority].to_i if options[:priority]


### PR DESCRIPTION
Sometimes options[:wait] can be a string and its better to competible with it.
