### PR TITLE
Update README extension in Getting Started guide

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -173,7 +173,7 @@ of the files and folders that Rails created by default:
 |log/|Application log files.|
 |public/|The only folder seen by the world as-is. Contains static files and compiled assets.|
 |Rakefile|This file locates and loads tasks that can be run from the command line. The task definitions are defined throughout the components of Rails. Rather than changing Rakefile, you should add your own tasks by adding files to the lib/tasks directory of your application.|
-|README.rdoc|This is a brief instruction manual for your application. You should edit this file to tell others what your application does, how to set it up, and so on.|
+|README.md|This is a brief instruction manual for your application. You should edit this file to tell others what your application does, how to set it up, and so on.|
 |test/|Unit tests, fixtures, and other test apparatus. These are covered in [Testing Rails Applications](testing.html).|
 |tmp/|Temporary files (like cache and pid files).|
 |vendor/|A place for all third-party code. In a typical Rails application this includes vendored gems.|


### PR DESCRIPTION
Generated Rails app READMEs are Markdown as of 9739f07d763e29b1c5d71cabf1ca8cfa4421e653
