### PR TITLE
Running tests with multiple line numbers

### DIFF
--- a/railties/lib/rails/test_unit/line_filtering.rb
+++ b/railties/lib/rails/test_unit/line_filtering.rb
@@ -30,9 +30,14 @@ module Rails
       end
 
       def derive_line_filters(patterns)
-        patterns.map do |file_and_line|
-          file, line = file_and_line.split(':')
-          Filter.new(@runnable, file, line) if file
+        patterns.flat_map do |file_and_line|
+          file, *lines = file_and_line.split(':')
+
+          if lines.empty?
+            Filter.new(@runnable, file, nil) if file
+          else
+            lines.map { |line| Filter.new(@runnable, file, line) }
+          end
         end
       end
   end

--- a/railties/lib/rails/test_unit/test_requirer.rb
+++ b/railties/lib/rails/test_unit/test_requirer.rb
@@ -15,7 +15,7 @@ module Rails
       private
         def expand_patterns(patterns)
           patterns.map do |arg|
-            arg = arg.gsub(/:(\d+)?$/, '')
+            arg = arg.gsub(/(:\d*)+?$/, '')
             if Dir.exist?(arg)
               "#{arg}/**/*_test.rb"
             else

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -294,6 +294,84 @@ module ApplicationTests
       end
     end
 
+    def test_more_than_one_line_filter
+      app_file 'test/models/post_test.rb', <<-RUBY
+        require 'test_helper'
+
+        class PostTest < ActiveSupport::TestCase
+          test "first filter" do
+            puts 'PostTest:FirstFilter'
+            assert true
+          end
+
+          test "second filter" do
+            puts 'PostTest:SecondFilter'
+            assert true
+          end
+
+          test "test line filter does not run this" do
+            assert true
+          end
+        end
+      RUBY
+
+      run_test_command('test/models/post_test.rb:4:9').tap do |output|
+        assert_match 'PostTest:FirstFilter', output
+        assert_match 'PostTest:SecondFilter', output
+        assert_match '2 runs, 2 assertions', output
+      end
+    end
+
+    def test_more_than_one_line_filter_with_multiple_files
+      app_file 'test/models/account_test.rb', <<-RUBY
+        require 'test_helper'
+
+        class AccountTest < ActiveSupport::TestCase
+          test "first filter" do
+            puts 'AccountTest:FirstFilter'
+            assert true
+          end
+
+          test "second filter" do
+            puts 'AccountTest:SecondFilter'
+            assert true
+          end
+
+          test "line filter does not run this" do
+            assert true
+          end
+        end
+      RUBY
+
+      app_file 'test/models/post_test.rb', <<-RUBY
+        require 'test_helper'
+
+        class PostTest < ActiveSupport::TestCase
+          test "first filter" do
+            puts 'PostTest:FirstFilter'
+            assert true
+          end
+
+          test "second filter" do
+            puts 'PostTest:SecondFilter'
+            assert true
+          end
+
+          test "line filter does not run this" do
+            assert true
+          end
+        end
+      RUBY
+
+      run_test_command('test/models/account_test.rb:4:9  test/models/post_test:4:9').tap do |output|
+        assert_match 'AccountTest:FirstFilter', output
+        assert_match 'AccountTest:SecondFilter', output
+        assert_match 'PostTest:FirstFilter', output
+        assert_match 'PostTest:SecondFilter', output
+        assert_match '4 runs, 4 assertions', output
+      end
+    end
+
     def test_multiple_line_filters
       create_test_file :models, 'account'
       create_test_file :models, 'post'


### PR DESCRIPTION
Now user can run multiple tests using multiple line numbers.

```
require 'test_helper'

class UserTest < ActiveSupport::TestCase
  test "the truth" do
    assert_equal 3, 2 + 1 
  end 

  test "the false" do
    assert_equal 3, 1 + 1 
  end 
end

```

To run multiple tests 

`bin/rails test test/models/user_test:4:8` 

output:

```
# Running:

F

Failure:
UserTest#test_the_false:
Expected: 3
  Actual: 2


bin/rails test test/models/user_test.rb:9

.

Finished in 0.195725s, 10.2184 runs/s, 10.2184 assertions/s.

2 runs, 2 assertions, 1 failures, 0 errors, 0 skips

```
