### PR TITLE
Add `redirect_back` and deprecate `redirect_to :back`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `redirect_back` method to `ActionController::Redirecting` to provide a
+    way to safely redirect to the `HTTP_REFERER` if it is present, falling back
+    to a provided redirect otherwise.
+
+    *Derek Prior*
+
 *   `ActionController::TestCase` will be moved to it's own gem in Rails 5.1
 
     With the speed improvements made to `ActionDispatch::IntegrationTest` we no

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate `redirect_to :back` in favor of `redirect_back`, which accepts a
+    required `fallback_location` argument, thus eliminating the possibility of a
+    `RedirectBackError`.
+
+    *Derek Prior*
+
 *   Add `redirect_back` method to `ActionController::Redirecting` to provide a
     way to safely redirect to the `HTTP_REFERER` if it is present, falling back
     to a provided redirect otherwise.

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -75,6 +75,29 @@ module ActionController
       self.response_body = "<html><body>You are being <a href=\"#{ERB::Util.unwrapped_html_escape(location)}\">redirected</a>.</body></html>"
     end
 
+    # Redirects the browser to the page that issued the request if possible,
+    # otherwise redirects to provided default fallback location.
+    #
+    # This avoids the <tt>ActionController::RedirectBackError</tt> that can
+    # occur if the request has no associated <tt>HTTP_REFERER</tt>.
+    #
+    #   redirect_back fallback_location: { action: "show", id: 5 }
+    #   redirect_back fallback_location: post
+    #   redirect_back fallback_location: "http://www.rubyonrails.org"
+    #   redirect_back fallback_location:  "/images/screenshot.jpg"
+    #   redirect_back fallback_location:  articles_url
+    #   redirect_back fallback_location:  proc { edit_post_url(@post) }
+    #
+    # All options that can be passed to <tt>redirect_to</tt> are accepted as
+    # options and the behavior is indetical.
+    def redirect_back(fallback_location:, **args)
+      if referer = request.headers["Referer"]
+        redirect_to referer, **args
+      else
+        redirect_to fallback_location, **args
+      end
+    end
+
     def _compute_redirect_to_location(request, options) #:nodoc:
       case options
       # The scheme name consist of a letter followed by any combination of

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -20,8 +20,6 @@ module ActionController
     # * <tt>String</tt> starting with <tt>protocol://</tt> (like <tt>http://</tt>) or a protocol relative reference (like <tt>//</tt>) - Is passed straight through as the target for redirection.
     # * <tt>String</tt> not containing a protocol - The current protocol and host is prepended to the string.
     # * <tt>Proc</tt> - A block that will be executed in the controller's context. Should return any option accepted by +redirect_to+.
-    # * <tt>:back</tt> - Back to the page that issued the request. Useful for forms that are triggered from multiple places.
-    #   Short-hand for <tt>redirect_to(request.env["HTTP_REFERER"])</tt>
     #
     # === Examples:
     #
@@ -30,7 +28,6 @@ module ActionController
     #   redirect_to "http://www.rubyonrails.org"
     #   redirect_to "/images/screenshot.jpg"
     #   redirect_to articles_url
-    #   redirect_to :back
     #   redirect_to proc { edit_post_url(@post) }
     #
     # The redirection happens as a "302 Found" header unless otherwise specified using the <tt>:status</tt> option:
@@ -61,10 +58,6 @@ module ActionController
     #   redirect_to post_url(@post), status: 301, flash: { updated_post_id: @post.id }
     #   redirect_to({ action: 'atom' }, alert: "Something serious happened")
     #
-    # When using <tt>redirect_to :back</tt>, if there is no referrer,
-    # <tt>ActionController::RedirectBackError</tt> will be raised. You
-    # may specify some fallback behavior for this case by rescuing
-    # <tt>ActionController::RedirectBackError</tt>.
     def redirect_to(options = {}, response_status = {}) #:doc:
       raise ActionControllerError.new("Cannot redirect to nil!") unless options
       raise ActionControllerError.new("Cannot redirect to a parameter hash!") if options.is_a?(ActionController::Parameters)
@@ -77,9 +70,6 @@ module ActionController
 
     # Redirects the browser to the page that issued the request if possible,
     # otherwise redirects to provided default fallback location.
-    #
-    # This avoids the <tt>ActionController::RedirectBackError</tt> that can
-    # occur if the request has no associated <tt>HTTP_REFERER</tt>.
     #
     #   redirect_back fallback_location: { action: "show", id: 5 }
     #   redirect_back fallback_location: post
@@ -110,6 +100,12 @@ module ActionController
       when String
         request.protocol + request.host_with_port + options
       when :back
+        ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)
+          `redirect_to :back` is deprecated and will be removed from Rails 5.1.
+          Please use `redirect_back(fallback_location: fallback_location)` where
+          `fallback_location` represents the location to use if the request has
+          no HTTP referer information.
+        MESSAGE
         request.headers["Referer"] or raise RedirectBackError
       when Proc
         _compute_redirect_to_location request, options.call

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -191,7 +191,11 @@ class RedirectTest < ActionController::TestCase
 
   def test_redirect_to_back_with_status
     @request.env["HTTP_REFERER"] = "http://www.example.com/coming/from"
-    get :redirect_to_back_with_status
+
+    assert_deprecated do
+      get :redirect_to_back_with_status
+    end
+
     assert_response 307
     assert_equal "http://www.example.com/coming/from", redirect_to_url
   end
@@ -240,7 +244,11 @@ class RedirectTest < ActionController::TestCase
 
   def test_redirect_to_back
     @request.env["HTTP_REFERER"] = "http://www.example.com/coming/from"
-    get :redirect_to_back
+
+    assert_deprecated do
+      get :redirect_to_back
+    end
+
     assert_response :redirect
     assert_equal "http://www.example.com/coming/from", redirect_to_url
   end
@@ -248,6 +256,11 @@ class RedirectTest < ActionController::TestCase
   def test_redirect_to_back_with_no_referer
     assert_raise(ActionController::RedirectBackError) {
       @request.env["HTTP_REFERER"] = nil
+
+      assert_deprecated do
+        get :redirect_to_back
+      end
+
       get :redirect_to_back
     }
   end

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -42,6 +42,10 @@ class RedirectController < ActionController::Base
     redirect_to :back, :status => 307
   end
 
+  def redirect_back_with_status
+    redirect_back(fallback_location: "/things/stuff", status: 307)
+  end
+
   def host_redirect
     redirect_to :action => "other_host", :only_path => false, :host => 'other.test.host'
   end
@@ -246,6 +250,23 @@ class RedirectTest < ActionController::TestCase
       @request.env["HTTP_REFERER"] = nil
       get :redirect_to_back
     }
+  end
+
+  def test_redirect_back
+    referer = "http://www.example.com/coming/from"
+    @request.env["HTTP_REFERER"] = referer
+
+    get :redirect_back_with_status
+
+    assert_response 307
+    assert_equal referer, redirect_to_url
+  end
+
+  def test_redirect_back_with_no_referer
+    get :redirect_back_with_status
+
+    assert_response 307
+    assert_equal "http://test.host/things/stuff", redirect_to_url
   end
 
   def test_redirect_to_record

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1150,7 +1150,7 @@ class ApplicationController < ActionController::Base
 
     def user_not_authorized
       flash[:error] = "You don't have access to this section."
-      redirect_to :back
+      redirect_back(fallback_location: root_path)
     end
 end
 

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -628,6 +628,14 @@ You can use `redirect_to` with any arguments that you could use with `link_to` o
 redirect_to :back
 ```
 
+This will raise `ActionController::RedirectBackError` if the request had no
+`HTTP_REFERER` information set. To guard against this case, you can provide a
+fall back redirect URL by using `redirect_back`:
+
+```ruby
+redirect_back(fallback_location: root_path)
+```
+
 #### Getting a Different Redirect Status Code
 
 Rails uses HTTP status code 302, a temporary redirect, when you call `redirect_to`. If you'd like to use a different status code, perhaps 301, a permanent redirect, you can use the `:status` option:

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -622,15 +622,10 @@ Another way to handle returning responses to an HTTP request is with `redirect_t
 redirect_to photos_url
 ```
 
-You can use `redirect_to` with any arguments that you could use with `link_to` or `url_for`. There's also a special redirect that sends the user back to the page they just came from:
-
-```ruby
-redirect_to :back
-```
-
-This will raise `ActionController::RedirectBackError` if the request had no
-`HTTP_REFERER` information set. To guard against this case, you can provide a
-fall back redirect URL by using `redirect_back`:
+You can use `redirect_back` to return the user to the page they just came from.
+This location is pulled from the `HTTP_REFERER` header which is not guaranteed
+to be set by the browser, so you must provide the `fallback_location`
+to use in this case.
 
 ```ruby
 redirect_back(fallback_location: root_path)


### PR DESCRIPTION
`redirect_to :back` is a somewhat common pattern in Rails apps, but it
is not completely safe. There are a number of circumstances where HTTP
referrer information is not available on the request. This happens often
with bot traffic and occasionally to user traffic depending on browser
security settings.

When there is no referrer available on the request, `redirect_to :back`
will raise `ActionController::RedirectBackError`, usually resulting in
an application error.

`redirect_to_back_or_default` is a helper I have added to many rails
applications to avoid this situation and now I'm proposing it be added
to Rails proper and encouraged in place of `redirect_to :back`.
