### PR TITLE
Allow normal version updates within a release series

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -232,8 +232,22 @@ module Rails
           ] + dev_edge_common
         else
           [GemfileEntry.version('rails',
-                            Rails::VERSION::STRING,
+                            rails_version_specifier,
                             "Bundle edge Rails instead: gem 'rails', github: 'rails/rails'")]
+        end
+      end
+
+      def rails_version_specifier(gem_version = Rails.gem_version)
+        if gem_version.prerelease?
+          next_series = gem_version
+          next_series = next_series.bump while next_series.segments.size > 2
+
+          [">= #{gem_version}", "< #{next_series}"]
+        elsif gem_version.segments.size == 3
+          "~> #{gem_version}"
+        else
+          patch = gem_version.segments[0, 3].join(".")
+          ["~> #{patch}", ">= #{gem_version}"]
         end
       end
 

--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  <%= '# ' if options.dev? || options.edge? -%>s.add_dependency "rails", "~> <%= Rails::VERSION::STRING %>"
+  <%= '# ' if options.dev? || options.edge? -%>s.add_dependency "rails", "<%= Array.wrap(rails_version_specifier).join('", "') %>"
 <% unless options[:skip_active_record] -%>
 
   s.add_development_dependency "<%= gem_for_database[0] %>"

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 <% if options[:skip_gemspec] -%>
-<%= '# ' if options.dev? || options.edge? -%>gem 'rails', '~> <%= Rails::VERSION::STRING %>'
+<%= '# ' if options.dev? || options.edge? -%>gem 'rails', '<%= Array.wrap(rails_version_specifier).join("', '") %>'
 <% else -%>
 # Declare your gem's dependencies in <%= name %>.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and

--- a/railties/test/generators/generator_test.rb
+++ b/railties/test/generators/generator_test.rb
@@ -80,6 +80,21 @@ module Rails
         }
         assert_equal gems.drop(2), generator.gemfile_entries
       end
+
+      def test_recommended_rails_versions
+        klass     = make_builder_class
+        generator = klass.start(['new', 'blah'])
+
+        specifier_for = -> v { generator.send(:rails_version_specifier, Gem::Version.new(v)) }
+
+        assert_equal '~> 4.1.13', specifier_for['4.1.13']
+        assert_equal ['>= 4.1.6.rc1', '< 4.2'], specifier_for['4.1.6.rc1']
+        assert_equal ['~> 4.1.7', '>= 4.1.7.1'], specifier_for['4.1.7.1']
+        assert_equal ['~> 4.1.7', '>= 4.1.7.1.2'], specifier_for['4.1.7.1.2']
+        assert_equal ['>= 4.1.7.1.rc2', '< 4.2'], specifier_for['4.1.7.1.rc2']
+        assert_equal ['>= 4.2.0.beta1', '< 4.3'], specifier_for['4.2.0.beta1']
+        assert_equal ['>= 5.0.0.beta1', '< 5.1'], specifier_for['5.0.0.beta1']
+      end
     end
   end
 end


### PR DESCRIPTION
We originally chose to apply very strict versioning on the `rails` entry in the Gemfile, because our future versioning policy was not strongly defined.

Now it is, and our policy is very much designed on the expectation that people will regularly update to the latest patch level in their release series... so we should encourage that.

Of course, Gemfile.lock will do its job and prevent unplanned updates, just as it does for every other gem in the bundle... but if you run `bundle update`, we want to get you the latest bug/security fixes without requiring a manual edit of the Gemfile entry.

Our current version could be a few different shapes, so it takes a bit of work to find the right specifier, but in principle, we match anything of the form x.y.*, where x.y matches our current release series.
