### PR TITLE
Fix letter case and grammar in Routing guide

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -392,7 +392,7 @@ The comments resource here will have the following routes generated for it:
 
 ### Routing concerns
 
-Routing Concerns allows you to declare common routes that can be reused inside other resources and routes. To define a concern:
+Routing concerns allow you to declare common routes that can be reused inside other resources and routes. To define a concern:
 
 ```ruby
 concern :commentable do


### PR DESCRIPTION
This minor commit changes "concerns" to lowercase to match the heading, and removes the "s" from "allow" to reflect the pluralization.
[ci skip]
