### PR TITLE
Add full set of MySQL CLI options to support SSL authentication when using db:structure dump and load

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Correctly pass MySQL options when using structure_dump or structure_load
+
+    Specifically, it fixes an issue when using SSL authentication.
+
+    *Alex Coomans*
+
 *   Fix regression when loading fixture files with symbol keys.
 
     Closes #22584.

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -129,15 +129,19 @@ IDENTIFIED BY '#{configuration['password']}' WITH GRANT OPTION;
       end
 
       def prepare_command_options
-        args = []
-        args.concat(['--user', configuration['username']]) if configuration['username']
-        args << "--password=#{configuration['password']}"  if configuration['password']
-        args.concat(['--default-character-set', configuration['encoding']]) if configuration['encoding']
-        configuration.slice('host', 'port', 'socket').each do |k, v|
-          args.concat([ "--#{k}", v.to_s ]) if v
-        end
-
-        args
+        {
+          'host'      => '--host',
+          'port'      => '--port',
+          'socket'    => '--socket',
+          'username'  => '--user',
+          'password'  => '--password',
+          'encoding'  => '--default-character-set',
+          'sslca'     => '--ssl-ca',
+          'sslcert'   => '--ssl-cert',
+          'sslcapath' => '--ssl-capath',
+          'sslcipher' => '--ssh-cipher',
+          'sslkey'    => '--ssl-key'
+        }.map { |opt, arg| "#{arg}=#{configuration[opt]}" if configuration[opt] }.compact
       end
 
       def run_cmd(cmd, args, action)

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -295,10 +295,19 @@ module ActiveRecord
 
     def test_structure_dump_with_port_number
       filename = "awesome-file.sql"
-      Kernel.expects(:system).with("mysqldump", "--port", "10000", "--result-file", filename, "--no-data", "test-db").returns(true)
+      Kernel.expects(:system).with("mysqldump", "--port=10000", "--result-file", filename, "--no-data", "test-db").returns(true)
 
       ActiveRecord::Tasks::DatabaseTasks.structure_dump(
         @configuration.merge('port' => 10000),
+        filename)
+    end
+
+    def test_structure_dump_with_ssl
+      filename = "awesome-file.sql"
+      Kernel.expects(:system).with("mysqldump", "--ssl-ca=ca.crt", "--result-file", filename, "--no-data", "test-db").returns(true)
+
+      ActiveRecord::Tasks::DatabaseTasks.structure_dump(
+        @configuration.merge("sslca" => "ca.crt"),
         filename)
     end
   end


### PR DESCRIPTION
Backport of #20126 to 4.2-stable
