### PR TITLE
Make `assert_recognizes` to traverse mounted engines

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make `assert_recognizes` to traverse mounted engines
+
+    *Yuichiro Kaneko*
+
 *   Add extension synonyms `yml` and `yaml` for MIME type `application/x-yaml`.
 
    *bogdanvlviv*

--- a/actionpack/lib/action_dispatch/routing/endpoint.rb
+++ b/actionpack/lib/action_dispatch/routing/endpoint.rb
@@ -1,10 +1,12 @@
 module ActionDispatch
   module Routing
     class Endpoint # :nodoc:
-      def dispatcher?;   false; end
-      def redirect?;     false; end
-      def matches?(req); true;  end
-      def app;           self;  end
+      def dispatcher?;                           false; end
+      def redirect?;                             false; end
+      def engine?;       rack_app.respond_to?(:routes); end
+      def matches?(req);                          true; end
+      def app;                                    self; end
+      def rack_app;                                app; end
     end
   end
 end

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -13,7 +13,7 @@ module ActionDispatch
       end
 
       def rack_app
-        app.app
+        app.rack_app
       end
 
       def path
@@ -45,7 +45,7 @@ module ActionDispatch
       end
 
       def engine?
-        rack_app.respond_to?(:routes)
+        app.engine?
       end
     end
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -751,6 +751,10 @@ module ActionDispatch
         end
 
         req = make_request(env)
+        recognize_path_with_request(req, path, extras)
+      end
+
+      def recognize_path_with_request(req, path, extras)
         @router.recognize(req) do |route, params|
           params.merge!(extras)
           params.each do |key, value|
@@ -770,6 +774,9 @@ module ActionDispatch
             end
 
             return req.path_parameters
+          elsif app.matches?(req) && app.engine?
+            path_parameters = app.rack_app.routes.recognize_path_with_request(req, path, extras)
+            return path_parameters
           end
         end
 

--- a/actionpack/test/dispatch/routing_assertions_test.rb
+++ b/actionpack/test/dispatch/routing_assertions_test.rb
@@ -1,13 +1,39 @@
 require 'abstract_unit'
+require 'rails/engine'
 require 'controller/fake_controllers'
 
 class SecureArticlesController < ArticlesController; end
 class BlockArticlesController < ArticlesController; end
 class QueryArticlesController < ArticlesController; end
 
+class SecureBooksController < BooksController; end
+class BlockBooksController < BooksController; end
+class QueryBooksController < BooksController; end
+
 class RoutingAssertionsTest < ActionController::TestCase
 
   def setup
+    engine = Class.new(Rails::Engine) do
+      def self.name
+        "blog_engine"
+      end
+    end
+    engine.routes.draw do
+      resources :books
+
+      scope 'secure', :constraints => { :protocol => 'https://' } do
+        resources :books, :controller => 'secure_books'
+      end
+
+      scope 'block', :constraints => lambda { |r| r.ssl? } do
+        resources :books, :controller => 'block_books'
+      end
+
+      scope 'query', :constraints => lambda { |r| r.params[:use_query] == 'true' } do
+        resources :books, :controller => 'query_books'
+      end
+    end
+
     @routes = ActionDispatch::Routing::RouteSet.new
     @routes.draw do
       resources :articles
@@ -23,6 +49,8 @@ class RoutingAssertionsTest < ActionController::TestCase
       scope 'query', :constraints => lambda { |r| r.params[:use_query] == 'true' } do
         resources :articles, :controller => 'query_articles'
       end
+
+      mount engine => "/shelf"
     end
   end
 
@@ -77,6 +105,49 @@ class RoutingAssertionsTest < ActionController::TestCase
   def test_assert_recognizes_raises_message
     err = assert_raise(Assertion) do
       assert_recognizes({ :controller => 'secure_articles', :action => 'index' }, 'http://test.host/secure/articles', {}, "This is a really bad msg")
+    end
+
+    assert_match err.message, "This is a really bad msg"
+  end
+
+  def test_assert_recognizes_with_engine
+    assert_recognizes({ :controller => 'books', :action => 'index' }, '/shelf/books')
+    assert_recognizes({ :controller => 'books', :action => 'show', :id => '1' }, '/shelf/books/1')
+  end
+
+  def test_assert_recognizes_with_engine_and_extras
+    assert_recognizes({ :controller => 'books', :action => 'index', :page => '1' }, '/shelf/books', { :page => '1' })
+  end
+
+  def test_assert_recognizes_with_engine_and_method
+    assert_recognizes({ :controller => 'books', :action => 'create' }, { :path => '/shelf/books', :method => :post })
+    assert_recognizes({ :controller => 'books', :action => 'update', :id => '1' }, { :path => '/shelf/books/1', :method => :put })
+  end
+
+  def test_assert_recognizes_with_engine_and_hash_constraint
+    assert_raise(Assertion) do
+      assert_recognizes({ :controller => 'secure_books', :action => 'index' }, 'http://test.host/shelf/secure/books')
+    end
+    assert_recognizes({ :controller => 'secure_books', :action => 'index', :protocol => 'https://' }, 'https://test.host/shelf/secure/books')
+  end
+
+  def test_assert_recognizes_with_engine_and_block_constraint
+    assert_raise(Assertion) do
+      assert_recognizes({ :controller => 'block_books', :action => 'index' }, 'http://test.host/shelf/block/books')
+    end
+    assert_recognizes({ :controller => 'block_books', :action => 'index' }, 'https://test.host/shelf/block/books')
+  end
+
+  def test_assert_recognizes_with_engine_and_query_constraint
+    assert_raise(Assertion) do
+      assert_recognizes({ :controller => 'query_books', :action => 'index', :use_query => 'false' }, '/shelf/query/books', { :use_query => 'false' })
+    end
+    assert_recognizes({ :controller => 'query_books', :action => 'index', :use_query => 'true' }, '/shelf/query/books', { :use_query => 'true' })
+  end
+
+  def test_assert_recognizes_raises_message_with_engine
+    err = assert_raise(Assertion) do
+      assert_recognizes({ :controller => 'secure_books', :action => 'index' }, 'http://test.host/shelf/secure/books', {}, "This is a really bad msg")
     end
 
     assert_match err.message, "This is a really bad msg"


### PR DESCRIPTION
Before this commit paths of mounted engines are not traversed
when `assert_recognizes` is called, causing strange test results.
This commit enable to traverse mounted paths.
