### PR TITLE
Ability to use alredy defined accessors for Validations::AcceptanceVa…

### DIFF
--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -4,7 +4,7 @@ module ActiveModel
     class AcceptanceValidator < EachValidator # :nodoc:
       def initialize(options)
         super({ allow_nil: true, accept: ["1", true] }.merge!(options))
-        setup!(options[:class])
+        setup!(options[:class]) unless options[:already_accessible]
       end
 
       def validate_each(record, attribute, value)
@@ -95,6 +95,8 @@ module ActiveModel
       #   checkbox. This should be set to, or include, +true+ if you are validating
       #   a database column, since the attribute is typecast from "1" to +true+
       #   before validation.
+      # * <tt>:already_accessible</tt> - Specifies should validator use already
+      #   defined accessors for attribute (default is: false).
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.

--- a/activemodel/test/cases/validations/acceptance_validation_test.rb
+++ b/activemodel/test/cases/validations/acceptance_validation_test.rb
@@ -5,6 +5,9 @@ require 'models/reply'
 require 'models/person'
 
 class AcceptanceValidationTest < ActiveModel::TestCase
+  class TopicWrapper < SimpleDelegator
+    include ActiveModel::Validations
+  end
 
   def teardown
     Topic.clear_validators!
@@ -26,6 +29,15 @@ class AcceptanceValidationTest < ActiveModel::TestCase
 
     t.terms_of_service = "1"
     assert t.valid?
+  end
+
+  def test_terms_of_service_agreement_no_acceptance_with_accessor
+    TopicWrapper.validates_acceptance_of(:approved, already_accessible: true)
+
+    t = Topic.new("title" => "We should be confirmed", "approved" => "")
+    wrapper = TopicWrapper.new(t)
+
+    assert wrapper.invalid?
   end
 
   def test_eula


### PR DESCRIPTION
If there is way to not redefine methods it's prefered way. This flag provides ability to use already defined accessor without all this magic with sending attr_reader, attr_writer and so on. Using `nil` by default to provide backward compatibility. 
