### PR TITLE
Fix NoMethodError preparable for Arel::Visitors::PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -30,7 +30,7 @@ module ActiveRecord
       def select_all(arel, name = nil, binds = [], preparable: nil)
         arel, binds = binds_from_relation arel, binds
         sql = to_sql(arel, binds)
-        if arel.is_a?(String) && preparable.nil?
+        if !prepared_statements || (arel.is_a?(String) && preparable.nil?)
           preparable = false
         else
           preparable = visitor.preparable

--- a/activerecord/test/cases/adapters/postgresql/prepared_statements_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/prepared_statements_test.rb
@@ -1,0 +1,22 @@
+require "cases/helper"
+require "models/developer"
+
+class PreparedStatementsTest < ActiveRecord::PostgreSQLTestCase
+  fixtures :developers
+
+  def setup
+    @default_prepared_statements = Developer.connection_config[:prepared_statements]
+    Developer.connection_config[:prepared_statements] = false
+  end
+
+  def teardown
+    Developer.connection_config[:prepared_statements] = @default_prepared_statements
+  end
+
+  def nothing_raised_with_falsy_prepared_statements
+    assert_nothing_raised do
+      Developer.where(id: 1)
+    end
+  end
+
+end


### PR DESCRIPTION
After upgrading to `5.0.0.beta1` I got an error called

```
  `select_all': undefined method `preparable' for #<Arel::Visitors::PostgreSQL:0x007ff9416cf718> (NoMethodError)
```

So I did debug the problem and I found that module `DetermineIfPreparableVisitor` is extended only in case database configs for `prepared_statements` is true.

```
  @visitor = Arel::Visitors::PostgreSQL.new self
  if self.class.type_cast_config_to_boolean(config.fetch(:prepared_statements) { true })
    @prepared_statements = true
    @visitor.extend(DetermineIfPreparableVisitor)
  else
    @prepared_statements = false
  end
```

for that, I did that to fix the problem, and it works fine now :+1: 
