### PR TITLE
Use rake proxy in the loading/application tests

### DIFF
--- a/railties/test/application/asset_debugging_test.rb
+++ b/railties/test/application/asset_debugging_test.rb
@@ -44,7 +44,7 @@ module ApplicationTests
     test "assets are concatenated when debug is off and compile is off either if debug_assets param is provided" do
       # config.assets.debug and config.assets.compile are false for production environment
       ENV["RAILS_ENV"] = "production"
-      output = Dir.chdir(app_path){ `bin/rake assets:precompile --trace 2>&1` }
+      output = Dir.chdir(app_path){ `bin/rails assets:precompile --trace 2>&1` }
       assert $?.success?, output
 
       # Load app env

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -19,7 +19,7 @@ module ApplicationTests
     def precompile!(env = nil)
       with_env env.to_h do
         quietly do
-          precompile_task = "bin/rake assets:precompile --trace 2>&1"
+          precompile_task = "bin/rails assets:precompile --trace 2>&1"
           output = Dir.chdir(app_path) { %x[ #{precompile_task} ] }
           assert $?.success?, output
           output
@@ -36,7 +36,7 @@ module ApplicationTests
 
     def clean_assets!
       quietly do
-        assert Dir.chdir(app_path) { system('bin/rake assets:clobber') }
+        assert Dir.chdir(app_path) { system('bin/rails assets:clobber') }
       end
     end
 

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -216,7 +216,7 @@ module ApplicationTests
     test "use schema cache dump" do
       Dir.chdir(app_path) do
         `rails generate model post title:string;
-         bin/rake db:migrate db:schema:cache:dump`
+         bin/rails db:migrate db:schema:cache:dump`
       end
       require "#{app_path}/config/environment"
       ActiveRecord::Base.connection.drop_table("posts") # force drop posts table for test.
@@ -226,7 +226,7 @@ module ApplicationTests
     test "expire schema cache dump" do
       Dir.chdir(app_path) do
         `rails generate model post title:string;
-         bin/rake db:migrate db:schema:cache:dump db:rollback`
+         bin/rails db:migrate db:schema:cache:dump db:rollback`
       end
       silence_warnings {
         require "#{app_path}/config/environment"

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -299,7 +299,7 @@ class LoadingTest < ActiveSupport::TestCase
       end
     MIGRATION
 
-    Dir.chdir(app_path) { `rake db:migrate`}
+    Dir.chdir(app_path) { `rails db:migrate`}
     require "#{rails_root}/config/environment"
 
     get "/title"
@@ -313,7 +313,7 @@ class LoadingTest < ActiveSupport::TestCase
       end
     MIGRATION
 
-    Dir.chdir(app_path) { `rake db:migrate` }
+    Dir.chdir(app_path) { `rails db:migrate` }
 
     get "/body"
     assert_equal "BODY", last_response.body

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -540,7 +540,7 @@ module ApplicationTests
       end
 
       def run_migration
-        Dir.chdir(app_path) { `bin/rake db:migrate` }
+        Dir.chdir(app_path) { `bin/rails db:migrate` }
       end
   end
 end

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -232,7 +232,7 @@ module ApplicationTests
 
       assert_successful_test_run "models/user_test.rb"
 
-      Dir.chdir(app_path) { `bin/rake db:test:prepare` }
+      Dir.chdir(app_path) { `bin/rails db:test:prepare` }
 
       assert_unsuccessful_run "models/user_test.rb", <<-ASSERTION
 Expected: ["id", "name"]


### PR DESCRIPTION
In the loading tests, it's better to use `rails db:migrate` instead of `rake db:migrate`.
