### PR TITLE
Use JRuby.reference to access subclasses method on JRuby.

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -2,9 +2,15 @@ require 'active_support/core_ext/module/anonymous'
 require 'active_support/core_ext/module/reachable'
 
 class Class
-  begin
-    ObjectSpace.each_object(Class.new) {}
+  if RUBY_ENGINE == 'jruby'
+    def descendants # :nodoc:
+      JRuby.reference(self).subclasses(true).to_a
+    end
 
+    def subclasses
+      JRuby.reference(self).subclasses(false).to_a
+    end
+  else
     def descendants # :nodoc:
       descendants = []
       ObjectSpace.each_object(singleton_class) do |k|
@@ -12,31 +18,22 @@ class Class
       end
       descendants
     end
-  rescue StandardError # JRuby
-    def descendants # :nodoc:
-      descendants = []
-      ObjectSpace.each_object(Class) do |k|
-        descendants.unshift k if k < self
-      end
-      descendants.uniq!
-      descendants
-    end
-  end
 
-  # Returns an array with the direct children of +self+.
-  #
-  #   Integer.subclasses # => [Fixnum, Bignum]
-  #
-  #   class Foo; end
-  #   class Bar < Foo; end
-  #   class Baz < Bar; end
-  #
-  #   Foo.subclasses # => [Bar]
-  def subclasses
-    subclasses, chain = [], descendants
-    chain.each do |k|
-      subclasses << k unless chain.any? { |c| c > k }
+    # Returns an array with the direct children of +self+.
+    #
+    #   Integer.subclasses # => [Fixnum, Bignum]
+    #
+    #   class Foo; end
+    #   class Bar < Foo; end
+    #   class Baz < Bar; end
+    #
+    #   Foo.subclasses # => [Bar]
+    def subclasses
+      subclasses, chain = [], descendants
+      chain.each do |k|
+	subclasses << k unless chain.any? { |c| c > k }
+      end
+      subclasses
     end
-    subclasses
   end
 end


### PR DESCRIPTION
Fixes #22376.

JRuby tracks all subclasses internally via a weak set, exposed
only to Java normally or to Ruby when a user requires
"jruby/core_ext". This patch uses the same functionality as the
JRuby ext to get a direct reference to the Java object for the
Ruby class and call the Java RubyClass.subclasses method to
retrieve immediate children or all descendants.

This improves performance of Class.descendants by nearly two orders
of magnitude when run against JRuby 9.0.5.0:

``` ruby
5.times { puts Benchmark.measure { 100_000.times { Numeric.descendants } } }
```

Before:

```
 11.510000   0.140000  11.650000 ( 10.082384)
  9.990000   0.020000  10.010000 (  9.931233)
 10.520000   0.040000  10.560000 ( 10.502978)
 10.290000   0.030000  10.320000 ( 10.276027)
 10.000000   0.030000  10.030000 (  9.942429)
```

After:

```
  1.620000   0.060000   1.680000 (  0.411112)
  0.520000   0.020000   0.540000 (  0.180844)
  0.330000   0.010000   0.340000 (  0.164856)
  0.240000   0.020000   0.260000 (  0.169034)
  0.170000   0.000000   0.170000 (  0.161201)
```
