### PR TITLE
Properly autosave polymorphic has_one associations

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -29,6 +29,7 @@ require "models/organization"
 require "models/guitar"
 require "models/tuning_peg"
 require "models/reply"
+require "models/image"
 
 class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
   def test_autosave_validation
@@ -215,6 +216,34 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
 
     eye.update(iris_attributes: { color: "blue" })
     assert_equal [false, false, false, false], eye.after_save_callbacks_stack
+  end
+
+  def test_association_type_gets_properly_saved
+    parrot = Parrot.create!(id: 23, name: "Polly")
+    post = Post.create!(id: 35, title: "On how Active Record associations get autosaved", body: "Is the behavior correct?")
+    image = Image.create!
+
+    parrot.image = image
+    post.main_image = image
+    parrot.save!
+
+    assert_not_nil image.reload.imageable
+    assert_equal image.imageable_identifier, parrot.id
+    assert_equal image.imageable_class, "Parrot"
+  end
+
+  def test_association_type_gets_properly_saved_with_same_foreign_keys
+    parrot = Parrot.create!(id: 23, name: "Polly")
+    post = Post.create!(id: 23, title: "On how Active Record associations get autosaved", body: "Is the behavior correct?")
+    image = Image.create!
+
+    parrot.image = image
+    post.main_image = image
+    parrot.save!
+
+    assert_not_nil image.reload.imageable
+    assert_equal image.imageable_identifier, parrot.id
+    assert_equal image.imageable_class, "Parrot"
   end
 end
 

--- a/activerecord/test/models/image.rb
+++ b/activerecord/test/models/image.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Image < ActiveRecord::Base
-  belongs_to :imageable, foreign_key: :imageable_identifier, foreign_type: :imageable_class
+  belongs_to :imageable, foreign_key: :imageable_identifier, foreign_type: :imageable_class, polymorphic: true
 end

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -6,6 +6,9 @@ class Parrot < ActiveRecord::Base
   has_and_belongs_to_many :pirates
   has_and_belongs_to_many :treasures
   has_many :loots, as: :looter
+
+  has_one :image, as: :imageable, foreign_key: :imageable_identifier, foreign_type: :imageable_class, class_name: "Image"
+
   alias_attribute :title, :name
 
   validates_presence_of :name


### PR DESCRIPTION
Fixes #23266

Current behavior of ActiveRecord is that (unless autosave option
is turned off) it autosaves the has one relation. This means the
following:

```
    class Driver < ActiveRecord::Base
      has_one :car
    end

    class Car < ActiveRecord::Base
      belongs_to :driver
    end

    driver1 = Driver.create!(id: 100)
    driver2 = Driver.create!(id: 143)
    car = Car.create!

    driver1.car = car # at this point car's driver_id is 100
    driver2.car = car # here it changes to 143
    driver1.save! # ActiveRecord autosaves car as well and sets
                  # car.driver_id back to 100

```

The caveat was that only the foreign_key was updated during autosave.
The problem appeared when the belongs_to association was polymorphic.
For example (this can also be seen in the test in the commit):

```
    class Image < ActiveRecord::Base
      belongs_to :imageable, polymorphic: true
    end

    class Post < ActiveRecord::Base
      has_one :image, as: :imageable
    end

    class Person < ActiveRecord::Base
      has_one :image, as: :imageable
    end

    post = Post.create!(id: 155)
    person = Person.create!(id: 204)
    image = Image.create!

    post.image = image # imageable_id set to 155,
                       # imageable_type set to "Post"
    person.image = image # imageable_id set to 204,
                         # imageable_type set to "Person"
    post.save! # only imageable_id is set to 155,
               # but imageable_type is still "Person"
               # result: image.imageable points either to nil
               # or some random Person # if there is Person with id 155

```

This commit fixes this behavior by making sure that if the relation is
polymorphic then except for the foreign_key the foreign_type is also
updated on the record.
