### PR TITLE
remove unnecessary gsub for `action_cable_meta_tag`

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -318,7 +318,6 @@ module Rails
           remove_file 'config/cable.yml'
           remove_file 'app/assets/javascripts/cable.coffee'
           remove_dir 'app/channels'
-          gsub_file 'app/views/layouts/application.html.erb', /action_cable_meta_tag/, '' unless options[:api]
         end
       end
 


### PR DESCRIPTION
If the specified `skip_action_cable` option, so as not to output the
`action_cable_meta_tag` in template, gsub is unnecessary.

ref: https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt#L6..L8
