### PR TITLE
Add --markdown-readme option to rails plugin generator

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add --markdown-readme option to `rails plugin` so plugin authors get the option
+    to start with a README.md file.
+
+    *Netto Farah*
+
 *   The generated config file for the development environment includes a new
     config line, commented out, showing how to enable the evented file watcher.
 

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -37,7 +37,7 @@ module Rails
     end
 
     def readme
-      template "README.rdoc"
+      template readme_filename
     end
 
     def gemfile
@@ -191,6 +191,9 @@ task default: :test
       class_option :api,          type: :boolean, default: false,
                                   desc: "Generate a smaller stack for API application plugins"
 
+      class_option :markdown_readme, type: :boolean, default: false,
+                                     desc: "Create a README.md file instead of README.rdoc"
+
       def initialize(*args)
         @dummy_path = nil
         super
@@ -310,6 +313,10 @@ task default: :test
 
       def mountable?
         options[:mountable]
+      end
+
+      def readme_filename
+        options[:markdown_readme] ? 'README.md' : 'README.rdoc'
       end
 
       def skip_git?

--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = "TODO: Description of <%= camelized_modules %>."
   s.license     = "MIT"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
+  s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "<%= readme_filename %>"]
 
   <%= '# ' if options.dev? || options.edge? -%>s.add_dependency "rails", "~> <%= Rails::VERSION::STRING %>"
 <% unless options[:skip_active_record] -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/README.md
+++ b/railties/lib/rails/generators/rails/plugin/templates/README.md
@@ -1,0 +1,3 @@
+= <%= camelized_modules %>
+
+This project rocks and uses MIT-LICENSE.

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -403,6 +403,22 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "bin/rails", /#!\/usr\/bin\/env ruby/
   end
 
+  def test_generates_rdoc_readme_by_default
+    run_generator
+    assert_file "README.rdoc"
+    assert_no_file "README.md"
+
+    assert_file "bukkits.gemspec", /s.files = Dir\["\{app,config,db,lib\}\/\*\*\/\*", "MIT-LICENSE", "Rakefile", "README\.rdoc"\]/
+  end
+
+  def test_passing_markdown_as_readme_format
+    run_generator [destination_root, "--markdown-readme"]
+    assert_file "README.md"
+    assert_no_file "README.rdoc"
+
+    assert_file "bukkits.gemspec", /s.files = Dir\["\{app,config,db,lib\}\/\*\*\/\*", "MIT-LICENSE", "Rakefile", "README\.md"\]/
+  end
+
   def test_passing_dummy_path_as_a_parameter
     run_generator [destination_root, "--dummy_path", "spec/dummy"]
     assert_file "spec/dummy"


### PR DESCRIPTION
This allows `rails plugin` authors to start their projects with a
README.md file instead of the default README.rdoc file.
