### PR TITLE
ActionMailer: support overriding template name in multipart

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Mails with multipart `format` blocks with implicit render now also check for
+    a template name in options hash instead of only using the action name.
+
+    *Marcus Ilgner*
+
 ## Rails 4.1.14 (November 12, 2015) ##
 
 *   No changes.

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -844,8 +844,9 @@ module ActionMailer
     def collect_responses(headers) #:nodoc:
       responses = []
 
+      template_name = headers.delete(:template_name) || action_name
       if block_given?
-        collector = ActionMailer::Collector.new(lookup_context) { render(action_name) }
+        collector = ActionMailer::Collector.new(lookup_context) { render(template_name) }
         yield(collector)
         responses = collector.responses
       elsif headers[:body]
@@ -855,9 +856,8 @@ module ActionMailer
         }
       else
         templates_path = headers.delete(:template_path) || self.class.mailer_name
-        templates_name = headers.delete(:template_name) || action_name
 
-        each_template(Array(templates_path), templates_name) do |template|
+        each_template(Array(templates_path), template_name) do |template|
           self.formats = template.formats
 
           responses << {

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -493,6 +493,12 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("TEXT Implicit Multipart", mail.text_part.body.decoded)
   end
 
+  test "you can specify a different template for multipart render" do
+    mail = BaseMailer.implicit_different_template_with_block('explicit_multipart_templates').deliver
+    assert_equal("HTML Explicit Multipart Templates", mail.html_part.body.decoded)
+    assert_equal("TEXT Explicit Multipart Templates", mail.text_part.body.decoded)
+  end
+
   test "should raise if missing template in implicit render" do
     BaseMailer.deliveries.clear
     assert_raises ActionView::MissingTemplate do

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -98,6 +98,13 @@ class BaseMailer < ActionMailer::Base
     mail(template_name: template_name)
   end
 
+  def implicit_different_template_with_block(template_name='')
+    mail(template_name: template_name) do |format|
+      format.text
+      format.html
+    end
+  end
+
   def explicit_different_template(template_name='')
     mail do |format|
       format.text { render template: "#{mailer_name}/#{template_name}" }


### PR DESCRIPTION
Implicit rendering in multipart blocks now also uses the template name from the options hash instead of always using the action name.

So you can now write

```
mail(template_name: template_name) do |format|
  format.text
  format.html
end
```

Since we use Rails 4.1 in our project, I used `4-1-stable` as a base branch. Should I create another PR for `master`?
