### PR TITLE
Prevent repeated DuplicatePstatement errors in prepared statement creation

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -627,6 +627,7 @@ module ActiveRecord
             begin
               @connection.prepare nextkey, sql
             rescue => e
+              @statements[sql_key] = nextkey if e.class == PG::DuplicatePstatement
               raise translate_exception_class(e, sql)
             end
             # Clear the queue


### PR DESCRIPTION
- In `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#prepared_statement`, the `sql_key` will now be added to the StatementPool causing later `prepared_statement` call on the same sql to not fail in the same manner.
