### PR TITLE
Fix remove_index for postgresql when running legacy migrations

### DIFF
--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -41,8 +41,9 @@ module ActiveRecord
         end
 
         def remove_index(table_name, options = {})
-          index_name = index_name_for_remove(table_name, options)
-          execute "DROP INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)}"
+          options = { column: options } unless options.is_a?(Hash)
+          options[:name] = index_name_for_remove(table_name, options)
+          super(table_name, options)
         end
 
         private


### PR DESCRIPTION
Fixes #22924

/cc @matthewd
