### PR TITLE
fix indentation of generated controller test

### DIFF
--- a/railties/lib/rails/generators/test_unit/scaffold/templates/api_functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/api_functional_test.rb
@@ -2,10 +2,10 @@ require 'test_helper'
 
 <% module_namespacing do -%>
 class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTest
-  <% if mountable_engine? -%>
+  <%- if mountable_engine? -%>
   include Engine.routes.url_helpers
 
-  <% end -%>
+  <%- end -%>
   setup do
     @<%= singular_table_name %> = <%= fixture_name %>(:one)
   end

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
@@ -5,7 +5,7 @@ class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTe
   <%- if mountable_engine? -%>
   include Engine.routes.url_helpers
 
-  <% end -%>
+  <%- end -%>
   setup do
     @<%= singular_table_name %> = <%= fixture_name %>(:one)
   end


### PR DESCRIPTION
```
# before
module Bukkits
  class UsersControllerTest < ActionDispatch::IntegrationTest
    include Engine.routes.url_helpers

      setup do
      @user = bukkits_users(:one)
    end
```

```
# after
module Bukkits
  class UsersControllerTest < ActionDispatch::IntegrationTest
    include Engine.routes.url_helpers

    setup do
      @user = bukkits_users(:one)
    end
```
