### PR TITLE
Shorten ActiveRecord::InternalMetadata.table_name to ar_internal_metadata

### DIFF
--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -14,6 +14,10 @@ module ActiveRecord
         "#{table_name_prefix}#{ActiveRecord::Base.internal_metadata_table_name}#{table_name_suffix}"
       end
 
+      def original_table_name
+        "#{table_name_prefix}active_record_internal_metadatas#{table_name_suffix}"
+      end
+
       def []=(key, value)
         first_or_initialize(key: key).update_attributes!(value: value)
       end
@@ -26,8 +30,17 @@ module ActiveRecord
         ActiveSupport::Deprecation.silence { connection.table_exists?(table_name) }
       end
 
+      def original_table_exists?
+        # This method will be removed in Rails 5.1
+        # Since it is only necessary when `active_record_internal_metadatas` could exist
+        ActiveSupport::Deprecation.silence { connection.table_exists?(original_table_name) }
+      end
+
       # Creates an internal metadata table with columns +key+ and +value+
       def create_table
+        if original_table_exists?
+          connection.rename_table(original_table_name, table_name)
+        end
         unless table_exists?
           key_options = connection.internal_string_options_for_primary_key
 

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -44,9 +44,9 @@ module ActiveRecord
 
       ##
       # :singleton-method:
-      # Accessor for the name of the internal metadata table. By default, the value is "active_record_internal_metadatas"
+      # Accessor for the name of the internal metadata table. By default, the value is "ar_internal_metadata"
       class_attribute :internal_metadata_table_name, instance_accessor: false
-      self.internal_metadata_table_name = "active_record_internal_metadatas"
+      self.internal_metadata_table_name = "ar_internal_metadata"
 
       ##
       # :singleton-method:

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -426,6 +426,21 @@ class MigrationTest < ActiveRecord::TestCase
     ENV["RACK_ENV"]  = original_rack_env
   end
 
+  def test_rename_internal_metadata_table
+    original_internal_metadata_table_name = ActiveRecord::Base.internal_metadata_table_name
+
+    ActiveRecord::Base.internal_metadata_table_name = "active_record_internal_metadatas"
+    Reminder.reset_table_name
+
+    ActiveRecord::Base.internal_metadata_table_name = original_internal_metadata_table_name
+    Reminder.reset_table_name
+
+    assert_equal "ar_internal_metadata", ActiveRecord::InternalMetadata.table_name
+  ensure
+    ActiveRecord::Base.internal_metadata_table_name = original_internal_metadata_table_name
+    Reminder.reset_table_name
+  end
+
   def test_proper_table_name_on_migration
     reminder_class = new_isolated_reminder_class
     migration = ActiveRecord::Migration.new

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -357,14 +357,14 @@ class MigrationTest < ActiveRecord::TestCase
   def test_internal_metadata_table_name
     original_internal_metadata_table_name = ActiveRecord::Base.internal_metadata_table_name
 
-    assert_equal "active_record_internal_metadatas", ActiveRecord::InternalMetadata.table_name
-    ActiveRecord::Base.table_name_prefix = "prefix_"
-    ActiveRecord::Base.table_name_suffix = "_suffix"
+    assert_equal "ar_internal_metadata", ActiveRecord::InternalMetadata.table_name
+    ActiveRecord::Base.table_name_prefix = "p_"
+    ActiveRecord::Base.table_name_suffix = "_s"
     Reminder.reset_table_name
-    assert_equal "prefix_active_record_internal_metadatas_suffix", ActiveRecord::InternalMetadata.table_name
+    assert_equal "p_ar_internal_metadata_s", ActiveRecord::InternalMetadata.table_name
     ActiveRecord::Base.internal_metadata_table_name = "changed"
     Reminder.reset_table_name
-    assert_equal "prefix_changed_suffix", ActiveRecord::InternalMetadata.table_name
+    assert_equal "p_changed_s", ActiveRecord::InternalMetadata.table_name
     ActiveRecord::Base.table_name_prefix = ""
     ActiveRecord::Base.table_name_suffix = ""
     Reminder.reset_table_name

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -38,7 +38,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_match %r{create_table "accounts"}, output
     assert_match %r{create_table "authors"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
-    assert_no_match %r{create_table "active_record_internal_metadatas"}, output
+    assert_no_match %r{create_table "ar_internal_metadata"}, output
   end
 
   def test_schema_dump_uses_force_cascade_on_create_table
@@ -159,7 +159,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "accounts"}, output
     assert_match %r{create_table "authors"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
-    assert_no_match %r{create_table "active_record_internal_metadatas"}, output
+    assert_no_match %r{create_table "ar_internal_metadata"}, output
   end
 
   def test_schema_dump_with_regexp_ignored_table
@@ -167,7 +167,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "accounts"}, output
     assert_match %r{create_table "authors"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
-    assert_no_match %r{create_table "active_record_internal_metadatas"}, output
+    assert_no_match %r{create_table "ar_internal_metadata"}, output
   end
 
   def test_schema_dumps_index_columns_in_right_order
@@ -345,7 +345,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "foo_.+_bar"}, output
     assert_no_match %r{add_index "foo_.+_bar"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
-    assert_no_match %r{create_table "active_record_internal_metadatas"}, output
+    assert_no_match %r{create_table "ar_internal_metadata"}, output
 
     if ActiveRecord::Base.connection.supports_foreign_keys?
       assert_no_match %r{add_foreign_key "foo_.+_bar"}, output

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -28,7 +28,7 @@ module ApplicationTests
         assert_not File.exist?("tmp/restart.txt")
         `bin/setup 2>&1`
         assert_equal 0, File.size("log/test.log")
-        assert_equal '["articles", "schema_migrations", "active_record_internal_metadatas"]', list_tables.call
+        assert_equal '["articles", "schema_migrations", "ar_internal_metadata"]', list_tables.call
         assert File.exist?("tmp/restart.txt")
       end
     end

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -222,14 +222,14 @@ module ApplicationTests
 
           assert_equal '["posts"]', list_tables[]
           `bin/rails db:schema:load`
-          assert_equal '["posts", "comments", "schema_migrations", "active_record_internal_metadatas"]', list_tables[]
+          assert_equal '["posts", "comments", "schema_migrations", "ar_internal_metadata"]', list_tables[]
 
           app_file 'db/structure.sql', <<-SQL
             CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar(255));
           SQL
 
           `bin/rails db:structure:load`
-          assert_equal '["posts", "comments", "schema_migrations", "active_record_internal_metadatas", "users"]', list_tables[]
+          assert_equal '["posts", "comments", "schema_migrations", "ar_internal_metadata", "users"]', list_tables[]
         end
       end
 


### PR DESCRIPTION
This pull request addresses the following error when tested with Oracle enhanced adapter.

It changes ActiveRecord::InternalMetadata.table_name to ar_internal_metadatas to support Oracle database which only supports 30 byte identifier length.

``` ruby
ActiveRecord::StatementInvalid:
OCIError: ORA-00972: identifier is too long: CREATE TABLE "ACTIVE_RECORD_INTERNAL_METADATAS" ("KEY" VARCHAR2(255), "VALUE" VARCHAR2(255), "CREATED_AT" TIMESTAMP NOT NULL, "UPDATED_AT" TIMESTAMP NOT NULL)
```

I think "ar_internal_metadatas" can explain what it intends.
