### PR TITLE
[ci skip] Add a dollar sign to each command in the READMEs

### DIFF
--- a/actionmailer/README.rdoc
+++ b/actionmailer/README.rdoc
@@ -146,7 +146,7 @@ The Base class has the full list of configuration options. Here's an example:
 
 The latest version of Action Mailer can be installed with RubyGems:
 
-  % gem install actionmailer
+  $ gem install actionmailer
 
 Source code can be downloaded as part of the Rails project on GitHub
 
@@ -173,4 +173,3 @@ Bug reports can be filed for the Ruby on Rails project here:
 Feature requests should be discussed on the rails-core mailing list here:
 
 * https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core
-

--- a/actionpack/README.rdoc
+++ b/actionpack/README.rdoc
@@ -28,7 +28,7 @@ can be used outside of Rails.
 
 The latest version of Action Pack can be installed with RubyGems:
 
-  % gem install actionpack
+  $ gem install actionpack
 
 Source code can be downloaded as part of the Rails project on GitHub
 
@@ -55,4 +55,3 @@ Bug reports can be filed for the Ruby on Rails project here:
 Feature requests should be discussed on the rails-core mailing list here:
 
 * https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core
-

--- a/actionview/README.rdoc
+++ b/actionview/README.rdoc
@@ -9,7 +9,7 @@ used to inline short Ruby snippets inside HTML), and XML Builder.
 
 The latest version of Action View can be installed with RubyGems:
 
-  % gem install actionview
+  $ gem install actionview
 
 Source code can be downloaded as part of the Rails project on GitHub
 
@@ -36,4 +36,3 @@ Bug reports can be filed for the Ruby on Rails project here:
 Feature requests should be discussed on the rails-core mailing list here:
 
 * https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core
-

--- a/activejob/README.md
+++ b/activejob/README.md
@@ -102,7 +102,7 @@ see the API Documentation for [ActiveJob::QueueAdapters](http://api.rubyonrails.
 The latest version of Active Job can be installed with RubyGems:
 
 ```
-  % gem install activejob
+  $ gem install activejob
 ```
 
 Source code can be downloaded as part of the Rails project on GitHub

--- a/activemodel/README.rdoc
+++ b/activemodel/README.rdoc
@@ -235,7 +235,7 @@ behavior out of the box:
 
 The latest version of Active Model can be installed with RubyGems:
 
-  % gem install activemodel
+  $ gem install activemodel
 
 Source code can be downloaded as part of the Rails project on GitHub
 
@@ -262,4 +262,3 @@ Bug reports can be filed for the Ruby on Rails project here:
 Feature requests should be discussed on the rails-core mailing list here:
 
 * https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core
-

--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -188,7 +188,7 @@ Admit the Database:
 
 The latest version of Active Record can be installed with RubyGems:
 
-  % gem install activerecord
+  $ gem install activerecord
 
 Source code can be downloaded as part of the Rails project on GitHub:
 
@@ -215,4 +215,3 @@ Bug reports can be filed for the Ruby on Rails project here:
 Feature requests should be discussed on the rails-core mailing list here:
 
 * https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core
-

--- a/activesupport/README.rdoc
+++ b/activesupport/README.rdoc
@@ -10,7 +10,7 @@ outside of Rails.
 
 The latest version of Active Support can be installed with RubyGems:
 
-  % gem install activesupport
+  $ gem install activesupport
 
 Source code can be downloaded as part of the Rails project on GitHub:
 
@@ -37,4 +37,3 @@ Bug reports can be filed for the Ruby on Rails project here:
 Feature requests should be discussed on the rails-core mailing list here:
 
 * https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core
-


### PR DESCRIPTION
According to https://github.com/rails/rails/pull/22443 in the guides there's always a dollar sign before every command, so why is in the main README a `$` and in every submodule a `%`?

Just eye candy..
