### PR TITLE
Remove empty lines in Rails development logger

### DIFF
--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -30,12 +30,6 @@ module Rails
     protected
 
       def call_app(request, env)
-        # Put some space between requests in development logs.
-        if development?
-          logger.debug ''
-          logger.debug ''
-        end
-
         instrumenter = ActiveSupport::Notifications.instrumenter
         instrumenter.start 'request.action_dispatch', request: request
         logger.info { started_request_message(request) }


### PR DESCRIPTION
This is causing bugs like #23215 to occur, to due to the extra spaces. Also, this is fixed upstream in the upcoming release of Sprockets 4.

cc @schneems 
