### PR TITLE
Fix postgresql line type test suite teardown

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -262,7 +262,7 @@ class PostgreSQLGeometricLineTest < ActiveRecord::PostgreSQLTestCase
   end
 
   teardown do
-    @connection.drop_table 'postgresql_lines', if_exists: true
+    @connection.drop_table('postgresql_lines', if_exists: true) unless skipped?
   end
 
   def test_geometric_line_type


### PR DESCRIPTION
Setup skips before initialising `@connection` variable, so we should check this in teardown. 
