### PR TITLE
Make `ActionMailer::TestCase.fixture_path` to be configurable.

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make `ActionMailer::TestCase.fixture_path` to be configurable.
+
+    *Yuichiro Kaneko*
+
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
 *   `config.force_ssl = true` will set

--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -21,9 +21,12 @@ module ActionMailer
 
       included do
         class_attribute :_mailer_class
+        class_attribute :fixture_path, instance_writer: false
         setup :initialize_test_deliveries
         setup :set_expected_mail
         teardown :restore_test_deliveries
+
+        self.fixture_path = File.join(Rails.root, 'test', 'fixtures')
       end
 
       module ClassMethods
@@ -95,7 +98,7 @@ module ActionMailer
         end
 
         def read_fixture(action)
-          IO.readlines(File.join(Rails.root, 'test', 'fixtures', self.class.mailer_class.name.underscore, action))
+          IO.readlines(File.join(fixture_path, self.class.mailer_class.name.underscore, action))
         end
     end
 

--- a/actionmailer/test/fixtures/another.path/base_mailer/welcome
+++ b/actionmailer/test/fixtures/another.path/base_mailer/welcome
@@ -1,0 +1,1 @@
+Welcome from another path

--- a/actionmailer/test/fixtures/base_mailer/welcome
+++ b/actionmailer/test/fixtures/base_mailer/welcome
@@ -1,0 +1,1 @@
+Welcome

--- a/actionmailer/test/test_case_test.rb
+++ b/actionmailer/test/test_case_test.rb
@@ -26,3 +26,20 @@ class CrazyStringNameMailerTest < ActionMailer::TestCase
     assert_equal TestTestMailer, self.class.mailer_class
   end
 end
+
+class MailerFixturePathTest < ActionMailer::TestCase
+  tests BaseMailer
+
+  def test_default_fixture_path
+    assert_equal ["Welcome"], read_fixture('welcome')
+  end
+end
+
+class MailerCustomFixturePathTest < ActionMailer::TestCase
+  tests BaseMailer
+  self.fixture_path = FIXTURE_LOAD_PATH + "/another.path"
+
+  def test_custom_fixture_path
+    assert_equal ["Welcome from another path"], read_fixture('welcome')
+  end
+end


### PR DESCRIPTION
Before this commit, `ActionMailer::TestCase.fixture_path` was hard
coded to `File.join(Rails.root, 'test', 'fixtures')` and workaround
was needed to use with other test frameworks which have different
directory structure (e.g. RSpec).
