### PR TITLE
Don’t generate immutable Base58 chars constant

### DIFF
--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -1,7 +1,10 @@
 require 'securerandom'
 
 module SecureRandom
-  BASE58_ALPHABET = ('0'..'9').to_a  + ('A'..'Z').to_a + ('a'..'z').to_a - ['0', 'O', 'I', 'l']
+  BASE58_ALPHABET = %w(1 2 3 4 5 6 7 8 9
+                       A B C D E F G H J K L M N P Q R S T U V W X Y Z
+                       a b c d e f g h i j k m n o p q r s t u v w x y z).freeze
+
   # SecureRandom.base58 generates a random base58 string.
   #
   # The argument _n_ specifies the length, of the random string to be generated.


### PR DESCRIPTION
This constant is simple enough and short enough that it doesn’t really seem worth generating -- it can just be specified as a literal.

This change cuts the allocations down from 92 objects (76 strings, 3 structs, 7 arrays, 6 nodes, and a hash) down to the minimally required 58 strings in 1 array.

``` ruby
require 'allocation_tracer'
require 'pp'

ObjectSpace::AllocationTracer.setup(%i{path line type})

result = ObjectSpace::AllocationTracer.trace do
  OLD_BASE58_ALPHABET = ('0'..'9').to_a  + ('A'..'Z').to_a + ('a'..'z').to_a - ['0', 'O', 'I', 'l']
  NEW_BASE58_ALPHABET = %w(1 2 3 4 5 6 7 8 9 A B C D E F G H J K L M N P Q R S T U V W X Y Z a b c d e f g h i j k m n o p q r s t u v w x y z)
end

pp result

# {["./base58_const_allocations.rb", 7, :T_STRING]=>[76, 0, 0, 0, 0, 0],
#  ["./base58_const_allocations.rb", 7, :T_STRUCT]=>[3, 0, 0, 0, 0, 0],
#  ["./base58_const_allocations.rb", 7, :T_ARRAY]=>[7, 0, 0, 0, 0, 0],
#  ["./base58_const_allocations.rb", 7, :T_NODE]=>[6, 0, 0, 0, 0, 0],
#  ["./base58_const_allocations.rb", 7, :T_HASH]=>[1, 0, 0, 0, 0, 0],
#  ["./base58_const_allocations.rb", 8, :T_STRING]=>[58, 0, 0, 0, 0, 0],
#  ["./base58_const_allocations.rb", 8, :T_ARRAY]=>[1, 0, 0, 0, 0, 0]}
```

It should also be immutable, so tacking on a `.freeze` as well.
