### PR TITLE
fixes issue #22231

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+#   Properly render hidden field for collection helpers
+
+    Fixes #22231
+
+    *Kyle Montag*
+
 *   Respect value of `:object` if `:object` is false when rendering.
 
     Fixes #22260.

--- a/actionview/lib/action_view/helpers/tags/collection_helpers.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_helpers.rb
@@ -97,14 +97,18 @@ module ActionView
           # Append a hidden field to make sure something will be sent back to the
           # server if all radio buttons are unchecked.
           if options.fetch('include_hidden', true)
-            rendered_collection + hidden_field
+            rendered_collection + hidden_field(builder_class)
           else
             rendered_collection
           end
         end
 
-        def hidden_field #:nodoc:
-          hidden_name = @html_options[:name] || "#{tag_name(false, @options[:index])}[]"
+        def hidden_field(builder_class) # :nodoc:
+          builder_class == ActionView::Helpers::Tags::CollectionCheckBoxes::CheckBoxBuilder ?
+              tag = "#{tag_name(false, @options[:index])}[]" :
+              tag = "#{tag_name(false, @options[:index])}"
+
+          hidden_name = @html_options[:name] || tag
           @template_object.hidden_field_tag(hidden_name, "", id: nil)
         end
       end

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -202,7 +202,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
     collection = [Category.new(1, 'Category 1'), Category.new(2, 'Category 2')]
     with_collection_radio_buttons :user, :category_ids, collection, :id, :name
 
-    assert_select "input[type=hidden][name='user[category_ids][]'][value='']", count: 1
+    assert_select "input[type=hidden][name='user[category_ids]'][value='']", count: 1
   end
 
   test 'collection radio buttons generates a hidden field using the given :name in :html_options' do
@@ -216,7 +216,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
     collection = [Category.new(1, 'Category 1'), Category.new(2, 'Category 2')]
     with_collection_radio_buttons :user, :category_ids, collection, :id, :name, { index: 322 }
 
-    assert_select "input[type=hidden][name='user[322][category_ids][]'][value='']", count: 1
+    assert_select "input[type=hidden][name='user[322][category_ids]'][value='']", count: 1
   end
 
   test 'collection radio buttons does not generate a hidden field if include_hidden option is false' do

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1604,7 +1604,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_active_true'>true</label>" +
       "<input checked='checked' id='post_active_false' name='post[active]' type='radio' value='false' />" +
       "<label for='post_active_false'>false</label>" +
-      "<input type='hidden' name='post[active][]' value='' />"
+      "<input type='hidden' name='post[active]' value='' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1628,7 +1628,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_active_false'>"+
       "<input checked='checked' id='post_active_false' name='post[active]' type='radio' value='false' />" +
       "false</label>" +
-      "<input type='hidden' name='post[active][]' value='' />"
+      "<input type='hidden' name='post[active]' value='' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1654,7 +1654,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_active_false'>"+
       "<input checked='checked' id='post_active_false' name='post[active]' type='radio' value='false' />" +
       "false</label>"+
-      "<input type='hidden' name='post[active][]' value='' />" +
+      "<input type='hidden' name='post[active]' value='' />" +
       "<input id='post_id' name='post[id]' type='hidden' value='1' />"
     end
 
@@ -1674,7 +1674,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='foo_post_active_true'>true</label>" +
       "<input checked='checked' id='foo_post_active_false' name='post[active]' type='radio' value='false' />" +
       "<label for='foo_post_active_false'>false</label>" +
-      "<input type='hidden' name='post[active][]' value='' />"
+      "<input type='hidden' name='post[active]' value='' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1693,7 +1693,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_1_active_true'>true</label>" +
       "<input checked='checked' id='post_1_active_false' name='post[1][active]' type='radio' value='false' />" +
       "<label for='post_1_active_false'>false</label>" +
-      "<input type='hidden' name='post[1][active][]' value='' />"
+      "<input type='hidden' name='post[1][active]' value='' />"
     end
 
     assert_dom_equal expected, output_buffer


### PR DESCRIPTION
check the `builder_class` of the given collection being rendered, produce the correct hidden tag depending on type.

fixes the bug noted in the OP and demonstrated via this app: https://github.com/kyamaguchi/rails5_collection_radio_buttons

issue link: https://github.com/rails/rails/issues/22231
