### PR TITLE
Deprecate find_in_batches and find_each, use AR::Relation#in_batches

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -49,6 +49,10 @@ module ActiveRecord
     # NOTE: You can't set the limit either, that's used to control
     # the batch sizes.
     def find_each(begin_at: nil, end_at: nil, batch_size: 1000, start: nil)
+      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          find_each is deprecated, and will be removed in Rails 5.1.
+          Please use in_batches.each_record instead.
+      MSG
       if start
         begin_at = start
         ActiveSupport::Deprecation.warn(<<-MSG.squish)
@@ -108,6 +112,10 @@ module ActiveRecord
     # NOTE: You can't set the limit either, that's used to control
     # the batch sizes.
     def find_in_batches(begin_at: nil, end_at: nil, batch_size: 1000, start: nil)
+      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          find_in_batches is deprecated, and will be removed in Rails 5.1.
+          Please use in_batches.each instead.
+      MSG
       if start
         begin_at = start
         ActiveSupport::Deprecation.warn(<<-MSG.squish)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -609,23 +609,23 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, firm.clients.where("name = 'Summit'").to_a.length
   end
 
-  def test_find_each
+  def test_each_record_in_batches
     firm = companies(:first_firm)
 
     assert ! firm.clients.loaded?
 
     assert_queries(4) do
-      firm.clients.find_each(:batch_size => 1) {|c| assert_equal firm.id, c.firm_id }
+      firm.clients.in_batches(of: 1).each_record { |c| assert_equal firm.id, c.firm_id }
     end
 
     assert ! firm.clients.loaded?
   end
 
-  def test_find_each_with_conditions
+  def test_each_record_in_batches_with_conditions
     firm = companies(:first_firm)
 
     assert_queries(2) do
-      firm.clients.where(name: 'Microsoft').find_each(batch_size: 1) do |c|
+      firm.clients.where(name: 'Microsoft').in_batches(of: 1).each_record do |c|
         assert_equal firm.id, c.firm_id
         assert_equal "Microsoft", c.name
       end
@@ -634,14 +634,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert ! firm.clients.loaded?
   end
 
-  def test_find_in_batches
+  def test_in_batches
     firm = companies(:first_firm)
 
     assert ! firm.clients.loaded?
 
     assert_queries(2) do
-      firm.clients.find_in_batches(:batch_size => 2) do |clients|
-        clients.each {|c| assert_equal firm.id, c.firm_id }
+      firm.clients.in_batches(of: 2, load: true) do |clients|
+        clients.each { |c| assert_equal firm.id, c.firm_id }
       end
     end
 

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -11,208 +11,6 @@ class EachTest < ActiveRecord::TestCase
     Post.count('id') # preheat arel's table cache
   end
 
-  def test_each_should_execute_one_query_per_batch
-    assert_queries(@total + 1) do
-      Post.find_each(:batch_size => 1) do |post|
-        assert_kind_of Post, post
-      end
-    end
-  end
-
-  def test_each_should_not_return_query_chain_and_execute_only_one_query
-    assert_queries(1) do
-      result = Post.find_each(:batch_size => 100000){ }
-      assert_nil result
-    end
-  end
-
-  def test_each_should_return_an_enumerator_if_no_block_is_present
-    assert_queries(1) do
-      Post.find_each(:batch_size => 100000).with_index do |post, index|
-        assert_kind_of Post, post
-        assert_kind_of Integer, index
-      end
-    end
-  end
-
-  if Enumerator.method_defined? :size
-    def test_each_should_return_a_sized_enumerator
-      assert_equal 11, Post.find_each(batch_size: 1).size
-      assert_equal 5, Post.find_each(batch_size:  2, begin_at: 7).size
-      assert_equal 11, Post.find_each(batch_size: 10_000).size
-    end
-  end
-
-  def test_each_enumerator_should_execute_one_query_per_batch
-    assert_queries(@total + 1) do
-      Post.find_each(:batch_size => 1).with_index do |post, index|
-        assert_kind_of Post, post
-        assert_kind_of Integer, index
-      end
-    end
-  end
-
-  def test_each_should_raise_if_select_is_set_without_id
-    assert_raise(ArgumentError) do
-      Post.select(:title).find_each(batch_size: 1) { |post|
-        flunk "should not call this block"
-      }
-    end
-  end
-
-  def test_each_should_execute_if_id_is_in_select
-    assert_queries(6) do
-      Post.select("id, title, type").find_each(:batch_size => 2) do |post|
-        assert_kind_of Post, post
-      end
-    end
-  end
-
-  def test_warn_if_limit_scope_is_set
-    assert_called(ActiveRecord::Base.logger, :warn) do
-      Post.limit(1).find_each { |post| post }
-    end
-  end
-
-  def test_warn_if_order_scope_is_set
-    assert_called(ActiveRecord::Base.logger, :warn) do
-      Post.order("title").find_each { |post| post }
-    end
-  end
-
-  def test_logger_not_required
-    previous_logger = ActiveRecord::Base.logger
-    ActiveRecord::Base.logger = nil
-    assert_nothing_raised do
-      Post.limit(1).find_each { |post| post }
-    end
-  ensure
-    ActiveRecord::Base.logger = previous_logger
-  end
-
-  def test_find_in_batches_should_return_batches
-    assert_queries(@total + 1) do
-      Post.find_in_batches(:batch_size => 1) do |batch|
-        assert_kind_of Array, batch
-        assert_kind_of Post, batch.first
-      end
-    end
-  end
-
-  def test_find_in_batches_should_start_from_the_start_option
-    assert_queries(@total) do
-      Post.find_in_batches(batch_size: 1, begin_at: 2) do |batch|
-        assert_kind_of Array, batch
-        assert_kind_of Post, batch.first
-      end
-    end
-  end
-
-  def test_find_in_batches_should_end_at_the_end_option
-    assert_queries(6) do
-      Post.find_in_batches(batch_size: 1, end_at: 5) do |batch|
-        assert_kind_of Array, batch
-        assert_kind_of Post, batch.first
-      end
-    end
-  end
-
-  def test_find_in_batches_shouldnt_execute_query_unless_needed
-    assert_queries(2) do
-      Post.find_in_batches(:batch_size => @total) {|batch| assert_kind_of Array, batch }
-    end
-
-    assert_queries(1) do
-      Post.find_in_batches(:batch_size => @total + 1) {|batch| assert_kind_of Array, batch }
-    end
-  end
-
-  def test_find_in_batches_should_quote_batch_order
-    c = Post.connection
-    assert_sql(/ORDER BY #{c.quote_table_name('posts')}.#{c.quote_column_name('id')}/) do
-      Post.find_in_batches(:batch_size => 1) do |batch|
-        assert_kind_of Array, batch
-        assert_kind_of Post, batch.first
-      end
-    end
-  end
-
-  def test_find_in_batches_should_not_use_records_after_yielding_them_in_case_original_array_is_modified
-    not_a_post = "not a post"
-    def not_a_post.id; end
-    not_a_post.stub(:id, ->{ raise StandardError.new("not_a_post had #id called on it") }) do
-      assert_nothing_raised do
-        Post.find_in_batches(:batch_size => 1) do |batch|
-          assert_kind_of Array, batch
-          assert_kind_of Post, batch.first
-
-          batch.map! { not_a_post }
-        end
-      end
-    end
-  end
-
-  def test_find_in_batches_should_ignore_the_order_default_scope
-    # First post is with title scope
-    first_post = PostWithDefaultScope.first
-    posts = []
-    PostWithDefaultScope.find_in_batches  do |batch|
-      posts.concat(batch)
-    end
-    # posts.first will be ordered using id only. Title order scope should not apply here
-    assert_not_equal first_post, posts.first
-    assert_equal posts(:welcome).id, posts.first.id
-  end
-
-  def test_find_in_batches_should_not_ignore_the_default_scope_if_it_is_other_then_order
-    special_posts_ids = SpecialPostWithDefaultScope.all.map(&:id).sort
-    posts = []
-    SpecialPostWithDefaultScope.find_in_batches do |batch|
-      posts.concat(batch)
-    end
-    assert_equal special_posts_ids, posts.map(&:id)
-  end
-
-  def test_find_in_batches_should_not_modify_passed_options
-    assert_nothing_raised do
-      Post.find_in_batches({ batch_size: 42, begin_at: 1 }.freeze){}
-    end
-  end
-
-  def test_find_in_batches_should_use_any_column_as_primary_key
-    nick_order_subscribers = Subscriber.order('nick asc')
-    start_nick = nick_order_subscribers.second.nick
-
-    subscribers = []
-    Subscriber.find_in_batches(batch_size: 1, begin_at: start_nick) do |batch|
-      subscribers.concat(batch)
-    end
-
-    assert_equal nick_order_subscribers[1..-1].map(&:id), subscribers.map(&:id)
-  end
-
-  def test_find_in_batches_should_use_any_column_as_primary_key_when_start_is_not_specified
-    assert_queries(Subscriber.count + 1) do
-      Subscriber.find_in_batches(batch_size: 1) do |batch|
-        assert_kind_of Array, batch
-        assert_kind_of Subscriber, batch.first
-      end
-    end
-  end
-
-  def test_find_in_batches_should_return_an_enumerator
-    enum = nil
-    assert_no_queries do
-      enum = Post.find_in_batches(:batch_size => 1)
-    end
-    assert_queries(4) do
-      enum.first(4) do |batch|
-        assert_kind_of Array, batch
-        assert_kind_of Post, batch.first
-      end
-    end
-  end
-
   def test_in_batches_should_not_execute_any_query
     assert_no_queries do
       assert_kind_of ActiveRecord::Batches::BatchEnumerator, Post.in_batches(of: 2)
@@ -441,34 +239,20 @@ class EachTest < ActiveRecord::TestCase
     assert_equal 2, person.reload.author_id # incremented only once
   end
 
-  def test_find_in_batches_start_deprecated
+  def test_find_each_deprecated
     assert_deprecated do
-      assert_queries(@total) do
-        Post.find_in_batches(batch_size: 1, start: 2) do |batch|
-          assert_kind_of Array, batch
-          assert_kind_of Post, batch.first
-        end
+      Post.find_each do |post|
+        assert_kind_of Post, post
       end
     end
   end
 
-  def test_find_each_start_deprecated
+  def test_find_in_batches_deprecated
     assert_deprecated do
-      assert_queries(@total) do
-        Post.find_each(batch_size: 1, start: 2) do |post|
-          assert_kind_of Post, post
-        end
+      Post.find_in_batches do |batch|
+        assert_kind_of Array, batch
+        assert_kind_of Post, batch.first
       end
-    end
-  end
-
-  if Enumerator.method_defined? :size
-    def test_find_in_batches_should_return_a_sized_enumerator
-      assert_equal 11, Post.find_in_batches(:batch_size => 1).size
-      assert_equal 6, Post.find_in_batches(:batch_size => 2).size
-      assert_equal 4, Post.find_in_batches(batch_size: 2, begin_at: 4).size
-      assert_equal 4, Post.find_in_batches(:batch_size => 3).size
-      assert_equal 1, Post.find_in_batches(:batch_size => 10_000).size
     end
   end
 end

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -420,16 +420,16 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert_equal [posts(:sti_comments)], Post.with_special_comments.with_post(4).to_a.uniq
   end
 
-  def test_scopes_batch_finders
+  def test_scopes_in_batches_finders
     assert_equal 4, Topic.approved.count
 
     assert_queries(5) do
-      Topic.approved.find_each(:batch_size => 1) {|t| assert t.approved? }
+      Topic.approved.in_batches(of: 1).each_record { |t| assert t.approved? }
     end
 
     assert_queries(3) do
-      Topic.approved.find_in_batches(:batch_size => 2) do |group|
-        group.each {|t| assert t.approved? }
+      Topic.approved.in_batches(of: 2, load: true) do |group|
+        group.each { |t| assert t.approved? }
       end
     end
   end


### PR DESCRIPTION
Regarding #20933, I think it would be a good idea to discuss the in_batches API and the deprecation of the find_each and find_in_batches. I am submitting this as a PR to help review how the deprecation would look like if you decide it should be done.

I added two new tests to ensure find_each and find_in_batches are deprecated, and removed the old tests. Let me know if I should keep the other tests.

Also, I would like to suggest to set `load: true` by default, so users are able to refactor their existing `find_in_batches` to `in_batches.each` instead of the more verbose `in_batches(load: true).each`.

Thanks!
