### PR TITLE
Deprecate the use of mutable query methods on `CollectionProxy`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate mutation of CollectionProxy (e.g. `order!`), as the proxy is cached, and the
+    result of the mutation is dropped at the next spawn / non-mutation
+    query method call (e.g. `order`)
+
+    *Ben Woosley*, *Victor Kmita*
+
 *   When calling `first` with a `limit` argument, return directly from the
     `loaded?` records if available.
 

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -35,6 +35,7 @@ module ActiveRecord
         @association = association
         super klass, klass.arel_table, klass.predicate_builder
         merge! association.scope(nullify: false)
+        @initialized = true
       end
 
       def target
@@ -1054,6 +1055,20 @@ module ActiveRecord
         proxy_association.reset_scope
         self
       end
+
+      private
+
+        def assert_mutability!
+          if defined?(@initialized) && @initialized
+            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+              You are attempting to modify a collection proxy in-place.
+              Please use a non-mutating version of this method, for example,
+              use `order` instead of `order!`.
+            MSG
+          end
+          super
+        end
+
     end
   end
 end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -666,8 +666,24 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_find_first_sanitized
     firm = Firm.all.merge!(:order => "id").first
     client2 = Client.find(2)
-    assert_equal client2, firm.clients.merge!(:where => ["#{QUOTED_TYPE} = ?", 'Client'], :order => "id").first
-    assert_equal client2, firm.clients.merge!(:where => ["#{QUOTED_TYPE} = :type", { :type => 'Client' }], :order => "id").first
+    assert_equal client2, firm.clients.merge(:where => ["#{QUOTED_TYPE} = ?", 'Client'], :order => "id").first
+    assert_equal client2, firm.clients.merge(:where => ["#{QUOTED_TYPE} = :type", { :type => 'Client' }], :order => "id").first
+  end
+
+  def test_mutate_association_is_dropped_by_spawn
+    post = posts(:thinking)
+    assert_deprecated {
+      assert_equal(
+        ['body ASC'],
+        post.comments.order!('body ASC').order_values
+      )
+    }
+    assert_deprecated {
+      assert_equal(
+        ['post_id ASC'],
+        post.comments.order!('body ASC').order('post_id ASC').order_values
+      )
+    }
   end
 
   def test_find_all_with_include_and_conditions

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -801,6 +801,22 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal post_with_no_comments, posts(:authorless)
   end
 
+  def test_mutate_association_is_dropped_by_spawn
+    post = posts(:thinking)
+    assert_deprecated {
+      assert_equal(
+        {'first_name' => 'Jeb'},
+        post.people.where!(first_name: "Jeb").where_values_hash
+      )
+    }
+    assert_deprecated {
+      assert_equal(
+        {'last_name' => 'Bob'},
+        post.people.where!(first_name: "Jeb").where(last_name: "Bob").where_values_hash
+      )
+    }
+  end
+
   def test_has_many_through_has_one_reflection
     assert_equal [comments(:eager_sti_on_associations_vs_comment)], authors(:david).very_special_comments
   end


### PR DESCRIPTION
Mutating the `CollectionProxy` is problematic because the underlying object
will accept the modifications, then throw them away soon after, at the next
`spawn`.

For example, at present, we get this unexpected behavior:

``` ruby
>> collection_proxy.order!('body ASC').order_values
=> ['body ASC']

>> collection_proxy.order!('body ASC').order('post_id ASC').order_values
=> ['post_id ASC']
```

Mutation is also problematic because `CollectionProxy` is cached in
`CollectionAssociation@proxy`. This warning is a step toward removing support for
`CollectionProxy` mutation.

[Ben Woosley & Victor Kmita]
