### PR TITLE
Ignoring spring temporary directory by default gitignore template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -23,3 +23,6 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+# Ignore Spring temporary directory.
+/spring-*


### PR DESCRIPTION
Should everyone need this. [Refer](https://github.com/rails/spring/blob/1b045fb2db87aa4f32ba36b185215125f91dc79f/lib/spring/env.rb#L36-L37)
