### PR TITLE
Remove unused ReaderMethodCache and  WriterMethodCache  constants from ActiveRecord

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -34,30 +34,6 @@ module ActiveRecord
 
     BLACKLISTED_CLASS_METHODS = %w(private public protected allocate new name parent superclass)
 
-    class AttributeMethodCache
-      def initialize
-        @module = Module.new
-        @method_cache = Concurrent::Map.new
-      end
-
-      def [](name)
-        @method_cache.compute_if_absent(name) do
-          safe_name = name.unpack('h*'.freeze).first
-          temp_method = "__temp__#{safe_name}"
-          ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
-          @module.module_eval method_body(temp_method, safe_name), __FILE__, __LINE__
-          @module.instance_method temp_method
-        end
-      end
-
-      private
-
-      # Override this method in the subclasses for method body.
-      def method_body(method_name, const_name)
-        raise NotImplementedError, "Subclasses must implement a method_body(method_name, const_name) method."
-      end
-    end
-
     class GeneratedAttributeMethods < Module; end # :nodoc:
 
     module ClassMethods

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -1,7 +1,6 @@
 module ActiveRecord
   module AttributeMethods
     module Read
-
       extend ActiveSupport::Concern
 
       module ClassMethods

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -1,8 +1,12 @@
 module ActiveRecord
   module AttributeMethods
     module Read
-      ReaderMethodCache = Class.new(AttributeMethodCache) {
-        private
+
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        protected
+
         # We want to generate the methods via module_eval rather than
         # define_method, because define_method is slower on dispatch.
         # Evaluating many similar methods may use more memory as the instruction
@@ -21,21 +25,6 @@ module ActiveRecord
         # to allocate an object on each call to the attribute method.
         # Making it frozen means that it doesn't get duped when used to
         # key the @attributes in read_attribute.
-        def method_body(method_name, const_name)
-          <<-EOMETHOD
-          def #{method_name}
-            name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{const_name}
-            _read_attribute(name) { |n| missing_attribute(n, caller) }
-          end
-          EOMETHOD
-        end
-      }.new
-
-      extend ActiveSupport::Concern
-
-      module ClassMethods
-        protected
-
         def define_method_attribute(name)
           safe_name = name.unpack('h*'.freeze).first
           temp_method = "__temp__#{safe_name}"

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -1,19 +1,6 @@
 module ActiveRecord
   module AttributeMethods
     module Write
-      WriterMethodCache = Class.new(AttributeMethodCache) {
-        private
-
-        def method_body(method_name, const_name)
-          <<-EOMETHOD
-          def #{method_name}(value)
-            name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{const_name}
-            write_attribute(name, value)
-          end
-          EOMETHOD
-        end
-      }.new
-
       extend ActiveSupport::Concern
 
       included do


### PR DESCRIPTION
`Module.methods_transplantable?` is deprecated and waiting for removal. Please refer [here](https://github.com/rails/rails/commit/b2bb2a46)

`AttributeMethodCache` class is also not used anymore. Check [here](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/attribute_methods.rb#L37). We should remove this as well. Shall I add the change in same PR?
