### PR TITLE
Changed default value of `:rc` option to `nil`

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -75,7 +75,7 @@ module Rails
         class_option :edge,               type: :boolean, default: false,
                                           desc: "Setup the #{name} with Gemfile pointing to Rails repository"
 
-        class_option :rc,                 type: :string, default: false,
+        class_option :rc,                 type: :string, default: nil,
                                           desc: "Path to file containing extra configuration options for rails command"
 
         class_option :no_rc,              type: :boolean, default: false,


### PR DESCRIPTION
- This fixes an error thrown by Thor because type of default value of
  `:rc` option which is `:boolean` does not match with it's default type
  which is `string`.
- Ref - https://github.com/erikhuda/thor/blob/master/lib/thor/parser/option.rb#L125
