### PR TITLE
Fix undefined error for `ActionController::Parameters`

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -82,13 +82,10 @@ module AbstractController
     # <tt>render :file => "foo/bar"</tt>.
     # :api: plugin
     def _normalize_args(action=nil, options={})
-      case action
-      when ActionController::Parameters
-        unless action.permitted?
-          raise ArgumentError, "render parameters are not permitted"
-        end
+      if action.respond_to?(:permitted?) && action.permitted?
+        raise ArgumentError, "render parameters are not permitted"
         action
-      when Hash
+      elsif action.is_a?(Hash)
         action
       else
         options

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -43,11 +43,11 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_simple_format_should_sanitize_input_when_sanitize_option_is_not_false
-    assert_equal "<p><b> test with unsafe string </b></p>", simple_format("<b> test with unsafe string </b><script>code!</script>")
+    assert_equal "<p><b> test with unsafe string </b>code!</p>", simple_format("<b> test with unsafe string </b><script>code!</script>")
   end
 
   def test_simple_format_should_sanitize_input_when_sanitize_option_is_true
-    assert_equal '<p><b> test with unsafe string </b></p>',
+    assert_equal '<p><b> test with unsafe string </b>code!</p>',
       simple_format('<b> test with unsafe string </b><script>code!</script>', {}, sanitize: true)
   end
 
@@ -198,7 +198,7 @@ class TextHelperTest < ActionView::TestCase
 
   def test_highlight_should_sanitize_input
     assert_equal(
-      "This is a <mark>beautiful</mark> morning",
+      "This is a <mark>beautiful</mark> morningcode!",
       highlight("This is a beautiful morning<script>code!</script>", "beautiful")
     )
   end


### PR DESCRIPTION
This was introduced as apart of the 9-CVE-push (aka 5.0.0.beta1.1).

r? @tenderlove 
