### PR TITLE
Prevent static middleware from attempting to serve a request with a null byte

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -22,7 +22,7 @@ module ActionDispatch
 
     def match?(path)
       path = URI.parser.unescape(path)
-      return false unless path.valid_encoding?
+      return false unless valid_path?(path)
 
       paths = [path, "#{path}#{ext}", "#{path}/index#{ext}"].map { |v|
         Rack::Utils.clean_path_info v
@@ -85,6 +85,10 @@ module ActionDispatch
         else
           false
         end
+      end
+
+      def valid_path?(path)
+        path.valid_encoding? && !path.include?("\0")
       end
   end
 

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -32,6 +32,10 @@ module StaticTests
     assert_equal "Hello, World!", get("/doorkeeper%E3E4".force_encoding('ASCII-8BIT')).body
   end
 
+  def test_handles_urls_with_null_byte
+    assert_equal "Hello, World!", get("/doorkeeper%00").body
+  end
+
   def test_sets_cache_control
     response = get("/index.html")
     assert_html "/index.html", response


### PR DESCRIPTION
This PR is a backport of #23035.
