### PR TITLE
No more no changes entries in the CHANGELOGs

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
-*   No changes.
-
-
 *   Added to Rails!
 
     *DHH*

--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
-*   No changes.
-
-
 *   `config.force_ssl = true` will set
     `config.action_mailer.default_url_options = { protocol: 'https' }`
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
-*   No changes.
-
-
 *   Deprecate `redirect_to :back` in favor of `redirect_back`, which accepts a
     required `fallback_location` argument, thus eliminating the possibility of a
     `RedirectBackError`.

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
-*   No changes.
-
-
 *   `I18n.translate` helper will wrap the missing translation keys
      in a <span> tag only if `debug_missing_translation` configuration
      be true. Default value is `true`. For example in `application.rb`:

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
-*   No changes.
-
-
 *   Fixed serializing `:at` option for `assert_enqueued_with`
     and `assert_performed_with`.
 

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
-*   No changes.
-
-
 *   Validate multiple contexts on `valid?` and `invalid?` at once.
 
     Example:

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -4,9 +4,6 @@
 
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
-*   No changes.
-
-
 *   Order the result of `find(ids)` to match the passed array, if the relation
     has no explicit order defined.
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
-*   No changes.
-
-
 *   Add thread_m/cattr_accessor/reader/writer suite of methods for declaring class and module variables that live per-thread.
     This makes it easy to declare per-thread globals that are encapsulated. Note: This is a sharp edge. A wild proliferation
     of globals is A Bad Thing. But like other sharp tools, when it's right, it's right.


### PR DESCRIPTION
During the `5.0.0.beta1` release, the CHANGELOGs got an entry like the
following:

```
* No changes.
```

It is kinda confusing as there are indeed changes after it. Not a
biggie, just a small pass over the CHANGELOGs.
