### PR TITLE
Fix race condition testing for job execution order

### DIFF
--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -78,7 +78,7 @@ class QueuingTest < ActiveSupport::TestCase
       TestJob.perform_later @id
       wait_for_jobs_to_finish_for(5.seconds)
       assert job_executed
-      assert_equal 'de', job_output
+      assert_equal 'de', job_executed_in_locale
     ensure
       I18n.available_locales = [:en]
       I18n.locale = :en

--- a/activejob/test/support/integration/dummy_app_template.rb
+++ b/activejob/test/support/integration/dummy_app_template.rb
@@ -18,8 +18,11 @@ class TestJob < ActiveJob::Base
   queue_as :integration_tests
 
   def perform(x)
-    File.open(Rails.root.join("tmp/\#{x}"), "w+") do |f|
-      f.write I18n.locale
+    File.open(Rails.root.join("tmp/\#{x}"), "wb+") do |f|
+      f.write Marshal.dump({
+        "locale" => I18n.locale.to_s || "en",
+        "executed_at" => Time.now.to_r
+      })
     end
   end
 end

--- a/activejob/test/support/integration/test_case_helpers.rb
+++ b/activejob/test/support/integration/test_case_helpers.rb
@@ -42,15 +42,23 @@ module TestCaseHelpers
       end
     end
 
+    def job_file(id)
+      Dummy::Application.root.join("tmp/#{id}")
+    end
+
     def job_executed(id=@id)
-      Dummy::Application.root.join("tmp/#{id}").exist?
+      job_file(id).exist?
+    end
+
+    def job_data(id)
+      Marshal.load(File.binread(job_file(id)))
     end
 
     def job_executed_at(id=@id)
-      File.new(Dummy::Application.root.join("tmp/#{id}")).ctime
+      job_data(id)["executed_at"]
     end
 
-    def job_output
-      File.read Dummy::Application.root.join("tmp/#{@id}")
+    def job_executed_in_locale(id=@id)
+      job_data(id)["locale"]
     end
 end


### PR DESCRIPTION
On most filesystems file ctime is limited to 1 second granularity, which means that on
faster computers multiple simple jobs (for instance dummy TestJob) can finish within the
same second.

The execution order test in ActiveJob integration tests relies on multiple TestJobs
writing files then comparing the ctime. As a result integration tests would sometimes
fail as the ctime of the files written by these TestJobs could have coincidental ctimes
making the comparison for job order fail.

This commit adds a far more precise execution time (to the extent that the Ruby Time
class allows) to the file created by TestJob, and updates the execution order assertion
to use it, removing the race condition.
