### PR TITLE
ActiveRecord::Base#find(array) returning result in the same order as the array passed

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -459,7 +459,11 @@ module ActiveRecord
       end
 
       if result.size == expected_size
-        result
+        # result
+        records_by_id = result.each_with_object(Hash.new) do |record, by_id|
+          by_id[record.id] = record
+        end
+        ids.first(expected_size).collect { |id| records_by_id[id] }
       else
         raise_record_not_found_exception!(ids, result.size, expected_size)
       end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -459,6 +459,7 @@ module ActiveRecord
       end
 
       if result.size == expected_size
+        return result if self.values[:order]
         records_by_id = result.index_by(&:id)
         ids.first(expected_size).collect { |id| records_by_id[id.to_i] }
       else

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -455,13 +455,13 @@ module ActiveRecord
       if offset_value && (ids.size - offset_value < expected_size)
         expected_size = ids.size - offset_value
       else
-        ids = ids.first(expected_size) unless self.values[:order]
+        ids = ids.first(expected_size) if order_values.empty?
       end
 
       result = where(primary_key => ids).to_a
 
       if result.size == expected_size
-        return result if self.values[:order]
+        return result if order_values.present?
         records_by_id = result.index_by(&:id)
         ids.collect { |id| records_by_id[id.to_i] }.compact
       else

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -459,11 +459,8 @@ module ActiveRecord
       end
 
       if result.size == expected_size
-        # result
-        records_by_id = result.each_with_object(Hash.new) do |record, by_id|
-          by_id[record.id] = record
-        end
-        ids.first(expected_size).collect { |id| records_by_id[id] }
+        records_by_id = result.index_by(&:id)
+        ids.first(expected_size).collect { |id| records_by_id[id.to_i] }
       else
         raise_record_not_found_exception!(ids, result.size, expected_size)
       end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -521,7 +521,8 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_find_by_slug_with_array
-    assert_equal Topic.find(['1-meowmeow', '2-hello']), Topic.find([1, 2])
+    assert_equal Topic.find([1, 2]), Topic.find(['1-meowmeow', '2-hello'])
+    assert_equal 'The Second Topic of the day', Topic.find(['2-hello', '1-meowmeow']).first.title
   end
 
   def test_find_by_slug_with_range

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -109,7 +109,7 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal 'The Fifth Topic of the day',  records[2].title
   end
 
-  def test_find_with_ids_and_offset # failing with offset
+  def test_find_with_ids_and_offset
     records = Topic.offset(2).find([3,2,5,1,4])
     assert_equal 3, records.size
     assert_equal 'The Fifth Topic of the day',  records[0].title
@@ -261,7 +261,7 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal topics(:second).title, Topic.find([2]).first.title
   end
 
-  def test_find_by_ids_with_limit_and_offset # failing with offset
+  def test_find_by_ids_with_limit_and_offset
     assert_equal 2, Entrant.limit(2).find([1,3,2]).size
     entrants = Entrant.limit(3).offset(2).find([1,3,2])
     assert_equal 1, entrants.size

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -76,6 +76,11 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal 'The Third Topic of the day', records[0].title
     assert_equal 'The First Topic',            records[1].title
     assert_equal 'The Fifth Topic of the day', records[2].title
+
+    records = Topic.order(:id).find([5,3,1])
+    assert_equal 'The First Topic',            records[0].title
+    assert_equal 'The Third Topic of the day', records[1].title
+    assert_equal 'The Fifth Topic of the day', records[2].title
   end
 
   def test_find_with_ids_and_limit

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -48,6 +48,18 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_find_with_ids_returning_ordered
+    records = Topic.find([4,2,5])
+    assert_equal 'The Fourth Topic of the day', records[0].title
+    assert_equal 'The Second Topic of the day', records[1].title
+    assert_equal 'The Fifth Topic of the day', records[2].title
+
+    records = Topic.find(4,2,5)
+    assert_equal 'The Fourth Topic of the day', records[0].title
+    assert_equal 'The Second Topic of the day', records[1].title
+    assert_equal 'The Fifth Topic of the day', records[2].title
+  end
+
   def test_find_passing_active_record_object_is_deprecated
     assert_deprecated do
       Topic.find(Topic.last)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -78,6 +78,13 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal 'The Fifth Topic of the day', records[2].title
   end
 
+  def test_find_with_ids_and_limit
+    records = Topic.limit(2).find([4,2,5])
+    assert_equal 2, records.size
+    assert_equal 'The Fourth Topic of the day', records[0].title
+    assert_equal 'The Second Topic of the day', records[1].title
+  end
+
   def test_find_passing_active_record_object_is_deprecated
     assert_deprecated do
       Topic.find(Topic.last)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -99,7 +99,17 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal 'The Fifth Topic of the day',  records[2].title
   end
 
-  def test_find_with_ids_and_offset
+  def test_find_with_ids_where_and_limit
+    # Please note that Topic 1 is the only not approved so
+    # if it were among the first 3 it would raise a ActiveRecord::RecordNotFound
+    records = Topic.where(approved: true).limit(3).find([3,2,5,1,4])
+    assert_equal 3, records.size
+    assert_equal 'The Third Topic of the day',  records[0].title
+    assert_equal 'The Second Topic of the day', records[1].title
+    assert_equal 'The Fifth Topic of the day',  records[2].title
+  end
+
+  def test_find_with_ids_and_offset # failing with offset
     records = Topic.offset(2).find([3,2,5,1,4])
     assert_equal 3, records.size
     assert_equal 'The Fifth Topic of the day',  records[0].title
@@ -251,7 +261,7 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal topics(:second).title, Topic.find([2]).first.title
   end
 
-  def test_find_by_ids_with_limit_and_offset
+  def test_find_by_ids_with_limit_and_offset # failing with offset
     assert_equal 2, Entrant.limit(2).find([1,3,2]).size
     entrants = Entrant.limit(3).offset(2).find([1,3,2])
     assert_equal 1, entrants.size

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -83,11 +83,28 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal 'The Fifth Topic of the day', records[2].title
   end
 
-  def test_find_with_ids_and_limit
-    records = Topic.limit(2).find([4,2,5])
+  def test_find_with_ids_with_limit_and_order_clause
+    # The order clause takes precedence over the informed ids
+    records = Topic.limit(2).order(:id).find([5,3,1])
     assert_equal 2, records.size
-    assert_equal 'The Fourth Topic of the day', records[0].title
+    assert_equal 'The First Topic',            records[0].title
+    assert_equal 'The Third Topic of the day', records[1].title
+  end
+
+  def test_find_with_ids_and_limit
+    records = Topic.limit(3).find([3,2,5,1,4])
+    assert_equal 3, records.size
+    assert_equal 'The Third Topic of the day',  records[0].title
     assert_equal 'The Second Topic of the day', records[1].title
+    assert_equal 'The Fifth Topic of the day',  records[2].title
+  end
+
+  def test_find_with_ids_and_offset
+    records = Topic.offset(2).find([3,2,5,1,4])
+    assert_equal 3, records.size
+    assert_equal 'The Fifth Topic of the day',  records[0].title
+    assert_equal 'The First Topic',             records[1].title
+    assert_equal 'The Fourth Topic of the day', records[2].title
   end
 
   def test_find_passing_active_record_object_is_deprecated
@@ -236,7 +253,9 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_find_by_ids_with_limit_and_offset
     assert_equal 2, Entrant.limit(2).find([1,3,2]).size
-    assert_equal 1, Entrant.limit(3).offset(2).find([1,3,2]).size
+    entrants = Entrant.limit(3).offset(2).find([1,3,2])
+    assert_equal 1, entrants.size
+    assert_equal 'Ruby Guru', entrants.first.name
 
     # Also test an edge case: If you have 11 results, and you set a
     #   limit of 3 and offset of 9, then you should find that there
@@ -244,6 +263,8 @@ class FinderTest < ActiveRecord::TestCase
     devs = Developer.all
     last_devs = Developer.limit(3).offset(9).find devs.map(&:id)
     assert_equal 2, last_devs.size
+    assert_equal 'fixture_10', last_devs[0].name
+    assert_equal 'Jamis', last_devs[1].name
   end
 
   def test_find_with_large_number

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -58,6 +58,24 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal 'The Fourth Topic of the day', records[0].title
     assert_equal 'The Second Topic of the day', records[1].title
     assert_equal 'The Fifth Topic of the day', records[2].title
+
+    records = Topic.find(['4','2','5'])
+    assert_equal 'The Fourth Topic of the day', records[0].title
+    assert_equal 'The Second Topic of the day', records[1].title
+    assert_equal 'The Fifth Topic of the day', records[2].title
+
+    records = Topic.find('4','2','5')
+    assert_equal 'The Fourth Topic of the day', records[0].title
+    assert_equal 'The Second Topic of the day', records[1].title
+    assert_equal 'The Fifth Topic of the day', records[2].title
+  end
+
+  def test_find_with_ids_and_order_clause
+    # The order clause takes precedence over the informed ids
+    records = Topic.order(:author_name).find([5,3,1])
+    assert_equal 'The Third Topic of the day', records[0].title
+    assert_equal 'The First Topic',            records[1].title
+    assert_equal 'The Fifth Topic of the day', records[2].title
   end
 
   def test_find_passing_active_record_object_is_deprecated


### PR DESCRIPTION
Picking up on the work in #20453, it occurred to me that we can easily apply the limit & offset ourselves, and then ignore them during the query.

Fixes #20338
Contains #20453
