### PR TITLE
Fix ActiveRecord::Relation#cache_key for relations with no results

### DIFF
--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -19,8 +19,14 @@ module ActiveRecord
           .unscope(:order)
         result = connection.select_one(query)
 
-        size = result["size"]
-        timestamp = column_type.deserialize(result["timestamp"])
+        if result.blank?
+          size = 0
+          timestamp = nil
+        else
+          size = result["size"]
+          timestamp = column_type.deserialize(result["timestamp"])
+        end
+
       end
 
       if timestamp

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -74,5 +74,10 @@ module ActiveRecord
 
       assert_match(/\Acomments\/query-(\h+)-0\Z/, empty_loaded_collection.cache_key)
     end
+
+    test "cache_key for queries with offset which return 0 rows" do
+      developers = Developer.offset(20)
+      assert_match(/\Adevelopers\/query-(\h+)-0\Z/, developers.cache_key)
+    end
   end
 end


### PR DESCRIPTION
- When relations return no result or 0 result then cache_key should
  handle it gracefully instead of blowing up trying to access
  `result[:size]` and `result[:timestamp]`.
- Fixes #23063.

r? @matthewd 
