### PR TITLE
Replace ActionMailer::Base.respond_to? with respond_to_missing?

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -541,8 +541,8 @@ module ActionMailer
         end
       end
 
-      def respond_to?(method, include_private = false) #:nodoc:
-        super || action_methods.include?(method.to_s)
+      def respond_to_missing?(method, include_private = false) #:nodoc:
+        action_methods.include?(method.to_s)
       end
 
     protected

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -541,10 +541,6 @@ module ActionMailer
         end
       end
 
-      def respond_to_missing?(method, include_private = false) #:nodoc:
-        action_methods.include?(method.to_s)
-      end
-
     protected
 
       def set_payload_for_mail(payload, mail) #:nodoc:
@@ -565,6 +561,12 @@ module ActionMailer
         else
           super
         end
+      end
+
+    private
+
+      def respond_to_missing?(method, include_all = false) #:nodoc:
+        action_methods.include?(method.to_s)
       end
     end
 


### PR DESCRIPTION
This simple refactor utilizes the `respond_to_missing?` hook introduced in Ruby 1.9
