### PR TITLE
add line break between method of generated channel js

### DIFF
--- a/actioncable/lib/rails/generators/channel/templates/assets/channel.coffee
+++ b/actioncable/lib/rails/generators/channel/templates/assets/channel.coffee
@@ -7,8 +7,8 @@ App.<%= class_name.underscore %> = App.cable.subscriptions.create "<%= class_nam
 
   received: (data) ->
     # Called when there's incoming data on the websocket for this channel
-
 <% actions.each do |action| -%>
+
   <%= action %>: ->
     @perform '<%= action %>'
 <% end -%>


### PR DESCRIPTION
```
# before
App.appearance = App.cable.subscriptions.create "AppearanceChannel",
  connected: ->
    # Called when the subscription is ready for use on the server

  disconnected: ->
    # Called when the subscription has been terminated by the server

  received: (data) ->
    # Called when there's incoming data on the websocket for this channel

  appear: ->
    @perform 'appear'
  away: ->
    @perform 'away'
```

```
# after
App.appearance = App.cable.subscriptions.create "AppearanceChannel",
  connected: ->
    # Called when the subscription is ready for use on the server

  disconnected: ->
    # Called when the subscription has been terminated by the server

  received: (data) ->
    # Called when there's incoming data on the websocket for this channel

  appear: ->
    @perform 'appear'

  away: ->
    @perform 'away'
```
