### PR TITLE
Fix ActiveRecord::Relation#cache_key for loaded empty collection

### DIFF
--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -7,7 +7,9 @@ module ActiveRecord
 
       if collection.loaded?
         size = collection.size
-        timestamp = collection.max_by(&timestamp_column).public_send(timestamp_column)
+        if size > 0
+          timestamp = collection.max_by(&timestamp_column).public_send(timestamp_column)
+        end
       else
         column_type = type_for_attribute(timestamp_column.to_s)
         column = "#{connection.quote_table_name(collection.table_name)}.#{connection.quote_column_name(timestamp_column)}"

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -66,5 +66,13 @@ module ActiveRecord
       developers = projects(:active_record).developers
       assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/, developers.cache_key)
     end
+
+    test "cache_key for loaded collection with zero size" do
+      Comment.delete_all
+      posts = Post.includes(:comments)
+      empty_loaded_collection = posts.first.comments
+
+      assert_match(/\Acomments\/query-(\h+)-0\Z/, empty_loaded_collection.cache_key)
+    end
   end
 end


### PR DESCRIPTION
- Before this patch if we try to find cache_key of a loaded but empty
  collection it used to give error because of trying to call `updated_at`
  on `nil` value generated by
  `collection.max_by(&timestamp_column).public_send(timestamp_column)`.
- This commit fixes above error by checking if size is greater than zero
  or not.

r? @matthewd 
