### PR TITLE
remove activemodel dependency on builder

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,6 @@ PATH
       globalid (>= 0.3.6)
     activemodel (5.0.0.beta1)
       activesupport (= 5.0.0.beta1)
-      builder (~> 3.1)
     activerecord (5.0.0.beta1)
       activemodel (= 5.0.0.beta1)
       activesupport (= 5.0.0.beta1)

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -19,6 +19,4 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_dependency 'activesupport', version
-
-  s.add_dependency 'builder', '~> 3.1'
 end


### PR DESCRIPTION
ActiveModel has a dependancy on builder, but does not use Builder since #21161 removed xml serialization.

This removes the dependency.
