### PR TITLE
show relative path the rerun snippet of test runner in rails engine

### DIFF
--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -44,7 +44,7 @@ module Rails
     end
 
     def relative_path_for(file)
-      file.sub(/^#{Rails.root}\/?/, '')
+      file.sub(/^#{app_root}\/?/, '')
     end
 
     private
@@ -65,6 +65,10 @@ module Rails
         end
 
         "#{self.executable} #{relative_path_for(assertion_path)}"
+      end
+
+      def app_root
+        @app_root ||= defined?(ENGINE_ROOT) ? ENGINE_ROOT : Rails.root
       end
   end
 end

--- a/railties/test/generators/plugin_test_helper.rb
+++ b/railties/test/generators/plugin_test_helper.rb
@@ -1,0 +1,24 @@
+require 'abstract_unit'
+require 'tmpdir'
+
+module PluginTestHelper
+  def create_test_file(name, pass: true)
+    plugin_file "test/#{name}_test.rb", <<-RUBY
+      require 'test_helper'
+
+      class #{name.camelize}Test < ActiveSupport::TestCase
+        def test_truth
+          puts "#{name.camelize}Test"
+          assert #{pass}, 'wups!'
+        end
+      end
+    RUBY
+  end
+
+  def plugin_file(path, contents, mode: 'w')
+    FileUtils.mkdir_p File.dirname("#{plugin_path}/#{path}")
+    File.open("#{plugin_path}/#{path}", mode) do |f|
+      f.puts contents
+    end
+  end
+end

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -1,7 +1,8 @@
-require 'tmpdir'
-require 'abstract_unit'
+require 'generators/plugin_test_helper'
 
 class PluginTestRunnerTest < ActiveSupport::TestCase
+  include PluginTestHelper
+
   def setup
     @destination_root = Dir.mktmpdir('bukkits')
     Dir.chdir(@destination_root) { `bundle exec rails plugin new bukkits --skip-bundle` }
@@ -99,25 +100,5 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
 
     def run_test_command(arguments)
       Dir.chdir(plugin_path) { `bin/test #{arguments}` }
-    end
-
-    def create_test_file(name, pass: true)
-      plugin_file "test/#{name}_test.rb", <<-RUBY
-        require 'test_helper'
-
-        class #{name.camelize}Test < ActiveSupport::TestCase
-          def test_truth
-            puts "#{name.camelize}Test"
-            assert #{pass}, 'wups!'
-          end
-        end
-      RUBY
-    end
-
-    def plugin_file(path, contents, mode: 'w')
-      FileUtils.mkdir_p File.dirname("#{plugin_path}/#{path}")
-      File.open("#{plugin_path}/#{path}", mode) do |f|
-        f.puts contents
-      end
     end
 end

--- a/railties/test/generators/test_runner_in_engine_test.rb
+++ b/railties/test/generators/test_runner_in_engine_test.rb
@@ -1,0 +1,31 @@
+require 'generators/plugin_test_helper'
+
+class TestRunnerInEngineTest < ActiveSupport::TestCase
+  include PluginTestHelper
+
+  def setup
+    @destination_root = Dir.mktmpdir('bukkits')
+    Dir.chdir(@destination_root) { `bundle exec rails plugin new bukkits --full --skip-bundle` }
+    plugin_file 'test/dummy/db/schema.rb', ''
+  end
+
+  def teardown
+    FileUtils.rm_rf(@destination_root)
+  end
+
+  def test_rerun_snippet_is_relative_path
+    create_test_file 'post', pass: false
+
+    output = run_test_command('test/post_test.rb')
+    assert_match %r{Running:\n\nPostTest\nF\n\nwups!\n\nbin/rails test test/post_test.rb:6}, output
+  end
+
+  private
+    def plugin_path
+      "#{@destination_root}/bukkits"
+    end
+
+    def run_test_command(arguments)
+      Dir.chdir(plugin_path) { `bin/rails test #{arguments}` }
+    end
+end


### PR DESCRIPTION
Since the absolute path is not required to re-run the test,
modified so that unnecessary information is not displayed.

``` ruby
# before
bin/rails test /path/to/blorgh/test/integration/navigation_test.rb:5

# after
bin/rails test test/integration/navigation_test.rb:5
```
