### PR TITLE
Lets not put fullstop at the end of a migration pending command

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -126,9 +126,9 @@ module ActiveRecord
   class PendingMigrationError < MigrationError#:nodoc:
     def initialize(message = nil)
       if !message && defined?(Rails.env)
-        super("Migrations are pending. To resolve this issue, run:\n\n\tbin/rails db:migrate RAILS_ENV=#{::Rails.env}.")
+        super("Migrations are pending. To resolve this issue, run:\n\n\tbin/rails db:migrate RAILS_ENV=#{::Rails.env}")
       elsif !message
-        super("Migrations are pending. To resolve this issue, run:\n\n\tbin/rails db:migrate.")
+        super("Migrations are pending. To resolve this issue, run:\n\n\tbin/rails db:migrate")
       else
         super
       end


### PR DESCRIPTION
- So that we can just copy paste the command and execute it
