### PR TITLE
remove backward compatibility code for Minitest 4

### DIFF
--- a/guides/bug_report_templates/generic_master.rb
+++ b/guides/bug_report_templates/generic_master.rb
@@ -19,9 +19,6 @@ require 'active_support'
 require 'active_support/core_ext/object/blank'
 require 'minitest/autorun'
 
-# Ensure backward compatibility with Minitest 4
-Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
-
 class BugTest < Minitest::Test
   def test_stuff
     assert "zomg".present?


### PR DESCRIPTION
The master branch is required Ruby 2.2.2+, for the Ruby 2.2 is bundled Minitest 5.4.3,
I think backward compatibility code for Minitest 4 is unnecessary.
