### PR TITLE
Prevent ActionCable reconnect if server forcefully disconnects user

### DIFF
--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -30,7 +30,8 @@ module ActionCable
 
   INTERNAL = {
     identifiers: {
-      ping: '_ping'.freeze
+      ping: '_ping'.freeze,
+      disconnect: '_disconnect'.freeze
     },
     message_types: {
       confirmation: 'confirm_subscription'.freeze,

--- a/actioncable/lib/action_cable/connection/internal_channel.rb
+++ b/actioncable/lib/action_cable/connection/internal_channel.rb
@@ -30,7 +30,8 @@ module ActionCable
           message = ActiveSupport::JSON.decode(message)
 
           case message['type']
-          when 'disconnect'
+            when 'disconnect'
+            transmit ActiveSupport::JSON.encode(identifier: ActionCable::INTERNAL[:identifiers][:disconnect], message: Time.now.to_i)
             logger.info "Removing connection (#{connection_identifier})"
             websocket.close
           end

--- a/actioncable/lib/action_cable/connection/internal_channel.rb
+++ b/actioncable/lib/action_cable/connection/internal_channel.rb
@@ -30,7 +30,7 @@ module ActionCable
           message = ActiveSupport::JSON.decode(message)
 
           case message['type']
-            when 'disconnect'
+          when 'disconnect'
             transmit ActiveSupport::JSON.encode(identifier: ActionCable::INTERNAL[:identifiers][:disconnect], message: Time.now.to_i)
             logger.info "Removing connection (#{connection_identifier})"
             websocket.close

--- a/actioncable/lib/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/lib/assets/javascripts/action_cable/connection.coffee
@@ -57,6 +57,10 @@ class ActionCable.Connection
     message: (event) ->
       {identifier, message, type} = JSON.parse(event.data)
 
+      if identifier is ActionCable.INTERNAL.identifiers.disconnect
+        @consumer.connectionMonitor.stop()
+        return
+
       switch type
         when message_types.confirmation
           @consumer.subscriptions.notify(identifier, "connected")


### PR DESCRIPTION
As we discussed with @dhh on old rails/actioncable repo. If we disconnect user from server [e.g. as with github you can't have several open tabs, only one should be active] he shouldn't reconnect.

Currently if user opens several tabs and server has code which disconnect previous user sessions, all user open tabs will disconnect each other. This commits prevents reconnect on _disconnect identifier. 
