### PR TITLE
WIP: ActiveSupport::PerThreadRegistry is deprecated, remove and replace it with thread_mattr_accessor

### DIFF
--- a/activerecord/lib/active_record/runtime_registry.rb
+++ b/activerecord/lib/active_record/runtime_registry.rb
@@ -1,4 +1,4 @@
-require 'active_support/per_thread_registry'
+require 'active_support/core_ext/module/attribute_accessors_per_thread'
 
 module ActiveRecord
   # This is a thread locals registry for Active Record. For example:
@@ -10,13 +10,6 @@ module ActiveRecord
   # See the documentation of ActiveSupport::PerThreadRegistry
   # for further details.
   class RuntimeRegistry # :nodoc:
-    extend ActiveSupport::PerThreadRegistry
-
-    attr_accessor :connection_handler, :sql_runtime, :connection_id
-
-    [:connection_handler, :sql_runtime, :connection_id].each do |val|
-      class_eval %{ def self.#{val}; instance.#{val}; end }, __FILE__, __LINE__
-      class_eval %{ def self.#{val}=(x); instance.#{val}=x; end }, __FILE__, __LINE__
-    end
+    thread_mattr_accessor :connection_handler, :sql_runtime, :connection_id
   end
 end


### PR DESCRIPTION
WIP: ActiveSupport::PerThreadRegistry is deprecated, remove and replace it with thread_mattr_accessor it by making use of thread_mattr_accessor and registry class methods.

WIP: Checking if all things pass first.
