### PR TITLE
Fix documentation related to `config.assets.cache_store` [ci skip]

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -1177,19 +1177,14 @@ TIP: For further details have a look at the docs of your production web server:
 Assets Cache Store
 ------------------
 
-The default Rails cache store will be used by Sprockets to cache assets in
-development and production. This can be changed by setting
-`config.assets.cache_store`:
+By default, Sprockets caches assets in `tmp/cache/assets` in development
+and production environments. This can be changed as follows:
 
 ```ruby
-config.assets.cache_store = :memory_store
-```
-
-The options accepted by the assets cache store are the same as the application's
-cache store.
-
-```ruby
-config.assets.cache_store = :memory_store, { size: 32.megabytes }
+config.assets.configure do |env|
+  env.cache = ActiveSupport::Cache.lookup_store(:memory_store,
+                                                { size: 32.megabytes })
+end
 ```
 
 To disable the assets cache store:

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -159,8 +159,6 @@ pipeline is enabled. It is set to true by default.
 
 * `config.assets.debug` disables the concatenation and compression of assets. Set to `true` by default in `development.rb`.
 
-* `config.assets.cache_store` defines the cache store that Sprockets will use. The default is the Rails file store.
-
 * `config.assets.compile` is a boolean that can be used to turn on live Sprockets compilation in production.
 
 * `config.assets.logger` accepts a logger conforming to the interface of Log4r or the default Ruby `Logger` class. Defaults to the same configured at `config.logger`. Setting `config.assets.logger` to false will turn off served assets logging.


### PR DESCRIPTION
- sprockets-rails no longer supports customizing cache store after
  rails/sprockets-rails@ecaeb27.
- Fixes #19835.

r? @schneems cc @rafaelfranca 
