### PR TITLE
Changed html_safe to raw in AV

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -765,7 +765,7 @@ module ActionView
       #   # => <label for="post_privacy_public">Public Post</label>
       #
       #   label(:post, :terms) do
-      #     'Accept <a href="/terms">Terms</a>.'.html_safe
+      #     raw('Accept <a href="/terms">Terms</a>.')
       #   end
       #   # => <label for="post_terms">Accept <a href="/terms">Terms</a>.</label>
       def label(object_name, method, content_or_options = nil, options = nil, &block)
@@ -1675,7 +1675,7 @@ module ActionView
       #   # => <label for="post_privacy_public">Public Post</label>
       #
       #   label(:terms) do
-      #     'Accept <a href="/terms">Terms</a>.'.html_safe
+      #     raw('Accept <a href="/terms">Terms</a>.')
       #   end
       #   # => <label for="post_terms">Accept <a href="/terms">Terms</a>.</label>
       def label(method, text = nil, options = {}, &block)

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -93,22 +93,22 @@ module ActionView
       #   select_tag "people", options_from_collection_for_select(@people, "id", "name", "1")
       #   # <select id="people" name="people"><option value="1" selected="selected">David</option></select>
       #
-      #   select_tag "people", "<option>David</option>".html_safe
+      #   select_tag "people", raw("<option>David</option>")
       #   # => <select id="people" name="people"><option>David</option></select>
       #
-      #   select_tag "count", "<option>1</option><option>2</option><option>3</option><option>4</option>".html_safe
+      #   select_tag "count", raw("<option>1</option><option>2</option><option>3</option><option>4</option>")
       #   # => <select id="count" name="count"><option>1</option><option>2</option>
       #   #    <option>3</option><option>4</option></select>
       #
-      #   select_tag "colors", "<option>Red</option><option>Green</option><option>Blue</option>".html_safe, multiple: true
+      #   select_tag "colors", raw("<option>Red</option><option>Green</option><option>Blue</option>"), multiple: true
       #   # => <select id="colors" multiple="multiple" name="colors[]"><option>Red</option>
       #   #    <option>Green</option><option>Blue</option></select>
       #
-      #   select_tag "locations", "<option>Home</option><option selected='selected'>Work</option><option>Out</option>".html_safe
+      #   select_tag "locations", raw("<option>Home</option><option selected='selected'>Work</option><option>Out</option>")
       #   # => <select id="locations" name="locations"><option>Home</option><option selected='selected'>Work</option>
       #   #    <option>Out</option></select>
       #
-      #   select_tag "access", "<option>Read</option><option>Write</option>".html_safe, multiple: true, class: 'form_input', id: 'unique_id'
+      #   select_tag "access", raw("<option>Read</option><option>Write</option>"), multiple: true, class: 'form_input', id: 'unique_id'
       #   # => <select class="form_input" id="unique_id" multiple="multiple" name="access[]"><option>Read</option>
       #   #    <option>Write</option></select>
       #
@@ -121,7 +121,7 @@ module ActionView
       #   select_tag "people", options_from_collection_for_select(@people, "id", "name"), prompt: "Select something"
       #   # => <select id="people" name="people"><option value="">Select something</option><option value="1">David</option></select>
       #
-      #   select_tag "destination", "<option>NYC</option><option>Paris</option><option>Rome</option>".html_safe, disabled: true
+      #   select_tag "destination", raw("<option>NYC</option><option>Paris</option><option>Rome</option>"), disabled: true
       #   # => <select disabled="disabled" id="destination" name="destination"><option>NYC</option>
       #   #    <option>Paris</option><option>Rome</option></select>
       #

--- a/actionview/lib/action_view/helpers/output_safety_helper.rb
+++ b/actionview/lib/action_view/helpers/output_safety_helper.rb
@@ -22,10 +22,10 @@ module ActionView #:nodoc:
       # the supplied separator, are HTML escaped unless they are HTML
       # safe, and the returned string is marked as HTML safe.
       #
-      #   safe_join(["<p>foo</p>".html_safe, "<p>bar</p>"], "<br />")
+      #   safe_join([raw("<p>foo</p>"), "<p>bar</p>"], "<br />")
       #   # => "<p>foo</p>&lt;br /&gt;&lt;p&gt;bar&lt;/p&gt;"
       #
-      #   safe_join(["<p>foo</p>".html_safe, "<p>bar</p>".html_safe], "<br />".html_safe)
+      #   safe_join([raw("<p>foo</p>"), raw("<p>bar</p>")], raw("<br />")
       #   # => "<p>foo</p><br /><p>bar</p>"
       #
       def safe_join(array, sep=$,)

--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -85,7 +85,7 @@ class ActiveModelHelperTest < ActionView::TestCase
   def test_field_error_proc
     old_proc = ActionView::Base.field_error_proc
     ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
-      %(<div class=\"field_with_errors\">#{html_tag} <span class="error">#{[instance.error_message].join(', ')}</span></div>).html_safe
+      raw(%(<div class=\"field_with_errors\">#{html_tag} <span class="error">#{[instance.error_message].join(', ')}</span></div>))
     end
 
     assert_dom_equal(

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -34,7 +34,7 @@ class CaptureHelperTest < ActionView::TestCase
   end
 
   def test_capture_doesnt_escape_twice
-    string = @av.capture { '&lt;em&gt;bar&lt;/em&gt;'.html_safe }
+    string = @av.capture { raw('&lt;em&gt;bar&lt;/em&gt;') }
     assert_equal '&lt;em&gt;bar&lt;/em&gt;', string
   end
 
@@ -171,7 +171,7 @@ class CaptureHelperTest < ActionView::TestCase
 
     @view_flow = ActionView::OutputFlow.new
     provide :title, "hi"
-    provide :title, "<p>title</p>".html_safe
+    provide :title, raw("<p>title</p>")
     assert_equal "hi<p>title</p>", content_for(:title)
   end
 

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -3207,7 +3207,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_time_tag_with_given_block
-    assert_match(/<time.*><span>Right now<\/span><\/time>/, time_tag(Time.now){ '<span>Right now</span>'.html_safe })
+    assert_match(/<time.*><span>Right now<\/span><\/time>/, time_tag(Time.now){ raw('<span>Right now</span>') })
   end
 
   def test_time_tag_with_different_format

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -336,7 +336,7 @@ class FormHelperTest < ActionView::TestCase
   def test_label_with_block_and_html
     assert_dom_equal(
       '<label for="post_terms">Accept <a href="/terms">Terms</a>.</label>',
-      label(:post, :terms) { 'Accept <a href="/terms">Terms</a>.'.html_safe }
+      label(:post, :terms) { raw('Accept <a href="/terms">Terms</a>.') }
     )
   end
 
@@ -351,7 +351,7 @@ class FormHelperTest < ActionView::TestCase
     with_locale :label do
       assert_dom_equal(
         '<label for="post_body"><b>Write entire text here</b></label>',
-        label(:post, :body) { |b| "<b>#{b.translation}</b>".html_safe }
+        label(:post, :body) { |b| raw("<b>#{b.translation}</b>") }
       )
     end
   end

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -588,7 +588,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
   def test_select_under_fields_for_with_string_and_given_prompt
     @post = Post.new
-    options = "<option value=\"abe\">abe</option><option value=\"mus\">mus</option><option value=\"hest\">hest</option>".html_safe
+    options = raw("<option value=\"abe\">abe</option><option value=\"mus\">mus</option><option value=\"hest\">hest</option>")
 
     output_buffer = fields_for :post, @post do |f|
       concat f.select(:category, options, :prompt => 'The prompt')

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -216,19 +216,19 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_select_tag
-    actual = select_tag "people", "<option>david</option>".html_safe
+    actual = select_tag "people", raw("<option>david</option>")
     expected = %(<select id="people" name="people"><option>david</option></select>)
     assert_dom_equal expected, actual
   end
 
   def test_select_tag_with_multiple
-    actual = select_tag "colors", "<option>Red</option><option>Blue</option><option>Green</option>".html_safe, multiple: true
+    actual = select_tag "colors", raw("<option>Red</option><option>Blue</option><option>Green</option>"), multiple: true
     expected = %(<select id="colors" multiple="multiple" name="colors[]"><option>Red</option><option>Blue</option><option>Green</option></select>)
     assert_dom_equal expected, actual
   end
 
   def test_select_tag_disabled
-    actual = select_tag "places", "<option>Home</option><option>Work</option><option>Pub</option>".html_safe, disabled: true
+    actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), disabled: true
     expected = %(<select id="places" disabled="disabled" name="places"><option>Home</option><option>Work</option><option>Pub</option></select>)
     assert_dom_equal expected, actual
   end
@@ -239,37 +239,37 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_select_tag_with_include_blank
-    actual = select_tag "places", "<option>Home</option><option>Work</option><option>Pub</option>".html_safe, :include_blank => true
+    actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), :include_blank => true
     expected = %(<select id="places" name="places"><option value=""></option><option>Home</option><option>Work</option><option>Pub</option></select>)
     assert_dom_equal expected, actual
   end
 
   def test_select_tag_with_include_blank_false
-    actual = select_tag "places", "<option>Home</option><option>Work</option><option>Pub</option>".html_safe, include_blank: false
+    actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), include_blank: false
     expected = %(<select id="places" name="places"><option>Home</option><option>Work</option><option>Pub</option></select>)
     assert_dom_equal expected, actual
   end
 
   def test_select_tag_with_include_blank_string
-    actual = select_tag "places", "<option>Home</option><option>Work</option><option>Pub</option>".html_safe, include_blank: 'Choose'
+    actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), include_blank: 'Choose'
     expected = %(<select id="places" name="places"><option value="">Choose</option><option>Home</option><option>Work</option><option>Pub</option></select>)
     assert_dom_equal expected, actual
   end
 
   def test_select_tag_with_prompt
-    actual = select_tag "places", "<option>Home</option><option>Work</option><option>Pub</option>".html_safe, :prompt => "string"
+    actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), :prompt => "string"
     expected = %(<select id="places" name="places"><option value="">string</option><option>Home</option><option>Work</option><option>Pub</option></select>)
     assert_dom_equal expected, actual
   end
 
   def test_select_tag_escapes_prompt
-    actual = select_tag "places", "<option>Home</option><option>Work</option><option>Pub</option>".html_safe, :prompt => "<script>alert(1337)</script>"
+    actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), :prompt => "<script>alert(1337)</script>"
     expected = %(<select id="places" name="places"><option value="">&lt;script&gt;alert(1337)&lt;/script&gt;</option><option>Home</option><option>Work</option><option>Pub</option></select>)
     assert_dom_equal expected, actual
   end
 
   def test_select_tag_with_prompt_and_include_blank
-    actual = select_tag "places", "<option>Home</option><option>Work</option><option>Pub</option>".html_safe, :prompt => "string", :include_blank => true
+    actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), :prompt => "string", :include_blank => true
     expected = %(<select name="places" id="places"><option value="">string</option><option value=""></option><option>Home</option><option>Work</option><option>Pub</option></select>)
     assert_dom_equal expected, actual
   end
@@ -433,9 +433,9 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal %(<input checked="checked" disabled="disabled" id="admin" name="admin" readonly="readonly" type="checkbox" value="1" />), check_box_tag("admin", 1, true, 'disabled' => true, :readonly => "yes")
     assert_dom_equal %(<input checked="checked" id="admin" name="admin" type="checkbox" value="1" />), check_box_tag("admin", 1, true, :disabled => false, :readonly => nil)
     assert_dom_equal %(<input type="checkbox" />), tag(:input, :type => "checkbox", :checked => false)
-    assert_dom_equal %(<select id="people" multiple="multiple" name="people[]"><option>david</option></select>), select_tag("people", "<option>david</option>".html_safe, :multiple => true)
-    assert_dom_equal %(<select id="people_" multiple="multiple" name="people[]"><option>david</option></select>), select_tag("people[]", "<option>david</option>".html_safe, :multiple => true)
-    assert_dom_equal %(<select id="people" name="people"><option>david</option></select>), select_tag("people", "<option>david</option>".html_safe, :multiple => nil)
+    assert_dom_equal %(<select id="people" multiple="multiple" name="people[]"><option>david</option></select>), select_tag("people", raw("<option>david</option>"), :multiple => true)
+    assert_dom_equal %(<select id="people_" multiple="multiple" name="people[]"><option>david</option></select>), select_tag("people[]", raw("<option>david</option>"), :multiple => true)
+    assert_dom_equal %(<select id="people" name="people"><option>david</option></select>), select_tag("people", raw("<option>david</option>"), :multiple => nil)
   end
 
   def test_stringify_symbol_keys

--- a/actionview/test/template/output_safety_helper_test.rb
+++ b/actionview/test/template/output_safety_helper_test.rb
@@ -18,10 +18,10 @@ class OutputSafetyHelperTest < ActionView::TestCase
   end
 
   test "safe_join should html_escape any items, including the separator, if they are not html_safe" do
-    joined = safe_join(["<p>foo</p>".html_safe, "<p>bar</p>"], "<br />")
+    joined = safe_join([raw("<p>foo</p>"), "<p>bar</p>"], "<br />")
     assert_equal "<p>foo</p>&lt;br /&gt;&lt;p&gt;bar&lt;/p&gt;", joined
 
-    joined = safe_join(["<p>foo</p>".html_safe, "<p>bar</p>".html_safe], "<br />".html_safe)
+    joined = safe_join([raw("<p>foo</p>"), raw("<p>bar</p>")], raw("<br />"))
     assert_equal "<p>foo</p><br /><p>bar</p>", joined
   end
 

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -143,10 +143,10 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_honors_html_safe_with_escaped_array_class
-    str = tag('p', :class => ['song>', 'play>'.html_safe])
+    str = tag('p', :class => ['song>', raw('play>')])
     assert_equal '<p class="song&gt; play>" />', str
 
-    str = tag('p', :class => ['song>'.html_safe, 'play>'])
+    str = tag('p', :class => [raw('song>'), 'play>'])
     assert_equal '<p class="song> play&gt;" />', str
   end
 

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -78,7 +78,7 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_button_to_with_path
     assert_dom_equal(
       %{<form method="post" action="/article/Hello" class="button_to"><input type="submit" value="Hello" /></form>},
-      button_to("Hello", article_path("Hello".html_safe))
+      button_to("Hello", article_path("Hello"))
     )
   end
 
@@ -106,7 +106,7 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_button_to_with_html_safe_URL
-    assert_dom_equal %{<form method="post" action="http://www.example.com/q1=v1&amp;q2=v2" class="button_to"><input type="submit" value="Hello" /></form>}, button_to("Hello", "http://www.example.com/q1=v1&amp;q2=v2".html_safe)
+    assert_dom_equal %{<form method="post" action="http://www.example.com/q1=v1&amp;q2=v2" class="button_to"><input type="submit" value="Hello" /></form>}, button_to("Hello", raw("http://www.example.com/q1=v1&amp;q2=v2"))
   end
 
   def test_button_to_with_query_and_no_name
@@ -232,7 +232,7 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_link_tag_with_img
-    link = link_to("<img src='/favicon.jpg' />".html_safe, "/")
+    link = link_to(raw("<img src='/favicon.jpg' />"), "/")
     expected = %{<a href="/"><img src='/favicon.jpg' /></a>}
     assert_dom_equal expected, link
   end
@@ -358,7 +358,7 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_link_tag_with_html_safe_string
     assert_dom_equal(
       %{<a href="/article/Gerd_M%C3%BCller">Gerd Müller</a>},
-      link_to("Gerd Müller", article_path("Gerd_Müller".html_safe))
+      link_to("Gerd Müller", article_path("Gerd_Müller"))
     )
   end
 
@@ -369,7 +369,7 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_link_tag_does_not_escape_html_safe_content
     assert_dom_equal %{<a href="/">Malicious <script>content</script></a>},
-      link_to("Malicious <script>content</script>".html_safe, "/")
+      link_to(raw("Malicious <script>content</script>"), "/")
   end
 
   def test_link_to_unless
@@ -380,7 +380,7 @@ class UrlHelperTest < ActiveSupport::TestCase
 
     assert_equal "<strong>Showing</strong>",
       link_to_unless(true, "Showing", url_hash) { |name|
-        "<strong>#{name}</strong>".html_safe
+        raw "<strong>#{name}</strong>"
       }
 
     assert_equal "test",
@@ -390,8 +390,8 @@ class UrlHelperTest < ActiveSupport::TestCase
 
     assert_equal %{&lt;b&gt;Showing&lt;/b&gt;}, link_to_unless(true, "<b>Showing</b>", url_hash)
     assert_equal %{<a href="/">&lt;b&gt;Showing&lt;/b&gt;</a>}, link_to_unless(false, "<b>Showing</b>", url_hash)
-    assert_equal %{<b>Showing</b>}, link_to_unless(true, "<b>Showing</b>".html_safe, url_hash)
-    assert_equal %{<a href="/"><b>Showing</b></a>}, link_to_unless(false, "<b>Showing</b>".html_safe, url_hash)
+    assert_equal %{<b>Showing</b>}, link_to_unless(true, raw("<b>Showing</b>"), url_hash)
+    assert_equal %{<a href="/"><b>Showing</b></a>}, link_to_unless(false, raw("<b>Showing</b>"), url_hash)
   end
 
   def test_link_to_if
@@ -541,13 +541,13 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_mail_to_with_img
     assert_dom_equal %{<a href="mailto:feedback@example.com"><img src="/feedback.png" /></a>},
-      mail_to('feedback@example.com', '<img src="/feedback.png" />'.html_safe)
+      mail_to('feedback@example.com', raw('<img src="/feedback.png" />'))
   end
 
   def test_mail_to_with_html_safe_string
     assert_dom_equal(
       %{<a href="mailto:david@loudthinking.com">david@loudthinking.com</a>},
-      mail_to("david@loudthinking.com".html_safe)
+      mail_to(raw("david@loudthinking.com"))
     )
   end
 


### PR DESCRIPTION
`html_safe` is not supposed to be public API for AV. This change removes usage of `html_safe` in favour of `raw()` in AV helpers.

Also changed usage of `html_safe` to make use of `raw()` instead so that the intended behaviour is verified with `raw()` in AV tests.
