### PR TITLE
Hook to allow custom behavior before raising uninitialized constant error

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,10 +1,14 @@
-*   `ActiveSupport::Cache::Store#namespaced_key`, 
-    `ActiveSupport::Cache::MemCachedStore#escape_key`, and 
-    `ActiveSupport::Cache::FileStore#key_file_path` 
+*   Added a before_raise_uninitialized_constant hook
+
+    *Chris Moody*
+
+*   `ActiveSupport::Cache::Store#namespaced_key`,
+    `ActiveSupport::Cache::MemCachedStore#escape_key`, and
+    `ActiveSupport::Cache::FileStore#key_file_path`
     are deprecated and replaced with `normalize_key` that now calls `super`.
-    
+
     `ActiveSupport::Cache::LocaleCache#set_cache_value` is deprecated and replaced with `write_cache_value`.
-    
+
     *Michael Grosser*
 
 *   Implements an evented file system monitor to asynchronously detect changes

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -564,9 +564,14 @@ module ActiveSupport #:nodoc:
         end
       end
 
+      return if before_raise_uninitialized_constant(qualified_name)
       name_error = NameError.new("uninitialized constant #{qualified_name}", const_name)
       name_error.set_backtrace(caller.reject {|l| l.starts_with? __FILE__ })
       raise name_error
+    end
+    def before_raise_uninitialized_constant(qualified_name)
+      #Hook for custom logic for loading classes
+      #Method should return true to avoid raising errors
     end
 
     # Remove the constants that have been autoloaded, and those that have been

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -564,7 +564,9 @@ module ActiveSupport #:nodoc:
         end
       end
 
-      return if before_raise_uninitialized_constant(qualified_name)
+      activated_name = before_raise_uninitialized_constant(qualified_name)
+      return  activated_name if activated_name.present?
+
       name_error = NameError.new("uninitialized constant #{qualified_name}", const_name)
       name_error.set_backtrace(caller.reject {|l| l.starts_with? __FILE__ })
       raise name_error
@@ -572,6 +574,7 @@ module ActiveSupport #:nodoc:
     def before_raise_uninitialized_constant(qualified_name)
       #Hook for custom logic for loading classes
       #Method should return true to avoid raising errors
+      return false
     end
 
     # Remove the constants that have been autoloaded, and those that have been


### PR DESCRIPTION
Fixed issue where constant name needs to be returned from hook.
