### PR TITLE
Don't catch all NameError to reraise as ActionController::RoutingError

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -30,9 +30,9 @@ module ActionDispatch
           controller = controller req
           res        = controller.make_response! req
           dispatch(controller, params[:action], req, res)
-        rescue NameError => e
+        rescue ActionController::RoutingError
           if @raise_on_name_error
-            raise ActionController::RoutingError, e.message, e.backtrace
+            raise
           else
             return [404, {'X-Cascade' => 'pass'}, []]
           end
@@ -42,6 +42,8 @@ module ActionDispatch
 
         def controller(req)
           req.controller_class
+        rescue NameError => e
+          raise ActionController::RoutingError, e.message, e.backtrace
         end
 
         def dispatch(controller, action, req, res)

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4592,3 +4592,44 @@ class TestDefaultUrlOptions < ActionDispatch::IntegrationTest
     assert_equal '/en/posts/2014/12/13', archived_posts_path(2014, 12, 13)
   end
 end
+
+class TestErrorsInController < ActionDispatch::IntegrationTest
+  class ::PostsController < ActionController::Base
+    def foo
+      nil.i_do_not_exist
+    end
+
+    def bar
+      NonExistingClass.new
+    end
+  end
+
+  Routes = ActionDispatch::Routing::RouteSet.new
+  Routes.draw do
+    get '/:controller(/:action)'
+  end
+
+  APP = build_app Routes
+
+  def app
+    APP
+  end
+
+  def test_legit_no_method_errors_are_not_caught
+    get '/posts/foo'
+    assert_equal 500, response.status
+  end
+
+  def test_legit_name_errors_are_not_caught
+    get '/posts/bar'
+    assert_equal 500, response.status
+  end
+
+  def test_legit_routing_not_found_responses
+    get '/posts/baz'
+    assert_equal 404, response.status
+
+    get '/i_do_not_exist'
+    assert_equal 404, response.status
+  end
+end


### PR DESCRIPTION
This is a fix for #22368.

All `NameError` errors and its descendants occurring during the processing of controllers' actions were caught by the dispatcher, having legit errors being re-raised as ActionController::RoutingError and resulting in 404 responses.

The expected behavior (both in development and in production) being letting them bubble up to the ShowException middleware to properly return a 500 response. With in the process, any handling by other middleware such as ExceptionNotifier one, for example.

Errors affected: `NameError`, `NoMethodError`.
