### PR TITLE
Fix broken number_to_currency conversion tests

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/numeric/inquiry'
+
 module ActiveSupport
   module NumberHelper
     class NumberToCurrencyConverter < NumberConverter # :nodoc:


### PR DESCRIPTION
- Required inquiry module which will define `negative?` and `positive?`
  methods for Ruby 2.2.
- Fixed tests broken due to d3f178bb92473b4d7bb400be56c983203.

r? @rafaelfranca 
