### PR TITLE
remove warnings from rake test

### DIFF
--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -30,7 +30,7 @@ module ApplicationTests
          env RAILS_ENV=production bin/rake db:create db:migrate;
          env RAILS_ENV=production bin/rake db:test:prepare test 2>&1`
 
-        assert_match /ActiveRecord::ProtectedEnvironmentError/, output
+        assert_match(/ActiveRecord::ProtectedEnvironmentError/, output)
       end
     end
 
@@ -40,7 +40,7 @@ module ApplicationTests
          env RAILS_ENV=test bin/rake db:create db:migrate;
          env RAILS_ENV=test bin/rake db:test:prepare test 2>&1`
 
-        refute_match /ActiveRecord::ProtectedEnvironmentError/, output
+        refute_match(/ActiveRecord::ProtectedEnvironmentError/, output)
       end
     end
 


### PR DESCRIPTION
This removes the following warnings.

```
test/application/rake_test.rb:33: warning: ambiguous first argument; put parentheses or a space even after `/' operator
test/application/rake_test.rb:43: warning: ambiguous first argument; put parentheses or a space even after `/' operator
```
