### PR TITLE
Enrich Action View Template types with symbols from Action Dispatch Mime.

### DIFF
--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -5,7 +5,7 @@ module ActionView
   class Template
     class Types
       class Type
-        SET = Struct.new(:symbols).new(Set.new([ :html, :text, :js, :css, :xml, :json ]))
+        SET = Struct.new(:symbols).new([ :html, :text, :js, :css, :xml, :json ])
 
         def self.[](type)
           if type.is_a?(self)

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -28,12 +28,15 @@ module ActionView
           @symbol = symbol.to_sym
         end
 
-        delegate :to_s, :to_sym, :to => :symbol
+        def to_s
+          @symbol.to_s
+        end
         alias to_str to_s
 
         def ref
           @symbol
         end
+        alias to_sym ref
 
         def ==(type)
           @symbol == type.to_sym unless type.blank?

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -5,13 +5,12 @@ module ActionView
   class Template
     class Types
       class Type
-        cattr_accessor :types
-        self.types = Set.new([ :html, :text, :js, :css, :xml, :json ])
+        SET = Set.new([ :html, :text, :js, :css, :xml, :json ])
 
         def self.[](type)
           return type if type.is_a?(self)
 
-          if type.is_a?(Symbol) || types.member?(type.to_s)
+          if type.is_a?(Symbol) || SET.member?(type.to_s)
             new(type)
           end
         end

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -6,13 +6,7 @@ module ActionView
     class Types
       class Type
         cattr_accessor :types
-        self.types = Set.new
-
-        def self.register(*t)
-          types.merge(t.map(&:to_s))
-        end
-
-        register :html, :text, :js, :css,  :xml, :json
+        self.types = Set.new([ :html, :text, :js, :css, :xml, :json ])
 
         def self.[](type)
           return type if type.is_a?(self)

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -32,7 +32,7 @@ module ActionView
         alias to_str to_s
 
         def ref
-          to_sym || to_s
+          @symbol
         end
 
         def ==(type)

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -5,7 +5,7 @@ module ActionView
   class Template
     class Types
       class Type
-        SET = Set.new([ :html, :text, :js, :css, :xml, :json ])
+        SET = Struct.new(:symbols).new(Set.new([ :html, :text, :js, :css, :xml, :json ]))
 
         def self.[](type)
           if type.is_a?(self)
@@ -46,6 +46,10 @@ module ActionView
 
       def self.[](type)
         type_klass[type]
+      end
+
+      def symbols
+        type_klass::SET.symbols
       end
     end
   end

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -36,8 +36,7 @@ module ActionView
         end
 
         def ==(type)
-          return false if type.blank?
-          symbol.to_sym == type.to_sym
+          @symbol == type.to_sym unless type.blank?
         end
       end
 

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -8,9 +8,9 @@ module ActionView
         SET = Set.new([ :html, :text, :js, :css, :xml, :json ])
 
         def self.[](type)
-          return type if type.is_a?(self)
-
-          if type.is_a?(Symbol) || SET.member?(type.to_s)
+          if type.is_a?(self)
+            type
+          else
             new(type)
           end
         end


### PR DESCRIPTION
Needed for https://github.com/rails/rails/pull/23085

Main point is that `Types::Type.types` wouldn't pick any Mime symbols from Action Dispatch. Add `Type::SET.symbols` that maps directly to `Mime::SET.symbols`.

The other commits were simplifying the internals and sparing some `to_sym` calls thrown about.
