### PR TITLE
Rails::Generators::Actions#gem should work even if frozen string is passed as argument

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -20,7 +20,7 @@ module Rails
 
         # Set the message to be shown in logs. Uses the git repo if one is given,
         # otherwise use name (version).
-        parts, message = [ quote(name) ], name
+        parts, message = [ quote(name) ], name.dup
         if version ||= options.delete(:version)
           parts   << quote(version)
           message << " (#{version})"

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -113,6 +113,14 @@ class ActionsTest < Rails::Generators::TestCase
     assert_file 'Gemfile', /^gem 'rspec', ">=2\.0'0"$/
   end
 
+  def test_gem_works_even_if_frozen_string_is_passed_as_argument
+    run_generator
+
+    action :gem, "frozen_gem".freeze, "1.0.0".freeze
+
+    assert_file 'Gemfile', /^gem 'frozen_gem', '1.0.0'$/
+  end
+
   def test_gem_group_should_wrap_gems_in_a_group
     run_generator
 


### PR DESCRIPTION
- Fixes #23137.

r? @matthewd as you mentioned that it's a bug.
