### PR TITLE
Move ApplicationCable::Channel section of readme

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -66,6 +66,13 @@ end
 Here `identified_by` is a connection identifier that can be used to find the specific connection again or later.
 Note that anything marked as an identifier will automatically create a delegate by the same name on any channel instances created off the connection.
 
+This relies on the fact that you will already have handled authentication of the user, and
+that a successful authentication sets a signed cookie with the `user_id`. This cookie is then
+automatically sent to the connection instance when a new connection is attempted, and you
+use that to set the `current_user`. By identifying the connection by this same current_user,
+you're also ensuring that you can later retrieve all open connections by a given user (and
+potentially disconnect them all if the user is deleted or deauthorized).
+
 Then you should define your `ApplicationCable::Channel` class in Ruby. This is the place where you put
 shared logic between your channels.
 
@@ -76,13 +83,6 @@ module ApplicationCable
   end
 end
 ```
-
-This relies on the fact that you will already have handled authentication of the user, and
-that a successful authentication sets a signed cookie with the `user_id`. This cookie is then
-automatically sent to the connection instance when a new connection is attempted, and you
-use that to set the `current_user`. By identifying the connection by this same current_user,
-you're also ensuring that you can later retrieve all open connections by a given user (and
-potentially disconnect them all if the user is deleted or deauthorized).
 
 The client-side needs to setup a consumer instance of this connection. That's done like so:
 


### PR DESCRIPTION
I believe the paragraph starting with "This relies" belongs with the one above it.
