### PR TITLE
ActionMailer: support overriding template name in multipart

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Mails with multipart `format` blocks with implicit render now also check for
+    a template name in options hash instead of only using the action name.
+
+    *Marcus Ilgner*
+
 *   `config.force_ssl = true` will set
     `config.action_mailer.default_url_options = { protocol: 'https' }`
 

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -893,9 +893,7 @@ module ActionMailer
 
     def collect_responses(headers)
       if block_given?
-        collector = ActionMailer::Collector.new(lookup_context) { render(action_name) }
-        yield(collector)
-        collector.responses
+        collect_responses_from_block(headers, &Proc.new)
       elsif headers[:body]
         [{
           body: headers.delete(:body),
@@ -904,6 +902,13 @@ module ActionMailer
       else
         collect_responses_from_templates(headers)
       end
+    end
+
+    def collect_responses_from_block(headers)
+      templates_name = headers[:template_name] || action_name
+      collector = ActionMailer::Collector.new(lookup_context) { render(templates_name) }
+      yield(collector)
+      collector.responses
     end
 
     def collect_responses_from_templates(headers)

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -539,6 +539,12 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("TEXT Implicit Multipart", mail.text_part.body.decoded)
   end
 
+  test "you can specify a different template for multipart render" do
+    mail = BaseMailer.implicit_different_template_with_block('explicit_multipart_templates').deliver
+    assert_equal("HTML Explicit Multipart Templates", mail.html_part.body.decoded)
+    assert_equal("TEXT Explicit Multipart Templates", mail.text_part.body.decoded)
+  end
+
   test "should raise if missing template in implicit render" do
     assert_raises ActionView::MissingTemplate do
       BaseMailer.implicit_different_template('missing_template').deliver_now

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -104,6 +104,13 @@ class BaseMailer < ActionMailer::Base
     mail(template_name: template_name)
   end
 
+  def implicit_different_template_with_block(template_name='')
+    mail(template_name: template_name) do |format|
+      format.text
+      format.html
+    end
+  end
+
   def explicit_different_template(template_name='')
     mail do |format|
       format.text { render template: "#{mailer_name}/#{template_name}" }


### PR DESCRIPTION
Implicit rendering in multipart blocks now also uses the template name from the options hash instead of always using the action name.

So you can now write

```
mail(template_name: template_name) do |format|
  format.text
  format.html
end
```
