### PR TITLE
Add Logger option to disable message broadcasts

### DIFF
--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -1,4 +1,3 @@
-require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/logger_silence'
 require 'logger'
 
@@ -6,16 +5,18 @@ module ActiveSupport
   class Logger < ::Logger
     include LoggerSilence
 
+    attr_accessor :broadcast_messages
+
     # Broadcasts logs to multiple loggers.
     def self.broadcast(logger) # :nodoc:
       Module.new do
         define_method(:add) do |*args, &block|
-          logger.add(*args, &block)
+          logger.add(*args, &block) if broadcast_messages
           super(*args, &block)
         end
 
         define_method(:<<) do |x|
-          logger << x
+          logger << x if broadcast_messages
           super(x)
         end
 
@@ -44,6 +45,7 @@ module ActiveSupport
     def initialize(*args)
       super
       @formatter = SimpleFormatter.new
+      @broadcast_messages = true
     end
 
     # Simple formatter which only displays the message.

--- a/activesupport/lib/active_support/logger_silence.rb
+++ b/activesupport/lib/active_support/logger_silence.rb
@@ -1,8 +1,9 @@
 require 'active_support/concern'
+require 'active_support/core_ext/module/attribute_accessors'
 
 module LoggerSilence
   extend ActiveSupport::Concern
-  
+
   included do
     cattr_accessor :silencer
     self.silencer = true

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -2,56 +2,69 @@ require 'abstract_unit'
 
 module ActiveSupport
   class BroadcastLoggerTest < TestCase
-    attr_reader :logger, :log1, :log2
+    attr_reader :logger, :receiving_logger
     def setup
-      @log1 = FakeLogger.new
-      @log2 = FakeLogger.new
-      @log1.extend Logger.broadcast @log2
-      @logger = @log1
+      @logger = FakeLogger.new
+      @receiving_logger = FakeLogger.new
+      @logger.extend Logger.broadcast @receiving_logger
     end
 
     def test_debug
       logger.debug "foo"
-      assert_equal 'foo', log1.adds.first[2]
-      assert_equal 'foo', log2.adds.first[2]
+      assert_equal 'foo', logger.adds.first[2]
+      assert_equal 'foo', receiving_logger.adds.first[2]
+    end
+
+    def test_debug_without_message_broadcasts
+      logger.broadcast_messages = false
+      logger.debug "foo"
+      assert_equal 'foo', logger.adds.first[2]
+      assert_equal [], receiving_logger.adds
     end
 
     def test_close
       logger.close
-      assert log1.closed, 'should be closed'
-      assert log2.closed, 'should be closed'
+      assert logger.closed, 'should be closed'
+      assert receiving_logger.closed, 'should be closed'
     end
 
     def test_chevrons
       logger << "foo"
-      assert_equal %w{ foo }, log1.chevrons
-      assert_equal %w{ foo }, log2.chevrons
+      assert_equal %w{ foo }, logger.chevrons
+      assert_equal %w{ foo }, receiving_logger.chevrons
+    end
+
+    def test_chevrons_without_message_broadcasts
+      logger.broadcast_messages = false
+      logger << "foo"
+      assert_equal %w{ foo }, logger.chevrons
+      assert_equal [], receiving_logger.chevrons
     end
 
     def test_level
       assert_nil logger.level
       logger.level = 10
-      assert_equal 10, log1.level
-      assert_equal 10, log2.level
+      assert_equal 10, logger.level
+      assert_equal 10, receiving_logger.level
     end
 
     def test_progname
       assert_nil logger.progname
       logger.progname = 10
-      assert_equal 10, log1.progname
-      assert_equal 10, log2.progname
+      assert_equal 10, logger.progname
+      assert_equal 10, receiving_logger.progname
     end
 
     def test_formatter
       assert_nil logger.formatter
       logger.formatter = 10
-      assert_equal 10, log1.formatter
-      assert_equal 10, log2.formatter
+      assert_equal 10, logger.formatter
+      assert_equal 10, receiving_logger.formatter
     end
 
     class FakeLogger
       attr_reader :adds, :closed, :chevrons
-      attr_accessor :level, :progname, :formatter
+      attr_accessor :level, :progname, :formatter, :broadcast_messages
 
       def initialize
         @adds      = []
@@ -60,6 +73,7 @@ module ActiveSupport
         @level     = nil
         @progname  = nil
         @formatter = nil
+        @broadcast_messages = true
       end
 
       def debug msg, &block


### PR DESCRIPTION
When setting the Rails logger to log to STDOUT, it would broadcast the
log twice in development. This adds a setting that will prevent messages
from being broadcast to multiple logs, while still allowing calls to
`#close`, `#level=`, `#progname=`, and `#formatter=` to be broadcasted.

Fixes #14769, #11415
