### PR TITLE
use underscored before dasherizing

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -506,4 +506,13 @@
 
     *Logan Leger*
 
+*   `#dasherize` should also support class names and camel cased strings
+
+    ```
+    "ClassName".dasherize # => "class-name"
+    "camelCase".dasherize # => "camel-case"
+    ```
+
+    *Paulo Ancheta*
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -182,8 +182,10 @@ module ActiveSupport
     # Replaces underscores with dashes in the string.
     #
     #   dasherize('puni_puni') # => "puni-puni"
-    def dasherize(underscored_word)
-      underscored_word.tr('_'.freeze, '-'.freeze)
+    #   dasherize('StringString') # => "string-string"
+    #   dasherize('stringString') # => "string-string"
+    def dasherize(word)
+      underscore(word).tr('_'.freeze, '-'.freeze)
     end
 
     # Removes the module part from the expression in the string.

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -374,6 +374,12 @@ class InflectorTest < ActiveSupport::TestCase
     end
   end
 
+  def test_class_to_dasherize
+    CamelCaseToDashes.each do |class_name, dasherized|
+      assert_equal(dasherized, ActiveSupport::Inflector.dasherize(class_name))
+    end
+  end
+
   def test_underscore_as_reverse_of_dasherize
     UnderscoresToDashes.each_key do |underscored|
       assert_equal(underscored, ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.dasherize(underscored)))

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -343,6 +343,12 @@ module InflectorTestCases
     "person_street_address" => "person-street-address"
   }
 
+  CamelCaseToDashes = {
+    "Street"              => "street",
+    "streetAddress"       => "street-address",
+    "PersonStreetAddress" => "person-street-address"
+  }
+
   Irregularities = {
     'person' => 'people',
     'man'    => 'men',


### PR DESCRIPTION
## Improve dasherize

`#dasherize` should also dasherize camel cased strings.

``` rb
For Example:
"SomeString".dasherize    # => "some-string"
"anotherString".dasherize # => "another-string"
```

_Previous behaviour only supports underscored word._
