### PR TITLE
Fix that WhereClause#merge was removing non-conflicting binds

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix that WhereClause#merge could remove non-conflicting bind
+    variables.
+
+    *Ben Woosley*
+
 *   When calling `first` with a `limit` argument, return directly from the
     `loaded?` records if available.
 

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -343,6 +343,10 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal clubs(:boring_club), members(:groucho).selected_club
   end
 
+  def test_has_one_through_with_merge_on_duplicate_where_default_scopes
+    assert_equal clubs(:moustache_club), members(:groucho).favourite_active_club
+  end
+
   def test_has_one_through_relationship_cannot_have_a_counter_cache
     assert_raise(ArgumentError) do
       Class.new(ActiveRecord::Base) do

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -37,6 +37,13 @@ module ActiveRecord
       assert_equal joined, [posts.first]
     end
 
+    def test_where_merges_bind_params_properly
+      scope = Post.where(foo: :bar).where(bar: :baz).merge(
+        Post.where(bar: :baz).where(foo: :bar)
+      )
+      assert_equal({"bar"=>:baz, "foo"=>:bar}, scope.where_values_hash)
+    end
+
     def test_where_copies_arel_bind_params
       chef = Chef.create!
       CakeDesigner.create!(chef: chef)

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -8,6 +8,8 @@ class Club < ActiveRecord::Base
 
   has_many :favourites, -> { where(memberships: { favourite: true }) }, through: :memberships, source: :member
 
+  default_scope { where(active: true) }
+
   private
 
   def private_method

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -12,6 +12,9 @@ class Member < ActiveRecord::Base
   has_one :organization, :through => :member_detail
   belongs_to :member_type
 
+  has_one :favourite_active_membership, -> { merge(Membership.favourite) }, class_name: 'Membership'
+  has_one :favourite_active_club, through: :favourite_active_membership, source: :club
+
   has_many :nested_member_types, :through => :member_detail, :source => :member_type
   has_one :nested_member_type, :through => :member_detail, :source => :member_type
 

--- a/activerecord/test/models/membership.rb
+++ b/activerecord/test/models/membership.rb
@@ -1,6 +1,10 @@
 class Membership < ActiveRecord::Base
   belongs_to :member
   belongs_to :club
+
+  scope :favourite, -> { where(favourite: true) }
+
+  default_scope { where(active: true) }
 end
 
 class CurrentMembership < Membership

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -158,6 +158,7 @@ ActiveRecord::Schema.define do
 
   create_table :clubs, force: true do |t|
     t.string :name
+    t.boolean :active, default: true
     t.integer :category_id
   end
 
@@ -458,6 +459,7 @@ ActiveRecord::Schema.define do
     t.datetime :joined_on
     t.integer :club_id, :member_id
     t.boolean :favourite, default: false
+    t.boolean :active, default: true
     t.string :type
   end
 


### PR DESCRIPTION
`WhereClause#merge` previously removed conflicting predicates by column
name, then removed any binds that matched the column name of a
removed predicate. This can be a bit overzealous, as it can remove
binds which happen to coincide with the column name of the conflicting
predicate but which relate to a different table altogether.[1]

When such a thing occurs, a database-dependent error like so is presented:

``` sql
ActiveRecord::StatementInvalid: PG::ProtocolViolation: ERROR:  bind message supplies 4 parameters, but prepared statement "a17" requires 5
: SELECT  "clubs".* FROM "clubs" INNER JOIN "memberships" ON "clubs"."id" = "memberships"."club_id" WHERE "clubs"."active" = $1 AND "memberships"."member_id" = $2 AND "memberships"."active" = $3 AND "memberships"."favourite" = $4 LIMIT $5
```

In this case, because either the non-conflicting bind for
`"clubs"."active"` or `"memberships"."active"` were removed from the
binds, so all the binds are shifted over by one, leaving `$5` without a
value.

The alternative here is to remove only binds which coincide with the
index of the removed bound predicate. As bound predicates reference
bind variables by index, e.g. `$1`, the correspondence here seems to be
correct.

Note that this does not cover all possible Arel predicates, but there
is now symmetry between what predicates and binds are excluded -
those for `equality_nodes?`, with LHS column match and RHS bind match.

[1] e.g. in the case where models are paranoid-deleted and several
default scopes reference the same deletion column name, which is how
we ran into it
