### PR TITLE
Ensure sucker_punch < v2 is installed due to the change in public API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :job do
   gem 'resque', require: false
   gem 'resque-scheduler', require: false
   gem 'sidekiq', require: false
-  gem 'sucker_punch', require: false
+  gem 'sucker_punch', '< 2.0', require: false
   gem 'delayed_job', require: false
   gem 'queue_classic', github: "QueueClassic/queue_classic", branch: 'master', require: false, platforms: :ruby
   gem 'sneakers', require: false


### PR DESCRIPTION
Sucker Punch author here. `v2` will soon be released, which introduces backwards-incompatible API changes. Need to ensure that version isn't installed until it's release, stable, and an accompanying PR for changes to ActiveJob are submitted.
