### PR TITLE
Issue 22429

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -17,7 +17,7 @@ module ActiveRecord
           column = self.class.columns_hash[attr_name]
           if column.nil?
             if Numeric === value || value !~ /[^0-9]/
-              !value.to_f.abs.ceil.zero?
+              !value.to_f.zero?
             else
               return false if ActiveModel::Type::Boolean::FALSE_VALUES.include?(value)
               !value.blank?

--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -17,7 +17,7 @@ module ActiveRecord
           column = self.class.columns_hash[attr_name]
           if column.nil?
             if Numeric === value || value !~ /[^0-9]/
-              !value.to_i.zero?
+              !value.to_f.abs.ceil.zero?
             else
               return false if ActiveModel::Type::Boolean::FALSE_VALUES.include?(value)
               !value.blank?

--- a/activerecord/test/cases/attribute_methods/query_test.rb
+++ b/activerecord/test/cases/attribute_methods/query_test.rb
@@ -12,13 +12,15 @@ module ActiveRecord
 
       def test_check_for_attribute_value
         [0.5, -0.5, '0.5', -3, 3].each do |val|
-          @product.create(price: val)
-          product = @product.where(price: val).select('price as dummy_price').first
+          @product.create(price: val, rating: "#{val}")
+          product = @product.where(price: val).select('price as dummy_price, rating as dummy_rating').first
           assert_equal product.dummy_price?, true
+          assert_equal product.dummy_rating?, true
         end
-        @product.create(price: 0)
-        product = @product.where(price: 0).select('price as dummy_price').first
+        @product.create(price: 0, rating: '0')
+        product = @product.where(price: 0).select('price as dummy_price, rating as dummy_rating').first
         assert_equal product.dummy_price?, false
+        assert_equal product.dummy_rating?, true
       end
     end
   end

--- a/activerecord/test/cases/attribute_methods/query_test.rb
+++ b/activerecord/test/cases/attribute_methods/query_test.rb
@@ -1,0 +1,25 @@
+require "cases/helper"
+require 'thread'
+
+module ActiveRecord
+  module AttributeMethods
+    class QueryTest < ActiveRecord::TestCase
+
+      def setup
+        @product = Class.new(ActiveRecord::Base)
+        @product.table_name = 'products'
+      end
+
+      def test_check_for_attribute_value
+        [0.5, -0.5, '0.5', -3, 3].each do |val|
+          @product.create(price: val)
+          product = @product.where(price: val).select('price as dummy_price').first
+          assert_equal product.dummy_price?, true
+        end
+        @product.create(price: 0)
+        product = @product.where(price: 0).select('price as dummy_price').first
+        assert_equal product.dummy_price?, false
+      end
+    end
+  end
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -668,6 +668,7 @@ ActiveRecord::Schema.define do
     t.references :type
     t.string     :name
     t.float      :price
+    t.string     :rating
   end
 
   create_table :product_types, force: true do |t|

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -667,6 +667,7 @@ ActiveRecord::Schema.define do
     t.references :collection
     t.references :type
     t.string     :name
+    t.float      :price
   end
 
   create_table :product_types, force: true do |t|


### PR DESCRIPTION
Attribute value check when column does not exists but numeric value exists in an attribute of type number (integer, float etc.) or in string format.
I kept one test case failing (activerecord/test/cases/attribute_methods/query_test.rb:23) because I need some opinion on it. 
I think if number is in string format then '0' should return true and if datatype is numeric the it should return false for 0.
For example (Same as given in test case):
Suppose table name is **products** which have two columns one is **rating** of type string for which '0' is valid value (not blank?) and another one is price of type float (or int or any numeric datatype) for which 0 is blank then:

``` ruby
if @product.rating = '0'
then @product.rating? should return true
if @product.price = 0
then @product.price? should return false
```

Please let me know your opinion on this so I can make this fix.
