### PR TITLE
Don't duplicate relative URL root in ActionMailer links

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Prevent `url_for` from duplicating the relative URL root when
+    `RAILS_RELATIVE_URL_ROOT` is set.
+
+    *Greg Barendt*
+
 ## Rails 4.2.5 (November 12, 2015) ##
 
 *   No changes.

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -29,6 +29,9 @@ module ActionMailer
       options.asset_host          ||= app.config.asset_host
       options.relative_url_root   ||= app.config.relative_url_root
 
+      options.default_url_options ||= {}
+      options.default_url_options[:script_name] ||= ''
+
       ActiveSupport.on_load(:action_mailer) do
         include AbstractController::UrlFor
         extend ::AbstractController::Railties::RoutesHelpers.with(app.routes, false)

--- a/actionmailer/test/url_test.rb
+++ b/actionmailer/test/url_test.rb
@@ -104,6 +104,22 @@ class ActionMailerUrlTest < ActionMailer::TestCase
     assert_url_for '/dummy_model' , [DummyModel]
   end
 
+  def test_url_for_with_relative_url_root
+    UrlTestMailer.delivery_method = :test
+
+    ENV['RAILS_RELATIVE_URL_ROOT'] = '/foo/bar'
+    ActionDispatch::Routing::RouteSet.relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT']
+    AppRoutes.draw do
+      scope ENV['RAILS_RELATIVE_URL_ROOT'] do
+        get '/welcome' => 'foo#bar', as: 'welcome'
+      end
+    end
+
+    assert_url_for '/foo/bar/welcome', :welcome
+
+    ENV.delete 'RAILS_RELATIVE_URL_ROOT'
+  end
+
   def test_signed_up_with_url
     UrlTestMailer.delivery_method = :test
 


### PR DESCRIPTION
As of Rails 4.2.3, using RAILS_RELATIVE_URL_ROOT to scope routes causes `url_for` to generate links with the relative URL root repeated when `url_for` is used inside an ActionMailer. Using the ActionMailer railtie to default `script_name` to an empty string fixes this.

This issue appears to have been introduced in https://github.com/rails/rails/commit/44ff0313c121f528a68b3bd21d6c7a96f313e3d3.

This PR includes a failing test that illustrates the behavior. Unfortunately, the test fails even with the fix in place because the setup for the ActionMailer URL tests doesn't appear to be executing the railtie first. This is my first time attempting to contribute to Rails so I don't really know my way around - if someone could give me some guidance on where/how to test this I would greatly appreciate it. Thanks!
