### PR TITLE
Use an appropriate rebuild task on Travis

### DIFF
--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -60,7 +60,14 @@ class Build
 
   def tasks
     if activerecord?
-      ['db:mysql:rebuild', "#{adapter}:#{'isolated_' if isolated?}test"]
+      tasks = ["#{adapter}:#{'isolated_' if isolated?}test"]
+      case adapter
+      when 'mysql2'
+        tasks.unshift 'db:mysql:rebuild'
+      when 'postgresql'
+        tasks.unshift 'db:postgresql:rebuild'
+      end
+      tasks
     else
       ["test", ('isolated' if isolated?), ('integration' if integration?)].compact.join(":")
     end


### PR DESCRIPTION
Use `db:mysql2:rebuild` when testing mysql2,
`db:postgresql:rebuild` when testing postgresql
and no rebuild task when testing others.
