### PR TITLE
Allow filtering of non-Global ID ActiveJob args

### DIFF
--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -35,4 +35,5 @@ module ActiveJob
   autoload :AsyncJob
   autoload :TestCase
   autoload :TestHelper
+  autoload :ArgumentsFilter
 end

--- a/activejob/lib/active_job/arguments_filter.rb
+++ b/activejob/lib/active_job/arguments_filter.rb
@@ -18,7 +18,7 @@ module ActiveJob
     private
 
     def formatted_arguments
-      @arguments.map { |arg| format(arg) }.flatten
+      @arguments.flat_map { |arg| format(arg) }
     end
 
     def format(arg)

--- a/activejob/lib/active_job/arguments_filter.rb
+++ b/activejob/lib/active_job/arguments_filter.rb
@@ -1,0 +1,45 @@
+module ActiveJob
+  class ArgumentsFilter
+    def initialize(job)
+      @job = job
+      @arguments = job.arguments
+    end
+
+    def filtered_arguments
+      return formatted_arguments.join(', ') if ActiveJob::Base.log_all_arguments
+
+      if action_mailer_job?
+        return (formatted_arguments[0..2] + global_id_args).join(', ')
+      end
+
+      global_id_args.join(', ')
+    end
+
+    private
+
+    def formatted_arguments
+      @arguments.map { |arg| format(arg) }.flatten
+    end
+
+    def format(arg)
+      case arg
+      when Hash
+        arg.transform_values { |value| format(value) }
+      when Array
+        arg.map { |value| format(value) }
+      when GlobalID::Identification
+        arg.to_global_id.to_s rescue arg.inspect
+      else
+        arg.inspect
+      end
+    end
+
+    def action_mailer_job?
+      @job.class.name == 'ActionMailer::DeliveryJob'
+    end
+
+    def global_id_args
+      formatted_arguments.select { |arg| arg.include?('gid://') }
+    end
+  end
+end

--- a/activejob/test/jobs/mailer_job.rb
+++ b/activejob/test/jobs/mailer_job.rb
@@ -1,0 +1,16 @@
+require_relative '../../../actionmailer/lib/action_mailer'
+require_relative '../support/job_buffer'
+
+class MailerJob < ActionMailer::Base
+  def welcome(email)
+    JobBuffer.add("Welcome, #{email}!")
+  end
+
+  def welcome_person(user)
+    JobBuffer.add("Welcome, #{user.id}!")
+  end
+
+  def welcome_both(user, email)
+    JobBuffer.add("Welcome, #{email}! Your id is #{user.id}")
+  end
+end


### PR DESCRIPTION
**Why**:
In some cases, a job might include sensitive information as one of the arguments, and there might not be an easy way to prevent those arguments from being passed.

For example, Devise sends the raw `reset_password_token` as an argument to their mailer. This results in the token being exposed in Active Job logs. Modifying the Devise code to prevent the token from being passed is not trivial.

**How**:
Provide an option to remove all non-Global ID arguments from the logs, by setting `Rails.application.config.active_job.log_all_arguments = false`.

When the option is set to `true` (default setting), the Active Job logs are formatted as they were before, i.e. all arguments are exposed. When set to `false`, all arguments that don't respond to `to_global_id` are removed. If the job is an `ActionMailer::DeliveryJob`, then the arguments also include the mailer class name, method, and `deliver_now`.
