### PR TITLE
Add support for Petabyte and Exabyte in number to human size

### DIFF
--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -261,6 +261,8 @@ module ActionView
       #   number_to_human_size(1234567)                                      # => 1.18 MB
       #   number_to_human_size(1234567890)                                   # => 1.15 GB
       #   number_to_human_size(1234567890123)                                # => 1.12 TB
+      #   number_to_human_size(1234567890123456)                             # => 1.1 PB
+      #   number_to_human_size(1234567890123456789)                          # => 1.07 EB
       #   number_to_human_size(1234567, precision: 2)                        # => 1.2 MB
       #   number_to_human_size(483989, precision: 2)                         # => 470 KB
       #   number_to_human_size(1234567, precision: 2, separator: ',')        # => 1,2 MB

--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -75,6 +75,8 @@ module ActiveSupport::NumericWithFormat
   #  1234567.to_s(:human_size)                               # => 1.18 MB
   #  1234567890.to_s(:human_size)                            # => 1.15 GB
   #  1234567890123.to_s(:human_size)                         # => 1.12 TB
+  #  1234567890123456.to_s(:human_size)                      # => 1.1 PB
+  #  1234567890123456789.to_s(:human_size)                   # => 1.07 EB
   #  1234567.to_s(:human_size, precision: 2)                 # => 1.2 MB
   #  483989.to_s(:human_size, precision: 2)                  # => 470 KB
   #  1234567.to_s(:human_size, precision: 2, separator: ',') # => 1,2 MB

--- a/activesupport/lib/active_support/locale/en.yml
+++ b/activesupport/lib/active_support/locale/en.yml
@@ -106,6 +106,8 @@ en:
           mb: "MB"
           gb: "GB"
           tb: "TB"
+          pb: "PB"
+          eb: "EB"
       # Used in NumberHelper.number_to_human()
       decimal_units:
         format: "%n %u"

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -235,6 +235,8 @@ module ActiveSupport
     #   number_to_human_size(1234567)                                # => 1.18 MB
     #   number_to_human_size(1234567890)                             # => 1.15 GB
     #   number_to_human_size(1234567890123)                          # => 1.12 TB
+    #   number_to_human_size(1234567890123456)                       # => 1.1 PB
+    #   number_to_human_size(1234567890123456789)                    # => 1.07 EB
     #   number_to_human_size(1234567, precision: 2)                  # => 1.2 MB
     #   number_to_human_size(483989, precision: 2)                   # => 470 KB
     #   number_to_human_size(1234567, precision: 2, separator: ',')  # => 1,2 MB

--- a/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
@@ -1,7 +1,7 @@
 module ActiveSupport
   module NumberHelper
     class NumberToHumanSizeConverter < NumberConverter #:nodoc:
-      STORAGE_UNITS = [:byte, :kb, :mb, :gb, :tb]
+      STORAGE_UNITS = [:byte, :kb, :mb, :gb, :tb, :pb, :eb]
 
       self.namespace      = :human
       self.validate_float = true

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -143,6 +143,14 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     gigabytes(number) * 1024
   end
 
+  def petabytes(number)
+    terabytes(number) * 1024
+  end
+
+  def exabytes(number)
+    petabytes(number) * 1024
+  end
+
   def test_to_s__phone
     assert_equal("555-1234", 5551234.to_s(:phone))
     assert_equal("800-555-1212", 8005551212.to_s(:phone))
@@ -266,7 +274,9 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_equal '1.18 MB',   1234567.to_s(:human_size)
     assert_equal '1.15 GB',   1234567890.to_s(:human_size)
     assert_equal '1.12 TB',   1234567890123.to_s(:human_size)
-    assert_equal '1030 TB',   terabytes(1026).to_s(:human_size)
+    assert_equal '1.1 PB',    1234567890123456.to_s(:human_size)
+    assert_equal '1.07 EB',   1234567890123456789.to_s(:human_size)
+    assert_equal '1030 EB',   exabytes(1026).to_s(:human_size)
     assert_equal '444 KB',    kilobytes(444).to_s(:human_size)
     assert_equal '1020 MB',   megabytes(1023).to_s(:human_size)
     assert_equal '3 TB',      terabytes(3).to_s(:human_size)
@@ -289,6 +299,8 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
       assert_equal '1.23 MB',    1234567.to_s(:human_size, :prefix => :si)
       assert_equal '1.23 GB',    1234567890.to_s(:human_size, :prefix => :si)
       assert_equal '1.23 TB',    1234567890123.to_s(:human_size, :prefix => :si)
+      assert_equal '1.23 PB',    1234567890123456.to_s(:human_size, :prefix => :si)
+      assert_equal '1.23 EB',    1234567890123456789.to_s(:human_size, :prefix => :si)
     end
   end
 

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -34,6 +34,14 @@ module ActiveSupport
         gigabytes(number) * 1024
       end
 
+      def petabytes(number)
+        terabytes(number) * 1024
+      end
+
+      def exabytes(number)
+        petabytes(number) * 1024
+      end
+
       def test_number_to_phone
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
           assert_equal("555-1234", number_helper.number_to_phone(5551234))
@@ -219,7 +227,9 @@ module ActiveSupport
           assert_equal '1.18 MB',    number_helper.number_to_human_size(1234567)
           assert_equal '1.15 GB',    number_helper.number_to_human_size(1234567890)
           assert_equal '1.12 TB',    number_helper.number_to_human_size(1234567890123)
-          assert_equal '1030 TB',   number_helper.number_to_human_size(terabytes(1026))
+          assert_equal '1.1 PB',   number_helper.number_to_human_size(1234567890123456)
+          assert_equal '1.07 EB',   number_helper.number_to_human_size(1234567890123456789)
+          assert_equal '1030 EB',   number_helper.number_to_human_size(exabytes(1026))
           assert_equal '444 KB',    number_helper.number_to_human_size(kilobytes(444))
           assert_equal '1020 MB',   number_helper.number_to_human_size(megabytes(1023))
           assert_equal '3 TB',      number_helper.number_to_human_size(terabytes(3))
@@ -245,6 +255,8 @@ module ActiveSupport
             assert_equal '1.23 MB',    number_helper.number_to_human_size(1234567, :prefix => :si)
             assert_equal '1.23 GB',    number_helper.number_to_human_size(1234567890, :prefix => :si)
             assert_equal '1.23 TB',    number_helper.number_to_human_size(1234567890123, :prefix => :si)
+            assert_equal '1.23 PB',    number_helper.number_to_human_size(1234567890123456, :prefix => :si)
+            assert_equal '1.23 EB',    number_helper.number_to_human_size(1234567890123456789, :prefix => :si)
           end
         end
       end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2024,12 +2024,14 @@ Produce a string representation of a number rounded to a precision:
 Produce a string representation of a number as a human-readable number of bytes:
 
 ```ruby
-123.to_s(:human_size)            # => 123 Bytes
-1234.to_s(:human_size)           # => 1.21 KB
-12345.to_s(:human_size)          # => 12.1 KB
-1234567.to_s(:human_size)        # => 1.18 MB
-1234567890.to_s(:human_size)     # => 1.15 GB
-1234567890123.to_s(:human_size)  # => 1.12 TB
+123.to_s(:human_size)                  # => 123 Bytes
+1234.to_s(:human_size)                 # => 1.21 KB
+12345.to_s(:human_size)                # => 12.1 KB
+1234567.to_s(:human_size)              # => 1.18 MB
+1234567890.to_s(:human_size)           # => 1.15 GB
+1234567890123.to_s(:human_size)        # => 1.12 TB
+1234567890123456.to_s(:human_size)     # => 1.1 PB
+1234567890123456789.to_s(:human_size)  # => 1.07 EB
 ```
 
 Produce a string representation of a number in human-readable words:


### PR DESCRIPTION
Refer - #22732.

As Rails already provide support for Petabyte and Exabyte, hence add petabyte and exabyte support for conversion as well.

Should I update CHANGELOG?
