### PR TITLE
Improve mysqldump

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -58,6 +58,7 @@ module ActiveRecord
         args.concat(["--result-file", "#{filename}"])
         args.concat(["--no-data"])
         args.concat(["--routines"])
+        args.concat(["--skip-comments"])
         args.concat(["#{configuration['database']}"])
 
         run_cmd('mysqldump', args, 'dumping')

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -255,7 +255,7 @@ module ActiveRecord
 
     def test_structure_dump
       filename = "awesome-file.sql"
-      Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "--routines", "test-db").returns(true)
+      Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db").returns(true)
 
       ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
     end
@@ -263,7 +263,7 @@ module ActiveRecord
     def test_warn_when_external_structure_dump_command_execution_fails
       filename = "awesome-file.sql"
       Kernel.expects(:system)
-        .with("mysqldump", "--result-file", filename, "--no-data", "--routines", "test-db")
+        .with("mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db")
         .returns(false)
 
       e = assert_raise(RuntimeError) {
@@ -274,7 +274,7 @@ module ActiveRecord
 
     def test_structure_dump_with_port_number
       filename = "awesome-file.sql"
-      Kernel.expects(:system).with("mysqldump", "--port=10000", "--result-file", filename, "--no-data", "--routines", "test-db").returns(true)
+      Kernel.expects(:system).with("mysqldump", "--port=10000", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db").returns(true)
 
       ActiveRecord::Tasks::DatabaseTasks.structure_dump(
         @configuration.merge('port' => 10000),
@@ -283,7 +283,7 @@ module ActiveRecord
 
     def test_structure_dump_with_ssl
       filename = "awesome-file.sql"
-      Kernel.expects(:system).with("mysqldump", "--ssl-ca=ca.crt", "--result-file", filename, "--no-data", "--routines", "test-db").returns(true)
+      Kernel.expects(:system).with("mysqldump", "--ssl-ca=ca.crt", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db").returns(true)
 
       ActiveRecord::Tasks::DatabaseTasks.structure_dump(
         @configuration.merge("sslca" => "ca.crt"),


### PR DESCRIPTION
After we running `rake db:structure:dump` in project members each other, there might have `diff` on `db/structure.sql` as below.

``` diff
--- MySQL dump 10.13  Distrib 5.7.9, for osx10.9 (x86_64)
+-- MySQL dump 10.13  Distrib 5.6.23, for osx10.10 (x86_64)
```

``` diff
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=437 DEFAULT CHARSET=utf8;
```

Because default output of `mysqldump` includes comments like MySQL version and AUTO_INCREMENT default value and so on.

In addition, after we running `rake db:migrate` when we set `config.active_record.schema_format=:sql` in `confing/application.rb`, there might have different `db/structure.sql` as below.

``` diff
--- Dump completed on 2016-01-28 13:34:00
+-- Dump completed on 2016-01-28 13:48:05
```

So, I added additional options to "mysqldump" command and I removed `AUTO_INCREMENT` default values from dumped SQL.
