### PR TITLE
Only write changed cookies back to the client

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -114,7 +114,9 @@ module ActionDispatch
       end
 
       def set_cookie(request, session_id, cookie)
-        cookie_jar(request)[@key] = cookie
+        if get_cookie(env) != cookie[:value] || cookie[:expires]
+          cookie_jar(request)[@key] = cookie
+        end
       end
 
       def get_cookie(req)

--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -114,7 +114,7 @@ module ActionDispatch
       end
 
       def set_cookie(request, session_id, cookie)
-        if get_cookie(env) != cookie[:value] || cookie[:expires]
+        if get_cookie(request) != cookie[:value] || cookie[:expires]
           cookie_jar(request)[@key] = cookie
         end
       end


### PR DESCRIPTION
Rack implements logic for only writing changed cookies back to the client in
https://github.com/rack/rack/blob/1-6-stable/lib/rack/session/abstract/id.rb#L360-L365

Rails overrides the behaviour of Rack and makes the writing unconditional. This patch
changes Rails to only write a new session cookie if the content has changed mimicking
the way Rack does it.
