### PR TITLE
Fix the order of `create_table` to match a comment about `:inverse_of…

### DIFF
--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -905,7 +905,6 @@ ActiveRecord::Schema.define do
     create_table(t, force: true) {}
   end
 
-  # NOTE - the following 4 tables are used by models that have :inverse_of options on the associations
   create_table :men, force: true do |t|
     t.string  :name
   end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -929,12 +929,12 @@ ActiveRecord::Schema.define do
     t.integer :zine_id
   end
 
-  create_table :wheels, force: true do |t|
-    t.references :wheelable, polymorphic: true
-  end
-
   create_table :zines, force: true do |t|
     t.string :title
+  end
+
+  create_table :wheels, force: true do |t|
+    t.references :wheelable, polymorphic: true
   end
 
   create_table :countries, force: true, id: false, primary_key: "country_id" do |t|


### PR DESCRIPTION
…` options

In ActiveRecord test :men, :faces, :interests and :zines tables are
used for `:inverse_of` test cases, not `:wheels`.
