### PR TITLE
ensure we *always* reset current_scope to previous_scope

### DIFF
--- a/activerecord/lib/active_record/scoping.rb
+++ b/activerecord/lib/active_record/scoping.rb
@@ -93,8 +93,8 @@ module ActiveRecord
 
         scope = previous_scope.merge(scope) if previous_scope && action == :merge
 
-        self.current_scope = scope
         begin
+          self.current_scope = scope
           yield
         ensure
           self.current_scope = previous_scope


### PR DESCRIPTION
There previously existed a very small chance that the line `self.current_scope = scope` would execute without the `ensure` block executing.  In Zendesk's case, a Timeout occurred after the `Thread.local` set happened but before we entered the `begin` block.

In this (admittedly extremely rare) case, the current_scope got stuck; it looked like this:

```
Model.find(5) # Timeout occurs, current_scope remains set
Model.find(10)
 -> <Model id:5>
Model.find(15)
 -> <Model id:5>
```

Which was disastrous and led to data corruption.

The fix is to set current_scope inside the `begin` block, so that we may never set current_scope without the `ensure` block also firing.
