### PR TITLE
Add `Routing` namespace to point appropriate constant

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -11,7 +11,7 @@ module ActionDispatch
     class Mapper
       URL_OPTIONS = [:protocol, :subdomain, :domain, :host, :port]
 
-      class Constraints < Endpoint #:nodoc:
+      class Constraints < Routing::Endpoint #:nodoc:
         attr_reader :app, :constraints
 
         SERVE = ->(app, req) { app.serve req }


### PR DESCRIPTION
Make it clear we use `ActionDispatch::Routing::Endpoint`
