### PR TITLE
Allow to set custom attr reader for validator

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 
+*   Set custom attr reader for validator.
+
+    *Max Melentiev*
+
 *   Validate multiple contexts on `valid?` and `invalid?` at once.
 
     Example:

--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -27,6 +27,13 @@ class ValidatesTest < ActiveModel::TestCase
     assert_equal ['is not a number'], person.errors[:title]
   end
 
+  def test_validates_with_attr_reader
+    Person.validates :title, numericality: {attr_reader: ->(attr) { send(attr).size }}
+    person = Person.new
+    person.title = 'Mr. Pacman'
+    assert person.valid?
+  end
+
   def test_validates_with_attribute_specified_as_string
     Person.validates "title", numericality: true
     person = Person.new


### PR DESCRIPTION
This allows to use standard validators for value-objects like this

``` ruby
validates_numericality_of :money_field, 
  greater_than: 0, 
  attr_reader: ->(attr) { send(attr).to_d }
# assume that `money_field` returns specific money object
```

'Cause `read_attribute` is separate method now, it also allows to reuse standard validators

``` ruby
class MatrixDeterminantValidator < ActiveModel::NumericalityValidator
  def read_attribute(*)
    super.determinant
  end
end

# and then
validates :matrix_field, matrix_determinant: {greater_than: 0}
```
