### PR TITLE
Better error message when running `rake routes` with CONTROLLER arg:

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   More explicit error message when running `rake routes`. `CONTROLLER` argument
+    can now be supplied in different ways:
+    `Rails::WelcomeController`, `Rails::Welcome`, `rails/welcome`
+
+    Fixes #22918
+
+    *Edouard Chin*
+
 *   Allow `ActionController::Parameters` instances as an argument to URL
     helper methods. An `ArguemntError` will be raised if the passed parameters
     are not secure.

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -7,6 +7,9 @@ class MountedRackApp
   end
 end
 
+class Rails::DummyController
+end
+
 module ActionDispatch
   module Routing
     class RoutesInspectorTest < ActiveSupport::TestCase
@@ -331,6 +334,41 @@ module ActionDispatch
           "  cart GET  /cart(.:format) cart#show"
         ], output
       end
+
+      def test_routes_with_undefined_filter
+        output = draw(:filter => 'Rails::MissingController') do
+          get 'photos/:id' => 'photos#show', :id => /[A-Z]\d{5}/
+        end
+
+        assert_equal [
+          "The controller Rails::MissingController does not exist!",
+          "For more information about routes, see the Rails guide: http://guides.rubyonrails.org/routing.html."
+        ], output
+      end
+
+      def test_no_routes_matched_filter
+        output = draw(:filter => 'rails/dummy') do
+          get 'photos/:id' => 'photos#show', :id => /[A-Z]\d{5}/
+        end
+
+        assert_equal [
+          "No routes were found for this controller",
+          "For more information about routes, see the Rails guide: http://guides.rubyonrails.org/routing.html."
+        ], output
+      end
+
+      def test_no_routes_were_defined
+        output = draw(:filter => 'Rails::DummyController') { }
+
+        assert_equal [
+          "You don't have any routes defined!",
+          "",
+          "Please add some routes in config/routes.rb.",
+          "",
+          "For more information about routes, see the Rails guide: http://guides.rubyonrails.org/routing.html."
+        ], output
+      end
+
     end
   end
 end


### PR DESCRIPTION
- `CONTROLLER` argument can now be supplied in different ways (Rails::WelcomeController, Rails::Welcome, rails/welcome)
- If `CONTROLLER` argument was supplied but it does not exist, will warn the user that this controller does not exist
- If `CONTROLLER` argument was supplied and no routes could be found matching this filter, will warn the user that no routes were found matching the supplied filter
- If no routes were defined in the config/routes.rb file, will warn the user with the original message

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #22918 |
