### PR TITLE
Be consistent in testing outputs from railties test and use /bin/rails

### DIFF
--- a/railties/test/application/asset_debugging_test.rb
+++ b/railties/test/application/asset_debugging_test.rb
@@ -44,7 +44,7 @@ module ApplicationTests
     test "assets are concatenated when debug is off and compile is off either if debug_assets param is provided" do
       # config.assets.debug and config.assets.compile are false for production environment
       ENV["RAILS_ENV"] = "production"
-      output = Dir.chdir(app_path){ `bin/rake assets:precompile --trace 2>&1` }
+      output = Dir.chdir(app_path){ `bin/rails assets:precompile --trace 2>&1` }
       assert $?.success?, output
 
       # Load app env

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -19,7 +19,7 @@ module ApplicationTests
     def precompile!(env = nil)
       with_env env.to_h do
         quietly do
-          precompile_task = "bin/rake assets:precompile --trace 2>&1"
+          precompile_task = "bin/rails assets:precompile --trace 2>&1"
           output = Dir.chdir(app_path) { %x[ #{precompile_task} ] }
           assert $?.success?, output
           output
@@ -36,7 +36,7 @@ module ApplicationTests
 
     def clean_assets!
       quietly do
-        assert Dir.chdir(app_path) { system('bin/rake assets:clobber') }
+        assert Dir.chdir(app_path) { system('bin/rails assets:clobber') }
       end
     end
 

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -216,7 +216,7 @@ module ApplicationTests
     test "use schema cache dump" do
       Dir.chdir(app_path) do
         `rails generate model post title:string;
-         bin/rake db:migrate db:schema:cache:dump`
+         bin/rails db:migrate db:schema:cache:dump`
       end
       require "#{app_path}/config/environment"
       ActiveRecord::Base.connection.drop_table("posts") # force drop posts table for test.
@@ -226,7 +226,7 @@ module ApplicationTests
     test "expire schema cache dump" do
       Dir.chdir(app_path) do
         `rails generate model post title:string;
-         bin/rake db:migrate db:schema:cache:dump db:rollback`
+         bin/rails db:migrate db:schema:cache:dump db:rollback`
       end
       silence_warnings {
         require "#{app_path}/config/environment"

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -22,14 +22,14 @@ module ApplicationTests
             end
           MIGRATION
 
-          output = `bin/rake db:migrate SCOPE=bukkits`
+          output = `bin/rails db:migrate SCOPE=bukkits`
           assert_no_match(/create_table\(:users\)/, output)
           assert_no_match(/CreateUsers/, output)
           assert_no_match(/add_column\(:users, :email, :string\)/, output)
 
           assert_match(/AMigration: migrated/, output)
 
-          output = `bin/rake db:migrate SCOPE=bukkits VERSION=0`
+          output = `bin/rails db:migrate SCOPE=bukkits VERSION=0`
           assert_no_match(/drop_table\(:users\)/, output)
           assert_no_match(/CreateUsers/, output)
           assert_no_match(/remove_column\(:users, :email\)/, output)
@@ -43,13 +43,13 @@ module ApplicationTests
           `bin/rails generate model user username:string password:string;
            bin/rails generate migration add_email_to_users email:string`
 
-           output = `bin/rake db:migrate`
+           output = `bin/rails db:migrate`
            assert_match(/create_table\(:users\)/, output)
            assert_match(/CreateUsers: migrated/, output)
            assert_match(/add_column\(:users, :email, :string\)/, output)
            assert_match(/AddEmailToUsers: migrated/, output)
 
-           output = `bin/rake db:rollback STEP=2`
+           output = `bin/rails db:rollback STEP=2`
            assert_match(/drop_table\(:users\)/, output)
            assert_match(/CreateUsers: reverted/, output)
            assert_match(/remove_column\(:users, :email, :string\)/, output)
@@ -58,7 +58,7 @@ module ApplicationTests
       end
 
       test 'migration status when schema migrations table is not present' do
-        output = Dir.chdir(app_path){ `bin/rake db:migrate:status 2>&1` }
+        output = Dir.chdir(app_path){ `bin/rails db:migrate:status 2>&1` }
         assert_equal "Schema migrations table does not exist yet.\n", output
       end
 
@@ -66,15 +66,15 @@ module ApplicationTests
         Dir.chdir(app_path) do
           `bin/rails generate model user username:string password:string;
            bin/rails generate migration add_email_to_users email:string;
-           bin/rake db:migrate`
+           bin/rails db:migrate`
 
-          output = `bin/rake db:migrate:status`
+          output = `bin/rails db:migrate:status`
 
           assert_match(/up\s+\d{14}\s+Create users/, output)
           assert_match(/up\s+\d{14}\s+Add email to users/, output)
 
-          `bin/rake db:rollback STEP=1`
-          output = `bin/rake db:migrate:status`
+          `bin/rails db:rollback STEP=1`
+          output = `bin/rails db:migrate:status`
 
           assert_match(/up\s+\d{14}\s+Create users/, output)
           assert_match(/down\s+\d{14}\s+Add email to users/, output)
@@ -87,15 +87,15 @@ module ApplicationTests
         Dir.chdir(app_path) do
           `bin/rails generate model user username:string password:string;
            bin/rails generate migration add_email_to_users email:string;
-           bin/rake db:migrate`
+           bin/rails db:migrate`
 
-          output = `bin/rake db:migrate:status`
+          output = `bin/rails db:migrate:status`
 
           assert_match(/up\s+\d{3,}\s+Create users/, output)
           assert_match(/up\s+\d{3,}\s+Add email to users/, output)
 
-          `bin/rake db:rollback STEP=1`
-          output = `bin/rake db:migrate:status`
+          `bin/rails db:rollback STEP=1`
+          output = `bin/rails db:migrate:status`
 
           assert_match(/up\s+\d{3,}\s+Create users/, output)
           assert_match(/down\s+\d{3,}\s+Add email to users/, output)
@@ -106,21 +106,21 @@ module ApplicationTests
         Dir.chdir(app_path) do
           `bin/rails generate model user username:string password:string;
            bin/rails generate migration add_email_to_users email:string;
-           bin/rake db:migrate`
+           bin/rails db:migrate`
 
-           output = `bin/rake db:migrate:status`
+           output = `bin/rails db:migrate:status`
 
            assert_match(/up\s+\d{14}\s+Create users/, output)
            assert_match(/up\s+\d{14}\s+Add email to users/, output)
 
-           `bin/rake db:rollback STEP=2`
-           output = `bin/rake db:migrate:status`
+           `bin/rails db:rollback STEP=2`
+           output = `bin/rails db:migrate:status`
 
            assert_match(/down\s+\d{14}\s+Create users/, output)
            assert_match(/down\s+\d{14}\s+Add email to users/, output)
 
-           `bin/rake db:migrate:redo`
-           output = `bin/rake db:migrate:status`
+           `bin/rails db:migrate:redo`
+           output = `bin/rails db:migrate:status`
 
            assert_match(/up\s+\d{14}\s+Create users/, output)
            assert_match(/up\s+\d{14}\s+Add email to users/, output)
@@ -133,21 +133,21 @@ module ApplicationTests
         Dir.chdir(app_path) do
           `bin/rails generate model user username:string password:string;
            bin/rails generate migration add_email_to_users email:string;
-           bin/rake db:migrate`
+           bin/rails db:migrate`
 
-           output = `bin/rake db:migrate:status`
+           output = `bin/rails db:migrate:status`
 
            assert_match(/up\s+\d{3,}\s+Create users/, output)
            assert_match(/up\s+\d{3,}\s+Add email to users/, output)
 
-           `bin/rake db:rollback STEP=2`
-           output = `bin/rake db:migrate:status`
+           `bin/rails db:rollback STEP=2`
+           output = `bin/rails db:migrate:status`
 
            assert_match(/down\s+\d{3,}\s+Create users/, output)
            assert_match(/down\s+\d{3,}\s+Add email to users/, output)
 
-           `bin/rake db:migrate:redo`
-           output = `bin/rake db:migrate:status`
+           `bin/rails db:migrate:redo`
+           output = `bin/rails db:migrate:status`
 
            assert_match(/up\s+\d{3,}\s+Create users/, output)
            assert_match(/up\s+\d{3,}\s+Add email to users/, output)
@@ -167,9 +167,9 @@ module ApplicationTests
             end
           MIGRATION
 
-          `bin/rake db:migrate`
+          `bin/rails db:migrate`
 
-           output = `bin/rake db:migrate:status`
+           output = `bin/rails db:migrate:status`
 
            assert_match(/up\s+001\s+One migration/, output)
            assert_match(/up\s+002\s+Two migration/, output)
@@ -184,7 +184,7 @@ module ApplicationTests
           output = `bin/rails generate model author name:string`
           version = output =~ %r{[^/]+db/migrate/(\d+)_create_authors\.rb} && $1
 
-          `bin/rake db:migrate db:rollback db:forward db:migrate:up db:migrate:down VERSION=#{version}`
+          `bin/rails db:migrate db:rollback db:forward db:migrate:up db:migrate:down VERSION=#{version}`
           assert !File.exist?("db/schema.rb"), "should not dump schema when configured not to"
         end
 
@@ -192,7 +192,7 @@ module ApplicationTests
 
         Dir.chdir(app_path) do
           `bin/rails generate model reviews book_id:integer`
-          `bin/rake db:migrate`
+          `bin/rails db:migrate`
 
           structure_dump = File.read("db/schema.rb")
           assert_match(/create_table "reviews"/, structure_dump)
@@ -202,7 +202,7 @@ module ApplicationTests
       test 'default schema generation after migration' do
         Dir.chdir(app_path) do
           `bin/rails generate model book title:string;
-           bin/rake db:migrate`
+           bin/rails db:migrate`
 
           structure_dump = File.read("db/schema.rb")
           assert_match(/create_table "books"/, structure_dump)
@@ -213,10 +213,10 @@ module ApplicationTests
         Dir.chdir(app_path) do
           `bin/rails generate model user username:string password:string;
            bin/rails generate migration add_email_to_users email:string;
-           bin/rake db:migrate
+           bin/rails db:migrate
            rm db/migrate/*email*.rb`
 
-          output = `bin/rake db:migrate:status`
+          output = `bin/rails db:migrate:status`
           File.write('test.txt', output)
 
           assert_match(/up\s+\d{14}\s+Create users/, output)

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -74,7 +74,7 @@ module ApplicationTests
 
         app_file "some_other_dir/blah.rb", "# TODO: note in some_other directory"
 
-        run_rake_notes "SOURCE_ANNOTATION_DIRECTORIES='some_other_dir' bin/rake notes" do |output, lines|
+        run_rake_notes "SOURCE_ANNOTATION_DIRECTORIES='some_other_dir' bin/rails notes" do |output, lines|
           assert_match(/note in app directory/, output)
           assert_match(/note in config directory/, output)
           assert_match(/note in db directory/, output)
@@ -102,7 +102,7 @@ module ApplicationTests
           end
         EOS
 
-        run_rake_notes "bin/rake notes_custom" do |output, lines|
+        run_rake_notes "bin/rails notes_custom" do |output, lines|
           assert_match(/\[FIXME\] note in lib directory/, output)
           assert_match(/\[TODO\] note in test directory/, output)
           assert_no_match(/OPTIMIZE/, output)
@@ -128,7 +128,7 @@ module ApplicationTests
 
       private
 
-      def run_rake_notes(command = 'bin/rake notes')
+      def run_rake_notes(command = 'bin/rails notes')
         boot_rails
         load_tasks
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -27,8 +27,8 @@ module ApplicationTests
     def test_the_test_rake_task_is_protected_when_previous_migration_was_production
       Dir.chdir(app_path) do
         output = `bin/rails generate model product name:string;
-         env RAILS_ENV=production bin/rake db:create db:migrate;
-         env RAILS_ENV=production bin/rake db:test:prepare test 2>&1`
+         env RAILS_ENV=production bin/rails db:create db:migrate;
+         env RAILS_ENV=production bin/rails db:test:prepare test 2>&1`
 
         assert_match(/ActiveRecord::ProtectedEnvironmentError/, output)
       end
@@ -37,8 +37,8 @@ module ApplicationTests
     def test_not_protected_when_previous_migration_was_not_production
       Dir.chdir(app_path) do
         output = `bin/rails generate model product name:string;
-         env RAILS_ENV=test bin/rake db:create db:migrate;
-         env RAILS_ENV=test bin/rake db:test:prepare test 2>&1`
+         env RAILS_ENV=test bin/rails db:create db:migrate;
+         env RAILS_ENV=test bin/rails db:test:prepare test 2>&1`
 
         refute_match(/ActiveRecord::ProtectedEnvironmentError/, output)
       end
@@ -55,7 +55,7 @@ module ApplicationTests
         Rails.application.initialize!
       RUBY
 
-      assert_match("SuperMiddleware", Dir.chdir(app_path){ `bin/rake middleware` })
+      assert_match("SuperMiddleware", Dir.chdir(app_path){ `bin/rails middleware` })
     end
 
     def test_initializers_are_executed_in_rake_tasks
@@ -70,7 +70,7 @@ module ApplicationTests
         end
       RUBY
 
-      output = Dir.chdir(app_path){ `bin/rake do_nothing` }
+      output = Dir.chdir(app_path){ `bin/rails do_nothing` }
       assert_match "Doing something...", output
     end
 
@@ -91,7 +91,7 @@ module ApplicationTests
         end
       RUBY
 
-      output = Dir.chdir(app_path) { `bin/rake do_nothing` }
+      output = Dir.chdir(app_path) { `bin/rails do_nothing` }
       assert_match 'Hello world', output
     end
 
@@ -112,14 +112,14 @@ module ApplicationTests
       RUBY
 
       Dir.chdir(app_path) do
-        assert system('bin/rake do_nothing RAILS_ENV=production'),
+        assert system('bin/rails do_nothing RAILS_ENV=production'),
                'should not be pre-required for rake even eager_load=true'
       end
     end
 
     def test_code_statistics_sanity
       assert_match "Code LOC: 14     Test LOC: 0     Code to Test Ratio: 1:0.0",
-        Dir.chdir(app_path){ `bin/rake stats` }
+        Dir.chdir(app_path){ `bin/rails stats` }
     end
 
     def test_rake_routes_calls_the_route_inspector
@@ -129,7 +129,7 @@ module ApplicationTests
         end
       RUBY
 
-      output = Dir.chdir(app_path){ `bin/rake routes` }
+      output = Dir.chdir(app_path){ `bin/rails routes` }
       assert_equal "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n", output
     end
 
@@ -142,7 +142,7 @@ module ApplicationTests
       RUBY
 
       ENV['CONTROLLER'] = 'cart'
-      output = Dir.chdir(app_path){ `bin/rake routes` }
+      output = Dir.chdir(app_path){ `bin/rails routes` }
       assert_equal "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n", output
     end
 
@@ -152,7 +152,7 @@ module ApplicationTests
         end
       RUBY
 
-      assert_equal <<-MESSAGE.strip_heredoc, Dir.chdir(app_path){ `bin/rake routes` }
+      assert_equal <<-MESSAGE.strip_heredoc, Dir.chdir(app_path){ `bin/rails routes` }
         You don't have any routes defined!
 
         Please add some routes in config/routes.rb.
@@ -170,7 +170,7 @@ module ApplicationTests
         end
       RUBY
 
-      output = Dir.chdir(app_path){ `bin/rake log_something RAILS_ENV=production && cat log/production.log` }
+      output = Dir.chdir(app_path){ `bin/rails log_something RAILS_ENV=production && cat log/production.log` }
       assert_match "Sample log message", output
     end
 
@@ -178,13 +178,13 @@ module ApplicationTests
       Dir.chdir(app_path) do
         `bin/rails generate model user username:string password:string;
          bin/rails generate model product name:string;
-         bin/rake db:migrate`
+         bin/rails db:migrate`
       end
 
       require "#{rails_root}/config/environment"
 
       # loading a specific fixture
-      errormsg = Dir.chdir(app_path) { `bin/rake db:fixtures:load FIXTURES=products` }
+      errormsg = Dir.chdir(app_path) { `bin/rails db:fixtures:load FIXTURES=products` }
       assert $?.success?, errormsg
 
       assert_equal 2, ::AppTemplate::Application::Product.count
@@ -193,20 +193,20 @@ module ApplicationTests
 
     def test_loading_only_yml_fixtures
       Dir.chdir(app_path) do
-        `bin/rake db:migrate`
+        `bin/rails db:migrate`
       end
 
       app_file "test/fixtures/products.csv", ""
 
       require "#{rails_root}/config/environment"
-      errormsg = Dir.chdir(app_path) { `bin/rake db:fixtures:load` }
+      errormsg = Dir.chdir(app_path) { `bin/rails db:fixtures:load` }
       assert $?.success?, errormsg
     end
 
     def test_scaffold_tests_pass_by_default
       output = Dir.chdir(app_path) do
         `bin/rails generate scaffold user username:string password:string;
-         RAILS_ENV=test bin/rake db:migrate test`
+         RAILS_ENV=test bin/rails db:migrate test`
       end
 
       assert_match(/7 runs, 12 assertions, 0 failures, 0 errors/, output)
@@ -225,7 +225,7 @@ module ApplicationTests
 
       output = Dir.chdir(app_path) do
         `bin/rails generate scaffold user username:string password:string;
-         RAILS_ENV=test bin/rake db:migrate test`
+         RAILS_ENV=test bin/rails db:migrate test`
       end
 
       assert_match(/5 runs, 7 assertions, 0 failures, 0 errors/, output)
@@ -238,7 +238,7 @@ module ApplicationTests
 
       output = Dir.chdir(app_path) do
         `bin/rails generate scaffold LineItems product:references cart:belongs_to;
-         RAILS_ENV=test bin/rake db:migrate test`
+         RAILS_ENV=test bin/rails db:migrate test`
       end
 
       assert_match(/7 runs, 12 assertions, 0 failures, 0 errors/, output)
@@ -249,8 +249,8 @@ module ApplicationTests
       add_to_config "config.active_record.schema_format = :sql"
       output = Dir.chdir(app_path) do
         `bin/rails generate scaffold user username:string;
-         bin/rake db:migrate;
-         bin/rake db:test:clone 2>&1 --trace`
+         bin/rails db:migrate;
+         bin/rails db:test:clone 2>&1 --trace`
       end
       assert_match(/Execute db:test:clone_structure/, output)
     end
@@ -259,8 +259,8 @@ module ApplicationTests
       add_to_config "config.active_record.schema_format = :sql"
       output = Dir.chdir(app_path) do
         `bin/rails generate scaffold user username:string;
-         bin/rake db:migrate;
-         bin/rake db:test:prepare 2>&1 --trace`
+         bin/rails db:migrate;
+         bin/rails db:test:prepare 2>&1 --trace`
       end
       assert_match(/Execute db:test:load_structure/, output)
     end
@@ -268,7 +268,7 @@ module ApplicationTests
     def test_rake_dump_structure_should_respect_db_structure_env_variable
       Dir.chdir(app_path) do
         # ensure we have a schema_migrations table to dump
-        `bin/rake db:migrate db:structure:dump SCHEMA=db/my_structure.sql`
+        `bin/rails db:migrate db:structure:dump SCHEMA=db/my_structure.sql`
       end
       assert File.exist?(File.join(app_path, 'db', 'my_structure.sql'))
     end
@@ -278,7 +278,7 @@ module ApplicationTests
 
       output = Dir.chdir(app_path) do
         `bin/rails g model post title:string;
-         bin/rake db:migrate:redo 2>&1 --trace;`
+         bin/rails db:migrate:redo 2>&1 --trace;`
       end
 
       # expect only Invoke db:structure:dump (first_time)
@@ -289,21 +289,21 @@ module ApplicationTests
       Dir.chdir(app_path) do
         `bin/rails generate model post title:string;
          bin/rails generate model product name:string;
-         bin/rake db:migrate db:schema:cache:dump`
+         bin/rails db:migrate db:schema:cache:dump`
       end
       assert File.exist?(File.join(app_path, 'db', 'schema_cache.dump'))
     end
 
     def test_rake_clear_schema_cache
       Dir.chdir(app_path) do
-        `bin/rake db:schema:cache:dump db:schema:cache:clear`
+        `bin/rails db:schema:cache:dump db:schema:cache:clear`
       end
       assert !File.exist?(File.join(app_path, 'db', 'schema_cache.dump'))
     end
 
     def test_copy_templates
       Dir.chdir(app_path) do
-        `bin/rake rails:templates:copy`
+        `bin/rails rails:templates:copy`
         %w(controller mailer scaffold).each do |dir|
           assert File.exist?(File.join(app_path, 'lib', 'templates', 'erb', dir))
         end
@@ -318,7 +318,7 @@ module ApplicationTests
       app_file "template.rb", ""
 
       output = Dir.chdir(app_path) do
-        `bin/rake rails:template LOCATION=template.rb`
+        `bin/rails rails:template LOCATION=template.rb`
       end
 
       assert_match(/Hello, World!/, output)
@@ -326,7 +326,7 @@ module ApplicationTests
 
     def test_tmp_clear_should_work_if_folder_missing
       FileUtils.remove_dir("#{app_path}/tmp")
-      errormsg = Dir.chdir(app_path) { `bin/rake tmp:clear` }
+      errormsg = Dir.chdir(app_path) { `bin/rails tmp:clear` }
       assert_predicate $?, :success?
       assert_empty errormsg
     end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -445,7 +445,8 @@ module ApplicationTests
     def test_pass_TEST_env_on_rake_test
       create_test_file :models, 'account'
       create_test_file :models, 'post', pass: false
-
+      # This specifically verifies TEST for backwards compatibility with rake test
+      # as bin/rails test already supports running tests from a single file more cleanly.
       output =  Dir.chdir(app_path) { `bin/rake test TEST=test/models/post_test.rb` }
 
       assert_match "PostTest", output, "passing TEST= should run selected test"
@@ -540,7 +541,7 @@ module ApplicationTests
       end
 
       def run_migration
-        Dir.chdir(app_path) { `bin/rake db:migrate` }
+        Dir.chdir(app_path) { `bin/rails db:migrate` }
       end
   end
 end

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -232,7 +232,7 @@ module ApplicationTests
 
       assert_successful_test_run "models/user_test.rb"
 
-      Dir.chdir(app_path) { `bin/rake db:test:prepare` }
+      Dir.chdir(app_path) { `bin/rails db:test:prepare` }
 
       assert_unsuccessful_run "models/user_test.rb", <<-ASSERTION
 Expected: ["id", "name"]


### PR DESCRIPTION
Be consistent in testing outputs from railties test and use /bin/rails everywhere(the default behaviour now) instead of mix of /bin/rake and /bin/rails everywhere
