### PR TITLE
remove extra spaces from deprecation message

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/string/strip'
+
 module ActiveRecord
   module AttributeMethods
     module TimeZoneConversion
@@ -77,7 +79,7 @@ module ActiveRecord
             !result &&
             cast_type.type == :time &&
             time_zone_aware_types.include?(:not_explicitly_configured)
-            ActiveSupport::Deprecation.warn(<<-MESSAGE)
+            ActiveSupport::Deprecation.warn(<<-MESSAGE.strip_heredoc)
               Time columns will become time zone aware in Rails 5.1. This
               still causes `String`s to be parsed as if they were in `Time.zone`,
               and `Time`s to be converted to `Time.zone`.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -3,6 +3,7 @@ require "active_record/relation/query_attribute"
 require "active_record/relation/where_clause"
 require "active_record/relation/where_clause_factory"
 require 'active_model/forbidden_attributes_protection'
+require 'active_support/core_ext/string/filters'
 
 module ActiveRecord
   module QueryMethods
@@ -694,7 +695,7 @@ module ActiveRecord
     def limit!(value) # :nodoc:
       if string_containing_comma?(value)
         # Remove `string_containing_comma?` when removing this deprecation
-        ActiveSupport::Deprecation.warn(<<-WARNING)
+        ActiveSupport::Deprecation.warn(<<-WARNING.squish)
           Passing a string to limit in the form "1,2" is deprecated and will be
           removed in Rails 5.1. Please call `offset` explicitly instead.
         WARNING


### PR DESCRIPTION
```
# before
DEPRECATION WARNING:               Time columns will become time zone aware in Rails 5.1. This
              still causes `String`s to be parsed as if they were in `Time.zone`,
              and `Time`s to be converted to `Time.zone`.

              To keep the old behavior, you must add the following to your initializer:

                  config.active_record.time_zone_aware_types = [:datetime]

              To silence this deprecation warning, add the following:

                  config.active_record.time_zone_aware_types << :time
```

```
# after
DEPRECATION WARNING: Time columns will become time zone aware in Rails 5.1. This
still causes `String`s to be parsed as if they were in `Time.zone`,
and `Time`s to be converted to `Time.zone`.

To keep the old behavior, you must add the following to your initializer:

    config.active_record.time_zone_aware_types = [:datetime]

To silence this deprecation warning, add the following:

    config.active_record.time_zone_aware_types << :time
```
