### PR TITLE
Avoid Hash from regarded as a proc on Ruby 2.3

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -146,7 +146,7 @@ module ActiveRecord
         private
 
         def interpolate(conditions)
-          if conditions.respond_to?(:to_proc)
+          if !conditions.is_a?(Hash) && conditions.respond_to?(:to_proc)
             instance_eval(&conditions)
           else
             conditions


### PR DESCRIPTION
Ruby 2.3 added to_proc() method to Hash class. interpolate() is expected to
pass-through hashes, but the new method broke the assumption. This patch
add an explicit check for Hash.

I am not sure about Rails 3 update policy, and expect such a bug fix is accepted.
