### PR TITLE
Remove not used test fixture

### DIFF
--- a/actionmailer/test/fixtures/async_mailer/welcome.erb
+++ b/actionmailer/test/fixtures/async_mailer/welcome.erb
@@ -1,1 +1,0 @@
-Welcome


### PR DESCRIPTION
'actionmailer/test/mailers/async_mailer.rb' was deleted by
f9da785d0b1b22317cfca25c15fb555e9016accb .
This template is not used now.
