### PR TITLE
Warn if a named scope is overwriting an existing scope or method

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -151,6 +151,7 @@ module ActiveRecord
               "a class method with the same name."
           end
 
+          valid_scope_name?(name)
           extension = Module.new(&block) if block
 
           if body.respond_to?(:to_proc)
@@ -167,6 +168,15 @@ module ActiveRecord
 
               scope || all
             end
+          end
+        end
+
+      protected
+
+        def valid_scope_name?(name)
+          if respond_to?(name, true)
+            logger.warn "Creating scope :#{name}. " \
+                        "Overwriting existing method #{self.name}.#{name}."
           end
         end
       end

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -455,7 +455,7 @@ class NamedScopingTest < ActiveRecord::TestCase
     [:public_method, :protected_method, :private_method].each do |reserved_method|
       assert Topic.respond_to?(reserved_method, true)
       ActiveRecord::Base.logger.expects(:warn)
-      Topic.scope(reserved_method)
+      Topic.scope(reserved_method, -> { })
     end
   end
 

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -440,6 +440,25 @@ class NamedScopingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_scopes_with_reserved_names
+    class << Topic
+      def public_method; end
+      public :public_method
+
+      def protected_method; end
+      protected :protected_method
+
+      def private_method; end
+      private :private_method
+    end
+
+    [:public_method, :protected_method, :private_method].each do |reserved_method|
+      assert Topic.respond_to?(reserved_method, true)
+      ActiveRecord::Base.logger.expects(:warn)
+      Topic.scope(reserved_method)
+    end
+  end
+
   def test_scopes_on_relations
     # Topic.replied
     approved_topics = Topic.all.approved.order('id DESC')

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -455,7 +455,7 @@ class NamedScopingTest < ActiveRecord::TestCase
     [:public_method, :protected_method, :private_method].each do |reserved_method|
       assert Topic.respond_to?(reserved_method, true)
       ActiveRecord::Base.logger.expects(:warn)
-      Topic.scope(reserved_method, -> { })
+      silence_warnings { Topic.scope(reserved_method, -> { }) }
     end
   end
 


### PR DESCRIPTION
I'd like to propose to bring back a warning once removed from ActiveRecord.

When defining a named scope, ActiveRecord 3 used to warn if the scope name conflicts with an existing scope or a class method.
Then, this behavior had been removed since AR 4.0 at f6db31ec16e42ee7713029f7120f0b011d1ddc6c. The commit message says,

> Users should run with -w if they want to be warned about redefined methods.

Sure. Ruby has the functionality. We can let ruby do that.
I totally agree that this is absolutely the right way, but who actually does this?

I recently gave this approach a try. I turned on the ruby warning on my Rails app, then my terminal was immediately filled with tremendous amount of warnings from the external libraries that are bundled to the app.

I tried to eliminate some of the warnings from the gems that I use: https://github.com/amatsuda?tab=contributions&from=2016-01-06&to=2016-01-11
But there still remains so many other gems that emit warnings.
TBH I don't know how we can extinguish all these warnings while one of the default bundled gem is not pursuing zero-warning code base.  https://github.com/sass/sass/issues/160

I have to conclude that turning on the `-w` switch on our apps is currently not a realistic solution to find a method redefinition in the app code.
We need the framework to detect the method redefinition, just as AR::Enum does. https://github.com/rails/rails/blob/43df26711856bc4b90780a185078fc84fa597564/activerecord/lib/active_record/enum.rb#L214-L222
