### PR TITLE
Suppress warning ambiguous first argument

### DIFF
--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -509,7 +509,7 @@ module CacheStoreBehavior
 
   def test_cache_miss_instrumentation
     @events = []
-    ActiveSupport::Notifications.subscribe /^cache_(.*)\.active_support$/ do |*args|
+    ActiveSupport::Notifications.subscribe(/^cache_(.*)\.active_support$/) do |*args|
       @events << ActiveSupport::Notifications::Event.new(*args)
     end
     assert_not @cache.fetch("bad_key") {}


### PR DESCRIPTION
Suppress warning (warning: ambiguous first argument; put
parentheses or a space even after `/' operator)
