### PR TITLE
Validate inclusion of each object in an array

### DIFF
--- a/activemodel/lib/active_model/validations/clusivity.rb
+++ b/activemodel/lib/active_model/validations/clusivity.rb
@@ -25,7 +25,11 @@ module ActiveModel
           delimiter
         end
 
-        members.send(inclusion_method(members), value)
+        if value.is_a?(Array)
+          value.all? { |v| members.send(inclusion_method(members), v) }
+        else
+          members.send(inclusion_method(members), value)
+        end
       end
 
       def delimiter

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -158,4 +158,21 @@ class InclusionValidationTest < ActiveModel::TestCase
   ensure
     Person.clear_validators!
   end
+
+  def test_validates_inclusion_of_with_array_value
+    Person.validates_inclusion_of :karma, in: %w( abe monkey )
+
+    p = Person.new
+    p.karma = %w(Lifo monkey)
+
+    assert p.invalid?
+    assert_equal ["is not included in the list"], p.errors[:karma]
+
+    p = Person.new
+    p.karma = %w(abe monkey)
+
+    assert p.valid?
+  ensure
+    Person.clear_validators!
+  end
 end


### PR DESCRIPTION
If the value for a specified attribute is an array, validating inclusion
will check if the array is present in the given members. `:each_object`
allow the user to specify that each object in the array must be present
in the given members.

This can be useful if you, for instance, use the `array: true` option on a database column and want to enforce that members of the array are included in a specified list of valid values.

Before:

```
validates_inclusion_of :features, in: %w(IR Bluetooth Wireless)
```

If the attribute `features` is an array containing `["Bluetooth"]` the above validation would fail, since `["IR", "Bluetooth", "Wireless"].include?(["Bluetooth"])` is `false`.

After:

```
validates_inclusion_of :features, in: %w(IR Bluetooth Wireless), each_object: true
```

Will now pass, since we're actually checking if each object in `features` are included in the given members.

This is my first pull request to Rails, so any feedback is highly appreciated.
