### PR TITLE
Change output timming of sample code

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -255,10 +255,10 @@ module ActiveSupport
       #     end
       #   end
       #
-      #   # val_1 => "new value 1"
-      #   # val_2 => "original value"
       #   # sleep 10 # First thread extend the life of cache by another 10 seconds
       #   # cache.fetch('foo') => "new value 1"
+      #   # val_1 => "new value 1"
+      #   # val_2 => "original value"
       #
       # Other options will be handled by the specific cache store implementation.
       # Internally, #fetch calls #read_entry, and calls #write_entry on a cache


### PR DESCRIPTION
I exec this sample code but `val_1` output is `nil`.
Beacuse first thread not finished at output.

Move output code at finished first thread.
