### PR TITLE
Fix AC::Parameters#to_unsafe_h to return all unfiltered values

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix `ActionController::Parameters#convert_parameters_to_hashes` to return filtered
+    or unfiltered values based on from where it is called, `to_h` or `to_unsafe_h`
+    respectively.
+
+    Fixes #22841
+
+    *Prathamesh Sonpatki*
+
 *   Add `ActionController::Parameters#include?`
 
     *Justin Coyne*

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -176,7 +176,7 @@ module ActionController
     #   safe_params.to_h # => {"name"=>"Senjougahara Hitagi"}
     def to_h
       if permitted?
-        convert_parameters_to_hashes(@parameters)
+        convert_parameters_to_hashes(@parameters, :to_h)
       else
         slice(*self.class.always_permitted_parameters).permit!.to_h
       end
@@ -186,7 +186,7 @@ module ActionController
     # <tt>ActiveSupport::HashWithIndifferentAccess</tt> representation of this
     # parameter.
     def to_unsafe_h
-      convert_parameters_to_hashes(@parameters)
+      convert_parameters_to_hashes(@parameters, :to_unsafe_h)
     end
     alias_method :to_unsafe_hash, :to_unsafe_h
 
@@ -595,16 +595,16 @@ module ActionController
         end
       end
 
-      def convert_parameters_to_hashes(value)
+      def convert_parameters_to_hashes(value, using)
         case value
         when Array
-          value.map { |v| convert_parameters_to_hashes(v) }
+          value.map { |v| convert_parameters_to_hashes(v, using) }
         when Hash
           value.transform_values do |v|
-            convert_parameters_to_hashes(v)
+            convert_parameters_to_hashes(v, using)
           end.with_indifferent_access
         when Parameters
-          value.to_h
+          value.send(using)
         else
           value
         end

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -298,6 +298,14 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert_not @params.to_h.is_a? ActionController::Parameters
   end
 
+  test "to_unsafe_h returns unfiltered params even after accessing few keys" do
+    params = ActionController::Parameters.new("f"=>{"language_facet"=>["Tibetan"]})
+    expected = {"f"=>{"language_facet"=>["Tibetan"]}}
+
+    assert params['f'].is_a? ActionController::Parameters
+    assert_equal expected, params.to_unsafe_h
+  end
+
   test "to_h only deep dups Ruby collections" do
     company = Class.new do
       attr_reader :dupped


### PR DESCRIPTION
- AC::Parameters#convert_parameters_to_hashes should return filtered or
  unfiltered values based on whether it is called from `to_h` or `to_unsafe_h`
  instead of always defaulting to `to_h`.
- Fixes #22841
