### PR TITLE
Add an after_bundle callback in Rails plugin templates

### DIFF
--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -121,7 +121,7 @@ Please refer to the [Changelog][railties] for detailed changes.
      [Pull Request](https://github.com/rails/rails/pull/22288))
 
 *   Introduced an `after_bundle` callback for use in Rails plugin templates.
-    ([Pull Request](https://github.com/rails/rails/pull/))
+    ([Pull Request](https://github.com/rails/rails/pull/23317))
 
 
 Action Pack

--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -120,6 +120,9 @@ Please refer to the [Changelog][railties] for detailed changes.
     ([Pull Request](https://github.com/rails/rails/pull/22457),
      [Pull Request](https://github.com/rails/rails/pull/22288))
 
+*   Introduced an `after_bundle` callback for use in Rails plugin templates.
+    ([Pull Request](https://github.com/rails/rails/pull/))
+
 
 Action Pack
 -----------

--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -120,9 +120,6 @@ Please refer to the [Changelog][railties] for detailed changes.
     ([Pull Request](https://github.com/rails/rails/pull/22457),
      [Pull Request](https://github.com/rails/rails/pull/22288))
 
-*   Introduced an `after_bundle` callback for use in Rails plugin templates.
-    ([Pull Request](https://github.com/rails/rails/pull/23317))
-
 
 Action Pack
 -----------

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -451,7 +451,7 @@
 *   Add `after_bundle` callbacks in Rails plugin templates.  Useful for allowing
     templates to perform actions that are dependent upon `bundle install`.
 
-    Fixes #<>
+    Fixes #<23315>
 
     *Ryan Manuel*
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -448,4 +448,11 @@
 
     *Alex Robbin*
 
+*   Add `after_bundle` callbacks in Rails plugin templates.  Useful for allowing
+    templates to perform actions that are dependent upon `bundle install`.
+
+    Fixes #<>
+
+    *Ryan Manuel*
+
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `after_bundle` callbacks in Rails plugin templates.  Useful for allowing
+    templates to perform actions that are dependent upon `bundle install`.
+
+    *Ryan Manuel*
+
 *   Bring back `TEST=` env for `rake test` task.
 
     *Yves Senn*
@@ -447,12 +452,5 @@
 *   Autoload any second level directories called `app/*/concerns`.
 
     *Alex Robbin*
-
-*   Add `after_bundle` callbacks in Rails plugin templates.  Useful for allowing
-    templates to perform actions that are dependent upon `bundle install`.
-
-    Fixes #<23315>
-
-    *Ryan Manuel*
 
 Please check [4-2-stable](https://github.com/rails/rails/blob/4-2-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -259,6 +259,12 @@ task default: :test
 
       public_task :apply_rails_template, :run_bundle
 
+      def run_after_bundle_callbacks
+        @after_bundle_callbacks.each do |callback|
+          callback.call
+        end
+      end
+
       def name
         @name ||= begin
           # same as ActiveSupport::Inflector#underscore except not replacing '-'

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -703,9 +703,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
 
     sequence = ['install', 'exec spring binstub --all', 'echo ran after_bundle']
-    ensure_bundler_first = -> command do
       @sequence_step ||= 0
-
+    ensure_bundler_first = -> command do
       assert_equal sequence[@sequence_step], command, "commands should be called in sequence #{sequence}"
       @sequence_step += 1
     end
@@ -717,6 +716,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
         end
       end
     end
+
+    assert_equal 3, @sequence_step
   end
 
   protected


### PR DESCRIPTION
Closes #23315.  This is based heavily off of the pull request at #16359.  after_bundle was added as part of that to give a hook to execute actions after bundle install was executed during app generation but not for plugin generation.  This pull request adds that functionality to plugin generation as well.  
