### PR TITLE
Added references option to join tables

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
@@ -19,7 +19,11 @@ class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Mi
   def change
     create_join_table :<%= join_tables.first %>, :<%= join_tables.second %> do |t|
     <%- attributes.each do |attribute| -%>
+      <%- if attribute.reference? -%>
+      t.references :<%= attribute.name %><%= attribute.inject_options %>
+      <%- else -%>
       <%= '# ' unless attribute.has_index? -%>t.index <%= attribute.index_name %><%= attribute.inject_index_options %>
+      <%- end -%>
     <%- end -%>
     end
   end


### PR DESCRIPTION
Fixes issue #22960
When creating join tables with the command

```
rails g migration CreateJoinTableShowroomUser showroom:references user:references
```

The migration will use references to create the joins and output:

```
 class CreateJoinTableShowroomUser < ActiveRecord::Migration
   def change
     create_join_table :showrooms, :users do |t|
       t.references :showroom, index: true, foreign_key: true
       t.references :user, index: true, foreign_key: true
     end
   end
 end
```

This allows for proper refrences with indexes and foreign keys to be easily used when
adding join tables. Without `:refrences` the normal output is generated:

```
class CreateJoinTableShowroomUser < ActiveRecord::Migration[5.0]
  def change
    create_join_table :showrooms, :users do |t|
      # t.index [:showroom_id, :user_id]
      # t.index [:user_id, :showroom_id]
    end#22960
  end
end
```
