### PR TITLE
Remove old comment about AC::Parameters>subclasses

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -432,6 +432,13 @@
 
     *Wojciech Wnętrzak*
 
+*   Instantiating an AR model with `ActionController::Parameters` now raises
+    an `ActiveModel::ForbiddenAttributesError` if the parameters include a
+    `type` field that has not been explicitly permitted. Previously, the
+    `type` field was simply ignored in the same situation.
+
+    *Prem Sichanugrist*
+
 *   PostgreSQL, `create_schema`, `drop_schema` and `rename_table` now quote
     schema names.
 

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -195,8 +195,6 @@ module ActiveRecord
 
       # Detect the subclass from the inheritance column of attrs. If the inheritance column value
       # is not self or a valid subclass, raises ActiveRecord::SubclassNotFound
-      # If this is a StrongParameters hash, and access to inheritance_column is not permitted,
-      # this will ignore the inheritance column and return nil
       def subclass_from_attributes(attrs)
         attrs = attrs.to_h if attrs.respond_to?(:permitted?)
         if attrs.is_a?(Hash)


### PR DESCRIPTION
[ci skip]

Q: What happens if you initialize an AR model by passing Parameters that
have not been whitelisted with `permit`?

A: An `ActiveModel::ForbiddenAttributesError` is raised.

I think this behavior is correct, and it's better than what used to happen,
with unpermitted parameter being simply ignored.
