### PR TITLE
Ensure assets digest default to disabled in test

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -43,4 +43,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  
+  # Disable asset fingerprinting 
+  config.assets.digest = false
 end


### PR DESCRIPTION
sprockets-rails >= 3.0.0 [enables digest by default for all environments](https://github.com/rails/sprockets-rails/pull/221), this ensure it stays disabled by default for the test environment
