### PR TITLE
Remove valgrind note about linux only support

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -862,8 +862,8 @@ such as Valgrind.
 
 ### Valgrind
 
-[Valgrind](http://valgrind.org/) is a Linux-only application for detecting
-C-based memory leaks and race conditions.
+[Valgrind](http://valgrind.org/) is an application for detecting C-based memory
+leaks and race conditions.
 
 There are Valgrind tools that can automatically detect many memory management
 and threading bugs, and profile your programs in detail. For example, if a C


### PR DESCRIPTION
Update the valgrind debugging documentation to remove the notes about being linux only as [3.11.0](http://valgrind.org/docs/manual/dist.news.html) introduces preliminary support for Mac OSX 10.11 (El Capitan).
