### PR TITLE
[ActionDispatch] Compare keys_to_keep in symbolized form

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -58,8 +58,8 @@ module ActionDispatch
             !options.key?(part) || (options[part] || recall[part]).nil?
           } | route.required_parts
 
-          parameterized_parts.delete_if do |bad_key, _|
-            !keys_to_keep.include?(bad_key)
+          (parameterized_parts.symbolize_keys.keys - keys_to_keep.map(&:to_sym)).each do |bad_key|
+            parameterized_parts.delete(bad_key)
           end
 
           if parameterize


### PR DESCRIPTION
Not comparing them in symbolized form was causing #12178 to occur. Now, everything is a symbol, and this makes strange formatting errors less likely to occur.
