### PR TITLE
Avoid multiple default paths to server.pid file

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -6,6 +6,8 @@ require 'rails'
 module Rails
   class Server < ::Rack::Server
     class Options
+      DEFAULT_PID_PATH = File.expand_path("tmp/pids/server.pid").freeze
+
       def parse!(args)
         args, options = args.dup, {}
 
@@ -91,7 +93,7 @@ module Rails
         environment:        (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || "development").dup,
         daemonize:          false,
         caching:            false,
-        pid:                File.expand_path("tmp/pids/server.pid")
+        pid:                Options::DEFAULT_PID_PATH
       })
     end
 

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -108,4 +108,13 @@ class Rails::ServerTest < ActiveSupport::TestCase
       end
     end
   end
+
+  def test_default_options
+    server = Rails::Server.new
+    old_default_options = server.default_options
+
+    Dir.chdir("..") do
+      assert_equal old_default_options, server.default_options
+    end
+  end
 end


### PR DESCRIPTION
Fix bug (#22811) that occurs when rails server is started in daemon mode
and optional path to the `server.pid` file is omitted. Store default path
in a constant instead of evaluating it multiple time using `File.expand_path`.

The bug in detail: The server startup procedure crashes, since it tries to
open a file at `/tmp/pids/server.pid` instead of
`<path to project>/tmp/pids/server.pid`. This bug was introduced in 51211a94bd
when Rack was upgraded from version 1.x to 2.x. Since version 2.x,
Rack does not memoize the options hash [1], and as a consequence
`Rails::Server#default_options` will be evaluated multiple times.
The hash returned by `Rails::Server#default_options` holds the default path
to the `server.pid` file. The path is generated with the method
`File.expand_path`. However, the return value of this method depends on the
current working directory [2], which changes once `Process.daemon` is invoked
by `Rack::Server#daemonize_app` and the process is detached from the current
shell.

Close #22811

[1]https://git.io/vzen2
[2]http://ruby-doc.org/core-2.1.5/File.html#method-c-expand_path
