### PR TITLE
[ci-skip] Fix link for 2.3 guides

### DIFF
--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -20,5 +20,5 @@ The guides for earlier releases:
 <a href="http://guides.rubyonrails.org/v4.1/">Rails 4.1</a>,
 <a href="http://guides.rubyonrails.org/v4.0/">Rails 4.0</a>,
 <a href="http://guides.rubyonrails.org/v3.2/">Rails 3.2</a>, and
-<a href="http://guides.rubyonrails.org/v2.3/">Rails 2.3</a>.
+<a href="http://guides.rubyonrails.org/v2.3.11/">Rails 2.3</a>.
 </p>


### PR DESCRIPTION
By some reason http://guides.rubyonrails.org/v2.3/ redirects to the edge guides, but http://guides.rubyonrails.org/v2.3.11/ works
