### PR TITLE
Throw error when user specifies unsupported features to unmapped types..

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1027,6 +1027,9 @@ module ActiveRecord
 
           column_type_sql
         else
+          if limit || precision || scale
+            raise(ActiveRecordError, "Type \"#{type}\" does not support :limit, :precision, or :scale")
+          end
           type.to_s
         end
       end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -241,6 +241,10 @@ module ActiveRecord
     test "type_to_sql returns a String for unmapped types" do
       assert_equal "special_db_type", @connection.type_to_sql(:special_db_type)
     end
+    
+    def test_type_to_sql_throws_error_when_umapped_types_include_options
+      assert_raises(ActiveRecord::ActiveRecordError) { @connection.type_to_sql(:special_db_type,1,1,1) }
+    end  
 
     unless current_adapter?(:PostgreSQLAdapter)
       def test_log_invalid_encoding


### PR DESCRIPTION
I was quickly coding yesterday and attempted to add a column like this,

`add_column :table, :int, :limit => 8`

But of course this doesn't work - I meant :integer instead or the native mysql :int so my :limit option was silently ignored to much confusion.

In this PR, we raise an error if we make it down to type_to_sql in connection_adapters/abstract/schema_statements.rb with precision,limit or scale set and a type that isn't handled elsewhere in the method.

This is much preferable to silently ignoring them.
