### PR TITLE
Fix the Railties tests

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -182,11 +182,7 @@ module Rails
 
       private
         def file_update_checker
-          if defined?(Listen) && Listen::Adapter.select() != Listen::Adapter::Polling
-            ActiveSupport::FileEventedUpdateChecker
-          else
-            ActiveSupport::FileUpdateChecker
-          end
+          ActiveSupport::FileUpdateChecker
         end
 
         class Custom #:nodoc:

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -61,7 +61,7 @@ module ApplicationTests
       test 'db:create failure because database exists' do
         with_database_existing do
           output = `bin/rake db:create 2>&1`
-          assert_match /already exists/, output
+          assert_match(/already exists/, output)
           assert_equal 0, $?.exitstatus
         end
       end
@@ -78,7 +78,7 @@ module ApplicationTests
       test 'db:create failure because bad permissions' do
         with_bad_permissions do
           output = `bin/rake db:create 2>&1`
-          assert_match /Couldn't create database/, output
+          assert_match(/Couldn't create database/, output)
           assert_equal 1, $?.exitstatus
         end
       end
@@ -86,7 +86,7 @@ module ApplicationTests
       test 'db:drop failure because database does not exist' do
         Dir.chdir(app_path) do
           output = `bin/rake db:drop 2>&1`
-          assert_match /does not exist/, output
+          assert_match(/does not exist/, output)
           assert_equal 0, $?.exitstatus
         end
       end
@@ -95,7 +95,7 @@ module ApplicationTests
         with_database_existing do
           with_bad_permissions do
             output = `bin/rake db:drop 2>&1`
-            assert_match /Couldn't drop/, output
+            assert_match(/Couldn't drop/, output)
             assert_equal 1, $?.exitstatus
           end
         end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -387,7 +387,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "bukkits.gemspec", /s.name\s+= "bukkits"/
     assert_file "bukkits.gemspec", /s.files = Dir\["\{app,config,db,lib\}\/\*\*\/\*", "MIT-LICENSE", "Rakefile", "README\.rdoc"\]/
-    assert_file "bukkits.gemspec", /s.test_files = Dir\["test\/\*\*\/\*"\]/
     assert_file "bukkits.gemspec", /s.version\s+ = Bukkits::VERSION/
   end
 
@@ -461,9 +460,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   def test_skipping_test_files
     run_generator [destination_root, "--skip-test"]
     assert_no_file "test"
-    assert_file "bukkits.gemspec" do |contents|
-      assert_no_match(/s.test_files = Dir\["test\/\*\*\/\*"\]/, contents)
-    end
     assert_file '.gitignore' do |contents|
       assert_no_match(/test\dummy/, contents)
     end

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -70,7 +70,7 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
     create_test_file 'post', pass: false
 
     output = run_test_command('test/post_test.rb')
-    assert_match %r{Running:\n\nPostTest\nF\n\nwups!\n\nbin/test #{plugin_path}/test/post_test.rb:6}, output
+    assert_match %r{Running:\n\nPostTest\nF\n\nwups!\n\nbin/test (/private)?#{plugin_path}/test/post_test.rb:6}, output
   end
 
   def test_only_inline_failure_output


### PR DESCRIPTION
Since 5a0e0e72995472e315738dcea5b5a12d6e3d3489, the railties tests were not reported was failed in cases of failures. We end up committing a lot of broken things to master. [Now that we reverted the offending commit](https://github.com/rails/rails/pull/22471) we can see the failures and fix them.

This PR updates some tests to match the new code.

It also revert the usage of `FileEventedUpdateChecker` by default since our tests need to be changed to match this new behavior. Since having broken master is preventing us to merge code I'm just reverting the change instead of updating the tests that may take some time.

After the build is green again I'll disable the branch protection.

cc @fxn @matthewd @tenderlove 

Closes #22488.
