### PR TITLE
Kill extra newline at the start of generated manifest.js

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/assets/config/manifest.js.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/config/manifest.js.tt
@@ -1,4 +1,3 @@
-
 <% unless options.api? -%>
 //= link_tree ../images
 <% end -%>


### PR DESCRIPTION
Just noticed that newly generated `manifest.js` file has extra line at the top.
