### PR TITLE
Add missing example for cookies.encrypted [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -77,6 +77,12 @@ module ActionDispatch
   #   # It can be read using the signed method `cookies.signed[:name]`
   #   cookies.signed[:user_id] = current_user.id
   #
+  #   # Sets an encrypted cookie value before sending it to the client which
+  #   # prevent users from reading and tampering with its value.
+  #   # The cookie is signed by your app's `secrets.secret_key_base` value.
+  #   # It can be read using the encrypted method `cookies.encrypted[:name]`
+  #   cookies.encrypted[:discount] = 45
+  #
   #   # Sets a "permanent" cookie (which expires in 20 years from now).
   #   cookies.permanent[:login] = "XJ-122"
   #
@@ -89,6 +95,7 @@ module ActionDispatch
   #   cookies.size                  # => 2
   #   JSON.parse(cookies[:lat_lon]) # => [47.68, -122.37]
   #   cookies.signed[:login]        # => "XJ-122"
+  #   cookies.encrypted[:discount]  # => 45
   #
   # Example for deleting:
   #


### PR DESCRIPTION
Main documentation for cookies is missing an example for encrypted cookies.

All other methods have an example in the main documentation so it makes sense to add some explanation for `encrypted` method.
