### PR TITLE
Handle specified schemas when removing a Postgres index

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -507,14 +507,27 @@ module ActiveRecord
         end
 
         def remove_index(table_name, options = {}) #:nodoc:
-          index_name = index_name_for_remove(table_name, options)
+          table = Utils.extract_schema_qualified_name(table_name.to_s)
+
+          if options.is_a?(Hash) && options.key?(:name)
+            provided_index = Utils.extract_schema_qualified_name(options[:name].to_s)
+
+            options[:name] = provided_index.identifier
+            table = PostgreSQL::Name.new(provided_index.schema, table.identifier) unless table.schema.present?
+
+            if provided_index.schema.present? && table.schema != provided_index.schema
+              raise ArgumentError.new("Index schema '#{provided_index.schema}' does not match table schema '#{table.schema}'")
+            end
+          end
+
+          index_to_remove = PostgreSQL::Name.new(table.schema, index_name_for_remove(table.to_s, options))
           algorithm =
-            if Hash === options && options.key?(:algorithm)
+            if options.is_a?(Hash) && options.key?(:algorithm)
               index_algorithms.fetch(options[:algorithm]) do
                 raise ArgumentError.new("Algorithm must be one of the following: #{index_algorithms.keys.map(&:inspect).join(', ')}")
               end
             end
-          execute "DROP INDEX #{algorithm} #{quote_table_name(index_name)}"
+          execute "DROP INDEX #{algorithm} #{quote_table_name(index_to_remove)}"
         end
 
         # Renames an index of a table. Raises error if length of new

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -334,6 +334,20 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  def test_remove_index_when_schema_specified
+    @connection.execute "CREATE INDEX \"things_Index\" ON #{SCHEMA_NAME}.things (name)"
+    assert_nothing_raised { @connection.remove_index "things", name: "#{SCHEMA_NAME}.things_Index" }
+
+    @connection.execute "CREATE INDEX \"things_Index\" ON #{SCHEMA_NAME}.things (name)"
+    assert_nothing_raised { @connection.remove_index "#{SCHEMA_NAME}.things", name: "things_Index" }
+
+    @connection.execute "CREATE INDEX \"things_Index\" ON #{SCHEMA_NAME}.things (name)"
+    assert_nothing_raised { @connection.remove_index "#{SCHEMA_NAME}.things", name: "#{SCHEMA_NAME}.things_Index" }
+
+    @connection.execute "CREATE INDEX \"things_Index\" ON #{SCHEMA_NAME}.things (name)"
+    assert_raises(ArgumentError) { @connection.remove_index "#{SCHEMA2_NAME}.things", name: "#{SCHEMA_NAME}.things_Index" }
+  end
+
   def test_primary_key_with_schema_specified
     [
       %("#{SCHEMA_NAME}"."#{PK_TABLE_NAME}"),


### PR DESCRIPTION
Adds back support for specifying the schema in the `name`option passed to `remove_index`. Support for this had been removed in https://github.com/rails/rails/pull/19456.
