### PR TITLE
Allow running console, server, dbconsole and runner from Engine

### DIFF
--- a/railties/lib/rails/commands/commands_tasks.rb
+++ b/railties/lib/rails/commands/commands_tasks.rb
@@ -11,30 +11,36 @@ module Rails
 
     attr_reader :argv
 
-    HELP_MESSAGE = <<-EOT
+    MAIN_COMMANDS = {
+      'generate'  => 'Generate new code (short-cut alias: "g")',
+      'console'   => 'Start the Rails console (short-cut alias: "c")',
+      'server'    => 'Start the Rails server (short-cut alias: "s")',
+      'test'      => 'Run tests (short-cut alias: "t")',
+      'dbconsole' => 'Start a console for the database specified in config/database.yml'\
+                    ' (short-cut alias: "db")',
+      'new'       => 'Create a new Rails application. "rails new my_app" creates a'\
+                    ' new application called MyApp in "./my_app"'
+    }
+
+    HELP_MESSAGE_TOP= <<-EOT
 Usage: rails COMMAND [ARGS]
 
 The most common rails commands are:
- generate    Generate new code (short-cut alias: "g")
- console     Start the Rails console (short-cut alias: "c")
- server      Start the Rails server (short-cut alias: "s")
- test        Run tests (short-cut alias: "t")
- dbconsole   Start a console for the database specified in config/database.yml
-             (short-cut alias: "db")
- new         Create a new Rails application. "rails new my_app" creates a
-             new application called MyApp in "./my_app"
+EOT
+
+    HELP_MESSAGE_MIDDLE = <<-EOT
 
 All commands can be run with -h (or --help) for more information.
 
 In addition to those commands, there are:
 EOT
 
-    ADDITIONAL_COMMANDS = [
-      [ 'destroy', 'Undo code generated with "generate" (short-cut alias: "d")' ],
-      [ 'plugin new', 'Generates skeleton for developing a Rails plugin' ],
-      [ 'runner',
-        'Run a piece of code in the application environment (short-cut alias: "r")' ]
-    ]
+    ADDITIONAL_COMMANDS = {
+      'destroy'    => 'Undo code generated with "generate" (short-cut alias: "d")',
+      'plugin new' => 'Generates skeleton for developing a Rails plugin',
+      'runner'     => 'Run a piece of code in the application environment'\
+                      '(short-cut alias: "r")'
+    }
 
     COMMAND_WHITELIST = %w(plugin generate destroy console server dbconsole runner new version help test)
 
@@ -118,8 +124,10 @@ EOT
     end
 
     def help
-      write_help_message
-      write_commands ADDITIONAL_COMMANDS + formatted_rake_tasks
+      puts HELP_MESSAGE_TOP
+      write_commands(main_commands)
+      puts HELP_MESSAGE_MIDDLE
+      write_commands(additional_commands)
     end
 
     private
@@ -175,6 +183,14 @@ EOT
         else
           command
         end
+      end
+
+      def main_commands
+        MAIN_COMMANDS
+      end
+
+      def additional_commands
+        ADDITIONAL_COMMANDS.merge(formatted_rake_tasks)
       end
   end
 end

--- a/railties/lib/rails/commands/rake_proxy.rb
+++ b/railties/lib/rails/commands/rake_proxy.rb
@@ -28,7 +28,7 @@ module Rails
       end
 
       def formatted_rake_tasks
-        rake_tasks.map { |t| [ t.name_with_args, t.comment ] }
+        rake_tasks.map { |t| [ t.name_with_args, t.comment ] }.to_h
       end
   end
 end

--- a/railties/lib/rails/engine/commands.rb
+++ b/railties/lib/rails/engine/commands.rb
@@ -3,9 +3,13 @@ require 'rails/engine/commands_tasks'
 ARGV << '--help' if ARGV.empty?
 
 aliases = {
-  "g" => "generate",
-  "d" => "destroy",
-  "t" => "test"
+  "g"  => "generate",
+  "d"  => "destroy",
+  "c"  => "console",
+  "s"  => "server",
+  "db" => "dbconsole",
+  "r"  => "runner",
+  "t"  => "test"
 }
 
 command = ARGV.shift


### PR DESCRIPTION
Right now, if you're in the root directory of a Rails app, you can run `rails [command]`, where command is any of the supported commands (`generate`, `destroy`, `console`, `server`, `dbconsole`, `runner`, `test`, `plugin new`). You can also run any of those in most subdirectories (`app/models/`, `config/initializers/`, etc). 

The only subdirectories you **cannot** run all those commands in, is within an Engine. When you're in an engine folder, you only get access to `generate`, `destroy` and `test`. 

This patch fixes that, so if you run, e.g. `rails console` from within an engine, a console will be opened in the parent application. The way I did this is by traversing up the directory structure until we find a `config/application.rb` file (since Engine's seem to, by design, not have access to the application they're mounted in). 

I'm working on an app that has several engines, and it's a daily annoyance that I try to run `rails console` or `rails server` from an Engine folder, and it doesn't work. Then I have to `cd ..` and try again.

A few things:
- How to test this? I can't find any tests that make sure the command `rails console` works in normal apps. Just that we can call `Rails::Console.new(...)`.
- How this will work for people developing 'standalone' Engines that are gems (like Gemified assets)? Running these newly supported commands there should either not work, or try to run from their `dummy_app` instead. If we do the latter, which environment should we pick for Engines within a Rails app that also have a dummy app? The main application or the dummy app?
- I assume the engine is a subdirectory of the main app. If it's not, these commands won't work, but we should display a good error message. 
- I assume we're working with mountable engines, since that's what I have the most experience with. How will this work for other engines/plugins? I think fine, but this should be investigated.
- `help` right now shows a normal application HELP_MESSAGE, not the one for engines. This is an easy fix, but it'd make the diff much busier. 
- I don't have support for 'plugin new', since that seems like something you probably should do from the main app.
- I'd like to make this functionality into a class, which inherits from the `CommandsTask` class. Then we can just leverage `railties/lib/rails/commands.rb` instead of having this special file for Engines. If I get the go-ahead, I'll work on that.

Thanks for reading. Any thoughts?
