### PR TITLE
Show redirect response code in assert_response messages

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -85,17 +85,15 @@ module ActionDispatch
           end
         end
 
-        def generate_response_message(type)
-          message = "Expected response to be a <#{type}>, but was"
+        def generate_response_message(type, code = @response.response_code)
+          "Expected response to be a <#{type}>, but was a <#{code}>"
+          .concat location_if_redirected
+        end
 
-          if @response.redirection?
-            redirect_is = normalize_argument_to_redirection(@response.location)
-            message << " a redirect to <#{redirect_is}>"
-          else
-            message << " <#{@response.response_code}>"
-          end
-
-          message
+        def location_if_redirected
+          return '' unless @response.redirection? && @response.location.present?
+          location = normalize_argument_to_redirection(@response.location)
+          " redirect to <#{location}>"
         end
     end
   end

--- a/actionpack/test/assertions/response_assertions_test.rb
+++ b/actionpack/test/assertions/response_assertions_test.rb
@@ -64,14 +64,35 @@ module ActionDispatch
         }
       end
 
-      def test_message_when_response_is_redirect_but_asserted_for_status_other_than_redirect
-        @response = FakeResponse.new :redirection, "http://test.host/posts/redirect/1"
-        error = assert_raises(Minitest::Assertion) do
-          assert_response :success
-        end
+      def test_error_message_shows_404_when_404_asserted_for_success
+        @response = ActionDispatch::Response.new
+        @response.status = 404
 
-        expected = "Expected response to be a <success>, but was a redirect to <http://test.host/posts/redirect/1>"
-        assert_equal expected, error.message
+        error = assert_raises(Minitest::Assertion) { assert_response :success }
+        expected = "Expected response to be a <success>, but was a <404>"
+        assert_match expected, error.message
+      end
+
+      def test_error_message_shows_302_redirect_when_302_asserted_for_success
+        @response = ActionDispatch::Response.new
+        @response.status = 302
+        @response.location = 'http://test.host/posts/redirect/1'
+
+        error = assert_raises(Minitest::Assertion) { assert_response :success }
+        expected = "Expected response to be a <success>, but was a <302>" \
+                   " redirect to <http://test.host/posts/redirect/1>"
+        assert_match expected, error.message
+      end
+
+      def test_error_message_shows_302_redirect_when_302_asserted_for_301
+        @response = ActionDispatch::Response.new
+        @response.status = 302
+        @response.location = 'http://test.host/posts/redirect/2'
+
+        error = assert_raises(Minitest::Assertion) { assert_response 301 }
+        expected = "Expected response to be a <301>, but was a <302>" \
+                   " redirect to <http://test.host/posts/redirect/2>"
+        assert_match expected, error.message
       end
     end
   end


### PR DESCRIPTION
Follow-up to PR #19977, which added the redirection path to the error
message of assert_response if response is :redirect, but which stopped
showing the 302 status code.

This PR brings back showing the 302 to make it clearer, and simplifies
the code somewhat.
