### PR TITLE
remove cors initializer from rails app

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -329,6 +329,12 @@ module Rails
         end
       end
 
+      def delete_api_initializers
+        unless options[:api]
+          remove_file 'config/initializers/cors.rb'
+        end
+      end
+
       def finish_template
         build(:leftovers)
       end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -151,6 +151,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file("config/initializers/cookies_serializer.rb", /Rails\.application\.config\.action_dispatch\.cookies_serializer = :json/)
   end
 
+  def test_new_application_not_include_api_initializers
+    run_generator
+
+    assert_no_file 'config/initializers/cors.rb'
+  end
+
   def test_rails_update_keep_the_cookie_serializer_if_it_is_already_configured
     app_root = File.join(destination_root, 'myapp')
     run_generator [app_root]


### PR DESCRIPTION
`rack-cors` gem is defined in Gemfile by default only if the api,
not defined by default in rails app.
