### PR TITLE
Use the correct reference to the redis connection

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -17,7 +17,7 @@ module ActionCable
       end
 
       def unsubscribe(channel, message_callback)
-        hi_redis_conn.pubsub.unsubscribe_proc(channel, message_callback)
+        redis_connection_for_subscriptions.pubsub.unsubscribe_proc(channel, message_callback)
       end
 
       private


### PR DESCRIPTION
Fixes #23193

This was throwing `There was an exception - NameError(undefined local variable or method`hi_redis_conn' for #ActionCable::SubscriptionAdapter::Redis:0x007fb1449e2b70)` on unsubscribe.
