### PR TITLE
Expanding the documentation for collection=objects [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1181,7 +1181,8 @@ module ActiveRecord
       # [collection=objects]
       #   Replaces the collections content by deleting and adding objects as appropriate. If the <tt>:through</tt>
       #   option is true callbacks in the join models are triggered except destroy callbacks, since deletion is
-      #   direct.
+      #   direct by default. You can specify <tt>dependent: :destroy</tt> or
+      #   <tt>dependent: :nullify</tt> to override this.
       # [collection_singular_ids]
       #   Returns an array of the associated objects' ids
       # [collection_singular_ids=ids]


### PR DESCRIPTION
I ran into a problem the other day where the has_many :through objects were being updated.  Callbacks on the callbacks on the join model weren't being called.  Looked up the documentation and it said exactly that.  So I went to look into why that was the case.  Only to find that if dependent: :destroy was added the callbacks on the join table were run.  Thought I might make it a little more clear for future me when I run into this problem the next time.

This is my first time trying to update the documentation.  Please let me know if there is anything else that needs to be done.
