### PR TITLE
Remove blank line generated in config.ru

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config.ru.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config.ru.tt
@@ -1,8 +1,8 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
-
 <%- unless options[:skip_action_cable] -%>
+
 # Action Cable uses EventMachine which requires that all classes are loaded in advance
 Rails.application.eager_load!
 require 'action_cable/process/logging'


### PR DESCRIPTION
Follow the lines of the other `.tt` files ([example](https://github.com/rails/rails/blob/1611ab4db173a7596a7a94c58dabf1483f070304/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt#L26)) that have the space after the
condition to avoid too many white lines in the resulted file.
