### PR TITLE
Fix Rails tutorial link

### DIFF
--- a/railties/RDOC_MAIN.rdoc
+++ b/railties/RDOC_MAIN.rdoc
@@ -57,7 +57,7 @@ can read more about Action Pack in its {README}[link:files/actionpack/README_rdo
 
 * The \README file created within your application.
 * {Getting Started with \Rails}[http://guides.rubyonrails.org/getting_started.html].
-* {Ruby on \Rails Tutorial}[http://ruby.railstutorial.org/ruby-on-rails-tutorial-book].
+* {Ruby on \Rails Tutorial}[http://www.railstutorial.org/book].
 * {Ruby on \Rails Guides}[http://guides.rubyonrails.org].
 * {The API Documentation}[http://api.rubyonrails.org].
 


### PR DESCRIPTION
[ci skip]

The old link is 404 not found.
The link matches what the rest of the documentation already points to:
- https://github.com/rails/rails/blame/2de2263118d6763c11a02db05079a5b7a97a0a34/guides/source/getting_started.md#L2052
- https://github.com/rails/rails/blame/2de2263118d6763c11a02db05079a5b7a97a0a34/README.md#L74
