### PR TITLE
prevent ArgumentError in sanitize_limit

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -335,7 +335,7 @@ module ActiveRecord
         if limit.is_a?(Integer) || limit.is_a?(Arel::Nodes::SqlLiteral)
           limit
         elsif limit.to_s.include?(',')
-          Arel.sql limit.to_s.split(',').map{ |i| Integer(i) }.join(',')
+          Arel.sql limit.to_s.split(',').map(&:to_i).join(',')
         else
           Integer(limit)
         end


### PR DESCRIPTION
``` ruby
irb(main):008:0* Integer "1.3"
ArgumentError: invalid value for Integer(): "1.3"

irb(main):010:0* "1.3".to_i
=> 1
```
