### PR TITLE
Fix a bug with initialize schema_migrations table

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -992,7 +992,7 @@ module ActiveRecord
           if (duplicate = inserting.detect {|v| inserting.count(v) > 1})
             raise "Duplicate migration #{duplicate}. Please renumber your migrations to resolve the conflict."
           end
-          execute "INSERT INTO #{sm_table} (version) VALUES #{inserting.map {|v| '(#{v})'}.join(', ') }"
+          execute "INSERT INTO #{sm_table} (version) VALUES #{inserting.map {|v| "('#{v}')"}.join(', ') }"
         end
       end
 


### PR DESCRIPTION
Performing a command `bundle exec rake db:drop db:create db:schema:load --trace` I get the following error:

``` ruby
-- initialize_schema_migrations_table()
   -> 0.0081s
rake aborted!
ActiveRecord::StatementInvalid: PG::SyntaxError: ERROR:  syntax error at or near "{"
LINE 1: ...NSERT INTO "schema_migrations" (version) VALUES (#{v}), (#{v...
                                                             ^
: INSERT INTO "schema_migrations" (version) VALUES (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (
#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v}), (#{v})
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:133:in `async_exec'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:133:in `block in execu
te'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:528:in `block in log'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:522:in `log'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:132:in `execute'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:995:in `assume_migrated_up
to_version'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/schema.rb:52:in `define'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/schema.rb:44:in `define'
/Users/mgrachev/mm/db/schema.rb:14:in `<top (required)>'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activesupport/lib/active_support/dependencies.rb:296:in `load'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activesupport/lib/active_support/dependencies.rb:296:in `block in load'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activesupport/lib/active_support/dependencies.rb:268:in `load_dependency'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activesupport/lib/active_support/dependencies.rb:296:in `load'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/tasks/database_tasks.rb:216:in `load_schema'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/tasks/database_tasks.rb:246:in `block in load_schema_current'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/tasks/database_tasks.rb:286:in `block in each_current_configuration'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/tasks/database_tasks.rb:285:in `each'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/tasks/database_tasks.rb:285:in `each_current_configuration'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/tasks/database_tasks.rb:245:in `load_schema_current'
/Users/mgrachev/mm/vendor/bundle/bundler/gems/rails-9864bcee8cfd/activerecord/lib/active_record/railties/databases.rake:260:in `block (3 levels) in <top (required)>'
/Users/mgrachev/mm/vendor/bundle/gems/rake-10.5.0/lib/rake/task.rb:240:in `call'
/Users/mgrachev/mm/vendor/bundle/gems/rake-10.5.0/lib/rake/task.rb:240:in `block in execute'
/Users/mgrachev/mm/vendor/bundle/gems/rake-10.5.0/lib/rake/task.rb:235:in `each'
/Users/mgrachev/mm/vendor/bundle/gems/rake-10.5.0/lib/rake/task.rb:235:in `execute'
```
