### PR TITLE
Default rendering behavior if respond_to collector doesn't have a block.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   When a `respond_to` collector with a block doesn't have a response, then
+    a `:no_content` response should be rendered.  This brings the default
+    rendering behavior introduced by https://github.com/rails/rails/issues/19036
+    to controller methods employing `respond_to`
+
+    *Justin Coyne*
+
 *   Update default rendering policies when the controller action did
     not explicitly indicate a response.
 

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -198,7 +198,7 @@ module ActionController #:nodoc:
         _process_format(format)
         _set_rendered_content_type format
         response = collector.response
-        response ? response.call : render({})
+        response.call if response
       else
         raise ActionController::UnknownFormat
       end

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -74,6 +74,14 @@ class RespondToController < ActionController::Base
     end
   end
 
+  def missing_templates
+    respond_to do |type|
+      # This test requires a block that is empty
+      type.json { }
+      type.xml
+    end
+  end
+
   def using_defaults_with_type_list
     respond_to(:html, :xml)
   end
@@ -622,6 +630,13 @@ class RespondToControllerTest < ActionController::TestCase
     assert_raises(ActionController::UnknownFormat) do
       get :using_defaults, format: "invalidformat"
     end
+  end
+
+  def test_missing_templates
+    get :missing_templates, format: :json
+    assert_response :no_content
+    get :missing_templates, format: :xml
+    assert_response :no_content
   end
 
   def test_invalid_variant


### PR DESCRIPTION
When a `respond_to` collector doesn't have a response, then a `:no_content` response should be rendered. This brings the default rendering behavior introduced by rails#19036 to controller methods
employing `respond_to`
