### PR TITLE
Plugin Usage and Installation instructions

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/README.md
+++ b/railties/lib/rails/generators/rails/plugin/templates/README.md
@@ -1,3 +1,28 @@
 # <%= camelized_modules %>
+Short description and motivation.
 
-This project rocks and uses MIT-LICENSE.
+## Usage
+How to use my plugin.
+
+## Installation
+Add this line to your application's Gemfile:
+
+```ruby
+gem '<%= name %>'
+```
+
+And then execute:
+```bash
+$ bundle
+```
+
+Or install it yourself as:
+```bash
+$ gem install <%= name %>
+```
+
+## Contributing
+Contribution directions go here.
+
+## License
+The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).


### PR DESCRIPTION
We could also add one more section for the License, but the generator already adds a `MIT-LICENSE` file to the plugin.
