### PR TITLE
Fix - Aliasing works after including Module

### DIFF
--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -50,7 +50,7 @@ module ActionDispatch
       end
 
       module Response
-        attr_reader :cache_control
+        attr_accessor :cache_control
 
         def last_modified
           if last = get_header(LAST_MODIFIED)

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -78,12 +78,12 @@ module ActionDispatch # :nodoc:
     cattr_accessor(:default_headers)
 
     include Rack::Response::Helpers
+    include ActionDispatch::Http::Cache::Response
     # Aliasing these off because AD::Http::Cache::Response defines them
     alias :_cache_control :cache_control
     alias :_cache_control= :cache_control=
 
     include ActionDispatch::Http::FilterRedirect
-    include ActionDispatch::Http::Cache::Response
     include MonitorMixin
 
     class Buffer # :nodoc:


### PR DESCRIPTION
1. adding attr_accessor for :cache_control
2. Including `ActionDispatch::Http::Cache::Response` before aliasing `cache_control`

cc: @tenderlove 

I created a new rails project (using Rails master) with ruby 2.2.2. When I started rails console/server i got following error:

``` sh
/Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/actionpack/lib/action_dispatch/http/response.rb:82:in `<class:Response>': undefined method `cache_control' for class `ActionDispatch::Response' (NameError)
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/actionpack/lib/action_dispatch/http/response.rb:34:in `<module:ActionDispatch>'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/actionpack/lib/action_dispatch/http/response.rb:5:in `<top (required)>'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/actionpack/lib/action_controller/metal/live.rb:1:in `require'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/actionpack/lib/action_controller/metal/live.rb:1:in `<top (required)>'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/actionpack/lib/action_controller.rb:4:in `require'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/actionpack/lib/action_controller.rb:4:in `<top (required)>'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/actionpack/lib/action_controller/railtie.rb:2:in `require'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/actionpack/lib/action_controller/railtie.rb:2:in `<top (required)>'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/activerecord/lib/active_record/railtie.rb:9:in `require'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/activerecord/lib/active_record/railtie.rb:9:in `<top (required)>'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/railties/lib/rails/all.rb:13:in `require'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/railties/lib/rails/all.rb:13:in `block in <top (required)>'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/railties/lib/rails/all.rb:11:in `each'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/railties/lib/rails/all.rb:11:in `<top (required)>'
    from /Volumes/Mr_A/VINSOL/Pariyojnayein/practice/hehe/config/application.rb:3:in `require'
    from /Volumes/Mr_A/VINSOL/Pariyojnayein/practice/hehe/config/application.rb:3:in `<top (required)>'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/railties/lib/rails/commands/commands_tasks.rb:146:in `require'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/railties/lib/rails/commands/commands_tasks.rb:146:in `require_application_and_environment!'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/railties/lib/rails/commands/commands_tasks.rb:68:in `console'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/railties/lib/rails/commands/commands_tasks.rb:40:in `run_command!'
    from /Users/akshayvishnoi/.rvm/gems/ruby-2.2.2/bundler/gems/rails-8bdbf88dfd23/railties/lib/rails/commands.rb:18:in `<top (required)>'
    from bin/rails:4:in `require'
    from bin/rails:4:in `<main>'
```
