### PR TITLE
Provide a better error message if a user mistypes the name of script …

### DIFF
--- a/railties/lib/rails/commands/runner.rb
+++ b/railties/lib/rails/commands/runner.rb
@@ -58,5 +58,11 @@ elsif File.exist?(code_or_file)
   $0 = code_or_file
   Kernel.load code_or_file
 else
-  eval(code_or_file, binding, __FILE__, __LINE__)
+  begin
+    eval(code_or_file, binding, __FILE__, __LINE__) 
+  rescue SyntaxError,NameError => err
+    $stderr.puts "Please specify a valid ruby command or the path of a script to run."
+    $stderr.puts "Run '#{$0} -h' for help."
+    exit 1
+  end
 end

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -74,6 +74,16 @@ module ApplicationTests
       assert_match "development", Dir.chdir(app_path) { `bin/rails runner "puts Rails.env"` }
     end
 
+    def test_runner_detects_syntax_errors
+      Dir.chdir(app_path) { `bin/rails runner "puts 'hello world" 2>&1` }
+      refute $?.success? 
+    end
+
+    def test_runner_detects_bad_script_name
+      Dir.chdir(app_path) { `bin/rails runner "iuiqwiourowe" 2>&1` }
+      refute $?.success? 
+    end
+
     def test_environment_with_rails_env
       with_rails_env "production" do
         assert_match "production", Dir.chdir(app_path) { `bin/rails runner "puts Rails.env"` }


### PR DESCRIPTION
If a user currently has a syntax error or mistypes the name of the script they wish to run with runner, eval ends up throwing an error message which is not very helpful.

With this patch, we catch SyntaxErrors (bad code) and NameErrors (often the result if they mistype the name of the script) and spit out a slightly more friendly message.

Included are two tests demonstrating this functionality.
