### PR TITLE
Make `SchemaMigration.drop_table` to one SQL

### DIFF
--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -37,10 +37,7 @@ module ActiveRecord
       end
 
       def drop_table
-        if table_exists?
-          connection.remove_index table_name, name: index_name
-          connection.drop_table(table_name)
-        end
+        connection.drop_table table_name, if_exists: true
       end
 
       def normalize_migration_number(number)


### PR DESCRIPTION
`SchemaMigration.drop_table` is only used in tests.
Simply we can use `drop_table if_exists: true`.
