### PR TITLE
Remove unnecessary enable,disable_extension on tests

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -146,8 +146,6 @@ class PostgresqlUUIDGenerationTest < ActiveRecord::PostgreSQLTestCase
   end
 
   setup do
-    enable_extension!('uuid-ossp', connection)
-
     connection.create_table('pg_uuids', id: :uuid, default: 'uuid_generate_v1()') do |t|
       t.string 'name'
       t.uuid 'other_uuid', default: 'uuid_generate_v4()'
@@ -172,7 +170,6 @@ class PostgresqlUUIDGenerationTest < ActiveRecord::PostgreSQLTestCase
     drop_table "pg_uuids"
     drop_table 'pg_uuids_2'
     connection.execute 'DROP FUNCTION IF EXISTS my_uuid_generator();'
-    disable_extension!('uuid-ossp', connection)
   end
 
   if ActiveRecord::Base.connection.supports_extensions?
@@ -217,8 +214,6 @@ class PostgresqlUUIDTestNilDefault < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
 
   setup do
-    enable_extension!('uuid-ossp', connection)
-
     connection.create_table('pg_uuids', id: false) do |t|
       t.primary_key :id, :uuid, default: nil
       t.string 'name'
@@ -227,7 +222,6 @@ class PostgresqlUUIDTestNilDefault < ActiveRecord::PostgreSQLTestCase
 
   teardown do
     drop_table "pg_uuids"
-    disable_extension!('uuid-ossp', connection)
   end
 
   if ActiveRecord::Base.connection.supports_extensions?
@@ -260,8 +254,6 @@ class PostgresqlUUIDTestInverseOf < ActiveRecord::PostgreSQLTestCase
   end
 
   setup do
-    enable_extension!('uuid-ossp', connection)
-
     connection.transaction do
       connection.create_table('pg_uuid_posts', id: :uuid) do |t|
         t.string 'title'
@@ -276,7 +268,6 @@ class PostgresqlUUIDTestInverseOf < ActiveRecord::PostgreSQLTestCase
   teardown do
       drop_table "pg_uuid_comments"
       drop_table "pg_uuid_posts"
-      disable_extension!('uuid-ossp', connection)
   end
 
   if ActiveRecord::Base.connection.supports_extensions?

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -80,12 +80,10 @@ module ActiveRecord
         end
 
         def test_renaming_table_doesnt_attempt_to_rename_non_existent_sequences
-          enable_extension!('uuid-ossp', connection)
           connection.create_table :cats, id: :uuid
           assert_nothing_raised { rename_table :cats, :felines }
           ActiveSupport::Deprecation.silence { assert connection.table_exists? :felines }
         ensure
-          disable_extension!('uuid-ossp', connection)
           connection.drop_table :cats, if_exists: true
           connection.drop_table :felines, if_exists: true
         end


### PR DESCRIPTION
uuid-ossp extension is alreadly enabled on test schema.
And `disable_extension!('uuid-ossp', connection)` can be a cause of test failure.
`ActiveRecord::StatementInvalid: PG::UndefinedFunction: ERROR:  function uuid_generate_v1() does not exist`
will happen depending on the execution order.
