### PR TITLE
Fix generated root path inside namespaces

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1905,8 +1905,7 @@ to this:
         end
 
         def match_root_route(options)
-          name = has_named_route?(:root) ? nil : :root
-          match '/', { :as => name, :via => :get }.merge!(options)
+          match '/', { :as => :root, :via => :get }.merge!(options)
         end
       end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1611,11 +1611,14 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_namespaced_roots
     draw do
+      root :to => "home#index"
+
       namespace :account do
         root :to => "account#index"
       end
     end
 
+    assert_equal '/', root_path
     assert_equal '/account', account_root_path
     get '/account'
     assert_equal 'account/account#index', @response.body
@@ -1774,11 +1777,14 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_root_works_in_the_resources_scope
     draw do
+      root :to => "home#index"
+
       resources :products do
         root :to => "products#root"
       end
     end
 
+    assert_equal '/', root_path
     get '/products'
     assert_equal 'products#root', @response.body
     assert_equal '/products', products_root_path


### PR DESCRIPTION
In Rails 4.2, we can generate root path inside a namespace like this

``` ruby
root to: "welcome#index"

namespace :admin do
  root to: "home#index" # => admin_root_path
end
```

But in the master branch, admin_root_path is not generated because of the previous definition of root_path.
So I fixed the `match_root_route` method in order to handle root path inside namescapes correctly.
