### PR TITLE
Get update_attributes working with SchemaMigration

### DIFF
--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -9,7 +9,7 @@ module ActiveRecord
   class SchemaMigration < ActiveRecord::Base # :nodoc:
     class << self
       def primary_key
-        nil
+        "version"
       end
 
       def table_name

--- a/activerecord/test/cases/ar_schema_test.rb
+++ b/activerecord/test/cases/ar_schema_test.rb
@@ -21,10 +21,10 @@ if ActiveRecord::Base.connection.supports_migrations?
       ActiveRecord::Migration.verbose = @original_verbose
     end
 
-    def test_has_no_primary_key
+    def test_has_has_primary_key
       old_primary_key_prefix_type = ActiveRecord::Base.primary_key_prefix_type
       ActiveRecord::Base.primary_key_prefix_type = :table_name_with_underscore
-      assert_nil ActiveRecord::SchemaMigration.primary_key
+      assert_equal "version", ActiveRecord::SchemaMigration.primary_key
 
       ActiveRecord::SchemaMigration.create_table
       assert_difference "ActiveRecord::SchemaMigration.count", 1 do


### PR DESCRIPTION
You cannot use `update_attributes` on models that do not have a primary key. Since SchemaMigration versions are guaranteed to be unique (they have a unique index on them) we can safely use them as a primary key.
