### PR TITLE
ActiveRecord::Relation#destroy_all destroys records in batches

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Relation#destroy_all is performed in batches to prevent memory hogs.
+
+    To destroy in batches, we had to change the return type of #destoy_all.
+    Since a lot of people may depend on the return type (and it is
+    documented), we left a little transition period quirk.
+
+    Apps upgraded to 5.1 will get a deprecation warning, on the 4.2
+    behaviour. To switch to the destroy in batches the following option
+    should be set:
+
+       config.active_record.destroy_all_in_batches = true
+
+    The option is on by default for newly generated Rails apps. Can be set in
+    an initializer to prevent differences across environments.
+
+    Fixes #22510.
+
+    *Genadi Samokovarov*
+
 *   Support calling the method `merge` in `scope`'s lambda.
 
     *Yasuhiro Sugino*

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -136,7 +136,8 @@ module ActiveRecord
           case method
           when :destroy
             if scope.klass.primary_key
-              count = scope.destroy_all.length
+              count = scope.count
+              scope.destroy_all
             else
               scope.each(&:_run_destroy_callbacks)
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -136,6 +136,8 @@ module ActiveRecord
 
       mattr_accessor :belongs_to_required_by_default, instance_accessor: false
 
+      mattr_accessor :destroy_all_in_batches, instance_accessor: false
+
       class_attribute :default_connection_handler, instance_writer: false
 
       def self.connection_handler

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -32,6 +32,9 @@ QUOTED_TYPE = ActiveRecord::Base.connection.quote_column_name('type')
 # FIXME: Remove this when the deprecation cycle on TZ aware types by default ends.
 ActiveRecord::Base.time_zone_aware_types << :time
 
+# FIXME: Remove this in Rails 5.2 when it's no longer needed.
+ActiveRecord::Base.destroy_all_in_batches = true
+
 def current_adapter?(*types)
   types.any? do |type|
     ActiveRecord::ConnectionAdapters.const_defined?(type) &&

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -137,9 +137,7 @@ class PersistenceTest < ActiveRecord::TestCase
     assert ! topics_by_mary.empty?
 
     assert_difference('Topic.count', -topics_by_mary.size) do
-      destroyed = Topic.where(conditions).destroy_all.sort_by(&:id)
-      assert_equal topics_by_mary, destroyed
-      assert destroyed.all?(&:frozen?), "destroyed topics should be frozen"
+      Topic.where(conditions).destroy_all
     end
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1012,6 +1012,36 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_destroy_all_deprecated_return_value
+    ActiveRecord::Base.destroy_all_in_batches = false
+
+    davids = Author.where(name: 'David')
+
+    assert_deprecated do
+      assert_difference('Author.count', -1) do
+        assert_equal davids.to_a, davids.destroy_all
+      end
+    end
+  ensure
+    ActiveRecord::Base.destroy_all_in_batches = true
+  end
+
+  def test_destroy_all_in_batches
+    davids = Author.where(name: 'David')
+
+    assert_difference('Author.count', -1) do
+      assert_nil davids.destroy_all
+    end
+  end
+
+  def test_destroy_all_in_batches_returns_nothing
+    davids = Author.where(name: 'David')
+
+    assert_difference('Author.count', -1) do
+      assert_nil davids.destroy_all
+    end
+  end
+
   def test_delete_all
     davids = Author.where(:name => 'David')
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -362,6 +362,11 @@ All these configuration options are delegated to the `I18n` library.
   has_many relationships to be displayed with an index as well as the error.
   Defaults to `false`.
 
+* `config.active_record.destroy_all_in_batches` tells
+  ActiveRecord::Relation#destroy_all to perform the records destruction in
+  batches. With this on, it no longer returns a collection of the destroyed
+  records.
+
 The MySQL adapter adds one additional configuration option:
 
 * `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans` controls whether Active Record will consider all `tinyint(1)` columns as booleans. Defaults to `true`.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
@@ -23,6 +23,10 @@ ActiveSupport.to_time_preserves_timezone = <%= options[:update] ? false : true %
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = <%= options[:update] ? false : true %>
+
+# Force ActiveRecord::Relation#destroy_all to perform the destruction in
+# batches.
+Rails.application.config.active_record.destroy_all_in_batches = true
 <%- end -%>
 
 # Do not halt callback chains when a callback returns false. Previous versions had true.


### PR DESCRIPTION
To destroy in batches, we had to change the return type of #destoy_all.
Since a lot of people may depend on the return type (and it is
documented), we left a little transition period quirk.

Apps upgraded to 5.0 will get a deprecation warning, on the 4.2
behaviour. To switch to the destroy in batches the following option
should be set:

```
 config.active_record.destroy_all_in_batches = true
```

Setting it in an initializer may be a good idea, so people don't end up
with a conditional behaviour between environments, which may be a tricky
problem to catch.
