### PR TITLE
Add HTTP status name to output of tests

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Provide the name of HTTP Status code in assertions.
+
+    *Sean Collins*
+
 *   More explicit error message when running `rake routes`. `CONTROLLER` argument
     can now be supplied in different ways:
     `Rails::WelcomeController`, `Rails::Welcome`, `rails/welcome`

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -95,6 +95,7 @@ module ActionDispatch
     autoload :TestProcess
     autoload :TestRequest
     autoload :TestResponse
+    autoload :AssertionResponse
   end
 end
 

--- a/actionpack/lib/action_dispatch/testing/assertion_response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertion_response.rb
@@ -1,0 +1,49 @@
+module ActionDispatch
+  # This is a class that abstracts away an asserted response.
+  # It purposely does not inherit from Response, because it doesn't need it.
+  # That means it does not have headers or a body.
+  #
+  # As an input to the initializer, we take a Fixnum, a String, or a Symbol.
+  # If it's a Fixnum or String, we figure out what its symbolized name.
+  # If it's a Symbol, we figure out what its corresponding code is.
+  # The resulting code will be a Fixnum, for real HTTP codes, and it will
+  # be a String for the pseudo-HTTP codes, such as:
+  #   :success, :missing, :redirect and :error
+  class AssertionResponse
+    attr_reader :code, :name
+
+    GENERIC_RESPONSE_CODES = { # :nodoc:
+      success: "2XX",
+      missing: "404",
+      redirect: "3XX",
+      error: "5XX"
+    }
+
+    def initialize(code_or_name)
+      if code_or_name.is_a?(Symbol)
+        @name = code_or_name
+        @code = code_from_name(code_or_name)
+      else
+        @name = name_from_code(code_or_name)
+        @code = code_or_name
+      end
+
+      raise ArgumentError, "Invalid response name: #{name}" if @code.nil?
+      raise ArgumentError, "Invalid response code: #{code}" if @name.nil?
+    end
+
+    def code_and_name
+      "#{code}: #{name}"
+    end
+
+    private
+
+    def code_from_name(name)
+      GENERIC_RESPONSE_CODES[name] || Rack::Utils::SYMBOL_TO_STATUS_CODE[name]
+    end
+
+    def name_from_code(code)
+      GENERIC_RESPONSE_CODES.invert[code] || Rack::Utils::HTTP_STATUS_CODES[code]
+    end
+  end
+end

--- a/actionpack/test/assertions/response_assertions_test.rb
+++ b/actionpack/test/assertions/response_assertions_test.rb
@@ -74,7 +74,18 @@ module ActionDispatch
         @response.status = 404
 
         error = assert_raises(Minitest::Assertion) { assert_response :success }
-        expected = "Expected response to be a <success>, but was a <404>"
+        expected = "Expected response to be a <2XX: success>,"\
+                   " but was a <404: Not Found>"
+        assert_match expected, error.message
+      end
+
+      def test_error_message_shows_404_when_asserted_for_200
+        @response = ActionDispatch::Response.new
+        @response.status = 404
+
+        error = assert_raises(Minitest::Assertion) { assert_response 200 }
+        expected = "Expected response to be a <200: OK>,"\
+                   " but was a <404: Not Found>"
         assert_match expected, error.message
       end
 
@@ -84,7 +95,8 @@ module ActionDispatch
         @response.location = 'http://test.host/posts/redirect/1'
 
         error = assert_raises(Minitest::Assertion) { assert_response :success }
-        expected = "Expected response to be a <success>, but was a <302>" \
+        expected = "Expected response to be a <2XX: success>,"\
+                   " but was a <302: Found>" \
                    " redirect to <http://test.host/posts/redirect/1>"
         assert_match expected, error.message
       end
@@ -95,7 +107,8 @@ module ActionDispatch
         @response.location = 'http://test.host/posts/redirect/2'
 
         error = assert_raises(Minitest::Assertion) { assert_response 301 }
-        expected = "Expected response to be a <301>, but was a <302>" \
+        expected = "Expected response to be a <301: Moved Permanently>,"\
+                   " but was a <302: Found>" \
                    " redirect to <http://test.host/posts/redirect/2>"
         assert_match expected, error.message
       end


### PR DESCRIPTION
Earlier today I came across a test failure, that said something along the lines of:

```
Expected response to be a <success>, but was a <401>
```

I didn't recognize 401 as being `Unauthorized` at first, so I had to go look it up.

Rails, through Rack, knows what a 401 means. This patch leverages that. It turns the above output into something more helpful:

```
Expected response to be a <2XX: success>, but was a <401: Unauthorized>
```

At first I thought I'd only provide the name if the name was asserted (e.g. `:not_found` would show `:not_authorized`, but 404 would show 401) but I can't think of a case where it's not helpful to have both.

The code to implement simply that is done in the first commit. The remainder of the commits are refactorings which move the logic of moving between symbol and code into an `AssertionResponse` class, which also simplifies the logic of `assert_response`, which was relatively gnarly.
