### PR TITLE
`set_field_encoding` is only needed for `MysqlAdapter`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -588,10 +588,8 @@ module ActiveRecord
         sql = "SHOW FULL FIELDS FROM #{quote_table_name(table_name)}"
         execute_and_free(sql, 'SCHEMA') do |result|
           each_hash(result).map do |field|
-            field_name = set_field_encoding(field[:Field])
-            sql_type = field[:Type]
-            type_metadata = fetch_type_metadata(sql_type, field[:Extra])
-            new_column(field_name, field[:Default], type_metadata, field[:Null] == "YES", nil, field[:Collation])
+            type_metadata = fetch_type_metadata(field[:Type], field[:Extra])
+            new_column(field[:Field], field[:Default], type_metadata, field[:Null] == "YES", nil, field[:Collation])
           end
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -185,10 +185,6 @@ module ActiveRecord
       def full_version
         @full_version ||= @connection.server_info[:version]
       end
-
-      def set_field_encoding field_name
-        field_name
-      end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -104,6 +104,11 @@ module ActiveRecord
         end
       end
 
+      def new_column(field, default, sql_type_metadata = nil, null = true, default_function = nil, collation = nil) # :nodoc:
+        field = set_field_encoding(field)
+        super
+      end
+
       def error_number(exception) # :nodoc:
         exception.errno if exception.respond_to?(:errno)
       end
@@ -463,7 +468,7 @@ module ActiveRecord
         @full_version ||= @connection.server_info
       end
 
-      def set_field_encoding field_name
+      def set_field_encoding(field_name)
         field_name.force_encoding(client_encoding)
         if internal_enc = Encoding.default_internal
           field_name = field_name.encode!(internal_enc)


### PR DESCRIPTION
Not needed for `Mysql2Adapter` and `AbstractMysqlAdapter`.
