### PR TITLE
keep session id even when session is not found

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/cache_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cache_store.rb
@@ -19,10 +19,7 @@ module ActionDispatch
 
       # Get a session from the cache.
       def find_session(env, sid)
-        unless sid and session = @cache.read(cache_key(sid))
-          sid, session = generate_sid, {}
-        end
-        [sid, session]
+        [sid || generate_sid, sid ? @cache.read(cache_key(sid)) : {}]
       end
 
       # Set a session in the cache.


### PR DESCRIPTION
When session id is driven by a client (provided by SPA webapp), don't regenerate it when session is not found in a cache as it will break a session link between client and server.
