### PR TITLE
Have ActionCable be an optional dependency, similar to Turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ end
 
 # Action Cable
 group :cable do
+  version = File.read(File.expand_path('../RAILS_VERSION', __FILE__)).strip
+  gem 'actioncable', version
   gem 'puma', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,6 @@ PATH
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     rails (5.0.0.beta1)
-      actioncable (= 5.0.0.beta1)
       actionmailer (= 5.0.0.beta1)
       actionpack (= 5.0.0.beta1)
       actionview (= 5.0.0.beta1)
@@ -297,6 +296,7 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
+  actioncable (= 5.0.0.beta1)
   activerecord-jdbcmysql-adapter (>= 1.3.0)
   activerecord-jdbcpostgresql-adapter (>= 1.3.0)
   activerecord-jdbcsqlite3-adapter (>= 1.3.0)

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord',  version
   s.add_dependency 'actionmailer',  version
   s.add_dependency 'activejob',     version
-  s.add_dependency 'actioncable',   version
   s.add_dependency 'railties',      version
 
   s.add_dependency 'bundler',         '>= 1.3.0', '< 2.0'

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -117,6 +117,7 @@ module Rails
          javascript_gemfile_entry,
          jbuilder_gemfile_entry,
          psych_gemfile_entry,
+         actioncable_gemfile_entry,
          @extra_entries].flatten.find_all(&@gem_filter)
       end
 
@@ -335,6 +336,13 @@ module Rails
         comment = 'Use Psych as the YAML engine, instead of Syck, so serialized ' \
                   'data can be read safely from different rubies (see http://git.io/uuLVag)'
         GemfileEntry.new('psych', '~> 2.0', comment, platforms: :rbx)
+      end
+
+      def actioncable_gemfile_entry
+        return [] if options[:skip_action_cable]
+
+        comment = 'WebSocket framework for Rails.'
+        GemfileEntry.new('actioncable', nil, comment)
       end
 
       def bundle_command(command)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -378,7 +378,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_generator_if_skip_action_cable_is_given
     run_generator [destination_root, "--skip-action-cable"]
+
+    assert_file "Gemfile" do |content|
+      assert_no_match(/actioncable/, content)
+    end
+
     assert_file "config/application.rb", /#\s+require\s+["']action_cable\/engine["']/
+  end
+
+  def test_action_cable
+    run_generator
+    assert_gem 'actioncable'
   end
 
   def test_inclusion_of_javascript_runtime


### PR DESCRIPTION
IMHO, ActionCable is something that is like a cherry on an ice cream sundae -- something that's super cool, but not something every app is going to need or want. Especially with gems like eventmachine, users can sometimes get weird installation errors, which could make onboarding difficult. ActionCable is still a dependency that is turned on by default, but now it is also opt out, without breaking the runtime dependencies of Rails. Open to feedback about this. :smiley: 
