### PR TITLE
remove `request_forgery_protection` initializer from rails api

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -303,6 +303,7 @@ module Rails
         if options[:api]
           remove_file 'config/initializers/session_store.rb'
           remove_file 'config/initializers/cookies_serializer.rb'
+          remove_file 'config/initializers/request_forgery_protection.rb'
         end
       end
 

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -89,6 +89,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
        config/initializers/assets.rb
        config/initializers/cookies_serializer.rb
        config/initializers/session_store.rb
+       config/initializers/request_forgery_protection.rb
        lib/assets
        vendor/assets
        test/helpers


### PR DESCRIPTION
In rails api, since default is so as not to use the `protect_from_forgery`,
`request_forgery_protection` initializer I think that's unnecessary
