### PR TITLE
Use `t.index` in `create_table` instead of `add_index` in test schema

### DIFF
--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -21,15 +21,14 @@ ActiveRecord::Schema.define do
     t.index :var_binary
   end
 
-  create_table :key_tests, force: true, :options => 'ENGINE=MyISAM' do |t|
+  create_table :key_tests, force: true, options: 'ENGINE=MyISAM' do |t|
     t.string :awesome
     t.string :pizza
     t.string :snacks
+    t.index :awesome, type: :fulltext, name: 'index_key_tests_on_awesome'
+    t.index :pizza, using: :btree, name: 'index_key_tests_on_pizza'
+    t.index :snacks, name: 'index_key_tests_on_snack'
   end
-
-  add_index :key_tests, :awesome, :type => :fulltext, :name => 'index_key_tests_on_awesome'
-  add_index :key_tests, :pizza, :using => :btree, :name => 'index_key_tests_on_pizza'
-  add_index :key_tests, :snacks, :name => 'index_key_tests_on_snack'
 
   create_table :collation_tests, id: false, force: true do |t|
     t.string :string_cs_column, limit: 1, collation: 'utf8_bin'

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -202,11 +202,10 @@ ActiveRecord::Schema.define do
     t.integer :rating, default: 1
     t.integer :account_id
     t.string :description, default: ""
+    t.index [:firm_id, :type, :rating], name: "company_index"
+    t.index [:firm_id, :type], name: "company_partial_index", where: "rating > 10"
+    t.index :name, name: 'company_name_index', using: :btree
   end
-
-  add_index :companies, [:firm_id, :type, :rating], name: "company_index"
-  add_index :companies, [:firm_id, :type], name: "company_partial_index", where: "rating > 10"
-  add_index :companies, :name, name: 'company_name_index', using: :btree
 
   create_table :content, force: true do |t|
     t.string :title
@@ -304,8 +303,8 @@ ActiveRecord::Schema.define do
   create_table :edges, force: true, id: false do |t|
     t.column :source_id, :integer, null: false
     t.column :sink_id,   :integer, null: false
+    t.index [:source_id, :sink_id], unique: true, name: 'unique_edge_index'
   end
-  add_index :edges, [:source_id, :sink_id], unique: true, name: 'unique_edge_index'
 
   create_table :engines, force: true do |t|
     t.integer :car_id
@@ -782,8 +781,8 @@ ActiveRecord::Schema.define do
     t.string :nick, null: false
     t.string :name
     t.column :books_count, :integer, null: false, default: 0
+    t.index :nick, unique: true
   end
-  add_index :subscribers, :nick, unique: true
 
   create_table :subscriptions, force: true do |t|
     t.string :subscriber_id


### PR DESCRIPTION
For reduce bootstrap queries in tests.
