### PR TITLE
Remove `add_source`

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -61,31 +61,6 @@ module Rails
         end
       end
 
-      # Add the given source to +Gemfile+
-      #
-      # If block is given, gem entries in block are wrapped into the source group.
-      #
-      #   add_source "http://gems.github.com/"
-      #
-      #   add_source "http://gems.github.com/" do
-      #     gem "rspec-rails"
-      #   end
-      def add_source(source, options={}, &block)
-        log :source, source
-
-        in_root do
-          if block
-            append_file "Gemfile", "source #{quote(source)} do", force: true
-            @in_group = true
-            instance_eval(&block)
-            @in_group = false
-            append_file "Gemfile", "\nend\n", force: true
-          else
-            prepend_file "Gemfile", "source #{quote(source)}\n", verbose: false
-          end
-        end
-      end
-
       # Adds a line inside the Application class for <tt>config/application.rb</tt>.
       #
       # If options <tt>:env</tt> is specified, the line is appended to the corresponding

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -38,20 +38,6 @@ class ActionsTest < Rails::Generators::TestCase
     assert_file 'lib/test_file.rb', 'heres block data'
   end
 
-  def test_add_source_adds_source_to_gemfile
-    run_generator
-    action :add_source, 'http://gems.github.com'
-    assert_file 'Gemfile', /source 'http:\/\/gems\.github\.com'/
-  end
-
-  def test_add_source_with_block_adds_source_to_gemfile_with_gem
-    run_generator
-    action :add_source, 'http://gems.github.com' do
-      gem 'rspec-rails'
-    end
-    assert_file 'Gemfile', /source 'http:\/\/gems\.github\.com' do\n  gem 'rspec-rails'\nend/
-  end
-
   def test_gem_should_put_gem_dependency_in_gemfile
     run_generator
     action :gem, 'will-paginate'


### PR DESCRIPTION
IMHO, having `add_source` is a monkey patch which promotes bad
conventions when using Bundler / Rubygems' Gemfile. It is important to
know the syntax behind Gemfiles, and how to properly declare things.
