### PR TITLE
Separate module for namespaced classes (created by Generator)

### DIFF
--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -74,6 +74,14 @@ module Rails
           !options[:skip_namespace] && engine_namespace
         end
 
+        # *Not* the engine namespace, but if someone names their generated
+        # item 'Foo::Bar', this will return Foo
+        def provided_namespace
+          if class_name.include?("::")
+            class_name.deconstantize
+          end
+        end
+
         def namespace
           engine_namespace
         end

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -41,7 +41,7 @@ module Rails
         # if namespace exists and is not skipped
         def module_namespacing(&block)
           content = capture(&block)
-          content = wrap_with_namespace(content) if namespaced?
+          content = wrap_with_namespace(content) if engine_namespaced?
           concat(content)
         end
 
@@ -52,7 +52,7 @@ module Rails
 
         def wrap_with_namespace(content)
           content = indent(content).chomp
-          "module #{namespace.name}\n#{content}\nend\n"
+          "module #{engine_namespace.name}\n#{content}\nend\n"
         end
 
         def inside_template
@@ -66,12 +66,20 @@ module Rails
           @inside_template
         end
 
-        def namespace
+        def engine_namespace
           Rails::Generators.namespace
         end
 
+        def engine_namespaced?
+          !options[:skip_namespace] && engine_namespace
+        end
+
+        def namespace
+          engine_namespace
+        end
+
         def namespaced?
-          !options[:skip_namespace] && namespace
+          engine_namespaced?
         end
 
         def file_path
@@ -184,7 +192,7 @@ module Rails
         end
 
         def mountable_engine?
-          defined?(ENGINE_ROOT) && namespaced?
+          defined?(ENGINE_ROOT) && engine_namespaced?
         end
 
         # Add a class collisions name to be checked on class initialization. You

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -87,7 +87,11 @@ module Rails
         end
 
         def class_path
-          inside_template? || !namespaced? ? regular_class_path : namespaced_class_path
+          if inside_template? || !namespaced?
+            regular_class_path
+          else
+            namespaced_class_path
+          end
         end
 
         def regular_class_path

--- a/railties/lib/rails/generators/resource_helpers.rb
+++ b/railties/lib/rails/generators/resource_helpers.rb
@@ -48,7 +48,7 @@ module Rails
         end
 
         def controller_class_name
-          (controller_class_path + [controller_file_name]).map!(&:camelize).join('::')
+          class_name.pluralize
         end
 
         def controller_i18n_scope

--- a/railties/lib/rails/generators/resource_helpers.rb
+++ b/railties/lib/rails/generators/resource_helpers.rb
@@ -48,7 +48,7 @@ module Rails
         end
 
         def controller_class_name
-          class_name.pluralize
+          @controller_file_name.camelize
         end
 
         def controller_i18n_scope

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -52,7 +52,8 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_file "app/models/admin.rb", /module Admin/
     assert_file "app/models/admin.rb", /def self\.table_name_prefix/
     assert_file "app/models/admin.rb", /'admin_'/
-    assert_file "app/models/admin/account.rb", /class Admin::Account < ActiveRecord::Base/
+    assert_file "app/models/admin/account.rb", /module Admin/
+    assert_file "app/models/admin/account.rb", /class Account < ActiveRecord::Base/
   end
 
   def test_migration

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -49,11 +49,11 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
   def test_model_with_namespace
     run_generator ["admin/account"]
-    assert_file "app/models/admin.rb", /module Admin/
-    assert_file "app/models/admin.rb", /def self\.table_name_prefix/
+    assert_file "app/models/admin.rb", /module Admin\n/
+    assert_file "app/models/admin.rb", /def self\.table_name_prefix\n/
     assert_file "app/models/admin.rb", /'admin_'/
-    assert_file "app/models/admin/account.rb", /module Admin/
-    assert_file "app/models/admin/account.rb", /class Account < ActiveRecord::Base/
+    assert_file "app/models/admin/account.rb", /module Admin\n/
+    assert_file "app/models/admin/account.rb", /class Account < ActiveRecord::Base\n/
   end
 
   def test_migration

--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -24,6 +24,7 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, 'admin/foo',  :name
     assert_name g, %w(admin),    :class_path
     assert_name g, 'Admin::Foo', :class_name
+    assert_name g, 'Admin',      :provided_namespace
     assert_name g, 'admin/foo',  :file_path
     assert_name g, 'foo',        :file_name
     assert_name g, 'Foo',        :human_name
@@ -38,6 +39,7 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, 'Admin::Foo', :name
     assert_name g, %w(admin),    :class_path
     assert_name g, 'Admin::Foo', :class_name
+    assert_name g, 'Admin',      :provided_namespace
     assert_name g, 'admin/foo',  :file_path
     assert_name g, 'foo',        :file_name
     assert_name g, 'foo',        :singular_name

--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -66,8 +66,9 @@ class NamedBaseTest < Rails::Generators::TestCase
   def test_scaffold_plural_names
     g = generator ['admin/foo']
     assert_name g, 'admin/foos',  :controller_name
+    assert_name g, 'Admin',       :provided_namespace
     assert_name g, %w(admin),     :controller_class_path
-    assert_name g, 'Admin::Foos', :controller_class_name
+    assert_name g, 'Foos',        :controller_class_name
     assert_name g, 'admin/foos',  :controller_file_path
     assert_name g, 'foos',        :controller_file_name
     assert_name g, 'admin.foos',  :controller_i18n_scope
@@ -76,8 +77,9 @@ class NamedBaseTest < Rails::Generators::TestCase
   def test_scaffold_plural_names_as_ruby
     g = generator ['Admin::Foo']
     assert_name g, 'Admin::Foos', :controller_name
+    assert_name g, 'Admin',       :provided_namespace
     assert_name g, %w(admin),     :controller_class_path
-    assert_name g, 'Admin::Foos', :controller_class_name
+    assert_name g, 'Foos',        :controller_class_name
     assert_name g, 'admin/foos',  :controller_file_path
     assert_name g, 'foos',        :controller_file_name
     assert_name g, 'admin.foos',  :controller_i18n_scope
@@ -130,8 +132,9 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, 'user',        :i18n_scope
     assert_name g, 'users',       :table_name
     assert_name g, 'Admin::Foos', :controller_name
+    assert_name g, nil,           :provided_namespace # since it'd be for model
     assert_name g, %w(admin),     :controller_class_path
-    assert_name g, 'Admin::Foos', :controller_class_name
+    assert_name g, 'Foos',        :controller_class_name
     assert_name g, 'admin/foos',  :controller_file_path
     assert_name g, 'foos',        :controller_file_name
     assert_name g, 'admin.foos',  :controller_i18n_scope

--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -7,34 +7,34 @@ class NamedBaseTest < Rails::Generators::TestCase
 
   def test_named_generator_with_underscore
     g = generator ['line_item']
-    assert_name g, 'line_item',      :name
-    assert_name g, ['LineItem'],     :camelized_name_segments
-    assert_name g, %w(),             :class_path
-    assert_name g, 'LineItem',       :class_name
-    assert_name g, nil,              :provided_namespace
-    assert_name g, 'line_item',      :file_path
-    assert_name g, 'line_item',      :file_name
-    assert_name g, 'Line item',      :human_name
-    assert_name g, 'line_item',      :singular_name
-    assert_name g, 'line_items',     :plural_name
-    assert_name g, 'line_item',      :i18n_scope
-    assert_name g, 'line_items',     :table_name
+    assert_name g, 'line_item',  :name
+    assert_name g, %w(LineItem), :camelized_name_segments
+    assert_name g, %w(),         :class_path
+    assert_name g, 'LineItem',   :class_name
+    assert_name g, %w(),         :provided_namespaces
+    assert_name g, 'line_item',  :file_path
+    assert_name g, 'line_item',  :file_name
+    assert_name g, 'Line item',  :human_name
+    assert_name g, 'line_item',  :singular_name
+    assert_name g, 'line_items', :plural_name
+    assert_name g, 'line_item',  :i18n_scope
+    assert_name g, 'line_items', :table_name
   end
 
   def test_named_generator_attributes
     g = generator ['admin/foo']
-    assert_name g, 'admin/foo',      :name
-    assert_name g, ['Admin', 'Foo'], :camelized_name_segments
-    assert_name g, %w(admin),        :class_path
-    assert_name g, 'Foo',            :class_name
-    assert_name g, 'Admin',          :provided_namespace
-    assert_name g, 'admin/foo',      :file_path
-    assert_name g, 'foo',            :file_name
-    assert_name g, 'Foo',            :human_name
-    assert_name g, 'foo',            :singular_name
-    assert_name g, 'foos',           :plural_name
-    assert_name g, 'admin.foo',      :i18n_scope
-    assert_name g, 'admin_foos',     :table_name
+    assert_name g, 'admin/foo',   :name
+    assert_name g, %w(Admin Foo), :camelized_name_segments
+    assert_name g, %w(admin),     :class_path
+    assert_name g, 'Foo',         :class_name
+    assert_name g, %w(Admin),     :provided_namespaces
+    assert_name g, 'admin/foo',   :file_path
+    assert_name g, 'foo',         :file_name
+    assert_name g, 'Foo',         :human_name
+    assert_name g, 'foo',         :singular_name
+    assert_name g, 'foos',        :plural_name
+    assert_name g, 'admin.foo',   :i18n_scope
+    assert_name g, 'admin_foos',  :table_name
   end
 
   def test_named_generator_attributes_as_ruby
@@ -43,7 +43,7 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, ['Admin', 'Foo'], :camelized_name_segments
     assert_name g, %w(admin),        :class_path
     assert_name g, 'Foo',            :class_name
-    assert_name g, 'Admin',          :provided_namespace
+    assert_name g, %w(Admin),        :provided_namespaces
     assert_name g, 'admin/foo',      :file_path
     assert_name g, 'foo',            :file_name
     assert_name g, 'foo',            :singular_name
@@ -65,19 +65,19 @@ class NamedBaseTest < Rails::Generators::TestCase
 
   def test_scaffold_plural_names
     g = generator ['admin/foo']
-    assert_name g, 'admin/foos',  :controller_name
-    assert_name g, 'Admin',       :provided_namespace
-    assert_name g, %w(admin),     :controller_class_path
-    assert_name g, 'Foos',        :controller_class_name
-    assert_name g, 'admin/foos',  :controller_file_path
-    assert_name g, 'foos',        :controller_file_name
-    assert_name g, 'admin.foos',  :controller_i18n_scope
+    assert_name g, 'admin/foos', :controller_name
+    assert_name g, %w(Admin),    :provided_namespaces
+    assert_name g, %w(admin),    :controller_class_path
+    assert_name g, 'Foos',       :controller_class_name
+    assert_name g, 'admin/foos', :controller_file_path
+    assert_name g, 'foos',       :controller_file_name
+    assert_name g, 'admin.foos', :controller_i18n_scope
   end
 
   def test_scaffold_plural_names_as_ruby
     g = generator ['Admin::Foo']
     assert_name g, 'Admin::Foos', :controller_name
-    assert_name g, 'Admin',       :provided_namespace
+    assert_name g, %w(Admin),     :provided_namespaces
     assert_name g, %w(admin),     :controller_class_path
     assert_name g, 'Foos',        :controller_class_name
     assert_name g, 'admin/foos',  :controller_file_path
@@ -132,7 +132,7 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, 'user',        :i18n_scope
     assert_name g, 'users',       :table_name
     assert_name g, 'Admin::Foos', :controller_name
-    assert_name g, nil,           :provided_namespace # since it'd be for model
+    assert_name g, %w(),          :provided_namespaces # since it'd be for model
     assert_name g, %w(admin),     :controller_class_path
     assert_name g, 'Foos',        :controller_class_name
     assert_name g, 'admin/foos',  :controller_file_path

--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -7,46 +7,50 @@ class NamedBaseTest < Rails::Generators::TestCase
 
   def test_named_generator_with_underscore
     g = generator ['line_item']
-    assert_name g, 'line_item',  :name
-    assert_name g, %w(),         :class_path
-    assert_name g, 'LineItem',   :class_name
-    assert_name g, 'line_item',  :file_path
-    assert_name g, 'line_item',  :file_name
-    assert_name g, 'Line item',  :human_name
-    assert_name g, 'line_item',  :singular_name
-    assert_name g, 'line_items', :plural_name
-    assert_name g, 'line_item',  :i18n_scope
-    assert_name g, 'line_items', :table_name
+    assert_name g, 'line_item',      :name
+    assert_name g, ['LineItem'],     :camelized_name_segments
+    assert_name g, %w(),             :class_path
+    assert_name g, 'LineItem',       :class_name
+    assert_name g, nil,              :provided_namespace
+    assert_name g, 'line_item',      :file_path
+    assert_name g, 'line_item',      :file_name
+    assert_name g, 'Line item',      :human_name
+    assert_name g, 'line_item',      :singular_name
+    assert_name g, 'line_items',     :plural_name
+    assert_name g, 'line_item',      :i18n_scope
+    assert_name g, 'line_items',     :table_name
   end
 
   def test_named_generator_attributes
     g = generator ['admin/foo']
-    assert_name g, 'admin/foo',  :name
-    assert_name g, %w(admin),    :class_path
-    assert_name g, 'Admin::Foo', :class_name
-    assert_name g, 'Admin',      :provided_namespace
-    assert_name g, 'admin/foo',  :file_path
-    assert_name g, 'foo',        :file_name
-    assert_name g, 'Foo',        :human_name
-    assert_name g, 'foo',        :singular_name
-    assert_name g, 'foos',       :plural_name
-    assert_name g, 'admin.foo',  :i18n_scope
-    assert_name g, 'admin_foos', :table_name
+    assert_name g, 'admin/foo',      :name
+    assert_name g, ['Admin', 'Foo'], :camelized_name_segments
+    assert_name g, %w(admin),        :class_path
+    assert_name g, 'Foo',            :class_name
+    assert_name g, 'Admin',          :provided_namespace
+    assert_name g, 'admin/foo',      :file_path
+    assert_name g, 'foo',            :file_name
+    assert_name g, 'Foo',            :human_name
+    assert_name g, 'foo',            :singular_name
+    assert_name g, 'foos',           :plural_name
+    assert_name g, 'admin.foo',      :i18n_scope
+    assert_name g, 'admin_foos',     :table_name
   end
 
   def test_named_generator_attributes_as_ruby
     g = generator ['Admin::Foo']
-    assert_name g, 'Admin::Foo', :name
-    assert_name g, %w(admin),    :class_path
-    assert_name g, 'Admin::Foo', :class_name
-    assert_name g, 'Admin',      :provided_namespace
-    assert_name g, 'admin/foo',  :file_path
-    assert_name g, 'foo',        :file_name
-    assert_name g, 'foo',        :singular_name
-    assert_name g, 'Foo',        :human_name
-    assert_name g, 'foos',       :plural_name
-    assert_name g, 'admin.foo',  :i18n_scope
-    assert_name g, 'admin_foos', :table_name
+    assert_name g, 'Admin::Foo',     :name
+    assert_name g, ['Admin', 'Foo'], :camelized_name_segments
+    assert_name g, %w(admin),        :class_path
+    assert_name g, 'Foo',            :class_name
+    assert_name g, 'Admin',          :provided_namespace
+    assert_name g, 'admin/foo',      :file_path
+    assert_name g, 'foo',            :file_name
+    assert_name g, 'foo',            :singular_name
+    assert_name g, 'Foo',            :human_name
+    assert_name g, 'foos',           :plural_name
+    assert_name g, 'admin.foo',      :i18n_scope
+    assert_name g, 'admin_foos',     :table_name
   end
 
   def test_named_generator_attributes_without_pluralized

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -344,8 +344,17 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin/user/special.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  module Admin\n    module User\n      module Special\n        class Role < ActiveRecord::Base/
-    assert_file "test/models/test_app/admin/user/special/role_test.rb", /module TestApp\n  class Admin::User::Special::RoleTest < ActiveSupport::TestCase/
+    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n/
+    assert_file "app/models/test_app/admin/user/special/role.rb", /  module Admin\n/
+    assert_file "app/models/test_app/admin/user/special/role.rb", /    module User\n/
+    assert_file "app/models/test_app/admin/user/special/role.rb", /      module Special\n/
+    assert_file "app/models/test_app/admin/user/special/role.rb", /        class Role < ActiveRecord::Base\n/
+
+    assert_file "test/models/test_app/admin/user/special/role_test.rb", /module TestApp\n/
+    assert_file "test/models/test_app/admin/user/special/role_test.rb", /  module Admin\n/
+    assert_file "test/models/test_app/admin/user/special/role_test.rb", /    module User\n/
+    assert_file "test/models/test_app/admin/user/special/role_test.rb", /      module Special\n/
+    assert_file "test/models/test_app/admin/user/special/role_test.rb", /        class RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/user/special/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_user_special_roles.rb"
 
@@ -356,11 +365,20 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Controller
     assert_file "app/controllers/test_app/admin/user/special/roles_controller.rb" do |content|
-      assert_match(/module TestApp\n  class Admin::User::Special::RolesController < ApplicationController/, content)
+      assert_match(/module TestApp\n/, content)
+      assert_match(/  module Admin\n/, content)
+      assert_match(/    module User\n/, content)
+      assert_match(/      module Special\n/, content)
+      assert_match(/        class RolesController < ApplicationController\n/, content)
     end
 
-    assert_file "test/controllers/test_app/admin/user/special/roles_controller_test.rb",
-                /module TestApp\n  class Admin::User::Special::RolesControllerTest < ActionController::TestCase/
+    assert_file "test/controllers/test_app/admin/user/special/roles_controller_test.rb" do |content|
+      assert_match(/module TestApp\n/, content)
+      assert_match(/  module Admin\n/, content)
+      assert_match(/    module User\n/, content)
+      assert_match(/      module Special\n/, content)
+      assert_match(/        class RolesControllerTest < ActionController::TestCase\n/, content)
+    end
 
     # Views
     %w(index edit new show _form).each do |view|

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -39,7 +39,7 @@ class NamespacedControllerGeneratorTest < NamespacedGeneratorTestCase
 
   def test_namespaced_controller_with_additional_namespace
     run_generator ["admin/account"]
-    assert_file "app/controllers/test_app/admin/account_controller.rb", /module TestApp/, /  class Admin::AccountController < ApplicationController/ do |contents|
+    assert_file "app/controllers/test_app/admin/account_controller.rb", /module TestApp/, /  module Admin/, /class AccountController < ApplicationController/ do |contents|
       assert_match %r(require_dependency "test_app/application_controller"), contents
     end
   end
@@ -99,7 +99,9 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
     assert_file "app/models/test_app/admin.rb", /module TestApp/, /module Admin/
     assert_file "app/models/test_app/admin.rb", /def self\.table_name_prefix/
     assert_file "app/models/test_app/admin.rb", /'test_app_admin_'/
-    assert_file "app/models/test_app/admin/account.rb", /module TestApp/, /class Admin::Account < ActiveRecord::Base/
+    assert_file "app/models/test_app/admin/account.rb", /module TestApp/
+    assert_file "app/models/test_app/admin/account.rb", /module Admin/
+    assert_file "app/models/test_app/admin/account.rb", /class Account < ActiveRecord::Base/
   end
 
   def test_migration
@@ -268,8 +270,12 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ActiveRecord::Base/
-    assert_file "test/models/test_app/admin/role_test.rb", /module TestApp\n  class Admin::RoleTest < ActiveSupport::TestCase/
+    assert_file "app/models/test_app/admin/role.rb", /module TestApp/
+    assert_file "app/models/test_app/admin/role.rb", /module Admin/
+    assert_file "app/models/test_app/admin/role.rb", /class Role < ActiveRecord::Base/
+    assert_file "test/models/test_app/admin/role_test.rb", /module TestApp/
+    assert_file "test/models/test_app/admin/role_test.rb", /module Admin/
+    assert_file "test/models/test_app/admin/role_test.rb", /class RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_roles.rb"
 
@@ -280,12 +286,14 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Controller
     assert_file "app/controllers/test_app/admin/roles_controller.rb" do |content|
-      assert_match(/module TestApp\n  class Admin::RolesController < ApplicationController/, content)
+      assert_match(/module TestApp/, content)
+      assert_match(/module Admin/, content)
+      assert_match(/class RolesController < ApplicationController/, content)
       assert_match(%r(require_dependency "test_app/application_controller"), content)
     end
 
     assert_file "test/controllers/test_app/admin/roles_controller_test.rb",
-                /module TestApp\n  class Admin::RolesControllerTest < ActionController::TestCase/
+                /module TestApp\n  module Admin\n    class RolesControllerTest < ActionController::TestCase/
 
     # Views
     %w(index edit new show _form).each do |view|
@@ -336,7 +344,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin/user/special.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  class Admin::User::Special::Role < ActiveRecord::Base/
+    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  module Admin\n    module User\n      module Special\n        class Role < ActiveRecord::Base/
     assert_file "test/models/test_app/admin/user/special/role_test.rb", /module TestApp\n  class Admin::User::Special::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/user/special/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_user_special_roles.rb"
@@ -402,8 +410,8 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ActiveRecord::Base/
-    assert_file "test/models/test_app/admin/role_test.rb", /module TestApp\n  class Admin::RoleTest < ActiveSupport::TestCase/
+    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  module Admin\n    class Role < ActiveRecord::Base/
+    assert_file "test/models/test_app/admin/role_test.rb", /module TestApp\n  module Admin\n    class RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_roles.rb"
 
@@ -414,10 +422,10 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Controller
     assert_file "app/controllers/test_app/admin/roles_controller.rb" do |content|
-      assert_match(/module TestApp\n  class Admin::RolesController < ApplicationController/, content)
+      assert_match(/module TestApp\n  module Admin\n    class RolesController < ApplicationController/, content)
       assert_match(%r(require_dependency "test_app/application_controller"), content)
     end
     assert_file "test/controllers/test_app/admin/roles_controller_test.rb",
-                /module TestApp\n  class Admin::RolesControllerTest < ActionController::TestCase/
+                /module TestApp\n  module Admin\n    class RolesControllerTest < ActionController::TestCase/
   end
 end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -205,8 +205,10 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Model
     assert_file "app/models/admin.rb", /module Admin/
-    assert_file "app/models/admin/role.rb", /class Admin::Role < ActiveRecord::Base/
-    assert_file "test/models/admin/role_test.rb", /class Admin::RoleTest < ActiveSupport::TestCase/
+    assert_file "app/models/admin/role.rb", /module Admin\n/
+    assert_file "app/models/admin/role.rb", /  class Role < ActiveRecord::Base\n/
+    assert_file "test/models/admin/role_test.rb", /module Admin\n/
+    assert_file "test/models/admin/role_test.rb", /  class RoleTest < ActiveSupport::TestCase\n/
     assert_file "test/fixtures/admin/roles.yml"
     assert_migration "db/migrate/create_admin_roles.rb"
 
@@ -217,22 +219,23 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Controller
     assert_file "app/controllers/admin/roles_controller.rb" do |content|
-      assert_match(/class Admin::RolesController < ApplicationController/, content)
+      assert_match(/module Admin\n/, content)
+      assert_match(/  class RolesController < ApplicationController\n/, content)
 
       assert_instance_method :index, content do |m|
-        assert_match(/@admin_roles = Admin::Role\.all/, m)
+        assert_match(/@admin_roles = Role\.all/, m)
       end
 
       assert_instance_method :show, content
 
       assert_instance_method :new, content do |m|
-        assert_match(/@admin_role = Admin::Role\.new/, m)
+        assert_match(/@admin_role = Role\.new/, m)
       end
 
       assert_instance_method :edit, content
 
       assert_instance_method :create, content do |m|
-        assert_match(/@admin_role = Admin::Role\.new\(admin_role_params\)/, m)
+        assert_match(/@admin_role = Role\.new\(admin_role_params\)/, m)
         assert_match(/@admin_role\.save/, m)
       end
 
@@ -245,12 +248,13 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :set_admin_role, content do |m|
-        assert_match(/@admin_role = Admin::Role\.find\(params\[:id\]\)/, m)
+        assert_match(/@admin_role = Role\.find\(params\[:id\]\)/, m)
       end
     end
 
     assert_file "test/controllers/admin/roles_controller_test.rb",
-                /class Admin::RolesControllerTest < ActionController::TestCase/
+                /module Admin\n/,
+                /  class RolesControllerTest < ActionController::TestCase\n/
 
     # Views
     %w(index edit new show _form).each do |view|


### PR DESCRIPTION
First, let me define two terms:

**Module namespacing**:

```
module A
  class B
    ...
  end
end
```

**Inline namespacing**

```
class A::B
  ...
end
```

(If there is already a different name for this distinction **please** let me know)
#### Summary:

This PR make generated classes use _module namespacing_ instead of the current, _inline namespacing_.
#### More Info:

Generators currently only use _module namespacing_ for Engines (specifically ones that have [`isolate_namespace`](http://guides.rubyonrails.org/engines.html#inside-an-engine)). So `rails generate model article` within an engine called `Blog`, creates the class `Article` inside the module `Blog` (which is _module_ namespacing, rather than _inline_ namespacing).

If you're **not** in an Engine, when you generate something with a namespaced name, like `Admin::Foo`, it will create classes with _inline namespacing_, so `class Admin::Foo`.

The problem is that code written inside an _inline namespaced_ class is still in the global namespace. Inside of class `Admin::Foo`, to refer to a class `Bar` also within `Admin`, you have to write `Admin::Bar`, rather than just `Bar`.

When I was creating classes in a namespace (within one app/engine), I had to modify every generated class to use _module namespacing_, instead, so the namespacing would work as desired. 

By actually putting the class in the module (as with _module namespacing_), all the code written within it will be in that module's namespace. 

This may need more work; I'm not certain Travis will pass.
And, I can squash the commits if this gets approved.
