### PR TITLE
Delete dead code comments

### DIFF
--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -141,20 +141,10 @@ class HelperTest < ActiveSupport::TestCase
   def test_helper_for_nested_controller
     assert_equal 'hello: Iz guuut!',
       call_controller(Fun::GamesController, "render_hello_world").last.body
-    # request  = ActionController::TestRequest.new
-    #
-    # resp = Fun::GamesController.action(:render_hello_world).call(request.env)
-    # assert_equal 'hello: Iz guuut!', resp.last.body
   end
 
   def test_helper_for_acronym_controller
     assert_equal "test: baz", call_controller(Fun::PdfController, "test").last.body
-    #
-    # request  = ActionController::TestRequest.new
-    # response = ActionDispatch::TestResponse.new
-    # request.action = 'test'
-    #
-    # assert_equal 'test: baz', Fun::PdfController.process(request, response).body
   end
 
   def test_default_helpers_only

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -469,11 +469,6 @@ class DateHelperTest < ActionView::TestCase
     expected << "</select>\n"
 
     assert_dom_equal expected, select_year(Time.mktime(2003, 8, 16), {:start_year => 2003, :end_year => 2005}, :class => 'selector', :accesskey => 'M')
-    #result = select_year(Time.mktime(2003, 8, 16), {:start_year => 2003, :end_year => 2005}, :class => 'selector', :accesskey => 'M')
-    #assert result.include?('<select id="date_year" name="date[year]"')
-    #assert result.include?('class="selector"')
-    #assert result.include?('accesskey="M"')
-    #assert result.include?('<option value="2003"')
   end
 
   def test_select_year_with_default_prompt
@@ -634,12 +629,6 @@ class DateHelperTest < ActionView::TestCase
     expected << "</select>\n"
 
     assert_dom_equal expected, select_minute(Time.mktime(2003, 8, 16, 8, 4, 18), {}, :class => 'selector', :accesskey => 'M')
-
-    #result = select_minute(Time.mktime(2003, 8, 16, 8, 4, 18), {}, :class => 'selector', :accesskey => 'M')
-    #assert result.include?('<select id="date_minute" name="date[minute]"')
-    #assert result.include?('class="selector"')
-    #assert result.include?('accesskey="M"')
-    #assert result.include?('<option value="00">00')
   end
 
   def test_select_minute_with_default_prompt
@@ -704,12 +693,6 @@ class DateHelperTest < ActionView::TestCase
     expected << "</select>\n"
 
     assert_dom_equal expected, select_second(Time.mktime(2003, 8, 16, 8, 4, 18), {}, :class => 'selector', :accesskey => 'M')
-
-    #result = select_second(Time.mktime(2003, 8, 16, 8, 4, 18), {}, :class => 'selector', :accesskey => 'M')
-    #assert result.include?('<select id="date_second" name="date[second]"')
-    #assert result.include?('class="selector"')
-    #assert result.include?('accesskey="M"')
-    #assert result.include?('<option value="00">00')
   end
 
   def test_select_second_with_default_prompt

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -390,11 +390,6 @@ class DateHelperTest < ActionView::TestCase
     expected << "</select>\n"
 
     assert_dom_equal expected, select_month(Time.mktime(2003, 8, 16), {}, :class => 'selector', :accesskey => 'M')
-    #result = select_month(Time.mktime(2003, 8, 16), {}, :class => 'selector', :accesskey => 'M')
-    #assert result.include?('<select id="date_month" name="date[month]"')
-    #assert result.include?('class="selector"')
-    #assert result.include?('accesskey="M"')
-    #assert result.include?('<option value="1">January')
   end
 
   def test_select_month_with_default_prompt

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -184,7 +184,6 @@ class FixturesTest < ActiveRecord::TestCase
   end
 
   def test_fixtures_from_root_yml_with_instantiation
-    # assert_equal 2, @accounts.size
     assert_equal 50, @unknown.credit_limit
   end
 

--- a/activesupport/bin/generate_tables
+++ b/activesupport/bin/generate_tables
@@ -50,16 +50,11 @@ module ActiveSupport
             ([0-9A-F]*);        # simple lowercase mapping
             ([0-9A-F]*)$/ix     # simple titlecase mapping
           codepoint.code              = $1.hex
-          #codepoint.name              = $2
-          #codepoint.category          = $3
           codepoint.combining_class   = Integer($4)
-          #codepoint.bidi_class        = $5
           codepoint.decomp_type       = $7
           codepoint.decomp_mapping    = ($8=='') ? nil : $8.split.collect(&:hex)
-          #codepoint.bidi_mirrored     = ($13=='Y') ? true : false
           codepoint.uppercase_mapping = ($16=='') ? 0 : $16.hex
           codepoint.lowercase_mapping = ($17=='') ? 0 : $17.hex
-          #codepoint.titlecase_mapping = ($18=='') ? nil : $18.hex
           @ucd.codepoints[codepoint.code] = codepoint
         end
 

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -162,7 +162,6 @@ class Time
 
   # Returns a new Time representing the start of the day (0:00)
   def beginning_of_day
-    #(self - seconds_since_midnight).change(usec: 0)
     change(:hour => 0)
   end
   alias :midnight :beginning_of_day


### PR DESCRIPTION
This removes code appearing in comments that no longer seem to be providing any value.
...that's it! :smile_cat: 

Each commit points to where the comment was originally introduced, but I'll be happy to squash.
:yellow_heart: :green_heart: :blue_heart: :purple_heart: :heart: 
