### PR TITLE
Fix netmask serialization for inet columns in PG

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix netmask serialization for inet columns in Postgres
+
+    For hosts (/32 in IPv4 and /128 in IPv6), Postgres keeps the netmask
+    for cidr, but drops it for inet. Previously ActiveRecord was
+    treating them both as cidr and always including a netmask. This
+    changes the serialization of inet columns to match Postgres.
+
+    The mismatched serializations could also cause Dirty to incorrectly
+    think an inet column with a /32 or /128 IP had changed when it
+    hadn't. This fixes that too.
+
+    *Thomas Morgan*
+
 *   Rework `ActiveRecord::Relation#last` 
     
     1. Always find last with ruby if relation is loaded

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/inet.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/inet.rb
@@ -6,6 +6,21 @@ module ActiveRecord
           def type
             :inet
           end
+
+          def serialize(value)
+            if IPAddr === value
+              subnet_mask = value.instance_variable_get(:@mask_addr)
+
+              # inet drops '/32' (IPv4) and '/128' (IPv6), unlike cidr which keeps them
+              if subnet_mask == (2**32 - 1) || subnet_mask == (2**128 - 1)
+                "#{value}"
+              else
+                "#{value}/#{subnet_mask.to_s(2).count('1')}"
+              end
+            else
+              value
+            end
+          end
         end
       end
     end

--- a/activerecord/test/cases/adapters/postgresql/cidr_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/cidr_test.rb
@@ -9,9 +9,13 @@ module ActiveRecord
           type = OID::Cidr.new
           ip = IPAddr.new("255.0.0.0/8")
           ip2 = IPAddr.new("127.0.0.1")
+          ip3 = IPAddr.new("2001:db8::/64")
+          ip4 = IPAddr.new("2001:db8::1")
 
           assert_equal "255.0.0.0/8", type.serialize(ip)
           assert_equal "127.0.0.1/32", type.serialize(ip2)
+          assert_equal "2001:db8::/64", type.serialize(ip3)
+          assert_equal "2001:db8::1/128", type.serialize(ip4)
         end
 
         test "casting does nothing with non-IPAddr objects" do

--- a/activerecord/test/cases/adapters/postgresql/inet_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/inet_test.rb
@@ -1,0 +1,23 @@
+require "cases/helper"
+require "ipaddr"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgreSQLAdapter < AbstractAdapter
+      class InetTest < ActiveRecord::PostgreSQLTestCase
+        test "type casting IPAddr for database" do
+          type = OID::Inet.new
+          ip = IPAddr.new("255.0.0.0/8")
+          ip2 = IPAddr.new("127.0.0.1/32")
+          ip3 = IPAddr.new("2001:db8::/64")
+          ip4 = IPAddr.new("2001:db8::1/128")
+
+          assert_equal "255.0.0.0/8", type.serialize(ip)
+          assert_equal "127.0.0.1", type.serialize(ip2)
+          assert_equal "2001:db8::/64", type.serialize(ip3)
+          assert_equal "2001:db8::1", type.serialize(ip4)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For hosts (/32 in IPv4 and /128 in IPv6), Postgres keeps the netmask
for cidr, but drops it for inet. Previously ActiveRecord was
treating them both as cidr and always including a netmask. This
changes the serialization of inet columns to match Postgres.

The mismatched serializations could also cause Dirty to incorrectly
think an inet column with a /32 or /128 IP had changed when it
hadn't. This fixes that too.
