### PR TITLE
PostgreSQL (9.1+): `:collation` support for string and text columns, fixes #23232.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -988,7 +988,8 @@
 
     *Ryuta Kamizono*
 
-*   PostgreSQL: `:collation` support for string and text columns.
+*   PostgreSQL: `:collation` support added for string and text columns, when
+    using PostgreSQL 9.1+.
 
     Example:
 
@@ -997,7 +998,7 @@
           t.text   :text_ja,   collation: 'ja_JP.UTF-8'
         end
 
-    *Ryuta Kamizono*
+    *Ryuta Kamizono*, *Remo Mueller*
 
 *   Remove `ActiveRecord::Serialization::XmlSerializer` from core.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -158,6 +158,10 @@ module ActiveRecord
         postgresql_version >= 90200
       end
 
+      def supports_collation?
+        postgresql_version >= 90100
+      end
+
       def index_algorithms
         { concurrently: 'CONCURRENTLY' }
       end
@@ -720,9 +724,10 @@ module ActiveRecord
         def column_definitions(table_name) # :nodoc:
           query(<<-end_sql, 'SCHEMA')
               SELECT a.attname, format_type(a.atttypid, a.atttypmod),
-                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
-             (SELECT c.collname FROM pg_collation c, pg_type t
-               WHERE c.oid = a.attcollation AND t.oid = a.atttypid AND a.attcollation <> t.typcollation)
+                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
+                     #{', (SELECT c.collname FROM pg_collation c, pg_type t
+                         WHERE c.oid = a.attcollation AND t.oid = a.atttypid
+                         AND a.attcollation <> t.typcollation)' if supports_collation?}
                 FROM pg_attribute a LEFT JOIN pg_attrdef d
                   ON a.attrelid = d.adrelid AND a.attnum = d.adnum
                WHERE a.attrelid = '#{quote_table_name(table_name)}'::regclass


### PR DESCRIPTION
The current implementation for collations doesn't work for PostgreSQL 8.4, as `pg_collation` was introduced in PostgreSQL 9.1. This patch fixes this to only include collation in `column_definitions` when PostgreSQL is 9.1+.
