### PR TITLE
Make `CollectionProxy` an Immutable Relation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Make `CollectionProxy` an Immutable Relation - it will raise
+    `ImmutableRelation` errors if mutation is attempted.
+
+    *Ben Woosley*, *Victor Kmita*
+
 *   When calling `first` with a `limit` argument, return directly from the
     `loaded?` records if available.
 

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -35,6 +35,7 @@ module ActiveRecord
         @association = association
         super klass, klass.arel_table, klass.predicate_builder
         merge! association.scope(nullify: false)
+        @initialized = true
       end
 
       def target
@@ -1054,6 +1055,14 @@ module ActiveRecord
         proxy_association.reset_scope
         self
       end
+
+      private
+
+        def assert_mutability!
+          raise ImmutableRelation if defined?(@initialized) && @initialized
+          super
+        end
+
     end
   end
 end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -666,8 +666,8 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_find_first_sanitized
     firm = Firm.all.merge!(:order => "id").first
     client2 = Client.find(2)
-    assert_equal client2, firm.clients.merge!(:where => ["#{QUOTED_TYPE} = ?", 'Client'], :order => "id").first
-    assert_equal client2, firm.clients.merge!(:where => ["#{QUOTED_TYPE} = :type", { :type => 'Client' }], :order => "id").first
+    assert_equal client2, firm.clients.merge(:where => ["#{QUOTED_TYPE} = ?", 'Client'], :order => "id").first
+    assert_equal client2, firm.clients.merge(:where => ["#{QUOTED_TYPE} = :type", { :type => 'Client' }], :order => "id").first
   end
 
   def test_find_all_with_include_and_conditions


### PR DESCRIPTION
Mutating the `CollectionProxy` is problematic for lots of reasons, not least
of which because `CollectionProxy` is cached in `CollectionAssociation@proxy`.

This removes the ability to mutate the proxy, thus disallowing paradoxic
behavior.

This is an alternative to #23302

[Ben Woosley & Victor Kmita]
