### PR TITLE
CodeStatistic will now ignore hidden files:

### DIFF
--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -33,7 +33,7 @@ class CodeStatistics #:nodoc:
       Hash[@pairs.map{|pair| [pair.first, calculate_directory_statistics(pair.last)]}]
     end
 
-    def calculate_directory_statistics(directory, pattern = /.*\.(rb|js|coffee|rake)$/)
+    def calculate_directory_statistics(directory, pattern = /^(?!\.).*?\.(rb|js|coffee|rake)$/)
       stats = CodeStatisticsCalculator.new
 
       Dir.foreach(directory) do |file_name|

--- a/railties/test/code_statistics_test.rb
+++ b/railties/test/code_statistics_test.rb
@@ -4,7 +4,7 @@ require 'rails/code_statistics'
 class CodeStatisticsTest < ActiveSupport::TestCase
   def setup
     @tmp_path = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', 'tmp'))
-    @dir_js   = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', 'tmp', 'lib.js'))
+    @dir_js   = File.join(@tmp_path, 'lib.js')
     FileUtils.mkdir_p(@dir_js)
   end
 
@@ -17,4 +17,17 @@ class CodeStatisticsTest < ActiveSupport::TestCase
       @code_statistics = CodeStatistics.new(['tmp dir', @tmp_path])
     end
   end
+
+  test 'ignores hidden files' do
+    File.write File.join(@tmp_path, '.example.rb'), <<-CODE
+      def foo
+        puts 'foo'
+      end
+    CODE
+
+    assert_nothing_raised do
+      CodeStatistics.new(['hidden file', @tmp_path])
+    end
+  end
+
 end


### PR DESCRIPTION
- Modify the default regex to not match hidden files

An `ArgumentError: invalid byte sequence in UTF-8` was raised if there was a binary file inside a directory. Those hidden files (with a `.rb`|`.js`... extension) were typically created by the filesystem.

| Q | A |
| --- | --- |
| Bug fix? | no, The exception will still be raised if a regular `.rb`, `.js`... contains binary text. This PR will be at least more convenient for the user, allowing him to run `rake stats` without first having to remove all those temporary files |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |

Fixes #22919
