### PR TITLE
use parent RAILS_ENV for rake child process

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -550,7 +550,7 @@ module ActiveRecord
           FileUtils.cd Rails.root do
             current_config = Base.connection_config
             Base.clear_all_connections!
-            system("bin/rails db:test:prepare")
+            system("RAILS_ENV=#{Rails.env} bin/rails db:test:prepare")
             # Establish a new connection, the old database may be gone (db:test:prepare uses purge)
             Base.establish_connection(current_config)
           end


### PR DESCRIPTION
load_schema_if_pending! runs a rake task to prepare the database if
necessary, but the child task does not necessarily run in the same Rails
environment as its parent. This could result in attempting to prepare
the wrong database depending on how the database is configured.

This change passes the environment to the task as an environment
variable which ensures the environment names match.

This PR is an example of one potential fix.
