### PR TITLE
Pass group values when including association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Pass SQL group by values when including scoped association
+
+    Fixes problem when added `group()` in association scope was lost
+    in eager loaded association.
+
+    *Lucjan Suski*
+
 *   Version the API presented to migration classes, so we can change parameter
     defaults without breaking existing migrations, or forcing them to be
     rewritten through a deprecation cycle.

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -107,7 +107,7 @@ module ActiveRecord
           @preloaded_records = slices.flat_map do |slice|
             records_for(slice)
           end
-          @preloaded_records.group_by do |record| 
+          @preloaded_records.group_by do |record|
             convert_key(record[association_key_name])
           end
         end
@@ -137,6 +137,10 @@ module ActiveRecord
 
           if order_values = preload_values[:order] || values[:order]
             scope.order!(order_values)
+          end
+
+          if group_values = preload_values[:group] || values[:group]
+            scope.group!(group_values)
           end
 
           if preload_values[:reordering] || values[:reordering]


### PR DESCRIPTION
This P/R fixes problem when you wanted to `.includes` association with `group` clause, which got stripped down.

The test case fails only for `postgresql` adapter.
