### PR TITLE
Revert a change that breaks render_to_string and add a test

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -117,7 +117,7 @@ module AbstractController
     def _normalize_render(*args, &block)
       options = _normalize_args(*args, &block)
       #TODO: remove defined? when we restore AP <=> AV dependency
-      if defined?(request) && request.variant.present?
+      if defined?(request) && request && request.variant.present?
         options[:variant] = request.variant
       end
       _normalize_options(options)

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -668,3 +668,11 @@ class HttpCacheForeverTest < ActionController::TestCase
     assert_response :not_modified
   end
 end
+
+class RenderToStringTest < ActiveSupport::TestCase
+  def test_render_to_string
+    controller = ActionController::Base.new
+    result = controller.render_to_string(plain: "Test String")
+    assert_equal(result, "Test String")
+  end
+end


### PR DESCRIPTION
Commit https://github.com/rails/rails/commit/1cf4bf90251482610ef4ffc253eb542c5778c27b fixed issue https://github.com/rails/rails/issues/14125 but was reverted by https://github.com/rails/rails/commit/e6425f6ecad2a1b771455f73ada9d15f72a687eb because it appeared to be useless and there wasn't a test for it. 

This commit adds the nil check on request back in and also contains a test that would fail in the future if it were removed.

If there's a better place for that test to live let me know but render_test.rb seemed appropriate.
