### PR TITLE
remove unused require

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -1,6 +1,5 @@
 require 'action_dispatch/middleware/cookies'
 require 'action_dispatch/middleware/flash'
-require 'active_support/core_ext/hash/indifferent_access'
 
 module ActionDispatch
   module TestProcess


### PR DESCRIPTION
`with_indifferent_access` had been used in `assigns` method, but has been removed in ca83436.
