### PR TITLE
Use CGI.escapeHTML for html escape

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -5,7 +5,6 @@ class ERB
   module Util
     HTML_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;', '"' => '&quot;', "'" => '&#39;' }
     JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003e', '<' => '\u003c', "\u2028" => '\u2028', "\u2029" => '\u2029' }
-    HTML_ESCAPE_REGEXP = /[&"'><]/
     HTML_ESCAPE_ONCE_REGEXP = /["><']|&(?!([a-zA-Z]+|(#\d+)|(#[xX][\dA-Fa-f]+));)/
     JSON_ESCAPE_REGEXP = /[\u2028\u2029&><]/u
 
@@ -37,7 +36,7 @@ class ERB
       if s.html_safe?
         s
       else
-        ActiveSupport::Multibyte::Unicode.tidy_bytes(s).gsub(HTML_ESCAPE_REGEXP, HTML_ESCAPE)
+        CGI.escapeHTML(ActiveSupport::Multibyte::Unicode.tidy_bytes(s))
       end
     end
     module_function :unwrapped_html_escape
@@ -243,8 +242,7 @@ module ActiveSupport #:nodoc:
     private
 
     def html_escape_interpolated_argument(arg)
-      (!html_safe? || arg.html_safe?) ? arg :
-        arg.to_s.gsub(ERB::Util::HTML_ESCAPE_REGEXP, ERB::Util::HTML_ESCAPE)
+      (!html_safe? || arg.html_safe?) ? arg : CGI.escapeHTML(arg.to_s)
     end
   end
 end


### PR DESCRIPTION
From Ruby 2.3, `CGI.escapeHTML` will be about 7 times faster than `gsub` by this patch https://github.com/ruby/ruby/pull/1164.
Since escaping HTML can be a bottleneck of rendering templates, I want to use faster implementation.
