### PR TITLE
Refactor `column_exists?` in `SchemaStatements`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -110,13 +110,14 @@ module ActiveRecord
       #
       def column_exists?(table_name, column_name, type = nil, options = {})
         column_name = column_name.to_s
-        columns(table_name).any?{ |c| c.name == column_name &&
-                                      (!type                     || c.type == type) &&
-                                      (!options.key?(:limit)     || c.limit == options[:limit]) &&
-                                      (!options.key?(:precision) || c.precision == options[:precision]) &&
-                                      (!options.key?(:scale)     || c.scale == options[:scale]) &&
-                                      (!options.key?(:default)   || c.default == options[:default]) &&
-                                      (!options.key?(:null)      || c.null == options[:null]) }
+        checks = []
+        checks << lambda { |c| c.name == column_name }
+        checks << lambda { |c| c.type == type } if type
+        [:limit, :precision, :scale, :default, :null].each do |attr|
+          checks << lambda { |c| c.send(attr) == options[attr] } if options.key?(attr)
+        end
+
+        columns(table_name).any? { |c| checks.all? { |check| check[c] } }
       end
 
       # Returns just a table's primary key


### PR DESCRIPTION
Like `index_exists?`:

``` ruby
      def index_exists?(table_name, column_name, options = {})
        column_names = Array(column_name).map(&:to_s)
        checks = []
        checks << lambda { |i| i.columns == column_names }
        checks << lambda { |i| i.unique } if options[:unique]
        checks << lambda { |i| i.name == options[:name].to_s } if options[:name]

        indexes(table_name).any? { |i| checks.all? { |check| check[i] } }
      end
```

https://github.com/rails/rails/blob/v5.0.0.beta1/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L83-L91
