### PR TITLE
renames #to_hash to #to_a in ActiveRecord::Result

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -599,7 +599,7 @@ module ActiveRecord
               column
             end
           else
-            basic_structure.to_hash
+            basic_structure.to_a
           end
         end
     end

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -19,7 +19,7 @@ module ActiveRecord
   #        ]
   #
   #   # Get an array of hashes representing the result (column => value):
-  #   result.to_hash
+  #   result.to_a
   #   # => [{"id" => 1, "title" => "title_1", "body" => "body_1"},
   #         {"id" => 2, "title" => "title_2", "body" => "body_2"},
   #         ...
@@ -55,7 +55,7 @@ module ActiveRecord
       end
     end
 
-    def to_hash
+    def to_a
       hash_rows
     end
 

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -14,12 +14,12 @@ module ActiveRecord
       assert_equal 3, result.length
     end
 
-    test "to_hash returns row_hashes" do
+    test "to_a returns row_hashes" do
       assert_equal [
         {'col_1' => 'row 1 col 1', 'col_2' => 'row 1 col 2'},
         {'col_1' => 'row 2 col 1', 'col_2' => 'row 2 col 2'},
         {'col_1' => 'row 3 col 1', 'col_2' => 'row 3 col 2'},
-      ], result.to_hash
+      ], result.to_a
     end
 
     test "each with block returns row hashes" do


### PR DESCRIPTION
method returns an array of hashes, not a hash
e.g. Hash.try_convert(result) calls #to_hash and raises a TypeError

[ActiveRecord::Result#to_hash](https://github.com/rails/rails/commit/59f7780a3454a14054d1d33d9b6e31192ab2e58b#diff-56dacac8e4a23c4e1d4f63562fa5d6d1R23)

It's unexpected for `#to_hash` to _not_ return a hash, e.g. [AwesomePrint](https://github.com/michaeldv/awesome_print) checks and uses `#to_hash` to inspect hash-convertible objects, as noted in [an AwesomePrint issue](https://github.com/michaeldv/awesome_print/issues/215).

Ruby core even expects `Hash` from `#to_hash`:

```
> Hash.try_convert(ActiveRecord::Base.connection.select_all("select * from users limit 1;"))
TypeError: can't convert ActiveRecord::Result to Hash (ActiveRecord::Result#to_hash gives Array)
```

(above copied from mailing list thread): [ActiveRecord::Result#to_hash doesn't return a hash](https://groups.google.com/forum/#!topic/rubyonrails-core/NmnCis3ejzY)

Defined `to_a` because it performs better than `Enumerable`'s inherited `to_a` via `each`.
