### PR TITLE
Fix .keep file issue with ActionCable

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -57,7 +57,7 @@ module Rails
       directory 'app'
 
       keep_file  'app/assets/images'
-      keep_file  'app/assets/javascripts/channels' unless options[:skip_action_cable]
+      empty_directory_with_keep_file 'app/assets/javascripts/channels' unless options[:skip_action_cable]
 
       keep_file  'app/controllers/concerns'
       keep_file  'app/models/concerns'


### PR DESCRIPTION
Fixes #22708
Make sure the channels file is create in assets/javascript/ so require
tree works in asset pipeline.
