### PR TITLE
Change 1.week to create 1 week durations instead of 7 days durations.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Change `ActiveSupport::Duration` creation with numeric methods like `1.week`
+    to create durations with more predictable and ISO8601-conformant parts.
+
+    This is to remove astonishment from getting `3600 seconds` from `1.hour`.
+
+    It should not affect current apps as duration's `value` (number of seconds) remains the same,
+    only hash of `parts` (and `inspect` value) is changed and only when it's constructed by calling
+    methods on integers. Manual construction of Durations isn't affected.
+    Inside the ActiveSupport::Duration itself most operations rely only on number of seconds.
+
+    Before:
+
+        [1.hour.inspect, 1.hour.value, 1.hour.parts] # => ["3600 seconds", 3600, [[:seconds, 3600]]]
+        [1.week.inspect, 1.week.value, 1.week.parts] # => ["7 days", 604800, [[:days, 7]]]
+
+    After:
+
+        [1.hour.inspect, 1.hour.value, 1.hour.parts] # => ["1 hour", 3600, [[:hours, 1]]]
+        [1.week.inspect, 1.week.value, 1.week.parts] # => ["1 week", 604800, [[:weeks, 1]]]
+
+    *Andrey Novikov*
+
 *   Fix behavior of JSON encoding for `Exception`.
 
     *namusyaka*

--- a/activesupport/lib/active_support/core_ext/numeric/time.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/time.rb
@@ -25,17 +25,17 @@ class Numeric
 
   # Returns a Duration instance matching the number of minutes provided.
   #
-  #   2.minutes # => 120 seconds
+  #   2.minutes # => 2 minutes
   def minutes
-    ActiveSupport::Duration.new(self * 60, [[:seconds, self * 60]])
+    ActiveSupport::Duration.new(self * 60, [[:minutes, self]])
   end
   alias :minute :minutes
 
   # Returns a Duration instance matching the number of hours provided.
   #
-  #   2.hours # => 7_200 seconds
+  #   2.hours # => 2 hours
   def hours
-    ActiveSupport::Duration.new(self * 3600, [[:seconds, self * 3600]])
+    ActiveSupport::Duration.new(self * 3600, [[:hours, self]])
   end
   alias :hour :hours
 
@@ -49,17 +49,17 @@ class Numeric
 
   # Returns a Duration instance matching the number of weeks provided.
   #
-  #   2.weeks # => 14 days
+  #   2.weeks # => 2 weeks
   def weeks
-    ActiveSupport::Duration.new(self * 7.days, [[:days, self * 7]])
+    ActiveSupport::Duration.new(self * 7.days, [[:weeks, self]])
   end
   alias :week :weeks
 
   # Returns a Duration instance matching the number of fortnights provided.
   #
-  #   2.fortnights # => 28 days
+  #   2.fortnights # => 4 weeks
   def fortnights
-    ActiveSupport::Duration.new(self * 2.weeks, [[:days, self * 14]])
+    ActiveSupport::Duration.new(self * 2.weeks, [[:weeks, self * 2]])
   end
   alias :fortnight :fortnights
 

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -117,7 +117,7 @@ module ActiveSupport
     def inspect #:nodoc:
       parts.
         reduce(::Hash.new(0)) { |h,(l,r)| h[l] += r; h }.
-        sort_by {|unit,  _ | [:years, :months, :days, :minutes, :seconds].index(unit)}.
+        sort_by {|unit,  _ | [:years, :months, :weeks, :days, :hours, :minutes, :seconds].index(unit)}.
         map     {|unit, val| "#{val} #{val == 1 ? unit.to_s.chop : unit.to_s}"}.
         to_sentence(locale: ::I18n.default_locale)
     end
@@ -139,6 +139,8 @@ module ActiveSupport
           if t.acts_like?(:time) || t.acts_like?(:date)
             if type == :seconds
               t.since(sign * number)
+            elsif [:hours, :minutes].include?(type)
+              t.in_time_zone.advance(type => sign * number)
             else
               t.advance(type => sign * number)
             end

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -66,8 +66,9 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal '10 years, 2 months, and 1 day',   (10.years + 2.months + 1.day).inspect
     assert_equal '10 years, 2 months, and 1 day',   (10.years + 1.month  + 1.day + 1.month).inspect
     assert_equal '10 years, 2 months, and 1 day',   (1.day + 10.years + 2.months).inspect
-    assert_equal '7 days',                          1.week.inspect
-    assert_equal '14 days',                         1.fortnight.inspect
+    assert_equal '7 days',                          7.days.inspect
+    assert_equal '1 week',                          1.week.inspect
+    assert_equal '2 weeks',                         1.fortnight.inspect
   end
 
   def test_inspect_locale


### PR DESCRIPTION
As it was proposed by @pixeltrix in discussion at https://github.com/rails/rails/pull/16917#discussion_r45749065 I'm changing `ActiveSupport::Duration` creation with numeric methods like `1.week` to create durations with more predictable and ISO8601-conformant parts. Because when `1.hour` is actually `3600 seconds` it's logically correct, but not expected and confusing.

See original discussion for details: https://github.com/rails/rails/pull/16917#discussion-diff-17523229

Before:

``` ruby
[1.hour.inspect, 1.hour.value, 1.hour.parts] # => ["3600 seconds", 3600, [[:seconds, 3600]]]
[1.week.inspect, 1.week.value, 1.week.parts] # => ["7 days", 604800, [[:days, 7]]]
```

After:

``` ruby
[1.hour.inspect, 1.hour.value, 1.hour.parts] # => ["1 hour", 3600, [[:hours, 1]]]
[1.week.inspect, 1.week.value, 1.week.parts] # => ["1 week", 604800, [[:weeks, 1]]]
```

r? @pixeltrix
