### PR TITLE
[close #23009] Limit key length

### DIFF
--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -5,6 +5,10 @@ module ActiveRecord
   # This class is used to create a table that keeps track of values and keys such
   # as which environment migrations were run in.
   class InternalMetadata < ActiveRecord::Base # :nodoc:
+    # Keys in mysql are limited to 191 characters, due to this no adapter can
+    # use a longer key
+    KEY_LIMIT = 191
+
     class << self
       def primary_key
         "key"
@@ -34,10 +38,11 @@ module ActiveRecord
       def create_table
         unless table_exists?
           connection.create_table(table_name, id: false) do |t|
-            t.column :key,   :string
+            t.column :key,   :string, null: false, limit: KEY_LIMIT
             t.column :value, :string
-            t.timestamps
             t.index  :key, unique: true, name: index_name
+
+            t.timestamps
           end
         end
       end

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -12,9 +12,35 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_initializes_schema_migrations_for_encoding_utf8mb4
-    smtn = ActiveRecord::Migrator.schema_migrations_table_name
-    connection.drop_table smtn, if_exists: true
+    with_encoding_utf8mb4 do
+      table_name = ActiveRecord::SchemaMigration.table_name
+      connection.drop_table table_name, if_exists: true
 
+      connection.initialize_schema_migrations_table
+
+      assert connection.column_exists?(table_name, :version, :string, collation: 'utf8_general_ci')
+    end
+  end
+
+  def test_initializes_internal_metadata_for_encoding_utf8mb4
+    with_encoding_utf8mb4 do
+      table_name = ActiveRecord::InternalMetadata.table_name
+      connection.drop_table table_name, if_exists: true
+
+      connection.initialize_internal_metadata_table
+
+      assert connection.column_exists?(table_name, :key, :string, collation: 'utf8_general_ci')
+    end
+  end
+
+  def test_key_limit_max_matches_max
+    assert_equal ActiveRecord::InternalMetadata::KEY_LIMIT ,ActiveRecord::ConnectionAdapters::Mysql2Adapter::MAX_INDEX_LENGTH_FOR_CHARSETS_OF_4BYTES_MAXLEN
+  end
+
+
+  private
+
+  def with_encoding_utf8mb4
     database_name = connection.current_database
     database_info = connection.select_one("SELECT * FROM information_schema.schemata WHERE schema_name = '#{database_name}'")
 
@@ -23,15 +49,11 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
 
     execute("ALTER DATABASE #{database_name} DEFAULT CHARACTER SET utf8mb4")
 
-    connection.initialize_schema_migrations_table
-
-    limit = ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::MAX_INDEX_LENGTH_FOR_CHARSETS_OF_4BYTES_MAXLEN
-    assert connection.column_exists?(smtn, :version, :string, limit: limit)
+    yield
   ensure
     execute("ALTER DATABASE #{database_name} DEFAULT CHARACTER SET #{original_charset} COLLATE #{original_collation}")
   end
 
-  private
   def connection
     @connection ||= ActiveRecord::Base.connection
   end


### PR DESCRIPTION
Mysql has a weird bug where it cannot index a string column of utf8mb4 if it is over a certain character limit. To get compatibility with msql we can add a limit to the key column. 191 characters is a very long key, it seems reasonable to limit across all adapters since using a longer key wouldn't be supported in mysql.

Thanks to @kamipo for the original PR and the test refactoring.

Conversation: https://github.com/rails/rails/pull/23009#issuecomment-171416629
