### PR TITLE
Better example for ActiveRecord::Relation#or

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -649,8 +649,8 @@ module ActiveRecord
     # they must differ only by #where (if no #group has been defined) or #having (if a #group is
     # present). Neither relation may have a #limit, #offset, or #distinct set.
     #
-    #    Post.where("id = 1").or(Post.where("id = 2"))
-    #    # SELECT `posts`.* FROM `posts`  WHERE (('id = 1' OR 'id = 2'))
+    #    Post.where("id = 1").or(Post.where("author_id = 3"))
+    #    # SELECT `posts`.* FROM `posts`  WHERE (('id = 1' OR 'author_id = 3'))
     #
     def or(other)
       spawn.or!(other)


### PR DESCRIPTION
The old example could have been achieved with `.where(id: [1, 2])`, I thought this illustrated the new feature a bit better.
