### PR TITLE
Replace x.times.map{} with Array.new(x){} in AD::Journey::Path::Pattern

### DIFF
--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -124,7 +124,7 @@ module ActionDispatch
           end
 
           def captures
-            (length - 1).times.map { |i| self[i + 1] }
+            Array.new(length - 1) { |i| self[i + 1] }
           end
 
           def [](x)


### PR DESCRIPTION
The former is more readable, performant and has fewer method calls.

``` ruby
Benchmark.ips do |x|
  x.report('times.map') { 5.times.map{} }
  x.report('Array.new') { Array.new(5){} }
  x.compare!
end
__END__
Calculating -------------------------------------
           times.map    21.188k i/100ms
           Array.new    30.449k i/100ms
-------------------------------------------------
           times.map    311.613k (± 3.5%) i/s -      1.568M
           Array.new    590.374k (± 1.2%) i/s -      2.954M

Comparison:
           Array.new:   590373.6 i/s
           times.map:   311612.8 i/s - 1.89x slower
```
