### PR TITLE
Fix AR::Relation#cache_key to remove select scope added by user

### DIFF
--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -15,6 +15,7 @@ module ActiveRecord
         column = "#{connection.quote_table_name(collection.table_name)}.#{connection.quote_column_name(timestamp_column)}"
 
         query = collection
+          .unscope(:select)
           .select("COUNT(*) AS size", "MAX(#{column}) AS timestamp")
           .unscope(:order)
         result = connection.select_one(query)

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -79,5 +79,11 @@ module ActiveRecord
       developers = Developer.offset(20)
       assert_match(/\Adevelopers\/query-(\h+)-0\Z/, developers.cache_key)
     end
+
+    test "cache_key with a relation having selected columns" do
+      developers = Developer.select(:salary)
+
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/, developers.cache_key)
+    end
   end
 end


### PR DESCRIPTION
- We don't need the select scope added by user as we only want to max
  timestamp and size of the collection. So we already know which columns
  to select.
- Additionally having user defined columns in select scope blows the cache_key
  method with PostGreSQL because it needs all `selected` columns in the group_by
  clause or aggregate function.
- Fixes #23038.

r? @matthewd 
