### PR TITLE
Fix changelog for per-form CSRF tokens

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 *   Add option for per-form CSRF tokens.
 
-    *Ben Toews*
+    *Greg Ose & Ben Toews*
 
 *   Add tests and documentation for `ActionController::Renderers::use_renderers`.
 


### PR DESCRIPTION
I wasn't thinking when I added updated the changelog in https://github.com/rails/rails/pull/22275. That PR was forwardporting some of the work @gregose was doing on our internal Rails fork. His name should be in the changelog too.

/cc @rafaelfranca
