### PR TITLE
Unify spelling of 'etc.'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Don't put *.swp, *.bak, etc here; those belong in a global ~/.gitignore.
+# Don't put *.swp, *.bak, etc. here; those belong in a global ~/.gitignore.
 # Check out https://help.github.com/articles/ignoring-files for how to set that up.
 
 .Gemfile

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -31,7 +31,7 @@ module ActionController
   #
   # The final caveat is that your actions are executed in a separate thread than
   # the main thread. Make sure your actions are thread safe, and this shouldn't
-  # be a problem (don't share state across threads, etc).
+  # be a problem (don't share state across threads, etc.).
   module Live
     extend ActiveSupport::Concern
 

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -215,7 +215,7 @@ module ActionController #:nodoc:
     # instance of the ActionController::MimeResponds::Collector class. This
     # object serves as a container in which available responses can be stored by
     # calling any of the dynamically generated, mime-type-specific methods such
-    # as +html+, +xml+ etc on the Collector. Each response is represented by a
+    # as +html+, +xml+, etc. on the Collector. Each response is represented by a
     # corresponding block if present.
     #
     # A subsequent call to #negotiate_format(request) will enable the Collector

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -396,7 +396,7 @@ module ActionDispatch
 
       # Whether the given cookie is to be deleted by this CookieJar.
       # Like <tt>[]=</tt>, you can pass in an options hash to test if a
-      # deletion applies to a specific <tt>:path</tt>, <tt>:domain</tt> etc.
+      # deletion applies to a specific <tt>:path</tt>, <tt>:domain</tt>, etc.
       def deleted?(name, options = {})
         options.symbolize_keys!
         handle_options(options)

--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -290,9 +290,9 @@ module ActionView
       #
       # You can also define your own unit-quantifier names if you want
       # to use other decimal units (eg.: 1500 becomes "1.5
-      # kilometers", 0.150 becomes "150 milliliters", etc). You may
+      # kilometers", 0.150 becomes "150 milliliters", etc.). You may
       # define a wide range of unit quantifiers, even fractional ones
-      # (centi, deci, mili, etc).
+      # (centi, deci, mili, etc.).
       #
       # ==== Options
       #

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -34,7 +34,7 @@ module RenderTestCases
     assert_equal "Hello world!", @view.render(:file => "test/hello_world")
   end
 
-  # Test if :formats, :locale etc. options are passed correctly to the resolvers.
+  # Test if :formats, :locale, etc. options are passed correctly to the resolvers.
   def test_render_file_with_format
     assert_match "<h1>No Comment</h1>", @view.render(:file => "comments/empty", :formats => [:html])
     assert_match "<error>No Comment</error>", @view.render(:file => "comments/empty", :formats => [:xml])

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -313,7 +313,7 @@ module ActiveRecord
 
       # Creates a new ConnectionPool object. +spec+ is a ConnectionSpecification
       # object which describes database connection information (e.g. adapter,
-      # host name, username, password, etc), as well as the maximum size for
+      # host name, username, password, etc.), as well as the maximum size for
       # this ConnectionPool.
       #
       # The default ConnectionPool maximum size is 5.

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -5,7 +5,7 @@ module ActiveRecord
 
     # Establishes the connection to the database. Accepts a hash as input where
     # the <tt>:adapter</tt> key must be specified with the name of a database adapter (in lower-case)
-    # example for regular databases (MySQL, PostgreSQL, etc):
+    # example for regular databases (MySQL, PostgreSQL, etc.):
     #
     #   ActiveRecord::Base.establish_connection(
     #     adapter:  "mysql2",

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -16,7 +16,7 @@ module ActiveSupport
   #   rgb['white'] # => '#FFFFFF'
   #
   # Internally symbols are mapped to strings when used as keys in the entire
-  # writing interface (calling <tt>[]=</tt>, <tt>merge</tt>, etc). This
+  # writing interface (calling <tt>[]=</tt>, <tt>merge</tt>, etc.). This
   # mapping belongs to the public interface. For example, given:
   #
   #   hash = ActiveSupport::HashWithIndifferentAccess.new(a: 1)

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -264,9 +264,9 @@ module ActiveSupport
     #
     # You can also define your own unit-quantifier names if you want
     # to use other decimal units (eg.: 1500 becomes "1.5
-    # kilometers", 0.150 becomes "150 milliliters", etc). You may
+    # kilometers", 0.150 becomes "150 milliliters", etc.). You may
     # define a wide range of unit quantifiers, even fractional ones
-    # (centi, deci, mili, etc).
+    # (centi, deci, mili, etc.).
     #
     # ==== Options
     #

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -34,7 +34,7 @@ Controller Naming Convention
 
 The naming convention of controllers in Rails favors pluralization of the last word in the controller's name, although it is not strictly required (e.g. `ApplicationController`). For example, `ClientsController` is preferable to `ClientController`, `SiteAdminsController` is preferable to `SiteAdminController` or `SitesAdminsController`, and so on.
 
-Following this convention will allow you to use the default route generators (e.g. `resources`, etc) without needing to qualify each `:path` or `:controller`, and will keep URL and path helpers' usage consistent throughout your application. See [Layouts & Rendering Guide](layouts_and_rendering.html) for more details.
+Following this convention will allow you to use the default route generators (e.g. `resources`, etc.) without needing to qualify each `:path` or `:controller`, and will keep URL and path helpers' usage consistent throughout your application. See [Layouts & Rendering Guide](layouts_and_rendering.html) for more details.
 
 NOTE: The controller naming convention differs from the naming convention of models, which are expected to be named in singular form.
 

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -207,7 +207,7 @@ end
 NOTE: Active Job's default behavior is to execute jobs ':inline'. So, you can use
 `deliver_later` now to send emails, and when you later decide to start sending
 them from a background job, you'll only need to set up Active Job to use a queueing
-backend (Sidekiq, Resque, etc).
+backend (Sidekiq, Resque, etc.).
 
 If you want to send emails right away (from a cronjob for example) just call
 `deliver_now`:

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -112,7 +112,7 @@ Action Controller
 | `:controller` | The controller name                                       |
 | `:action`     | The action                                                |
 | `:params`     | Hash of request parameters without any filtered parameter |
-| `:format`     | html/js/json/xml etc                                      |
+| `:format`     | html/js/json/xml etc.                                     |
 | `:method`     | HTTP request verb                                         |
 | `:path`       | Request path                                              |
 
@@ -134,7 +134,7 @@ Action Controller
 | `:controller`   | The controller name                                       |
 | `:action`       | The action                                                |
 | `:params`       | Hash of request parameters without any filtered parameter |
-| `:format`       | html/js/json/xml etc                                      |
+| `:format`       | html/js/json/xml etc.                                     |
 | `:method`       | HTTP request verb                                         |
 | `:path`         | Request path                                              |
 | `:status`       | HTTP status code                                          |

--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -82,7 +82,7 @@ used. Instead of:
 English
 -------
 
-Please use American English (*color*, *center*, *modularize*, etc). See [a list of American and British English spelling differences here](http://en.wikipedia.org/wiki/American_and_British_English_spelling_differences).
+Please use American English (*color*, *center*, *modularize*, etc.). See [a list of American and British English spelling differences here](http://en.wikipedia.org/wiki/American_and_British_English_spelling_differences).
 
 Oxford Comma
 ------------

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -474,7 +474,7 @@ app/models/article.rb:
   * [ 23] Have to fix this one before pushing!
 ```
 
-NOTE. When using specific annotations and custom annotations, the annotation name (FIXME, BUG etc) is not displayed in the output lines.
+NOTE. When using specific annotations and custom annotations, the annotation name (FIXME, BUG, etc.) is not displayed in the output lines.
 
 By default, `rake notes` will look in the `app`, `config`, `db`, `lib` and `test` directories. If you would like to search other directories, you can provide them as a comma separated list in an environment variable `SOURCE_ANNOTATION_DIRECTORIES`.
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -877,7 +877,7 @@ Many modern web servers can be used as a proxy server to balance third-party ele
 
 One such application server you can use is [Unicorn](http://unicorn.bogomips.org/) to run behind a reverse proxy.
 
-In this case, you would need to configure the proxy server (NGINX, Apache, etc) to accept connections from your application server (Unicorn). By default Unicorn will listen for TCP connections on port 8080, but you can change the port or configure it to use sockets instead.
+In this case, you would need to configure the proxy server (NGINX, Apache, etc.) to accept connections from your application server (Unicorn). By default Unicorn will listen for TCP connections on port 8080, but you can change the port or configure it to use sockets instead.
 
 You can find more information in the [Unicorn readme](http://unicorn.bogomips.org/README.html) and understand the [philosophy](http://unicorn.bogomips.org/PHILOSOPHY.html) behind it.
 

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -651,7 +651,7 @@ def upload
 end
 ```
 
-Once a file has been uploaded, there are a multitude of potential tasks, ranging from where to store the files (on disk, Amazon S3, etc) and associating them with models to resizing image files and generating thumbnails. The intricacies of this are beyond the scope of this guide, but there are several libraries designed to assist with these. Two of the better known ones are [CarrierWave](https://github.com/jnicklas/carrierwave) and [Paperclip](https://github.com/thoughtbot/paperclip).
+Once a file has been uploaded, there are a multitude of potential tasks, ranging from where to store the files (on disk, Amazon S3, etc.) and associating them with models to resizing image files and generating thumbnails. The intricacies of this are beyond the scope of this guide, but there are several libraries designed to assist with these. Two of the better known ones are [CarrierWave](https://github.com/jnicklas/carrierwave) and [Paperclip](https://github.com/thoughtbot/paperclip).
 
 NOTE: If the user has not selected a file the corresponding parameter will be an empty string.
 

--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -411,7 +411,7 @@ def start &blk
   check_pid! if options[:pid]
 
   # Touch the wrapped app, so that the config.ru is loaded before
-  # daemonization (i.e. before chdir, etc).
+  # daemonization (i.e. before chdir, etc.).
   wrapped_app
 
   daemonize_app if options[:daemonize]

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1108,7 +1108,7 @@ Your mailer classes - like every other part of your Rails application - should b
 The goals of testing your mailer classes are to ensure that:
 
 * emails are being processed (created and sent)
-* the email content is correct (subject, sender, body, etc)
+* the email content is correct (subject, sender, body, etc.)
 * the right emails are being sent at the right times
 
 #### From All Sides

--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -21,7 +21,7 @@ STATS_DIRECTORIES = [
   [ name, "#{File.dirname(Rake.application.rakefile_location)}/#{dir}" ]
 end.select { |name, dir| File.directory?(dir) }
 
-desc "Report code statistics (KLOCs, etc) from the application or engine"
+desc "Report code statistics (KLOCs, etc.) from the application or engine"
 task :stats do
   require 'rails/code_statistics'
   CodeStatistics.new(*STATS_DIRECTORIES).to_s


### PR DESCRIPTION
Spelling as recommended [here](https://english.stackexchange.com/questions/23022/how-to-deal-with-abbreviations-like-etc-at-the-end-of-parentheses-which-are-c) and [here](https://english.stackexchange.com/questions/1469/when-ending-a-list-with-etc-should-there-be-a-comma-before-etc).
