### PR TITLE
add `constraint_to` option to SSL middleware

### DIFF
--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -39,6 +39,13 @@ class RedirectSSLTest < SSLTest
     assert_equal redirect[:body].join, @response.body
   end
 
+  test 'constrain to can avoid redirect' do
+    constraining = { constrain_to: -> request { request.path !~ /healthcheck/ } }
+
+    assert_not_redirected 'http://example.org/healthcheck', redirect: constraining
+    assert_redirected from: 'http://example.org/', redirect: constraining
+  end
+
   test 'https is not redirected' do
     assert_not_redirected 'https://example.org'
   end


### PR DESCRIPTION
The `force_ssl` option redirects each request to https, but it would be great to be able to exclude a path from the redirection. My use-case would be when the app is behind a load balancer, I'd like to be able to do an http health check against the app.
If you think this is reasonable, I will add a changelog entry and add this to the guides.
