### PR TITLE
Fix URL typo in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@ The Rails team is committed to fostering a welcoming community.
 
 **Our Code of Conduct can be found here**:
 
-http://rubyonrails.org/conduct/
+http://rubyonrails.org/conduct
 
 For a history of updates, see the page history here:
 


### PR DESCRIPTION
The URL in the code_of_conduct file points to http://rubyonrails.org/conduct/.
With a trailing '/', the URL resolves to a 404.  Without it, life is sweet!
