### PR TITLE
ActionCable testing

### DIFF
--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -49,4 +49,6 @@ module ActionCable
   autoload :Channel
   autoload :RemoteConnections
   autoload :SubscriptionAdapter
+  autoload :TestCase
+  autoload :TestHelper
 end

--- a/actioncable/lib/action_cable/subscription_adapter.rb
+++ b/actioncable/lib/action_cable/subscription_adapter.rb
@@ -3,6 +3,7 @@ module ActionCable
     extend ActiveSupport::Autoload
 
     autoload :Base
+    autoload :Test
     autoload :SubscriberMap
     autoload :ChannelPrefix
   end

--- a/actioncable/lib/action_cable/subscription_adapter/test.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/test.rb
@@ -1,0 +1,32 @@
+module ActionCable
+  module SubscriptionAdapter
+    # == Test adapter for Action Cable
+    #
+    # The test adapter should be used only in testing. Along with
+    # <tt>ActionCable::TestHelper</tt> it makes a great tool to test your Rails application.
+    #
+    # To use the test adapter set adapter value to +test+ in your +cable.yml+.
+    class Test < Base
+      def broadcast(channel, payload)
+        broadcasts(channel) << payload
+      end
+
+      def broadcasts(channel)
+        channels_data[channel] ||= []
+      end
+
+      def clear_messages(channel)
+        channels_data[channel] = []
+      end
+
+      def reset!
+        @channels_data = nil
+      end
+
+      private
+        def channels_data
+          @channels_data ||= {}
+        end
+    end
+  end
+end

--- a/actioncable/lib/action_cable/test_case.rb
+++ b/actioncable/lib/action_cable/test_case.rb
@@ -1,0 +1,7 @@
+require "active_support/test_case"
+
+module ActionCable
+  class TestCase < ActiveSupport::TestCase
+    include ActionCable::TestHelper
+  end
+end

--- a/actioncable/lib/action_cable/test_helper.rb
+++ b/actioncable/lib/action_cable/test_helper.rb
@@ -1,0 +1,124 @@
+module ActionCable
+  # Provides helper methods for testing Action Cable broadcasting
+  module TestHelper
+    extend ActiveSupport::Concern
+
+    included do
+      def before_setup # :nodoc:
+        server = ActionCable.server
+        test_adapter = ActionCable::SubscriptionAdapter::Test.new(server)
+
+        @old_pubsub_adapter = server.pubsub
+
+        server.instance_variable_set(:@pubsub, test_adapter)
+        super
+      end
+
+      def after_teardown # :nodoc:
+        super
+        ActionCable.server.instance_variable_set(:@pubsub, @old_pubsub_adapter)
+      end
+
+      # Asserts that the number of broadcasted messages to the channel matches the given number.
+      #
+      #   def test_broadcasts
+      #     assert_broadcasts 'messages', 0
+      #     ActionCable.server.broadcast 'messages', { text: 'hello' }
+      #     assert_broadcasts 'messages', 1
+      #     ActionCable.server.broadcast 'messages', { text: 'world' }
+      #     assert_broadcasts 'messages', 2
+      #   end
+      #
+      # If a block is passed, that block should cause the specified number of
+      # messages to be broadcasted.
+      #
+      #   def test_broadcasts_again
+      #     assert_broadcasts('messages', 1) do
+      #       ActionCable.server.broadcast 'messages', { text: 'hello' }
+      #     end
+      #
+      #     assert_broadcasts('messages', 2) do
+      #       ActionCable.server.broadcast 'messages', { text: 'hi' }
+      #       ActionCable.server.broadcast 'messages', { text: 'how are you?' }
+      #     end
+      #   end
+      def assert_broadcasts(channel, number)
+        if block_given?
+          original_count = broadcasts_size(channel)
+          yield
+          new_count = broadcasts_size(channel)
+          assert_equal number, new_count - original_count, "#{number} broadcasts to #{channel} expected, but #{new_count - original_count} were sent"
+        else
+          actual_count = broadcasts_size(channel)
+          assert_equal number, actual_count, "#{number} broadcasts to #{channel} expected, but #{actual_count} were sent"
+        end
+      end
+
+      # Asserts that no messages have been sent to the channel.
+      #
+      #   def test_no_broadcasts
+      #     assert_no_broadcasts 'messages'
+      #     ActionCable.server.broadcast 'messages', { text: 'hi' }
+      #     assert_broadcasts 'messages', 1
+      #   end
+      #
+      # If a block is passed, that block should not cause any message to be sent.
+      #
+      #   def test_broadcasts_again
+      #     assert_no_broadcasts 'messages' do
+      #       # No job messages should be sent from this block
+      #     end
+      #   end
+      #
+      # Note: This assertion is simply a shortcut for:
+      #
+      #   assert_broadcasts 'messages', 0, &block
+      def assert_no_broadcasts(channel, &block)
+        assert_broadcasts channel, 0, &block
+      end
+
+      # Asserts that the specified message has been sent to the channel.
+      #
+      #   def test_assert_transmited_message
+      #     ActionCable.server.broadcast 'messages', text: 'hello'
+      #     assert_broadcast_on('messages', text: 'hello')
+      #   end
+      #
+      # If a block is passed, that block should cause a message with the specified data to be sent.
+      #
+      #   def test_assert_broadcast_on_again
+      #     assert_broadcast_on('messages', text: 'hello') do
+      #       ActionCable.server.broadcast 'messages', text: 'hello'
+      #     end
+      #   end
+      def assert_broadcast_on(channel, data)
+        serialized_msg = ActiveSupport::JSON.encode(data)
+        new_messages = broadcasts(channel)
+        if block_given?
+          old_messages = new_messages
+          clear_messages(channel)
+
+          yield
+          new_messages = broadcasts(channel)
+          clear_messages(channel)
+
+          # Restore all sent messages
+          (old_messages + new_messages).each { |m| pubsub_adapter.broadcast(channel, m) }
+        end
+
+        assert_includes new_messages, serialized_msg, "No messages sent with #{data} to #{channel}"
+      end
+
+      def pubsub_adapter # :nodoc:
+        ActionCable.server.pubsub
+      end
+
+      delegate :broadcasts, :clear_messages, to: :pubsub_adapter
+
+      private
+        def broadcasts_size(channel) # :nodoc:
+          broadcasts(channel).size
+        end
+    end
+  end
+end

--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -13,6 +13,11 @@ end
 # Require all the stubs and models
 Dir[File.expand_path("stubs/*.rb", __dir__)].each { |file| require file }
 
+# # Set test adapter and logger
+ActionCable.server.config.cable = { "adapter" => "test" }
+ActionCable.server.config.logger =
+  ActiveSupport::TaggedLogging.new ActiveSupport::Logger.new(StringIO.new)
+
 class ActionCable::TestCase < ActiveSupport::TestCase
   def wait_for_async
     wait_for_executor Concurrent.global_io_executor

--- a/actioncable/test/test_helper_test.rb
+++ b/actioncable/test/test_helper_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+require "stubs/test_server"
+
+class TransmissionsTest < ActionCable::TestCase
+  def test_assert_broadcasts
+    assert_nothing_raised do
+      assert_broadcasts("test", 1) do
+        ActionCable.server.broadcast "test", "message"
+      end
+    end
+  end
+
+  def test_assert_broadcasts_with_no_block
+    assert_nothing_raised do
+      ActionCable.server.broadcast "test", "message"
+      assert_broadcasts "test", 1
+    end
+
+    assert_nothing_raised do
+      ActionCable.server.broadcast "test", "message 2"
+      ActionCable.server.broadcast "test", "message 3"
+      assert_broadcasts "test", 3
+    end
+  end
+
+  def test_assert_no_broadcasts_with_no_block
+    assert_nothing_raised do
+      assert_no_broadcasts "test"
+    end
+  end
+
+  def test_assert_no_broadcasts
+    assert_nothing_raised do
+      assert_no_broadcasts("test") do
+        ActionCable.server.broadcast "test2", "message"
+      end
+    end
+  end
+
+  def test_assert_broadcasts_message_too_few_sent
+    ActionCable.server.broadcast "test", "hello"
+    error = assert_raises Minitest::Assertion do
+      assert_broadcasts("test", 2) do
+        ActionCable.server.broadcast "test", "world"
+      end
+    end
+
+    assert_match(/2 .* but 1/, error.message)
+  end
+
+  def test_assert_broadcasts_message_too_many_sent
+    error = assert_raises Minitest::Assertion do
+      assert_broadcasts("test", 1) do
+        ActionCable.server.broadcast "test", "hello"
+        ActionCable.server.broadcast "test", "world"
+      end
+    end
+
+    assert_match(/1 .* but 2/, error.message)
+  end
+end
+
+class TransmitedDataTest < ActionCable::TestCase
+  include ActionCable::TestHelper
+
+  def test_assert_broadcast_on
+    assert_nothing_raised do
+      assert_broadcast_on("test", "message") do
+        ActionCable.server.broadcast "test", "message"
+      end
+    end
+  end
+
+  def test_assert_broadcast_on_with_hash
+    assert_nothing_raised do
+      assert_broadcast_on("test", text: "hello") do
+        ActionCable.server.broadcast "test", text: "hello"
+      end
+    end
+  end
+
+  def test_assert_broadcast_on_with_no_block
+    assert_nothing_raised do
+      ActionCable.server.broadcast "test", "hello"
+      assert_broadcast_on "test", "hello"
+    end
+
+    assert_nothing_raised do
+      ActionCable.server.broadcast "test", "world"
+      assert_broadcast_on "test", "world"
+    end
+  end
+
+  def test_assert_broadcast_on_message
+    ActionCable.server.broadcast "test", "hello"
+    error = assert_raises Minitest::Assertion do
+      assert_broadcast_on("test", "world")
+    end
+
+    assert_match(/No messages sent/, error.message)
+  end
+end


### PR DESCRIPTION
I've started to play with ActionCable and realized that we don't have any tools for Cable testing.
Here is a kind of scratch of what (as I think) Cable testing could be.

This test helper only deals with transmissions (just like ActiveJob's one). Example:

``` ruby
test 'message broadcasting block style' do
  assert_transmissions(1, "messages:#{@hello_msg.id}:comments") do
    CommentRelayJob.perform_now(@hello_comment)
  end
end
```

More examples can be found [here](https://github.com/palkan/actioncable-examples/blob/master/test/jobs/comment_relay_job_test.rb).

And there are some questions to discuss:
- How to unit test channels?
- Do we need such testing at all?
