### PR TITLE
Remove AV dependence on AP's Mime

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -136,7 +136,7 @@ module ActionView
         tag(
           "link",
           "rel"   => tag_options[:rel] || "alternate",
-          "type"  => tag_options[:type] || Mime[type].to_s,
+          "type"  => tag_options[:type] || Template::Types[type].to_s,
           "title" => tag_options[:title] || type.to_s.upcase,
           "href"  => url_options.is_a?(Hash) ? url_for(url_options.merge(:only_path => false)) : url_options
         )

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -67,7 +67,7 @@ module ActionView
       def self.get(details)
         if details[:formats]
           details = details.dup
-          details[:formats] &= Mime::SET.symbols
+          details[:formats] &= Template::Types.symbols
         end
         @details_keys[details] ||= new
       end

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -84,7 +84,7 @@ module ActionView
     end
 
     def rendered_format
-      Mime[lookup_context.rendered_format]
+      Template::Types[lookup_context.rendered_format]
     end
 
     private

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -48,7 +48,7 @@ module ActionView
         type_klass[type]
       end
 
-      def symbols
+      def self.symbols
         type_klass::SET.symbols
       end
     end


### PR DESCRIPTION
There are some test failures, although I'm not really sure why -- AP's Mime has the same end user facing API as AV's Mime implementation. Help would be appreciated! ^_^

Relevant Links:
- ref #17030
- AV's Mime implementation was introduced [here](https://github.com/rails/rails/commit/67f55e282236eef53adc6036e735190b1dda5a47) by @drogus
- other PR implementation was #22700 

r? @rafaelfranca 
