### PR TITLE
clarify the touch true option does not trigger after_save/update [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1591,6 +1591,8 @@ module ActiveRecord
       #   If true, the associated object will be touched (the updated_at/on attributes set to current time)
       #   when this record is either saved or destroyed. If you specify a symbol, that attribute
       #   will be updated with the current time in addition to the updated_at/on attribute.
+      #   Please note that with touching no validation is performed and only the +after_touch+,
+      #   +after_commit+ and +after_rollback+ callbacks are executed.
       # [:inverse_of]
       #   Specifies the name of the #has_one or #has_many association on the associated
       #   object that is the inverse of this #belongs_to association. Does not work in


### PR DESCRIPTION
I've gotten tripped up more than a few times on this, thinking that
using `belongs_to` with `touch: true` would trigger my after_save or
after_update callbacks. The same text is in the documentation for the
touch method itself, but I think its helpful to repeat it again here.
It might save people some time.
