### PR TITLE
fix TypeError when using submit_tag with Symbol value

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -447,7 +447,7 @@ module ActionView
           unless tag_options["data-disable-with"] == false || (tag_options["data"] && tag_options["data"][:disable_with] == false)
             disable_with_text = tag_options["data-disable-with"]
             disable_with_text ||= tag_options["data"][:disable_with] if tag_options["data"]
-            disable_with_text ||= value.clone
+            disable_with_text ||= value.to_s.clone
             tag_options.deep_merge!("data" => { "disable_with" => disable_with_text })
           else
             tag_options["data"].delete(:disable_with) if tag_options["data"]

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -510,6 +510,13 @@ class FormTagHelperTest < ActionView::TestCase
     )
   end
 
+  def test_submit_tag_with_symbol_value
+    assert_dom_equal(
+      %(<input data-disable-with="Save" name='commit' type="submit" value="Save" />),
+      submit_tag(:Save)
+    )
+  end
+
 
   def test_button_tag
     assert_dom_equal(


### PR DESCRIPTION
The use of Symbol to the argument of submit_tag is, it had to work with Rails 4, but it is an error in Rails 5.

Reproduction script is follow. 

``` ruby
require 'bundler/inline'
gemfile(true) do
  source 'https://rubygems.org'
  gem 'rails', '5.0.0.beta1'
  #gem 'rails', '4.2.5'
end

require 'rack/test'
require 'action_controller/railtie'

class TestApp < Rails::Application
  config.root = File.dirname(__FILE__)
  config.session_store :cookie_store, key: 'cookie_store_key'
  secrets.secret_token    = 'secret_token'
  secrets.secret_key_base = 'secret_key_base'

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger
end

class TestController < ActionController::Base
  include Rails.application.routes.url_helpers
end

require 'minitest/autorun'

class BugTest < Minitest::Test
  include Rack::Test::Methods

  def test_submit_tag
    expect = %(<input type=\"submit\" name=\"commit\" value=\"Save\" />)
    assert_equal expect, helper.submit_tag(:Save)  # => TypeError: can't clone Symbol
  end

  private
    def helper
      TestController.helpers
    end
end 
```

This PR fix it.
