### PR TITLE
Application.js should be generated as "async defer" by default.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -9,10 +9,10 @@
     <%- else -%>
       <%- if gemfile_entries.any? { |m| m.name == 'turbolinks' } -%>
     <%%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload', async: true, defer: true %>
       <%- else -%>
     <%%= stylesheet_link_tag    'application', media: 'all' %>
-    <%%= javascript_include_tag 'application' %>
+    <%%= javascript_include_tag 'application', async: true, defer: true %>
       <%- end -%>
     <%- end -%>
   </head>


### PR DESCRIPTION
For a while now, pull requests (#15766 #5815) have been opened to move the default application.js script tag to the bottom of the document before the closing body tag.

External scripts (indeed, any script tags) block the document parser, meaning that any DOM content _after_ a `script` with a `src` cannot be parsed until after the script is downloaded and executed. This is Not A Good Thing. [Here's an example of problems this may cause - watch how the images do not appear until the script is downloaded (after 2 seconds of simulated download time)](http://stevesouders.com/cuzillion/?c0=hc1hfff0_0_f&c1=hj1hfff2_0_f&c2=bi1hfff0_0_f&c3=bi1hfff0_0_f&t=1452468665705). [Moving the script to the bottom, in this simplistic case](http://stevesouders.com/cuzillion/?c0=hc1hfff0_0_f&c1=bi1hfff0_0_f&c2=bi1hfff0_0_f&c3=bj1hfff2_0_f&t=1452468798181), allows the images to appear before the script is downloaded.

Encouraging Rails developers to use an external script in the head tag, without `async` or `defer` attributes, is unnecessarily slowing down their page renders and encouraging bad JavaScript habits.
## APPROACH

Moving Javascript to the end of the document is, as far as I can tell, mostly outdated advice since the adoption of the `async` and `defer` attributes. 
- Old concerns about network blocking are no longer valid. Browsers allow 6 parallel connections per hostname, so application.js is not crowding out other requests. In addition, as Rails developers adopt HTTP/2 compatible `asset_host`s, like Cloudflare, parallel connections will be a thing of the past and all assets will be downloaded over a single connection, intelligently prioritized with stream priorities. 
- If a browser supports `async` or `defer` attributes (IE8+, all majors), adding those attributes to an external script in the HEAD unblocks the document parser, achieving a similar effect to moving it to the end of the document, with the added advantage that DOMContentLoaded is not blocked either. [As an example, see this page.](http://stevesouders.com/cuzillion/?c0=hc1hfff0_0_f&c1=bi1hfff0_0_f&c2=bi1hfff0_0_f&c3=bj1hfff2_0_t&t=1452525621434). DOMContentLoaded fires immediately, while "scripts at the bottom" still delays the event until that script is downloaded. Nearly all major websites, such as Github and Basecamp, use some combination of `async` and `defer` attributes.

The reason both async and defer attributes are added is for IE8->IE9 compatibility, which do not support `async`. These browsers will ignore the `async` attribute and execute the `defer` instruction. All other browsers will perform the `async` behavior and ignore `defer`. `defer`, while not _exactly_ the same as `async`, also achieves the effect of unblocking document parsing. The slight difference is in that a) `defer` always delays until DOMContentLoaded and b) makes some promises about when scripts will be executed (in order), which `async` does not. 
## TURBOLINKS

We cannot move application.js to the end of the document because Turbolinks assumes application.js lives in the head tag. Moving application.js to the end of the body will cause application.js to be re-executed on every page:change. 

Marking application.js as `async` and `defer` will achieve document parser unblocking without breaking Turbolinks - in fact, I think it shows the great strength of Turbolinks' progressive enhancement, since Turbolinks is not required to render the page, we can go ahead and render the page without downloading it.

For an example of a Turbolinks-enabled site using `async`, [see my implementation of TodoMVC with Rails and Turbolinks](http://todomvc-turbolinks.herokuapp.com/).
## PROBLEMS/CONCERNS

A common (anti) pattern in Rails projects is to use JQuery selectors or event management inside inline script tags inserted in a particular view. [See this example in Rubygems.org](https://github.com/rubygems/rubygems.org/blob/master/app/views/pages/data.html.erb#L12). When this pattern is adopted, `application.js` must be loaded before the remainder of the document, slowing page render. This approach is incompatible with an `async` application.js. However, it appears that Rails may be taking a stance against inline scripts anyway with the possible adoption of #15777, though that looks stalled and may include the `unsafe-inline` option when merged. Users that continue to attempt to use inline scripts with dependencies inside application.js will find those functions are undefined, which is not a helpful error message and they will probably not understand why those functions are undefined.

`async` makes no guarantees about the order of execution of scripts. Many developers depend on script order in the document being their implicit dependency ordering. Thankfully, the Javascript community has solved these concerns with things like AMD, but many Rails developers are unfamiliar with these approaches.

The guides should probably be updated to reflect working with an `async` application.js and how that changes the way developers should use Javascript in their applications. 

Even when application.js has an `async` attribute, there may be some small benefit to moving it to the closing body tag - if application.js finishes downloading before DOMContentLoaded has fired, it _may_ execute and delay DOMContentLoaded and block further parsing. As an example, github.com puts their main Javascript file at the closing body tag _and_ adds an `async` attribute. Again, this cannot be recommended by the default layout now because of Turbolinks, and even so, I'm not convinced of the benefits in the majority of cases.
## CONCLUSION

`async` and `defer` is the future of fast webpages, and already used in major production applications. It encourages other Javascript best practices and is compatible with Turbolinks. Adding it to `application.js` would be a net benefit to the Rails community.
