### PR TITLE
Duplicate assert_generates options before modifying it

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -86,6 +86,7 @@ module ActionDispatch
         end
         # Load routes.rb if it hasn't been loaded.
 
+        options = options.clone
         generated_path, query_string_keys = @routes.generate_extras(options, defaults)
         found_extras = options.reject { |k, _| ! query_string_keys.include? k }
 


### PR DESCRIPTION
`assert_generates` shouldn't modify the `options` passed to it.
You can see [here](https://github.com/blowmage/minitest-rails/pull/192/files#diff-e6deb02c82fac01b5f42acc67ea74a64R24) how this can be a problem that didn't exist before 5.0.

Also you can see that the options are cloned in [assert_recognizes](https://github.com/pschambacher/rails/blob/407baa2b4cc462e42c9aaccc9850adad4462ea7e/actionpack/lib/action_dispatch/testing/assertions/routing.rb#L48) and in [assert_routing](https://github.com/pschambacher/rails/blob/407baa2b4cc462e42c9aaccc9850adad4462ea7e/actionpack/lib/action_dispatch/testing/assertions/routing.rb#L130).
