### PR TITLE
Add tests for ActionController::Renderers::use_renderers

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add tests and documentation for `ActionController::Renderers::use_renderers`.
+
+    *Benjamin Fleischer*
+
 *   Fix `ActionController::Parameters#convert_parameters_to_hashes` to return filtered
     or unfiltered values based on from where it is called, `to_h` or `to_unsafe_h`
     respectively.

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -26,6 +26,40 @@ module ActionController
     end
 
     module ClassMethods
+
+      # Adds, by name, a renderer or renderers to the +_renderers+ available
+      # to call within controller actions.
+      #
+      # It is useful when rendering from an <tt>ActionController::Metal</tt> controller or
+      # otherwise to add an available renderer proc to a specific controller.
+      #
+      # Both <tt>ActionController::Base</tt> and <tt>ActionController::API</tt>
+      # include <tt>ActionController::Renderers::All</tt>, making all renderers
+      # avaialable in the controller. See <tt>Renderers::RENDERERS</tt> and <tt>Renderers.add</tt>.
+      #
+      # Since <tt>ActionController::Metal</tt> controllers cannot render, the controller
+      # must include <tt>AbstractController::Rendering</tt>, <tt>ActionController::Rendering</tt>,
+      # and <tt>ActionController::Renderers</tt>, and have at lest one renderer.
+      #
+      # Rather than including <tt>ActionController::Renderers::All</tt> and including all renderers,
+      # you may specify which renderers to include by passing the renderer name or names to
+      # +use_renderers+. For example, a controller that includes only the <tt>:json</tt> renderer
+      # (+_render_with_renderer_json+) might look like:
+      #
+      #   class MetalRenderingController < ActionController::Metal
+      #     include AbstractController::Rendering
+      #     include ActionController::Rendering
+      #     include ActionController::Renderers
+      #
+      #     use_renderers :json
+      #
+      #     def show
+      #       render json: record
+      #     end
+      #   end
+      #
+      # You must specify a +use_renderer+, else the +controller.renderer+ and
+      # +controller._renderers+ will be <tt>nil</tt>, and the action will fail.
       def use_renderers(*args)
         renderers = _renderers + args
         self._renderers = renderers.freeze

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -371,6 +371,12 @@ module RoutingTestHelpers
   end
 end
 
+class MetalRenderingController < ActionController::Metal
+  include AbstractController::Rendering
+  include ActionController::Rendering
+  include ActionController::Renderers
+end
+
 class ResourcesController < ActionController::Base
   def index() head :ok end
   alias_method :show, :index

--- a/actionpack/test/controller/metal/renderers_test.rb
+++ b/actionpack/test/controller/metal/renderers_test.rb
@@ -1,0 +1,42 @@
+require 'abstract_unit'
+require 'active_support/core_ext/hash/conversions'
+
+class MetalRenderingJsonController < MetalRenderingController
+  class Model
+    def to_json(options = {})
+      { a: 'b' }.to_json(options)
+    end
+
+    def to_xml(options = {})
+      { a: 'b' }.to_xml(options)
+    end
+  end
+
+  use_renderers :json
+
+  def one
+    render json: Model.new
+  end
+
+  def two
+    render xml: Model.new
+  end
+end
+
+class RenderersMetalTest < ActionController::TestCase
+  tests MetalRenderingJsonController
+
+  def test_render_json
+    get :one
+    assert_response :success
+    assert_equal({ a: 'b' }.to_json, @response.body)
+    assert_equal 'application/json', @response.content_type
+  end
+
+  def test_render_xml
+    get :two
+    assert_response :success
+    assert_equal(" ", @response.body)
+    assert_equal 'text/plain', @response.content_type
+  end
+end


### PR DESCRIPTION
Adding tests per @rafaelfranca in https://github.com/rails/rails/pull/22416
- [x] test use_renderers in an ActionController::Metal subclass
- [ ] test `include ActionController::Renderers::All`
- [x] Document usage in guides
- [ ] Show with Mime::RespondsTo

`use_renderers` was introduced in 2009 without tests and
has not been tested since.

https://github.com/rails/rails/commit/f9d570bdd80010825c21eb32204471ba525915fa
https://github.com/rails/rails/commit/aed135d3e261cbee153a35fcfbeb47e2e02b12e4

I have found it used in the wild in [thoughtbot's copycopter](https://github.com/copycopter/copycopter-server/blob/d3607c4a032357d121148fee278cba44f87f41e9/app/controllers/api/v2/base_controller.rb#L8)

Most of the time, developers use controllers that include Renderers::All

Ref:
- https://github.com/rails/rails/pull/21496/
- https://github.com/rails/rails/pull/22416

Questions:
- Why wouldn't someone include Renderers::All?
- Please review if these tests are a reasonable representation of usage
