### PR TITLE
- Changed from bin/rake to bin/rails at more application places.

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -253,7 +253,7 @@ The generator checks that there exist the directories for models, controllers, h
 The migration requires that we **migrate**, that is, run some Ruby code (living in that `20130717151933_create_high_scores.rb`) to modify the schema of our database. Which database? The SQLite3 database that Rails will create for you when we run the `rake db:migrate` command. We'll talk more about Rake in-depth in a little while.
 
 ```bash
-$ bin/rake db:migrate
+$ bin/rails db:migrate
 ==  CreateHighScores: migrating ===============================================
 -- create_table(:high_scores)
    -> 0.0017s

--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -25,8 +25,8 @@ $ rails new blog -m http://example.com/template.rb
 You can use the rake task `rails:template` to apply templates to an existing Rails application. The location of the template needs to be passed in to an environment variable named LOCATION. Again, this can either be path to a file or a URL.
 
 ```bash
-$ bin/rake rails:template LOCATION=~/template.rb
-$ bin/rake rails:template LOCATION=http://example.com/template.rb
+$ bin/rails rails:template LOCATION=~/template.rb
+$ bin/rails rails:template LOCATION=http://example.com/template.rb
 ```
 
 Template API

--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -96,7 +96,7 @@ NOTE: `ActionDispatch::MiddlewareStack` is Rails equivalent of `Rack::Builder`, 
 Rails has a handy rake task for inspecting the middleware stack in use:
 
 ```bash
-$ bin/rake middleware
+$ bin/rails middleware
 ```
 
 For a freshly generated Rails application, this might produce something like:
@@ -178,7 +178,7 @@ And now if you inspect the middleware stack, you'll find that `Rack::Lock` is
 not a part of it.
 
 ```bash
-$ bin/rake middleware
+$ bin/rails middleware
 (in /Users/lifo/Rails/blog)
 use ActionDispatch::Static
 use #<ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x00000001c304c8>


### PR DESCRIPTION
- Changed from bin/rake to bin/rails at more application places.
- Only ones left are from the upgrading guide, and command line guide explicit section about rake

Follow up of https://github.com/rails/rails/pull/23119

r? @maclover7 
