### PR TITLE
Add #== back to ActionDispatch::MiddlewareStack::Middleware

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -14,6 +14,15 @@ module ActionDispatch
 
       def name; klass.name; end
 
+      def ==(middleware)
+        case middleware
+        when Middleware
+          klass == middleware.klass
+        when Class
+          klass == middleware
+        end
+      end
+
       def inspect
         if klass.is_a?(Class)
           klass.to_s

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -131,4 +131,16 @@ class MiddlewareStackTest < ActiveSupport::TestCase
       assert_equal BazMiddleware, @stack.last.klass
     end
   end
+
+  test "can check if Middleware are equal - Class" do
+    assert_equal BazMiddleware, BazMiddleware
+  end
+
+  test "can check if Middleware are equal - Middleware" do
+    assert_equal @stack.middlewares.first, @stack.middlewares.first
+  end
+
+  test "klass is correct" do
+    assert_equal @stack.middlewares.first.klass, FooMiddleware
+  end
 end


### PR DESCRIPTION
This was causing bug #22738 to occur. Also added extra tests to make
sure everything is A-OK. This behavior was removed in https://github.com/rails/rails/commit/2a3c47ff5d4ed7391d8a2d02a6baa1f1f55a8df3.

r? @rafaelfranca 
