### PR TITLE
Remove "app/channels" if --skip-action-cable

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -321,6 +321,12 @@ module Rails
         end
       end
 
+      def delete_app_channels_skipping_action_cable
+        if options[:skip_action_cable]
+          remove_dir 'app/channels'
+        end
+      end
+
       def finish_template
         build(:leftovers)
       end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -379,6 +379,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_generator_if_skip_action_cable_is_given
     run_generator [destination_root, "--skip-action-cable"]
     assert_file "config/application.rb", /#\s+require\s+["']action_cable\/engine["']/
+    assert_no_file "app/channels"
   end
 
   def test_inclusion_of_javascript_runtime


### PR DESCRIPTION
If I generate a new rails app with the `--skip-action-cable` option, I probably should not see `app/channels/application_cable/channel.rb` and `app/channels/application_cable/connection.rb`.

What do you think?
