### PR TITLE
Consistently warn that passing an offset to `find_nth` is deprecated

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -489,20 +489,19 @@ module ActiveRecord
     end
 
     def find_nth(index, offset = nil)
+      # TODO: once the offset argument is removed we rely on offset_index
+      # within find_nth_with_limit, rather than pass it in via
+      # find_nth_with_limit_and_offset
+      if offset
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          Passing an offset argument to find_nth is deprecated,
+          please use Relation#offset instead.
+        MSG
+      end
       if loaded?
         @records[index]
       else
-        # TODO: once the offset argument is removed we rely on offset_index
-        # within find_nth_with_limit, rather than pass it in via
-        # find_nth_with_limit_and_offset
-        if offset
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            Passing an offset argument to find_nth is deprecated,
-            please use Relation#offset instead.
-          MSG
-        else
-          offset = offset_index
-        end
+        offset ||= offset_index
         @offsets[offset + index] ||= find_nth_with_limit_and_offset(index, 1, offset: offset).first
       end
     end


### PR DESCRIPTION
@bogdan pointed out that a `loaded?` relation would not warn that the supplied
offset would be removed. This fixes that oversight.

https://github.com/rails/rails/commit/16a476e4f8f802774ae7c8dca2e59f4e672dc591#commitcomment-15706834

Although this second argument is probably not widely used, and would be
ignored anyway in the loaded? case, this could protect callers from gotchas.

[Ben Woosley & Victor Kmita]
