### PR TITLE
Remove `delete_sql` in sqlite3 adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -285,11 +285,6 @@ module ActiveRecord
         @connection.changes
       end
 
-      def delete_sql(sql, name = nil) #:nodoc:
-        sql += " WHERE 1=1" unless sql =~ /WHERE/i
-        super sql, name
-      end
-
       def select_rows(sql, name = nil, binds = [])
         exec_query(sql, name, binds).rows
       end


### PR DESCRIPTION
`sql += " WHERE 1=1"` was introduced in 69cb942.
But it is not needed. ref https://www.sqlite.org/lang_delete.html
