### PR TITLE
Improve how modules are included

### DIFF
--- a/actionpack/lib/action_controller/api.rb
+++ b/actionpack/lib/action_controller/api.rb
@@ -137,9 +137,7 @@ module ActionController
       ParamsWrapper
     ]
 
-    MODULES.each do |mod|
-      include mod
-    end
+    include *MODULES
 
     ActiveSupport.run_load_hooks(:action_controller, self)
   end

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -245,9 +245,7 @@ module ActionController
       ParamsWrapper
     ]
 
-    MODULES.each do |mod|
-      include mod
-    end
+    include *MODULES
     setup_renderer!
 
     # Define some internal variables that should not be propagated to the view.


### PR DESCRIPTION
`include` method accepts multiple arguments.
