### PR TITLE
Fix test for AC::Parameters#to_unsafe_h

### DIFF
--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -294,8 +294,8 @@ class ParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "to_unsafe_h returns unfiltered params" do
-    assert @params.to_h.is_a? ActiveSupport::HashWithIndifferentAccess
-    assert_not @params.to_h.is_a? ActionController::Parameters
+    assert @params.to_unsafe_h.is_a? ActiveSupport::HashWithIndifferentAccess
+    assert_not @params.to_unsafe_h.is_a? ActionController::Parameters
   end
 
   test "to_h only deep dups Ruby collections" do


### PR DESCRIPTION
- Test should call `to_unsafe_h` instead of `to_h`
