### PR TITLE
Subscribing to notifications while inside the said instrumented section

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -42,8 +42,8 @@ module ActiveSupport
         listeners_for(name).each { |s| s.start(name, id, payload) }
       end
 
-      def finish(name, id, payload)
-        listeners_for(name).each { |s| s.finish(name, id, payload) }
+      def finish(name, id, payload, listeners = listeners_for(name))
+        listeners.each { |s| s.finish(name, id, payload) }
       end
 
       def publish(name, *args)

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -15,14 +15,15 @@ module ActiveSupport
       # and publish it. Notice that events get sent even if an error occurs
       # in the passed-in block.
       def instrument(name, payload={})
-        start name, payload
+        # some of the listeners might have state
+        listeners_state = start name, payload
         begin
           yield payload
         rescue Exception => e
           payload[:exception] = [e.class.name, e.message]
           raise e
         ensure
-          finish name, payload
+          finish_with_state listeners_state, name, payload
         end
       end
 
@@ -34,6 +35,10 @@ module ActiveSupport
       # Send a finish notification with +name+ and +payload+.
       def finish(name, payload)
         @notifier.finish name, @id, payload
+      end
+
+      def finish_with_state(listeners_state, name, payload)
+        @notifier.finish name, @id, payload, listeners_state
       end
 
       private

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -42,6 +42,21 @@ module Notifications
       ActiveSupport::Notifications.instrument(name)
       assert_equal expected, events
     end
+
+    def test_subsribing_to_instrumentation_while_inside_it
+      # the repro requires that there are no evented subscribers for the "foo" event,
+      # so we have to duplicate some of the setup code
+      old_notifier = ActiveSupport::Notifications.notifier
+      ActiveSupport::Notifications.notifier = ActiveSupport::Notifications::Fanout.new
+
+      ActiveSupport::Notifications.subscribe('foo', TestSubscriber.new)
+
+      ActiveSupport::Notifications.instrument('foo') do
+        ActiveSupport::Notifications.subscribe('foo') {}
+      end
+    ensure
+      ActiveSupport::Notifications.notifier = old_notifier
+    end
   end
 
   class UnsubscribeTest < TestCase


### PR DESCRIPTION
@skaestle posted a repro case for #21873, though the post has now been deleted:

> @sgrif hello! would you mind reopening this issue? I have created a small rails (4.2.5) app that showcases the error: https://github.com/skaestle/investigate-rails-notification.
> 
> this happens when an error is thrown while subscribed to `process_action.action_controller`: https://github.com/skaestle/investigate-rails-notification/blob/master/app/controllers/posts_controller.rb#L7

The issue is that subscribing to a notification while inside the said instrumented section sometimes results in an error.

```
ActiveSupport::Notifications.instrument('foo') do
  ActiveSupport::Notifications.subscribe('foo') {}
end
```

I'm not sure if such a use case should be supported, but I'm submitting a PR anyways. I **cannot** rule out that a legitimate use case exists: ie for example, if the loading of Rails Engines was instrumented and an Engine (while being loaded) subscribed to the notification, it might error out.
