### PR TITLE
stop reversing forwarded ips

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -113,7 +113,7 @@ module ActionDispatch
 
         # Could be a CSV list and/or repeated headers that were concatenated.
         client_ips    = ips_from(@req.client_ip).reverse
-        forwarded_ips = ips_from(@req.x_forwarded_for).reverse
+        forwarded_ips = ips_from(@req.x_forwarded_for)
 
         # +Client-Ip+ and +X-Forwarded-For+ should not, generally, both be set.
         # If they are both set, it means that either:


### PR DESCRIPTION
The first IP address in `X-Forwarded-For` is the original client. Currently, the order of the IP addresses is reversed, so if multiple proxies have forwarded the request, `calculate_ip` will return the final proxy, rather than the original client. This commit stops reversing the order, so that the original client is returned rather than the final proxy.
