### PR TITLE
Fix inner explicit ID selection (4.2 Backport of #22251)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Regression bug for selecting from a table using the same table in a where clause via
+    a belongs_to relation.
+
+    E.g.: `Group.where(item: Groups.all.select(:item_id))`
+
+    Worked properly in 4.1.8 and 4.2.0
+
+    Backport of https://github.com/rails/rails/pull/22251
+    Fixes #20602
+
+    *Tim Breitkreutz*
+
 *   Introduce `connection.data_sources` and `connection.data_source_exists?`.
     These methods determine what relations can be used to back Active Record
     models (usually tables and views).

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -66,7 +66,7 @@ module ActiveRecord
 
         column = reflection.foreign_key
 
-        if base_class
+        if base_class && base_class.primary_key.present?
           primary_key = reflection.association_primary_key(base_class)
           value = convert_value_to_association_ids(value, primary_key)
         end
@@ -136,7 +136,7 @@ module ActiveRecord
     def self.convert_value_to_association_ids(value, primary_key)
       case value
       when Relation
-        value.select(primary_key)
+        value.select_values.empty? ? value.select(primary_key) : value
       when Array
         value.map { |v| convert_value_to_association_ids(v, primary_key) }
       when Base

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -24,6 +24,7 @@ require 'models/admin/user'
 require 'models/ship'
 require 'models/treasure'
 require 'models/parrot'
+require 'models/like'
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
@@ -1010,6 +1011,23 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     record = Record.create!
     Column.create! record: record
     assert_equal 1, Column.count
+  end
+
+  def test_self_query_thru_belongs_to_self_without_primary_key
+    post = posts(:welcome)
+    like = post.likes.create!
+    like2 = post.likes.create!
+
+    likes = Like.where(post: Like.all.select(:post_id))
+    assert_equal [like.id, like2.id], likes.map(&:id)
+    assert_equal [like.post_id, like2.post_id], likes.map(&:post_id)
+  end
+
+  def test_self_query_thru_belongs_to_self_with_primary_key
+    post = posts(:welcome)
+
+    comments = Comment.where(post: post.comments.select(:post_id))
+    assert_equal 2, comments.count
   end
 end
 

--- a/activerecord/test/models/like.rb
+++ b/activerecord/test/models/like.rb
@@ -1,0 +1,4 @@
+class Like < ActiveRecord::Base
+  # Represents a legacy table with no primary key
+  belongs_to :post
+end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -156,6 +156,8 @@ class Post < ActiveRecord::Base
   has_many :lazy_readers_unscope_skimmers, -> { skimmers_or_not }, :class_name => 'LazyReader'
   has_many :lazy_people_unscope_skimmers, :through => :lazy_readers_unscope_skimmers, :source => :person
 
+  has_many :likes
+
   def self.top(limit)
     ranked_by_comments.limit_by(limit)
   end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -400,6 +400,10 @@ ActiveRecord::Schema.define do
     t.references :student
   end
 
+  create_table :likes, id: false, force: true do |t|
+    t.integer :post_id
+  end
+
   create_table :lint_models, force: true
 
   create_table :line_items, force: true do |t|


### PR DESCRIPTION
Back port of https://github.com/rails/rails/pull/22251

Fix a regression bug (appeared since 4.1.8 and 4.2.0) where a belongs_to relationship would result in failing inner (explicit) selection such as:

```
Planet(star: Planet.all.select(:star_id))
```

This appeared to happen because the inner relation would get duplicate selections resulting in badly formed SQL such as:

```
SELECT `planets`.* FROM `planets` WHERE `planets`.`star_id` IN (SELECT `planets`.`star_id`, id FROM `planets`)
```

This fix makes it so that extra clauses will not be added to the inner SELECT in the SQL. There were different symptoms in the case of no primary key as well (See Issue #20602 description).
