### PR TITLE
Update web-console to 3.0.0

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -41,7 +41,7 @@ group :development do
   <%- if options.dev? || options.edge? -%>
   gem 'web-console', github: 'rails/web-console'
   <%- else -%>
-  gem 'web-console', '~> 2.0'
+  gem 'web-console', '~> 3.0'
   <%- end -%>
 <%- end -%>
 <% if spring_install? -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -505,7 +505,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_match(/gem 'web-console',\s+github: 'rails\/web-console'/, content)
-      assert_no_match(/gem 'web-console', '~> 2.0'/, content)
+      assert_no_match(/gem 'web-console', '~> 3.0'/, content)
     end
   end
 
@@ -514,7 +514,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_match(/gem 'web-console',\s+github: 'rails\/web-console'/, content)
-      assert_no_match(/gem 'web-console', '~> 2.0'/, content)
+      assert_no_match(/gem 'web-console', '~> 3.0'/, content)
     end
   end
 


### PR DESCRIPTION
Web Console 3.0.0 is compatible with Rails 5, while the 2.x.x releases
aren't.
