### PR TITLE
do not generate ActionCable channel JS stub with --api: fixes #22669

### DIFF
--- a/actioncable/lib/rails/generators/channel/channel_generator.rb
+++ b/actioncable/lib/rails/generators/channel/channel_generator.rb
@@ -9,7 +9,9 @@ module Rails
 
       def create_channel_file
         template "channel.rb", File.join('app/channels', class_path, "#{file_name}_channel.rb")
-        template "assets/channel.coffee", File.join('app/assets/javascripts/channels', class_path, "#{file_name}.coffee")
+        if Rails::Generators.options[:rails][:assets]
+          template "assets/channel.coffee", File.join('app/assets/javascripts/channels', class_path, "#{file_name}.coffee")
+        end
       end
 
       protected

--- a/railties/test/generators/channel_generator_test.rb
+++ b/railties/test/generators/channel_generator_test.rb
@@ -1,0 +1,30 @@
+require 'generators/generators_test_helper'
+require 'rails/generators/channel/channel_generator'
+
+class ChannelGeneratorTest < Rails::Generators::TestCase
+  include GeneratorsTestHelper
+
+  def test_channel_skeleton_is_created
+    Rails::Generators.options[:rails][:assets] = true
+    run_generator ["appearance"]
+
+    assert_file "app/channels/appearance_channel.rb" do |channel|
+      assert_match(/class AppearanceChannel < ApplicationCable::Channel/, channel)
+    end
+
+    assert_file "app/assets/javascripts/channels/appearance.coffee" do |channel|
+      assert_match(/App.cable.subscriptions.create "AppearanceChannel"/, channel)
+    end
+  end
+
+  def test_api_only_skips_js_creation
+    Rails::Generators.options[:rails][:assets] = false
+    run_generator ["appearance"]
+
+    assert_file "app/channels/appearance_channel.rb" do |channel|
+      assert_match(/class AppearanceChannel < ApplicationCable::Channel/, channel)
+    end
+
+    assert_no_file "app/assets/javascripts/channels/appearance.coffee"
+  end
+end


### PR DESCRIPTION
This is my attempt to fix this issue (#22669).
I hope this is a valid approach.

Cheers.
