### PR TITLE
Explain the connection pool error message better

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -197,7 +197,7 @@ module ActiveRecord
 
             elapsed = Time.now - t0
             if elapsed >= timeout
-              msg = 'could not obtain a database connection within %0.3f seconds (waited %0.3f seconds)' %
+              msg = 'could not obtain a connection from the pool within %0.3f seconds (waited %0.3f seconds); all pooled connections were in use' %
                 [timeout, elapsed]
               raise ConnectionTimeoutError, msg
             end


### PR DESCRIPTION
The previous message was misleading (especially for Ops guys) when
diagnosing problems relating to the database connection.

The message was suggesting that the connection cannot be obtain which
normally assumes the connection to the database.

But this isn't the case as the connection could not be retrieved from
the application's internal connection pool

The new message should make it more explicit and remove the confusion.
