### PR TITLE
When deleting through records, take into account association conditions

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1215,4 +1215,20 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   ensure
     TenantMembership.current_member = nil
   end
+
+  def test_has_many_through_update_ids_with_conditions
+    author = Author.create :name => "Bill"
+    category = categories(:general)
+    author.update(special_categories_with_condition_ids: [category.id],
+                  nonspecial_categories_with_condition_ids: [category.id])
+
+    assert_equal [category.id], author.special_categories_with_condition_ids
+    assert_equal [category.id], author.nonspecial_categories_with_condition_ids
+
+    author.update(nonspecial_categories_with_condition_ids: [])
+    author.reload
+
+    assert_equal [category.id], author.special_categories_with_condition_ids
+    assert_equal [], author.nonspecial_categories_with_condition_ids
+  end
 end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -85,6 +85,9 @@ class Author < ActiveRecord::Base
   has_many :special_categories, :through => :special_categorizations, :source => :category
   has_one  :special_category,   :through => :special_categorizations, :source => :category
 
+  has_many :special_categories_with_conditions, -> { where(categorizations: {special: true}) }, :through => :categorizations, :source => :category
+  has_many :nonspecial_categories_with_conditions, -> { where(categorizations: {special: false}) }, :through => :categorizations, :source => :category
+
   has_many :categories_like_general, -> { where(:name => 'General') }, :through => :categorizations, :source => :category, :class_name => 'Category'
 
   has_many :categorized_posts, :through => :categorizations, :source => :post


### PR DESCRIPTION
Fixes #18424.

When deleting through records, it didn't take into account the
conditions that may have been affecting join model table, but was
defined in association definition.
