### PR TITLE
Reuse generator options used while creating app for updating Rails versions

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Reuse generator options used while creating app for updating Rails version.
+
+    Saves all the options passed while creating new app into `.rails`
+    file and reuses these options when `bin/rails app:update` is run.
+
+   *Cristian Bica*, *Prathamesh Sonpatki*, *Siva Gollapalli*
+
 *   The application generator writes a new file `config/spring.rb`, which tells
     Spring to watch additional common files.
 

--- a/railties/lib/rails/commands/application.rb
+++ b/railties/lib/rails/commands/application.rb
@@ -14,4 +14,4 @@ module Rails
 end
 
 args = Rails::Generators::ARGVScrubber.new(ARGV).prepare!
-Rails::Generators::AppGenerator.start args
+Rails::Generators::AppGenerator.start args, raw_options: args[1..-1]

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -11,6 +11,10 @@ module Rails
     def root
       @root ||= Pathname.new(File.expand_path('../../fixtures', __FILE__))
     end
+
+    def root=(root)
+      @root = Pathname.new(root)
+    end
   end
 end
 Rails.application.config.root = Rails.root


### PR DESCRIPTION
- Saves all the options passed while creating new app into `.rails`
  file.
- Reuses these options when `rake rails:update` is run.
- A sample `.rails` file - https://gist.github.com/prathamesh-sonpatki/dec79cf253ed7e5dc6ee
