### PR TITLE
ActionCable README.md fixes

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -399,16 +399,16 @@ The above will start a cable server on port 28080. Remember to point your client
 
 ### In app
 
-If you are using a threaded server like Puma or Thin, the current implementation of ActionCable can run side-along with your Rails application. For example, to listen for WebSocket requests on `/websocket`, match requests on that path:
+If you are using a threaded server like Puma or Thin, the current implementation of ActionCable can run side-along with your Rails application. For example, to listen for WebSocket requests on `/cable`, match requests on that path:
 
 ```ruby
 # config/routes.rb
 Example::Application.routes.draw do
-  match "/websocket", :to => ActionCable.server, via: [:get, :post]
+  match "/cable", :to => ActionCable.server, via: [:get, :post]
 end
 ```
 
-You can use `App.cable = ActionCable.createConsumer("/websocket")` to connect to the cable server.
+You can use `App.cable = ActionCable.createConsumer()` to connect to the cable server if `action_cable_meta_tag` is included in the layout. A custom path is specified as first argument to `createConsumer` (e.g. `App.cable = ActionCable.createConsumer("/websocket")`).
 
 For every instance of your server you create and for every worker your server spawns, you will also have a new instance of ActionCable, but the use of Redis keeps messages synced across connections.
 

--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -364,7 +364,7 @@ Then add the following line to your layout before your JavaScript tag:
 And finally, create your consumer like so:
 
 ```coffeescript
-App.cable = Cable.createConsumer()
+App.cable = ActionCable.createConsumer()
 ```
 
 For a full list of all configuration options, see the `ActionCable::Server::Configuration` class.
@@ -408,7 +408,7 @@ Example::Application.routes.draw do
 end
 ```
 
-You can use `App.cable = Cable.createConsumer("/websocket")` to connect to the cable server.
+You can use `App.cable = ActionCable.createConsumer("/websocket")` to connect to the cable server.
 
 For every instance of your server you create and for every worker your server spawns, you will also have a new instance of ActionCable, but the use of Redis keeps messages synced across connections.
 

--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -1,4 +1,4 @@
-# Action Cable –- Integrated WebSockets for Rails
+# Action Cable – Integrated WebSockets for Rails
 
 Action Cable seamlessly integrates WebSockets with the rest of your Rails application.
 It allows for real-time features to be written in Ruby in the same style


### PR DESCRIPTION
I fixed some issues in the README.md file that became obvious when I updated an experiment to a current Rails version that includes ActionCable.

Some of the CoffeeScript examples still used "Cable" instead of "ActionCable" (16bee0f) and in the (in-app) server config example there was no reference to the default (`/cable`) websocket path and `action_cable_meta_tag` (cb6f337). As a christmas bonus, I fixed the strange dashes in the headline (9f00021) :wink:.

Hope, that's not too trivial for a PR!
