### PR TITLE
Use correct timezone when parsing date in json

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix parsing JSON time in `YYYY-MM-DD hh:mm:ss` (without `Z`).
+    Before such time was considered in UTC timezone, now, to comply with standard, it uses local timezone.
+
+    *Grzegorz Witek*
+
 *   Match `HashWithIndifferentAccess#default`'s behaviour with `Hash#default`.
 
     *David Cornu*

--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -8,7 +8,8 @@ module ActiveSupport
 
   module JSON
     # matches YAML-formatted dates
-    DATE_REGEX = /^(?:\d{4}-\d{2}-\d{2}|\d{4}-\d{1,2}-\d{1,2}[T \t]+\d{1,2}:\d{2}:\d{2}(\.[0-9]*)?(([ \t]*)Z|[-+]\d{2}?(:\d{2})?))$/
+    DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
+    DATETIME_REGEX = /^(?:\d{4}-\d{2}-\d{2}|\d{4}-\d{1,2}-\d{1,2}[T \t]+\d{1,2}:\d{2}:\d{2}(\.[0-9]*)?(([ \t]*)Z|[-+]\d{2}?(:\d{2})?)?)$/
 
     class << self
       # Parses a JSON string (JavaScript Object Notation) into a hash.
@@ -48,7 +49,13 @@ module ActiveSupport
           nil
         when DATE_REGEX
           begin
-            DateTime.parse(data)
+            Date.parse(data)
+          rescue ArgumentError
+            data
+          end
+        when DATETIME_REGEX
+          begin
+            Time.zone.parse(data)
           rescue ArgumentError
             data
           end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/22171

Time specified in ISO 8601 format without `Z` should be parsed as local time, yet until now it was treated as UTC.

This commit fixes problem by parsing time using timezone specified in application config.

The downside of this solution is performance hit (`Time.zone.parse` is ~ 1.6x slower than `Time.parse`), so maybe there's a better solution.

Additionally, `YYYY-MM-DD` format is parsed as `Date` not `DateTime` as it was until now (recommended by @pixeltrix https://github.com/rails/rails/issues/22171#issuecomment-155489658)

/cc @maclover7 @pixeltrix @chancancode
