### PR TITLE
Weird Behaviour of autoloading 

### DIFF
--- a/activesupport/test/constantize_test_cases.rb
+++ b/activesupport/test/constantize_test_cases.rb
@@ -24,6 +24,13 @@ class Object
   include AddtlGlobalConstants
 end
 
+module Concerns
+  module Likable
+    def do_fancy_likeable_stuff_in_model
+    end
+  end
+end
+
 module ConstantizeTestCases
   include DependenciesTestHelpers
 
@@ -104,6 +111,7 @@ module ConstantizeTestCases
     assert_nil yield('Object::Object::Object::ABC')
     assert_nil yield('A::Object::B')
     assert_nil yield('A::Object::Object::Object::B')
+    assert_nil yield('Likable')
 
     assert_raises(NameError) do
       with_autoloading_fixtures do


### PR DESCRIPTION
We had some autoloading issues in combination with a polymorphic association where we were trying to add a counter cache. 

The association definition looks like this:

``` ruby
belongs_to :likable, polymorphic: true, counter_cache: true
```

We also have a `likable` concern in `app/models/concerns/likeable.rb`, which is in the `Concerns` namespace, however it seems to confuse the autoloading somehow.

```
LoadError: Unable to autoload constant Likable, expected app/models/concerns/likable.rb to define it
from .rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:495:in `load_missing_constant'
```

For now, I'm just going to rename the `Likable` concern. However, it would be nice to know if you'd consider the behaviour a bug?
