### PR TITLE
Fix varbinary with default ''

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -31,8 +31,6 @@ module ActiveRecord
         def extract_default
           if blob_or_text_column?
             @default = null || strict ? nil : ''
-          elsif missing_default_forged_as_empty_string?(default)
-            @default = nil
           end
         end
 
@@ -58,17 +56,6 @@ module ActiveRecord
         end
 
         private
-
-        # MySQL misreports NOT NULL column default when none is given.
-        # We can't detect this for columns which may have a legitimate ''
-        # default (string) but we can for others (integer, datetime, boolean,
-        # and the rest).
-        #
-        # Test whether the column has default '', is not null, and is not
-        # a type allowing default ''.
-        def missing_default_forged_as_empty_string?(default)
-          type != :string && !null && default == ''
-        end
 
         def assert_valid_default(default)
           if blob_or_text_column? && default.present?

--- a/activerecord/test/cases/column_definition_test.rb
+++ b/activerecord/test/cases/column_definition_test.rb
@@ -49,6 +49,16 @@ module ActiveRecord
           assert_equal "a", varbinary_column.default
         end
 
+        def test_should_be_empty_string_default_for_mysql_binary_data_types
+          type = SqlTypeMetadata.new(type: :binary, sql_type: "binary(1)")
+          binary_column = AbstractMysqlAdapter::Column.new("title", "", type, false)
+          assert_equal "", binary_column.default
+
+          type = SqlTypeMetadata.new(type: :binary, sql_type: "varbinary")
+          varbinary_column = AbstractMysqlAdapter::Column.new("title", "", type, false)
+          assert_equal "", varbinary_column.default
+        end
+
         def test_should_not_set_default_for_blob_and_text_data_types
           assert_raise ArgumentError do
             AbstractMysqlAdapter::Column.new("title", "a", SqlTypeMetadata.new(sql_type: "blob"))


### PR DESCRIPTION
A `(?:var)?binary` with default '' is a correct definition.
Remove `missing_default_forged_as_empty_string?` method for fixing this
issue because this method is a workaround for older mysql legacy adapter
(19c99ac, f7015336).
