### PR TITLE
Ability to reject deeply nested blank attributes

### DIFF
--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -37,12 +37,30 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     assert pirate.birds_with_reject_all_blank.empty?
   end
 
+  def test_should_not_build_a_new_record_using_nested_reject_all_even_if_destroy_is_given
+    pirate = Pirate.create!(:catchphrase => "Don' botharrr talkin' like one, savvy?")
+    pirate.ship_with_reject_nested_all_blank_attributes = {:name => '', :color => '', :_destroy => '0',
+      :parts_attributes => {"1" => {:name => '', :_destroy => '0'}}}
+    pirate.save!
+
+    assert pirate.ship_with_reject_nested_all_blank.blank?
+  end
+
   def test_should_not_build_a_new_record_if_reject_all_blank_returns_false
     pirate = Pirate.create!(:catchphrase => "Don' botharrr talkin' like one, savvy?")
     pirate.birds_with_reject_all_blank_attributes = [{:name => '', :color => ''}]
     pirate.save!
 
     assert pirate.birds_with_reject_all_blank.empty?
+  end
+
+  def test_should_not_build_a_new_record_if_nested_reject_all_blank_returns_false
+    pirate = Pirate.create!(:catchphrase => "Don' botharrr talkin' like one, savvy?")
+    pirate.ship_with_reject_nested_all_blank_attributes = {:name => '', :color => '',
+      :parts_attributes => {"1" => { :name => '' }}}
+    pirate.save!
+
+    assert pirate.ship_with_reject_nested_all_blank.blank?
   end
 
   def test_should_build_a_new_record_if_reject_all_blank_does_not_return_false
@@ -52,6 +70,17 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
 
     assert_equal 1, pirate.birds_with_reject_all_blank.count
     assert_equal 'Tweetie', pirate.birds_with_reject_all_blank.first.name
+  end
+
+  def test_should_build_a_new_record_if_nested_reject_all_blank_does_not_return_false
+    pirate = Pirate.create!(:catchphrase => "Don' botharrr talkin' like one, savvy?")
+    pirate.ship_with_reject_nested_all_blank_attributes = {:name => 'The Smashing',
+      :parts_attributes => {"1" => {:name => 'Argh The First Part'}}}
+    pirate.save!
+
+    assert_equal 'The Smashing', pirate.ship_with_reject_nested_all_blank.name
+    assert_equal 1, pirate.ship_with_reject_nested_all_blank.parts.count
+    assert_equal 'Argh The First Part', pirate.ship_with_reject_nested_all_blank.parts.first.name
   end
 
   def test_should_raise_an_ArgumentError_for_non_existing_associations

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -19,6 +19,7 @@ class Pirate < ActiveRecord::Base
   has_many :treasure_estimates, :through => :treasures, :source => :price_estimates
 
   has_one :ship
+  has_one :ship_with_reject_nested_all_blank, :class_name => "Ship"
   has_one :update_only_ship, :class_name => 'Ship'
   has_one :non_validated_ship, :class_name => 'Ship'
   has_many :birds, -> { order('birds.id ASC') }
@@ -42,6 +43,7 @@ class Pirate < ActiveRecord::Base
   accepts_nested_attributes_for :parrots_with_method_callbacks, :parrots_with_proc_callbacks,
     :birds_with_method_callbacks, :birds_with_proc_callbacks, :allow_destroy => true
   accepts_nested_attributes_for :birds_with_reject_all_blank, :reject_if => :all_blank
+  accepts_nested_attributes_for :ship_with_reject_nested_all_blank, :reject_if => :nested_all_blank
 
   validates_presence_of :catchphrase
 


### PR DESCRIPTION
Allow passing `:nested_all_blank` as argument for `accepts_nested_attributes_for` to reject fully blank attributes by recursion traversing of all hashes in attributes.

Can be used to filter blank attributes if model depends more than one level of nesting.
Related to #19490

Using recursive traverse instead of stack because of:

```
Calculating -------------------------------------
           recursion     5.320k i/100ms
               stack     3.905k i/100ms
-------------------------------------------------
           recursion     58.193k (± 3.7%) i/s -    292.600k
               stack     40.710k (± 3.3%) i/s -    206.965k

Comparison:
           recursion:    58193.3 i/s
               stack:    40710.1 i/s - 1.43x slower

Calculating -------------------------------------
recursion with value     8.036k i/100ms
    stack with value     4.658k i/100ms
-------------------------------------------------
recursion with value     87.259k (± 3.8%) i/s -    441.980k
    stack with value     48.642k (± 3.5%) i/s -    246.874k

Comparison:
recursion with value:    87259.5 i/s
    stack with value:    48642.5 i/s - 1.79x slower
```

[source](https://gist.github.com/ignat-zakrevsky/6779db323c64faf4ed89)
