### PR TITLE
initializers/cookies_serializer is not new to 5.0

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/cookies_serializer.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/cookies_serializer.rb
@@ -1,4 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-# This is a new Rails 5.0 default, so introduced as a config to ensure apps made with earlier versions of Rails aren't affected when upgrading.
 Rails.application.config.action_dispatch.cookies_serializer = :json


### PR DESCRIPTION
[ci skip]

The initializer has existed since 4.1, for instance see:
https://github.com/rails/rails/blob/v4.1.0/railties/lib/rails/generators/rails/app/templates/config/initializers/cookies_serializer.rb
