### PR TITLE
Fix warning introduced in API response fix

### DIFF
--- a/actionpack/test/controller/api/renderers_test.rb
+++ b/actionpack/test/controller/api/renderers_test.rb
@@ -51,7 +51,9 @@ class RenderersApiTest < ActionController::TestCase
   end
 
   def test_render_text
-    get :text
+    assert_deprecated do
+      get :text
+    end
     assert_response :internal_server_error
     assert_equal('Hi from text', @response.body)
   end


### PR DESCRIPTION
- Fix warning introduced in https://github.com/vipulnsward/rails/commit/77acc004efad07dfd4d4f83be14ef897968a3fd9 when fixing API  responses.
- render :text is deprecated, so added an assertion around it.
