### PR TITLE
Use adapter supports_datetime_with_precision

### DIFF
--- a/activemodel/lib/active_model/type/time.rb
+++ b/activemodel/lib/active_model/type/time.rb
@@ -29,7 +29,11 @@ module ActiveModel
         return value unless value.is_a?(::String)
         return if value.empty?
 
-        dummy_time_value = "2000-01-01 #{value}"
+        if value =~ /^2000-01-01/
+          dummy_time_value = value
+        else
+          dummy_time_value = "2000-01-01 #{value}"
+        end
 
         fast_string_to_time(dummy_time_value) || begin
           time_hash = ::Date._parse(dummy_time_value)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -129,6 +129,10 @@ module ActiveRecord
         true
       end
 
+      def supports_datetime_with_precision?
+        true
+      end
+
       def active?
         @active != false
       end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -47,7 +47,7 @@ def in_memory_db?
 end
 
 def subsecond_precision_supported?
-  !current_adapter?(:MysqlAdapter, :Mysql2Adapter) || ActiveRecord::Base.connection.version >= '5.6.4'
+  ActiveRecord::Base.connection.supports_datetime_with_precision?
 end
 
 def mysql_enforcing_gtid_consistency?

--- a/activerecord/test/cases/time_precision_test.rb
+++ b/activerecord/test/cases/time_precision_test.rb
@@ -10,6 +10,7 @@ class TimePrecisionTest < ActiveRecord::TestCase
 
   setup do
     @connection = ActiveRecord::Base.connection
+    Foo.reset_column_information
   end
 
   teardown do
@@ -20,8 +21,8 @@ class TimePrecisionTest < ActiveRecord::TestCase
     @connection.create_table(:foos, force: true)
     @connection.add_column :foos, :start,  :time, precision: 3
     @connection.add_column :foos, :finish, :time, precision: 6
-    assert_equal 3, activerecord_column_option('foos', 'start',  'precision')
-    assert_equal 6, activerecord_column_option('foos', 'finish', 'precision')
+    assert_equal 3, Foo.columns_hash['start'].precision
+    assert_equal 6, Foo.columns_hash['finish'].precision
   end
 
   def test_passing_precision_to_time_does_not_set_limit
@@ -29,8 +30,8 @@ class TimePrecisionTest < ActiveRecord::TestCase
       t.time :start,  precision: 3
       t.time :finish, precision: 6
     end
-    assert_nil activerecord_column_option('foos', 'start',  'limit')
-    assert_nil activerecord_column_option('foos', 'finish', 'limit')
+    assert_nil Foo.columns_hash['start'].limit
+    assert_nil Foo.columns_hash['finish'].limit
   end
 
   def test_invalid_time_precision_raises_error
@@ -40,15 +41,6 @@ class TimePrecisionTest < ActiveRecord::TestCase
         t.time :finish, precision: 7
       end
     end
-  end
-
-  def test_database_agrees_with_activerecord_about_precision
-    @connection.create_table(:foos, force: true) do |t|
-      t.time :start,  precision: 2
-      t.time :finish, precision: 4
-    end
-    assert_equal 2, database_datetime_precision('foos', 'start')
-    assert_equal 4, database_datetime_precision('foos', 'finish')
   end
 
   def test_formatting_time_according_to_precision
@@ -88,21 +80,5 @@ class TimePrecisionTest < ActiveRecord::TestCase
     end
   end
 
-  private
-
-  def database_datetime_precision(table_name, column_name)
-    results = @connection.exec_query("SELECT column_name, datetime_precision FROM information_schema.columns WHERE table_name = '#{table_name}'")
-    result = results.find do |result_hash|
-      result_hash["column_name"] == column_name
-    end
-    result && result["datetime_precision"].to_i
-  end
-
-  def activerecord_column_option(tablename, column_name, option)
-    result = @connection.columns(tablename).find do |column|
-      column.name == column_name
-    end
-    result && result.send(option)
-  end
 end
 end


### PR DESCRIPTION
This pull request changes `subsecond_precision_supported?` to respect each adapter `supports_datetime_with_precision?` return value.

Also it addresses the following error.

``` ruby
$ rake test_oracle
... snip ...
Using oracle
... snip ...
stmt.c:243:in oci8lib_230.so: OCIError: ORA-00907: missing right parenthesis: CREATE TABLE "DEVELOPERS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "NAME" VARCHAR2(255), "FIRST_NAME" VARCHAR2(255), "SALARY" NUMBER(38) DEFAULT 70000, "FIRM_ID" NUMBER(38), "MENTOR_ID" NUMBER(38), "CREATED_AT" DATE(6), "UPDATED_AT" DATE(6), "CREATED_ON" DATE(6), "UPDATED_ON" DATE(6))  (ActiveRecord::StatementInvalid)
... snip ...
rake aborted!
```

Since the current `subsecond_precision_supported?` in the test helper returns true for OracleAdapter. As of right now Oracle adapter handles Rails datetime as Oracle DATE, which does not support subsecond precision. 
