### PR TITLE
A cookie value is incorrect if value contains an escapable string in Rails 5 ActionController::TestCase

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -337,7 +337,7 @@ module ActionDispatch
       end
 
       def to_header
-        @cookies.map { |k,v| "#{k}=#{v}" }.join ';'
+        @cookies.map { |k,v| "#{::Rack::Utils.escape(k)}=#{::Rack::Utils.escape(v)}" }.join ';'
       end
 
       def handle_options(options) #:nodoc:

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -137,6 +137,11 @@ XML
       head :created, location: 'created resource'
     end
 
+    def read_cookie
+      cookies["foo"]
+      render plain: 'ok'
+    end
+
     def delete_cookie
       cookies.delete("foo")
       render plain: 'ok'
@@ -825,8 +830,10 @@ XML
 
   def test_should_have_knowledge_of_client_side_cookie_state_even_if_they_are_not_set
     cookies['foo'] = 'bar'
+    cookies['escape'] = '+'
     get :no_op
     assert_equal 'bar', cookies['foo']
+    assert_equal '+', cookies['escape']
   end
 
   def test_should_detect_if_cookie_is_deleted


### PR DESCRIPTION
In Rails 4.2 we get correct cookie value in action method if cookie value contains an escapable string. 
But we get incorrect cookie value after upgrading Rails 5.0.0.beta1.

So the pull request fixes this problem.

Tiny example code is the following. Test code set the escapable string `+` in `cookies[:value]`, controller code checks `cookies[:value]` is equal to `+`. 
Test is passed in Rails 4.2.5 but fail in Rails 5.0.0.beta1.

``` ruby
# test code
class CookieControllerTest < ActionController::TestCase
  test "get + in action" do
    cookies[:value] = '+'
    get :index
    assert_response :success
  end
end

# controller code
class CookieController < ApplicationController
  def index
    raise unless cookies[:value] == '+' # cookies[:value] is ' ' in Rails 5.0.0.beta1
    render plain: 'plus'
  end
end
```

Sample application to reproduce this problem is [here](https://github.com/ma2gedev/cookie_test). In master branch application runs on Rails 5.0.0.beta1, runs on Rails 4.2.5 in rails42 branch.
