### PR TITLE
match the environment variable name that actually checking and error message

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -43,7 +43,7 @@ module ActiveRecord
       LOCAL_HOSTS    = ['127.0.0.1', 'localhost']
 
       def check_protected_environments!
-        unless ENV['DISABLE_DATABASE_internal_metadata']
+        unless ENV['DISABLE_DATABASE_ENVIRONMENT_CHECK']
           current = ActiveRecord::Migrator.current_environment
           stored  = ActiveRecord::Migrator.last_stored_environment
 


### PR DESCRIPTION
The error message has become a `DISABLE_DATABASE_ENVIRONMENT_CHECK`, modified to match the error message.

ref: https://github.com/rails/rails/blob/master/activerecord/lib/active_record/migration.rb#L161
