### PR TITLE
Speed up asset_path method

### DIFF
--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -115,7 +115,7 @@ module ActionView
     #   )
     #
     module AssetUrlHelper
-      URI_REGEXP = %r{^[-a-z]+://|^(?:cid|data):|^//}i
+      URI_REGEXP = %r{^(?:[-a-z]+://|cid:|data:|//)}i
 
       # Computes the path to asset in public directory. If :type
       # options is set, a file extension will be appended and scoped
@@ -131,10 +131,12 @@ module ActionView
         raise ArgumentError, "nil is not a valid asset source" if source.nil?
 
         source = source.to_s
-        return "" unless source.present?
-        return source if source =~ URI_REGEXP
+        return "" if source.empty?
+        return source if URI_REGEXP === source
 
-        tail, source = source[/([\?#].+)$/], source.sub(/([\?#].+)$/, ''.freeze)
+        if index = source.index(/[?#]/)
+          source, tail = source[0, index], source[index..-1]
+        end
 
         if extname = compute_asset_extname(source, options)
           source = "#{source}#{extname}"


### PR DESCRIPTION
The asset_path is called many times in application.
I've done refactoring because the following points are worrisome.
- present? is slow than empty?
- The regular expression of url check is inefficiency
- =~ is slow than ===
- It's not necessary to perform the regular expression two times

```
Calculating -------------------------------------
              origin     9.249k i/100ms
           my_tuning    10.705k i/100ms
-------------------------------------------------
              origin    112.747k (± 6.8%) i/s -    564.189k
           my_tuning    141.343k (± 6.7%) i/s -    706.530k

Comparison:
           my_tuning:   141343.3 i/s
              origin:   112747.5 i/s - 1.25x slower
```

benchmark is follow
https://gist.github.com/tsukasaoishi/a374dc7ba391fe949f94
