### PR TITLE
Define `:foreign_type` as a valid option in `SingularAssociation`

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -5,7 +5,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_options(options)
-      super + [:foreign_type, :polymorphic, :touch, :counter_cache, :optional]
+      super + [:polymorphic, :touch, :counter_cache, :optional]
     end
 
     def self.valid_dependent_options

--- a/activerecord/lib/active_record/associations/builder/has_one.rb
+++ b/activerecord/lib/active_record/associations/builder/has_one.rb
@@ -5,7 +5,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_options(options)
-      valid = super + [:as, :foreign_type]
+      valid = super + [:as]
       valid += [:through, :source, :source_type] if options[:through]
       valid
     end

--- a/activerecord/lib/active_record/associations/builder/singular_association.rb
+++ b/activerecord/lib/active_record/associations/builder/singular_association.rb
@@ -3,7 +3,7 @@
 module ActiveRecord::Associations::Builder # :nodoc:
   class SingularAssociation < Association #:nodoc:
     def self.valid_options(options)
-      super + [:dependent, :primary_key, :inverse_of, :required]
+      super + [:foreign_type, :dependent, :primary_key, :inverse_of, :required]
     end
 
     def self.define_accessors(model, reflection)


### PR DESCRIPTION
`:foreign_type` is a valid option for `belongs_to` and `has_one`
so remove this to `SingularAssociation`.
