### PR TITLE
Re-add ActionController::ApiRendering

### DIFF
--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -41,6 +41,10 @@ module ActionController
     autoload :UrlFor
   end
 
+  autoload_under "api" do
+    autoload :ApiRendering
+  end
+
   autoload :TestCase,           'action_controller/test_case'
   autoload :TemplateAssertions, 'action_controller/test_case'
 

--- a/actionpack/lib/action_controller/api.rb
+++ b/actionpack/lib/action_controller/api.rb
@@ -112,7 +112,7 @@ module ActionController
 
       UrlFor,
       Redirecting,
-      Rendering,
+      ApiRendering,
       Renderers::All,
       ConditionalGet,
       BasicImplicitRender,

--- a/actionpack/lib/action_controller/api/api_rendering.rb
+++ b/actionpack/lib/action_controller/api/api_rendering.rb
@@ -1,0 +1,14 @@
+module ActionController
+  module ApiRendering
+    extend ActiveSupport::Concern
+
+    included do
+      include Rendering
+    end
+
+    def render_to_body(options = {})
+      _process_options(options)
+      super
+    end
+  end
+end

--- a/actionpack/test/controller/api/renderers_test.rb
+++ b/actionpack/test/controller/api/renderers_test.rb
@@ -19,6 +19,14 @@ class RenderersApiController < ActionController::API
   def two
     render xml: Model.new
   end
+
+  def plain
+    render plain: 'Hi from plain', status: 500
+  end
+
+  def text
+    render text: 'Hi from text', status: 500
+  end
 end
 
 class RenderersApiTest < ActionController::TestCase
@@ -34,5 +42,17 @@ class RenderersApiTest < ActionController::TestCase
     get :two
     assert_response :success
     assert_equal({ a: 'b' }.to_xml, @response.body)
+  end
+
+  def test_render_plain
+    get :plain
+    assert_response :internal_server_error
+    assert_equal('Hi from plain', @response.body)
+  end
+
+  def test_render_text
+    get :text
+    assert_response :internal_server_error
+    assert_equal('Hi from text', @response.body)
   end
 end


### PR DESCRIPTION
- Fixes bug #23142.
- Bug was occurring only with ActionController::API, because `_process_options` wasn't being run for API requests, even though it was being run for normal app requests.
