### PR TITLE
Remove arity check for `RouteSet#draw`

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -371,10 +371,6 @@ module ActionDispatch
       end
 
       def eval_block(block)
-        if block.arity == 1
-          raise "You are using the old router DSL which has been removed in Rails 3.1. " <<
-            "Please check how to update your routes file at: http://www.engineyard.com/blog/2010/the-lowdown-on-routes-in-rails-3/"
-        end
         mapper = Mapper.new(self)
         if default_scope
           mapper.with_default_scope(default_scope, &block)

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -289,12 +289,6 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     assert_equal({:id=>"1", :filters=>"foo", :format=>"js"}, params)
   end
 
-  def test_draw_with_block_arity_one_raises
-    assert_raise(RuntimeError) do
-      rs.draw { |map| map.match '/:controller(/:action(/:id))' }
-    end
-  end
-
   def test_specific_controller_action_failure
     rs.draw do
       mount lambda {} => "/foo"


### PR DESCRIPTION
This code was added for migration from Rails 3.1 to upper,
now we are developing Rails 5.
