### PR TITLE
titleize the model name on default submit buttons

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1922,6 +1922,8 @@ module ActionView
             @object_name.to_s.humanize
           end
 
+          model = model.downcase
+
           defaults = []
           defaults << :"helpers.submit.#{object_name}.#{key}"
           defaults << :"helpers.submit.#{key}"

--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -31,6 +31,26 @@ end
 class GoodCustomer < Customer
 end
 
+class TicketType < Struct.new(:name)
+  extend ActiveModel::Naming
+  include ActiveModel::Conversion
+  extend ActiveModel::Translation
+
+  def initialize(*args)
+    super
+  end
+
+  def persisted=(boolean)
+    @persisted = boolean
+  end
+
+  def persisted?
+    @persisted
+  end
+
+  attr_accessor :name
+end
+
 class Post < Struct.new(:title, :author_name, :body, :secret, :persisted, :written_on, :cost)
   extend ActiveModel::Naming
   include ActiveModel::Conversion

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -128,6 +128,8 @@ class FormHelperTest < ActionView::TestCase
     @post_delegator.title = 'Hello World'
 
     @car = Car.new("#000FFF")
+
+    @ticket_type = TicketType.new
   end
 
   Routes = ActionDispatch::Routing::RouteSet.new
@@ -135,6 +137,8 @@ class FormHelperTest < ActionView::TestCase
     resources :posts do
       resources :comments
     end
+
+    resources :ticket_types
 
     namespace :admin do
       resources :posts do
@@ -1872,6 +1876,20 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_lowercase_model_name_default_submit_button_value
+    form_for(@ticket_type) do |f|
+      concat f.submit
+    end
+
+    expected =
+      '<form class="new_ticket_type" id="new_ticket_type" action="/ticket_types" accept-charset="UTF-8" method="post">' +
+        hidden_fields +
+        '<input type="submit" name="commit" value="Create ticket type" data-disable-with="Create ticket type" />' +
+      '</form>'
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_for_with_symbol_object_name
     form_for(@post, as: "other_name", html: { id: "create-post" }) do |f|
       concat f.label(:title, class: 'post_title')
@@ -2239,7 +2257,7 @@ class FormHelperTest < ActionView::TestCase
         end
 
         expected = whole_form('/posts', 'new_post', 'new_post') do
-          "<input name='commit' data-disable-with='Create Post' type='submit' value='Create Post' />"
+          "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />"
         end
 
         assert_dom_equal expected, output_buffer
@@ -2254,7 +2272,7 @@ class FormHelperTest < ActionView::TestCase
       end
 
       expected = whole_form('/posts/123', 'edit_post_123', 'edit_post', method: 'patch') do
-      "<input name='commit' data-disable-with='Confirm Post changes' type='submit' value='Confirm Post changes' />"
+      "<input name='commit' data-disable-with='Confirm post changes' type='submit' value='Confirm post changes' />"
       end
 
       assert_dom_equal expected, output_buffer
@@ -2282,7 +2300,7 @@ class FormHelperTest < ActionView::TestCase
       end
 
       expected = whole_form('/posts/123', 'edit_another_post', 'edit_another_post', method: 'patch') do
-      "<input name='commit' data-disable-with='Update your Post' type='submit' value='Update your Post' />"
+      "<input name='commit' data-disable-with='Update your post' type='submit' value='Update your post' />"
       end
 
       assert_dom_equal expected, output_buffer


### PR DESCRIPTION
pull request implementing [lighthouse's diff](https://activereload-lighthouse.s3.amazonaws.com/assets/788f6edd05fb31c12e49bfcfa742a3674dea0204/titleize_model_name_value_submit_button.diff?AWSAccessKeyId=AKIAJ4QBZRZBVMOUBNZA&Expires=1766395107&Signature=73X5KBv0PmFeHBP3SiUtPtVWvzw%3D) to titleize the model names on submit buttons. So, for a model `TicketType`, the submit button would read "Create Ticket Type", rather than "Create Ticket type". References [issue 791](https://github.com/rails/rails/issues/791)
