### PR TITLE
Mime negotiation format from extension improvements

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -67,8 +67,8 @@ module ActionDispatch
 
           v = if params_readable
             Array(Mime[parameters[:format]])
-          elsif format = format_from_path_extension
-            Array(Mime[format])
+          elsif extension_format = format_from_path_extension
+            [extension_format]
           elsif use_accept_header && valid_accept_header
             accepts
           elsif xhr?
@@ -166,7 +166,7 @@ module ActionDispatch
       def format_from_path_extension
         path = @env['action_dispatch.original_path'] || @env['PATH_INFO']
         if match = path && path.match(/\.(\w+)\z/)
-          match.captures.first
+          Mime[match.captures.first]
         end
       end
     end

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -67,10 +67,10 @@ module ActionDispatch
 
           v = if params_readable
             Array(Mime[parameters[:format]])
-          elsif extension_format = format_from_path_extension
-            [extension_format]
           elsif use_accept_header && valid_accept_header
             accepts
+          elsif extension_format = format_from_path_extension
+            [extension_format]
           elsif xhr?
             [Mime[:js]]
           else

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -909,6 +909,15 @@ class RequestFormat < BaseRequestTest
       assert_equal [Mime[:html]], request.formats
     end
   end
+
+  test "formats from accept headers have higher precedence than path extension" do
+    request = stub_request 'HTTP_ACCEPT' => 'application/json',
+                           'PATH_INFO' => '/foo.xml'
+
+    assert_called(request, :parameters, times: 1, returns: {}) do
+      assert_equal [Mime[:json]], request.formats
+    end
+  end
 end
 
 class RequestMimeType < BaseRequestTest

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -897,6 +897,18 @@ class RequestFormat < BaseRequestTest
       ActionDispatch::Request.ignore_accept_header = old_ignore_accept_header
     end
   end
+
+  test "format taken from the path extension" do
+    request = stub_request 'PATH_INFO' => '/foo.xml'
+    assert_called(request, :parameters, times: 1, returns: {}) do
+      assert_equal [Mime[:xml]], request.formats
+    end
+
+    request = stub_request 'PATH_INFO' => '/foo.123'
+    assert_called(request, :parameters, times: 1, returns: {}) do
+      assert_equal [Mime[:html]], request.formats
+    end
+  end
 end
 
 class RequestMimeType < BaseRequestTest


### PR DESCRIPTION
- Fix for problem described here https://github.com/rails/rails/issues/22747#issuecomment-166503385
- Format determined from request path (when router was not yet invoked) should not override format provided by `Accept` header.
