### PR TITLE
Fix "instance variable not initialized" in tests

### DIFF
--- a/actionpack/test/assertions/response_assertions_test.rb
+++ b/actionpack/test/assertions/response_assertions_test.rb
@@ -19,6 +19,11 @@ module ActionDispatch
         end
       end
 
+      def setup
+        @controller = nil
+        @request = nil
+      end
+
       def test_assert_response_predicate_methods
         [:success, :missing, :redirect, :error].each do |sym|
           @response = FakeResponse.new RESPONSE_PREDICATES[sym].to_s.sub(/\?/, '').to_sym


### PR DESCRIPTION
The ActionPack test suite had a handful of these warnings when run. This
was due to `assert_response` being tested outside the context of a
controller instance where those instance variables would already have
been initialized.
