### PR TITLE
Adding action_controller require

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext/class/attribute'
 require 'action_view'
 require 'action_view/view_paths'
 require 'set'
+require 'action_controller'
 
 module AbstractController
   class DoubleRenderError < Error


### PR DESCRIPTION
Since be543e8e18246d5c2faa336eb3c0a03b797f3517, rendering now uses
StrongParameters to verify if render parameters are allowed. As a
consequence, if action_controller has not been loaded before (as in the
case of using actionmailer without railties), causes an Uninitialized
constant error for ActionController::Parameters:

```
NameError:
  uninitialized constant AbstractController::Rendering::ActionController
  # ruby/2.3.0/gems/actionpack-4.2.5.1/lib/abstract_controller/rendering.rb:81:in
  # `_normalize_args'
  # ruby/2.3.0/gems/actionview-4.2.5.1/lib/action_view/rendering.rb:114:in
  # `_normalize_args'
  # ruby/2.3.0/gems/actionpack-4.2.5.1/lib/abstract_controller/rendering.rb:113:in
  # `_normalize_render'
  # ruby/2.3.0/gems/actionpack-4.2.5.1/lib/abstract_controller/rendering.rb:24:in
  # `render'
```

I couldn't get the standard bug report to function as it loads action_controller to start.
My very simple example is https://github.com/hugocorbucci/actionmailer_4.5.2.1_bug.
The real one that identified this problem was https://github.com/agile-alliance-brazil/certificates (build failure: https://snap-ci.com/agile-alliance-brazil/certificates/branch/master/logs/defaultPipeline/78/FastFeedback)
