### PR TITLE
Reset PATH_INFO between ActionController tests

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -601,6 +601,7 @@ module ActionController
         env.delete_if { |k, v| k =~ /^action_dispatch\.rescue/ }
         env.delete 'action_dispatch.request.query_parameters'
         env.delete 'action_dispatch.request.request_parameters'
+        env.delete 'PATH_INFO'
         env
       end
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -150,6 +150,14 @@ XML
       render html: '<body class="foo"></body>'.html_safe
     end
 
+    def path_one
+      render plain: request.fullpath
+    end
+
+    def path_two
+      render plain: request.fullpath
+    end
+
     private
 
       def generate_url(opts)
@@ -965,6 +973,14 @@ XML
     assert_raise(ActiveSupport::TestCase::Assertion) do
       assert_redirected_to 'created resource'
     end
+  end
+
+  def test_request_path_correct
+    get :path_one
+    assert_equal "/test_case_test/test/path_one", @response.body
+
+    get :path_two
+    assert_equal "/test_case_test/test/path_two", @response.body
   end
 end
 


### PR DESCRIPTION
I ran into a very-hard-to-diagnose bug when trying to write tests for https://github.com/rails/rails/pull/22275. `request.env['PATH_INFO']` is not reset between test requests. This causes `request.fullpath` (and probably other methods) to return incorrect values on subsequent requests.

0456caf introduces a test case demonstrating this bug. `request.env['PATH_INFO']` was `/test_case_test/test/path_one` for both requests.

6cc3534 fixes this bug by deleting `PATH_INFO` from the request env between requests.

I'm not :100: on this fix because it breaks any tests that explicitly set `@request.env['PATH_INFO']` ([example](https://github.com/rails/rails/blob/master/actionpack/test/controller/force_ssl_test.rb#L258)).

/cc @jeremy because he is reviewing https://github.com/rails/rails/pull/22275
