### PR TITLE
[ci skip] Update doc/resource link removed by #21211

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -37,6 +37,7 @@ curve diving straight into Rails. There are several curated lists of online reso
 for learning Ruby:
 
 * [Official Ruby Programming Language website](https://www.ruby-lang.org/en/documentation/)
+* [List of Free Programming Books](https://github.com/vhf/free-programming-books/blob/master/free-programming-books.md#ruby)
 
 Be aware that some resources, while still excellent, cover versions of Ruby as old as
 1.6, and commonly 1.8, and will not include some syntax that you will see in day-to-day


### PR DESCRIPTION
The link removed by #21211 was pointing to a "proxy" page displaying `vhf/free-programming-books` content.

With this PR, I suggest to add it back, since it can be a valuable resource.
