### PR TITLE
Process throws in `ActionController::Live#process`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Process throws in `ActionController::Live#process` with a new throw
+    rather than raising an `UncaughtThrowError`.
+
+    *Jean-Philippe Doyle*
+
 *   Add option for per-form CSRF tokens.
 
     *Ben Toews*

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -267,6 +267,7 @@ module ActionController
       }
 
       @_response.await_commit
+      throw error.tag, error.value if error.is_a?(UncaughtThrowError)
       raise error if error
     end
 

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -190,6 +190,10 @@ module ActionController
         raise Exception, 'Exception in controller'
       end
 
+      def throw_in_controller
+        throw :stop, { details: :scope }
+      end
+
       def bad_request_error
         raise ActionController::BadRequest
       end
@@ -405,6 +409,12 @@ module ActionController
     def test_exception_in_controller_before_streaming
       assert_raises(ActionController::LiveStreamTest::Exception) do
         get :exception_in_controller, format: 'text/event-stream'
+      end
+    end
+
+    def test_throw_in_controller_before_streaming
+      assert_throws(:stop, { details: :scope }) do
+        get :throw_in_controller, format: 'text/event-stream'
       end
     end
 


### PR DESCRIPTION
The `ActionController::Live` is re-raising exceptions from the live processing thread and I think it should also re-throw throws made in the processing thread as this would be the expected behavior from a regular non-live action.

Raising throws as `UncaughtThrowError` is causing issues with middleware/filters using a throw/catch logic such as in [this issue with Devise & Warden](https://github.com/plataformatec/devise/issues/2332).

Not sure this is totally a sane thing to do, feedback welcome.
