### PR TITLE
Associate a new parent record with children

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -556,6 +556,8 @@ module ActiveRecord
                                   "new records could not be saved."
           end
 
+          associate_all_records(target)
+
           target
         end
 
@@ -644,6 +646,14 @@ module ActiveRecord
           collection = fetch_first_nth_or_last_using_find?(args) ? scope : load_target
           collection.send(type, *args).tap do |record|
             set_inverse_instance record if record.is_a? ActiveRecord::Base
+          end
+        end
+
+        def associate_all_records(target)
+          if owner.new_record? && target.all? {|record| record.new_record? }
+            target.each do |new_record|
+              associate_record(new_record)
+            end
           end
         end
     end

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -57,6 +57,10 @@ module ActiveRecord
         end
       end
 
+      def associate_record(record)
+        set_owner_attributes(record)
+      end
+
       private
 
         # Returns the number of records in this collection.

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -345,6 +345,22 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
     @pirate.update(update_only_ship_attributes: { id: @pirate.ship.id, name: 'Mayflower' })
   end
 
+  def test_accepts_nested_attributes_and_has_many_work_with_validate_presence_of
+    assert Pirate.new.update(
+      :catchphrase => "Don' botharrr talkin' like one, savvy?",
+      treasures: [
+        Treasure.new(name: 'pearl')
+      ]
+    )
+  end
+
+  def test_accepts_nested_attributes_and_has_one_work_with_validate_presence_of
+    assert Pirate.new.update(
+      :catchphrase => "Don' botharrr talkin' like one, savvy?",
+      ship: Ship.new(name: 'foo')
+    )
+  end
+
   def test_should_create_new_model_when_nothing_is_there_and_update_only_is_true
     @ship.delete
 


### PR DESCRIPTION
Potential Fix for https://github.com/rails/rails/issues/22358

When a new record is instantiated and that record has children that are
instantiated at the same time through `accepts_nested_attributes_for`,
and we try to save all of those records. Under certain circumstances all
of those records can fail to save to the database.

Below is one such example:

```
class Car
  has_many :seats #this also happens with has_one
  accepts_nested_attributes_for :seats
end

class Seat
  belongs_to :car
  validates_presence_of :car
end

Car.new.update_attributes(seats: [Seat.new])
```

The problem is when use `accepts_nested_attributes_for` and instantiate
a new owner record with children we do **not** associate the children
with the owner. Then when we try to save the owner record the
validations are run on the owner and on the children and since the child
object validates the presence of it's owner, the validation fails and
the database transaction is aborted.

This commit fixes the issue by making sure that when both the owner and
children are new instances, then the owner record is associated to it's
children when the children's attributes are being assigned to them.

API Changes

In `ActiveRecord::Associations::Association`

I've introduced `Association#instantiation_attributes` that
takes care of generating an attributes hash that contains the
owners_name and the owner.

In `Association#set_owner_attributes` I've added in a conditional that
says if both the owner and the child are new records then we associate
both instances using `instantiation_attributes` otherwise  we know that
the objects need to be associated using the `creation_attributes`.

In `ActiveRecord::Associations::CollectionAssociation`

I've introduced `CollectionAssociation#associate_all_records` if the
owner and all of it's children are new instances then this code iterates
through all the children and associates them with their owner.
