### PR TITLE
Fix single-quotes string interpolation

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -992,7 +992,7 @@ module ActiveRecord
           if (duplicate = inserting.detect {|v| inserting.count(v) > 1})
             raise "Duplicate migration #{duplicate}. Please renumber your migrations to resolve the conflict."
           end
-          execute "INSERT INTO #{sm_table} (version) VALUES #{inserting.map {|v| '(#{v})'}.join(', ') }"
+          execute "INSERT INTO #{sm_table} (version) VALUES #{inserting.map {|v| "(#{v})"}.join(', ') }"
         end
       end
 


### PR DESCRIPTION
This line was throwing an error for me when migrating.

`ActiveRecord::StatementInvalid: PG::SyntaxError: ERROR:  syntax error at or near "{"
LINE 1: ...NSERT INTO "schema_migrations" (version) VALUES (#{v}), (#{v...`
