### PR TITLE
[ci skip] Fix typo in docs

### DIFF
--- a/actioncable/lib/action_cable/connection/identification.rb
+++ b/actioncable/lib/action_cable/connection/identification.rb
@@ -11,7 +11,7 @@ module ActionCable
       end
 
       class_methods do
-        # Mark a key as being a connection identifier index that can then used to find the specific connection again later.
+        # Mark a key as being a connection identifier index that can then be used to find the specific connection again later.
         # Common identifiers are current_user and current_account, but could be anything really.
         #
         # Note that anything marked as an identifier will automatically create a delegate by the same name on any


### PR DESCRIPTION
Found this small omission while reviewing the ActionCable docs.
[Dave Moore]
