### PR TITLE
Fix AR::Relation#last bugs instroduced in 7705fc

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Rework `ActiveRecord::Relation#last` 
+    
+    1. Never perform additional SQL on loaded relation
+    2. Use SQL reverse order instead of loading relation if relation doesn't have limit
+    3. Deprecated relation loading when SQL order can not be automatically reversed
+
+        Topic.order("title").load.last(3)
+          # before: SELECT ...
+          # after: No SQL
+
+        Topic.order("title").last
+          # before: SELECT * FROM `topics`
+          # after:  SELECT * FROM `topics` ORDER BY `topics`.`title` DESC LIMIT 1
+
+        Topic.order("coalesce(author, title)").last
+          # before: SELECT * FROM `topics`
+          # after:  Deprecation Warning for irreversible order
+
+    *Bogdan Gusiev*
+
+
 *   Allow `joins` to be unscoped.
 
     Closes #13775.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1112,6 +1112,8 @@ module ActiveRecord
 
       order_query.flat_map do |o|
         case o
+        when Arel::Attribute
+          o.desc
         when Arel::Nodes::Ordering
           o.reverse
         when String


### PR DESCRIPTION
Fix bugs identifier in https://github.com/rails/rails/pull/16400#issuecomment-177338024

I realized that `last` should work pretty different on a relation with `limit` and without it.
So the fix is pretty different from what we all expected:
We need to use `offset` instead of `reverse_order` on such a relation.

cc @eileencodes @rafaelfranca @sgrif 
