### PR TITLE
Optimize ActiveSupport::Cache::Entry serializer

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -9,6 +9,7 @@ require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/object/to_param'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/string/strip'
+autoload :ASCE_5, 'active_support/cache/entry/asce_5'
 
 module ActiveSupport
   # See ActiveSupport::Cache::Store for documentation.
@@ -17,6 +18,7 @@ module ActiveSupport
     autoload :MemoryStore,   'active_support/cache/memory_store'
     autoload :MemCacheStore, 'active_support/cache/mem_cache_store'
     autoload :NullStore,     'active_support/cache/null_store'
+    autoload :Entry,         'active_support/cache/entry'
 
     # These options mean something to all cache implementations. Individual cache
     # implementations may support additional options.
@@ -598,106 +600,6 @@ module ActiveSupport
 
           write(name, result, options)
           result
-        end
-    end
-
-    # This class is used to represent cache entries. Cache entries have a value and an optional
-    # expiration time. The expiration time is used to support the :race_condition_ttl option
-    # on the cache.
-    #
-    # Since cache entries in most instances will be serialized, the internals of this class are highly optimized
-    # using short instance variable names that are lazily defined.
-    class Entry # :nodoc:
-      DEFAULT_COMPRESS_LIMIT = 16.kilobytes
-
-      # Create a new cache entry for the specified value. Options supported are
-      # +:compress+, +:compress_threshold+, and +:expires_in+.
-      def initialize(value, options = {})
-        if should_compress?(value, options)
-          @value = compress(value)
-          @compressed = true
-        else
-          @value = value
-        end
-
-        @created_at = Time.now.to_f
-        @expires_in = options[:expires_in]
-        @expires_in = @expires_in.to_f if @expires_in
-      end
-
-      def value
-        compressed? ? uncompress(@value) : @value
-      end
-
-      # Check if the entry is expired. The +expires_in+ parameter can override
-      # the value set when the entry was created.
-      def expired?
-        @expires_in && @created_at + @expires_in <= Time.now.to_f
-      end
-
-      def expires_at
-        @expires_in ? @created_at + @expires_in : nil
-      end
-
-      def expires_at=(value)
-        if value
-          @expires_in = value.to_f - @created_at
-        else
-          @expires_in = nil
-        end
-      end
-
-      # Returns the size of the cached value. This could be less than
-      # <tt>value.size</tt> if the data is compressed.
-      def size
-        if defined?(@s)
-          @s
-        else
-          case value
-          when NilClass
-            0
-          when String
-            @value.bytesize
-          else
-            @s = Marshal.dump(@value).bytesize
-          end
-        end
-      end
-
-      # Duplicate the value in a class. This is used by cache implementations that don't natively
-      # serialize entries to protect against accidental cache modifications.
-      def dup_value!
-        if @value && !compressed? && !(@value.is_a?(Numeric) || @value == true || @value == false)
-          if @value.is_a?(String)
-            @value = @value.dup
-          else
-            @value = Marshal.load(Marshal.dump(@value))
-          end
-        end
-      end
-
-      private
-        def should_compress?(value, options)
-          if value && options[:compress]
-            compress_threshold = options[:compress_threshold] || DEFAULT_COMPRESS_LIMIT
-            serialized_value_size = (value.is_a?(String) ? value : Marshal.dump(value)).bytesize
-
-            return true if serialized_value_size >= compress_threshold
-          end
-
-          false
-        end
-
-        def compressed?
-          defined?(@compressed) ? @compressed : false
-        end
-
-        def compress(value)
-          Zlib::Deflate.deflate(Marshal.dump(value))
-        end
-
-        def uncompress(value)
-          Marshal.load(Zlib::Inflate.inflate(value))
         end
     end
   end

--- a/activesupport/lib/active_support/cache/entry.rb
+++ b/activesupport/lib/active_support/cache/entry.rb
@@ -1,0 +1,115 @@
+# This class is used to represent cache entries. Cache entries have a value and an optional
+# expiration time. The expiration time is used to support the :race_condition_ttl option
+# on the cache.
+#
+# Since cache entries in most instances will be serialized, the internals of this class are highly optimized
+# using short instance variable names that are lazily defined.
+module ActiveSupport
+  module Cache
+    class Entry # :nodoc:
+      DEFAULT_COMPRESS_LIMIT = 16.kilobytes
+
+      MAX_OVERHEAD = 129
+      MIN_OVERHEAD = 85
+
+      # Max overhead bytes for a Marshal-serialized string.
+      MAX_STRING_OVERHEAD = 15
+
+      def self.new(*args)
+        entry = ASCE_5.allocate
+        entry.send(:initialize, *args)
+        entry
+      end
+
+      # Create a new cache entry for the specified value. Options supported are
+      # +:compress+, +:compress_threshold+, and +:expires_in+.
+      def initialize(value, options = {})
+        if should_compress?(value, options)
+          @value = compress(value)
+          @compressed = true
+        else
+          @value = value
+        end
+
+        @created_at = Time.now.to_f
+        @expires_in = options[:expires_in]
+        @expires_in = @expires_in.to_f if @expires_in
+      end
+
+      def value
+        compressed? ? uncompress(@value) : @value
+      end
+
+      # Check if the entry is expired. The +expires_in+ parameter can override
+      # the value set when the entry was created.
+      def expired?
+        @expires_in && @created_at + @expires_in <= Time.now.to_f
+      end
+
+      def expires_at
+        @expires_in ? @created_at + @expires_in : nil
+      end
+
+      def expires_at=(value)
+        if value
+          @expires_in = value.to_f - @created_at
+        else
+          @expires_in = nil
+        end
+      end
+
+      # Returns the size of the cached value. This could be less than
+      # <tt>value.size</tt> if the data is compressed.
+      def size
+        if defined?(@s)
+          @s
+        else
+          case value
+            when NilClass
+              0
+            when String
+              @value.bytesize + MAX_STRING_OVERHEAD
+            else
+              @s = Marshal.dump(@value).bytesize
+          end
+        end
+      end
+
+      # Duplicate the value in a class. This is used by cache implementations that don't natively
+      # serialize entries to protect against accidental cache modifications.
+      def dup_value!
+        if @value && !compressed? && !(@value.is_a?(Numeric) || @value == true || @value == false)
+          if @value.is_a?(String)
+            @value = @value.dup
+          else
+            @value = Marshal.load(Marshal.dump(@value))
+          end
+        end
+      end
+
+      private
+      def should_compress?(value, options)
+        if value && options[:compress]
+          compress_threshold = options[:compress_threshold] || DEFAULT_COMPRESS_LIMIT
+          serialized_value_size = (value.is_a?(String) ? value : Marshal.dump(value)).bytesize
+
+          return true if serialized_value_size >= compress_threshold
+        end
+
+        false
+      end
+
+      def compressed?
+        defined?(@compressed) ? @compressed : false
+      end
+
+      def compress(value)
+        Zlib::Deflate.deflate(Marshal.dump(value))
+      end
+
+      def uncompress(value)
+        Marshal.load(Zlib::Inflate.inflate(value))
+      end
+    end
+  end
+end

--- a/activesupport/lib/active_support/cache/entry/asce_5.rb
+++ b/activesupport/lib/active_support/cache/entry/asce_5.rb
@@ -1,0 +1,36 @@
+# Entry-object implementation for reduced serialization overhead.
+class ASCE_5 < ActiveSupport::Cache::Entry
+  MAX_OVERHEAD = 16
+  MIN_OVERHEAD = 12
+
+  def _dump(levels)
+    expires_at = @expires_in ? [@created_at.to_f + @expires_in].pack('L') : ''.b
+    expires_at << Marshal.dump(@value, levels)
+  end
+
+  def self._load(str)
+    self.allocate.send(:marshal_load, str)
+  end
+
+  private
+  MARSHAL_HEADER = [Marshal::MAJOR_VERSION, Marshal::MINOR_VERSION]
+  ZLIB_HEADER = [120, 156]
+
+  def marshal_load(str)
+    # Detect Marshal object based on header bytes
+    has_expires_at = str[0..1].unpack('C*') != MARSHAL_HEADER
+    if has_expires_at
+      expires_at = str.slice!(0,4).unpack('L').first
+      @created_at = [Time.now.to_f, expires_at - 1].min
+      @expires_in = expires_at - @created_at
+    else
+      @created_at = Time.now.to_f
+      @expires_in = nil
+    end
+    @value = Marshal.load(str)
+    @s = str.bytesize
+    # Detect Zlib-compressed value based on header bytes
+    @compressed = true if @value.is_a?(String) && @value[0..1].unpack('C*') == ZLIB_HEADER
+    self
+  end
+end

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -105,11 +105,9 @@ module ActiveSupport
       end
 
       protected
-
-        PER_ENTRY_OVERHEAD = 240
-
+        MARSHAL_OVERHEAD = Marshal.dump('').bytesize
         def cached_size(key, entry) # :nodoc:
-          key.to_s.bytesize + entry.size + PER_ENTRY_OVERHEAD
+          key.to_s.bytesize + entry.size + entry.class::MAX_OVERHEAD + MARSHAL_OVERHEAD
         end
 
         def read_entry(key, options) # :nodoc:


### PR DESCRIPTION
This PR subclasses the existing `ActiveSupport::Cache::Entry` class with several object-size optimizations:
- Use a shorter `ASCE_5` fully qualified class name (6 bytes) instead of `ActiveSupport::Cache::Entry` (27 bytes). (ASCE_5 is short for "ActiveSupport Cache Entry, version 5" - the particular short-name is open for discussion)
- Provide custom Marshal (de)serialization methods to pack the `Entry` instance variables (`@s`, `@compressed`, `@value`, `@expires_in`, `@created_at`) into a fixed-format bitstream, rather than relying on the default Marshal implementation (which adds the full names of all instance variables to the serialized representation).
- Merge `created_at` and `expires_in` into a single `expires_at` timestamp (`created_at` is only ever used in combination with `expires_in`, to calculate the expiration timestamp)
- (de-)serialize the `expires_at` timestamp as a 32-bit long rather than an arbitrarily-sized `numeric`.

Backwards compatibility with existing caches should be retained, since the `ActiveSupport::Cache::Entry` implementation is left (mostly) untouched. The only change is that `Entry#new` is overridden to allow newly-created cache entries to be (de-)serialized using the optimized `ASCE_5` implementation by default. Since `ASCE_5` provides the same interface as `Entry`, everything else can be left unchanged.

The actual byte-size overheads in the old and new implementation are both verified through unit tests, showing that the optimizations reduce per-object cache serialization overhead from **85-129** to **12-16** bytes.
