### PR TITLE
`InternalMetadata` accepts all unicode charsets like utf8mb4 for MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -116,7 +116,8 @@ module ActiveRecord
                                       (!options.key?(:precision) || c.precision == options[:precision]) &&
                                       (!options.key?(:scale)     || c.scale == options[:scale]) &&
                                       (!options.key?(:default)   || c.default == options[:default]) &&
-                                      (!options.key?(:null)      || c.null == options[:null]) }
+                                      (!options.key?(:null)      || c.null == options[:null]) &&
+                                      (!options.key?(:collation) || c.collation == options[:collation]) }
       end
 
       # Returns just a table's primary key
@@ -970,6 +971,10 @@ module ActiveRecord
 
       def initialize_internal_metadata_table
         ActiveRecord::InternalMetadata.create_table
+      end
+
+      def internal_string_options_for_primary_key # :nodoc:
+        { null: false }
       end
 
       def assume_migrated_upto_version(version, migrations_paths)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -72,14 +72,12 @@ module ActiveRecord
         end
       end
 
-      MAX_INDEX_LENGTH_FOR_CHARSETS_OF_4BYTES_MAXLEN = 191
       CHARSETS_OF_4BYTES_MAXLEN = ['utf8mb4', 'utf16', 'utf16le', 'utf32']
-      def initialize_schema_migrations_table
-        if CHARSETS_OF_4BYTES_MAXLEN.include?(charset)
-          ActiveRecord::SchemaMigration.create_table(MAX_INDEX_LENGTH_FOR_CHARSETS_OF_4BYTES_MAXLEN)
-        else
-          ActiveRecord::SchemaMigration.create_table
-        end
+
+      def internal_string_options_for_primary_key # :nodoc:
+        super.tap { |options|
+          options[:collation] = collation.sub(/\A[^_]+/, 'utf8') if CHARSETS_OF_4BYTES_MAXLEN.include?(charset)
+        }
       end
 
       def version

--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -33,8 +33,10 @@ module ActiveRecord
       # Creates an internal metadata table with columns +key+ and +value+
       def create_table
         unless table_exists?
+          key_options = connection.internal_string_options_for_primary_key
+
           connection.create_table(table_name, id: false) do |t|
-            t.column :key,   :string
+            t.column :key,   :string, key_options
             t.column :value, :string
             t.timestamps
             t.index  :key, unique: true, name: index_name

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -24,10 +24,9 @@ module ActiveRecord
         ActiveSupport::Deprecation.silence { connection.table_exists?(table_name) }
       end
 
-      def create_table(limit=nil)
+      def create_table
         unless table_exists?
-          version_options = {null: false}
-          version_options[:limit] = limit if limit
+          version_options = connection.internal_string_options_for_primary_key
 
           connection.create_table(table_name, id: false) do |t|
             t.column :version, :string, version_options

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -22,6 +22,17 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
     end
   end
 
+  def test_initializes_internal_metadata_for_encoding_utf8mb4
+    with_encoding_utf8mb4 do
+      table_name = ActiveRecord::InternalMetadata.table_name
+      connection.drop_table table_name, if_exists: true
+
+      connection.initialize_internal_metadata_table
+
+      assert connection.column_exists?(table_name, :key, :string, collation: 'utf8_general_ci')
+    end
+  end
+
   private
 
   def with_encoding_utf8mb4

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -12,9 +12,19 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_initializes_schema_migrations_for_encoding_utf8mb4
-    smtn = ActiveRecord::Migrator.schema_migrations_table_name
-    connection.drop_table smtn, if_exists: true
+    with_encoding_utf8mb4 do
+      table_name = ActiveRecord::SchemaMigration.table_name
+      connection.drop_table table_name, if_exists: true
 
+      connection.initialize_schema_migrations_table
+
+      assert connection.column_exists?(table_name, :version, :string, collation: 'utf8_general_ci')
+    end
+  end
+
+  private
+
+  def with_encoding_utf8mb4
     database_name = connection.current_database
     database_info = connection.select_one("SELECT * FROM information_schema.schemata WHERE schema_name = '#{database_name}'")
 
@@ -23,15 +33,11 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
 
     execute("ALTER DATABASE #{database_name} DEFAULT CHARACTER SET utf8mb4")
 
-    connection.initialize_schema_migrations_table
-
-    limit = ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::MAX_INDEX_LENGTH_FOR_CHARSETS_OF_4BYTES_MAXLEN
-    assert connection.column_exists?(smtn, :version, :string, limit: limit)
+    yield
   ensure
     execute("ALTER DATABASE #{database_name} DEFAULT CHARACTER SET #{original_charset} COLLATE #{original_collation}")
   end
 
-  private
   def connection
     @connection ||= ActiveRecord::Base.connection
   end


### PR DESCRIPTION
It is necessary for avoiding the index length problem.
