### PR TITLE
AC::Parameters#at_json: restore Rails 4.2’s value

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -109,7 +109,8 @@ module ActionController
     cattr_accessor :permit_all_parameters, instance_accessor: false
     cattr_accessor :action_on_unpermitted_parameters, instance_accessor: false
 
-    delegate :keys, :key?, :has_key?, :empty?, :include?, :inspect, to: :@parameters
+    delegate :keys, :key?, :has_key?, :empty?, :include?, :inspect,
+      :as_json, to: :@parameters
 
     # By default, never raise an UnpermittedParameters exception if these
     # params are present. The default includes both 'controller' and 'action'

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -27,6 +27,12 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_not @params[:person][:name].permitted?
   end
 
+  test "as_json returns the JSON representation of the parameters hash" do
+    assert_not @params.as_json.key? "parameters"
+    assert_not @params.as_json.key? "permitted"
+    assert @params.as_json.key? "person"
+  end
+
   test "each carries permitted status" do
     @params.permit!
     @params.each { |key, value| assert(value.permitted?) if key == "person" }


### PR DESCRIPTION
Fixes #23026

See discussion at #23026
