### PR TITLE
Adds exception object to instrumenter's payload

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -510,4 +510,10 @@
 
     *Logan Leger*
 
+*   Adds `:exception_object` key to ActiveSupport::Notifications::Instrumenter payload when an exception is raised
+
+    Adds new key/value pair to payload when an exception is raised: e.g. `:exception_object => #<RuntimeError: FAIL>`
+
+    *Ryan T. Hosford*
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -21,6 +21,7 @@ module ActiveSupport
           yield payload
         rescue Exception => e
           payload[:exception] = [e.class.name, e.message]
+          payload[:exception_object] = e
           raise e
         ensure
           finish_with_state listeners_state, name, payload

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -232,7 +232,7 @@ module Notifications
 
       assert_equal 1, @events.size
       assert_equal Hash[:payload => "notifications",
-        :exception => ["RuntimeError", "FAIL"]], @events.last.payload
+        :exception => ["RuntimeError", "FAIL"], :exception_object => e], @events.last.payload
     end
 
     def test_event_is_pushed_even_without_block


### PR DESCRIPTION
- Addresses problem noted in #16418:
  "When an Exception is raised, instrumentations have no way of getting the backtrace. Only the Exception name and message which is often not enough."
- Adds third element to payload's :exception value
  e.g. `:exception => ["RuntimeError", "FAIL", #<RuntimeError: FAIL>]`
- Updates relevant test
