### PR TITLE
Allow client side events through ActionCable channels

### DIFF
--- a/actioncable/lib/action_cable/channel/broadcasting.rb
+++ b/actioncable/lib/action_cable/channel/broadcasting.rb
@@ -9,7 +9,8 @@ module ActionCable
 
       class_methods do
         # Broadcast a hash to a unique broadcasting for this <tt>model</tt> in this channel.
-        def broadcast_to(model, message)
+        def broadcast_to(model, message = nil)
+          return EventProxy.new(self, model) if message.nil? # If invoked with single argument
           ActionCable.server.broadcast(broadcasting_for([ channel_name, model ]), message)
         end
 
@@ -22,6 +23,19 @@ module ActionCable
           else
             model.to_param
           end
+        end
+      end
+
+      # This class is used internally to provide a method proxy for evented client side channels
+      class EventProxy
+        def initialize(channel, model)
+          @channel, @model = channel, model
+        end
+
+        def method_missing(meth, *args)
+          message = {event_name: meth}
+          message[:args] = args if args.any?
+          @channel.broadcast_to(@model, message)
         end
       end
     end

--- a/actioncable/lib/action_cable/channel/broadcasting.rb
+++ b/actioncable/lib/action_cable/channel/broadcasting.rb
@@ -5,7 +5,7 @@ module ActionCable
     module Broadcasting
       extend ActiveSupport::Concern
 
-      delegate :broadcasting_for, to: :class
+      delegate :broadcasting_for, :broadcast_to, to: :class
 
       class_methods do
         # Broadcast a hash to a unique broadcasting for this <tt>model</tt> in this channel.

--- a/actioncable/lib/action_cable/channel/broadcasting.rb
+++ b/actioncable/lib/action_cable/channel/broadcasting.rb
@@ -32,10 +32,17 @@ module ActionCable
           @channel, @model = channel, model
         end
 
-        def method_missing(meth, *args)
-          message = {event_name: meth}
+        # Allow triggering of any named event, useful to be explicit or to trigger events having
+        # a name not valid as ruby method name
+        def trigger(event_name, *args)
+          message = {event_name: event_name}
           message[:args] = args if args.any?
           @channel.broadcast_to(@model, message)
+        end
+
+        # Broadcast any method called as event named like the invoked method
+        def method_missing(meth, *args)
+          trigger meth, *args
         end
       end
     end

--- a/actioncable/lib/assets/javascripts/action_cable/consumer.coffee
+++ b/actioncable/lib/assets/javascripts/action_cable/consumer.coffee
@@ -2,6 +2,7 @@
 #= require action_cable/connection_monitor
 #= require action_cable/subscriptions
 #= require action_cable/subscription
+#= require action_cable/evented_subscription
 
 # The ActionCable.Consumer establishes the connection to a server-side Ruby Connection object. Once established,
 # the ActionCable.ConnectionMonitor will ensure that its properly maintained through heartbeats and checking for stale updates.

--- a/actioncable/lib/assets/javascripts/action_cable/evented_subscription.coffee
+++ b/actioncable/lib/assets/javascripts/action_cable/evented_subscription.coffee
@@ -1,0 +1,75 @@
+# An evented subscription is created through the ActionCable.Subscriptions instance available on the consumer.
+# It provides an extension to standard ActionCable.Subscription class by exposing a basic event handler to
+# to trigger client side events using server method calls.
+#
+# When using an EventedSubscription the `@received` method must not be implemented (if so it will be overwritten).
+#
+# An example demonstrates the basic functionality:
+#
+#   App.appearance = App.cable.subscriptions.createEvented "AppearanceChannel",
+#     connected: ->
+#       # Called once the subscription has been successfully completed
+#       @on 'user_appeared', @showUserBadge
+#
+#     showUserBadge: (badge)->
+#       # arguments are provided server side
+#       jQuery('#badges').append(badge)
+#
+#
+#   # Callbacks can be registered outside channel building, using inline callbacks
+#   jQuery ->
+#     App.appearance.on 'user_connected', (user_id)->
+#       console.debug "User #{user_id} connected"
+#     App.appearance.on 'user_disconnected', (user_id)->
+#       console.debug "User #{user_id} disconnected"
+#
+#   # Finally callbacks can be removed for whatever reason using .off method
+#   App.appearance.off 'user_connected' # Remove all event handlers for 'user_connected' event
+#
+# With evented subscriptions events can be triggered server side with a nice DSL that is automatically translated to
+# javascript events.
+#
+# This is how the server component would look with EventedSubscription:
+#
+#   class AppearanceChannel < ApplicationActionCable::Channel
+#     def subscribed
+#       stream_from 'user_events' # Every client will subscribe on user events on connection
+#       broadcast_to('user_events').user_connected(current_user.id) # Notify all users of connection
+#     end
+#   end
+#
+# When broadcasting needs some intensive task (e.g. a heavy partial rendering) a background task might be a better choice
+#
+#   def perform(user)
+#     template = UsersController.render(partial: 'users/badge', locals: { user: user }
+#     AppearanceChannel.broadcast_to('user_events').user_appeared(template)
+#   end
+#
+class ActionCable.EventedSubscription extends ActionCable.Subscription
+
+  # Install an event handler for a named event
+  on: (eventName, callback)->
+    @eventsFor(eventName).push(callback)
+
+  # Remove all event handlers for a given event
+  off: (eventName)->
+    delete @__managed_events[eventName] # Reset callback for this event
+
+  # Private API
+
+  # Implementation for client side events. Server side an event payload is built and this method unwrap it and trigger
+  # registered event handlers for the named event
+  received: (eventPayload) ->
+    # Called server side with MyChannel.broadcast_to(channel_name).some_event(args)
+    args = [eventPayload.event_name].concat eventPayload.args
+    @trigger.apply(this, args)
+
+  # Event dispatcher for named events
+  trigger: (eventName, args...)->
+    # Invoke registered callbacks for the given event if any
+    cb.apply(this, args) for cb in @eventsFor(eventName) if @eventsFor(eventName).length
+
+  # Utility function to retrieve callbacks for a named event
+  eventsFor: (eventName)->
+    @__managed_events ||= {}
+    @__managed_events[eventName] ||= []

--- a/actioncable/lib/assets/javascripts/action_cable/subscriptions.coffee
+++ b/actioncable/lib/assets/javascripts/action_cable/subscriptions.coffee
@@ -15,6 +15,11 @@ class ActionCable.Subscriptions
     params = if typeof channel is "object" then channel else {channel}
     new ActionCable.Subscription this, params, mixin
 
+  createEvented: (channelName, mixin)->
+    channel = channelName
+    params = if typeof channel is "object" then channel else {channel}
+    new ActionCable.EventedSubscription this, params, mixin
+
   # Private
 
   add: (subscription) ->

--- a/actioncable/test/channel/broadcasting_test.rb
+++ b/actioncable/test/channel/broadcasting_test.rb
@@ -31,6 +31,12 @@ class ActionCable::Channel::BroadcastingTest < ActiveSupport::TestCase
     ChatChannel.broadcast_to(Room.new(1)).some_other_event
   end
 
+  test "events with invalid method names using trigger" do
+    ActionCable.stubs(:server).returns (server = mock)
+    server.expects(:broadcast).with('action_cable:channel:broadcasting_test:chat:Room#1-Campfire', event_name: 'user:connected')
+    ChatChannel.broadcast_to(Room.new(1)).trigger 'user:connected'
+  end
+
   test "broadcasting_for with an object" do
     assert_equal "Room#1-Campfire", ChatChannel.broadcasting_for(Room.new(1))
   end

--- a/actioncable/test/channel/broadcasting_test.rb
+++ b/actioncable/test/channel/broadcasting_test.rb
@@ -15,6 +15,22 @@ class ActionCable::Channel::BroadcastingTest < ActiveSupport::TestCase
     ChatChannel.broadcast_to(Room.new(1), "Hello World")
   end
 
+  test "broadcast_to with single argument" do
+    proxy = ChatChannel.broadcast_to(Room.new(1))
+    assert_instance_of ActionCable::Channel::Broadcasting::EventProxy, proxy
+  end
+
+  test "proxied methods are converted in an event hash" do
+    ActionCable.stubs(:server).returns (server = mock)
+    arguments = {event_name: :some_event, args: [:foo, :bar]}
+    server.expects(:broadcast).with('action_cable:channel:broadcasting_test:chat:Room#1-Campfire', arguments)
+    # Proxied methods are converted into json messages and broadcasted
+    ChatChannel.broadcast_to(Room.new(1)).some_event(:foo, :bar)
+    # Without arguments it only broadcast event name
+    server.expects(:broadcast).with('action_cable:channel:broadcasting_test:chat:Room#1-Campfire', event_name: :some_other_event)
+    ChatChannel.broadcast_to(Room.new(1)).some_other_event
+  end
+
   test "broadcasting_for with an object" do
     assert_equal "Room#1-Campfire", ChatChannel.broadcasting_for(Room.new(1))
   end


### PR DESCRIPTION
This PR refers to [this comment](https://github.com/rails/rails/issues/22673#issuecomment-170962314) last part.

I tried to implement a generic way to support server side event triggering with a nice DSL.

In this way action cable users need to create an evented subscription (tied to a channel) and then they can
trigger javascript events from server code. Here's a quick and dirty example

``` coffee
channel = App.cable.subscriptions.createEvented "UserChannel"

# Simple event listener
channel.on 'subscribed', (id, name)->
  console.debug 'User', name, 'just subscribed'

# Multiple callbacks can be attached to same event
channel.on 'subscribed', (id, name)->
  console.debug "I forgot its id, it was", id

# Doing some DOM manipulations
jQuery ->
  channel.on 'user_profile', (markup)->
    $('#users').append(markup)

```

Server side events can be called server side using the channel class

``` ruby
# Be sure to restart your server when you modify this file. Action Cable runs in an EventMachine loop that does not support auto reloading.
class UserChannel < ApplicationCable::Channel
  def subscribed
    # Delegated to class, use channel_name and given model to compute stream name
    # A simple proxy will convert method calls into events and send them on the wire
    broadcast_to(current_user).subscribed current_user.id, current_user.name
  end
end

# Outside Channel class you can call .broadcast_to directly on class, e.g. in a background job
user = User.first
# Assuming someone is following this user via UserChannel#stream_for(user)
UserChannel.broadcast_to(user).user_profile "<p>User #{user.name}</p>"
```

Let me know what do you think.
