### PR TITLE
fixes typo in 5.0 release notes

### DIFF
--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -385,7 +385,7 @@ Please refer to the [Changelog][active-model] for detailed changes.
 ### Deprecations
 
 *   Deprecated returning `false` as a way to halt Active Model and
-    `ActiveModel::Valdiations` callback chains. The recommended way is to
+    `ActiveModel::Validations` callback chains. The recommended way is to
     `throw(:abort)`. ([Pull Request](https://github.com/rails/rails/pull/17227))
 
 ### Notable changes


### PR DESCRIPTION
Just a quick fix for a typo I noticed in the 5.0 release notes, changing `ActiveModel::Valdiations` to `ActiveModel::Validations` 
