### PR TITLE
Prevent static middleware from attempting to serve a request with a null byte

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -27,7 +27,7 @@ module ActionDispatch
     # in the server's `public/` directory (see Static#call).
     def match?(path)
       path = ::Rack::Utils.unescape_path path
-      return false unless path.valid_encoding?
+      return false unless valid_path?(path)
       path = Rack::Utils.clean_path_info path
 
       paths = [path, "#{path}#{ext}", "#{path}/#{@index}#{ext}"]
@@ -93,6 +93,10 @@ module ActionDispatch
         else
           false
         end
+      end
+
+      def valid_path?(path)
+        path.valid_encoding? && !path.include?("\0")
       end
   end
 

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -40,6 +40,10 @@ module StaticTests
     assert_equal "Hello, World!", get("/doorkeeper%E3E4".force_encoding('ASCII-8BIT')).body
   end
 
+  def test_handles_urls_with_null_byte
+    assert_equal "Hello, World!", get("/doorkeeper%00").body
+  end
+
   def test_sets_cache_control
     app = assert_deprecated do
       ActionDispatch::Static.new(DummyApp, @root, "public, max-age=60")


### PR DESCRIPTION
File paths cannot contain null byte characters and methods that do file path operations such as `Rack::Utils#clean_path_info` will raise unwanted `ArgumentError` exceptions.

By implementing this change the Static middleware will delegate serving the request to the application stack instead of raising an error and responding with a 500 status. Resolves #22235.
