### PR TITLE
Remove unused dev_edge_common variable

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -219,16 +219,14 @@ module Rails
       end
 
       def rails_gemfile_entry
-        dev_edge_common = [
-        ]
         if options.dev?
           [
             GemfileEntry.path('rails', Rails::Generators::RAILS_DEV_PATH)
-          ] + dev_edge_common
+          ]
         elsif options.edge?
           [
             GemfileEntry.github('rails', 'rails/rails')
-          ] + dev_edge_common
+          ]
         else
           [GemfileEntry.version('rails',
                             rails_version_specifier,


### PR DESCRIPTION
`dev_edge_common` was introduced in 3ac70bd to accommodate for gems
needed to build Rails 5 alpha, but that array is empty 477bed8 (Rails 5.0.0.beta1).
