### PR TITLE
Its ideal to set Vary: Accept-Encoding, irrespective of whether gzipped or not

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -65,7 +65,7 @@ module ActionDispatch
         status, headers, body = @file_server.call(request.env)
       end
 
-      headers['Vary'] = 'Accept-Encoding' if gzip_path
+      headers['Vary'] = 'Accept-Encoding'
 
       return [status, headers, body]
     ensure

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -233,7 +233,7 @@ module StaticTests
     def assert_html(body, response)
       assert_equal body, response.body
       assert_equal "text/html", response.headers["Content-Type"]
-      assert_nil response.headers["Vary"]
+      assert_not_nil response.headers["Vary"]
     end
 
     def get(path, headers = {})


### PR DESCRIPTION
Its ideal to set Vary: Accept-Encoding, irrespective of whether gzipped version exists or not. This is helpful for CDN's to later distinguish assets, based on previous, current copies and introduced gzip version if any.
For ref: https://www.fastly.com/blog/best-practices-for-using-the-vary-header
This change sets `Vary` header always, to be on safer side

r? @schneems 
