### PR TITLE
Opt-in to ActionCable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'rack-cache', '~> 1.2'
 gem 'jquery-rails'
 gem 'coffee-rails', '~> 4.1.0'
 gem 'turbolinks'
+gem 'actioncable'
 
 # require: false so bcrypt is loaded only when has_secure_password is used.
 # This is to avoid Active Model (and by extension the entire framework)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,6 @@ PATH
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     rails (5.0.0.beta1)
-      actioncable (= 5.0.0.beta1)
       actionmailer (= 5.0.0.beta1)
       actionpack (= 5.0.0.beta1)
       actionview (= 5.0.0.beta1)
@@ -297,6 +296,7 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
+  actioncable
   activerecord-jdbcmysql-adapter (>= 1.3.0)
   activerecord-jdbcpostgresql-adapter (>= 1.3.0)
   activerecord-jdbcsqlite3-adapter (>= 1.3.0)

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord',  version
   s.add_dependency 'actionmailer',  version
   s.add_dependency 'activejob',     version
-  s.add_dependency 'actioncable',   version
   s.add_dependency 'railties',      version
 
   s.add_dependency 'bundler',         '>= 1.3.0', '< 2.0'

--- a/railties/lib/rails/all.rb
+++ b/railties/lib/rails/all.rb
@@ -6,7 +6,6 @@ require "rails"
   action_view/railtie
   action_mailer/railtie
   active_job/railtie
-  action_cable/engine
   rails/test_unit/railtie
   sprockets/railtie
 ).each do |railtie|

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -51,8 +51,8 @@ module Rails
         class_option :skip_active_record, type: :boolean, aliases: '-O', default: false,
                                           desc: 'Skip Active Record files'
 
-        class_option :skip_action_cable,  type: :boolean, aliases: '-C', default: false,
-                                          desc: 'Skip Action Cable files'
+        class_option :with_action_cable,  type: :boolean, aliases: '-C', default: false,
+                                          desc: 'Generate Action Cable files'
 
         class_option :skip_sprockets,     type: :boolean, aliases: '-S', default: false,
                                           desc: 'Skip Sprockets files'
@@ -113,6 +113,7 @@ module Rails
       def gemfile_entries
         [rails_gemfile_entry,
          database_gemfile_entry,
+         action_cable_gemfile_entry,
          assets_gemfile_entry,
          javascript_gemfile_entry,
          jbuilder_gemfile_entry,
@@ -171,11 +172,15 @@ module Rails
       end
 
       def include_all_railties?
-        options.values_at(:skip_active_record, :skip_action_mailer, :skip_test, :skip_sprockets, :skip_action_cable).none?
+        options.values_at(:skip_active_record, :skip_action_mailer, :skip_test, :skip_sprockets).none?
       end
 
       def comment_if(value)
         options[value] ? '# ' : ''
+      end
+
+      def comment_unless(value)
+        options[value] ? '' : '# '
       end
 
       def keeps?
@@ -275,6 +280,13 @@ module Rails
           when "sqlite3"    then options[:database].replace "jdbcsqlite3"
           end
         end
+      end
+
+      def action_cable_gemfile_entry
+        return [] unless options[:with_action_cable]
+
+        [GemfileEntry.version('actioncable', '~> 5.0',
+                              'Use ActionCable for websockets')]
       end
 
       def assets_gemfile_entry

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -57,7 +57,7 @@ module Rails
       directory 'app'
 
       keep_file  'app/assets/images'
-      empty_directory_with_keep_file 'app/assets/javascripts/channels' unless options[:skip_action_cable]
+      empty_directory_with_keep_file 'app/assets/javascripts/channels' if options[:with_action_cable]
 
       keep_file  'app/controllers/concerns'
       keep_file  'app/models/concerns'
@@ -82,7 +82,7 @@ module Rails
         directory "environments"
         directory "initializers"
         directory "locales"
-        directory "redis" unless options[:skip_action_cable]
+        directory "redis" if options[:with_action_cable]
       end
     end
 
@@ -313,12 +313,11 @@ module Rails
         end
       end
 
-      def delete_action_cable_files_skipping_action_cable
-        if options[:skip_action_cable]
-          remove_file 'config/redis/cable.yml'
-          remove_file 'app/assets/javascripts/cable.coffee'
-          remove_dir 'app/channels'
-        end
+      def delete_action_cable_files_unless_required_action_cable
+        return if options[:with_action_cable]
+        remove_file 'config/redis/cable.yml'
+        remove_file 'app/assets/javascripts/cable.coffee'
+        remove_dir 'app/channels'
       end
 
       def delete_non_api_initializers_if_api_option

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -3,7 +3,7 @@
   <head>
     <title><%= camelized %></title>
     <%%= csrf_meta_tags %>
-    <%- unless options[:skip_action_cable] -%>
+    <%- if options[:with_action_cable] -%>
     <%%= action_cable_meta_tag %>
     <%- end -%>
 

--- a/railties/lib/rails/generators/rails/app/templates/config.ru.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config.ru.tt
@@ -1,7 +1,7 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
-<%- unless options[:skip_action_cable] -%>
+<%- if options[:with_action_cable] -%>
 
 # Action Cable uses EventMachine which requires that all classes are loaded in advance
 Rails.application.eager_load!

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -2,6 +2,7 @@ require File.expand_path('../boot', __FILE__)
 
 <% if include_all_railties? -%>
 require 'rails/all'
+<%= comment_unless :with_action_cable %>require "action_cable/engine"
 <% else -%>
 require "rails"
 # Pick the frameworks you want:
@@ -11,7 +12,7 @@ require "active_job/railtie"
 require "action_controller/railtie"
 <%= comment_if :skip_action_mailer %>require "action_mailer/railtie"
 require "action_view/railtie"
-<%= comment_if :skip_action_cable %>require "action_cable/engine"
+<%= comment_unless :with_action_cable %>require "action_cable/engine"
 <%= comment_if :skip_sprockets %>require "sprockets/railtie"
 <%= comment_if :skip_test %>require "rails/test_unit/railtie"
 <% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -40,7 +40,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  <%- unless options[:skip_action_cable] -%>
+  <%- if options[:with_action_cable] -%>
   # Action Cable endpoint configuration
   # config.action_cable.url = 'wss://example.com/cable'
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -389,12 +389,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_generator_if_skip_action_cable_is_given
-    run_generator [destination_root, "--skip-action-cable"]
-    assert_file "config/application.rb", /#\s+require\s+["']action_cable\/engine["']/
-    assert_no_file "config/redis/cable.yml"
-    assert_no_file "app/assets/javascripts/cable.coffee"
-    assert_no_file "app/channels"
+  def test_generator_if_with_action_cable_is_given
+    run_generator [destination_root, "--with-action-cable"]
+    assert_file "config/application.rb", /require\s+["']action_cable\/engine["']/
+    assert_file "config/redis/cable.yml"
+    assert_file "app/assets/javascripts/cable.coffee"
+    assert_file "app/channels"
   end
 
   def test_inclusion_of_javascript_runtime


### PR DESCRIPTION
Rather than having ActionCable be opt-out, make it opt-in.
This saves a lot of unnecessary dependencies if ActionCable is not used.
