### PR TITLE
Controller-wide fragment cache key prefixes

### DIFF
--- a/actionpack/lib/action_controller/caching/fragments.rb
+++ b/actionpack/lib/action_controller/caching/fragments.rb
@@ -14,6 +14,12 @@ module ActionController
     #
     #   expire_fragment('name_of_cache')
     module Fragments
+      extend ActiveSupport::Concern
+
+      included do
+        helper_method :fragment_cache_key if respond_to?(:helper_method)
+      end
+
       # Given a key (as described in +expire_fragment+), returns
       # a key suitable for use in reading, writing, or expiring a
       # cached fragment. All keys are prefixed with <tt>views/</tt> and uses

--- a/actionpack/lib/action_controller/caching/fragments.rb
+++ b/actionpack/lib/action_controller/caching/fragments.rb
@@ -17,15 +17,54 @@ module ActionController
       extend ActiveSupport::Concern
 
       included do
+        if respond_to?(:class_attribute)
+          class_attribute :fragment_cache_keys
+        else
+          mattr_writer :fragment_cache_keys
+        end
+
+        self.fragment_cache_keys = []
+
         helper_method :fragment_cache_key if respond_to?(:helper_method)
+      end
+
+      module ClassMethods
+        # Allows you to specify controller-wide key prefixes for
+        # cache fragments. Pass either a constant +value+, or a block
+        # which computes a value each time a cache key is generated.
+        #
+        # For example, you may want to prefix all fragment cache keys
+        # with a global version identifier, so you can easily
+        # invalidate all caches.
+        #
+        #   class ApplicationController
+        #     fragment_cache_key "v1"
+        #   end
+        #
+        # When it's time to invalidate all fragments, simply change
+        # the string constant. Or, progressively roll out the cache
+        # invalidation using a computed value:
+        #
+        #   class ApplicationController
+        #     fragment_cache_key do
+        #       @account.id.odd? ? "v1" : "v2"
+        #     end
+        #   end
+        def fragment_cache_key(value = nil, &key)
+          self.fragment_cache_keys += [key || ->{ value }]
+        end
       end
 
       # Given a key (as described in +expire_fragment+), returns
       # a key suitable for use in reading, writing, or expiring a
-      # cached fragment. All keys are prefixed with <tt>views/</tt> and uses
-      # ActiveSupport::Cache.expand_cache_key for the expansion.
+      # cached fragment. All keys begin with <tt>views/</tt>,
+      # followed by any controller-wide key prefix values, ending
+      # with the specified +key+ value. The key is expanded using
+      # ActiveSupport::Cache.expand_cache_key.
       def fragment_cache_key(key)
-        ActiveSupport::Cache.expand_cache_key(key.is_a?(Hash) ? url_for(key).split("://").last : key, :views)
+        head = self.class.fragment_cache_keys.map { |key| instance_exec(&key) }
+        tail = key.is_a?(Hash) ? url_for(key).split("://").last : key
+        ActiveSupport::Cache.expand_cache_key([*head, *tail], :views)
       end
 
       # Writes +content+ to the location signified by

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -419,3 +419,28 @@ class AutomaticCollectionCacheTest < ActionController::TestCase
     assert_equal 1, @controller.partial_rendered_times
   end
 end
+
+class FragmentCacheKeyTestController < CachingController
+  attr_accessor :account_id
+
+  fragment_cache_key "v1"
+  fragment_cache_key { account_id }
+end
+
+class FragmentCacheKeyTest < ActionController::TestCase
+  def setup
+    super
+    @store = ActiveSupport::Cache::MemoryStore.new
+    @controller = FragmentCacheKeyTestController.new
+    @controller.perform_caching = true
+    @controller.cache_store = @store
+  end
+
+  def test_fragment_cache_key
+    @controller.account_id = "123"
+    assert_equal 'views/v1/123/what a key', @controller.fragment_cache_key('what a key')
+
+    @controller.account_id = nil
+    assert_equal 'views/v1//what a key', @controller.fragment_cache_key('what a key')
+  end
+end

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -216,14 +216,6 @@ module ActionView
         end
       end
 
-      # Given a key (as described in ActionController::Caching::Fragments.expire_fragment),
-      # returns a key suitable for use in reading, writing, or expiring a
-      # cached fragment. All keys are prefixed with <tt>views/</tt> and uses
-      # ActiveSupport::Cache.expand_cache_key for the expansion.
-      def fragment_cache_key(key)
-        ActiveSupport::Cache.expand_cache_key(key.is_a?(Hash) ? url_for(key).split("://").last : key, :views)
-      end
-
     private
 
       def fragment_name_with_digest(name, virtual_path) #:nodoc:

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -9,6 +9,10 @@ module RenderTestCases
     @assigns = { :secret => 'in the sauce' }
     @view = Class.new(ActionView::Base) do
       def view_cache_dependencies; end
+
+      def fragment_cache_key(key)
+        ActiveSupport::Cache.expand_cache_key(key, :views)
+      end
     end.new(paths, @assigns)
 
     @controller_view = TestController.new.view_context


### PR DESCRIPTION
This branch adds a `fragment_cache_key` macro to `ActionController::Base` for specifying controller-wide fragment cache key prefixes, in the spirit of the `etag` macro.

Extracted from Basecamp 3, where we’re using it like this:

``` ruby
class ApplicationController < ActionController::Base
  fragment_cache_key "v1"
  fragment_cache_key { @account.try(:id) }
end
```

Effectively adding two additional values to the front of the key for each `<% cache ... %>` block:
1. A global version string (`"v1"`), which we can change to expire all fragments globally, or conditionally for rollout, when we make large cross-cutting changes to many helpers.
2. The ID of the current account, which lets us expire fragments on a per-account level for support purposes using e.g. `redis-cli`.
