### PR TITLE
wrapping i18n missing keys made optional

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `I18n.translate` helper will wrap the missing translation keys
+     in a <span> tag only if `debug_missing_translation` configuration
+     be true. Default value is `true`. For example in `application.rb`:
+
+       # in order to turn off missing key wrapping
+       config.action_view.debug_missing_tranlation = false
+
+     *Sameer Rahmani*
+
 *   Respect value of `:object` if `:object` is false when rendering.
 
     Fixes #22260.

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -6,7 +6,15 @@ module ActionView
   # = Action View Translation Helpers
   module Helpers
     module TranslationHelper
+      extend ActiveSupport::Concern
+
       include TagHelper
+
+      included do
+        mattr_accessor :debug_missing_translation
+        self.debug_missing_translation = true
+      end
+
       # Delegates to <tt>I18n#translate</tt> but also performs three additional
       # functions.
       #
@@ -94,6 +102,8 @@ module ActionView
           if interpolations.any?
             title << ", " << interpolations.map { |k, v| "#{k}: #{ERB::Util.html_escape(v)}" }.join(', ')
           end
+
+          return title unless ActionView::Base.debug_missing_translation
 
           content_tag('span', keys.last.to_s.titleize, class: 'translation_missing', title: title)
         end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -6,6 +6,7 @@ module ActionView
   class Railtie < Rails::Railtie # :nodoc:
     config.action_view = ActiveSupport::OrderedOptions.new
     config.action_view.embed_authenticity_token_in_remote_forms = false
+    config.action_view.debug_missing_translation = true
 
     config.eager_load_namespaces << ActionView
 

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -54,6 +54,16 @@ class TranslationHelperTest < ActiveSupport::TestCase
     end
   end
 
+  def test_returns_missing_tranlation_message_without_span_wrap
+    old_value = ActionView::Base.debug_missing_translation
+    ActionView::Base.debug_missing_translation = false
+
+    expected = 'translation missing: en.translations.missing'
+    assert_equal expected, translate(:"translations.missing")
+  ensure
+    ActionView::Base.debug_missing_translation = old_value
+  end
+
   def test_returns_missing_translation_message_wrapped_into_span
     expected = '<span class="translation_missing" title="translation missing: en.translations.missing">Missing</span>'
     assert_equal expected, translate(:"translations.missing")

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -461,6 +461,8 @@ encrypted cookies salt value. Defaults to `'signed encrypted cookie'`.
 * `config.action_view.automatically_disable_submit_tag` determines whether
   submit_tag should automatically disable on click, this defaults to true.
 
+* `config.action_view.debug_missing_translation` determins whether to wrap the missing translations key in a `<span>` tag or not. This defaults to true.
+
 ### Configuring Action Mailer
 
 There are a number of settings available on `config.action_mailer`:


### PR DESCRIPTION
`I18n.translate` helper will wrap the missing translation keys
in a <span> tag only if `wrap_missing_key` configuration.
Default value is `true`. For example in `application.rb`:

``` ruby
    # in order to turn off missing key wrapping
    config.i18n.wrap_missing_key = false
```
