### PR TITLE
Fix the API documentation layout of after_*_commit

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -233,19 +233,19 @@ module ActiveRecord
         set_callback(:commit, :after, *args, &block)
       end
 
-      # Shortcut for +after_commit :hook, on: :create+.
+      # Shortcut for <tt>after_commit :hook, on: :create</tt>.
       def after_create_commit(*args, &block)
         set_options_for_callbacks!(args, on: :create)
         set_callback(:commit, :after, *args, &block)
       end
 
-      # Shortcut for +after_commit :hook, on: :update+.
+      # Shortcut for <tt>after_commit :hook, on: :update</tt>.
       def after_update_commit(*args, &block)
         set_options_for_callbacks!(args, on: :update)
         set_callback(:commit, :after, *args, &block)
       end
 
-      # Shortcut for +after_commit :hook, on: :destroy+.
+      # Shortcut for <tt>after_commit :hook, on: :destroy</tt>.
       def after_destroy_commit(*args, &block)
         set_options_for_callbacks!(args, on: :destroy)
         set_callback(:commit, :after, *args, &block)


### PR DESCRIPTION
Just noticed this on the [edge API](http://edgeapi.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html).

<img width="334" alt="screen shot 2016-01-20 at 6 31 39 pm" src="https://cloud.githubusercontent.com/assets/604618/12455374/1abea996-bfa4-11e5-9988-aa052a244628.png">

vs

<img width="321" alt="screen shot 2016-01-20 at 6 31 10 pm" src="https://cloud.githubusercontent.com/assets/604618/12455384/23d5a17e-bfa4-11e5-9bea-5d67b5eb019e.png">
