### PR TITLE
Make `postgresql_version` public

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -390,12 +390,12 @@ module ActiveRecord
         "average" => "avg",
       }
 
-      protected
+      # Returns the version of the connected PostgreSQL server.
+      def postgresql_version
+        @connection.server_version
+      end
 
-        # Returns the version of the connected PostgreSQL server.
-        def postgresql_version
-          @connection.server_version
-        end
+      protected
 
         # See http://www.postgresql.org/docs/current/static/errcodes-appendix.html
         FOREIGN_KEY_VIOLATION = "23503"


### PR DESCRIPTION
This is useful to libraries that want to feature gate based on the
version of PostgreSQL the user is connected to. For instance, I want to
know if the user is connected to a version of Postgres that supports
concurrent materialized view refreshes. I could add that as a method on
the adapter as a PR, but rails has no need for this itself.

Rails is already using the postgresql_version for its own feature gating
and this makes that possible for other libraries.
