### PR TITLE
Change default ACa adapter for development & test

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/cable.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/cable.yml
@@ -4,9 +4,7 @@ production:
   url: redis://localhost:6379/1
 
 development:
-  adapter: redis
-  url: redis://localhost:6379/2
+  adapter: async
 
 test:
-  adapter: redis
-  url: redis://localhost:6379/3
+  adapter: async


### PR DESCRIPTION
I've left `redis` in the default Gemfile, so production will still work out of the box... but for most development / test users, I don't think there's any need to actually use a redis instance locally.

Unlike ActiveRecord and databases, the ActionCable adapters have a very narrow API, in which they behave identically -- so they really should be casually interchangeable.

This also avoids the current file's misleading implication that different DB numbers provide environment separation: Redis pubsub ignores DB numbers completely.

r? @dhh
