### PR TITLE
Fix the code of conduct link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@ The Rails team is committed to fostering a welcoming community.
 
 **Our Code of Conduct can be found here**:
 
-http://rubyonrails.org/conduct/
+http://rubyonrails.org/conduct
 
 For a history of updates, see the page history here:
 


### PR DESCRIPTION
The link to the code of conduct was broken, this fixes the link.
