### PR TITLE
Commit before freezing the headers

### DIFF
--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -91,7 +91,7 @@ module ActionDispatch
 
         DATE          = 'Date'.freeze
         LAST_MODIFIED = "Last-Modified".freeze
-        SPECIAL_KEYS  = Set.new(%w[extras no-cache max-age public must-revalidate])
+        SPECIAL_KEYS  = Set.new(%w[extras no-cache max-age public private must-revalidate])
 
         def cache_control_segments
           if cache_control = _cache_control

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -412,6 +412,13 @@ module ActionDispatch # :nodoc:
     end
 
     def before_sending
+      # Normally we've already committed by now, but it's possible
+      # (e.g., if the controller action tries to read back its own
+      # response) to get here before that. In that case, we must force
+      # an "early" commit: we're about to freeze the headers, so this is
+      # our last chance.
+      commit! unless committed?
+
       headers.freeze
       request.commit_cookie_jar! unless committed?
     end

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -37,6 +37,27 @@ class ResponseTest < ActiveSupport::TestCase
     assert_equal "closed stream", e.message
   end
 
+  def test_read_body_during_action
+    @response.body = "Hello, World!"
+
+    # even though there's no explicitly set content-type,
+    assert_equal nil, @response.content_type
+
+    # after the action reads back @response.body,
+    assert_equal "Hello, World!", @response.body
+
+    # the response can be built.
+    status, headers, body = @response.to_a
+    assert_equal 200, status
+    assert_equal({
+      "Content-Type" => "text/html; charset=utf-8"
+    }, headers)
+
+    parts = []
+    body.each { |part| parts << part }
+    assert_equal ["Hello, World!"], parts
+  end
+
   def test_response_body_encoding
     body = ["hello".encode(Encoding::UTF_8)]
     response = ActionDispatch::Response.new 200, {}, body


### PR DESCRIPTION
This shouldn't generally come up: under a standard flow, we don't start sending until after the commit. But application code always finds a way.
