### PR TITLE
Remove `DEFAULT NULL` for primary key column to support MySQL 5.7

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -111,7 +111,7 @@ module ActiveRecord
       QUOTED_TRUE, QUOTED_FALSE = '1', '0'
 
       NATIVE_DATABASE_TYPES = {
-        :primary_key => "int(11) DEFAULT NULL auto_increment PRIMARY KEY",
+        :primary_key => "int(11) auto_increment PRIMARY KEY",
         :string      => { :name => "varchar", :limit => 255 },
         :text        => { :name => "text" },
         :integer     => { :name => "int", :limit => 4 },

--- a/activerecord/test/cases/adapters/mysql/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql/connection_test.rb
@@ -64,7 +64,7 @@ class MysqlConnectionTest < ActiveRecord::TestCase
   def test_exec_no_binds
     @connection.exec_query('drop table if exists ex')
     @connection.exec_query(<<-eosql)
-      CREATE TABLE `ex` (`id` int(11) DEFAULT NULL auto_increment PRIMARY KEY,
+      CREATE TABLE `ex` (`id` int(11) auto_increment PRIMARY KEY,
         `data` varchar(255))
     eosql
     result = @connection.exec_query('SELECT id, data FROM ex')
@@ -86,7 +86,7 @@ class MysqlConnectionTest < ActiveRecord::TestCase
   def test_exec_with_binds
     @connection.exec_query('drop table if exists ex')
     @connection.exec_query(<<-eosql)
-      CREATE TABLE `ex` (`id` int(11) DEFAULT NULL auto_increment PRIMARY KEY,
+      CREATE TABLE `ex` (`id` int(11) auto_increment PRIMARY KEY,
         `data` varchar(255))
     eosql
     @connection.exec_query('INSERT INTO ex (id, data) VALUES (1, "foo")')
@@ -102,7 +102,7 @@ class MysqlConnectionTest < ActiveRecord::TestCase
   def test_exec_typecasts_bind_vals
     @connection.exec_query('drop table if exists ex')
     @connection.exec_query(<<-eosql)
-      CREATE TABLE `ex` (`id` int(11) DEFAULT NULL auto_increment PRIMARY KEY,
+      CREATE TABLE `ex` (`id` int(11) auto_increment PRIMARY KEY,
         `data` varchar(255))
     eosql
     @connection.exec_query('INSERT INTO ex (id, data) VALUES (1, "foo")')

--- a/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql/mysql_adapter_test.rb
@@ -10,7 +10,7 @@ module ActiveRecord
         @conn.exec_query('drop table if exists ex')
         @conn.exec_query(<<-eosql)
           CREATE TABLE `ex` (
-            `id` int(11) DEFAULT NULL auto_increment PRIMARY KEY,
+            `id` int(11) auto_increment PRIMARY KEY,
             `number` integer,
             `data` varchar(255))
         eosql
@@ -64,7 +64,7 @@ module ActiveRecord
         @conn.exec_query('drop table if exists ex_with_non_standard_pk')
         @conn.exec_query(<<-eosql)
           CREATE TABLE `ex_with_non_standard_pk` (
-            `code` INT(11) DEFAULT NULL auto_increment,
+            `code` INT(11) auto_increment,
              PRIMARY KEY  (`code`))
         eosql
         pk, seq = @conn.pk_and_sequence_for('ex_with_non_standard_pk')
@@ -76,7 +76,7 @@ module ActiveRecord
         @conn.exec_query('drop table if exists ex_with_custom_index_type_pk')
         @conn.exec_query(<<-eosql)
           CREATE TABLE `ex_with_custom_index_type_pk` (
-            `id` INT(11) DEFAULT NULL auto_increment,
+            `id` INT(11) auto_increment,
              PRIMARY KEY  USING BTREE (`id`))
         eosql
         pk, seq = @conn.pk_and_sequence_for('ex_with_custom_index_type_pk')


### PR DESCRIPTION
Cherry-pick f7a35cc5cfb1f970cdea58fb9b47e06c57f532f9 from Rails 4.
