### PR TITLE
Fix failing test using custom file watcher

### DIFF
--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -169,6 +169,8 @@ class LoadingTest < ActiveSupport::TestCase
       config.file_watcher = Class.new do
         def initialize(*); end
         def updated?; false; end
+        def execute; end
+        def execute_if_updated; false; end
       end
     RUBY
 


### PR DESCRIPTION
LoadingTest#test_does_not_reload_constants_on_development_if_custom_file_watcher_always_returns_false in railties/test/application/loading_test.rb is failing with: `NoMethodError: undefined method 'execute' for #<#<Class:0x00000002465a30>:0x00000001f79698>`

The test creates an anonymous class to be used as a custom file watcher using `config.file_watcher=`. Per the Rails guides for Configuring, the class set to `config.file_watcher`:

> Must conform to ActiveSupport::FileUpdateChecker API.

Per the docs for ActiveSupport::FileUpdateChecker, the API depends on four methods: #initialize, #updated?, #execute, and #execute_if_updated. The custom file watcher in the failing test only implements the first two methods.

This pull request adds #execute and #execute_if_updated to the custom file_watcher, conforming it to the ActiveSupport::FileUpdateChecker API, and passing the test.
