### PR TITLE
Add support for passing flags to MySQL2 adapter by array

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -11,8 +11,13 @@ module ActiveRecord
 
       config[:username] = 'root' if config[:username].nil?
       config[:flags] ||= 0
+
       if Mysql2::Client.const_defined? :FOUND_ROWS
-        config[:flags] |= Mysql2::Client::FOUND_ROWS
+        if config[:flags].kind_of? Array
+          config[:flags].push "FOUND_ROWS".freeze
+        else
+          config[:flags] |= Mysql2::Client::FOUND_ROWS          
+        end
       end
 
       client = Mysql2::Client.new(config)

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -87,7 +87,14 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
       assert_equal (Mysql2::Client::COMPRESS |  Mysql2::Client::FOUND_ROWS), ActiveRecord::Base.connection.raw_connection.query_options[:flags]
     end
   end
-
+  
+  def test_passing_flags_by_array_to_adapter
+    run_without_connection do |orig_connection|             
+      ActiveRecord::Base.establish_connection(orig_connection.merge({flags: ['COMPRESS'] }))
+      assert_equal ["COMPRESS", "FOUND_ROWS"], ActiveRecord::Base.connection.raw_connection.query_options[:flags]
+    end
+  end
+  
   def test_mysql_strict_mode_specified_default
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.merge({strict: :default}))


### PR DESCRIPTION
This adds support for passing connection flags to MySQL2 as an array.

The mysql2 gem's current readme.md file already claims this syntax works via activerecord so we might as well actually support it with the bonus of avoiding magic constants in configurations.
