### PR TITLE
Fix - `to_s(:db)` in numeric range

### DIFF
--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -120,7 +120,11 @@ module ActiveSupport::NumericWithFormat
     when :human_size
       return ActiveSupport::NumberHelper.number_to_human_size(self, options)
     else
-      super
+      if is_a?(Float) || format.is_a?(Symbol)
+        super()
+      else
+        super
+      end
     end
   end
 

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -406,6 +406,26 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     end
   end
 
+  def test_to_s_with_invalid_formatter
+    assert_equal '123', 123.to_s(:invalid)
+    assert_equal '2.5', 2.5.to_s(:invalid)
+    assert_equal '100000000000000000000', (100**10).to_s(:invalid)
+    assert_equal '1000010.0', BigDecimal("1000010").to_s(:invalid)
+  end
+
+  def test_default_to_s
+    assert_equal '123', 123.to_s
+    assert_equal '1111011', 123.to_s(2)
+
+    assert_equal '2.5', 2.5.to_s
+
+    assert_equal '100000000000000000000', (100**10).to_s
+    assert_equal '1010110101111000111010111100010110101100011000100000000000000000000', (100**10).to_s(2)
+
+    assert_equal '1000010.0', BigDecimal("1000010").to_s
+    assert_equal '10000 10.0', BigDecimal("1000010").to_s('5F')
+  end
+
   def test_in_milliseconds
     assert_equal 10_000, 10.seconds.in_milliseconds
   end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -1,5 +1,6 @@
 require 'abstract_unit'
 require 'active_support/time'
+require 'active_support/core_ext/numeric'
 require 'active_support/core_ext/range'
 
 class RangeTest < ActiveSupport::TestCase
@@ -11,6 +12,11 @@ class RangeTest < ActiveSupport::TestCase
   def test_to_s_from_times
     date_range = Time.utc(2005, 12, 10, 15, 30)..Time.utc(2005, 12, 10, 17, 30)
     assert_equal "BETWEEN '2005-12-10 15:30:00' AND '2005-12-10 17:30:00'", date_range.to_s(:db)
+  end
+
+  def test_to_s_with_numeric
+    number_range = (1..100)
+    assert_equal "BETWEEN '1' AND '100'", number_range.to_s(:db)
   end
 
   def test_date_range


### PR DESCRIPTION
When `to_s(:db)` is applied on numeric range

Previously,
 `to_s(:db)` was called on both the limits but `Fixnum#to_s` expects `base` in the argument and tries to convert `:db` into integer and raises exception `TypeError: no implicit conversion of Symbol into Integer`.

Solution - Using to_s after rescue if to_s(:db) is not available on limits of range.
