### PR TITLE
Remove action_cable_meta_tag when skip Action Cable

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -318,6 +318,7 @@ module Rails
           remove_file 'config/cable.yml'
           remove_file 'app/assets/javascripts/cable.coffee'
           remove_dir 'app/channels'
+          gsub_file 'app/views/layouts/application.html.erb', /action_cable_meta_tag/, ''
         end
       end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -395,6 +395,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "config/cable.yml"
     assert_no_file "app/assets/javascripts/cable.coffee"
     assert_no_file "app/channels"
+    assert_file "app/views/layouts/application.html.erb" do |content|
+      assert_no_match(/action_cable_meta_tag/, content)
+    end
     assert_file "Gemfile" do |content|
       assert_no_match(/em-hiredis/, content)
       assert_no_match(/redis/, content)


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/pull/22685.

This line should be removed when skipped Action Cable otherwise an error will be raised:

```
ActionView::Template::Error (undefined local variable or method `action_cable_meta_tag' for #<#<Class:0x007fcd8b0ea910>:0x007fcd8a956550>):
     7:
     8:     title Rebase Now
     9:     = csrf_meta_tags
    10:     = action_cable_meta_tag
    11:
    12:     = stylesheet_link_tag "application", media: "all", "data-turbolinks-track" => true
    13:     = javascript_include_tag "application", "data-turbolinks-track" => true
  app/views/layouts/application.slim:10:in `_app_views_layouts_application_slim__3755798539176732894_70260378895220'
```
