### PR TITLE
Bump mail gem constraint from [~> 2.5, >= 2.5.4] to ~> 2.6

### DIFF
--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'actionview', version
   s.add_dependency 'activejob', version
 
-  s.add_dependency 'mail', ['~> 2.5', '>= 2.5.4']
+  s.add_dependency 'mail', '~> 2.6'
   s.add_dependency 'rails-dom-testing', '~> 1.0', '>= 1.0.5'
 end


### PR DESCRIPTION
_This PR represents a placeholder to discuss bumping the Mail gem_

Without wanting to claim the hard work of others!!! I would love to see Mail get bumped to ~> 2.6 for Rails 5, here's why:

[Jeremyevan's PR to use a text-based columnar storage](https://github.com/mime-types/ruby-mime-types/pull/96) in the Mime-types gem has been shown to [significantly decrease memory when a user opts in to it](https://github.com/rubygems/rubygems.org/pull/1172) (I've seen 20mb decrease personally). This memory saving behavior is [a default in the 3.0 release of Mime-types](https://github.com/mime-types/ruby-mime-types/issues/85#issuecomment-158469362) ([as well as a raft of other, really lovely changes](https://github.com/mime-types/ruby-mime-types/commit/026ceeaab6cf6d4ca2e6a06a15affca86023ed4d)). Given that [Mail works with Mime-types 3.0](https://github.com/mikel/mail/commit/d4ffe72b0b2b0c6c8a49130bfe8e792d0542ac0e) and when [Mail 2.6.4 has finished brewing](https://github.com/mikel/mail/pull/953#issuecomment-171555920) it'll allow [Mime-types 3.0](https://github.com/mikel/mail/blob/d4ffe72b0b2b0c6c8a49130bfe8e792d0542ac0e/mail.gemspec#L17) It would be great for Rails to nudge users to pick up this behavior too.

This memory decrease could be seen as a "feature" and It would be ace for users get it for free when doing a major upgrade to Rails 5.

I'd love to hear your thoughts @jeremy, @halostatue and others.

Thanks!
