### PR TITLE
Ensure Action Cable files are removed when `skip_action_cable` is set.

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -313,6 +313,14 @@ module Rails
         end
       end
 
+      def delete_action_cable_files_skipping_action_cable
+        if options[:skip_action_cable]
+          remove_file 'config/redis/cable.yml'
+          remove_file 'app/assets/javascripts/cable.coffee'
+          remove_dir 'app/channels'
+        end
+      end
+
       def delete_non_api_initializers_if_api_option
         if options[:api]
           remove_file 'config/initializers/session_store.rb'

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -379,6 +379,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_generator_if_skip_action_cable_is_given
     run_generator [destination_root, "--skip-action-cable"]
     assert_file "config/application.rb", /#\s+require\s+["']action_cable\/engine["']/
+    assert_no_file "config/redis/cable.yml"
+    assert_no_file "app/assets/javascripts/cable.coffee"
+    assert_no_file "app/channels"
   end
 
   def test_inclusion_of_javascript_runtime


### PR DESCRIPTION
The Action Cable generators creates four files which need to be removed
if `skip_action_cable` is set. In addition, `skip_action_cable` should
be set to `true` when `options[:api]` is set.
1. `app/assets/javascripts/cable.coffee`
2. `app/channels/application_cable/channel.rb`
3. `app/channels/application_cable/connection.rb`
4. `config/redis/cable.yml`

Fixes #22669.
