### PR TITLE
Use Module.prepend instead of alias_method for Range#to_s

### DIFF
--- a/activesupport/lib/active_support/core_ext/range/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/range/conversions.rb
@@ -1,34 +1,31 @@
-class Range
+module ActiveSupport::RangeWithFormat
   RANGE_FORMATS = {
     :db => Proc.new { |start, stop| "BETWEEN '#{start.to_s(:db)}' AND '#{stop.to_s(:db)}'" }
   }
 
   # Convert range to a formatted string. See RANGE_FORMATS for predefined formats.
   #
-  # This method is aliased to <tt>to_s</tt>.
-  #
   #   range = (1..100)           # => 1..100
   #
-  #   range.to_formatted_s       # => "1..100"
   #   range.to_s                 # => "1..100"
-  #
-  #   range.to_formatted_s(:db)  # => "BETWEEN '1' AND '100'"
   #   range.to_s(:db)            # => "BETWEEN '1' AND '100'"
   #
-  # == Adding your own range formats to to_formatted_s
+  # == Adding your own range formats to to_s
   # You can add your own formats to the Range::RANGE_FORMATS hash.
   # Use the format name as the hash key and a Proc instance.
   #
   #   # config/initializers/range_formats.rb
   #   Range::RANGE_FORMATS[:short] = ->(start, stop) { "Between #{start.to_s(:db)} and #{stop.to_s(:db)}" }
-  def to_formatted_s(format = :default)
+  def to_s(format = :default)
     if formatter = RANGE_FORMATS[format]
       formatter.call(first, last)
     else
-      to_default_s
+      super()
     end
   end
 
   alias_method :to_default_s, :to_s
-  alias_method :to_s, :to_formatted_s
+  alias_method :to_formatted_s, :to_s
 end
+
+Range.prepend(ActiveSupport::RangeWithFormat)


### PR DESCRIPTION
This is a follow-up pull request to #19434 - now that Ruby 2.2.2 is out we can switch to #prepend.

Looks like `to_formatted_s` and `to_default_s` are neither mentioned, nor tested, so we can treat them as private API that was required for `alias_method_chain` - but deprecation warning is left just in case. 

/cc @rafaelfranca @kirs @sgrif 
