### PR TITLE
Update middleware docs regarding ActionDispatch::LoadInterlock [ci skip]

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -192,7 +192,7 @@ An API application comes with the following middlewares by default:
 
 - `Rack::Sendfile`
 - `ActionDispatch::Static`
-- `Rack::Lock`
+- `ActionDispatch::LoadInterlock`
 - `ActiveSupport::Cache::Strategy::LocalCache::Middleware`
 - `ActionDispatch::RequestId`
 - `Rails::Rack::Logger`
@@ -261,9 +261,6 @@ for a URL in the Rails cache, and add an `If-Modified-Since` header to any
 subsequent inbound requests for the same URL.
 
 Think of it as page caching using HTTP semantics.
-
-NOTE: This middleware is always outside of the `Rack::Lock` mutex, even in
-single-threaded applications.
 
 ### Using Rack::Sendfile
 

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -412,7 +412,7 @@ Ruby version              2.2.2 (x86_64-linux)
 RubyGems version          2.4.6
 Rack version              1.6
 JavaScript Runtime        Node.js (V8)
-Middleware                Rack::Sendfile, ActionDispatch::Static, Rack::Lock, #<ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x007ffd131a7c88>, Rack::Runtime, Rack::MethodOverride, ActionDispatch::RequestId, Rails::Rack::Logger, ActionDispatch::ShowExceptions, ActionDispatch::DebugExceptions, ActionDispatch::RemoteIp, ActionDispatch::Reloader, ActionDispatch::Callbacks, ActiveRecord::Migration::CheckPending, ActiveRecord::ConnectionAdapters::ConnectionManagement, ActiveRecord::QueryCache, ActionDispatch::Cookies, ActionDispatch::Session::CookieStore, ActionDispatch::Flash, Rack::Head, Rack::ConditionalGet, Rack::ETag
+Middleware                Rack::Sendfile, ActionDispatch::Static, ActionDispatch::LoadInterlock, #<ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x007ffd131a7c88>, Rack::Runtime, Rack::MethodOverride, ActionDispatch::RequestId, Rails::Rack::Logger, ActionDispatch::ShowExceptions, ActionDispatch::DebugExceptions, ActionDispatch::RemoteIp, ActionDispatch::Reloader, ActionDispatch::Callbacks, ActiveRecord::Migration::CheckPending, ActiveRecord::ConnectionAdapters::ConnectionManagement, ActiveRecord::QueryCache, ActionDispatch::Cookies, ActionDispatch::Session::CookieStore, ActionDispatch::Flash, Rack::Head, Rack::ConditionalGet, Rack::ETag
 Application root          /home/foobar/commandsapp
 Environment               development
 Database adapter          sqlite3

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -200,7 +200,7 @@ Every Rails application comes with a standard set of middleware which it uses in
 
 * `ActionDispatch::SSL` forces every request to be served using HTTPS. Enabled if `config.force_ssl` is set to `true`. Options passed to this can be configured by setting `config.ssl_options`.
 * `ActionDispatch::Static` is used to serve static assets. Disabled if `config.public_file_server.enabled` is `false`. Set `config.public_file_server.index_name` if you need to serve a static directory index file that is not named `index`. For example, to serve `main.html` instead of `index.html` for directory requests, set `config.public_file_server.index_name` to `"main"`.
-* `Rack::Lock` wraps the app in mutex so it can only be called by a single thread at a time. Only enabled when `config.cache_classes` is `false`.
+* `ActionDispatch::LoadInterlock` allows thread safe code reloading. Disabled if `config.allow_concurrency` is `false`, which causes `Rack::Lock` to be loaded. `Rack::Lock` wraps the app in mutex so it can only be called by a single thread at a time.
 * `ActiveSupport::Cache::Strategy::LocalCache` serves as a basic memory backed cache. This cache is not thread safe and is intended only for serving as a temporary memory cache for a single thread.
 * `Rack::Runtime` sets an `X-Runtime` header, containing the time (in seconds) taken to execute the request.
 * `Rails::Rack::Logger` notifies the logs that the request has begun. After request is complete, flushes all the logs.

--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -104,7 +104,7 @@ For a freshly generated Rails application, this might produce something like:
 ```ruby
 use Rack::Sendfile
 use ActionDispatch::Static
-use Rack::Lock
+use ActionDispatch::LoadInterlock
 use #<ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x000000029a0838>
 use Rack::Runtime
 use Rack::MethodOverride
@@ -171,10 +171,10 @@ Add the following lines to your application configuration:
 
 ```ruby
 # config/application.rb
-config.middleware.delete Rack::Lock
+config.middleware.delete Rack::Runtime
 ```
 
-And now if you inspect the middleware stack, you'll find that `Rack::Lock` is
+And now if you inspect the middleware stack, you'll find that `Rack::Runtime` is
 not a part of it.
 
 ```bash
@@ -218,6 +218,10 @@ Much of Action Controller's functionality is implemented as Middlewares. The fol
 **`Rack::Lock`**
 
 * Sets `env["rack.multithread"]` flag to `false` and wraps the application within a Mutex.
+
+**`ActionDispatch::LoadInterlock`**
+
+* Used for thread safe code reloading during development.
 
 **`ActiveSupport::Cache::Strategy::LocalCache::Middleware`**
 


### PR DESCRIPTION
Noticed that the guides didn't mention this feature yet. Figured it was safe to remove the Rack::Lock references for the cache middleware because it's not something that is encountered in default configurations.

r? @matthewd 
