### PR TITLE
Restore ability to pass extra options to cache stores

### DIFF
--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -172,6 +172,9 @@ class FunctionalCachingController < CachingController
 
   def fragment_cached_without_digest
   end
+
+  def fragment_cached_with_options
+  end
 end
 
 class FunctionalFragmentCachingTest < ActionController::TestCase
@@ -213,6 +216,15 @@ CACHED
 
     assert_equal expected_body, @response.body
     assert_equal "<p>ERB</p>", @store.read("views/nodigest")
+  end
+
+  def test_fragment_caching_with_options
+    get :fragment_cached_with_options
+    assert_response :success
+    expected_body = "<body>\n<p>ERB</p>\n</body>\n"
+
+    assert_equal expected_body, @response.body
+    assert_equal "<p>ERB</p>", @store.read("views/with_options")
   end
 
   def test_render_inline_before_fragment_caching

--- a/actionpack/test/fixtures/functional_caching/fragment_cached_with_options.html.erb
+++ b/actionpack/test/fixtures/functional_caching/fragment_cached_with_options.html.erb
@@ -1,0 +1,3 @@
+<body>
+<%= cache 'with_options', :skip_digest => true, :expires_in => 1.minute do %><p>ERB</p><% end %>
+</body>

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -208,7 +208,7 @@ module ActionView
       #
       # The digest will be generated using +virtual_path:+ if it is provided.
       #
-      def cache_fragment_name(name = {}, skip_digest: nil, virtual_path: nil)
+      def cache_fragment_name(name = {}, skip_digest: nil, virtual_path: nil, **_options)
         if skip_digest
           name
         else


### PR DESCRIPTION
This PR restores the ability to pass options to the cache helper methods which will be passed on the cache store. This functionality worked in 4.x.

The `cache` helper methods are supposed to pass any extra options to the cache store. For example :expires_in would be a valid option if memcache was the cache store.

``` erb
<%= cache 'example_of_cached_time', :expires_in => 1.minute do %>
  <p>Some content that will be cached for a minute starting at <%= Time.now %></p>
<% end %>
```

The change in commit da16745 inadvertently broke the ability to pass any options other than :skip_digest and :virtual_path when some methods were changed to use keyword arguments.
