### PR TITLE
display detailed information in inline reporting

### DIFF
--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -12,7 +12,7 @@ module Rails
       if output_inline? && result.failure && (!result.skipped? || options[:verbose])
         io.puts
         io.puts
-        io.puts result.failures.map(&:message)
+        io.puts format_failures(result)
         io.puts
         io.puts format_rerun_snippet(result)
         io.puts
@@ -54,6 +54,12 @@ module Rails
 
       def fail_fast?
         options[:fail_fast]
+      end
+
+      def format_failures(result)
+        result.failures.map do |failure|
+          "#{failure.result_label}:\n#{result.class}##{result.name}:\n#{failure.message}\n"
+        end
       end
 
       def format_rerun_snippet(result)

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -344,7 +344,8 @@ module ApplicationTests
       create_test_file :models, 'post', pass: false
 
       output = run_test_command('test/models/post_test.rb')
-      assert_match %r{Running:\n\nPostTest\nF\n\nwups!\n\nbin/rails test test/models/post_test.rb:6}, output
+      expect = %r{Running:\n\nPostTest\nF\n\nFailure:\nPostTest#test_truth:\nwups!\n\nbin/rails test test/models/post_test.rb:6\n\n\n\n}
+      assert_match expect, output
     end
 
     def test_only_inline_failure_output

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -71,7 +71,8 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
     create_test_file 'post', pass: false
 
     output = run_test_command('test/post_test.rb')
-    assert_match %r{Running:\n\nPostTest\nF\n\nwups!\n\nbin/test (/private)?#{plugin_path}/test/post_test.rb:6}, output
+    expect = %r{Running:\n\nPostTest\nF\n\nFailure:\nPostTest#test_truth:\nwups!\n\nbin/test (/private)?#{plugin_path}/test/post_test.rb:6}
+    assert_match expect, output
   end
 
   def test_only_inline_failure_output

--- a/railties/test/generators/test_runner_in_engine_test.rb
+++ b/railties/test/generators/test_runner_in_engine_test.rb
@@ -17,7 +17,8 @@ class TestRunnerInEngineTest < ActiveSupport::TestCase
     create_test_file 'post', pass: false
 
     output = run_test_command('test/post_test.rb')
-    assert_match %r{Running:\n\nPostTest\nF\n\nwups!\n\nbin/rails test test/post_test.rb:6}, output
+    expect = %r{Running:\n\nPostTest\nF\n\nFailure:\nPostTest#test_truth:\nwups!\n\nbin/rails test test/post_test.rb:6}
+    assert_match expect, output
   end
 
   private

--- a/railties/test/test_unit/reporter_test.rb
+++ b/railties/test/test_unit/reporter_test.rb
@@ -61,14 +61,16 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     @reporter.record(failed_test)
     @reporter.report
 
-    assert_match %r{\A\n\nboo\n\nbin/rails test .*test/test_unit/reporter_test.rb:\d+\n\n\z}, @output.string
+    expect = %r{\A\n\nFailure:\nTestUnitReporterTest::ExampleTest#woot:\nboo\n\nbin/rails test test/test_unit/reporter_test.rb:\d+\n\n\z}
+    assert_match expect, @output.string
   end
 
   test "outputs errors inline" do
     @reporter.record(errored_test)
     @reporter.report
 
-    assert_match %r{\A\n\nArgumentError: wups\n    No backtrace\n\nbin/rails test .*test/test_unit/reporter_test.rb:6\n\n\z}, @output.string
+    expect = %r{\A\n\nError:\nTestUnitReporterTest::ExampleTest#woot:\nArgumentError: wups\n    No backtrace\n\nbin/rails test .*test/test_unit/reporter_test.rb:6\n\n\z}
+    assert_match expect, @output.string
   end
 
   test "outputs skipped tests inline if verbose" do
@@ -76,7 +78,8 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     verbose.record(skipped_test)
     verbose.report
 
-    assert_match %r{\A\n\nskipchurches, misstemples\n\nbin/rails test .*test/test_unit/reporter_test.rb:\d+\n\n\z}, @output.string
+    expect = %r{\A\n\nSkipped:\nTestUnitReporterTest::ExampleTest#woot:\nskipchurches, misstemples\n\nbin/rails test test/test_unit/reporter_test.rb:\d+\n\n\z}
+    assert_match expect, @output.string
   end
 
   test "does not output rerun snippets after run" do


### PR DESCRIPTION
The errors message only was not displayed, as if it did not use the inline reporting,
modified to also information the method name and the like in error are displayed.

```
# before
Failed assertion, no message given.

bin/rails test test/models/user_test.rb:5
```

```
# after
Failure:
UserTest#test_the_truth [/home/yaginuma/program/rails/master/test/models/user_test.rb:5]:
Failed assertion, no message given.

bin/rails test test/models/user_test.rb:5
```

Context: #22483
