### PR TITLE
[Action Cable] Add functionality to create custom callbacks on the client-side...

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -73,7 +73,6 @@ class ActionCable.Connection
   events:
     message: (event) ->
       {identifier, message, type} = JSON.parse(event.data)
-      ping = identifier == ActionCable.INTERNAL.identifiers.ping
 
       switch type
         when message_types.confirmation
@@ -83,7 +82,9 @@ class ActionCable.Connection
           @consumer.subscriptions.reject(identifier)
         else
           @consumer.subscriptions.notify(identifier, "received", message)
-          @dispatchEvent("received", message, JSON.parse(identifier).channel) unless ping
+
+          if identifier isnt ActionCable.INTERNAL.identifiers.ping
+            @dispatchEvent("received", message, JSON.parse(identifier).channel)
 
     open: ->
       ActionCable.log("WebSocket onopen event")

--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -100,7 +100,10 @@ class ActionCable.Connection
       @disconnect()
 
   dispatchEvent: (identifier, eventName, message = null) ->
-    channel = if identifier then JSON.parse(identifier).channel else null
+    if identifier && identifier != ActionCable.INTERNAL.identifiers.ping
+      channel = JSON.parse(identifier).channel
+    else
+      channel = null
 
     event = document.createEvent('Event')
     event.initEvent("actioncable:#{eventName}", true, false)

--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -101,13 +101,13 @@ class ActionCable.Connection
 
   dispatchEvent: (identifier, eventName, message = null) ->
     if identifier && identifier != ActionCable.INTERNAL.identifiers.ping
-      channel = JSON.parse(identifier).channel
+      channel = JSON.parse(identifier)
     else
       channel = null
 
     event = document.createEvent('Event')
     event.initEvent("actioncable:#{eventName}", true, false)
-    event.data = {channel, message}
+    event.data = Object.assign({message}, channel)
     document.dispatchEvent(event)
 
   disconnect: ->

--- a/actioncable/app/assets/javascripts/action_cable/subscription.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/subscription.coffee
@@ -49,6 +49,7 @@ class ActionCable.Subscription
     extend(this, mixin)
     @subscriptions.add(this)
     @consumer = @subscriptions.consumer
+    @listeners = []
 
   # Perform a channel action with the optional data passed as an attribute
   perform: (action, data = {}) ->
@@ -66,3 +67,21 @@ class ActionCable.Subscription
       for key, value of properties
         object[key] = value
     object
+
+  # Add a function to be called when data is received
+  addListener: (fn) ->
+    @listeners.push(fn)
+    return fn;
+
+  notifyListeners: (data) ->
+    @listeners.forEach (fn) ->
+      fn(data)
+
+  removeListener: (fn) ->
+    index = @listeners.indexOf(fn)
+    if index == -1
+      console.error(JSON.parse(this.identifier)['channel'] + ':' +  ' removeListener failed because the function' +
+          ' passed in was not found among the listeners. This might be because an anonymous function was' +
+          ' given. Try passing in the exact function given to addListener (it will return the function).')
+    else
+      @listeners.splice(index, 1)

--- a/actioncable/app/assets/javascripts/action_cable/subscription.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/subscription.coffee
@@ -49,7 +49,6 @@ class ActionCable.Subscription
     extend(this, mixin)
     @subscriptions.add(this)
     @consumer = @subscriptions.consumer
-    @listeners = []
 
   # Perform a channel action with the optional data passed as an attribute
   perform: (action, data = {}) ->
@@ -67,21 +66,3 @@ class ActionCable.Subscription
       for key, value of properties
         object[key] = value
     object
-
-  # Add a function to be called when data is received
-  addListener: (fn) ->
-    @listeners.push(fn)
-    return fn;
-
-  notifyListeners: (data) ->
-    @listeners.forEach (fn) ->
-      fn(data)
-
-  removeListener: (fn) ->
-    index = @listeners.indexOf(fn)
-    if index == -1
-      console.error(JSON.parse(this.identifier)['channel'] + ':' +  ' removeListener failed because the function' +
-          ' passed in was not found among the listeners. This might be because an anonymous function was' +
-          ' given. Try passing in the exact function given to addListener (it will return the function).')
-    else
-      @listeners.splice(index, 1)


### PR DESCRIPTION
Add functionality to create custom callbacks on the client-side when data is received on a channel (Action Cable)

i.e. Given a room channel, one can create a callback like so:

``` javascript
App.room.addListener(function(data) {
  // Callback code
})
```

This allows for more flexibility in the placement of callback code. My specific use case was a React component that handles the updating of it's state when data is received on an Action Cable channel.
