### PR TITLE
Added ability to use ActiveRecord store with non db field. 

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -134,7 +134,7 @@ module ActiveRecord
 
     private
       def store_accessor_for(store_attribute)
-        type_for_attribute(store_attribute.to_s).accessor
+        type_for_attribute(store_attribute.to_s).try(:accessor) || StringKeyedHashAccessor
       end
 
       class HashAccessor # :nodoc:
@@ -146,7 +146,7 @@ module ActiveRecord
         def self.write(object, attribute, key, value)
           prepare(object, attribute)
           if value != read(object, attribute, key)
-            object.public_send :"#{attribute}_will_change!"
+            object.public_send :"#{attribute}_will_change!" if object.respond_to?(:"#{attribute}_will_change!")
             object.public_send(attribute)[key] = value
           end
         end

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -191,4 +191,9 @@ class StoreTest < ActiveRecord::TestCase
     second_dump = YAML.dump(loaded)
     assert_equal @john, YAML.load(second_dump)
   end
+
+  test "write and read attribute without database column" do
+    @john.shoe_size = 9
+    assert_equal @john.shoe_size, 9
+  end
 end

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -20,6 +20,7 @@ class Admin::User < ActiveRecord::Base
   store :preferences, :accessors => [ :remember_login ]
   store :json_data, :accessors => [ :height, :weight ], :coder => Coder.new
   store :json_data_empty, :accessors => [ :is_a_good_guy ], :coder => Coder.new
+  store :store_without_column, accessors: [ :shoe_size ]
 
   def phone_number
     read_store_attribute(:settings, :phone_number).gsub(/(\d{3})(\d{3})(\d{4})/,'(\1) \2-\3')
@@ -36,5 +37,9 @@ class Admin::User < ActiveRecord::Base
   def color=(value)
     value = 'blue' unless %w(black red green blue).include?(value)
     super
+  end
+
+  def store_without_column
+    @store_without_column ||= {}
   end
 end


### PR DESCRIPTION
This change will allow more flexible use of the store. When a database column is not required for the store to function then the developer will be able to handle persisting the data as he or she wishes.

My primary motivation for this change is to get better support for attr_encrypted gem. Attr_encrypted gem adds accessors for encrypted attributes and stores the data in prefixed column (encrypted_attr_name). Currently getting it to work with store requires a dummy column in the database although all the data is stored in the prefixed column.
