### PR TITLE
Call new_record? instead of transaction_record_state(:new_record)

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -459,11 +459,11 @@ module ActiveRecord
       actions.any? do |action|
         case action
         when :create
-          transaction_record_state(:new_record)
+          new_record?
         when :destroy
           destroyed?
         when :update
-          !(transaction_record_state(:new_record) || destroyed?)
+          !(new_record? || destroyed?)
         end
       end
     end


### PR DESCRIPTION
The `transaction_record_state` method depends on `remember_transaction_record_state` being called first, which is not true in all cases. In such cases, an `update` may behave like a `create` and vice versa.
