### PR TITLE
Freeze queue name to reduce allocations

### DIFF
--- a/activejob/lib/active_job/queue_name.rb
+++ b/activejob/lib/active_job/queue_name.rb
@@ -44,7 +44,7 @@ module ActiveJob
       if @queue_name.is_a?(Proc)
         @queue_name = self.class.queue_name_from_part(instance_exec(&@queue_name))
       end
-      @queue_name
+      @queue_name.freeze
     end
 
   end


### PR DESCRIPTION
As a hash key, it's good to freeze it in order to prevent duplicate their value.

frozen

```
Finished in 0.071046s, 1393.4634 runs/s, 3251.4146 assertions/s.

99 runs, 231 assertions, 0 failures, 0 errors, 0 skips
```

not frozen

```
Finished in 0.071991s, 1375.1719 runs/s, 3208.7344 assertions/s.

99 runs, 231 assertions, 0 failures, 0 errors, 0 skips
```
