### PR TITLE
HSTS without IncludeSubdomains is often useless

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -36,7 +36,7 @@ module ActionDispatch
     HSTS_EXPIRES_IN = 15552000
 
     def self.default_hsts_options
-      { expires: HSTS_EXPIRES_IN, subdomains: false, preload: false }
+      { expires: HSTS_EXPIRES_IN, subdomains: true, preload: false }
     end
 
     def initialize(app, redirect: {}, hsts: {}, **options)


### PR DESCRIPTION
1) Because if you forget to add Secure; to the session cookie, it will leak to http:// subdomain in some cases
2) Because http:// subdomain can Cookie Bomb/cookie force main domain or be used for phishing.

That's why _by default_ it must include subdomains as it's much more common scenario. Very few websites _intend_ to leave their blog.app.com working over http:// while having everything else encrypted. 

Yes, many developers forget to add subdomains=true manually, believe me :)
