### PR TITLE
Remove log message broadcast flag

### DIFF
--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -5,26 +5,16 @@ module ActiveSupport
   class Logger < ::Logger
     include LoggerSilence
 
-    # If +true+, will broadcast all messages sent to this logger to any
-    # logger linked to this one via +broadcast+.
-    #
-    # If +false+, the logger will still forward calls to +close+, +progname=+,
-    # +formatter=+ and +level+ to any linked loggers, but no calls to +add+ or
-    # +<<+.
-    #
-    # Defaults to +true+.
-    attr_accessor :broadcast_messages # :nodoc:
-
     # Broadcasts logs to multiple loggers.
     def self.broadcast(logger) # :nodoc:
       Module.new do
         define_method(:add) do |*args, &block|
-          logger.add(*args, &block) if broadcast_messages
+          logger.add(*args, &block)
           super(*args, &block)
         end
 
         define_method(:<<) do |x|
-          logger << x if broadcast_messages
+          logger << x
           super(x)
         end
 
@@ -53,7 +43,6 @@ module ActiveSupport
     def initialize(*args)
       super
       @formatter = SimpleFormatter.new
-      @broadcast_messages = true
       after_initialize if respond_to? :after_initialize
     end
 

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -15,13 +15,6 @@ module ActiveSupport
       assert_equal 'foo', receiving_logger.adds.first[2]
     end
 
-    def test_debug_without_message_broadcasts
-      logger.broadcast_messages = false
-      logger.debug "foo"
-      assert_equal 'foo', logger.adds.first[2]
-      assert_equal [], receiving_logger.adds
-    end
-
     def test_close
       logger.close
       assert logger.closed, 'should be closed'
@@ -32,13 +25,6 @@ module ActiveSupport
       logger << "foo"
       assert_equal %w{ foo }, logger.chevrons
       assert_equal %w{ foo }, receiving_logger.chevrons
-    end
-
-    def test_chevrons_without_message_broadcasts
-      logger.broadcast_messages = false
-      logger << "foo"
-      assert_equal %w{ foo }, logger.chevrons
-      assert_equal [], receiving_logger.chevrons
     end
 
     def test_level
@@ -64,7 +50,7 @@ module ActiveSupport
 
     class FakeLogger
       attr_reader :adds, :closed, :chevrons
-      attr_accessor :level, :progname, :formatter, :broadcast_messages
+      attr_accessor :level, :progname, :formatter
 
       def initialize
         @adds      = []
@@ -73,7 +59,6 @@ module ActiveSupport
         @level     = nil
         @progname  = nil
         @formatter = nil
-        @broadcast_messages = true
       end
 
       def debug msg, &block


### PR DESCRIPTION
This change forces non-`AS::Logger` objects to support the
`broadcast_messages` flag, which means loggers such as the one in Ruby's
standard library cannot be used.

Fixes #22917 

/cc @schneems 
