### PR TITLE
do not create an empty `test/helpers` directory

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -134,7 +134,6 @@ module Rails
       empty_directory_with_keep_file 'test/controllers'
       empty_directory_with_keep_file 'test/mailers'
       empty_directory_with_keep_file 'test/models'
-      empty_directory_with_keep_file 'test/helpers'
       empty_directory_with_keep_file 'test/integration'
 
       template 'test/test_helper.rb'
@@ -271,7 +270,6 @@ module Rails
       def delete_app_helpers_if_api_option
         if options[:api]
           remove_dir 'app/helpers'
-          remove_dir 'test/helpers'
         end
       end
 

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -91,7 +91,6 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
        config/initializers/request_forgery_protection.rb
        lib/assets
        vendor/assets
-       test/helpers
        tmp/cache/assets)
   end
 end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -36,7 +36,6 @@ DEFAULT_APP_FILES = %w(
   test/fixtures/files
   test/controllers
   test/models
-  test/helpers
   test/mailers
   test/integration
   vendor
@@ -643,7 +642,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
       test/controllers
       test/mailers
       test/models
-      test/helpers
       test/integration
       tmp
       vendor/assets/stylesheets


### PR DESCRIPTION
Since e5e4d08, Rails no longer generates helpers tests,
I think that there is no need to create a `test/helpers` directory by default.
