### PR TITLE
Remove unused deprecation notice

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -296,14 +296,6 @@ db_namespace = namespace :db do
   end
 
   namespace :test do
-
-    task :deprecated do
-      Rake.application.top_level_tasks.grep(/^db:test:/).each do |task|
-        $stderr.puts "WARNING: #{task} is deprecated. The Rails test helper now maintains " \
-                     "your test schema automatically, see the release notes for details."
-      end
-    end
-
     # desc "Recreate the test database from the current schema"
     task :load => %w(db:test:purge) do
       case ActiveRecord::Base.schema_format


### PR DESCRIPTION
The `rake db:test:*` tasks were deprecated in #13528, but were
undeprecated and added back in via #17739.
