### PR TITLE
[ci skip] Remove incorrect comments

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -98,7 +98,7 @@ module ActiveRecord
   # There are four types of callbacks accepted by the callback macros: Method references (symbol), callback objects,
   # inline methods (using a proc), and inline eval methods (using a string). Method references and callback objects
   # are the recommended approaches, inline methods using a proc are sometimes appropriate (such as for
-  # creating mix-ins), and inline eval methods are deprecated.
+  # creating mix-ins).
   #
   # The method reference callbacks work by specifying a protected or private method available in the object, like this:
   #


### PR DESCRIPTION
`ActiveRecord`'s string callback is not deprecated.
