### PR TITLE
Favor git: 'https://' over github: '...' remotes

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -193,9 +193,9 @@ module Rails
 
         def self.github(name, github, branch = nil, comment = nil)
           if branch
-            new(name, nil, comment, github: github, branch: branch)
+            new(name, nil, comment, git: "https://github.com/#{github}", branch: branch)
           else
-            new(name, nil, comment, github: github)
+            new(name, nil, comment, git: "https://github.com/#{github}")
           end
         end
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -36,7 +36,7 @@ group :development do
 <%- unless options.api? -%>
   # Access an IRB console on exception pages or by using <%%= console %> in views
   <%- if options.dev? || options.edge? -%>
-  gem 'web-console', github: 'rails/web-console'
+  gem 'web-console', git: 'https://github.com/rails/web-console'
   <%- else -%>
   gem 'web-console', '~> 3.0'
   <%- end -%>


### PR DESCRIPTION
From Bundler docs on Security:

> http:// and git:// URLs are insecure. A man-in-the-middle attacker
> could tamper with the code as you check it out, and potentially supply
> you with malicious code instead of the code you meant to check out.
> Because the :github shortcut uses a git:// URL in Bundler 1.x versions,
> we recommend using using HTTPS URLs or overriding the :github shortcut
> with your own HTTPS git source.

Source: http://bundler.io/git.html
