### PR TITLE
Remove unintentional differences in behaviour of SafeBuffer and String

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1955,7 +1955,8 @@ module ActionView
               else
                 options[:child_index] = nested_child_index(name)
               end
-              output << fields_for_nested_model("#{name}[#{options[:child_index]}]", child, options, block)
+              fields = fields_for_nested_model("#{name}[#{options[:child_index]}]", child, options, block)
+              output << fields if fields
             end
             output
           elsif association

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -896,7 +896,7 @@ module ActionView
 
         def form_tag_with_body(html_options, content)
           output = form_tag_html(html_options)
-          output << content
+          output << content if content
           output.safe_concat("</form>")
         end
 

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -206,7 +206,8 @@ module ActiveSupport #:nodoc:
         escaped_args = Array(args).map { |arg| html_escape_interpolated_argument(arg.to_s) }
       end
 
-      self.class.new(super(escaped_args))
+      new_str = super(escaped_args)
+      dup.replace(new_str)
     end
 
     def html_safe?

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -200,9 +200,9 @@ module ActiveSupport #:nodoc:
     def %(args)
       case args
       when Hash
-        escaped_args = Hash[args.map { |k,arg| [k, html_escape_interpolated_argument(arg)] }]
+        escaped_args = Hash[args.map { |k,arg| [k, html_escape_interpolated_argument(arg.to_s)] }]
       else
-        escaped_args = Array(args).map { |arg| html_escape_interpolated_argument(arg) }
+        escaped_args = Array(args).map { |arg| html_escape_interpolated_argument(arg.to_s) }
       end
 
       self.class.new(super(escaped_args))
@@ -242,7 +242,11 @@ module ActiveSupport #:nodoc:
     private
 
     def html_escape_interpolated_argument(arg)
-      (!html_safe? || arg.html_safe?) ? arg : CGI.escapeHTML(arg.to_s)
+      if html_safe? && !arg.html_safe? && arg.respond_to?(:to_str)
+        CGI.escapeHTML(arg.to_str)
+      else
+        arg
+      end
     end
   end
 end

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -194,7 +194,8 @@ module ActiveSupport #:nodoc:
     end
 
     def +(other)
-      dup.concat(other)
+      new_str = super(html_escape_interpolated_argument(other))
+      dup.replace(new_str)
     end
 
     def %(args)

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -642,7 +642,7 @@ class OutputSafetyTest < ActiveSupport::TestCase
   def setup
     @string = "hello"
     @object = Class.new(Object) do
-      def to_s
+      def to_str
         "other"
       end
     end.new

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -36,6 +36,11 @@ class SafeBufferTest < ActiveSupport::TestCase
     assert_equal "&lt;script&gt;", @buffer
   end
 
+  test "Should still concat integer codepoint" do
+    @buffer << 97 << 60 << 98
+    assert_equal "a<b", @buffer
+  end
+
   test "Should be considered safe" do
     assert @buffer.html_safe?
   end
@@ -104,6 +109,10 @@ class SafeBufferTest < ActiveSupport::TestCase
 
     assert_raise TypeError do
       @buffer + {"hello" => "world"}
+    end
+
+    assert_raise TypeError do
+      @buffer + 123
     end
 
     assert_raise TypeError do

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -192,6 +192,16 @@ class SafeBufferTest < ActiveSupport::TestCase
     assert_equal '#&lt;Foo&gt;', x
   end
 
+  test 'Should continue unsafe on interpolation' do
+    fmt = ' foo %s bar '.html_safe
+    fmt.strip!
+    assert !fmt.html_safe?, "should not be safe"
+
+    x = fmt % ["<br/>"]
+    assert_equal 'foo <br/> bar', x
+    assert !x.html_safe?, "should not be safe"
+  end
+
   test 'Should escape unsafe interpolated args' do
     x = 'foo %{x} bar'.html_safe % { x: '<br/>' }
     assert_equal 'foo &lt;br/&gt; bar', x


### PR DESCRIPTION
See #22947 

It makes sense that SafeBuffer should behave like String unless there is a good reason not to. Implicit type coercion was never documented. There was a single test case involving a string-like class with `to_s` method and I believe it was a mistake. Ruby's String uses `to_str` internally to support duck typing but not allow implicit type casts - method `to_s` is defined for all objects and `to_str` is not. 

String interpolation does implicit type coercion so we keep it in SafeBuffer too.
