### PR TITLE
Remove `config.assets.version`

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -1264,9 +1264,6 @@ options.
 In `application.rb`:
 
 ```ruby
-# Version of your assets, change this if you want to expire all your assets
-config.assets.version = '1.0'
-
 # Change the path that assets are served from config.assets.prefix = "/assets"
 ```
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -30,7 +30,7 @@ Rails.application.configure do
   # yet still be able to expire them through the digest params.
   config.assets.digest = true
 
-  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+  # `config.assets.precompile` has moved to config/initializers/assets.rb
   <%- end -%>
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
@@ -1,8 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
-# Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
-
 # Add additional assets to the asset load path
 # Rails.application.config.assets.paths << Emoji.images_path
 


### PR DESCRIPTION
This pull request is an attempt to confirm whether this setting is obsolete or not, and to remove the obsolete code in Rails if it is in fact obsolete.

This removes `config.assets.version` from the generated `config/initializers/assets.rb` and a couple other places.

I can't figure out what this setting is supposed to do in the current version of Rails.  See also [this stackoverflow question](http://stackoverflow.com/questions/32548755/rails-4-2-rails-application-config-assets-version-doesnt-invalidate-digest-asse).

I've tried generating a brand new Rails app with Rails 4.2.5 and changing the `assets.version` doesn't seem to do anything for me as far as changing asset URLs. Looking through the sprockets source code it seems like perhaps this functionality [was removed](https://github.com/rails/sprockets/commit/07e5e29e2ec93c70c6783c4fc6f3c34f1a3442a8)?

Perhaps I misunderstand what this setting is supposed to do. Apologies for the distraction if so.
