### PR TITLE
Re-enable automatic inference of inverse_of for autosave associations

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -281,7 +281,6 @@ module ActiveRecord
       end
 
       def autosave=(autosave)
-        @automatic_inverse_of = false
         @options[:autosave] = autosave
         parent_reflection = self.parent_reflection
         if parent_reflection

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -601,7 +601,8 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
     new_ship = Ship.create(name: 'new name')
     assert_queries(2) do
-      # One query for updating name and second query for updating pirate_id
+      # One query for nullifying pirate_id on the previous ship and second query
+      # for updating pirate_id on new_ship
       pirate.ship = new_ship
     end
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1369,7 +1369,7 @@ module AutosaveAssociationOnACollectionAssociationTests
     @pirate.send(@association_name).each_with_index { |child, i| child.name = new_names[i] }
 
     @pirate.save
-    assert_equal new_names, @pirate.reload.send(@association_name).map(&:name)
+    assert_equal new_names.to_set, @pirate.reload.send(@association_name).map(&:name).to_set
   end
 
   def test_should_automatically_save_bang_the_associated_models
@@ -1377,7 +1377,7 @@ module AutosaveAssociationOnACollectionAssociationTests
     @pirate.send(@association_name).each_with_index { |child, i| child.name = new_names[i] }
 
     @pirate.save!
-    assert_equal new_names, @pirate.reload.send(@association_name).map(&:name)
+    assert_equal new_names.to_set, @pirate.reload.send(@association_name).map(&:name).to_set
   end
 
   def test_should_update_children_when_autosave_is_true_and_parent_is_new_but_child_is_not

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -1096,3 +1096,25 @@ class TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations < ActiveR
     assert_equal ["Ship name can't be blank"], part.errors.full_messages
   end
 end
+
+class TestModelsInstantiatedViaNestedAttributesHaveReflectionOnParent < ActiveRecord::TestCase
+  setup do
+    @pirate = Pirate.new(catchphrase: 'Yarrr!')
+    @ship = Ship.new(name: "The Black Rock")
+  end
+
+  def test_accepts_nested_attributes_and_has_one_work_with_validate_presence_of
+    assert @pirate.update(ship_attributes: { name: "Pearl", validate_pirate: true }),
+           "expected pirate to be saved successfully, but it wasn't"
+  end
+
+  def test_accepts_nested_attributes_and_has_many_work_with_validate_presence_of
+    assert @pirate.update(unscoped_birds_attributes: [{ name: "Polly", validate_pirate: true }]),
+           "expected pirate to be saved successfully, but it wasn't"
+  end
+
+  def test_accepts_nested_attributes_and_belongs_to_work_with_validate_presence_of
+    assert @ship.update(pirate_attributes: { catchphrase: 'Yarrr!', validate_ship: true }),
+           "expected ship to be saved successfully, but it wasn't"
+  end
+end

--- a/activerecord/test/models/bird.rb
+++ b/activerecord/test/models/bird.rb
@@ -4,6 +4,9 @@ class Bird < ActiveRecord::Base
 
   accepts_nested_attributes_for :pirate
 
+  attr_accessor :validate_pirate
+  validates :pirate, presence: true, if: :validate_pirate
+
   attr_accessor :cancel_save_from_callback
   before_save :cancel_save_callback_method, :if => :cancel_save_from_callback
   def cancel_save_callback_method

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -21,6 +21,7 @@ class Pirate < ActiveRecord::Base
   has_one :ship
   has_one :update_only_ship, :class_name => 'Ship'
   has_one :non_validated_ship, :class_name => 'Ship'
+  has_many :unscoped_birds, class_name: 'Bird'
   has_many :birds, -> { order('birds.id ASC') }
   has_many :birds_with_method_callbacks, :class_name => "Bird",
     :before_add    => :log_before_add,
@@ -37,6 +38,7 @@ class Pirate < ActiveRecord::Base
   has_one :foo_bulb, -> { where :name => 'foo' }, :foreign_key => :car_id, :class_name => "Bulb"
 
   accepts_nested_attributes_for :parrots, :birds, :allow_destroy => true, :reject_if => proc(&:empty?)
+  accepts_nested_attributes_for :unscoped_birds
   accepts_nested_attributes_for :ship, :allow_destroy => true, :reject_if => proc(&:empty?)
   accepts_nested_attributes_for :update_only_ship, :update_only => true
   accepts_nested_attributes_for :parrots_with_method_callbacks, :parrots_with_proc_callbacks,
@@ -44,6 +46,9 @@ class Pirate < ActiveRecord::Base
   accepts_nested_attributes_for :birds_with_reject_all_blank, :reject_if => :all_blank
 
   validates_presence_of :catchphrase
+
+  attr_accessor :validate_ship
+  validates :ship, presence: true, if: :validate_ship
 
   def ship_log
     @ship_log ||= []

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -13,6 +13,9 @@ class Ship < ActiveRecord::Base
 
   validates_presence_of :name
 
+  attr_accessor :validate_pirate
+  validates :pirate, presence: true, if: :validate_pirate
+
   attr_accessor :cancel_save_from_callback
   before_save :cancel_save_callback_method, :if => :cancel_save_from_callback
   def cancel_save_callback_method


### PR DESCRIPTION
Fixes issues: #9336, #22391, #22358, #23163, #23171, and probably more.

We weren't automatically inferring the inverse_of for autosaved associations. This appears to have been a hack in order to avoid double-save problems with nested attributes but at the expense of not being able to access the parent model during the save callback chain.

Among other things this was preventing validation of parent(s) when creating childen via nested attributes.

The correct fix is to automatically infer inverse_of for autosaved associations and to address the root issue of double queries, which is to ensure that child records saved in callbacks do not cause a duplicate save on the parent.

We do this by wrapping autosaves of associated records in a block which temporarily disables the reverse autosave leading back to the record which triggered it. This ensures we only save each record in the chain once.
