### PR TITLE
Explicitly define `columns` method as an interface

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -92,7 +92,9 @@ module ActiveRecord
 
       # Returns an array of Column objects for the table specified by +table_name+.
       # See the concrete implementation for details on the expected parameter values.
-      def columns(table_name) end
+      def columns(table_name)
+        raise NotImplementedError, "#columns is not implemented"
+      end
 
       # Checks to see if a column exists in a given table.
       #


### PR DESCRIPTION
`ActiveRecord::ConnectionAdapters::SchemaStatements#columns` is defined
here as an interface method here. So changes to raise `NotImplementedError`
same as `tables`, `views` ...etc.
