### PR TITLE
AR::Relation#exists? doesn't have to query if the relation is loaded and no condition was given

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Relation#exists? now doesn't query to the DB if the relation was loaded and
+    no condition was given.
+
+    *Akira Matsuda*
+
 *   Bumped the minimum supported version of PostgreSQL to >= 9.1.
     Both PG 9.0 and 8.4 are past their end of life date:
     http://www.postgresql.org/support/versioning/

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -270,6 +270,8 @@ module ActiveRecord
     #   Person.exists?(false)
     #   Person.exists?
     def exists?(conditions = :none)
+      return any? if (conditions == :none) && loaded?
+
       if Base === conditions
         conditions = conditions.id
         ActiveSupport::Deprecation.warn(<<-MSG.squish)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -959,6 +959,10 @@ class RelationTest < ActiveRecord::TestCase
   def test_exists
     davids = Author.where(:name => 'David')
     assert davids.exists?
+
+    davids.load
+    assert davids.exists?
+
     assert davids.exists?(authors(:david).id)
     assert ! davids.exists?(authors(:mary).id)
     assert ! davids.exists?("42")
@@ -968,6 +972,9 @@ class RelationTest < ActiveRecord::TestCase
     fake  = Author.where(:name => 'fake author')
     assert ! fake.exists?
     assert ! fake.exists?(authors(:david).id)
+
+    fake.load
+    assert ! fake.exists?
   end
 
   def test_exists_uses_existing_scope


### PR DESCRIPTION
Here's a patch aiming to reduce unneeded DB queries.
