### PR TITLE
Fixed duration of 1.month so 12.months == 1.year

### DIFF
--- a/activesupport/lib/active_support/core_ext/integer/time.rb
+++ b/activesupport/lib/active_support/core_ext/integer/time.rb
@@ -18,7 +18,7 @@ class Integer
   #   # equivalent to Time.now.advance(months: 4, years: 5)
   #   (4.months + 5.years).from_now
   def months
-    ActiveSupport::Duration.new(self * 30.4375.days, [[:months, self]])
+    ActiveSupport::Duration.new(self * 30.4375.days.to_i, [[:months, self]])
   end
   alias :month :months
 

--- a/activesupport/lib/active_support/core_ext/integer/time.rb
+++ b/activesupport/lib/active_support/core_ext/integer/time.rb
@@ -18,7 +18,7 @@ class Integer
   #   # equivalent to Time.now.advance(months: 4, years: 5)
   #   (4.months + 5.years).from_now
   def months
-    ActiveSupport::Duration.new(self * 30.days, [[:months, self]])
+    ActiveSupport::Duration.new(self * 30.4375.days, [[:months, self]])
   end
   alias :month :months
 

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -12,7 +12,7 @@ class NumericExtTimeAndDateTimeTest < ActiveSupport::TestCase
       10.minutes => 600,
       1.hour + 15.minutes => 4500,
       2.days + 4.hours + 30.minutes => 189000,
-      5.years + 1.month + 1.fortnight => 161589600
+      5.years + 1.month + 1.fortnight => 161627400
     }
   end
 

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -61,9 +61,9 @@ class NumericExtTimeAndDateTimeTest < ActiveSupport::TestCase
   end
 
   def test_duration_after_conversion_is_no_longer_accurate
-    assert_equal 30.days.to_i.seconds.since(@now), 1.month.to_i.seconds.since(@now)
+    assert_equal 30.4375.days.to_i.seconds.since(@now), 1.month.to_i.seconds.since(@now)
     assert_equal 365.25.days.to_f.seconds.since(@now), 1.year.to_f.seconds.since(@now)
-    assert_equal 30.days.to_i.seconds.since(@dtnow), 1.month.to_i.seconds.since(@dtnow)
+    assert_equal 30.4375.days.to_i.seconds.since(@dtnow), 1.month.to_i.seconds.since(@dtnow)
     assert_equal 365.25.days.to_f.seconds.since(@dtnow), 1.year.to_f.seconds.since(@dtnow)
   end
 


### PR DESCRIPTION
`1.month` used to be equal to `30.days`, which caused that

``` ruby
1.year == 12.months # => false
```

With this change, one year equals 12 months.
