### PR TITLE
Allow pluralize text helper method to receive a block

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow `pluralize` to receive a block for customizing the 
+    output of the method
+
+        pluralize(2, 'person') { |count, unit| "<em>#{count}</em> #{unit}" }
+        # => <em>2</em> people
+
+    *Carlos Ramirez III*
+
 *   Fix `collection_radio_buttons` hidden_field name and make it appear
     before the actual input radio tags to make the real value override
     the hidden when passed.

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -207,6 +207,8 @@ module ActionView
       # it will use the Inflector to determine the plural form for the given locale,
       # which defaults to I18n.locale
       #
+      # A block can be provided to customize the output of the method
+      #
       # The word will be pluralized using rules defined for the locale
       # (you must define your own inflection rules for languages other than English).
       # See ActiveSupport::Inflector.pluralize
@@ -225,6 +227,9 @@ module ActionView
       #
       #   pluralize(2, 'Person', locale: :de)
       #   # => 2 Personen
+      #
+      #   pluralize(2, 'person') { |count, unit| "<em>#{count}</em> #{unit}" }
+      #   # => <em>2</em> people
       def pluralize(count, singular, deprecated_plural = nil, plural: nil, locale: I18n.locale)
         if deprecated_plural
           ActiveSupport::Deprecation.warn("Passing plural as a positional argument " \
@@ -239,7 +244,11 @@ module ActionView
           plural || singular.pluralize(locale)
         end
 
-        "#{count || 0} #{word}"
+        if block_given?
+          yield(count || 0, word)
+        else
+          "#{count || 0} #{word}"
+        end
       end
 
       # Wraps the +text+ into lines no longer than +line_width+ width. This method

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -405,6 +405,13 @@ class TextHelperTest < ActionView::TestCase
     end
   end
 
+  def test_pluralization_with_block
+    block = Proc.new { |count, unit| "<em>#{count}</em> #{unit}" }
+
+    assert_equal("<em>1</em> count", pluralize(1, "count", &block))
+    assert_equal("<em>2</em> counts", pluralize(2, "count", &block))
+  end
+
   def test_deprecated_plural_as_positional_argument
     assert_deprecated do
       pluralize(2, 'count', 'counters')


### PR DESCRIPTION
An enhancement to the `pluralize` text helper method that allows it to receive a block which can be used to customize the output. Useful when needing to wrap the count with some markup or append some classes for display in the view. 

E.g.

```
<% pluralize(1, "person") do |count, unit| %>
   <strong><%= count %></strong> <%= unit %>
<% end %>
```
