### PR TITLE
Use assert over assert_predicate in assert_response

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -31,7 +31,7 @@ module ActionDispatch
 
         if Symbol === type
           if [:success, :missing, :redirect, :error].include?(type)
-            assert_predicate @response, RESPONSE_PREDICATES[type], message
+            assert @response.send(RESPONSE_PREDICATES[type]), message
           else
             code = Rack::Utils::SYMBOL_TO_STATUS_CODE[type]
             if code.nil?

--- a/actionpack/test/assertions/response_assertions_test.rb
+++ b/actionpack/test/assertions/response_assertions_test.rb
@@ -70,8 +70,8 @@ module ActionDispatch
           assert_response :success
         end
 
-        expected = "Expected response to be a <success>, but was a redirect to <http://test.host/posts/redirect/1>."
-        assert_match expected, error.message
+        expected = "Expected response to be a <success>, but was a redirect to <http://test.host/posts/redirect/1>"
+        assert_equal expected, error.message
       end
     end
   end


### PR DESCRIPTION
- `assert_predicate` appends its own error message at the end of message
  generated by `assert_response` and because of that the error message
  displays the whole `response` object.
- For eg.
  
  Expected response to be a <success>, but was a redirect to http://test.host/posts.
  Expected #ActionDispatch::TestResponse:0x007fb1cc1cf6f8....(lambda)}>> to be successful?.
- Complete message can be found here -
  https://gist.github.com/prathamesh-sonpatki/055afb74b66108e71ded#file-gistfile1-txt-L19.
- After this change the message from `assert_predicate` won't be
  displayed and only message generated by `assert_response` will be shown
  as follows:
  
  Expected response to be a <success>, but was a redirect to http://test.host/posts
