### PR TITLE
Fix `connection#create` in PG adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -119,6 +119,7 @@ module ActiveRecord
         value      = exec_insert(sql, name, binds, pk, sequence_name)
         id_value || last_inserted_id(value)
       end
+      alias create insert
 
       # Executes the update statement and returns the number of rows affected.
       def update(arel, name = nil, binds = [])

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -140,7 +140,6 @@ module ActiveRecord
         super
         id_value || @connection.last_id
       end
-      alias :create :insert_sql
 
       def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
         execute to_sql(sql, binds), name

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -90,10 +90,6 @@ module ActiveRecord
           end
         end
 
-        def create
-          super.insert
-        end
-
         # The internal PostgreSQL identifier of the money data type.
         MONEY_COLUMN_TYPE_OID = 790 #:nodoc:
         # The internal PostgreSQL identifier of the BYTEA data type.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -294,7 +294,6 @@ module ActiveRecord
         super
         id_value || @connection.last_insert_row_id
       end
-      alias :create :insert_sql
 
       def select_rows(sql, name = nil, binds = [])
         exec_query(sql, name, binds).rows

--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -6,14 +6,23 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
   end
 
   def test_insert_should_return_the_inserted_id
+    assert_not_nil return_the_inserted_id(method: :insert)
+  end
+
+  def test_create_should_return_the_inserted_id
+    assert_not_nil return_the_inserted_id(method: :create)
+  end
+
+  private
+
+  def return_the_inserted_id(method:)
     # Oracle adapter uses prefetched primary key values from sequence and passes them to connection adapter insert method
     if current_adapter?(:OracleAdapter)
       sequence_name = "accounts_seq"
       id_value = @connection.next_sequence_value(sequence_name)
-      id = @connection.insert("INSERT INTO accounts (id, firm_id,credit_limit) VALUES (accounts_seq.nextval,42,5000)", nil, :id, id_value, sequence_name)
+      @connection.send(method, "INSERT INTO accounts (id, firm_id,credit_limit) VALUES (accounts_seq.nextval,42,5000)", nil, :id, id_value, sequence_name)
     else
-      id = @connection.insert("INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)")
+      @connection.send(method, "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)")
     end
-    assert_not_nil id
   end
 end


### PR DESCRIPTION
Originally `connection#create` had aliased to `connection#insert` in PG adapter. [v3.2.22/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L594](https://github.com/rails/rails/blob/v3.2.22/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L594)
But it was broken by #7447. Re-alias `create` to `insert` for fixing it.
