### PR TITLE
Match `String#to_time`'s behaviour to ruby

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Match `String#to_time`'s behaviour to that of ruby's implementation for edge cases.
+
+    `nil` is now returned instead of the current date if the string provided does
+    contain time information, but none that is used to build the `Time` object.
+
+    GH#22958
+
+    *Siim Liiser*
+
 *   Match `HashWithIndifferentAccess#default`'s behaviour with `Hash#default`.
 
     *David Cornu*

--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -18,7 +18,8 @@ class String
   #   "12/13/2012".to_time               # => ArgumentError: argument out of range
   def to_time(form = :local)
     parts = Date._parse(self, false)
-    return if parts.empty?
+    used_keys = %i(year mon mday hour min sec sec_fraction offset)
+    return if (parts.keys & used_keys).empty?
 
     now = Time.now
     time = Time.new(

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -444,6 +444,7 @@ class StringConversionsTest < ActiveSupport::TestCase
       assert_equal Time.local(2011, 2, 27, 17, 50), "2011-02-27 13:50 -0100".to_time
       assert_equal Time.utc(2011, 2, 27, 23, 50), "2011-02-27 22:50 -0100".to_time(:utc)
       assert_equal Time.local(2005, 2, 27, 22, 50), "2005-02-27 14:50 -0500".to_time
+      assert_nil "010".to_time
       assert_nil "".to_time
     end
   end


### PR DESCRIPTION
Previously `String#to_time` returned the midnight of the current date
in some cases where there was no relavant information in the string.
Now the method returns `nil` instead in those cases.

Solves issue #22958 
