### PR TITLE
`substitute_at` is no longer used

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -74,9 +74,8 @@ module ActiveRecord
               value = foreign_klass.base_class.name
               column = klass.columns_hash[reflection.type.to_s]
 
-              substitute = klass.connection.substitute_at(column)
               binds << Relation::QueryAttribute.new(column.name, value, klass.type_for_attribute(column.name))
-              constraint = constraint.and table[reflection.type].eq substitute
+              constraint = constraint.and table[reflection.type].eq(Arel::Nodes::BindParam.new)
             end
 
             joins << table.create_join(table, table.create_on(constraint), join_type)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -311,12 +311,6 @@ module ActiveRecord
         {}
       end
 
-      # Returns a bind substitution value given a bind +column+
-      # NOTE: The column param is currently being used by the sqlserver-adapter
-      def substitute_at(column, _unused = 0)
-        Arel::Nodes::BindParam.new
-      end
-
       # REFERENTIAL INTEGRITY ====================================
 
       # Override to turn off referential integrity while executing <tt>&block</tt>.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -99,7 +99,7 @@ module ActiveRecord
       end
 
       substitutes = values.map do |(arel_attr, _)|
-        [arel_attr, connection.substitute_at(klass.columns_hash[arel_attr.name])]
+        [arel_attr, Arel::Nodes::BindParam.new]
       end
 
       [substitutes, binds]

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -322,11 +322,6 @@ module ActiveRecord
         end
       end
 
-      def test_substitute_at
-        bind = @connection.substitute_at(nil)
-        assert_equal Arel.sql('$1'), bind.to_sql
-      end
-
       def test_partial_index
         with_example_table do
           @connection.add_index 'ex', %w{ id number }, :name => 'partial', :where => "number > 100"

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -130,11 +130,6 @@ module ActiveRecord
         assert_equal 'UTF-8', @conn.encoding
       end
 
-      def test_bind_value_substitute
-        bind_param = @conn.substitute_at('foo')
-        assert_equal Arel.sql('?'), bind_param.to_sql
-      end
-
       def test_exec_no_binds
         with_example_table 'id int, data string' do
           result = @conn.exec_query('SELECT id, data FROM ex')

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -39,7 +39,7 @@ module ActiveRecord
       end
 
       def test_binds_are_logged
-        sub   = @connection.substitute_at(@pk)
+        sub   = Arel::Nodes::BindParam.new
         binds = [Relation::QueryAttribute.new("id", 1, Type::Value.new)]
         sql   = "select * from topics where id = #{sub.to_sql}"
 


### PR DESCRIPTION
Arel handles substitution for bind parameters by now.
