### PR TITLE
Fix `test_find_with_order_on_included_associations_with_construct_finder_sql_for_association_limiting_and_is_distinct` to NULL-agnostic way

### DIFF
--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -19,7 +19,7 @@ require 'models/car'
 require 'models/tyre'
 
 class FinderTest < ActiveRecord::TestCase
-  fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :customers, :categories, :categorizations, :cars
+  fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :author_addresses, :customers, :categories, :categorizations, :cars
 
   def test_find_by_id_with_hash
     assert_raises(ActiveRecord::StatementInvalid) do
@@ -993,10 +993,13 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_find_with_order_on_included_associations_with_construct_finder_sql_for_association_limiting_and_is_distinct
-    assert_equal 2, Post.includes(authors: :author_address).order('author_addresses.id DESC ').limit(2).to_a.size
+    assert_equal 2, Post.includes(authors: :author_address).
+      where.not(author_addresses: { id: nil }).
+      order('author_addresses.id DESC').limit(2).to_a.size
 
     assert_equal 3, Post.includes(author: :author_address, authors: :author_address).
-                              order('author_addresses_authors.id DESC ').limit(3).to_a.size
+      where.not(author_addresses_authors: { id: nil }).
+      order('author_addresses_authors.id DESC').limit(3).to_a.size
   end
 
   def test_find_with_nil_inside_set_passed_for_one_attribute

--- a/activerecord/test/fixtures/author_addresses.yml
+++ b/activerecord/test/fixtures/author_addresses.yml
@@ -3,3 +3,9 @@ david_address:
 
 david_address_extra:
   id: 2
+
+mary_address:
+  id: 3
+
+bob_address:
+  id: 4

--- a/activerecord/test/fixtures/authors.yml
+++ b/activerecord/test/fixtures/authors.yml
@@ -9,7 +9,9 @@ david:
 mary:
   id: 2
   name: Mary
+  author_address_id: 3
 
 bob:
   id: 3
   name: Bob
+  author_address_id: 4


### PR DESCRIPTION
This is a blocker of #22241.

The sort order of NULL depends on the RDBS implementation. This commit
is to fix the test to NULL-agnostic way.

Example:

```
    activerecord_unittest=# SELECT  DISTINCT "posts"."id", author_addresses_authors.id AS alias_0 FROM "posts" LEFT OUTER JOIN "authors" ON "authors"."id" = "posts"."author_id" LEFT OUTER JOIN "author_addresses" ON "author_addresses"."id" = "authors"."author_address_id" LEFT OUTER JOIN "categorizations" ON "categorizations"."category_id" = "posts"."id" LEFT OUTER JOIN "authors" "authors_posts" ON "authors_posts"."id" = "categorizations"."author_id" LEFT OUTER JOIN "author_addresses" "author_addresses_authors" ON "author_addresses_authors"."id" = "authors_posts"."author_address_id" ORDER BY author_addresses_authors.id DESC;
     id | alias_0
    ----+---------
      1 |
      2 |
      3 |
      4 |
      5 |
      6 |
      7 |
      8 |
      9 |
     10 |
     11 |
      1 |       1
    (12 rows)
```

```
    root@localhost [activerecord_unittest] > SELECT  DISTINCT `posts`.`id`, author_addresses_authors.id AS alias_0 FROM `posts` LEFT OUTER JOIN `authors` ON `authors`.`id` = `posts`.`author_id` LEFT OUTER JOIN `author_addresses` ON `author_addresses`.`id` = `authors`.`author_address_id` LEFT OUTER JOIN `categorizations` ON `categorizations`.`category_id` = `posts`.`id` LEFT OUTER JOIN `authors` `authors_posts` ON `authors_posts`.`id` = `categorizations`.`author_id` LEFT OUTER JOIN `author_addresses` `author_addresses_authors` ON `author_addresses_authors`.`id` = `authors_posts`.`author_address_id` ORDER BY author_addresses_authors.id DESC;
    +----+---------+
    | id | alias_0 |
    +----+---------+
    |  1 |       1 |
    |  3 |    NULL |
    |  1 |    NULL |
    |  2 |    NULL |
    |  4 |    NULL |
    |  5 |    NULL |
    |  6 |    NULL |
    |  7 |    NULL |
    |  8 |    NULL |
    |  9 |    NULL |
    | 10 |    NULL |
    | 11 |    NULL |
    +----+---------+
    12 rows in set (0.00 sec)
```
