### PR TITLE
Validates secure password length is < 72 bytes

### DIFF
--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -15,6 +15,7 @@ en:
       empty: "can't be empty"
       blank: "can't be blank"
       present: "must be blank"
+      too_long_in_bytes: "is too long (maximum is %{count} bytes)"
       too_long:
         one: "is too long (maximum is 1 character)"
         other: "is too long (maximum is %{count} characters)"

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -2,10 +2,10 @@ module ActiveModel
   module SecurePassword
     extend ActiveSupport::Concern
 
-    # BCrypt hash function can handle maximum 72 characters, and if we pass
-    # password of length more than 72 characters it ignores extra characters.
+    # BCrypt hash function can handle maximum 72 bytes, and if we pass
+    # password of length more than 72 bytes it ignores extra characters.
     # Hence need to put a restriction on password length.
-    MAX_PASSWORD_LENGTH_ALLOWED = 72
+    MAX_PASSWORD_BYTE_LENGTH_ALLOWED = 72
 
     class << self
       attr_accessor :min_cost # :nodoc:
@@ -74,7 +74,11 @@ module ActiveModel
             record.errors.add(:password, :blank) unless record.password_digest.present?
           end
 
-          validates_length_of :password, maximum: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED
+          validate do |record|
+            if record.password.present? && record.password.bytes.size > ActiveModel::SecurePassword::MAX_PASSWORD_BYTE_LENGTH_ALLOWED
+              record.errors.add(:password, :too_long_in_bytes, count: ActiveModel::SecurePassword::MAX_PASSWORD_BYTE_LENGTH_ALLOWED)
+            end
+          end
           validates_confirmation_of :password, allow_blank: true
         end
       end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -59,12 +59,12 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_equal ["can't be blank"], @user.errors[:password]
   end
 
-  test 'create a new user with validation and password length greater than 72' do
-    @user.password = 'a' * 73
-    @user.password_confirmation = 'a' * 73
+  test 'create a new user with validation and password length greater than 72 bytes' do
+    @user.password = 'Ä' * 37
+    @user.password_confirmation = 'Ä' * 37
     assert !@user.valid?(:create), 'user should be invalid'
     assert_equal 1, @user.errors.count
-    assert_equal ["is too long (maximum is 72 characters)"], @user.errors[:password]
+    assert_equal ["is too long (maximum is 72 bytes)"], @user.errors[:password]
   end
 
   test "create a new user with validation and a blank password confirmation" do
@@ -129,11 +129,11 @@ class SecurePasswordTest < ActiveModel::TestCase
   end
 
   test 'updating an existing user with validation and password length greater than 72' do
-    @existing_user.password = 'a' * 73
-    @existing_user.password_confirmation = 'a' * 73
+    @existing_user.password = 'ち' * 25
+    @existing_user.password_confirmation = 'ち' * 25
     assert !@existing_user.valid?(:update), 'user should be invalid'
     assert_equal 1, @existing_user.errors.count
-    assert_equal ["is too long (maximum is 72 characters)"], @existing_user.errors[:password]
+    assert_equal ["is too long (maximum is 72 bytes)"], @existing_user.errors[:password]
   end
 
   test "updating an existing user with validation and a blank password confirmation" do


### PR DESCRIPTION
BCrypt uses only 72 bytes (not 72 characters)
