### PR TITLE
Update counter cache only if the relation is actually saved.

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -9,12 +9,10 @@ module ActiveRecord
       def replace(record)
         if record
           raise_on_type_mismatch!(record)
-          update_counters_on_replace(record)
           replace_keys(record)
           set_inverse_instance(record)
           @updated = true
         else
-          decrement_counters
           remove_keys
         end
 

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -31,11 +31,9 @@ module ActiveRecord::Associations::Builder # :nodoc:
           foreign_key  = reflection.foreign_key
           cache_column = reflection.counter_cache_column
 
-          if (@_after_create_counter_called ||= false)
-            @_after_create_counter_called = false
-          elsif (@_after_replace_counter_called ||= false)
-            @_after_replace_counter_called = false
-          elsif saved_change_to_attribute?(foreign_key) && !new_record?
+          association_changed = saved_change_to_attribute?(foreign_key) || (reflection.polymorphic? && saved_change_to_attribute?(reflection.foreign_type))
+
+          if association_changed && !new_record?
             if reflection.polymorphic?
               model     = attribute_in_database(reflection.foreign_type).try(:constantize)
               model_was = attribute_before_last_save(reflection.foreign_type).try(:constantize)
@@ -46,13 +44,14 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
             foreign_key_was = attribute_before_last_save foreign_key
             foreign_key     = attribute_in_database foreign_key
+            primary_key     = reflection.options[:primary_key] || model.primary_key
 
             if foreign_key && model.respond_to?(:increment_counter)
-              model.increment_counter(cache_column, foreign_key)
+              model.increment_counter_for_key(cache_column, primary_key, foreign_key)
             end
 
             if foreign_key_was && model_was.respond_to?(:decrement_counter)
-              model_was.decrement_counter(cache_column, foreign_key_was)
+              model_was.decrement_counter_for_key(cache_column, primary_key, foreign_key_was)
             end
           end
         end

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -54,15 +54,38 @@ module ActiveRecord
         return true
       end
 
+      # Convenience method for #update_counters_for_key that identifies the record
+      # by primary_id of the model.
+      #
+      # ==== Parameters
+      # * +id+ - The id of the object you wish to update a counter on or an array of ids.
+      # * +counters+ - A Hash containing the names of the fields
+      #   to update as keys and the amount to update the field by as values.
+      #
+      # ==== Examples
+      #   # For the Posts with id of 10 and 15, increment the comment_count by 1
+      #   Post.update_counters [10, 15], comment_count: 1
+      #   # Executes the following SQL:
+      #   # UPDATE posts
+      #   #    SET comment_count = COALESCE(comment_count, 0) + 1
+      #   #  WHERE id IN (10, 15)
+      #
+      #
+      def update_counters(id, counters)
+        update_counters_for_key(primary_key, id, counters)
+      end
+
       # A generic "counter updater" implementation, intended primarily to be
-      # used by #increment_counter and #decrement_counter, but which may also
+      # used by #increment_counter_for_key and #decrement_counter_for_key, but which may also
       # be useful on its own. It simply does a direct SQL update for the record
-      # with the given ID, altering the given hash of counters by the amount
-      # given by the corresponding value:
+      # with the given value in given column, altering the given hash of counters by the amount
+      # given by the corresponding value. This method allows to update counter cache in record
+      # identified by any key (id, slug, uuid etc).
       #
       # ==== Parameters
       #
-      # * +id+ - The id of the object you wish to update a counter on or an array of ids.
+      # * +key_name+ - Column name of the key you want to identify the object by
+      # * +key_value+ - The value of the key object you wish to update a counter on or an array of values
       # * +counters+ - A Hash containing the names of the fields
       #   to update as keys and the amount to update the field by as values.
       # * <tt>:touch</tt> option - Touch timestamp columns when updating.
@@ -71,31 +94,26 @@ module ActiveRecord
       #
       # ==== Examples
       #
-      #   # For the Post with id of 5, decrement the comment_count by 1, and
+      #   # For the Post with slug of 5-recent-news, decrement the comment_count by 1, and
       #   # increment the action_count by 1
-      #   Post.update_counters 5, comment_count: -1, action_count: 1
+      #   Post.update_counters_for_key "slug", "5-recent-news", comment_count: -1, action_count: 1
+      #
       #   # Executes the following SQL:
       #   # UPDATE posts
       #   #    SET comment_count = COALESCE(comment_count, 0) - 1,
       #   #        action_count = COALESCE(action_count, 0) + 1
-      #   #  WHERE id = 5
-      #
-      #   # For the Posts with id of 10 and 15, increment the comment_count by 1
-      #   Post.update_counters [10, 15], comment_count: 1
-      #   # Executes the following SQL:
-      #   # UPDATE posts
-      #   #    SET comment_count = COALESCE(comment_count, 0) + 1
-      #   #  WHERE id IN (10, 15)
+      #   #  WHERE slug = "5-recent-news"
       #
       #   # For the Posts with id of 10 and 15, increment the comment_count by 1
       #   # and update the updated_at value for each counter.
       #   Post.update_counters [10, 15], comment_count: 1, touch: true
       #   # Executes the following SQL:
       #   # UPDATE posts
-      #   #    SET comment_count = COALESCE(comment_count, 0) + 1,
+      #   #    SET comment_count = COALESCE(comment_count, 0) + 1
       #   #    `updated_at` = '2016-10-13T09:59:23-05:00'
       #   #  WHERE id IN (10, 15)
-      def update_counters(id, counters)
+
+      def update_counters_for_key(key_name, key_value, counters)
         touch = counters.delete(:touch)
 
         updates = counters.map do |counter_name, value|
@@ -109,7 +127,7 @@ module ActiveRecord
           updates << sanitize_sql_for_assignment(touch_updates) unless touch_updates.empty?
         end
 
-        unscoped.where(primary_key => id).update_all updates.join(", ")
+        unscoped.where(key_name => key_value).update_all updates.join(", ")
       end
 
       # Increment a numeric field by one, via a direct SQL update.
@@ -139,6 +157,28 @@ module ActiveRecord
         update_counters(id, counter_name => 1, touch: touch)
       end
 
+      # Increment a numeric field by one, via a direct SQL update for record that
+      # is identified by given column name.
+      #
+      # This method is used primarily for maintaining counter_cache columns that are
+      # used to store aggregate values. For example, a +DiscussionBoard+ may cache
+      # posts_count and comments_count to avoid running an SQL query to calculate the
+      # number of posts and comments there are, each time it is displayed.
+      #
+      # ==== Parameters
+      #
+      # * +counter_name+ - The name of the field that should be incremented.
+      # * +key_name+ - key_value name of the key you want to identify the object by
+      # * +key_value+ - The value of the key object you wish to increment a counter on or an array of values
+      #
+      # ==== Examples
+      #
+      #   # Increment the posts_count column for the record with slug = "15-my-posts"
+      #   DiscussionBoard.increment_counter(:posts_count, "slug", "15-my-posts")
+      def increment_counter_for_key(counter_name, key_name, key_value)
+        update_counters_for_key(key_name, key_value, counter_name => 1)
+      end
+
       # Decrement a numeric field by one, via a direct SQL update.
       #
       # This works the same as #increment_counter but reduces the column value by
@@ -164,6 +204,26 @@ module ActiveRecord
         update_counters(id, counter_name => -1, touch: touch)
       end
 
+      # Decrement a numeric field by one, via a direct SQL update for record that
+      # is identified by given column name.
+      #
+      # This works the same as #increment_counter_for_key but reduces the column value by
+      # 1 instead of increasing it.
+      #
+      # ==== Parameters
+      #
+      # * +counter_name+ - The name of the field that should be decremented.
+      # * +key_name+ - key_value name of the key you want to identify the object by
+      # * +key_value+ - The value of the key object you wish to decrement a counter on or an array of values
+      #
+      # ==== Examples
+      #
+      #   # Decrement the posts_count column for the record with an id of 5
+      #   DiscussionBoard.decrement_counter(:posts_count, 5)
+      def decrement_counter_for_key(counter_name, key_name, key_value)
+        update_counters_for_key(key_name, key_value, counter_name => -1)
+      end
+
       private
         def touch_updates(touch)
           touch = timestamp_attributes_for_update_in_model if touch == true
@@ -180,7 +240,6 @@ module ActiveRecord
         each_counter_cached_associations do |association|
           if send(association.reflection.name)
             association.increment_counters
-            @_after_create_counter_called = true
           end
         end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -23,6 +23,10 @@ require "models/admin/user"
 require "models/ship"
 require "models/treasure"
 require "models/parrot"
+require "models/dog_lover"
+require "models/dog"
+require "models/car"
+require "models/engine"
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
@@ -387,15 +391,18 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_belongs_to_counter_with_assigning_nil
-    post = Post.find(1)
-    comment = Comment.find(1)
+    car = Car.create!
+    engine1 = Engine.create!(car_id: car.id)
+    engine2 = Engine.create!(car_id: car.id)
 
-    assert_equal post.id, comment.post_id
-    assert_equal 2, Post.find(post.id).comments.size
+    assert_equal car.id, engine1.car_id
+    assert_equal car.id, engine2.car_id
+    assert_equal 2, Car.find(car.id).engines.size
 
-    comment.post = nil
+    engine1.my_car = nil
+    engine1.save!
 
-    assert_equal 1, Post.find(post.id).comments.size
+    assert_equal 1, Car.find(car.id).engines.size
   end
 
   def test_belongs_to_with_primary_key_counter
@@ -406,12 +413,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, debate.reload.replies_count
     assert_equal 0, debate2.reload.replies_count
 
-    reply.topic_with_primary_key = debate2
+    reply.update_attribute(:topic_with_primary_key, debate2)
 
     assert_equal 0, debate.reload.replies_count
     assert_equal 1, debate2.reload.replies_count
 
-    reply.topic_with_primary_key = nil
+    reply.update_attribute(:topic_with_primary_key, nil)
 
     assert_equal 0, debate.reload.replies_count
     assert_equal 0, debate2.reload.replies_count
@@ -439,11 +446,13 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
     reply1.topic = nil
 
+    assert reply1.save
     assert_equal 0, Topic.find(topic1.id).replies.size
     assert_equal 0, Topic.find(topic2.id).replies.size
 
     reply1.topic = topic1
 
+    assert reply1.save
     assert_equal 1, Topic.find(topic1.id).replies.size
     assert_equal 0, Topic.find(topic2.id).replies.size
 
@@ -653,6 +662,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
     reply = Reply.create(title: "re: zoom", content: "speedy quick!")
     reply.topic = topic
+    reply.save
 
     assert_equal 1, topic.reload[:replies_count]
     assert_equal 1, topic.replies.size
@@ -679,6 +689,21 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     reply.destroy
     assert_equal 4, topic.reload[:replies_count]
     assert_equal 4, topic.replies.size
+  end
+
+  def test_counter_cache_is_not_incremented_if_the_association_is_not_saved_to_db
+    car = Car.create!
+    engine = Engine.create!
+
+    engine.my_car = car
+
+    assert_equal 0, Car.find(car.id).engines_count
+    assert_equal nil, Engine.find(engine.id).car_id
+
+    engine.save!
+
+    assert_equal 1, Car.find(car.id).engines_count
+    assert_equal car.id, Engine.find(engine.id).car_id
   end
 
   def test_concurrent_counter_cache_double_destroy
@@ -708,12 +733,21 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
     silly = SillyReply.create(title: "gaga", content: "boo-boo")
     silly.reply = reply
+  end
 
-    assert_equal 1, reply.reload[:replies_count]
-    assert_equal 1, reply.replies.size
+  def test_counter_cache_with_custom_column_name
+    breeder = DogLover.create!
+    dog = Dog.create!
+    assert_equal 0, breeder[:bred_dogs_count]
 
-    reply[:replies_count] = 17
-    assert_equal 17, reply.replies.size
+    dog.breeder = breeder
+    dog.save!
+
+    assert_equal 1, breeder.reload[:bred_dogs_count]
+    assert_equal 1, breeder.bred_dogs.size
+
+    breeder[:bred_dogs_count] = 17
+    assert_equal 17, breeder.bred_dogs.size
   end
 
   def test_replace_counter_cache
@@ -972,7 +1006,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
     assert_difference lambda { post.reload.tags_count }, -1 do
       assert_difference "comment.reload.tags_count", +1 do
-        tagging.taggable = comment
+        tagging.update_attribute(:taggable, comment)
       end
     end
   end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define do
 
   create_table :cars, force: true do |t|
     t.string  :name
-    t.integer :engines_count
+    t.integer :engines_count, default: 0
     t.integer :wheels_count
     t.column :lock_version, :integer, null: false, default: 0
     t.timestamps null: false


### PR DESCRIPTION
Fixes #18988, #22602, #23265, #28203

**Description of the problem**
So far the counter cached was incremented when one of two things
happened in following scenario.

```
  class Post < ActiveRecord::Base
    has_many :coments
  end

  class Comment < ActiveRecord::base
    belongs_to :post, counter_cache: true
  end
```
1. `comment.post = post` was called. This would increment the counter
   cache for post in the db
2. Comment was saved with updated post_id and the counter cache is
   incremented in update callback

This solution (especially the fact that we did counter cache increment in situation #1) had few problems:
-  We bumped the counter cache even if in the end the Comment was not
  saved. For example if something like this happened:

```
    comment.post = post
    raise SomeException
```

  then the comment wouldn't have post_id, but post would end up with
- If someone did the following

```
    comment.post = post
    comment.save!
```

   Post would end up with comments_count = 2 because the counter cache
   would get bumped on both of conditions above.
- The bump in situation 1 was made outside of transaction that saves
  the comment which means we would make unnecessary call to db.
- comment.post = post and comment.post_id = post.id are not consistent.
  Former bumps the bumper cache while the latter does not.

**Solution**
This commit removes the counter cache increment on association
assignment. This means that comment.post = post won't bump the counter.
It will only happen when the comment will get saved. This will ensure
more consistency of data in DB.

**Other changes that are introduced in this commit**:
1. Counter cache incrementer/decrementer can work with foreign_keys
   other than the primary_key of the model. That's why methods
   updates_counters_for_key, increment_counter_for_key and
   decrement_counter_for_key has been introduced.
2. The update callback that bumps counter cache will properly increment
   counter cache for polymorphic association even if the only thing that
   was changed was type of the related object but it happened to have the
   same id as the previously related object.

**Notes about chaned tests:**
1. In test_belongs_to_counter_with_assigning_nil I changed the models
   under test as Comment's post_id is non nullable therefore comment could
   never have been saved with post_id = nil. Moreover this test in its
   original form shown how flawed the previous behavior of counter cache
   was. When nil was assigned to comment.post, that post's comments_count
   would get decremented, but in the end it would be possible to save that
   comment and it would result in inconsistent data.
2. test_counter_cache_with_custom_column_name - the relation of
   SillyReply is basically broken. It uses the same foreign_key "parent_id"
   as the Reply (its superclass) topic relation. That's why I used
   DogLovers and Dogs for the test of custom names for counter caches.
3. Other tests have been updated to actually save the objects in order
   to bump counter cache.
