### PR TITLE
`OID::Money.precision` is unused since #15239

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/money.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/money.rb
@@ -3,8 +3,6 @@ module ActiveRecord
     module PostgreSQL
       module OID # :nodoc:
         class Money < Type::Decimal # :nodoc:
-          class_attribute :precision
-
           def type
             :money
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -645,12 +645,6 @@ module ActiveRecord
         # connected server's characteristics.
         def connect
           @connection = PGconn.connect(@connection_parameters)
-
-          # Money type has a fixed precision of 10 in PostgreSQL 8.2 and below, and as of
-          # PostgreSQL 8.3 it has a fixed precision of 19. PostgreSQLColumn.extract_precision
-          # should know about this but can't detect it there, so deal with it here.
-          OID::Money.precision = (postgresql_version >= 80300) ? 19 : 10
-
           configure_connection
         rescue ::PG::Error => error
           if error.message.include?("does not exist")


### PR DESCRIPTION
Address to a398cd0.

``` ruby
p PostgreSQLAdapter::OID::Money.precision
# => 19

p PostgreSQLAdapter::OID::Money.new.precision
# => nil
```

r? @rafaelfranca 
