### PR TITLE
Concern generator

### DIFF
--- a/railties/lib/rails/generators/rails/concern/USAGE
+++ b/railties/lib/rails/generators/rails/concern/USAGE
@@ -1,0 +1,11 @@
+Description:
+    Generates concern for the class.
+
+Example:
+    `rails generate concern User::Authentication`
+
+        create  app/models/user/authentication.rb
+
+    `rails generate concern admin_controller/localized`
+
+        create  app/controllers/admin_controller/localized.rb

--- a/railties/lib/rails/generators/rails/concern/concern_generator.rb
+++ b/railties/lib/rails/generators/rails/concern/concern_generator.rb
@@ -1,0 +1,19 @@
+module Rails
+  module Generators
+    class ConcernGenerator < NamedBase # :nodoc:
+      argument :base, type: :string, required: false,
+        banner: 'Base dir with the class',
+        description: 'Use it when class is not inside app/models or app/controllers.'
+
+      def create_concern_files
+        template 'concern.rb', File.join(base_path, "#{file_path}.rb")
+      end
+
+      private
+
+      def base_path
+        base || file_path.include?('_controller/') ? 'app/controllers' : 'app/models'
+      end
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/concern/templates/concern.rb
+++ b/railties/lib/rails/generators/rails/concern/templates/concern.rb
@@ -1,0 +1,14 @@
+module <%= class_name %>
+  extend ActiveSupport::Concern
+
+  included do
+  end
+
+  module ClassMethods
+    def class_method
+    end
+  end
+
+  def instance_method
+  end
+end

--- a/railties/test/generators/concern_generator_test.rb
+++ b/railties/test/generators/concern_generator_test.rb
@@ -1,0 +1,39 @@
+require 'generators/generators_test_helper'
+require 'rails/generators/rails/concern/concern_generator'
+
+class ConcernGeneratorTest < Rails::Generators::TestCase
+  include GeneratorsTestHelper
+  arguments %w(User::Authentication)
+
+  def test_concern_is_created
+    run_generator
+    assert_file 'app/models/user/authentication.rb' do |content|
+      assert_match(/module User::Authentication/, content)
+      assert_match(/extend ActiveSupport::Concern/, content)
+      assert_match(/included do/, content)
+    end
+  end
+
+  def test_concern_on_revoke
+    concern_path = 'app/models/user/authentication.rb'
+    run_generator
+    assert_file concern_path
+    run_generator ['User::Authentication'], behavior: :revoke
+    assert_no_file concern_path
+  end
+end
+
+class ControllerConcernGeneratorTest < Rails::Generators::TestCase
+  include GeneratorsTestHelper
+  self.generator_class = Rails::Generators::ConcernGenerator
+  arguments %w(admin_controller/localized)
+
+  def test_concern_is_created
+    run_generator
+    assert_file 'app/controllers/admin_controller/localized.rb' do |content|
+      assert_match(/module AdminController::Localized/, content)
+      assert_match(/extend ActiveSupport::Concern/, content)
+      assert_match(/included do/, content)
+    end
+  end
+end


### PR DESCRIPTION
It'll generate concern for a class with a basic template. WDYT?

From `USAGE`

```
Example:
    `rails generate concern User::Authentication`

        create  app/models/user/authentication.rb

    `rails generate concern admin_controller/localized`

        create  app/controllers/admin_controller/localized.rb
```

Seems like I can also insert `include #{concern_name}` into target class automatically.
