### PR TITLE
indent resource in namespace

### DIFF
--- a/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
+++ b/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
@@ -21,7 +21,7 @@ module Rails
         end
 
         # inserts the primary resource
-        write("resources :#{file_name.pluralize}", route_length + 1)
+        write("resources :#{file_name.pluralize}", route_length + 2)
 
         # ends blocks
         regular_class_path.each_index do |index|


### PR DESCRIPTION
When you run `rails g controller admin::reports show` it creates the namespaced resource without indentation inside the block. Like this:

``` ruby
  namespace :admin do
  get 'reports/show'
  end
```

This fixes the indentation making it look like this:

``` ruby
  namespace :admin do
    get 'reports/show'
  end
```
