### PR TITLE
Regression test for #23307

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -992,7 +992,7 @@ module ActiveRecord
           if (duplicate = inserting.detect {|v| inserting.count(v) > 1})
             raise "Duplicate migration #{duplicate}. Please renumber your migrations to resolve the conflict."
           end
-          execute "INSERT INTO #{sm_table} (version) VALUES #{inserting.map {|v| '(#{v})'}.join(', ') }"
+          execute "INSERT INTO #{sm_table} (version) VALUES #{inserting.map {|v| "('#{v}')"}.join(', ') }"
         end
       end
 

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -274,6 +274,26 @@ module ApplicationTests
             ActiveRecord::Base.connection_config[:database]
         end
       end
+      
+      test "db:schema:load after db:drop db:create" do
+        Dir.chdir(app_path) do
+          app_file 'db/migrate/1_migration.rb', <<-RUBY
+            # dummy file
+          RUBY
+          app_file 'db/schema.rb', <<-RUBY
+            ActiveRecord::Schema.define(version: 20140423102712) do
+              create_table("comments") do |t|
+                t.string :name
+              end
+            end
+          RUBY
+
+          `bin/rails db:drop db:create db:schema:load`
+
+          tables = `bin/rails runner 'p ActiveRecord::Base.connection.tables'`.strip
+          assert_match(/"comments"/, tables)
+        end
+      end
 
       test 'db:test:load_structure without database_url' do
         require "#{app_path}/config/environment"


### PR DESCRIPTION
This exercises `assume_migrated_upto_version` in `activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb`

`db:drop db:create db:schema:load` and triggers the error mentioned in #23307
