### PR TITLE
Fix `ActionDispatch::IntegrationTest#open_session`

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -454,6 +454,7 @@ module ActionDispatch
       # simultaneously.
       def open_session
         dup.tap do |session|
+          session.reset!
           yield session if block_given?
         end
       end


### PR DESCRIPTION
Reset a new session directly after its creation in
`ActionDispatch::IntegrationTest#open_session`. Reset the session to a clean
state before making it available to the client's test code.

Issue #22742 reports unexpected behavior of integration tests that run multiple
sessions. For example an `ActionDispatch::Flash` instance is shared across
multiple sessions, though a client code will rightfully assume that each new
session has its own flash hash.

The following test failed due to this behavior:

```
class Issue22742Test < ActionDispatch::IntegrationTest
  test 'issue #22742' do
    integration_session # initialize first session
    a = open_session
    b = open_session

    refute_same(a.integration_session, b.integration_session)
  end
end
```

Instead of creating a new `ActionDispatch::Integration::Session` instance,
the same instance is shared across all newly opened test sessions. This is
due to the way how new test sessions are created in
`ActionDispatch::IntegrationTest#open_session`. The already existing
`ActionDispatch::IntegrationTest` instance is duplicated  with `Object#dup`,
This approach was introduced in commit 15c31c7639b. `Object#dup` copies the
instance variables, but not the objects they reference. Therefore this issue
only occurred when the current test instance had been tapped in such a way that
the instance variable `@integration_session` was initialized before creating the
new test session.

Close #22742
