### PR TITLE
Add `before_dependent_destroy`

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -137,7 +137,11 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
     def self.add_destroy_callbacks(model, reflection)
       name = reflection.name
-      model.before_destroy lambda { |o| o.association(name).handle_dependency }
+      model.before_destroy(lambda do |o|
+        run_callbacks(:dependent_destroy) do
+          o.association(name).handle_dependency
+        end
+      end)
     end
   end
 end

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -213,7 +213,7 @@ module ActiveRecord
   # Let's look at the code below:
   #
   #   class Topic < ActiveRecord::Base
-  #     has_many :children, dependent: destroy
+  #     has_many :children, dependent: :destroy
   #
   #     before_destroy :log_children
   #
@@ -228,7 +228,7 @@ module ActiveRecord
   # You can use the +prepend+ option on the +before_destroy+ callback to avoid this.
   #
   #   class Topic < ActiveRecord::Base
-  #     has_many :children, dependent: destroy
+  #     has_many :children, dependent: :destroy
   #
   #     before_destroy :log_children, prepend: true
   #
@@ -239,6 +239,28 @@ module ActiveRecord
   #   end
   #
   # This way, the +before_destroy+ gets executed before the <tt>dependent: destroy</tt> is called, and the data is still available.
+  #
+  # Another alternative is to use +before_dependent_destroy+ callback instead. That frees the developer to hook into both
+  # +before_destroy+ and +before_dependent_destroy+ very clearly.
+  #
+  #   class Topic < ActiveRecord::Base
+  #     has_many :children, dependent: :destroy
+  #
+  #     before_dependent_destroy :log_children
+  #     before_destroy :enqueue_background_cleaner
+  #
+  #     private
+  #       def log_children
+  #         # Child processing
+  #       end
+  #
+  #       def enqueue_background_cleaner
+  #         # Enqueue background cleaner processing
+  #       end
+  #   end
+  #
+  # Note that +before_dependent_destroy+ runs regardless of the +dependent+ value, meaning it runs
+  # before +dependent: :delete_all+ and +dependent: :nullify+ as well.
   #
   # == \Transactions
   #
@@ -277,7 +299,7 @@ module ActiveRecord
       :after_initialize, :after_find, :after_touch, :before_validation, :after_validation,
       :before_save, :around_save, :after_save, :before_create, :around_create,
       :after_create, :before_update, :around_update, :after_update,
-      :before_destroy, :around_destroy, :after_destroy, :after_commit, :after_rollback
+      :before_dependent_destroy, :before_destroy, :around_destroy, :after_destroy, :after_commit, :after_rollback
     ]
 
     module ClassMethods # :nodoc:
@@ -288,7 +310,7 @@ module ActiveRecord
       include ActiveModel::Validations::Callbacks
 
       define_model_callbacks :initialize, :find, :touch, :only => :after
-      define_model_callbacks :save, :create, :update, :destroy
+      define_model_callbacks :save, :create, :update, :dependent_destroy, :destroy
     end
 
     def destroy #:nodoc:

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -78,6 +78,42 @@ class ImmutableDeveloper < ActiveRecord::Base
     end
 end
 
+class RelatedProject < ActiveRecord::Base
+  self.table_name = 'projects'
+end
+
+class RelatedDeveloper < ActiveRecord::Base
+  self.table_name = 'developers'
+end
+
+class RelatedDeveloperProject < ActiveRecord::Base
+  self.table_name = 'developers_projects'
+
+  belongs_to :developer, class_name: RelatedProject, foreign_key: 'developer_id'
+  belongs_to :project, class_name: RelatedDeveloper, foreign_key: 'project_id'
+end
+
+class RelatedProject < ActiveRecord::Base
+  has_many :developers_projects, class_name: RelatedDeveloperProject, foreign_key: 'project_id'
+  has_many :developers, class_name: RelatedDeveloper, through: :developers_projects
+end
+
+class RelatedDeveloper < ActiveRecord::Base
+  has_many :developers_projects, class_name: RelatedDeveloperProject, foreign_key: 'developer_id'
+  has_many :projects, class_name: RelatedProject, through: :developers_projects, dependent: :destroy
+
+  before_dependent_destroy :store_projects_in_memory
+
+  attr_reader :projects_in_memory
+
+  private
+    def store_projects_in_memory
+      @projects_in_memory = self.projects.map do |project|
+        RelatedProject.find_by_id(project.id)
+      end
+    end
+end
+
 class DeveloperWithCanceledCallbacks < ActiveRecord::Base
   self.table_name = 'developers'
 
@@ -174,6 +210,8 @@ end
 
 class CallbacksTest < ActiveRecord::TestCase
   fixtures :developers
+  fixtures :projects
+  fixtures :developers_projects
 
   def test_initialize
     david = CallbackDeveloper.new
@@ -467,6 +505,15 @@ class CallbacksTest < ActiveRecord::TestCase
       assert !someone.save
     end
     assert_save_callbacks_not_called(someone)
+  end
+
+  #TODO handle delete_all and nullify as well. Also, handle around hook
+  def test_before_dependent_destroy_happens_before_dependent_destroy_regardless_of_order
+    andy = RelatedDeveloper.find(1)
+    projects = andy.projects.map(&:clone)
+    assert !projects.empty?
+    andy.destroy!
+    assert_equal projects, andy.projects_in_memory
   end
 
   def test_deprecated_before_create_returning_false


### PR DESCRIPTION
A more intuitive alternative to `before_destroy prepend:true` when
wanting to ensure execution before the dependent destroy operation

This refreshes the implementation in https://github.com/rails/rails/pull/20537 for the upcoming Rails 5 to address https://github.com/rails/rails/issues/670

Also, it addresses @rafaelsales 's concern regarding Ruby 1.9 >= syntax for hashes:

<blockquote>
@rafaelsales: Since no backwards compatibility is planned for this, we can use Ruby >= 1.9 syntax for hashes
</blockquote>


I look forward to getting this incorporated in Rails along with many new and exciting changes.

Thanks for upholding the highest standards of quality, performance, and intuitive API design.

Andy Maleh
