### PR TITLE
`exec_insert` should include `sql_for_insert` and `last_inserted_id`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -131,14 +131,10 @@ module ActiveRecord
       def exec_query(sql, name = 'SQL', binds = [], prepare: false)
         result = execute(sql, name)
         @connection.next_result while @connection.more_results?
-        ActiveRecord::Result.new(result.fields, result.to_a)
+        ActiveRecord::Result.new(result.fields, result.to_a) if result
       end
 
       alias exec_without_stmt exec_query
-
-      def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
-        execute to_sql(sql, binds), name
-      end
 
       def exec_delete(sql, name, binds)
         execute to_sql(sql, binds), name

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -690,15 +690,7 @@ module ActiveRecord
         end
 
         # Returns the current ID of a table's sequence.
-        def last_insert_id(sequence_name) #:nodoc:
-          Integer(last_insert_id_value(sequence_name))
-        end
-
-        def last_insert_id_value(sequence_name)
-          last_insert_id_result(sequence_name).rows.first.first
-        end
-
-        def last_insert_id_result(sequence_name) #:nodoc:
+        def last_insert_id_result(sequence_name) # :nodoc:
           exec_query("SELECT currval('#{sequence_name}')", 'SQL')
         end
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -102,35 +102,21 @@ module ActiveRecord
         end
       end
 
-      def test_insert_sql_with_returning_disabled
-        connection = connection_without_insert_returning
-        id = connection.insert_sql("insert into postgresql_partitioned_table_parent (number) VALUES (1)")
-        expect = connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
-        assert_equal expect.to_i, id
-      end
-
       def test_exec_insert_with_returning_disabled
-        connection = connection_without_insert_returning
-        result = connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], 'id', 'postgresql_partitioned_table_parent_id_seq')
-        expect = connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
-        assert_equal expect.to_i, result.rows.first.first
-      end
-
-      def test_exec_insert_with_returning_disabled_and_no_sequence_name_given
         connection = connection_without_insert_returning
         result = connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], 'id')
         expect = connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
         assert_equal expect.to_i, result.rows.first.first
       end
 
-      def test_exec_insert_default_values_with_returning_disabled_and_no_sequence_name_given
+      def test_exec_insert_default_values_with_returning_disabled
         connection = connection_without_insert_returning
         result = connection.exec_insert("insert into postgresql_partitioned_table_parent DEFAULT VALUES", nil, [], 'id')
         expect = connection.query('select max(id) from postgresql_partitioned_table_parent').first.first
         assert_equal expect.to_i, result.rows.first.first
       end
 
-      def test_exec_insert_default_values_quoted_schema_with_returning_disabled_and_no_sequence_name_given
+      def test_exec_insert_default_values_quoted_schema_with_returning_disabled
         connection = connection_without_insert_returning
         result = connection.exec_insert('insert into "public"."postgresql_partitioned_table_parent" DEFAULT VALUES', nil, [], 'id')
         expect = connection.query('select max(id) from postgresql_partitioned_table_parent').first.first


### PR DESCRIPTION
`exec_insert` can not get the correct return value unless calling both
`sql_for_insert` and `last_inserted_id`.
