### PR TITLE
Add missing require to strong_parameters.rb

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/string/filters'
 require 'active_support/rescuable'
 require 'action_dispatch/http/upload'
+require 'rack/test'
 require 'stringio'
 require 'set'
 


### PR DESCRIPTION
The file [references Rack::Test here](https://github.com/rails/rails/blame/master/actionpack/lib/action_controller/metal/strong_parameters.rb#L670) so it's better off requiring 'rack/test' in the first place.
