### PR TITLE
Autoload ReferenceDefinition class in abstract adapter so that it can be used by #add_reference in schema_statements

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -23,6 +23,7 @@ module ActiveRecord
       autoload :TableDefinition
       autoload :Table
       autoload :AlterTable
+      autoload :ReferenceDefinition
     end
 
     autoload_at 'active_record/connection_adapters/abstract/connection_pool' do


### PR DESCRIPTION
- Fixes #22916.
