### PR TITLE
Fix AC::Parameter#[] to not change class of value for given key

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -399,7 +399,7 @@ module ActionController
     #   params[:person] # => {"name"=>"Francesco"}
     #   params[:none]   # => nil
     def [](key)
-      convert_hashes_to_parameters(key, @parameters[key])
+      convert_value_to_parameters(@parameters[key])
     end
 
     # Assigns a value to a given +key+. The given key may still get filtered out


### PR DESCRIPTION
- convert_hashes_to_parameters changes class of value hash from
  HashWithIndifferentAccess to AC::Parameters.
- But we don't want to convert hash into parameter in this case, we
  really only want to convert value into parameters. So calling
  convert_value_to_parameters instead of convert_hashes_to_parameters.
