### PR TITLE
Change show_exceptions default on test template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = true
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
why would you not want to know about exceptions on test env?

looked for references on PR and issues here but no luck, plus it seems the commit that introduced the config on test template had the intention of raising exceptions (_"Raise exceptions instead of rendering error templates in test environment"_ https://github.com/huoxito/rails/commit/d898a4ba425a201827f07a5bb11c8c6bf85159b8) I just don't get why it defaults to false.

I find myself always updating this to have better failure feedback on acceptance tests. Let me know if I'm missing something pls (I'm running railties tests but it takes forever to finish, so far all green to me)
