### PR TITLE
Clean up internal metadata definition

### DIFF
--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -33,13 +33,12 @@ module ActiveRecord
       # Creates an internal metadata table with columns +key+ and +value+
       def create_table
         unless table_exists?
-          connection.create_table(table_name, primary_key: :key, id: false ) do |t|
+          connection.create_table(table_name, id: false) do |t|
             t.column :key,   :string
             t.column :value, :string
             t.timestamps
+            t.index  :key, unique: true, name: index_name
           end
-
-          connection.add_index table_name, :key, unique: true, name: index_name
         end
       end
     end

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -31,8 +31,8 @@ module ActiveRecord
 
           connection.create_table(table_name, id: false) do |t|
             t.column :version, :string, version_options
+            t.index  :version, unique: true, name: index_name
           end
-          connection.add_index table_name, :version, unique: true, name: index_name
         end
       end
 


### PR DESCRIPTION
I extracted and squashed some changes (e1f1b77, 5ceea1a) from #23009.
r? @schneems

Use `t.index` in `create_table` instead of `add_index`

It is slightly more efficient.

Revert "Use `key` as primary key in schema."

This reverts commit 350ae6cdc1ea83e21c23abd10e7e99c9a0bbdbd2.

`:primary_key` option does nothing if `id: false`.

https://github.com/rails/rails/blob/v5.0.0.beta1/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L251-L261
