### PR TITLE
Use the hash syntax in the order clause in `in_batches`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Use the hash syntax in the order clause in `in_batches`. This fixes
+    problems when using fully qualified identifiers as table names for the
+    sqlserver adapter. The fully qualitifed table names may not be used in
+    the order clause.
+
+    *Jippe Holwerda*
+
 *   Add schema dumping support for PostgreSQL geometric data types.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -196,7 +196,7 @@ module ActiveRecord
         logger.warn("Scoped order and limit are ignored, it's forced to be batch order and batch size")
       end
 
-      relation = relation.reorder(batch_order).limit(of)
+      relation = relation.reorder(table[primary_key].name.to_sym => :asc).limit(of)
       relation = apply_limits(relation, begin_at, end_at)
       batch_relation = relation
 
@@ -229,10 +229,6 @@ module ActiveRecord
       relation = relation.where(table[primary_key].gteq(begin_at)) if begin_at
       relation = relation.where(table[primary_key].lteq(end_at)) if end_at
       relation
-    end
-
-    def batch_order
-      "#{quoted_table_name}.#{quoted_primary_key} ASC"
     end
   end
 end

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -196,7 +196,7 @@ module ActiveRecord
         logger.warn("Scoped order and limit are ignored, it's forced to be batch order and batch size")
       end
 
-      relation = relation.reorder(table[primary_key].name.to_sym => :asc).limit(of)
+      relation = relation.reorder(primary_key => :asc).limit(of)
       relation = apply_limits(relation, begin_at, end_at)
       batch_relation = relation
 

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -196,7 +196,7 @@ module ActiveRecord
         logger.warn("Scoped order and limit are ignored, it's forced to be batch order and batch size")
       end
 
-      relation = relation.reorder(primary_key => :asc).limit(of)
+      relation = relation.reorder(batch_order).limit(of)
       relation = apply_limits(relation, begin_at, end_at)
       batch_relation = relation
 
@@ -229,6 +229,10 @@ module ActiveRecord
       relation = relation.where(table[primary_key].gteq(begin_at)) if begin_at
       relation = relation.where(table[primary_key].lteq(end_at)) if end_at
       relation
+    end
+
+    def batch_order
+      { primary_key => :asc }
     end
   end
 end


### PR DESCRIPTION
This fixes problems when using [fully qualified identifiers](https://technet.microsoft.com/en-us/library/ms187879%28v=sql.105%29.aspx) as table names for the
sqlserver adapter. The fully qualitifed table names may not be used in
the order clause.

Also see https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/426 and https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/427.
