### PR TITLE
Remove <br> from scaffold form, in favor of using CSS

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
@@ -14,15 +14,15 @@
 <% attributes.each do |attribute| -%>
   <div class="field">
 <% if attribute.password_digest? -%>
-    <%%= f.label :password %><br>
+    <%%= f.label :password %>
     <%%= f.password_field :password %>
   </div>
 
   <div class="field">
-    <%%= f.label :password_confirmation %><br>
+    <%%= f.label :password_confirmation %>
     <%%= f.password_field :password_confirmation %>
 <% else -%>
-    <%%= f.label :<%= attribute.column_name %> %><br>
+    <%%= f.label :<%= attribute.column_name %> %>
     <%%= f.<%= attribute.field_type %> :<%= attribute.column_name %> %>
 <% end -%>
   </div>

--- a/railties/lib/rails/generators/rails/scaffold/templates/scaffold.css
+++ b/railties/lib/rails/generators/rails/scaffold/templates/scaffold.css
@@ -78,3 +78,7 @@ div.actions {
   font-size: 12px;
   list-style: square;
 }
+
+label {
+  display: block;
+}


### PR DESCRIPTION
Using `<br>` to place the next element below is not semantic. Instead, we should be using CSS to place the next element on a new line.

**"br elements must be used only for line breaks that are actually part of the content, as in poems or addresses."** - [HTML5 spec](http://www.w3.org/TR/html5/text-level-semantics.html#the-br-element)

This PR makes the scaffolds lighter and easier to modify, since users won't have to remove the `<br>` tags.
