### PR TITLE
Refactor `connection.insert_sql`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -115,9 +115,7 @@ module ActiveRecord
       # If the next id was calculated in advance (as in Oracle), it should be
       # passed in as +id_value+.
       def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [])
-        sql, binds = sql_for_insert(to_sql(arel, binds), pk, id_value, sequence_name, binds)
-        value      = exec_insert(sql, name, binds, pk, sequence_name)
-        id_value || last_inserted_id(value)
+        insert_sql(to_sql(arel, binds), name, pk, id_value, sequence_name, binds)
       end
       alias create insert
 
@@ -352,6 +350,13 @@ module ActiveRecord
       end
       alias join_to_delete join_to_update
 
+      # Executes an INSERT query and returns the new record's ID
+      def insert_sql(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [])
+        sql, binds = sql_for_insert(sql, pk, id_value, sequence_name, binds)
+        value = exec_insert(sql, name, binds, pk, sequence_name)
+        id_value || last_inserted_id(value)
+      end
+
       protected
 
         # Returns a subquery for the given key using the join information.
@@ -368,12 +373,6 @@ module ActiveRecord
 
         def select_prepared(sql, name = nil, binds = [])
           exec_query(sql, name, binds, prepare: true)
-        end
-
-        # Returns the last auto-generated ID from the affected table.
-        def insert_sql(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil)
-          execute(sql, name)
-          id_value
         end
 
         # Executes the update statement and returns the number of rows affected.

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -136,11 +136,6 @@ module ActiveRecord
 
       alias exec_without_stmt exec_query
 
-      def insert_sql(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil)
-        super
-        id_value || @connection.last_id
-      end
-
       def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
         execute to_sql(sql, binds), name
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -73,21 +73,13 @@ module ActiveRecord
         end
 
         # Executes an INSERT query and returns the new record's ID
-        def insert_sql(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil)
+        def insert_sql(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = []) # :nodoc:
           unless pk
             # Extract the table from the insert sql. Yuck.
             table_ref = extract_table_ref_from_insert_sql(sql)
             pk = primary_key(table_ref) if table_ref
           end
-
-          if pk && use_insert_returning?
-            select_value("#{sql} RETURNING #{quote_column_name(pk)}")
-          elsif pk
-            super
-            last_insert_id_value(sequence_name || default_sequence_name(table_ref, pk))
-          else
-            super
-          end
+          super
         end
 
         # The internal PostgreSQL identifier of the money data type.
@@ -171,12 +163,6 @@ module ActiveRecord
         alias :exec_update :exec_delete
 
         def sql_for_insert(sql, pk, id_value, sequence_name, binds)
-          unless pk
-            # Extract the table from the insert sql. Yuck.
-            table_ref = extract_table_ref_from_insert_sql(sql)
-            pk = primary_key(table_ref) if table_ref
-          end
-
           if pk && use_insert_returning?
             sql = "#{sql} RETURNING #{quote_column_name(pk)}"
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -290,11 +290,6 @@ module ActiveRecord
         super sql, name
       end
 
-      def insert_sql(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil) #:nodoc:
-        super
-        id_value || @connection.last_insert_row_id
-      end
-
       def select_rows(sql, name = nil, binds = [])
         exec_query(sql, name, binds).rows
       end


### PR DESCRIPTION
`connection.insert_sql` is almost the same as `connection.insert`.
