### PR TITLE
remove `per_form_csrf_tokens` initializer from Rails API

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -327,6 +327,7 @@ module Rails
           remove_file 'config/initializers/session_store.rb'
           remove_file 'config/initializers/cookies_serializer.rb'
           remove_file 'config/initializers/request_forgery_protection.rb'
+          remove_file 'config/initializers/per_form_csrf_tokens.rb'
         end
       end
 

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -89,6 +89,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
        config/initializers/cookies_serializer.rb
        config/initializers/session_store.rb
        config/initializers/request_forgery_protection.rb
+       config/initializers/per_form_csrf_tokens.rb
        lib/assets
        vendor/assets
        test/helpers


### PR DESCRIPTION
Because the form is not in the Rails API,
`per_form_csrf_tokens` initializer I think unnecessary.
