### PR TITLE
Fix Regression in Numericality Validations

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -39,7 +39,7 @@ module ActiveModel
           return
         end
 
-        if raw_value.is_a?(String)
+        unless raw_value.is_a?(Numeric)
           value = parse_raw_value_as_a_number(raw_value)
         end
 

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -39,6 +39,10 @@ module ActiveModel
           return
         end
 
+        if raw_value.is_a?(String)
+          value = parse_raw_value_as_a_number(raw_value)
+        end
+
         options.slice(*CHECKS.keys).each do |option, option_value|
           case option
           when :odd, :even
@@ -63,10 +67,13 @@ module ActiveModel
     protected
 
       def is_number?(raw_value)
-        parsed_value = Kernel.Float(raw_value) if raw_value !~ /\A0[xX]/
-        !parsed_value.nil?
+        !parse_raw_value_as_a_number(raw_value).nil?
       rescue ArgumentError, TypeError
         false
+      end
+
+      def parse_raw_value_as_a_number(raw_value)
+        Kernel.Float(raw_value) if raw_value !~ /\A0[xX]/
       end
 
       def is_integer?(raw_value)

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -79,6 +79,13 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!([97.18, 98, BigDecimal.new('98')]) # Notice the 97.18 as a float is greater than 97.18 as a BigDecimal due to floating point precision
   end
 
+  def test_validates_numericality_with_greater_than_using_string_value
+    Topic.validates_numericality_of :approved, greater_than: 10
+
+    invalid!(['-10', '9', '9.9', '10'], 'must be greater than 10')
+    valid!(['10.1', '11'])
+  end
+
   def test_validates_numericality_with_greater_than_or_equal
     Topic.validates_numericality_of :approved, greater_than_or_equal_to: 10
 
@@ -91,6 +98,13 @@ class NumericalityValidationTest < ActiveModel::TestCase
 
     invalid!([-97.18, 97.17, 97, BigDecimal.new('97.17'), BigDecimal.new('-97.18')], 'must be greater than or equal to 97.18')
     valid!([97.18, 98, BigDecimal.new('97.19')])
+  end
+
+  def test_validates_numericality_with_greater_than_or_equal_using_string_value
+    Topic.validates_numericality_of :approved, greater_than_or_equal_to: 10
+
+    invalid!(['-10', '9', '9.9'], 'must be greater than or equal to 10')
+    valid!(['10', '10.1', '11'])
   end
 
   def test_validates_numericality_with_equal_to
@@ -107,6 +121,13 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!([BigDecimal.new('97.18')])
   end
 
+  def test_validates_numericality_with_equal_to_using_string_value
+    Topic.validates_numericality_of :approved, equal_to: 10
+
+    invalid!(['-10', '9', '9.9', '10.1', '11'], 'must be equal to 10')
+    valid!(['10'])
+  end
+
   def test_validates_numericality_with_less_than
     Topic.validates_numericality_of :approved, less_than: 10
 
@@ -121,6 +142,13 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!([-97.0, 97.0, -97, 97, BigDecimal.new('-97'), BigDecimal.new('97')])
   end
 
+  def test_validates_numericality_with_less_than_using_string_value
+    Topic.validates_numericality_of :approved, less_than: 10
+
+    invalid!(['10', '10.1', '11'], 'must be less than 10')
+    valid!(['-10', '9', '9.9'])
+  end
+
   def test_validates_numericality_with_less_than_or_equal_to
     Topic.validates_numericality_of :approved, less_than_or_equal_to: 10
 
@@ -133,6 +161,13 @@ class NumericalityValidationTest < ActiveModel::TestCase
 
     invalid!([97.18, 98], 'must be less than or equal to 97.18')
     valid!([-97.18, BigDecimal.new('-97.18'), BigDecimal.new('97.18')])
+  end
+
+  def test_validates_numericality_with_less_than_or_equal_using_string_value
+    Topic.validates_numericality_of :approved, less_than_or_equal_to: 10
+
+    invalid!(['10.1', '11'], 'must be less than or equal to 10')
+    valid!(['-10', '9', '9.9', '10'])
   end
 
   def test_validates_numericality_with_odd
@@ -161,6 +196,13 @@ class NumericalityValidationTest < ActiveModel::TestCase
 
     invalid!([0, 0.0])
     valid!([-1, 42])
+  end
+
+  def test_validates_numericality_with_other_than_using_string_value
+    Topic.validates_numericality_of :approved, other_than: 0
+
+    invalid!(['0', '0.0'])
+    valid!(['-1', '1.1', '42'])
   end
 
   def test_validates_numericality_with_proc


### PR DESCRIPTION
A regression (#22744) introduced in 7500dae caused certain numericality
validations to raise an error when run against an attribute with a
string value. Previously, these validations would successfully run
against string values because the value was cast to a numeric class.

This commit resolves the regression by converting string values to
floats before performing numericality comparison validations.

I'm happy to hear feedback on these changes or suggestions for a better approach.

(Note that the tests added here pass on `4-2-stable`.)

[fixes #22744]
