### PR TITLE
Add :except option to validations

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -57,7 +57,7 @@ module ActiveModel
   class Errors
     include Enumerable
 
-    CALLBACKS_OPTIONS = [:if, :unless, :on, :allow_nil, :allow_blank, :strict]
+    CALLBACKS_OPTIONS = [:if, :unless, :on, :except, :allow_nil, :allow_blank, :strict]
     MESSAGE_OPTIONS = [:message]
 
     attr_reader :messages, :details

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -72,6 +72,8 @@ module ActiveModel
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:except</tt> - Specifies the contexts where this validation is skipped.
+      #   Runs in all validation contexts by default (nil). Use the same syntax as for +:on+
       # * <tt>:allow_nil</tt> - Skip validation if attribute is +nil+.
       # * <tt>:allow_blank</tt> - Skip validation if attribute is blank.
       # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
@@ -87,7 +89,7 @@ module ActiveModel
         validates_with BlockValidator, _merge_attributes(attr_names), &block
       end
 
-      VALID_OPTIONS_FOR_VALIDATE = [:on, :if, :unless, :prepend].freeze # :nodoc:
+      VALID_OPTIONS_FOR_VALIDATE = [:on, :except, :if, :unless, :prepend].freeze # :nodoc:
 
       # Adds a validation method or block to the class. This is useful when
       # overriding the +validate+ instance method becomes too unwieldy and
@@ -138,6 +140,8 @@ module ActiveModel
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:except</tt> - Specifies the contexts where this validation is skipped.
+      #   Runs in all validation contexts by default (nil). Use the same syntax as for +:on+
       # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,
@@ -158,12 +162,20 @@ module ActiveModel
           end
         end
 
-        if options.key?(:on)
+        if options.key?(:on) || options.key?(:except)
           options = options.dup
-          options[:if] = Array(options[:if])
-          options[:if].unshift ->(o) {
-            !(Array(options[:on]) & Array(o.validation_context)).empty?
-          }
+          if options.key?(:on)
+            options[:if] = Array(options[:if])
+            options[:if].unshift ->(o) {
+              !(Array(options[:on]) & Array(o.validation_context)).empty?
+            }
+          end
+          if options.key?(:except)
+            options[:unless] = Array(options[:unless])
+            options[:unless].unshift ->(o) {
+              !(Array(options[:except]) & Array(o.validation_context)).empty?
+            }
+          end
         end
 
         args << options
@@ -319,7 +331,8 @@ module ActiveModel
     #   person.valid? # => true
     #
     # Context can optionally be supplied to define which callbacks to test
-    # against (the context is defined on the validations using <tt>:on</tt>).
+    # against (the context is defined on the validations using <tt>:on</tt>
+    # and <tt>:except</tt>).
     #
     #   class Person
     #     include ActiveModel::Validations
@@ -358,7 +371,8 @@ module ActiveModel
     #   person.invalid? # => false
     #
     # Context can optionally be supplied to define which callbacks to test
-    # against (the context is defined on the validations using <tt>:on</tt>).
+    # against (the context is defined on the validations using <tt>:on</tt>
+    # and <tt>:except</tt>).
     #
     #   class Person
     #     include ActiveModel::Validations
@@ -377,8 +391,10 @@ module ActiveModel
     # Runs all the validations within the specified context. Returns +true+ if
     # no errors are found, raises +ValidationError+ otherwise.
     #
-    # Validations with no <tt>:on</tt> option will run no matter the context. Validations with
-    # some <tt>:on</tt> option will only run in the specified context.
+    # Validations with no <tt>:on</tt> and no <tt>except</tt> option will run
+    # no matter the context. Validations with some <tt>:on</tt> option will
+    # only run in the specified context. Validations with some <tt>:except</tt>
+    # option will not run in the specified context.
     def validate!(context = nil)
       valid?(context) || raise_validation_error
     end

--- a/activemodel/lib/active_model/validations/absence.rb
+++ b/activemodel/lib/active_model/validations/absence.rb
@@ -21,7 +21,7 @@ module ActiveModel
       # * <tt>:message</tt> - A custom error message (default is: "must be blank").
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except+, +:allow_nil+, +:allow_blank+, and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_absence_of(*attr_names)
         validates_with AbsenceValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -97,7 +97,7 @@ module ActiveModel
       #   before validation.
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except+, +:allow_nil+, +:allow_blank+, and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information.
       def validates_acceptance_of(*attr_names)
         validates_with AcceptanceValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -55,12 +55,19 @@ module ActiveModel
         #   person.name   # => "bob"
         def before_validation(*args, &block)
           options = args.last
-          if options.is_a?(Hash) && options[:on]
-            options[:if] = Array(options[:if])
-            options[:on] = Array(options[:on])
-            options[:if].unshift ->(o) {
-              options[:on].include? o.validation_context
-            }
+          if options.is_a?(Hash) && (options[:on] || options[:except])
+            if options[:on]
+              options[:if], options[:on] = Array(options[:if]), Array(options[:on])
+              options[:if].unshift ->(o) {
+                options[:on].include? o.validation_context
+              }
+            end
+            if options[:except]
+              options[:unless], options[:except] = Array(options[:unless]), Array(options[:except])
+              options[:unless].unshift ->(o) {
+                options[:except].include? o.validation_context
+              }
+            end
           end
           set_callback(:validation, :before, *args, &block)
         end
@@ -95,11 +102,16 @@ module ActiveModel
         def after_validation(*args, &block)
           options = args.extract_options!
           options[:prepend] = true
-          options[:if] = Array(options[:if])
           if options[:on]
-            options[:on] = Array(options[:on])
+            options[:if], options[:on] = Array(options[:if]), Array(options[:on])
             options[:if].unshift ->(o) {
               options[:on].include? o.validation_context
+            }
+          end
+          if options[:except]
+            options[:unless], options[:except] = Array(options[:unless]), Array(options[:except])
+            options[:unless].unshift ->(o) {
+              options[:except].include? o.validation_context
             }
           end
           set_callback(:validation, :after, *(args << options), &block)

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -69,7 +69,7 @@ module ActiveModel
       #   non-text columns (+true+ by default).
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except+, +:allow_nil+, +:allow_blank+, and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_confirmation_of(*attr_names)
         validates_with ConfirmationValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/exclusion.rb
+++ b/activemodel/lib/active_model/validations/exclusion.rb
@@ -38,7 +38,7 @@ module ActiveModel
       #   reserved").
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except+, +:allow_nil+, +:allow_blank+, and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_exclusion_of(*attr_names)
         validates_with ExclusionValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/format.rb
+++ b/activemodel/lib/active_model/validations/format.rb
@@ -103,7 +103,7 @@ module ActiveModel
       #   beginning or end of the string. These anchors are <tt>^</tt> and <tt>$</tt>.
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except+, +:allow_nil+, +:allow_blank+, and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_format_of(*attr_names)
         validates_with FormatValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/inclusion.rb
+++ b/activemodel/lib/active_model/validations/inclusion.rb
@@ -36,7 +36,7 @@ module ActiveModel
       #   not included in the list").
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except+, +:allow_nil+, +:allow_blank+, and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_inclusion_of(*attr_names)
         validates_with InclusionValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -145,7 +145,7 @@ module ActiveModel
       #   <tt>too_long</tt>/<tt>too_short</tt>/<tt>wrong_length</tt> message.
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+ and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except+ and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_length_of(*attr_names)
         validates_with LengthValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -131,7 +131,7 @@ module ActiveModel
       # * <tt>:even</tt> - Specifies the value must be an even number.
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+ .
+      # +:if+, +:unless+, +:on+, +:except+, +:allow_nil+, +:allow_blank+, and +:strict+ .
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       #
       # The following checks can also be supplied with a proc or a symbol which

--- a/activemodel/lib/active_model/validations/presence.rb
+++ b/activemodel/lib/active_model/validations/presence.rb
@@ -29,7 +29,7 @@ module ActiveModel
       # * <tt>:message</tt> - A custom error message (default is: "can't be blank").
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except+, +:allow_nil+, +:allow_blank+, and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_presence_of(*attr_names)
         validates_with PresenceValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -76,6 +76,8 @@ module ActiveModel
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:except</tt> - Specifies the contexts where this validation is skipped.
+      #   Runs in all validation contexts by default (nil). Use the same syntax as for +:on+
       # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,
@@ -97,7 +99,7 @@ module ActiveModel
       #   validates :token, uniqueness: true, strict: TokenGenerationException
       #
       #
-      # Finally, the options +:if+, +:unless+, +:on+, +:allow_blank+, +:allow_nil+, +:strict+
+      # Finally, the options +:if+, +:unless+, +:on+, +:except+, +:allow_blank+, +:allow_nil+, +:strict+
       # and +:message+ can be given to one specific validator, as a hash:
       #
       #   validates :password, presence: { if: :password_required?, message: 'is forgotten.' }, confirmation: true
@@ -153,7 +155,7 @@ module ActiveModel
       # When creating custom validators, it might be useful to be able to specify
       # additional default keys. This can be done by overwriting this method.
       def _validates_default_keys # :nodoc:
-        [:if, :unless, :on, :allow_blank, :allow_nil , :strict]
+        [:if, :unless, :on, :except, :allow_blank, :allow_nil , :strict]
       end
 
       def _parse_validates_options(options) # :nodoc:

--- a/activemodel/lib/active_model/validations/with.rb
+++ b/activemodel/lib/active_model/validations/with.rb
@@ -47,6 +47,8 @@ module ActiveModel
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:except</tt> - Specifies the contexts where this validation is skipped.
+      #   Runs in all validation contexts by default (nil). Use the same syntax as for +:on+
       # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>).
@@ -122,7 +124,7 @@ module ActiveModel
     #     end
     #   end
     #
-    # Standard configuration options (<tt>:on</tt>, <tt>:if</tt> and
+    # Standard configuration options (<tt>:on</tt>, <tt>:except</tt>, <tt>:if</tt> and
     # <tt>:unless</tt>), which are available on the class version of
     # +validates_with+, should instead be placed on the +validates+ method
     # as these are applied and tested in the callback.

--- a/activemodel/test/cases/validations/validations_context_test.rb
+++ b/activemodel/test/cases/validations/validations_context_test.rb
@@ -34,10 +34,23 @@ class ValidationsContextTest < ActiveModel::TestCase
     assert topic.valid?(:create), "Validation doesn't run on create if 'on' is set to update"
   end
 
+  test "with a class that adds errors excluding create and validating a new model" do
+    Topic.validates_with(ValidatorThatAddsErrors, except: :create)
+    topic = Topic.new
+    assert topic.valid?(:create), "Validation does run on create if 'except' is set to create"
+  end
+
   test "with a class that adds errors on create and validating a new model" do
     Topic.validates_with(ValidatorThatAddsErrors, on: :create)
     topic = Topic.new
     assert topic.invalid?(:create), "Validation does run on create if 'on' is set to create"
+    assert topic.errors[:base].include?(ERROR_MESSAGE)
+  end
+
+  test "with a class that adds errors excluding update and validating a new model" do
+    Topic.validates_with(ValidatorThatAddsErrors, except: :update)
+    topic = Topic.new
+    assert topic.invalid?(:create), "Validation doesn't run on create if 'except' is set to update"
     assert topic.errors[:base].include?(ERROR_MESSAGE)
   end
 
@@ -54,6 +67,21 @@ class ValidationsContextTest < ActiveModel::TestCase
     assert topic.errors[:base].include?(ERROR_MESSAGE)
   end
 
+  test "with a class that adds errors excluding multiple contexts and validating a new model" do
+    Topic.validates_with(ValidatorThatAddsErrors, except: [:context1, :context2])
+
+    topic = Topic.new
+    assert topic.valid?(:context1), "Validation ran on context1 when 'except' is set to context1 and context2"
+
+    assert topic.valid?(:context2), "Validation ran on context2 when 'except' is set to context1 and context2"
+
+    assert topic.invalid?, "Validation did not run with no context given when 'except' is set to context1 and context2"
+    assert topic.errors[:base].include?(ERROR_MESSAGE)
+
+    assert topic.invalid?(:context3), "Validation did not run on context3 when 'except' is set to context1 and context2"
+    assert topic.errors[:base].include?(ERROR_MESSAGE)
+  end
+
   test "with a class that validating a model for a multiple contexts" do
     Topic.validates_with(ValidatorThatAddsErrors, on: :context1)
     Topic.validates_with(AnotherValidatorThatAddsErrors, on: :context2)
@@ -64,5 +92,25 @@ class ValidationsContextTest < ActiveModel::TestCase
     assert topic.invalid?([:context1, :context2]), "Validation did not run on context1 when 'on' is set to context1 and context2"
     assert topic.errors[:base].include?(ERROR_MESSAGE)
     assert topic.errors[:base].include?(ANOTHER_ERROR_MESSAGE)
+  end
+
+  test "with a class that validating a model excluding multiple contexts" do
+    Topic.validates_with(ValidatorThatAddsErrors, except: :context1)
+    Topic.validates_with(AnotherValidatorThatAddsErrors, except: :context2)
+
+    topic = Topic.new
+    assert topic.invalid?, "Validation didn't run with no context given when 'except' is set to context1 and context2"
+    assert topic.errors[:base].include?(ERROR_MESSAGE)
+    assert topic.errors[:base].include?(ANOTHER_ERROR_MESSAGE)
+
+    assert topic.invalid?(:context1), "Validation didn't run with no context given when 'except' is set to context1"
+    assert !topic.errors[:base].include?(ERROR_MESSAGE)
+    assert topic.errors[:base].include?(ANOTHER_ERROR_MESSAGE)
+
+    assert topic.invalid?(:context2), "Validation didn't run with no context given when 'except' is set to context2"
+    assert topic.errors[:base].include?(ERROR_MESSAGE)
+    assert !topic.errors[:base].include?(ANOTHER_ERROR_MESSAGE)
+
+    assert topic.valid?([:context1, :context2]), "Validation ran on context1 and context2 when 'except' is set to context1 and context2"
   end
 end

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -170,7 +170,7 @@ class ValidationsTest < ActiveModel::TestCase
       # A common mistake -- we meant to call 'validates'
       Topic.validate :title, presence: true
     end
-    message = 'Unknown key: :presence. Valid keys are: :on, :if, :unless, :prepend. Perhaps you meant to call `validates` instead of `validate`?'
+    message = 'Unknown key: :presence. Valid keys are: :on, :except, :if, :unless, :prepend. Perhaps you meant to call `validates` instead of `validate`?'
     assert_equal message, error.message
   end
 
@@ -260,6 +260,20 @@ class ValidationsTest < ActiveModel::TestCase
     assert t.author_name.nil?
 
     # If block should fire
+    assert t.invalid?(:update)
+    assert t.author_name == "bad"
+  end
+
+  def test_validation_with_unless_and_except
+    Topic.validates_presence_of :title, unless: Proc.new{|x| x.author_name = "bad"; false }, except: :create
+
+    t = Topic.new(title: "")
+
+    # Unless block should not fire
+    assert t.valid?(:create)
+    assert t.author_name.nil?
+
+    # Unless block should fire
     assert t.invalid?(:update)
     assert t.author_name == "bad"
   end
@@ -368,6 +382,18 @@ class ValidationsTest < ActiveModel::TestCase
 
     t = Topic.new(title: "Valid title")
     assert t.validate!(:context)
+  end
+
+  def test_validate_with_bang_and_excluded_context
+    Topic.validates :title, presence: true, except: :context
+
+    t = Topic.new
+
+    assert t.validate!(:context)
+
+    assert_raise(ActiveModel::ValidationError) do
+      t.validate!
+    end
   end
 
   def test_strict_validation_in_validates

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -29,8 +29,8 @@ module ActiveRecord
   # = Active Record \Validations
   #
   # Active Record includes the majority of its validations from ActiveModel::Validations
-  # all of which accept the <tt>:on</tt> argument to define the context where the
-  # validations are active. Active Record will always supply either the context of
+  # all of which accept <tt>:on</tt> and <tt>:except</tt> arguments to define the contexts where the
+  # validations are active or excluded. Active Record will always supply either the context of
   # <tt>:create</tt> or <tt>:update</tt> dependent on whether the model is a
   # {new_record?}[rdoc-ref:Persistence#new_record?].
   module Validations
@@ -58,8 +58,9 @@ module ActiveRecord
     # If the argument is +false+ (default is +nil+), the context is set to <tt>:create</tt> if
     # {new_record?}[rdoc-ref:Persistence#new_record?] is +true+, and to <tt>:update</tt> if it is not.
     #
-    # \Validations with no <tt>:on</tt> option will run no matter the context. \Validations with
-    # some <tt>:on</tt> option will only run in the specified context.
+    # \Validations with no <tt>:on</tt> and no <tt>except</tt> option will run no matter the context.
+    # \Validations with some <tt>:on</tt> option will # only run in the specified context.
+    # \Validations with some <tt>:except</tt> option will not run in the specified context.
     def valid?(context = nil)
       context ||= default_validation_context
       output = super(context)

--- a/activerecord/lib/active_record/validations/associated.rb
+++ b/activerecord/lib/active_record/validations/associated.rb
@@ -41,6 +41,8 @@ module ActiveRecord
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:except</tt> - Specifies the contexts where this validation is skipped.
+      #   Runs in all validation contexts by default (nil). Use the same syntax as for +:on+
       # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,

--- a/activerecord/lib/active_record/validations/presence.rb
+++ b/activerecord/lib/active_record/validations/presence.rb
@@ -49,6 +49,8 @@ module ActiveRecord
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:except</tt> - Specifies the contexts where this validation is skipped.
+      #   Runs in all validation contexts by default (nil). Use the same syntax as for +:on+
       # * <tt>:if</tt> - Specifies a method, proc or string to call to determine if
       #   the validation should occur (e.g. <tt>if: :allow_validation</tt>, or
       #   <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method, proc

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -32,6 +32,7 @@ class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
     person = Class.new(ActiveRecord::Base) {
       self.table_name = 'people'
       validate :should_be_cool, :on => :create
+      validate :should_be_awesome, :except => :create
       def self.name; 'Person'; end
 
       private
@@ -39,6 +40,12 @@ class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
       def should_be_cool
         unless self.first_name == 'cool'
           errors.add :first_name, "not cool"
+        end
+      end
+
+      def should_be_awesome
+        unless self.first_name == 'awesome'
+          errors.add :first_name, "not awesome"
         end
       end
     }
@@ -49,7 +56,7 @@ class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
     }
 
     u = person.create!(first_name: 'cool')
-    u.update_attributes!(first_name: 'nah') # still valid because validation only applies on 'create'
+    u.update_attributes!(first_name: 'awesome')
     assert reference.create!(person: u).persisted?
   end
 

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -801,6 +801,15 @@ class Person < ActiveRecord::Base
 end
 ```
 
+### `:except`
+
+The `:except` option lets you specify when the validation should not happen. The
+default behavior for all the built-in validation helpers is to be run on save
+(both when you're creating a new record and when you're updating it). If you
+want to change it, you can use `except: :create` to don't run the validation when a
+new record is created or `except: :update` to don't run the validation only when a record
+is updated.
+
 Strict Validations
 ------------------
 


### PR DESCRIPTION
The same way that `ActiveModel::Validations::ClassMethods#validates` accepts the option `on` to specify the contexts where this validation is active, I'm adding the option `except` to exclude contexts where the validation is active.

**Use case**
Publication has many Page, AttachmentFile, Image, Comments etc...

All those model have their own set of validation that execute on create and on update. Some of them are quite expensive (such as triggering database access to verify uniqueness)

Publication can be _published_. Before publishing we run a specific set of validations with `on: :publishing` options. Those validation are not needed for the model to exist on the database, but needed for the publishing operation. But, we don't want to run again the expensive original sets of validation, we assume they are already valid anyhow because the record exists in the database.

**How to do**
Currently, this works perfectly:

```
with_options unless: Proc.new { |record| record.validation_context == :publishing } do |record|
  record.validates_presence_of :things
  record.validates_uniqueness_of :fields, scope: :publication_id
end

with_options on: :publishing do |record|
  record.validates_presence_of :pages
end
```

**PR**
But it is not very intuitive and require to dive a bit into the source code to find about validation_context before being able to implement it.

This PR is to be able to write:

```
with_options except: :publishing do |record|
  ...
end
```
