### PR TITLE
Configurable redirect and secure cookies for ActionDispatch::SSL

### DIFF
--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -12,25 +12,31 @@ class SSLTest < ActionDispatch::IntegrationTest
 end
 
 class RedirectSSLTest < SSLTest
-  def assert_not_redirected(url, headers: {})
-    self.app = build_app
+
+  def assert_not_redirected(url, headers: {}, redirect: {}, deprecated_host: nil,
+    deprecated_port: nil)
+
+    self.app = build_app ssl_options: { redirect: redirect,
+      host: deprecated_host, port: deprecated_port
+    }
+
     get url, headers: headers
     assert_response :ok
   end
 
-  def assert_redirected(host: nil, port: nil, status: 301, body: [],
-    deprecated_host: nil, deprecated_port: nil,
+  def assert_redirected(redirect: {}, deprecated_host: nil, deprecated_port: nil,
     from: 'http://a/b?c=d', to: from.sub('http', 'https'))
 
-    self.app = build_app ssl_options: {
-      redirect: { host: host, port: port, status: status, body: body },
+    redirect = { status: 301, body: [] }.merge(redirect)
+
+    self.app = build_app ssl_options: { redirect: redirect,
       host: deprecated_host, port: deprecated_port
     }
 
     get from
-    assert_response status
+    assert_response redirect[:status] || 301
     assert_redirected_to to
-    assert_equal body.join, @response.body
+    assert_equal redirect[:body].join, @response.body
   end
 
   test 'https is not redirected' do
@@ -46,31 +52,31 @@ class RedirectSSLTest < SSLTest
   end
 
   test 'redirect with non-301 status' do
-    assert_redirected status: 307
+    assert_redirected redirect: { status: 307 }
   end
 
   test 'redirect with custom body' do
-    assert_redirected body: ['foo']
+    assert_redirected redirect: { body: ['foo'] }
   end
 
   test 'redirect to specific host' do
-    assert_redirected host: 'ssl', to: 'https://ssl/b?c=d'
+    assert_redirected redirect: { host: 'ssl' }, to: 'https://ssl/b?c=d'
   end
 
   test 'redirect to default port' do
-    assert_redirected port: 443
+    assert_redirected redirect: { port: 443 }
   end
 
   test 'redirect to non-default port' do
-    assert_redirected port: 8443, to: 'https://a:8443/b?c=d'
+    assert_redirected redirect: { port: 8443 }, to: 'https://a:8443/b?c=d'
   end
 
   test 'redirect to different host and non-default port' do
-    assert_redirected host: 'ssl', port: 8443, to: 'https://ssl:8443/b?c=d'
+    assert_redirected redirect: { host: 'ssl', port: 8443 }, to: 'https://ssl:8443/b?c=d'
   end
 
   test 'redirect to different host including port' do
-    assert_redirected host: 'ssl:443', to: 'https://ssl:443/b?c=d'
+    assert_redirected redirect: { host: 'ssl:443' }, to: 'https://ssl:443/b?c=d'
   end
 
   test ':host is deprecated, moved within redirect: { host: … }' do
@@ -83,6 +89,10 @@ class RedirectSSLTest < SSLTest
     assert_deprecated do
       assert_redirected deprecated_port: 1, to: 'https://a:1/b?c=d'
     end
+  end
+
+  test 'no redirect with redirect set to false' do
+    assert_not_redirected 'http://example.org', redirect: false
   end
 end
 
@@ -185,6 +195,11 @@ class SecureCookiesTest < SSLTest
   def test_flag_cookies_as_secure_with_ignore_case
     get headers: { 'Set-Cookie' => 'problem=def; path=/; Secure; HttpOnly' }
     assert_cookies 'problem=def; path=/; Secure; HttpOnly'
+  end
+
+  def test_cookies_as_not_secure_with_secure_cookies_disabled
+    get headers: { 'Set-Cookie' => DEFAULT }, ssl_options: { secure_cookies: false }
+    assert_cookies *DEFAULT.split("\n")
   end
 
   def test_no_cookies

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -68,7 +68,7 @@ module Rails
           middleware.use ::ActionDispatch::Cookies unless config.api_only
 
           if !config.api_only && config.session_store
-            if config.force_ssl && !config.session_options.key?(:secure)
+            if config.force_ssl && config.ssl_options.fetch(:secure_cookies, true) && !config.session_options.key?(:secure)
               config.session_options[:secure] = true
             end
             middleware.use config.session_store, config.session_options

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -20,10 +20,17 @@ module ApplicationTests
       @app ||= Rails.application
     end
 
-    test "config.force_ssl sets cookie to secure only" do
+    test "config.force_ssl sets cookie to secure only by default" do
       add_to_config "config.force_ssl = true"
       require "#{app_path}/config/environment"
       assert app.config.session_options[:secure], "Expected session to be marked as secure"
+    end
+
+    test "config.force_ssl doesn't set cookie to secure only when changed from default" do
+      add_to_config "config.force_ssl = true"
+      add_to_config "config.ssl_options = { secure_cookies: false }"
+      require "#{app_path}/config/environment"
+      assert !app.config.session_options[:secure]
     end
 
     test "session is not loaded if it's not used" do


### PR DESCRIPTION
The `ActionDispatch::SSL` middleware is enabled by the `config.force_ssl` option. It can be configured with `config.ssl_options` to customise the redirect when sending someone to an SSL version of their URL (e.g. host and port), and the precise header that should be used for HSTS, allowing advanced users to override the sensible defaults.

This PR provides a greater degree of configurability to the middleware, allowing the secure cookies functionality and the redirect to be turned off, but defaulting to leaving them on (which, to be sure, is the sensible and secure default). 

This change provides more flexibility for those who want it (e.g. in our setup we handle the redirect in nginx, and would prefer Rails not to do it) with no cost in terms of backwards compatibility or ease of use.
