### PR TITLE
Don't ignore classes that already inherited AC::Base

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -51,6 +51,11 @@ module ActionController
         extend ::AbstractController::Railties::RoutesHelpers.with(app.routes)
         extend ::ActionController::Railties::Helpers
 
+        o = Class.new
+        o.extend ::AbstractController::Railties::RoutesHelpers.with(app.routes)
+        o.extend ::ActionController::Railties::Helpers
+        descendants.each {|d| o.inherited(d) }
+
         options.each do |k,v|
           k = "#{k}="
           if respond_to?(k)


### PR DESCRIPTION
This is a Truly Terrible implementation, and clearly not what we should do.

But I think we do need to do something: there's nothing to prevent anyone from inheriting from `ActionController::Base` before this initializer / `on_load` block gets run... but these two modules assume they're adding omniscient `inherited` hooks.

See https://github.com/rails/rails-controller-testing/issues/8 -- while it was originally caused by an explicit bad dependency that _forced_ things to occur in the wrong order, it's now simply unconstrained. That was enough to fix it for @sgrif, but in my example, things are still loading "too soon".
