### PR TITLE
WIP: Errors in logs should show log tags as well.

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -149,22 +149,26 @@ module ActionDispatch
     def log_error(request, wrapper)
       logger = logger(request)
       return unless logger
-
       exception = wrapper.exception
 
       trace = wrapper.application_trace
       trace = wrapper.framework_trace if trace.empty?
 
       ActiveSupport::Deprecation.silence do
-        message = "\n#{exception.class} (#{exception.message}):\n"
-        message << exception.annoted_source_code.to_s if exception.respond_to?(:annoted_source_code)
-        message << "  " << trace.join("\n  ")
-        logger.fatal("#{message}\n\n")
+        logger.fatal "  "
+        logger.fatal "#{exception.class} (#{exception.message}):"
+        log_array logger, exception.annoted_source_code if exception.respond_to?(:annoted_source_code)
+        logger.fatal "  "
+        log_array logger, trace
       end
     end
 
-    def logger(request)
-      request.logger || stderr_logger
+    def log_array logger, array
+      array.map { |line| logger.fatal line}
+    end
+
+    def logger request
+      request.logger || ActionView::Base.logger || stderr_logger
     end
 
     def stderr_logger

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -135,13 +135,13 @@ module ActionView
         end
 
         def formatted_code_for(source_code, line_counter, indent, output)
-          start_value = (output == :html) ? {} : ""
+          start_value = (output == :html) ? {} : []
           source_code.inject(start_value) do |result, line|
             line_counter += 1
             if output == :html
               result.update(line_counter.to_s => "%#{indent}s %s\n" % ["", line])
             else
-              result << "%#{indent}s: %s\n" % [line_counter, line]
+              result << "%#{indent}s: %s" % [line_counter, line]
             end
           end
         end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -226,13 +226,13 @@ module RenderTestCases
     assert_match %r!method.*doesnt_exist!, e.message
     assert_equal "", e.sub_template_message
     assert_equal "1", e.line_number
-    assert_equal "1: <%= doesnt_exist %>", e.annoted_source_code.strip
+    assert_equal "1: <%= doesnt_exist %>", e.annoted_source_code[0].strip
     assert_equal File.expand_path("#{FIXTURE_LOAD_PATH}/test/_raise.html.erb"), e.file_name
   end
 
   def test_render_error_indentation
     e = assert_raises(ActionView::Template::Error) { @view.render(:partial => "test/raise_indentation") }
-    error_lines = e.annoted_source_code.split("\n")
+    error_lines = e.annoted_source_code
     assert_match %r!error\shere!, e.message
     assert_equal "11", e.line_number
     assert_equal "     9: <p>Ninth paragraph</p>", error_lines.second
@@ -252,7 +252,7 @@ module RenderTestCases
     assert_match %r!method.*doesnt_exist!, e.message
     assert_equal "", e.sub_template_message
     assert_equal "1", e.line_number
-    assert_equal "1: <%= doesnt_exist %>", e.annoted_source_code.strip
+    assert_equal "1: <%= doesnt_exist %>", e.annoted_source_code[0].strip
     assert_equal File.expand_path("#{FIXTURE_LOAD_PATH}/test/_raise.html.erb"), e.file_name
   end
 


### PR DESCRIPTION
- Changed formatted_code_for to return array of logs to be tagged for each line
- Changed some render tests to match new behaviour of return

Fixes #22979 

r? @schneems 

Opening to get feedback on the logger to be used. We construct new logger from env, that doesn't log tags, which for example- `ActionView::Base.logger` does.
 What's an appropriate logger here though? I believe `ActionView::Base.logger`, since thats where the error arises from.
