### PR TITLE
Fix wrong file:line in Deprecation.deprecation_warning message

### DIFF
--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -14,7 +14,7 @@ module ActiveSupport
       def warn(message = nil, callstack = nil)
         return if silenced
 
-        callstack ||= caller_locations(2)
+        callstack ||= caller_locations(3)
         deprecation_message(callstack, message).tap do |m|
           behavior.each { |b| b.call(m, callstack) }
         end
@@ -37,7 +37,7 @@ module ActiveSupport
       end
 
       def deprecation_warning(deprecated_method_name, message = nil, caller_backtrace = nil)
-        caller_backtrace ||= caller_locations(2)
+        caller_backtrace ||= caller_locations(3)
         deprecated_method_warning(deprecated_method_name, message).tap do |msg|
           warn(msg, caller_backtrace)
         end


### PR DESCRIPTION
Trim 1 more from caller_locations due to delegation.

The existing ActiveSupport::Deprecation.deprecation_warning and warn calls
reference their own file:line number, not the caller/offender.

It appears to be due to some delegation @matthewd discovered:
https://github.com/rails/rails/blob/491f488f5ac4e50abfbd1a434971e41e48aa2f15/activesupport/lib/active_support/deprecation/instance_delegator.rb#L19

I would like to add a test so this doesn't regress but it's difficult.
The existing [ActiveSupport::Deprecation::Reporting.extract_callstack](https://github.com/rails/rails/blob/a7379ce9efb01fb3cd6d9cf6b09b698995377d5a/activesupport/lib/active_support/deprecation/reporting.rb#L86)
method builds the message by first excluding callstack frames within
the rails gem directory.

Below is a standalone script/test that, when run outside of the rails gem,
duplicates the problem.

```
  1) Failure:
ReportingTest#test_deprecation_warning [reporting_test.rb:48]:
Expected /reporting_test.rb:44/ to match "DEPRECATION WARNING: old is deprecated and will be removed from Rails 5.0. (called from old at reporting_test.rb:29)".

  2) Failure:
ReportingTest#test_warn [reporting_test.rb:59]:
Expected /reporting_test.rb:55/ to match "DEPRECATION WARNING: NO. (called from old2 at reporting_test.rb:34)".

2 runs, 6 assertions, 2 failures, 0 errors, 0 skips
```

SCRIPT: reporting_test.rb

``` ruby
  begin
    require 'bundler/inline'
  rescue LoadError => e
    $stderr.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
    raise e
  end

  gemfile(true) do
    source 'https://rubygems.org'
    # gem 'rails',           github: 'jrafanie/rails', branch: 'fix_deprecation_reporting_callstack'

    gem 'rails',           github: 'rails/rails', branch: 'master'
    gem 'arel',            github: 'rails/arel'
    gem 'rack',            github: 'rack/rack'
    gem 'sprockets',       github: 'rails/sprockets'
    gem 'sprockets-rails', github: 'rails/sprockets-rails'
    gem 'sass-rails',      github: 'rails/sass-rails'
    gem 'sqlite3'
  end

  require 'active_support/deprecation'
  require 'active_support/testing/deprecation'
  require 'minitest/autorun'

  class ReportingTest < ActiveSupport::TestCase
    def setup
      @klass = Class.new do
        def old
          ActiveSupport::Deprecation.deprecation_warning(:old)
          :old
        end

        def old2
          ActiveSupport::Deprecation.warn("NO")
          :old2
        end
      end
    end

    def test_deprecation_warning
      line = nil
      result, warning = collect_deprecations do
        line = __LINE__ + 1
        @klass.new.old
      end

      assert_equal :old, result
      assert_match /#{__FILE__}:#{line}/, warning.first
    end

    def test_warn
      line = nil
      result, warning = collect_deprecations do
        line = __LINE__ + 1
        @klass.new.old2
      end

      assert_equal :old2, result
      assert_match /#{__FILE__}:#{line}/, warning.first
    end
  end
```
