### PR TITLE
Prevent destructive action on production database

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -40,6 +40,7 @@ module ActiveRecord
   autoload :CounterCache
   autoload :DynamicMatchers
   autoload :Enum
+  autoload :InternalMetadata
   autoload :Explain
   autoload :Inheritance
   autoload :Integration

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -969,6 +969,10 @@ module ActiveRecord
         ActiveRecord::SchemaMigration.create_table
       end
 
+      def initialize_internal_metadata_table
+        ActiveRecord::InternalMetadata.create_table
+      end
+
       def assume_migrated_upto_version(version, migrations_paths)
         migrations_paths = Array(migrations_paths)
         version = version.to_i

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -521,6 +521,7 @@ module ActiveRecord
       end
 
       def table_exists?(table_name)
+        # Update lib/active_record/internal_metadata.rb when this gets removed
         ActiveSupport::Deprecation.warn(<<-MSG.squish)
           #table_exists? currently checks both tables and views.
           This behavior is deprecated and will be changed with Rails 5.1 to only check tables.

--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -4,7 +4,7 @@ require 'active_record/scoping/named'
 module ActiveRecord
   # This class is used to create a table that keeps track of values and keys such
   # as which environment migrations were run in.
-  class InternalMetadata < ActiveRecord::Base
+  class InternalMetadata < ActiveRecord::Base # :nodoc:
     class << self
       def primary_key
         "key"
@@ -18,13 +18,11 @@ module ActiveRecord
         "#{table_name_prefix}unique_#{ActiveRecord::Base.internal_metadata_table_name}#{table_name_suffix}"
       end
 
-      def store(hash)
-        hash.each do |key, value|
-          first_or_initialize(key: key).update_attributes!(value: value)
-        end
+      def []=(key, value)
+        first_or_initialize(key: key).update_attributes!(value: value)
       end
 
-      def value_for(key)
+      def [](key)
         where(key: key).pluck(:value).first
       end
 

--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -35,7 +35,7 @@ module ActiveRecord
       # Creates a internal metadata table with columns +key+ and +value+
       def create_table
         unless table_exists?
-          connection.create_table(table_name, id: false) do |t|
+          connection.create_table(table_name, primary_key: :key, id: false ) do |t|
             t.column :key,   :string
             t.column :value, :string
             t.timestamps

--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -1,0 +1,49 @@
+require 'active_record/scoping/default'
+require 'active_record/scoping/named'
+
+module ActiveRecord
+  # This class is used to create a table that keeps track of values and keys such
+  # as which environment migrations were run in.
+  class InternalMetadata < ActiveRecord::Base
+    class << self
+      def primary_key
+        "key"
+      end
+
+      def table_name
+        "#{table_name_prefix}#{ActiveRecord::Base.internal_metadata_table_name}#{table_name_suffix}"
+      end
+
+      def index_name
+        "#{table_name_prefix}unique_#{ActiveRecord::Base.internal_metadata_table_name}#{table_name_suffix}"
+      end
+
+      def store(hash)
+        hash.each do |key, value|
+          first_or_initialize(key: key).update_attributes!(value: value)
+        end
+      end
+
+      def value_for(key)
+        where(key: key).pluck(:value).first
+      end
+
+      def table_exists?
+        ActiveSupport::Deprecation.silence { connection.table_exists?(table_name) }
+      end
+
+      # Creates a internal metadata table with columns +key+ and +value+
+      def create_table
+        unless table_exists?
+          connection.create_table(table_name, id: false) do |t|
+            t.column :key,   :string
+            t.column :value, :string
+            t.timestamps
+          end
+
+          connection.add_index table_name, :key, unique: true, name: index_name
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -164,7 +164,7 @@ module ActiveRecord
   end
 
   class EnvironmentMismatchError < ActiveRecordError
-    def initialize(current: current, stored: stored)
+    def initialize(current: , stored: )
       msg =  "You are attempting to modify a database that was last run in #{ stored } environment.\n"
       msg << "You are running in #{ current } environment."
       msg << "if you are sure you want to continue, run the same command with the environment variable\n"

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1233,15 +1233,15 @@ module ActiveRecord
       else
         migrated << version
         ActiveRecord::SchemaMigration.create!(version: version.to_s)
-        ActiveRecord::InternalMetadata.store(environment: current_environment)
+        ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Migrator.current_environment
       end
     end
 
     def self.last_stored_environment
-      ActiveRecord::InternalMetadata.value_for(:environment)
+      ActiveRecord::InternalMetadata[:environment]
     end
 
-    def current_environment
+    def self.current_environment
       ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
     end
 

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -44,6 +44,19 @@ module ActiveRecord
 
       ##
       # :singleton-method:
+      # Accessor for the name of the internal metadata table. By default, the value is "active_record_internal_metadatas"
+      class_attribute :internal_metadata_table_name, instance_accessor: false
+      self.internal_metadata_table_name = "active_record_internal_metadatas"
+
+      ##
+      # :singleton-method:
+      # Accessor for an array of names of environments where destructive actions should be prohibited. By default,
+      # the value is ["production"]
+      class_attribute :protected_environments, instance_accessor: false
+      self.protected_environments = ["production"]
+
+      ##
+      # :singleton-method:
       # Indicates whether table names should be the pluralized versions of the corresponding class names.
       # If true, the default table name for a Product class will be +products+. If false, it would just be +product+.
       # See table_name for the full rules on table/class naming. This is true, by default.

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -51,6 +51,9 @@ module ActiveRecord
         initialize_schema_migrations_table
         connection.assume_migrated_upto_version(info[:version], migrations_paths)
       end
+
+      ActiveRecord::InternalMetadata.create_table
+      ActiveRecord::InternalMetadata.store("environment" => ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
     end
 
     private

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -53,7 +53,7 @@ module ActiveRecord
       end
 
       ActiveRecord::InternalMetadata.create_table
-      ActiveRecord::InternalMetadata.store("environment" => ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
+      ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Migrator.current_environment
     end
 
     private

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -254,7 +254,7 @@ HEADER
       end
 
       def ignored?(table_name)
-        [ActiveRecord::Base.schema_migrations_table_name, ignore_tables].flatten.any? do |ignored|
+        [ActiveRecord::Base.schema_migrations_table_name, ActiveRecord::Base.internal_metadata_table_name, ignore_tables].flatten.any? do |ignored|
           ignored === remove_prefix_and_suffix(table_name)
         end
       end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -221,7 +221,7 @@ module ActiveRecord
           raise ArgumentError, "unknown format #{format.inspect}"
         end
         ActiveRecord::InternalMetadata.create_table
-        ActiveRecord::InternalMetata.store("environment" => ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
+        ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Migrator.current_environment
       end
 
       def load_schema_for(*args)

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -43,8 +43,17 @@ module ActiveRecord
       LOCAL_HOSTS    = ['127.0.0.1', 'localhost']
 
       def check_protected_environments!
-        if !ENV['DISABLE_DATABASE_internal_metadata'] && ActiveRecord::Migrator.protected_environment?
-          raise ActiveRecord::ProtectedEnvironmentError.new(ActiveRecord::Migrator.last_stored_environment)
+        unless ENV['DISABLE_DATABASE_internal_metadata']
+          current = ActiveRecord::Migrator.current_environment
+          stored  = ActiveRecord::Migrator.last_stored_environment
+
+          if ActiveRecord::Migrator.protected_environment?
+            raise ActiveRecord::ProtectedEnvironmentError.new(stored)
+          end
+
+          if current != stored
+            raise EnvironmentMismatchError.new(current: current, stored: stored)
+          end
         end
       rescue ActiveRecord::NoDatabaseError
       end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -42,6 +42,13 @@ module ActiveRecord
 
       LOCAL_HOSTS    = ['127.0.0.1', 'localhost']
 
+      def check_protected_environments!
+        if !ENV['DISABLE_DATABASE_internal_metadata'] && ActiveRecord::Migrator.protected_environment?
+          raise ActiveRecord::ProtectedEnvironmentError.new(ActiveRecord::Migrator.last_stored_environment)
+        end
+      rescue ActiveRecord::NoDatabaseError
+      end
+
       def register_task(pattern, task)
         @tasks ||= {}
         @tasks[pattern] = task
@@ -204,6 +211,8 @@ module ActiveRecord
         else
           raise ArgumentError, "unknown format #{format.inspect}"
         end
+        ActiveRecord::InternalMetadata.create_table
+        ActiveRecord::InternalMetata.store("environment" => ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
       end
 
       def load_schema_for(*args)

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -51,8 +51,8 @@ module ActiveRecord
             raise ActiveRecord::ProtectedEnvironmentError.new(stored)
           end
 
-          if current != stored
-            raise EnvironmentMismatchError.new(current: current, stored: stored)
+          if stored && stored != current
+            raise ActiveRecord::EnvironmentMismatchError.new(current: current, stored: stored)
           end
         end
       rescue ActiveRecord::NoDatabaseError

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -380,7 +380,7 @@ class MigrationTest < ActiveRecord::TestCase
     old_path        = ActiveRecord::Migrator.migrations_paths
     ActiveRecord::Migrator.migrations_paths = migrations_path
 
-    assert_equal current_env, ActiveRecord::InternalMetadata.value_for("environment")
+    assert_equal current_env, ActiveRecord::InternalMetadata[:environment]
 
     original_rails_env  = ENV["RAILS_ENV"]
     original_rack_env   = ENV["RACK_ENV"]
@@ -391,7 +391,7 @@ class MigrationTest < ActiveRecord::TestCase
 
     sleep 1 # mysql by default does not store fractional seconds in the database
     ActiveRecord::Migrator.up(migrations_path)
-    assert_equal new_env, ActiveRecord::InternalMetadata.value_for("environment")
+    assert_equal new_env, ActiveRecord::InternalMetadata[:environment]
   ensure
     ActiveRecord::Migrator.migrations_paths = old_path
     ENV["RAILS_ENV"] = original_rails_env

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -354,6 +354,50 @@ class MigrationTest < ActiveRecord::TestCase
     Reminder.reset_table_name
   end
 
+  def test_internal_metadata_table_name
+    original_internal_metadata_table_name = ActiveRecord::Base.internal_metadata_table_name
+
+    assert_equal "active_record_internal_metadatas", ActiveRecord::InternalMetadata.table_name
+    ActiveRecord::Base.table_name_prefix = "prefix_"
+    ActiveRecord::Base.table_name_suffix = "_suffix"
+    Reminder.reset_table_name
+    assert_equal "prefix_active_record_internal_metadatas_suffix", ActiveRecord::InternalMetadata.table_name
+    ActiveRecord::Base.internal_metadata_table_name = "changed"
+    Reminder.reset_table_name
+    assert_equal "prefix_changed_suffix", ActiveRecord::InternalMetadata.table_name
+    ActiveRecord::Base.table_name_prefix = ""
+    ActiveRecord::Base.table_name_suffix = ""
+    Reminder.reset_table_name
+    assert_equal "changed", ActiveRecord::InternalMetadata.table_name
+  ensure
+    ActiveRecord::Base.internal_metadata_table_name = original_internal_metadata_table_name
+    Reminder.reset_table_name
+  end
+
+  def test_internal_metadata_stores_environment
+    current_env     = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+    migrations_path = MIGRATIONS_ROOT + "/valid"
+    old_path        = ActiveRecord::Migrator.migrations_paths
+    ActiveRecord::Migrator.migrations_paths = migrations_path
+
+    assert_equal current_env, ActiveRecord::InternalMetadata.value_for("environment")
+
+    original_rails_env  = ENV["RAILS_ENV"]
+    original_rack_env   = ENV["RACK_ENV"]
+    ENV["RAILS_ENV"]    = ENV["RACK_ENV"] = "foofoo"
+    new_env     = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+
+    refute_equal current_env, new_env
+
+    sleep 1 # mysql by default does not store fractional seconds in the database
+    ActiveRecord::Migrator.up(migrations_path)
+    assert_equal new_env, ActiveRecord::InternalMetadata.value_for("environment")
+  ensure
+    ActiveRecord::Migrator.migrations_paths = old_path
+    ENV["RAILS_ENV"] = original_rails_env
+    ENV["RACK_ENV"]  = original_rack_env
+  end
+
   def test_proper_table_name_on_migration
     reminder_class = new_isolated_reminder_class
     migration = ActiveRecord::Migration.new

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -38,6 +38,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_match %r{create_table "accounts"}, output
     assert_match %r{create_table "authors"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
+    assert_no_match %r{create_table "internal_metadatas"}, output
   end
 
   def test_schema_dump_uses_force_cascade_on_create_table
@@ -158,6 +159,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "accounts"}, output
     assert_match %r{create_table "authors"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
+    assert_no_match %r{create_table "internal_metadatas"}, output
   end
 
   def test_schema_dump_with_regexp_ignored_table
@@ -165,6 +167,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "accounts"}, output
     assert_match %r{create_table "authors"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
+    assert_no_match %r{create_table "internal_metadatas"}, output
   end
 
   def test_schema_dumps_index_columns_in_right_order
@@ -342,6 +345,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "foo_.+_bar"}, output
     assert_no_match %r{add_index "foo_.+_bar"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
+    assert_no_match %r{create_table "internal_metadatas"}, output
 
     if ActiveRecord::Base.connection.supports_foreign_keys?
       assert_no_match %r{add_foreign_key "foo_.+_bar"}, output

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -38,7 +38,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_match %r{create_table "accounts"}, output
     assert_match %r{create_table "authors"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
-    assert_no_match %r{create_table "internal_metadatas"}, output
+    assert_no_match %r{create_table "active_record_internal_metadatas"}, output
   end
 
   def test_schema_dump_uses_force_cascade_on_create_table
@@ -159,7 +159,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "accounts"}, output
     assert_match %r{create_table "authors"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
-    assert_no_match %r{create_table "internal_metadatas"}, output
+    assert_no_match %r{create_table "active_record_internal_metadatas"}, output
   end
 
   def test_schema_dump_with_regexp_ignored_table
@@ -167,7 +167,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "accounts"}, output
     assert_match %r{create_table "authors"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
-    assert_no_match %r{create_table "internal_metadatas"}, output
+    assert_no_match %r{create_table "active_record_internal_metadatas"}, output
   end
 
   def test_schema_dumps_index_columns_in_right_order
@@ -345,7 +345,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "foo_.+_bar"}, output
     assert_no_match %r{add_index "foo_.+_bar"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
-    assert_no_match %r{create_table "internal_metadatas"}, output
+    assert_no_match %r{create_table "active_record_internal_metadatas"}, output
 
     if ActiveRecord::Base.connection.supports_foreign_keys?
       assert_no_match %r{add_foreign_key "foo_.+_bar"}, output

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -23,7 +23,7 @@ module ActiveRecord
       ActiveRecord::Migrator.stubs(:current_version).returns(1)
 
       protected_environments = ActiveRecord::Base.protected_environments.dup
-      current_env            = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+      current_env            = ActiveRecord::Migrator.current_environment
       assert !protected_environments.include?(current_env)
       # Assert no error
       ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -18,6 +18,34 @@ module ActiveRecord
     sqlite3:    :sqlite_tasks
   }
 
+  class DatabaseTasksUtilsTask< ActiveRecord::TestCase
+    def test_raises_an_error_when_called_with_protected_environment
+      ActiveRecord::Migrator.stubs(:current_version).returns(1)
+
+      protected_environments = ActiveRecord::Base.protected_environments.dup
+      current_env            = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+      assert !protected_environments.include?(current_env)
+      # Assert no error
+      ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+
+      ActiveRecord::Base.protected_environments << current_env
+      assert_raise(ActiveRecord::ProtectedEnvironmentError) do
+        ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+      end
+    ensure
+      ActiveRecord::Base.protected_environments = protected_environments
+    end
+
+    def test_raises_an_error_if_no_migrations_have_been_made
+      ActiveRecord::InternalMetadata.stubs(:table_exists?).returns(false)
+      ActiveRecord::Migrator.stubs(:current_version).returns(1)
+
+      assert_raise(ActiveRecord::NoEnvironmentInSchemaError) do
+        ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
+      end
+    end
+  end
+
   class DatabaseTasksRegisterTask < ActiveRecord::TestCase
     def test_register_task
       klazz = Class.new do

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -28,7 +28,7 @@ module ApplicationTests
         assert_not File.exist?("tmp/restart.txt")
         `bin/setup 2>&1`
         assert_equal 0, File.size("log/my.log")
-        assert_equal '["articles", "schema_migrations"]', list_tables.call
+        assert_equal '["articles", "schema_migrations", "internal_metadatas"]', list_tables.call
         assert File.exist?("tmp/restart.txt")
       end
     end

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -28,7 +28,7 @@ module ApplicationTests
         assert_not File.exist?("tmp/restart.txt")
         `bin/setup 2>&1`
         assert_equal 0, File.size("log/my.log")
-        assert_equal '["articles", "schema_migrations", "internal_metadatas"]', list_tables.call
+        assert_equal '["articles", "schema_migrations", "active_record_internal_metadatas"]', list_tables.call
         assert File.exist?("tmp/restart.txt")
       end
     end

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -116,11 +116,11 @@ class LoadingTest < ActiveSupport::TestCase
     require "#{rails_root}/config/environment"
     setup_ar!
 
-    assert_equal [ActiveRecord::SchemaMigration], ActiveRecord::Base.descendants
+    assert_equal [ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata], ActiveRecord::Base.descendants
     get "/load"
-    assert_equal [ActiveRecord::SchemaMigration, Post], ActiveRecord::Base.descendants
+    assert_equal [ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata, Post], ActiveRecord::Base.descendants
     get "/unload"
-    assert_equal [ActiveRecord::SchemaMigration], ActiveRecord::Base.descendants
+    assert_equal [ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata], ActiveRecord::Base.descendants
   end
 
   test "initialize cant be called twice" do

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -222,14 +222,14 @@ module ApplicationTests
 
           assert_equal '["posts"]', list_tables[]
           `bin/rake db:schema:load`
-          assert_equal '["posts", "comments", "schema_migrations", "internal_metadatas"]', list_tables[]
+          assert_equal '["posts", "comments", "schema_migrations", "active_record_internal_metadatas"]', list_tables[]
 
           app_file 'db/structure.sql', <<-SQL
             CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar(255));
           SQL
 
           `bin/rake db:structure:load`
-          assert_equal '["posts", "comments", "schema_migrations", "internal_metadatas", "users"]', list_tables[]
+          assert_equal '["posts", "comments", "schema_migrations", "active_record_internal_metadatas", "users"]', list_tables[]
         end
       end
 

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -85,7 +85,7 @@ module ApplicationTests
 
       test 'db:drop failure because database does not exist' do
         Dir.chdir(app_path) do
-          output = `bin/rake db:drop 2>&1`
+          output = `bin/rake db:drop:_unsafe --trace 2>&1`
           assert_match(/does not exist/, output)
           assert_equal 0, $?.exitstatus
         end
@@ -222,14 +222,14 @@ module ApplicationTests
 
           assert_equal '["posts"]', list_tables[]
           `bin/rake db:schema:load`
-          assert_equal '["posts", "comments", "schema_migrations"]', list_tables[]
+          assert_equal '["posts", "comments", "schema_migrations", "internal_metadatas"]', list_tables[]
 
           app_file 'db/structure.sql', <<-SQL
             CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar(255));
           SQL
 
           `bin/rake db:structure:load`
-          assert_equal '["posts", "comments", "schema_migrations", "users"]', list_tables[]
+          assert_equal '["posts", "comments", "schema_migrations", "internal_metadatas", "users"]', list_tables[]
         end
       end
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -24,6 +24,26 @@ module ApplicationTests
       assert $task_loaded
     end
 
+    def test_the_test_rake_task_is_protected_when_previous_migration_was_production
+      Dir.chdir(app_path) do
+        output = `bin/rails generate model product name:string;
+         env RAILS_ENV=production bin/rake db:create db:migrate;
+         env RAILS_ENV=production bin/rake db:test:prepare test 2>&1`
+
+        assert_match /ActiveRecord::ProtectedEnvironmentError/, output
+      end
+    end
+
+    def test_not_protected_when_previous_migration_was_not_production
+      Dir.chdir(app_path) do
+        output = `bin/rails generate model product name:string;
+         env RAILS_ENV=test bin/rake db:create db:migrate;
+         env RAILS_ENV=test bin/rake db:test:prepare test 2>&1`
+
+        refute_match /ActiveRecord::ProtectedEnvironmentError/, output
+      end
+    end
+
     def test_environment_is_required_in_rake_tasks
       app_file "config/environment.rb", <<-RUBY
         SuperMiddleware = Struct.new(:app)


### PR DESCRIPTION
This PR introduces a key/value type store to Active Record that can be used for storing internal values. It is an alternative implementation to #21237 cc @sgrif @matthewd.

It is possible to run your tests against your production database by accident right now. While infrequently, but as an anecdotal data point, Heroku receives a non-trivial number of requests for a database restore due to this happening. In these cases the loss can be large.

To prevent against running tests against production we can store the "environment" version that was used when migrating the database in a new internal table. Before executing tests we can see if the database is a listed in `protected_environments` and abort. There is a manual escape valve to force this check from happening with environment variable `DISABLE_DATABASE_ENVIRONMENT_CHECK=1`.
