### PR TITLE
Add colored output to the new test reporter.

### DIFF
--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -49,6 +49,12 @@ module Minitest
       options[:fail_fast] = true
     end
 
+    opts.on("-c", "--[no-]color",
+            "Enable color in the output") do |value|
+      options[:color] = value
+    end
+
+    options[:color] = true
     options[:output_inline] = true
     options[:patterns] = opts.order!
   end
@@ -80,6 +86,8 @@ module Minitest
     # Disable the extra failure output after a run, unless output is deferred.
     self.hide_aggregated_results = options[:output_inline]
 
+    self.reporter.reporters.clear
+    self.reporter << SummaryReporter.new(options[:io], options)
     self.reporter << ::Rails::TestUnitReporter.new(options[:io], options)
   end
 


### PR DESCRIPTION
This patch adds green/red/yellow ANSI color codes to `Rails::TestUnitReporter` and enables it by default (based on a CLI flag). 

![](https://dl.dropboxusercontent.com/s/0ss4c0p0b7jmujv/2015-12-22%20at%2011.06%20AM.png)

The output on iTerm's "Dark Background" preset:

![](https://dl.dropboxusercontent.com/s/pgp86aq49jybz3j/2015-12-22%20at%2012.09%20PM.png)

If we want a programatic way to disable this, we could add a class attribute to be the fallback value in case the CLI flag isn't present, so developers can disable the colouring forever on their `test_helper.rb` (a counterpart to RSpec's `.rspec` config file) - let me know if makes sense to add this to this PR. 

/cc @kaspth :smile: 
