### PR TITLE
[close #23084] Deprecated StrongParameters

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -109,7 +109,7 @@ module ActionController
     cattr_accessor :permit_all_parameters, instance_accessor: false
     cattr_accessor :action_on_unpermitted_parameters, instance_accessor: false
 
-    delegate :keys, :key?, :has_key?, :empty?, :include?, :inspect,
+    delegate :keys, :key?, :has_key?, :values, :has_value?, :value?, :empty?, :include?, :inspect,
       :as_json, to: :@parameters
 
     # By default, never raise an UnpermittedParameters exception if these

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -583,11 +583,13 @@ module ActionController
     def method_missing(method_sym, *args, &block)
       if @parameters.respond_to?(method_sym)
         message = <<-DEPRECATE.squish
-          Method #{ method_sym } is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherit from
-          hash. Using this deprecated behavior exposes potential security problems. if you continue to use this method
-          you may be creating a security vulunerability in your app that can be exploited. Instead, consider using one
-          of these public methods that will not be deprecated:
-          #{ public_methods.inspect }
+          Method #{ method_sym } is deprecated and will be removed in Rails 5.1,
+          as `ActionController::Parameters` no longer inherits from
+          hash. Using this deprecated behavior exposes potential security
+          problems. If you continue to use this method you may be creating
+          a security vulunerability in your app that can be exploited. Instead,
+          consider using one of these documented methods which are not
+          deprecated: http://api.rubyonrails.org/v#{ActionPack.version}/classes/ActionController/Parameters.html
         DEPRECATE
         ActiveSupport::Deprecation.warn(message)
         @parameters.public_send(method_sym, *args, &block)

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -580,6 +580,22 @@ module ActionController
       dup
     end
 
+    def method_missing(method_sym, *args, &block)
+      if @parameters.respond_to?(method_sym)
+        message = <<-DEPRECATE.squish
+          Method #{ method_sym } is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherit from
+          hash. Using this deprecated behavior exposes potential security problems. if you continue to use this method
+          you may be creating a security vulunerability in your app that can be exploited. Instead, consider using one
+          of these public methods that will not be deprecated:
+          #{ public_methods.inspect }
+        DEPRECATE
+        ActiveSupport::Deprecation.warn(message)
+        @parameters.public_send(method_sym, *args, &block)
+      else
+        super
+      end
+    end
+
     protected
       def permitted=(new_permitted)
         @permitted = new_permitted

--- a/actionpack/test/controller/required_params_test.rb
+++ b/actionpack/test/controller/required_params_test.rb
@@ -65,4 +65,10 @@ class ParametersRequireTest < ActiveSupport::TestCase
         .require([:first_name, :title])
     end
   end
+
+  test "Deprecated method are deprecated" do
+    assert_deprecated do
+      ActionController::Parameters.new(foo: "bar").merge!({bar: "foo"})
+    end
+  end
 end

--- a/actionpack/test/controller/required_params_test.rb
+++ b/actionpack/test/controller/required_params_test.rb
@@ -66,7 +66,14 @@ class ParametersRequireTest < ActiveSupport::TestCase
     end
   end
 
-  test "Deprecated method are deprecated" do
+  test "value params" do
+    params = ActionController::Parameters.new(foo: "bar", dog: "cinco")
+    assert_equal ["bar", "cinco"], params.values
+    assert params.has_value?("cinco")
+    assert params.value?("cinco")
+  end
+
+  test "Deprecated methods are deprecated" do
     assert_deprecated do
       ActionController::Parameters.new(foo: "bar").merge!({bar: "foo"})
     end


### PR DESCRIPTION
We can provide a more flexible upgrade experience by warning users they are using unsafe methods instead of forcing the safe API by deprecating before removal. This PR provides this functionality.
