### PR TITLE
Allow users to pass flags from database.yml

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -10,9 +10,9 @@ module ActiveRecord
       config = config.symbolize_keys
 
       config[:username] = 'root' if config[:username].nil?
-
+      config[:flags] ||= 0
       if Mysql2::Client.const_defined? :FOUND_ROWS
-        config[:flags] = Mysql2::Client::FOUND_ROWS
+        config[:flags] |= Mysql2::Client::FOUND_ROWS
       end
 
       client = Mysql2::Client.new(config)

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -83,6 +83,13 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
       assert_equal [['']], result.rows
     end
   end
+  
+  def test_passing_arbitary_flags_to_adapter
+    run_without_connection do |orig_connection|             
+      ActiveRecord::Base.establish_connection(orig_connection.merge({flags: Mysql2::Client::COMPRESS}))
+      assert_equal (Mysql2::Client::COMPRESS |  Mysql2::Client::FOUND_ROWS), ActiveRecord::Base.connection.raw_connection.query_options[:flags]
+    end
+  end
 
   def test_mysql_strict_mode_specified_default
     run_without_connection do |orig_connection|


### PR DESCRIPTION
The MySQL 2 adapter currently clobbers any flags you pass via database.yml.

This short patch allows the user to include their own flags as an integer.

The MySQL2 gem master branch includes support for specifying flags as an array, however stable does not yet include this - so I did not include support for that here.
