### PR TITLE
Avoid `Time.parse` for static date

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -228,7 +228,7 @@ module ActionController
       expires_in 100.years, public: public
 
       yield if stale?(etag: "#{version}-#{request.fullpath}",
-                      last_modified: Time.parse('2011-01-01').utc,
+                      last_modified: Time.new(2011, 1, 1).utc,
                       public: public)
     end
 


### PR DESCRIPTION
This seemed like an obvious overhead to me.

``` ruby
Benchmark.ips do |x|
  x.report('Time.parse') { Time.parse('2011-01-01') }
  x.report('Time.new')   { Time.new(2011, 1, 1) }
end
```

```
Calculating -------------------------------------
          Time.parse     6.640k i/100ms
            Time.new    15.082k i/100ms
-------------------------------------------------
          Time.parse     71.915k (± 3.1%) i/s -    365.200k
            Time.new    167.645k (± 3.3%) i/s -    844.592k
```
