### PR TITLE
Fix typo in strong params hash deprecation message

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -587,11 +587,11 @@ module ActionController
     def method_missing(method_sym, *args, &block)
       if @parameters.respond_to?(method_sym)
         message = <<-DEPRECATE.squish
-          Method #{ method_sym } is deprecated and will be removed in Rails 5.1,
+          Method #{method_sym} is deprecated and will be removed in Rails 5.1,
           as `ActionController::Parameters` no longer inherits from
           hash. Using this deprecated behavior exposes potential security
           problems. If you continue to use this method you may be creating
-          a security vulunerability in your app that can be exploited. Instead,
+          a security vulnerability in your app that can be exploited. Instead,
           consider using one of these documented methods which are not
           deprecated: http://api.rubyonrails.org/v#{ActionPack.version}/classes/ActionController/Parameters.html
         DEPRECATE


### PR DESCRIPTION
and remove unecessary spaces in string interpolation.
