### PR TITLE
Define Model#present? and Model#blank? methods

### DIFF
--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -40,6 +40,7 @@ module ActiveModel
   autoload :Model
   autoload :Name, 'active_model/naming'
   autoload :Naming
+  autoload :Presence
   autoload :SecurePassword
   autoload :Serialization
   autoload :TestCase

--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -60,6 +60,7 @@ module ActiveModel
     include ActiveModel::AttributeAssignment
     include ActiveModel::Validations
     include ActiveModel::Conversion
+    include ActiveModel::Presence
 
     included do
       extend ActiveModel::Naming

--- a/activemodel/lib/active_model/presence.rb
+++ b/activemodel/lib/active_model/presence.rb
@@ -1,0 +1,24 @@
+module ActiveModel
+  # == Active \Model \Presence
+  #
+  # A Module that explicitly defines `present?` and `blank?`.
+  module Presence
+    # Every model object is present:
+    #
+    #   Model.new.present?  #=> true
+    #
+    # @return [true]
+    def present?
+      true
+    end
+
+    # No model object is blank:
+    #
+    #   Model.new.blank?  #=> false
+    #
+    # @return [false]
+    def blank?
+      false
+    end
+  end
+end

--- a/activemodel/test/cases/presence_test.rb
+++ b/activemodel/test/cases/presence_test.rb
@@ -1,0 +1,14 @@
+require 'cases/helper'
+require 'models/contact'
+
+class PresenceTest < ActiveModel::TestCase
+  test 'Model#present?' do
+    contact = Contact.new
+    assert_equal true, contact.present?
+  end
+
+  test 'Model#blank?' do
+    contact = Contact.new
+    assert_equal false, contact.blank?
+  end
+end

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -319,6 +319,7 @@ module ActiveRecord #:nodoc:
     include Store
     include SecureToken
     include Suppressor
+    include ActiveModel::Presence
   end
 
   ActiveSupport.run_load_hooks(:active_record, Base)


### PR DESCRIPTION
While hunting the performance problem on our app, I noticed (literally) hundreds of `AR#present?` calls.

It's true that most of `if model.present?` can be replaced with `if model`, which means the app code is wrong in the most cases, but many Rails programmers tend to write `model.present?` especially if they are not very much familiar with Ruby.
I bet, `git grep`ing your Rails app, you'll find at least 10 or 20 occurrences of `model.present?`  (e.g. `current_user.present?`).

This method call does not only make the code looking a little bit redundant but actually makes so many extra method calls.

Here's the recorded stack trace of `model.present?` on current AR master. This is what exactly happens when calling `model.present?`
### Before this patch:

```
Object#present?
Object#blank?
ActiveRecord::AttributeMethods#respond_to?
ActiveModel::AttributeMethods#respond_to?
Kernel#respond_to?
Kernel#respond_to_missing?
Kernel#respond_to?
Kernel#respond_to_missing?
Symbol#to_s
ActiveModel::AttributeMethods#matched_attribute_method
Kernel#class
ActiveModel::AttributeMethods::ClassMethods#attribute_method_matchers_matching
ActiveModel::AttributeMethods::ClassMethods#attribute_method_matchers_cache
Concurrent::Collection::MriMapBackend#compute_if_absent
Concurrent::Collection::NonConcurrentMapBackend#[]
Mutex#synchronize
Concurrent::Collection::NonConcurrentMapBackend#compute_if_absent
Hash#fetch
#<Class:ActiveRecord::Base>#attribute_method_matchers
Symbol#to_proc
Enumerable#partition
Array#each
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#plain?
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#plain?
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#plain?
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#plain?
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#plain?
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#plain?
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#plain?
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#plain?
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#plain?
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#plain?
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#plain?
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#plain?
Array#reverse
Array#flatten
Array#map
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#match
Regexp#=~
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#match
Regexp#=~
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#match
Regexp#=~
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#match
Regexp#=~
#<Class:ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher::AttributeMethodMatch>#new
Struct#initialize
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#match
Regexp#=~
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#match
Regexp#=~
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#match
Regexp#=~
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#match
Regexp#=~
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#match
Regexp#=~
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#match
Regexp#=~
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#match
Regexp#=~
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher#match
Regexp#=~
#<Class:ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher::AttributeMethodMatch>#new
Struct#initialize
Array#compact
Enumerable#detect
Array#each
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher::AttributeMethodMatch#attr_name
ActiveRecord::AttributeMethods::PrimaryKey#attribute_method?
ActiveRecord::AttributeMethods#attribute_method?
ActiveRecord::AttributeSet#key?
ActiveRecord::LazyAttributeHash#key?
Hash#key?
Hash#key?
Hash#key?
ActiveModel::AttributeMethods::ClassMethods::AttributeMethodMatcher::AttributeMethodMatch#attr_name
ActiveRecord::AttributeMethods::PrimaryKey#attribute_method?
ActiveRecord::AttributeMethods#attribute_method?
ActiveRecord::AttributeSet#key?
ActiveRecord::LazyAttributeHash#key?
Hash#key?
Hash#key?
Hash#key?
NilClass#nil?
```

So I'm proposing a new Module representing models' presence -- obviously, if there's an instance, the model should be present.

This patch bypasses these 85 method calls scanning through all attributes in favor of 1 simple method call.
### After this patch:

```
ActiveModel::Presence#present?
```

(I'm sorry if this dups. I thought I once saw a similar proposal somewhere, but I couldn't find one in the past PRs/issues in this repo)
