### PR TITLE
Fix `enum` bug where default column value from migrations was not bei…

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `enum` bug where default column value from migrations was not
+    being respected.
+
+   *Jon Moss*
+
 *   Run `type` attributes through attributes API type-casting before
     instantiating the corresponding subclass. This makes it possible to define
     custom STI mappings.

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -124,7 +124,7 @@ module ActiveRecord
 
       def deserialize(value)
         return if value.nil?
-        mapping.key(value)
+        mapping.key(value.to_i)
       end
 
       def serialize(value)

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -411,4 +411,8 @@ class EnumTest < ActiveRecord::TestCase
     assert book.proposed?, "expected fixture to default to proposed status"
     assert book.in_english?, "expected fixture to default to english language"
   end
+
+  test "default column value is respected" do
+    assert(Book.new.proposed?)
+  end
 end


### PR DESCRIPTION
…ng respected
- ref #23187.
- Correct behavior was introduced in https://github.com/rails/rails/commit/933decceaf6092020ba7ba768b51b2db9d5b882f, but this behavior, was reverted in https://github.com/rails/rails/commit/e991c7b8cd69d7ba5e221a19e5f386e3ba02eb9d.
