### PR TITLE
MySQL 5.7 support for 4-2-stable

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -606,12 +606,10 @@ module ActiveRecord
 
       # SHOW VARIABLES LIKE 'name'
       def show_variable(name)
-        begin
-          variables = select_all("select @@#{name} as 'Value'", 'SCHEMA')
-          variables.first['Value'] unless variables.empty?
-        rescue ActiveRecord::StatementInvalid => _e
-          nil
-        end
+        variables = select_all("select @@#{name} as 'Value'", 'SCHEMA')
+        variables.first['Value'] unless variables.empty?
+      rescue ActiveRecord::StatementInvalid
+        nil
       end
 
       # Returns a table's primary key and belonging sequence.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -606,8 +606,12 @@ module ActiveRecord
 
       # SHOW VARIABLES LIKE 'name'
       def show_variable(name)
-        variables = select_all("SHOW VARIABLES LIKE '#{name}'", 'SCHEMA')
-        variables.first['Value'] unless variables.empty?
+        begin
+          variables = select_all("select @@#{name} as 'Value'", 'SCHEMA')
+          variables.first['Value'] unless variables.empty?
+        rescue ActiveRecord::StatementInvalid => _e
+          nil
+        end
       end
 
       # Returns a table's primary key and belonging sequence.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -717,7 +717,9 @@ module ActiveRecord
 
         subselect = Arel::SelectManager.new(select.engine)
         subselect.project Arel.sql(key.name)
-        subselect.from subsubselect.as('__active_record_temp')
+        # Materialized subquery by adding distinct
+        # to work with MySQL 5.7.6 which sets optimizer_switch='derived_merge=on'
+        subselect.from subsubselect.distinct.as('__active_record_temp')
       end
 
       def add_index_length(option_strings, column_names, options = {})

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -245,7 +245,7 @@ module ActiveRecord
         return @client_encoding if @client_encoding
 
         result = exec_query(
-          "SHOW VARIABLES WHERE Variable_name = 'character_set_client'",
+          "select @@character_set_client",
           'SCHEMA')
         @client_encoding = ENCODINGS[result.rows.last.last]
       end


### PR DESCRIPTION
This pull request backports #19359 and #21318 which fixes #21108 into 4-2-stable branch since there are some updates from users who use homebrew to install MySQL 5.7.
