### PR TITLE
Move responsibility for TZ awareness on arrays and ranges

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -6,7 +6,8 @@ module ActiveRecord
           include Type::Helpers::Mutable
 
           attr_reader :subtype, :delimiter
-          delegate :type, :user_input_in_time_zone, :limit, to: :subtype
+          attr_writer :subtype
+          delegate :type, :limit, to: :subtype
 
           def initialize(subtype, delimiter = ',')
             @subtype = subtype

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -4,11 +4,13 @@ require 'support/connection_helper'
 if ActiveRecord::Base.connection.respond_to?(:supports_ranges?) && ActiveRecord::Base.connection.supports_ranges?
   class PostgresqlRange < ActiveRecord::Base
     self.table_name = "postgresql_ranges"
+    self.time_zone_aware_types = [:datetime]
   end
 
   class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
     self.use_transactional_tests = false
     include ConnectionHelper
+    include InTimeZone
 
     def setup
       @connection = PostgresqlRange.connection
@@ -174,6 +176,26 @@ _SQL
                             Time.parse('2010-01-01 14:30:00 +0100')...Time.parse('2010-01-01 13:30:00 +0000'))
     end
 
+    def test_timezone_awareness_tzrange
+      tz = "Pacific Time (US & Canada)"
+
+      in_time_zone tz do
+        PostgresqlRange.reset_column_information
+        time_string = Time.current.to_s
+        time = Time.zone.parse(time_string)
+
+        record = PostgresqlRange.new(tstz_range: time_string..time_string)
+        assert_equal time..time, record.tstz_range
+        assert_equal ActiveSupport::TimeZone[tz], record.tstz_range.begin.time_zone
+
+        record.save!
+        record.reload
+
+        assert_equal time..time, record.tstz_range
+        assert_equal ActiveSupport::TimeZone[tz], record.tstz_range.begin.time_zone
+      end
+    end
+
     def test_create_tsrange
       tz = ::ActiveRecord::Base.default_timezone
       assert_equal_round_trip(@new_range, :ts_range,
@@ -186,6 +208,26 @@ _SQL
                               Time.send(tz, 2010, 1, 1, 14, 30, 0)...Time.send(tz, 2011, 2, 2, 14, 30, 0))
       assert_nil_round_trip(@first_range, :ts_range,
                             Time.send(tz, 2010, 1, 1, 14, 30, 0)...Time.send(tz, 2010, 1, 1, 14, 30, 0))
+    end
+
+    def test_timezone_awareness_tsrange
+      tz = "Pacific Time (US & Canada)"
+
+      in_time_zone tz do
+        PostgresqlRange.reset_column_information
+        time_string = Time.current.to_s
+        time = Time.zone.parse(time_string)
+
+        record = PostgresqlRange.new(ts_range: time_string..time_string)
+        assert_equal time..time, record.ts_range
+        assert_equal ActiveSupport::TimeZone[tz], record.ts_range.begin.time_zone
+
+        record.save!
+        record.reload
+
+        assert_equal time..time, record.ts_range
+        assert_equal ActiveSupport::TimeZone[tz], record.ts_range.begin.time_zone
+      end
     end
 
     def test_create_numrange


### PR DESCRIPTION
Instead of having a "TZ-aware array of times", we now have an "array of TZ-aware times". And we gain a similar arrangement for ranges, which were previously TZ-ignorant.

Fixes #21142 (includes its tests), and thereby also fixes #21116.

---

@sgrif this seems like an improvement (no more `user_input_in_time_zone` in the array type), but also doesn't feel like it's quite there... the `subtype` machinery shouldn't be happening in TZConversion, either.

I was pondering something like:

``` ruby
matcher = ->(name, type) { type.respond_to?(:subtype) }
decorate_matching_attribute_types(matcher, :_subtype_decoration) do |type|
  type.dup.tap do |wrapper_type|
    wrapper_type.subtype = attribute_type_decorations.apply(name, wrapper_type.subtype)
  end
end
```

... but if nothing else, that's problematic because the decorator doesn't get the `name`. (Other than that, it does seem to work: https://github.com/matthewd/rails/commit/b0874aa2eacd42ae9225759f6a100310d00b0ac7).

I imagine you'd want the dup-with-new-subtype operation to be combined into a method, too, so the classes remain properly immutable. Should we have a `class Type::Wrapper < Type::Value` that centralises `subtype` handling?
