### PR TITLE
Fix using add_resource with a block after gem in custom generators

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix using `add_source` with a block after using `gem` in a custom generator.
+
+    *Will Fisher*
+
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
 *   No changes.

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -75,7 +75,7 @@ module Rails
 
         in_root do
           if block
-            append_file "Gemfile", "source #{quote(source)} do", force: true
+            append_file "Gemfile", "\nsource #{quote(source)} do", force: true
             @in_group = true
             instance_eval(&block)
             @in_group = false

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -52,6 +52,15 @@ class ActionsTest < Rails::Generators::TestCase
     assert_file 'Gemfile', /source 'http:\/\/gems\.github\.com' do\n  gem 'rspec-rails'\nend/
   end
 
+  def test_add_source_with_block_adds_source_to_gemfile_after_gem
+    run_generator
+    action :gem, 'will-paginate'
+    action :add_source, 'http://gems.github.com' do
+      gem 'rspec-rails'
+    end
+    assert_file 'Gemfile', /gem 'will-paginate'\nsource 'http:\/\/gems\.github\.com' do\n  gem 'rspec-rails'\nend/
+  end
+
   def test_gem_should_put_gem_dependency_in_gemfile
     run_generator
     action :gem, 'will-paginate'


### PR DESCRIPTION
This fixes using `add_source` with a block after calling `gem` in a custom generator.  Otherwise it tries to create a Gemfile with the output from both methods on the same line and would then throw an error when `bundle install` gets run

for example if a custom generator had the following

``` ruby
gem "font-awesome-rails"

add_source "https://rails-assets.org" do
  gem 'rails-assets-bootstrap'
  gem 'rails-assets-jasny-bootstrap'
end
```

it would generate

``` ruby
gem 'font-awesome-rails'source 'https://rails-assets.org' do
  gem 'rails-assets-bootstrap'
  gem 'rails-assets-jasny-bootstrap'
end
```

and now generates

``` ruby
gem 'font-awesome-rails'
source 'https://rails-assets.org' do
  gem 'rails-assets-bootstrap'
  gem 'rails-assets-jasny-bootstrap'
end
```
