### PR TITLE
Add support for specifying comments for tables, columns, and indexes in database itself

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Add support for database schema comments for tables, columns and indexes
+    for PostgreSQL and MySQL.
+
+    It allows to specify commentaries for database objects in migrations and
+    store them in database itself, allowing to see them with DBA tools and
+    in `db/schema.rb` file and thus automatically documents database schema:
+
+        create_table "pages", force: :cascade, comment: 'Arbitrary content pages' do |t|
+          # ...
+          t.string "path",   comment: "Path fragment of page URL used for routing"
+          t.string "locale", comment: "RFC 3066 locale code of website language section"
+          t.index ["locale", "path"], name: 'page_uri_index' comment: "Main index used to lookup page by it's URI."
+          # ...
+        end
+
+    *Andrey Novikov*
+
 *   Add `quoted_time` for truncating the date part of a TIME column value.
     This fixes queries on TIME column on MariaDB, as it doesn't ignore the 
     date part of the string when it coerces to time.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -54,6 +54,7 @@ module ActiveRecord
             end
 
             create_sql << "(#{statements.join(', ')}) " if statements.present?
+            add_table_options!(create_sql, table_options(o))
             create_sql << "#{o.options}"
             create_sql << " AS #{@conn.to_sql(o.as)}" if o.as
             create_sql
@@ -82,6 +83,16 @@ module ActiveRecord
             "DROP CONSTRAINT #{quote_column_name(name)}"
           end
 
+          def table_options(o)
+            options = {}
+            options[:comment] = o.comment
+            options
+          end
+
+          def add_table_options!(sql, _options)
+            sql
+          end
+
           def column_options(o)
             column_options = {}
             column_options[:null] = o.null unless o.null.nil?
@@ -92,6 +103,7 @@ module ActiveRecord
             column_options[:auto_increment] = o.auto_increment
             column_options[:primary_key] = o.primary_key
             column_options[:collation] = o.collation
+            column_options[:comment] = o.comment
             column_options
           end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -3,14 +3,14 @@ module ActiveRecord
     # Abstract representation of an index definition on a table. Instances of
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#indexes
-    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using) #:nodoc:
+    class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using, :comment) #:nodoc:
     end
 
     # Abstract representation of a column definition. Instances of this type
     # are typically created by methods in TableDefinition, and added to the
     # +columns+ attribute of said TableDefinition object, in order to be used
     # for generating a number of table creation or table changing SQL statements.
-    class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :auto_increment, :primary_key, :collation, :sql_type) #:nodoc:
+    class ColumnDefinition < Struct.new(:name, :type, :limit, :precision, :scale, :default, :null, :first, :after, :auto_increment, :primary_key, :collation, :sql_type, :comment) #:nodoc:
 
       def primary_key?
         primary_key || type.to_sym == :primary_key
@@ -207,9 +207,9 @@ module ActiveRecord
       include ColumnMethods
 
       attr_accessor :indexes
-      attr_reader :name, :temporary, :options, :as, :foreign_keys
+      attr_reader :name, :temporary, :options, :as, :foreign_keys, :comment
 
-      def initialize(name, temporary, options, as = nil)
+      def initialize(name, temporary, options, as = nil, comment = nil)
         @columns_hash = {}
         @indexes = {}
         @foreign_keys = []
@@ -218,6 +218,7 @@ module ActiveRecord
         @options = options
         @as = as
         @name = name
+        @comment = comment
       end
 
       def primary_keys(name = nil) # :nodoc:
@@ -373,6 +374,7 @@ module ActiveRecord
         column.auto_increment = options[:auto_increment]
         column.primary_key = type == :primary_key || options[:primary_key]
         column.collation   = options[:collation]
+        column.comment     = options[:comment]
         column
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -46,12 +46,14 @@ module ActiveRecord
           spec[:collation] = collation
         end
 
+        spec[:comment] = column.comment.inspect if column.comment
+
         spec
       end
 
       # Lists the valid migration options
       def migration_keys
-        [:name, :limit, :precision, :scale, :default, :null, :collation]
+        [:name, :limit, :precision, :scale, :default, :null, :collation, :comment]
       end
 
       private

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -18,6 +18,11 @@ module ActiveRecord
         nil
       end
 
+      # Returns comment associated with given table in database
+      def table_comment(table_name)
+        nil
+      end
+
       # Truncates a table alias according to the limits of the current adapter.
       def table_alias_for(table_name)
         table_name[0...table_alias_length].tr('.', '_')
@@ -255,7 +260,7 @@ module ActiveRecord
       #
       # See also TableDefinition#column for details on how to create columns.
       def create_table(table_name, options = {})
-        td = create_table_definition table_name, options[:temporary], options[:options], options[:as]
+        td = create_table_definition table_name, options[:temporary], options[:options], options[:as], options[:comment]
 
         if options[:id] != false && !options[:as]
           pk = options.fetch(:primary_key) do
@@ -265,7 +270,7 @@ module ActiveRecord
           if pk.is_a?(Array)
             td.primary_keys pk
           else
-            td.primary_key pk, options.fetch(:id, :primary_key), options
+            td.primary_key pk, options.fetch(:id, :primary_key), options.except(:comment)
           end
         end
 
@@ -280,6 +285,13 @@ module ActiveRecord
         unless supports_indexes_in_create?
           td.indexes.each_pair do |column_name, index_options|
             add_index(table_name, column_name, index_options)
+          end
+        end
+
+        if supports_comments? && !supports_comments_in_create?
+          change_table_comment(table_name, options[:comment]) if options[:comment]
+          td.columns.each do |column|
+            change_column_comment(table_name, column.name, column.comment) if column.comment
           end
         end
 
@@ -1078,7 +1090,7 @@ module ActiveRecord
       def add_index_options(table_name, column_name, options = {}) #:nodoc:
         column_names = Array(column_name)
 
-        options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :using, :algorithm, :type)
+        options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :using, :algorithm, :type, :comment)
 
         index_type = options[:type].to_s if options.key?(:type)
         index_type ||= options[:unique] ? "UNIQUE" : ""
@@ -1106,11 +1118,23 @@ module ActiveRecord
         end
         index_columns = quoted_columns_for_index(column_names, options).join(", ")
 
-        [index_name, index_type, index_columns, index_options, algorithm, using]
+        comment = options[:comment] if options.key?(:comment)
+
+        [index_name, index_type, index_columns, index_options, algorithm, using, comment]
       end
 
       def options_include_default?(options)
         options.include?(:default) && !(options[:null] == false && options[:default].nil?)
+      end
+
+      # Adds comment for given table or drops it if +nil+ given
+      def change_table_comment(table_name, comment)
+        raise NotImplementedError, "change_table_comment is not implemented"
+      end
+
+      # Adds comment for given table column or drops it if +nil+ given
+      def change_column_comment(table_name, column_name, comment) #:nodoc:
+        raise NotImplementedError, "change_column_comment is not implemented"
       end
 
       protected
@@ -1194,8 +1218,8 @@ module ActiveRecord
         end
 
       private
-      def create_table_definition(name, temporary = false, options = nil, as = nil)
-        TableDefinition.new(name, temporary, options, as)
+      def create_table_definition(name, temporary = false, options = nil, as = nil, comment = nil)
+        TableDefinition.new(name, temporary, options, as, comment)
       end
 
       def create_alter_table(name)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -278,6 +278,16 @@ module ActiveRecord
         false
       end
 
+      # Does adapter supports comments on database objects (tables, columns, indexes)?
+      def supports_comments?
+        false
+      end
+
+      # Can comments for tables, columns, and indexes be specified in create/alter table statements?
+      def supports_comments_in_create?
+        false
+      end
+
       # This is meant to be implemented by the adapters that support extensions
       def disable_extension(name)
       end

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -5,7 +5,7 @@ module ActiveRecord
   module ConnectionAdapters
     # An abstract definition of a column in a table.
     class Column
-      attr_reader :name, :default, :sql_type_metadata, :null, :table_name, :default_function, :collation
+      attr_reader :name, :default, :sql_type_metadata, :null, :table_name, :default_function, :collation, :comment
 
       delegate :precision, :scale, :limit, :type, :sql_type, to: :sql_type_metadata, allow_nil: true
 
@@ -15,7 +15,7 @@ module ActiveRecord
       # +default+ is the type-casted default value, such as +new+ in <tt>sales_stage varchar(20) default 'new'</tt>.
       # +sql_type_metadata+ is various information about the type of the column
       # +null+ determines if this column allows +NULL+ values.
-      def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, default_function = nil, collation = nil)
+      def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, default_function = nil, collation = nil, comment = nil)
         @name = name.freeze
         @table_name = table_name
         @sql_type_metadata = sql_type_metadata
@@ -23,6 +23,7 @@ module ActiveRecord
         @default = default
         @default_function = default_function
         @collation = collation
+        @comment = comment
       end
 
       def has_default?

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -45,6 +45,14 @@ module ActiveRecord
         !mariadb? && version >= '5.7.8'
       end
 
+      def supports_comments?
+        true
+      end
+
+      def supports_comments_in_create?
+        true
+      end
+
       # HELPER METHODS ===========================================
 
       def each_hash(result) # :nodoc:

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -138,6 +138,9 @@ HEADER
           table_options = @connection.table_options(table)
           tbl.print ", options: #{table_options.inspect}" unless table_options.blank?
 
+          comment = @connection.table_comment(table)
+          tbl.print ", comment: #{comment.inspect}" if comment
+
           tbl.puts " do |t|"
 
           # then dump all non-primary key columns
@@ -209,6 +212,7 @@ HEADER
             statement_parts << "where: #{index.where.inspect}" if index.where
             statement_parts << "using: #{index.using.inspect}" if index.using
             statement_parts << "type: #{index.type.inspect}" if index.type
+            statement_parts << "comment: #{index.comment.inspect}" if index.comment
 
             "  #{statement_parts.join(', ')}"
           end

--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -1,0 +1,91 @@
+require 'cases/helper'
+require 'support/schema_dumping_helper'
+
+class CommentTest < ActiveRecord::TestCase
+  include SchemaDumpingHelper
+  self.use_transactional_tests = false if current_adapter?(:Mysql2Adapter)
+
+  class Commented < ActiveRecord::Base
+    self.table_name = 'commenteds'
+  end
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+
+    @connection.transaction do
+      @connection.create_table('commenteds', comment: 'A table with comment', force: true) do |t|
+        t.string  'name',    comment: 'Comment should help clarify the column purpose'
+        t.boolean 'obvious', comment: 'Question is: should you comment obviously named objects?'
+        t.string  'content'
+        t.index   'name',    comment: %Q["Very important" index that powers all the performance.\nAnd it's fun!]
+      end
+    end
+  end
+
+  teardown do
+    @connection.drop_table 'commenteds', if_exists: true
+  end
+
+  if current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter)
+
+    def test_column_created_in_block
+      Commented.reset_column_information
+      column = Commented.columns_hash['name']
+      assert_equal :string, column.type
+      assert_equal 'Comment should help clarify the column purpose', column.comment
+    end
+
+    def test_add_column_with_comment_later
+      @connection.add_column :commenteds, :rating, :integer, comment: 'I am running out of imagination'
+      Commented.reset_column_information
+      column = Commented.columns_hash['rating']
+
+      assert_equal :integer, column.type
+      assert_equal 'I am running out of imagination', column.comment
+    end
+
+    def test_add_index_with_comment_later
+      @connection.add_index :commenteds, :obvious, name: 'idx_obvious', comment: 'We need to see obvious comments'
+      index = @connection.indexes('commenteds').find { |idef| idef.name == 'idx_obvious' }
+      assert_equal 'We need to see obvious comments', index.comment
+    end
+
+    def test_add_comment_to_column
+      @connection.change_column :commenteds, :content, :string, comment: 'Whoa, content describes itself!'
+
+      Commented.reset_column_information
+      column = Commented.columns_hash['content']
+
+      assert_equal :string, column.type
+      assert_equal 'Whoa, content describes itself!', column.comment
+    end
+
+    def test_remove_comment_from_column
+      @connection.change_column :commenteds, :obvious, :string, comment: nil
+
+      Commented.reset_column_information
+      column = Commented.columns_hash['obvious']
+
+      assert_equal :string, column.type
+      assert_nil column.comment
+    end
+
+    def test_schema_dump_with_comments
+      # Do all the stuff from other tests
+      @connection.add_column    :commenteds, :rating, :integer, comment: 'I am running out of imagination'
+      @connection.change_column :commenteds, :content, :string, comment: 'Whoa, content describes itself!'
+      @connection.change_column :commenteds, :obvious, :string, comment: nil
+      @connection.add_index     :commenteds, :obvious, name: 'idx_obvious', comment: 'We need to see obvious comments'
+      # And check that these changes are reflected in dump
+      output = dump_table_schema 'commenteds'
+      assert_match %r[create_table "commenteds",.+\s+comment: "A table with comment"], output
+      assert_match %r[t\.string\s+"name",\s+comment: "Comment should help clarify the column purpose"], output
+      assert_match %r[t\.string\s+"obvious"\n], output
+      assert_match %r[t\.string\s+"content",\s+comment: "Whoa, content describes itself!"], output
+      assert_match %r[t\.integer\s+"rating",\s+comment: "I am running out of imagination"], output
+      assert_match %r[add_index\s+.+\s+comment: "\\\"Very important\\\" index that powers all the performance.\\nAnd it's fun!"], output
+      assert_match %r[add_index\s+.+\s+name: "idx_obvious",.+\s+comment: "We need to see obvious comments"], output
+    end
+
+  end
+end

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -355,6 +355,13 @@ end
 will append `ENGINE=BLACKHOLE` to the SQL statement used to create the table
 (when using MySQL or MariaDB, the default is `ENGINE=InnoDB`).
 
+Also you can pass the `:comment` option with any description for the table
+that will be stored in database itself and can be viewed with database administration
+tools, such as MySQL Workbench or PgAdmin III. It's highly recommended to specify
+comments in migrations for applications with large databases as it helps people
+to understand data model and generate documentation.
+Currently only MySQL and PostgreSQL supports comments.
+
 ### Creating a Join Table
 
 The migration method `create_join_table` creates an HABTM (has and belongs to
@@ -454,6 +461,7 @@ number of digits after the decimal point.
 are using a dynamic value (such as a date), the default will only be calculated
 the first time (i.e. on the date the migration is applied).
 * `index`        Adds an index for the column.
+* `comment`      Adds a comment for the column.
 
 Some adapters may support additional options; see the adapter specific API docs
 for further information.


### PR DESCRIPTION
This pull request adds support for specifying comments for database objects in migrations, storing them inside database, and dumping them into `db/schema.rb` file for PostgreSQL and MySQL.

``` ruby
create_table "pages", force: :cascade, comment: 'Arbitrary content pages' do |t|
  # ...
  t.string "path",    comment: "Path fragment of page URL used for routing"
  t.string "locale",  comment: "RFC 3066 locale code of website language section"
  t.index ["locale", "path"], name: 'page_uri_index' comment: "Main index used to lookup page by it's URI."
  t.text   "content", comment: "HTML code of page"
  # ...
end
```

In my opinion it is really useful feature, allowing people to create documented data model right from Rails migrations. New people can look for tables, columns, and indexes meaning right in `db/schema.rb` (or right in model files with gems like @ctran's [annotate_models](https://github.com/ctran/annotate_models)) and DBA can view that information directly from MySQL Workbench, PgAdmin III, DBeaver or anything else. Afterwards any existing data modelling tool can be used to generate data model documentation (such as ER diagrams and table structure) automatically with minimal editing.

For example in my work recently was situation when we were need to send documentation to customer and database schema was part of it. We lost a day helping writers to make this docs as we explained tables and table columns meaning only in our internal wiki (and it was incomplete because everyone always forgets to edit it when writing a migration) and writers came to us with autogenerated docs from our staging database. And there was a lot of manual docs merging and investigation.

Among built in adapters only PostgreSQL and MySQL supports it (SQLite does not). Also [oracle_enhanced](https://github.com/rsim/oracle-enhanced) adapter supports comments with exactly same syntax (actually I follow it's syntax). May be @rsim, @yahonda, or @cdinger will also review and say whether I should change something for ease of integration of [oracle_enhanced](https://github.com/rsim/oracle-enhanced) implementation with my implementation.

Comment implementation in RDBMS differs heavily:
- PostgreSQL have only separate `COMMENT` command to set or delete comments on any database objects (like Oracle) and have no syntax to specify comments at time of creation or modification object. See docs: http://www.postgresql.org/docs/current/static/sql-comment.html
- MySQL only have special options in syntax of `CREATE TABLE` and `ALTER TABLE` commands and column and index definitions. No separate commands. See docs: http://dev.mysql.com/doc/refman/5.7/en/create-table.html

Here ActiveRecord takes all dirty work and hides all differences between implementations. I think this is awesome.

Unfortunately I'm not really experienced in ActiveRecord hacking and most of the work I have done blindly, just by inserting code chunks here and there and seeing what errors will occur and whether tests will pass. Is there any docs about ActiveRecord internals and architecture? I would be glad to read them. Please review carefully and tell me what I should change. I think this PR should be considered as Work In Progress, hence it already do it's job well.

Also I think that note about importance of schema documentation should be added to guides, but can't imagine good place and good words for it (and my English really isn't good enough for guides yet). Any suggestions are welcome!
