### PR TITLE
make generated controller test work correctly

### DIFF
--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -161,6 +161,10 @@ module Rails
           @route_url ||= class_path.collect {|dname| "/" + dname }.join + "/" + plural_file_name
         end
 
+        def url_helper_prefix
+          @url_helper_prefix ||= (class_path + [file_name]).join('_')
+        end
+
         # Tries to retrieve the application name or simply return application.
         def application_name
           if defined?(Rails) && Rails.application

--- a/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb
@@ -13,7 +13,7 @@ class <%= class_name %>ControllerTest < ActionDispatch::IntegrationTest
 <% else -%>
 <% actions.each do |action| -%>
   test "should get <%= action %>" do
-    get <%= file_name %>_<%= action %>_url
+    get <%= url_helper_prefix %>_<%= action %>_url
     assert_response :success
   end
 

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -234,6 +234,11 @@ module ApplicationTests
       assert_match "0 failures, 0 errors, 0 skips", run_test_command('')
     end
 
+    def test_generated_controller_works_with_rails_test
+      create_controller
+      assert_match "0 failures, 0 errors, 0 skips", run_test_command('')
+    end
+
     def test_run_multiple_folders
       create_test_file :models, 'account'
       create_test_file :controllers, 'accounts_controller'
@@ -447,6 +452,10 @@ module ApplicationTests
         script 'generate scaffold user name:string'
         Dir.chdir(app_path) { File.exist?('app/models/user.rb') }
         run_migration
+      end
+
+      def create_controller
+        script 'generate controller admin/dashboard index'
       end
 
       def run_migration


### PR DESCRIPTION
Since the `#file_name` that not consideration for the namespace, if generate a controller with a namespace, not the correct url helper generation, it had become an error to run the test.

Modified to generate the correct url helper, even if it is produced a namespace with controller.
