### PR TITLE
Change email validation regex to be more restrictive

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
+*   Update email validation regular expression to more accurately catch invalid
+    email addresses.
+
+    Add tests for EmailValidator.
+
+    *Stafford Brunk*
+
 *   Validate multiple contexts on `valid?` and `invalid?` at once.
 
     Example:

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -13,7 +13,7 @@ module ActiveModel
       #   validates :terms, acceptance: true
       #   validates :password, confirmation: true
       #   validates :username, exclusion: { in: %w(admin superuser) }
-      #   validates :email, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: :create }
+      #   validates :email, format: { with: /\A((?:[\w+\-].?)+)@([a-z\d\-]+(?:\.[a-z]+)*\.[a-z]+)\z/i, on: :create }
       #   validates :age, inclusion: { in: 0..9 }
       #   validates :first_name, length: { maximum: 30 }
       #   validates :age, numericality: true
@@ -26,7 +26,7 @@ module ActiveModel
       #   class EmailValidator < ActiveModel::EachValidator
       #     def validate_each(record, attribute, value)
       #       record.errors.add attribute, (options[:message] || "is not an email") unless
-      #         value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+      #         value =~ /\A((?:[\w+\-].?)+)@([a-z\d\-]+(?:\.[a-z]+)*\.[a-z]+)\z/i
       #     end
       #   end
       #

--- a/activemodel/test/cases/validators/email_validator_test.rb
+++ b/activemodel/test/cases/validators/email_validator_test.rb
@@ -1,0 +1,27 @@
+require 'cases/helper'
+require 'models/contact'
+require 'validators/namespace/email_validator'
+
+class EmailValidatorTest < ActiveModel::TestCase
+  setup :setup_contact
+  teardown :reset_callbacks
+
+  def setup_contact
+    reset_callbacks
+    Contact.validates :contact, email: true
+  end
+
+  def reset_callbacks
+    Contact.clear_validators!
+  end
+
+  def test_validates_compliant_email
+    c = Contact.new(contact: 'rawr/foo.bar+baz_bat@example.com')
+    assert c.valid?
+  end
+
+  def test_validates_noncompliant_email
+    c = Contact.new(contact: 'http://foo.bar+baz_bat@example.com')
+    assert c.invalid?
+  end
+end

--- a/activemodel/test/validators/email_validator.rb
+++ b/activemodel/test/validators/email_validator.rb
@@ -1,6 +1,6 @@
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     record.errors[attribute] << (options[:message] || "is not an email") unless
-      value =~ /^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/i
+      value =~ /\A((?:[\w+\-].?)+)@([a-z\d\-]+(?:\.[a-z]+)*\.[a-z]+)\z/i
   end
 end

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -978,7 +978,7 @@ instance.
 ```ruby
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+    unless value =~ /\A((?:[\w+\-].?)+)@([a-z\d\-]+(?:\.[a-z]+)*\.[a-z]+)\z/i
       record.errors[attribute] << (options[:message] || "is not an email")
     end
   end


### PR DESCRIPTION
The current regex will allow invalid values to be validated. An example
would be the address http://foo.bar@foobar.com. The updated regex more
accurately follows email address restrictions and uses the preferred
line start/end syntax.

The documentation for the email validation regex was inconsistent. That is fixed.

The `EmailValidator` was not tested. I added tests for it.

Thanks!
