### PR TITLE
Using #fetch with a block to provide a default for a missing Hash key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ services:
   - redis
   - rabbitmq
 addons:
-  postgresql: "9.3"
+  postgresql: "9.4"

--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -113,7 +113,7 @@ module ActionController #:nodoc:
       def send_file_headers!(options)
         type_provided = options.has_key?(:type)
 
-        content_type = options.fetch(:type, DEFAULT_SEND_FILE_TYPE)
+        content_type = options.fetch(:type) { DEFAULT_SEND_FILE_TYPE }
         raise ArgumentError, ":type option required" if content_type.nil?
 
         if content_type.is_a?(Symbol)
@@ -128,7 +128,7 @@ module ActionController #:nodoc:
           self.content_type = content_type
         end
 
-        disposition = options.fetch(:disposition, DEFAULT_SEND_FILE_DISPOSITION)
+        disposition = options.fetch(:disposition) { DEFAULT_SEND_FILE_DISPOSITION }
         unless disposition.nil?
           disposition  = disposition.to_s
           disposition += %(; filename="#{options[:filename]}") if options[:filename]

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -251,7 +251,7 @@ module ActionController #:nodoc:
       end
 
       def response
-        response = @responses.fetch(format, @responses[Mime::ALL])
+        response = @responses.fetch(format) { @responses[Mime::ALL] }
         if response.is_a?(VariantCollector) # `format.html.phone` - variant inline syntax
           response.variant
         elsif response.nil? || response.arity == 0 # `format.html` - just a format, call its block

--- a/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
@@ -20,7 +20,7 @@ module ActionDispatch
       request      = ActionDispatch::Request.new(env)
       status       = request.path_info[1..-1].to_i
       content_type = request.formats.first
-      body         = { :status => status, :error => Rack::Utils::HTTP_STATUS_CODES.fetch(status, Rack::Utils::HTTP_STATUS_CODES[500]) }
+      body         = { status: status, error: Rack::Utils::HTTP_STATUS_CODES.fetch(status) { Rack::Utils::HTTP_STATUS_CODES[500] } }
 
       render(status, content_type, body)
     end

--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -116,10 +116,10 @@ module ActionDispatch
       end
 
       def redirect_to_https(request)
-        [ @redirect.fetch(:status, 301),
+        [ @redirect.fetch(:status) { 301 },
           { 'Content-Type' => 'text/html',
             'Location' => https_location_for(request) },
-          @redirect.fetch(:body, []) ]
+          @redirect.fetch(:body) { [] } ]
       end
 
       def https_location_for(request)

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -908,9 +908,9 @@ module ActionDispatch
 
           defaults = {
             module:         path,
-            as:             options.fetch(:as, path),
-            shallow_path:   options.fetch(:path, path),
-            shallow_prefix: options.fetch(:as, path)
+            as:             options.fetch(:as) { path },
+            shallow_path:   options.fetch(:path) { path },
+            shallow_prefix: options.fetch(:as) { path }
           }
 
           path_scope(options.delete(:path) { path }) do
@@ -1586,7 +1586,7 @@ module ActionDispatch
           options_constraints = options.delete(:constraints) || {}
 
           path_types = paths.group_by(&:class)
-          path_types.fetch(String, []).each do |_path|
+          path_types.fetch(String) { [] }.each do |_path|
             route_options = options.dup
             if _path && option_path
               ActiveSupport::Deprecation.warn <<-eowarn
@@ -1606,7 +1606,7 @@ to this:
             decomposed_match(_path, controller, route_options, _path, to, via, formatted, anchor, options_constraints)
           end
 
-          path_types.fetch(Symbol, []).each do |action|
+          path_types.fetch(Symbol) { [] }.each do |action|
             route_options = options.dup
             decomposed_match(action, controller, route_options, option_path, to, via, formatted, anchor, options_constraints)
           end
@@ -1658,7 +1658,7 @@ to this:
             action = nil
           end
 
-          as = if !options.fetch(:as, true) # if it's set to nil or false
+          as = if !options.fetch(:as) { true } # if it's set to nil or false
                  options.delete(:as)
                else
                  name_for_action(options.delete(:as), action)

--- a/actionview/lib/action_view/helpers/atom_feed_helper.rb
+++ b/actionview/lib/action_view/helpers/atom_feed_helper.rb
@@ -51,7 +51,7 @@ module ActionView
       # * <tt>:language</tt>: Defaults to "en-US".
       # * <tt>:root_url</tt>: The HTML alternative that this feed is doubling for. Defaults to / on the current host.
       # * <tt>:url</tt>: The URL for this feed. Defaults to the current URL.
-      # * <tt>:id</tt>: The id for this feed. Defaults to "tag:localhost,2005:/posts", in this case. 
+      # * <tt>:id</tt>: The id for this feed. Defaults to "tag:localhost,2005:/posts", in this case.
       # * <tt>:schema_date</tt>: The date at which the tag scheme for the feed was first used. A good default is the year you
       #   created the feed. See http://feedvalidator.org/docs/error/InvalidTAG.html for more information. If not specified,
       #   2005 is used (as an "I don't care" value).
@@ -189,7 +189,7 @@ module ActionView
               @xml.updated((options[:updated] || record.updated_at).xmlschema)
             end
 
-            type = options.fetch(:type, 'text/html')
+            type = options.fetch(:type) { 'text/html' }
 
             url = options.fetch(:url) { @view.polymorphic_url(record) }
             @xml.link(:rel => 'alternate', :type => type, :href => url) if url

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1966,7 +1966,7 @@ module ActionView
         def fields_for_nested_model(name, object, fields_options, block)
           object = convert_to_model(object)
           emit_hidden_id = object.persisted? && fields_options.fetch(:include_id) {
-            options.fetch(:include_id, true)
+            options.fetch(:include_id) { true }
           }
 
           @template.fields_for(name, object, fields_options) do |f|

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -779,7 +779,7 @@ module ActionView
           else
             selected = Array.wrap(selected)
             options = selected.extract_options!.symbolize_keys
-            selected_items = options.fetch(:selected, selected)
+            selected_items = options.fetch(:selected) { selected }
             [selected_items, options[:disabled]]
           end
         end

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -129,7 +129,7 @@ module ActionView
           value = options.fetch(:selected) { value(object) }
           select = content_tag("select", add_options(option_tags, options, value), html_options)
 
-          if html_options["multiple"] && options.fetch(:include_hidden, true)
+          if html_options["multiple"] && options.fetch(:include_hidden) { true }
             tag("input", :disabled => html_options["disabled"], :name => html_options["name"], :type => "hidden", :value => "") + select
           else
             select
@@ -138,7 +138,7 @@ module ActionView
 
         def placeholder_required?(html_options)
           # See https://html.spec.whatwg.org/multipage/forms.html#attr-select-required
-          html_options["required"] && !html_options["multiple"] && html_options.fetch("size", 1).to_i == 1
+          html_options["required"] && !html_options["multiple"] && html_options.fetch("size") { 1 }.to_i == 1
         end
 
         def add_options(option_tags, options, value = nil)

--- a/actionview/lib/action_view/helpers/tags/collection_helpers.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_helpers.rb
@@ -96,7 +96,7 @@ module ActionView
 
           # Append a hidden field to make sure something will be sent back to the
           # server if all radio buttons are unchecked.
-          if options.fetch('include_hidden', true)
+          if options.fetch('include_hidden') { true }
             hidden_field + rendered_collection
           else
             rendered_collection

--- a/actionview/lib/action_view/helpers/tags/file_field.rb
+++ b/actionview/lib/action_view/helpers/tags/file_field.rb
@@ -6,7 +6,7 @@ module ActionView
         def render
           options = @options.stringify_keys
 
-          if options.fetch("include_hidden", true)
+          if options.fetch("include_hidden") { true }
             add_default_name_and_id(options)
             options[:type] = "file"
             tag("input", name: options["name"], type: "hidden", value: "") + tag("input", options)

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -91,8 +91,7 @@ module ActionView
       #   # => "Once upon a time in a wo...<a href="#">Continue</a>"
       def truncate(text, options = {}, &block)
         if text
-          length  = options.fetch(:length, 30)
-
+          length  = options.fetch(:length) { 30 }
           content = text.truncate(length, options)
           content = options[:escape] == false ? content.html_safe : ERB::Util.html_escape(content)
           content << capture(&block) if block_given? && text.length > length
@@ -128,7 +127,7 @@ module ActionView
       #   highlight('<a href="javascript:alert(\'no!\')">ruby</a> on rails', 'rails', sanitize: false)
       #   # => "<a>ruby</a> on <mark>rails</mark>"
       def highlight(text, phrases, options = {})
-        text = sanitize(text) if options.fetch(:sanitize, true)
+        text = sanitize(text) if options.fetch(:sanitize) { true }
 
         if text.blank? || phrases.blank?
           text || ""
@@ -140,7 +139,7 @@ module ActionView
           if block_given?
             text.gsub(/(#{match})(?![^<]*?>)/i) { |found| yield found }
           else
-            highlighter = options.fetch(:highlighter, '<mark>\1</mark>')
+            highlighter = options.fetch(:highlighter) { '<mark>\1</mark>' }
             text.gsub(/(#{match})(?![^<]*?>)/i, highlighter)
           end
         end.html_safe
@@ -173,7 +172,7 @@ module ActionView
       def excerpt(text, phrase, options = {})
         return unless text && phrase
 
-        separator = options.fetch(:separator, nil) || ""
+        separator = options.fetch(:separator) { nil } || ""
         case phrase
         when Regexp
           regex = phrase
@@ -297,9 +296,9 @@ module ActionView
       #   simple_format("<blink>Blinkable!</blink> It's true.", {}, sanitize: false)
       #   # => "<p><blink>Blinkable!</blink> It's true.</p>"
       def simple_format(text, html_options = {}, options = {})
-        wrapper_tag = options.fetch(:wrapper_tag, :p)
+        wrapper_tag = options.fetch(:wrapper_tag) { :p }
 
-        text = sanitize(text) if options.fetch(:sanitize, true)
+        text = sanitize(text) if options.fetch(:sanitize) { true }
         paragraphs = split_paragraphs(text)
 
         if paragraphs.empty?
@@ -350,7 +349,7 @@ module ActionView
       #  <% end %>
       def cycle(first_value, *values)
         options = values.extract_options!
-        name = options.fetch(:name, 'default')
+        name = options.fetch(:name) { 'default' }
 
         values.unshift(*first_value)
 
@@ -462,8 +461,8 @@ module ActionView
         def cut_excerpt_part(part_position, part, separator, options)
           return "", "" unless part
 
-          radius   = options.fetch(:radius, 100)
-          omission = options.fetch(:omission, "...")
+          radius   = options.fetch(:radius) { 100 }
+          omission = options.fetch(:omission) { "..." }
 
           part = part.split(separator)
           part.delete("")

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -27,7 +27,7 @@ module ActionView
       Accessors.send :define_method, :"default_#{name}", &block
       Accessors.module_eval <<-METHOD, __FILE__, __LINE__ + 1
         def #{name}
-          @details.fetch(:#{name}, [])
+          @details.fetch(:#{name}) { [] }
         end
 
         def #{name}=(value)

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -26,7 +26,7 @@ module ActionView
       end
 
       def cache_collection?
-        @options.fetch(:cache, automatic_cache_eligible?)
+        @options.fetch(:cache) { automatic_cache_eligible? }
       end
 
       def automatic_cache_eligible?

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -3531,7 +3531,7 @@ class FormHelperTest < ActionView::TestCase
   def hidden_fields(options = {})
     method = options[:method]
 
-    if options.fetch(:enforce_utf8, true)
+    if options.fetch(:enforce_utf8) { true }
       txt = %{<input name="utf8" type="hidden" value="&#x2713;" />}
     else
       txt = ''

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -12,7 +12,7 @@ class FormTagHelperTest < ActionView::TestCase
 
   def hidden_fields(options = {})
     method = options[:method]
-    enforce_utf8 = options.fetch(:enforce_utf8, true)
+    enforce_utf8 = options.fetch(:enforce_utf8) { true }
 
     ''.tap do |txt|
       if enforce_utf8

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -63,7 +63,7 @@ module ActiveModel
 
         include InstanceMethodsOnActivation
 
-        if options.fetch(:validations, true)
+        if options.fetch(:validations) { true }
           include ActiveModel::Validations
 
           # This ensures the model has a password by checking whether the password_digest

--- a/activemodel/test/cases/callbacks_test.rb
+++ b/activemodel/test/cases/callbacks_test.rb
@@ -33,7 +33,7 @@ class CallbacksTest < ActiveModel::TestCase
     def initialize(options = {})
       @callbacks = []
       @valid = options[:valid]
-      @before_create_returns = options.fetch(:before_create_returns, true)
+      @before_create_returns = options.fetch(:before_create_returns) { true }
       @before_create_throws = options[:before_create_throws]
     end
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -434,7 +434,7 @@ module ActiveRecord
 
       def scope(opts = {})
         scope = super()
-        scope.none! if opts.fetch(:nullify, true) && null_scope?
+        scope.none! if opts.fetch(:nullify) { true } && null_scope?
         scope
       end
 

--- a/activerecord/lib/active_record/attribute_set/builder.rb
+++ b/activerecord/lib/active_record/attribute_set/builder.rb
@@ -94,7 +94,7 @@ module ActiveRecord
     private
 
     def assign_default_value(name)
-      type = additional_types.fetch(name, types[name])
+      type = additional_types.fetch(name) { types[name] }
       value_present = true
       value = values.fetch(name) { value_present = false }
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -256,7 +256,7 @@ module ActiveRecord
           if pk.is_a?(Array)
             td.primary_keys pk
           else
-            td.primary_key pk, options.fetch(:id, :primary_key), options
+            td.primary_key pk, options.fetch(:id) { :primary_key }, options
           end
         end
 
@@ -1075,7 +1075,7 @@ module ActiveRecord
         index_type ||= options[:unique] ? "UNIQUE" : ""
         index_name = options[:name].to_s if options.key?(:name)
         index_name ||= index_name(table_name, column: column_names)
-        max_index_length = options.fetch(:internal, false) ? index_name_length : allowed_index_name_length
+        max_index_length = options.fetch(:internal) { false } ? index_name_length : allowed_index_name_length
 
         if options.key?(:algorithm)
           algorithm = index_algorithms.fetch(options[:algorithm]) {

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -49,7 +49,7 @@ module ActiveRecord
         @connection = connection
         @state = TransactionState.new
         @records = []
-        @joinable = options.fetch(:joinable, true)
+        @joinable = options.fetch(:joinable) { true }
         @run_commit_callbacks = run_commit_callbacks
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -780,7 +780,7 @@ module ActiveRecord
       end
 
       def strict_mode?
-        self.class.type_cast_config_to_boolean(@config.fetch(:strict, true))
+        self.class.type_cast_config_to_boolean(@config.fetch(:strict) { true })
       end
 
       def valid_type?(type)
@@ -976,7 +976,7 @@ module ActiveRecord
       end
 
       def configure_connection
-        variables = @config.fetch(:variables, {}).stringify_keys
+        variables = @config.fetch(:variables) { {} }.stringify_keys
 
         # By default, MySQL 'where id is null' selects the last inserted id; Turn this off.
         variables['sql_auto_is_null'] = 0

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -31,7 +31,7 @@ module ActiveRecord
         # a record (as primary keys cannot be +nil+). This might be done via the
         # +SecureRandom.uuid+ method and a +before_save+ callback, for instance.
         def primary_key(name, type = :primary_key, **options)
-          options[:default] = options.fetch(:default, 'uuid_generate_v4()') if type == :uuid
+          options[:default] = options.fetch(:default) { 'uuid_generate_v4()' } if type == :uuid
           super
         end
 

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -128,7 +128,7 @@ module ActiveRecord
       end
 
       def serialize(value)
-        mapping.fetch(value, value)
+        mapping.fetch(value) { value }
       end
 
       def assert_valid_value(value)

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -655,7 +655,7 @@ module ActiveRecord
           # Resolve enums
           model_class.defined_enums.each do |name, values|
             if row.include?(name)
-              row[name] = values.fetch(row[name], row[name])
+              row[name] = values.fetch(row[name]) { row[name] }
             end
           end
 

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -99,7 +99,7 @@ module ActiveRecord
 
     def column_type(name, type_overrides = {})
       type_overrides.fetch(name) do
-        column_types.fetch(name, IDENTITY_TYPE)
+        column_types.fetch(name) { IDENTITY_TYPE }
       end
     end
 

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -70,9 +70,9 @@ class Class
   # To opt out of both instance methods, pass <tt>instance_accessor: false</tt>.
   def class_attribute(*attrs)
     options = attrs.extract_options!
-    instance_reader = options.fetch(:instance_accessor, true) && options.fetch(:instance_reader, true)
-    instance_writer = options.fetch(:instance_accessor, true) && options.fetch(:instance_writer, true)
-    instance_predicate = options.fetch(:instance_predicate, true)
+    instance_reader = options.fetch(:instance_accessor) { true } && options.fetch(:instance_reader) { true }
+    instance_writer = options.fetch(:instance_accessor) { true } && options.fetch(:instance_writer) { true }
+    instance_predicate = options.fetch(:instance_predicate) { true }
 
     attrs.each do |name|
       remove_possible_singleton_method(name)

--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -124,12 +124,12 @@ class Date
   #   Date.new(2007, 5, 12).change(year: 2005, month: 1) # => Date.new(2005, 1, 12)
   def change(options)
     ::Date.new(
-      options.fetch(:year, year),
-      options.fetch(:month, month),
-      options.fetch(:day, day)
+      options.fetch(:year) { year },
+      options.fetch(:month) { month },
+      options.fetch(:day) { day }
     )
   end
-  
+
   # Allow Date to be compared with Time by converting to DateTime and relying on the <=> from there.
   def compare_with_coercion(other)
     if other.is_a?(Time)

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -41,14 +41,14 @@ class DateTime
   #   DateTime.new(2012, 8, 29, 22, 35, 0).change(year: 1981, hour: 0) # => DateTime.new(1981, 8, 29, 0, 0, 0)
   def change(options)
     ::DateTime.civil(
-      options.fetch(:year, year),
-      options.fetch(:month, month),
-      options.fetch(:day, day),
-      options.fetch(:hour, hour),
-      options.fetch(:min, options[:hour] ? 0 : min),
-      options.fetch(:sec, (options[:hour] || options[:min]) ? 0 : sec + sec_fraction),
-      options.fetch(:offset, offset),
-      options.fetch(:start, start)
+      options.fetch(:year) { year },
+      options.fetch(:month) { month },
+      options.fetch(:day) { day },
+      options.fetch(:hour) { hour },
+      options.fetch(:min) { options[:hour] ? 0 : min },
+      options.fetch(:sec) { (options[:hour] || options[:min]) ? 0 : sec + sec_fraction },
+      options.fetch(:offset) { offset },
+      options.fetch(:start) { start }
     )
   end
 
@@ -59,20 +59,20 @@ class DateTime
   def advance(options)
     unless options[:weeks].nil?
       options[:weeks], partial_weeks = options[:weeks].divmod(1)
-      options[:days] = options.fetch(:days, 0) + 7 * partial_weeks
+      options[:days] = options.fetch(:days) { 0 } + 7 * partial_weeks
     end
 
     unless options[:days].nil?
       options[:days], partial_days = options[:days].divmod(1)
-      options[:hours] = options.fetch(:hours, 0) + 24 * partial_days
+      options[:hours] = options.fetch(:hours) { 0 } + 24 * partial_days
     end
 
     d = to_date.advance(options)
     datetime_advanced_by_date = change(:year => d.year, :month => d.month, :day => d.day)
     seconds_to_advance = \
-      options.fetch(:seconds, 0) +
-      options.fetch(:minutes, 0) * 60 +
-      options.fetch(:hours, 0) * 3600
+      options.fetch(:seconds) { 0 } +
+      options.fetch(:minutes) { 0 } * 60 +
+      options.fetch(:hours) { 0 } * 3600
 
     if seconds_to_advance.zero?
       datetime_advanced_by_date

--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -22,13 +22,13 @@ class String
 
     now = Time.now
     time = Time.new(
-      parts.fetch(:year, now.year),
-      parts.fetch(:mon, now.month),
-      parts.fetch(:mday, now.day),
-      parts.fetch(:hour, 0),
-      parts.fetch(:min, 0),
-      parts.fetch(:sec, 0) + parts.fetch(:sec_fraction, 0),
-      parts.fetch(:offset, form == :utc ? 0 : nil)
+      parts.fetch(:year) { now.year },
+      parts.fetch(:mon) { now.month },
+      parts.fetch(:mday) { now.day },
+      parts.fetch(:hour) { 0 },
+      parts.fetch(:min) { 0 },
+      parts.fetch(:sec) { 0 } + parts.fetch(:sec_fraction) { 0 },
+      parts.fetch(:offset) { form == :utc ? 0 : nil }
     )
 
     form == :utc ? time.utc : time.getlocal

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -86,18 +86,18 @@ class Time
   #   Time.new(2012, 8, 29, 22, 35, 0).change(year: 1981, day: 1)  # => Time.new(1981, 8, 1, 22, 35, 0)
   #   Time.new(2012, 8, 29, 22, 35, 0).change(year: 1981, hour: 0) # => Time.new(1981, 8, 29, 0, 0, 0)
   def change(options)
-    new_year  = options.fetch(:year, year)
-    new_month = options.fetch(:month, month)
-    new_day   = options.fetch(:day, day)
-    new_hour  = options.fetch(:hour, hour)
-    new_min   = options.fetch(:min, options[:hour] ? 0 : min)
-    new_sec   = options.fetch(:sec, (options[:hour] || options[:min]) ? 0 : sec)
+    new_year  = options.fetch(:year) { year }
+    new_month = options.fetch(:month) { month }
+    new_day   = options.fetch(:day) { day }
+    new_hour  = options.fetch(:hour) { hour }
+    new_min   = options.fetch(:min) { options[:hour] ? 0 : min }
+    new_sec   = options.fetch(:sec) { (options[:hour] || options[:min]) ? 0 : sec }
 
     if new_nsec = options[:nsec]
       raise ArgumentError, "Can't change both :nsec and :usec at the same time: #{options.inspect}" if options[:usec]
       new_usec = Rational(new_nsec, 1000)
     else
-      new_usec  = options.fetch(:usec, (options[:hour] || options[:min] || options[:sec]) ? 0 : Rational(nsec, 1000))
+      new_usec  = options.fetch(:usec) { (options[:hour] || options[:min] || options[:sec]) ? 0 : Rational(nsec, 1000) }
     end
 
     if utc?
@@ -124,21 +124,21 @@ class Time
   def advance(options)
     unless options[:weeks].nil?
       options[:weeks], partial_weeks = options[:weeks].divmod(1)
-      options[:days] = options.fetch(:days, 0) + 7 * partial_weeks
+      options[:days] = options.fetch(:days) { 0 } + 7 * partial_weeks
     end
 
     unless options[:days].nil?
       options[:days], partial_days = options[:days].divmod(1)
-      options[:hours] = options.fetch(:hours, 0) + 24 * partial_days
+      options[:hours] = options.fetch(:hours) { 0 } + 24 * partial_days
     end
 
     d = to_date.advance(options)
     d = d.gregorian if d.julian?
     time_advanced_by_date = change(:year => d.year, :month => d.month, :day => d.day)
     seconds_to_advance = \
-      options.fetch(:seconds, 0) +
-      options.fetch(:minutes, 0) * 60 +
-      options.fetch(:hours, 0) * 3600
+      options.fetch(:seconds) { 0 } +
+      options.fetch(:minutes) { 0 } * 60 +
+      options.fetch(:hours) { 0 } * 3600
 
     if seconds_to_advance.zero?
       time_advanced_by_date

--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -61,7 +61,7 @@ module ActiveSupport
           ext = @ph.normalize_extension(file.extname)
 
           file.dirname.ascend do |dir|
-            if @dirs.fetch(dir, []).include?(ext)
+            if @dirs.fetch(dir) { [] }.include?(ext)
               break true
             elsif dir == @lcsp || dir.root?
               break false

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -133,7 +133,7 @@ module ActiveSupport
         "#{inflections.acronyms[match] || match.downcase}"
       end
 
-      if options.fetch(:capitalize, true)
+      if options.fetch(:capitalize) { true }
         result.sub!(/\A\w/) { |match| match.upcase }
       end
 

--- a/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
@@ -20,7 +20,7 @@ module ActiveSupport
         end
 
         def delimiter_pattern
-          options.fetch(:delimiter_pattern, DEFAULT_DELIMITER_REGEX)
+          options.fetch(:delimiter_pattern) { DEFAULT_DELIMITER_REGEX }
         end
 
     end

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -441,13 +441,13 @@ module ActiveSupport
         return if parts.empty?
 
         time = Time.new(
-          parts.fetch(:year, now.year),
-          parts.fetch(:mon, now.month),
-          parts.fetch(:mday, parts[:year] || parts[:mon] ? 1 : now.day),
-          parts.fetch(:hour, 0),
-          parts.fetch(:min, 0),
-          parts.fetch(:sec, 0) + parts.fetch(:sec_fraction, 0),
-          parts.fetch(:offset, 0)
+          parts.fetch(:year) { now.year },
+          parts.fetch(:mon) { now.month },
+          parts.fetch(:mday) { parts[:year] || parts[:mon] ? 1 : now.day },
+          parts.fetch(:hour) { 0 },
+          parts.fetch(:min) { 0 },
+          parts.fetch(:sec) { 0 } + parts.fetch(:sec_fraction) { 0 },
+          parts.fetch(:offset) { 0 }
         )
 
         if parts[:offset]

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -68,7 +68,7 @@ module Rails
           middleware.use ::ActionDispatch::Cookies unless config.api_only
 
           if !config.api_only && config.session_store
-            if config.force_ssl && config.ssl_options.fetch(:secure_cookies, true) && !config.session_options.key?(:secure)
+            if config.force_ssl && config.ssl_options.fetch(:secure_cookies) { true } && !config.session_options.key?(:secure)
               config.session_options[:secure] = true
             end
             middleware.use config.session_store, config.session_options

--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -41,7 +41,7 @@ module Rails
       @@command_options = {}
 
       def parse_options_for(command_name)
-        @@command_options.fetch(command_name, proc {}).call(@option_parser, @options)
+        @@command_options.fetch(command_name) { proc {} }.call(@option_parser, @options)
       end
 
       def build_option_parser

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -86,7 +86,7 @@ module Rails
 
     def default_options
       super.merge({
-        Port:               ENV.fetch('PORT', 3000).to_i,
+        Port:               ENV.fetch('PORT') { 3000 }.to_i,
         DoNotReverseLookup: true,
         environment:        (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || "development").dup,
         daemonize:          false,

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb
@@ -52,7 +52,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     # Only allow a trusted parameter "white list" through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
-      params.fetch(:<%= singular_table_name %>, {})
+      params.fetch(:<%= singular_table_name %>) { {} }
       <%- else -%>
       params.require(:<%= singular_table_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
       <%- end -%>

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -59,7 +59,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     # Only allow a trusted parameter "white list" through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
-      params.fetch(:<%= singular_table_name %>, {})
+      params.fetch(:<%= singular_table_name %>) { {} }
       <%- else -%>
       params.require(:<%= singular_table_name %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
       <%- end -%>

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -56,7 +56,7 @@ module Rails
       end
 
       def add(path, options = {})
-        with = Array(options.fetch(:with, path))
+        with = Array(options.fetch(:with) { path })
         @root[path] = Path.new(self, path, with, options)
       end
 

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -56,7 +56,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/controllers/users_controller.rb" do |content|
       assert_match(/def user_params/, content)
-      assert_match(/params\.fetch\(:user, \{\}\)/, content)
+      assert_match(/params\.fetch\(:user\) \{ \{\} \}/, content)
     end
   end
 


### PR DESCRIPTION
When the default is passed as an argument to `#fetch`, it is always evaluated whether it is needed or not. By using blocks instead of argument, we've now introduced a much better performance regression as the default value allocation would only have been triggered when it was actually needed.
