### PR TITLE
Action Cable channel generator doesn't create JS assets if options[:rails][:assets] is false

### DIFF
--- a/actioncable/lib/rails/generators/channel/channel_generator.rb
+++ b/actioncable/lib/rails/generators/channel/channel_generator.rb
@@ -9,7 +9,9 @@ module Rails
 
       def create_channel_file
         template "channel.rb", File.join('app/channels', class_path, "#{file_name}_channel.rb")
-        template "assets/channel.coffee", File.join('app/assets/javascripts/channels', class_path, "#{file_name}.coffee")
+        if Rails::Generators.options[:rails][:assets]
+          template "assets/channel.coffee", File.join('app/assets/javascripts/channels', class_path, "#{file_name}.coffee")
+        end
       end
 
       protected

--- a/railties/test/generators/channel_generator_test.rb
+++ b/railties/test/generators/channel_generator_test.rb
@@ -1,0 +1,30 @@
+require 'generators/generators_test_helper'
+require 'rails/generators/channel/channel_generator'
+
+class ChannelGeneratorTest < Rails::Generators::TestCase
+  include GeneratorsTestHelper
+  tests Rails::Generators::ChannelGenerator
+
+  def test_channel_is_created
+    run_generator ['chat']
+    
+    assert_file "app/channels/chat_channel.rb" do |channel|
+      assert_match(/class ChatChannel < ApplicationCable::Channel/, channel)
+    end
+
+    assert_file "app/assets/javascripts/channels/chat.coffee" do |channel|
+      assert_match(/App.cable.subscriptions.create "ChatChannel"/, channel)
+    end
+  end
+
+  def test_channel_asset_is_not_created
+    Rails::Generators.options[:rails][:assets] = false
+    run_generator ['chat']
+
+    assert_file "app/channels/chat_channel.rb" do |channel|
+      assert_match(/class ChatChannel < ApplicationCable::Channel/, channel)
+    end
+
+    assert_no_file "app/assets/javascripts/channels/chat.coffee"
+  end
+end


### PR DESCRIPTION
Fix for #22669
