### PR TITLE
Prevent a 500 in the default controller scaffold

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb
@@ -52,7 +52,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     # Only allow a trusted parameter "white list" through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
-      params[:<%= singular_table_name %>]
+      params.fetch(:<%= singular_table_name %>, {})
       <%- else -%>
       params.require(:<%= singular_table_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
       <%- end -%>

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -59,7 +59,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     # Only allow a trusted parameter "white list" through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
-      params[:<%= singular_table_name %>]
+      params.fetch(:<%= singular_table_name %>, {})
       <%- else -%>
       params.require(:<%= singular_table_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
       <%- end -%>

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -56,7 +56,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/controllers/users_controller.rb" do |content|
       assert_match(/def user_params/, content)
-      assert_match(/params\[:user\]/, content)
+      assert_match(/params\.fetch\(:user, \{\}\)/, content)
     end
   end
 


### PR DESCRIPTION
In a newly generated controller, if you update a record with no attributes,
you'll hit a 500 from a guard in `assign_attributes` raising:

``` ruby
ArgumentError: When assigning attributes, you must pass a hash as an argument.
    app/controllers/users_controller.rb:44:in `block in update'
    app/controllers/users_controller.rb:43:in `update'
    test/controllers/users_controller_test.rb:37:in `block in <class:UsersControllerTest>'
```

Not a biggie, but may be quite confusing for the folks new to the
framework.
