### PR TITLE
Test if each_object(singleton_class) works, since JRuby added it.

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -3,7 +3,8 @@ require 'active_support/core_ext/module/reachable'
 
 class Class
   begin
-    ObjectSpace.each_object(Class.new) {}
+    # Test if this Ruby supports each_object against singleton_class
+    ObjectSpace.each_object(Numeric.singleton_class) {}
 
     def descendants # :nodoc:
       descendants = []
@@ -12,7 +13,7 @@ class Class
       end
       descendants
     end
-  rescue StandardError # JRuby
+  rescue StandardError # JRuby 9.0.4.0 and earlier
     def descendants # :nodoc:
       descendants = []
       ObjectSpace.each_object(Class) do |k|


### PR DESCRIPTION
Fixes #22376.

JRuby 9.0.5.0 will support ObjectSpace.each_object against a
class's singleton class, since that's essentially just walking an
internal subclasses structure we already maintain. This test was
too narrow, requiring that each_object support an arbitrary class
but only actually needing it to work against a class's singleton.

This improves performance of Class.descendants by nearly two orders
of magnitude when run against JRuby 9.0.5.0:

``` ruby
5.times { puts Benchmark.measure { 100_000.times { Numeric.descendants } } }
```

Before:

```
 11.510000   0.140000  11.650000 ( 10.082384)
  9.990000   0.020000  10.010000 (  9.931233)
 10.520000   0.040000  10.560000 ( 10.502978)
 10.290000   0.030000  10.320000 ( 10.276027)
 10.000000   0.030000  10.030000 (  9.942429)
```

After:

```
  1.380000   0.040000   1.420000 (  0.365850)
  0.210000   0.000000   0.210000 (  0.149574)
  0.180000   0.020000   0.200000 (  0.141094)
  0.140000   0.000000   0.140000 (  0.140634)
  0.190000   0.010000   0.200000 (  0.147962)
```
