### PR TITLE
Transform all hash keys to string keys

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -235,6 +235,10 @@ module ActiveRecord
         # hash and merges with the rest of the hash.
         # Connection details inside of the "url" key win any merge conflicts
         def resolve_hash_connection(spec)
+          # Not guaranteed Hash has `String` or `Symbol` keys,
+          # transform all to strings.
+          spec.stringify_keys!
+
           if spec["url"] && spec["url"] !~ /^jdbc:/
             connection_hash = resolve_url_connection(spec.delete("url"))
             spec.merge!(connection_hash)

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -75,6 +75,14 @@ module ActiveRecord
             "encoding" => "utf8" }, spec)
         end
 
+        def test_hash_url
+          spec = resolve({ url:'abstract://foo?encoding=utf8' })
+          assert_equal({
+            "adapter"  => "abstract",
+            "host"     => "foo",
+            "encoding" => "utf8" }, spec)
+        end
+
         def test_encoded_password
           password = 'am@z1ng_p@ssw0rd#!'
           encoded_password = URI.encode_www_form_component(password)


### PR DESCRIPTION
Deals with an awkward failure in
ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver#resolve_hash_connection,
where hash keys that were being sent in were not confirmed to be filled
with `String` keys, which was causing failures if `Symbol` keys were
sent in.

Fixes #22765.
