### PR TITLE
remove unused variable from render test

### DIFF
--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -275,7 +275,7 @@ class ExpiresInRenderTest < ActionController::TestCase
     file.write "secrets!"
     file.flush
     assert_raises ActionView::MissingTemplate do
-      response = get :dynamic_render, params: { id: file.path }
+      get :dynamic_render, params: { id: file.path }
     end
   ensure
     file.close


### PR DESCRIPTION
This removes the following warning.

```
rails/actionpack/test/controller/render_test.rb:278: warning: assigned but unused variable - response
```
