### PR TITLE
prevent --skip-action-cable from erroring when --api option is used

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -318,7 +318,7 @@ module Rails
           remove_file 'config/cable.yml'
           remove_file 'app/assets/javascripts/cable.coffee'
           remove_dir 'app/channels'
-          gsub_file 'app/views/layouts/application.html.erb', /action_cable_meta_tag/, ''
+          gsub_file 'app/views/layouts/application.html.erb', /action_cable_meta_tag/, '' unless options[:api]
         end
       end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -405,6 +405,18 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_generator_if_skip_action_cable_is_given_for_an_api_app
+    run_generator [destination_root, "--skip-action-cable", "--api"]
+    assert_file "config/application.rb", /#\s+require\s+["']action_cable\/engine["']/
+    assert_no_file "config/cable.yml"
+    assert_no_file "app/assets/javascripts/cable.coffee"
+    assert_no_file "app/channels"
+    assert_file "Gemfile" do |content|
+      assert_no_match(/em-hiredis/, content)
+      assert_no_match(/redis/, content)
+    end
+  end
+
   def test_action_cable_redis_gems
     run_generator
     assert_gem 'em-hiredis'


### PR DESCRIPTION
Fixes #22868 
