### PR TITLE
rake log:clear task updated 

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -392,7 +392,7 @@ rake assets:clobber     # Remove compiled assets
 rake assets:precompile  # Compile all the assets named in config.assets.precompile
 rake db:create          # Create the database from config/database.yml for the current Rails.env
 ...
-rake log:clear          # Truncates all *.log files in log/ to zero bytes (specify which logs with LOGS=test,development)
+rake log:clear          # Truncates all/specified *.log files in log/ to zero bytes (specify which logs with LOGS=test,development)
 rake middleware         # Prints out your Rack middleware stack
 ...
 rake tmp:clear          # Clear cache and socket files from tmp/ (narrow w/ tmp:cache:clear, tmp:sockets:clear)

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Specify log file names or all logs to clear `rake log:clear`
+
+    Specify which logs to clear when using the `rake log:clear` task, e.g. `rake log:clear LOGS=test,staging`
+
+    Clear all logs from log/*.log e.g. `rake log:clear ENV['LOGS']=all`
+
+    By default `rake log:clear` clears standard environment log files i.e. 'development,test,production'
+
+    *Pramod Shinde*
+
 *   Fix using `add_source` with a block after using `gem` in a custom generator.
 
     *Will Fisher*

--- a/railties/lib/rails/tasks/log.rake
+++ b/railties/lib/rails/tasks/log.rake
@@ -1,5 +1,12 @@
 namespace :log do
-  desc "Truncates all *.log files in log/ to zero bytes (specify which logs with LOGS=test,development)"
+  
+  ## 
+  # Truncates all/specified log files
+  # ENV['LOGS'] 
+  #   - defaults to standard environment log files i.e. 'development,test,production'
+  #   - ENV['LOGS']=all truncates all files i.e. log/*.log
+  #   - ENV['LOGS']='test,development' truncates only specified files
+  desc "Truncates all/specified *.log files in log/ to zero bytes (specify which logs with LOGS=test,development)"
   task :clear do
     log_files.each do |file|
       clear_log_file(file)
@@ -7,15 +14,21 @@ namespace :log do
   end
 
   def log_files
-    if ENV['LOGS']
-      ENV['LOGS'].split(',')
-                  .map    { |file| "log/#{file.strip}.log" }
-                  .select { |file| File.exist?(file) }
-    else
+    if ENV['LOGS'] == 'all'
       FileList["log/*.log"]
+    elsif ENV['LOGS']
+      log_files_to_truncate(ENV['LOGS'])
+    else
+      log_files_to_truncate("development,test,production")
     end
   end
 
+  def log_files_to_truncate(envs)
+    envs.split(',')
+        .map    { |file| "log/#{file.strip}.log" }
+        .select { |file| File.exist?(file) }
+  end
+  
   def clear_log_file(file)
     f = File.open(file, "w")
     f.close

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -21,13 +21,13 @@ module ApplicationTests
         RUBY
 
         list_tables = lambda { `bin/rails runner 'p ActiveRecord::Base.connection.tables'`.strip }
-        File.write("log/my.log", "zomg!")
+        File.write("log/test.log", "zomg!")
 
         assert_equal '[]', list_tables.call
-        assert_equal 5, File.size("log/my.log")
+        assert_equal 5, File.size("log/test.log")
         assert_not File.exist?("tmp/restart.txt")
         `bin/setup 2>&1`
-        assert_equal 0, File.size("log/my.log")
+        assert_equal 0, File.size("log/test.log")
         assert_equal '["articles", "schema_migrations", "active_record_internal_metadatas"]', list_tables.call
         assert File.exist?("tmp/restart.txt")
       end


### PR DESCRIPTION
- Avoided truncating all files if no ENV['LOGS'] specified
- Updated task to accept LOGS=all for truncating all files from log/ i.e. log/*log
- If no LOGS specified will truncates standard environment log files i.e. 'development,test,staging,production'
- CHANGELOG update added
