### PR TITLE
Put "Using Rails for API-only Applications" in table of contents

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -135,6 +135,10 @@
       work_in_progress: true
       url: profiling.html
       description: This guide explains how to profile your Rails applications to improve performance.
+    -
+      name: Using Rails for API-only Applications
+      url: api_app.html
+      description: This guide explains how to effectively use Rails to develop a JSON API application.
 
 -
   name: Extending Rails


### PR DESCRIPTION
When I was looking for more info regarding this the only way I ended up
on that page was by googling something along the lines of "rails new
api" (as I wanted to find out what are the proper parameters when
generating api app). I think it's beneficial to have that page in table
of contents.
