### PR TITLE
Extract options for cache_fragment_name method to allow expires_in on cache method

### DIFF
--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -166,7 +166,8 @@ module ActionView
       # You can only declare one collection in a partial template file.
       def cache(name = {}, options = {}, &block)
         if controller.respond_to?(:perform_caching) && controller.perform_caching
-          safe_concat(fragment_for(cache_fragment_name(name, options), options, &block))
+          name_options = options.slice(:skip_digest, :virtual_path)
+          safe_concat(fragment_for(cache_fragment_name(name, name_options), options, &block))
         else
           yield
         end


### PR DESCRIPTION
This is in Rails 5.0.0.beta1.

In previous versions of Rails, you could pass an `expires_in` key with the `cache` method:

``` erb
<% cache "some_key", expires_in: 10.minutes do %>
  <% some_hardcore_thing_goes_here %>
<% end %>
```

However, this is no longer possible in 5.0.0.beta1 as `cache_fragment_name` does not take this as a valid option:

``` ruby
def cache_fragment_name(name = {}, skip_digest: nil, virtual_path: nil)
  if skip_digest
    name
  else
    fragment_name_with_digest(name, virtual_path)
  end
end
```

This is the correct behaviour for _this_ method: it would do nothing with an `expires_in` keyword if it got it. Where that option is actually used is in the `fragment_for` method call in the `cache` method:

``` ruby
def cache(name = {}, options = {}, &block)
  if controller.respond_to?(:perform_caching) && controller.perform_caching
    safe_concat(fragment_for(cache_fragment_name(name, options), options, &block))
  else
    yield
  end

  nil
end
```

The same options are being passed to `fragment_for` and to `cache_fragment_name`, which is causing this behaviour. `fragment_for` will use this option to expire the key, but `cache_fragment_name` complains when it's given this option.

---

I tried my hand at writing a test for this but I couldn't figure it out, sorry.
