### PR TITLE
Allow #permit to take its list of permitted parameters as a Set

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -377,7 +377,7 @@ module ActionController
     def permit(*filters)
       params = self.class.new
 
-      filters.flatten.each do |filter|
+      filters.map { |f| f.is_a?(Set) ? f.to_a : f }.flatten.each do |filter|
         case filter
         when Symbol, String
           permitted_scalar_filter(params, filter)

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -255,6 +255,10 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert_equal "32", @params[:person].permit([ :age ])[:age]
   end
 
+  test "permitting parameters as a set" do
+    assert_equal "32", @params[:person].permit(Set.new([:age]))[:age]
+  end
+
   test "to_h returns empty hash on unpermitted params" do
     assert @params.to_h.is_a? ActiveSupport::HashWithIndifferentAccess
     assert_not @params.to_h.is_a? ActionController::Parameters


### PR DESCRIPTION
[benchmark](https://gist.github.com/ojab/0c45f2c9b15268855c75#file-bench-rb) shows negligible performance differences here on both ruby-2.2.3 & jruby-9.0.4.0.
MRI results:

```
Calculating -------------------------------------
              before     4.098k i/100ms
               after     3.964k i/100ms
-------------------------------------------------
              before     47.053k (± 7.0%) i/s -    237.684k
               after     46.758k (± 4.7%) i/s -    233.876k
```
