### PR TITLE
remove warning from postgresql geometric test

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -262,7 +262,9 @@ class PostgreSQLGeometricLineTest < ActiveRecord::PostgreSQLTestCase
   end
 
   teardown do
-    @connection.drop_table 'postgresql_lines', if_exists: true
+    if defined?(@connection)
+      @connection.drop_table 'postgresql_lines', if_exists: true
+    end
   end
 
   def test_geometric_line_type


### PR DESCRIPTION
This removes the following warning which has been out in the case of a PostgreSQL 9.3 below.

```
activerecord/test/cases/adapters/postgresql/geometric_test.rb:265: warning: instance variable @connection not initialized
```
