### PR TITLE
TestController#parameters returns AC::Parameters

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `ActionView::TestCase::Controller#params` returns an instance of
+    `ActionController::Parameters`.
+
+    *Justin Coyne*
+
 *   Fix regression in `submit_tag` when a symbol is used as label argument.
 
     *Yuuji Yaginuma*

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -28,7 +28,7 @@ module ActionView
         @response = ActionDispatch::TestResponse.new
 
         @request.env.delete('PATH_INFO')
-        @params = {}
+        @params = ActionController::Parameters.new
       end
     end
 

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -42,6 +42,10 @@ module ActionView
       assert_same view, view
     end
 
+    test "exposes params" do
+      assert params.is_a? ActionController::Parameters
+    end
+
     test "exposes view as _view for backwards compatibility" do
       assert_same _view, view
     end


### PR DESCRIPTION
Fixes #22827
ActionView::TestCase::TestController#parameters should return an
instance of ActionController::Parameters rather than a hash. This
enables helper methods to use the correct interface.
