### PR TITLE
Make Parameters#to_h and #to_unsafe_h return HWIA

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -162,8 +162,8 @@ module ActionController
       end
     end
 
-    # Returns a safe +Hash+ representation of this parameter with all
-    # unpermitted keys removed.
+    # Returns a safe <tt>ActiveSupport::HashWithIndifferentAccess</tt>
+    # representation of this parameter with all unpermitted keys removed.
     #
     #   params = ActionController::Parameters.new({
     #     name: 'Senjougahara Hitagi',
@@ -175,15 +175,17 @@ module ActionController
     #   safe_params.to_h # => {"name"=>"Senjougahara Hitagi"}
     def to_h
       if permitted?
-        @parameters.to_h
+        @parameters.deep_dup
       else
         slice(*self.class.always_permitted_parameters).permit!.to_h
       end
     end
 
-    # Returns an unsafe, unfiltered +Hash+ representation of this parameter.
+    # Returns an unsafe, unfiltered
+    # <tt>ActiveSupport::HashWithIndifferentAccess</tt> representation of this
+    # parameter.
     def to_unsafe_h
-      @parameters.to_h
+      @parameters.deep_dup
     end
     alias_method :to_unsafe_hash, :to_unsafe_h
 

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -256,7 +256,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "to_h returns empty hash on unpermitted params" do
-    assert @params.to_h.is_a? Hash
+    assert @params.to_h.is_a? ActiveSupport::HashWithIndifferentAccess
     assert_not @params.to_h.is_a? ActionController::Parameters
     assert @params.to_h.empty?
   end
@@ -264,7 +264,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
   test "to_h returns converted hash on permitted params" do
     @params.permit!
 
-    assert @params.to_h.is_a? Hash
+    assert @params.to_h.is_a? ActiveSupport::HashWithIndifferentAccess
     assert_not @params.to_h.is_a? ActionController::Parameters
   end
 
@@ -273,7 +273,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
       ActionController::Parameters.permit_all_parameters = true
       params = ActionController::Parameters.new(crab: "Senjougahara Hitagi")
 
-      assert params.to_h.is_a? Hash
+      assert params.to_h.is_a? ActiveSupport::HashWithIndifferentAccess
       assert_not @params.to_h.is_a? ActionController::Parameters
       assert_equal({ "crab" => "Senjougahara Hitagi" }, params.to_h)
     ensure
@@ -294,7 +294,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "to_unsafe_h returns unfiltered params" do
-    assert @params.to_h.is_a? Hash
+    assert @params.to_h.is_a? ActiveSupport::HashWithIndifferentAccess
     assert_not @params.to_h.is_a? ActionController::Parameters
   end
 end


### PR DESCRIPTION
This makes these two methods to be more inline with the previous behavior of Parameters as Parameters used to be inherited from HWIA.

Fixes #21391
