### PR TITLE
Fix edge case with ActionView::Template::Error reraise

### DIFF
--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -59,6 +59,9 @@ module ActionView
     class Error < ActionViewError #:nodoc:
       SOURCE_CODE_RADIUS = 3
 
+      # Override to prevent #cause resetting during re-raise.
+      attr_reader :cause
+
       def initialize(template, original_exception = nil)
         if original_exception
           ActiveSupport::Deprecation.warn("Passing #original_exception is deprecated and has no effect. " \
@@ -67,6 +70,7 @@ module ActionView
 
         super($!.message)
         set_backtrace($!.backtrace)
+        @cause = $!
         @template, @sub_templates = template, nil
       end
 


### PR DESCRIPTION
When you re-raise an ActionView::Template::Error, the `#cause` can change.
You can see this behaviour with [nack](https://github.com/josh/nack). Currently, `web-console` doesn't
run the console in the proper binding in the case of errors in the
views, because when we follow the `#cause` of the exception it is an
[`EOFError`](https://github.com/josh/nack/blob/d523cc870c0a11dcf349388a15adfecba9314f97/lib/nack/server.rb#L108).

This also affects [pow](http://pow.cx/) as it runs on [nack](https://github.com/josh/nack).
