### PR TITLE
Added dollarsign to the README.md for consistancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ and may also be used independently outside Rails.
 
 1. Install Rails at the command prompt if you haven't yet:
 
-        gem install rails
+        $ gem install rails
 
 2. At the command prompt, create a new Rails application:
 
-        rails new myapp
+        $ rails new myapp
 
    where "myapp" is the application name.
 
 3. Change directory to `myapp` and start the web server:
 
-        cd myapp
-        rails server
+        $ cd myapp
+        $ rails server
 
    Run with `--help` or `-h` for options.
 


### PR DESCRIPTION
I was looking over the README.md on github.com/rails/rails and notice it does not have the $ sign before each command. This seems to be a consistency issue with the guides.rubyonrails.org as all the commands there have the $ before each command. I have submitted this request to address that issue.
