### PR TITLE
Remove use_renderers

### DIFF
--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -25,14 +25,6 @@ module ActionController
       self._renderers = Set.new.freeze
     end
 
-    module ClassMethods
-      def use_renderers(*args)
-        renderers = _renderers + args
-        self._renderers = renderers.freeze
-      end
-      alias use_renderer use_renderers
-    end
-
     def render_to_body(options)
       _render_to_body_with_renderer(options) || super
     end


### PR DESCRIPTION
Was introduced in 2009 without tests and doesn't
appear to have ever been used.

https://github.com/rails/rails/commit/f9d570bdd80010825c21eb32204471ba525915fa
https://github.com/rails/rails/commit/aed135d3e261cbee153a35fcfbeb47e2e02b12e4

Extracted from https://github.com/rails/rails/pull/21496/
