### PR TITLE
Add method to print a duration in words

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -180,6 +180,21 @@ module ActionView
 
       alias_method :distance_of_time_in_words_to_now, :time_ago_in_words
 
+      # Reports an ActiveSupport::Duration in words.
+      #
+      #   duration_in_words(3.minutes)                    # => 3 minutes
+      #   duration_in_words(15.hours)                     # => about 15 hours
+      #   duration_in_words(1.second)                     # => less than a minute
+      #   duration_in_words(1.year - 10.days - 5.hours)   # => 12 months
+      #
+      # Note that you have to pass an ActiveSupport::Duration
+      #
+      def duration_in_words(duration, options = {})
+        distance_of_time_in_words(duration.ago, Time.now, options)
+      end
+
+      alias_method :duration_of_time_in_words, :duration_in_words
+
       # Returns a set of select tags (one for year, month, and day) pre-selected for accessing a specified date-based
       # attribute (identified by +method+) on an object assigned to the template (identified by +object+).
       #

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -195,6 +195,13 @@ class DateHelperTest < ActionView::TestCase
     assert_equal "about 1 year", time_ago_in_words(1.year.ago - 1.day)
   end
 
+  def test_duration_in_words
+    assert_equal "3 minutes", duration_in_words(3.minutes)
+    assert_equal "about 15 hours", duration_in_words(15.hours)
+    assert_equal "less than a minute", duration_in_words(1.second)
+    assert_equal "12 months", duration_in_words(1.year - 10.days - 5.hours)
+  end
+
   def test_select_day
     expected = %(<select id="date_day" name="date[day]">\n)
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)


### PR DESCRIPTION
I think a method to print a duration in words is really useful.
Because if you calculate 2 Time objects with each other, a duration will come out, and at the moment there's no function to print a duration in words.

Example:

You have a start and an end date of a ticket.
To calculate how long the ticket was "open" you have to do this:
`end_time` - `start_time`

And to print that duration calculated above, you'd have to write your own helper or hack a little bit with `time_ago_in_words`.
So why not add a `duration_in_words` function?
