### PR TITLE
Allow use of minitest-rails gem with test runner

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow use of minitest-rails gem with Rails test runner.
+
+    Fixes #22455.
+
+    *Chris Kottom*
+
 *   Add `bin/test` script to rails plugin.
 
     `bin/test` can use the same API as `bin/rails test`.

--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -14,7 +14,7 @@ module Minitest
   SummaryReporter.prepend AggregatedResultSuppresion
 
   def self.plugin_rails_options(opts, options)
-    executable = Rails::TestUnitReporter.executable
+    executable = ::Rails::TestUnitReporter.executable
     opts.separator ""
     opts.separator "Usage: #{executable} [options] [files or directories]"
     opts.separator "You can run a single test by appending a line number to a filename:"


### PR DESCRIPTION
Add explicit global namespace to Rails::TestUnitReporter to resolve a namespace conflict between minitest-rails and Rails test runner.  Fixes #22455.
