### PR TITLE
Fix uncountable noun routing

### DIFF
--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -285,7 +285,7 @@ module ActionDispatch
           case record
           when Symbol, String
             record_name = record.to_s
-            if uncountable?(record_name)
+            if index_route?(route) && uncountable?(record_name)
               "#{record_name}_index"
             else
               record_name
@@ -317,6 +317,10 @@ module ActionDispatch
 
         def get_method_for_string(str)
           "#{prefix}#{str}_#{suffix}"
+        end
+
+        def index_route?(route)
+          !%w(new edit destroy).include?(route.first)
         end
 
         def uncountable?(str)

--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -284,7 +284,12 @@ module ActionDispatch
           route <<
           case record
           when Symbol, String
-            record.to_s
+            record_name = record.to_s
+            if uncountable?(record_name)
+              "#{record_name}_index"
+            else
+              record_name
+            end
           when Class
             @key_strategy.call record.model_name
           else
@@ -312,6 +317,10 @@ module ActionDispatch
 
         def get_method_for_string(str)
           "#{prefix}#{str}_#{suffix}"
+        end
+
+        def uncountable?(str)
+          ActiveSupport::Inflector.inflections.uncountable.include?(str)
         end
 
         [nil, 'new', 'edit'].each do |action|

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -478,6 +478,28 @@ module AbstractController
         end
       end
 
+      def test_url_for_with_array_include_uncountable_nonu_record_name
+        host = 'example.com'
+        namespace = :admin
+        record_name = ActiveSupport::Inflector.inflections.uncountable.first
+
+        with_routing do |set|
+          set.draw do
+            namespace namespace do
+              resources record_name
+            end
+          end
+
+          kls = Class.new { include set.url_helpers }
+          kls.default_url_options[:host] = host
+
+          assert_equal(
+            "http://#{host}/admin/#{record_name}",
+             kls.new.url_for([namespace, record_name])
+          )
+        end
+      end
+
       private
         def extract_params(url)
           url.split('?', 2).last.split('&').sort

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -495,7 +495,7 @@ module AbstractController
 
           assert_equal(
             "http://#{host}/#{namespace}/#{record_name}",
-             kls.new.url_for([namespace, record_name])
+            kls.new.url_for([namespace, record_name])
           )
         end
       end

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -478,7 +478,7 @@ module AbstractController
         end
       end
 
-      def test_url_for_with_array_include_uncountable_nonu_record_name
+      def test_url_for_with_array_include_uncountable_noun_record_name
         host = 'example.com'
         namespace = :admin
         record_name = ActiveSupport::Inflector.inflections.uncountable.first

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -494,7 +494,7 @@ module AbstractController
           kls.default_url_options[:host] = host
 
           assert_equal(
-            "http://#{host}/admin/#{record_name}",
+            "http://#{host}/#{namespace}/#{record_name}",
              kls.new.url_for([namespace, record_name])
           )
         end


### PR DESCRIPTION
When generate a URL, an `ActionController::UrlGenerationError` occurs with the following case.
- last route name is an uncountable noun
- Given list parameter to `link_to` method.
- The last parameter on the list is character string or symbol.

``` rb
# routes.rb
namspace :admin do
  resources :information
end

# Error example
link_to "Text", [:admin, :information] # => ActionController::UrlGenerationError
```

This is because dynamic method generation for URL generation is wrong.

---

I made the patch which solved this problem, I want you to confirm it.
