### PR TITLE
Simplify `RailsGuides::Generator#select_only` a bit

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -162,7 +162,7 @@ module RailsGuides
     def select_only(guides)
       prefixes = ENV['ONLY'].split(",").map(&:strip)
       guides.select do |guide|
-        prefixes.any? { |p| guide.start_with?(p) || guide.start_with?("kindle") }
+        guide.start_with?('kindle'.freeze, *prefixes)
       end
     end
 


### PR DESCRIPTION
The main goal is to improve readability, but as a side effect this commit makes the method a little bit faster.

``` ruby
def benchmark(guide, prefixes)
  raise unless (prefixes.any?{ |p| guide.start_with?(p) } || guide.start_with?("kindle")) \
             == guide.start_with?('kindle'.freeze, *prefixes)
  Benchmark.ips do |x|
    x.report('N calls') do
      prefixes.any?{ |p| guide.start_with?(p) } || guide.start_with?("kindle")
    end
    x.report('1 call') do
      guide.start_with?('kindle'.freeze, *prefixes)
    end
    x.compare!
  end
end

[["kindle/welcome",     %w[assoc caching]],
 ["association_basics", %w[assoc caching]],
 ["caching_with_rails", %w[assoc caching]],
 ["wont_match",         %w[assoc caching]],

 ["kindle/welcome",     %w[assoc]],
 ["association_basics", %w[assoc]],
 ["wont_match",         %w[assoc]],

 ["kindle/welcome", []],
 ["wont_match",     []],

].each do |guide, prefixes|
  puts "==== guide=#{guide.inspect}, prefixes=#{prefixes.inspect} ===="
  benchmark(guide, prefixes)
end
__END__
==== guide="kindle/welcome", prefixes=["assoc", "caching"] ====
Calculating -------------------------------------
             N calls    10.204k i/100ms
              1 call    16.102k i/100ms
-------------------------------------------------
             N calls    373.323k (±45.0%) i/s -      1.276M
              1 call      1.636M (±32.9%) i/s -      6.682M

Comparison:
              1 call:  1635857.9 i/s
             N calls:   373323.3 i/s - 4.38x slower

==== guide="association_basics", prefixes=["assoc", "caching"] ====
Calculating -------------------------------------
             N calls    28.728k i/100ms
              1 call    32.373k i/100ms
-------------------------------------------------
             N calls      1.088M (±16.0%) i/s -      5.200M
              1 call      1.719M (±15.6%) i/s -      8.320M

Comparison:
              1 call:  1718786.4 i/s
             N calls:  1088202.2 i/s - 1.58x slower

==== guide="caching_with_rails", prefixes=["assoc", "caching"] ====
Calculating -------------------------------------
             N calls    25.853k i/100ms
              1 call    28.314k i/100ms
-------------------------------------------------
             N calls    821.928k (±14.6%) i/s -      4.007M
              1 call      1.358M (±16.3%) i/s -      6.541M

Comparison:
              1 call:  1357809.8 i/s
             N calls:   821927.9 i/s - 1.65x slower

==== guide="wont_match", prefixes=["assoc", "caching"] ====
Calculating -------------------------------------
             N calls    21.350k i/100ms
              1 call    32.431k i/100ms
-------------------------------------------------
             N calls    605.106k (± 8.9%) i/s -      3.010M
              1 call      1.437M (±12.8%) i/s -      7.070M

Comparison:
              1 call:  1437478.0 i/s
             N calls:   605105.6 i/s - 2.38x slower

==== guide="kindle/welcome", prefixes=["assoc"] ====
Calculating -------------------------------------
             N calls    24.608k i/100ms
              1 call    34.649k i/100ms
-------------------------------------------------
             N calls    774.374k (± 8.4%) i/s -      3.839M
              1 call      1.830M (±15.4%) i/s -      8.905M

Comparison:
              1 call:  1830191.1 i/s
             N calls:   774374.3 i/s - 2.36x slower

==== guide="association_basics", prefixes=["assoc"] ====
Calculating -------------------------------------
             N calls    29.273k i/100ms
              1 call    31.793k i/100ms
-------------------------------------------------
             N calls      1.106M (±10.2%) i/s -      5.474M
              1 call      1.568M (±14.6%) i/s -      7.694M

Comparison:
              1 call:  1568382.6 i/s
             N calls:  1106283.7 i/s - 1.42x slower

==== guide="wont_match", prefixes=["assoc"] ====
Calculating -------------------------------------
             N calls    26.055k i/100ms
              1 call    32.899k i/100ms
-------------------------------------------------
             N calls    797.683k (± 8.3%) i/s -      3.986M
              1 call      1.620M (±13.6%) i/s -      7.962M

Comparison:
              1 call:  1620011.8 i/s
             N calls:   797683.4 i/s - 2.03x slower

==== guide="kindle/welcome", prefixes=[] ====
Calculating -------------------------------------
             N calls    30.724k i/100ms
              1 call    33.370k i/100ms
-------------------------------------------------
             N calls      1.140M (± 9.7%) i/s -      5.653M
              1 call      1.818M (±19.6%) i/s -      8.242M

Comparison:
              1 call:  1817651.9 i/s
             N calls:  1139779.6 i/s - 1.59x slower

==== guide="wont_match", prefixes=[] ====
Calculating -------------------------------------
             N calls    29.989k i/100ms
              1 call    35.392k i/100ms
-------------------------------------------------
             N calls      1.162M (±11.2%) i/s -      5.728M
              1 call      1.876M (±14.8%) i/s -      9.167M

Comparison:
              1 call:  1876150.4 i/s
             N calls:  1161992.0 i/s - 1.61x slower
```
