### PR TITLE
Remove `limit: 11` as backward-compatibility with Rails 2.0

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -980,7 +980,6 @@ module ActiveRecord
         when 3; 'mediumint'
         when nil, 4; 'int'
         when 5..8; 'bigint'
-        when 11; 'int(11)' # backward compatibility with Rails 2.0
         else raise(ActiveRecordError, "No integer type has byte size #{limit}")
         end
       end


### PR DESCRIPTION
Integer limit as a byte size was introduced from Rails 2.1.
`limit: 11` is not a byte size, but take care for backward-compatibility
with Rails 2.0 (a892af6). Integer limit out of range should be allowed
to raise by #6349. I think we should remove this backward-compatibility.
