### PR TITLE
Fix ActiveRecord::Inheritance default bug

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -201,7 +201,9 @@ module ActiveRecord
         if attrs.is_a?(Hash)
           subclass_name = attrs.with_indifferent_access[inheritance_column]
 
-          if subclass_name.present?
+          if subclass_name == base_class.to_s
+            subclass_name.constantize
+          elsif subclass_name.present?
             find_sti_class(subclass_name)
           end
         end

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -500,6 +500,23 @@ class InheritanceComputeTypeTest < ActiveRecord::TestCase
     ActiveRecord::Base.connection.change_column_default :companies, :type, original_type
     Company.reset_column_information
   end
+
+  def test_inheritance_new_with_base_class_subclass_as_default
+    original_type = Company.columns_hash['type'].default
+    ActiveRecord::Base.connection.change_column_default :companies, :type, 'Company'
+    Company.reset_column_information
+
+    company = Company.new # without arguments
+    assert_equal 'Company', company.type
+    assert_instance_of Company, company
+
+    firm = Company.new(type: 'Client') # overwrite the default type
+    assert_equal 'Client', firm.type
+    assert_instance_of Client, firm
+  ensure
+    ActiveRecord::Base.connection.change_column_default :companies, :type, original_type
+    Company.reset_column_information
+  end
 end
 
 class InheritanceAttributeTest < ActiveRecord::TestCase


### PR DESCRIPTION
This fixes a bug where if you have the default value for a model's
`type` column, then an STI error will not be raised. Closes #23285.
