### PR TITLE
Update ActiveJob adapter for sucker_punch 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :job do
   gem 'resque', require: false
   gem 'resque-scheduler', require: false
   gem 'sidekiq', require: false
-  gem 'sucker_punch', '< 2.0', require: false
+  gem 'sucker_punch', require: false
   gem 'delayed_job', require: false
   gem 'queue_classic', github: "QueueClassic/queue_classic", branch: 'master', require: false, platforms: :ruby
   gem 'sneakers', require: false
@@ -58,6 +58,7 @@ group :job do
   gem 'qu-redis', require: false
   gem 'delayed_job_active_record', require: false
   gem 'sequel', require: false
+  gem 'celluloid', require: false
 end
 
 # Action Cable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     bunny (2.2.1)
       amq-protocol (>= 2.0.0)
     byebug (8.2.1)
-    celluloid (0.17.2)
+    celluloid (0.17.3)
       celluloid-essentials
       celluloid-extras
       celluloid-fsm
@@ -151,7 +151,6 @@ GEM
       activesupport (>= 4.1.0)
     hiredis (0.5.2)
     hitimes (1.2.3)
-    hitimes (1.2.3-x86-mingw32)
     i18n (0.7.0)
     jquery-rails (4.0.5)
       rails-dom-testing (~> 1.0)
@@ -260,8 +259,8 @@ GEM
     sqlite3 (1.3.11-x64-mingw32)
     sqlite3 (1.3.11-x86-mingw32)
     stackprof (0.2.7)
-    sucker_punch (1.6.0)
-      celluloid (~> 0.17.2)
+    sucker_punch (2.0.0)
+      concurrent-ruby (~> 1.0.0)
     thor (0.19.1)
     thread (0.1.7)
     thread_safe (0.3.5)
@@ -299,6 +298,7 @@ DEPENDENCIES
   bcrypt-ruby (~> 3.0.0)
   benchmark-ips
   byebug
+  celluloid
   coffee-rails (~> 4.1.0)
   dalli (>= 2.2.1)
   delayed_job
@@ -334,7 +334,7 @@ DEPENDENCIES
   sneakers
   sqlite3 (~> 1.3.6)
   stackprof
-  sucker_punch (< 2.0)
+  sucker_punch
   turbolinks
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/activejob/lib/active_job/queue_adapters.rb
+++ b/activejob/lib/active_job/queue_adapters.rb
@@ -27,7 +27,7 @@ module ActiveJob
   #   | Resque            | Yes   | Yes    | Yes (Gem)  | Queue      | Global  | Yes     |
   #   | Sidekiq           | Yes   | Yes    | Yes        | Queue      | No      | Job     |
   #   | Sneakers          | Yes   | Yes    | No         | Queue      | Queue   | No      |
-  #   | Sucker Punch      | Yes   | Yes    | No         | No         | No      | No      |
+  #   | Sucker Punch      | Yes   | Yes    | Yes        | No         | No      | No      |
   #   | Active Job Async  | Yes   | Yes    | Yes        | No         | No      | No      |
   #   | Active Job Inline | No    | Yes    | N/A        | N/A        | N/A     | N/A     |
   #


### PR DESCRIPTION
This PR includes two changes for 2.0.0:
- Breaking API change around `async.perform` --> `perform_async`
- New addition of `perform_in`, which now allows end users of the
  adapter to use the `enqueued_at` public API method.

cc @brandonhilkert 
r? @eileencodes 
