### PR TITLE
Add option to error on ignored order or limit

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Added a configuration option to have active record raise an ArgumentError
+    if the order or limit is ignored in a batch query, rather than logging a
+    warning message.
+
+    *Scott Ringwelski*
+
 *   Bumped the minimum supported version of PostgreSQL to >= 9.1.
     Both PG 9.0 and 8.4 are past their end of life date:
     http://www.postgresql.org/support/versioning/

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -72,6 +72,14 @@ module ActiveRecord
 
       ##
       # :singleton-method:
+      # Specifies if an error should be raised on query limit or order being
+      # ignored when doing batch queries. Useful in applications where the
+      # limit or scope being ignored is error-worthy, rather than a warning.
+      mattr_accessor :error_on_ignored_order_or_limit, instance_writer: false
+      self.error_on_ignored_order_or_limit = false
+
+      ##
+      # :singleton-method:
       # Specify whether or not to use timestamps for migration versions
       mattr_accessor :timestamped_migrations, instance_writer: false
       self.timestamped_migrations = true

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -164,6 +164,42 @@ class EachTest < ActiveRecord::TestCase
     assert_equal posts(:welcome).id, posts.first.id
   end
 
+  def test_find_in_batches_should_error_on_ignore_the_order
+    assert_raise(ArgumentError) do
+      PostWithDefaultScope.find_in_batches(error_on_ignore: true){}
+    end
+  end
+
+  def test_find_in_batches_should_not_error_if_config_overriden
+    # Set the config option which will be overriden
+    prev = ActiveRecord::Base.error_on_ignored_order_or_limit
+    ActiveRecord::Base.error_on_ignored_order_or_limit = true
+    assert_nothing_raised do
+      PostWithDefaultScope.find_in_batches(error_on_ignore: false){}
+    end
+  ensure
+    # Set back to default
+    ActiveRecord::Base.error_on_ignored_order_or_limit = prev
+  end
+
+  def test_find_in_batches_should_error_on_config_specified_to_error
+    # Set the config option
+    prev = ActiveRecord::Base.error_on_ignored_order_or_limit
+    ActiveRecord::Base.error_on_ignored_order_or_limit = true
+    assert_raise(ArgumentError) do
+      PostWithDefaultScope.find_in_batches(){}
+    end
+  ensure
+    # Set back to default
+    ActiveRecord::Base.error_on_ignored_order_or_limit = prev
+  end
+
+  def test_find_in_batches_should_not_error_by_default
+    assert_nothing_raised do
+      PostWithDefaultScope.find_in_batches(){}
+    end
+  end
+
   def test_find_in_batches_should_not_ignore_the_default_scope_if_it_is_other_then_order
     special_posts_ids = SpecialPostWithDefaultScope.all.map(&:id).sort
     posts = []

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -279,6 +279,8 @@ All these configuration options are delegated to the `I18n` library.
 
 * `config.active_record.schema_format` controls the format for dumping the database schema to a file. The options are `:ruby` (the default) for a database-independent version that depends on migrations, or `:sql` for a set of (potentially database-dependent) SQL statements.
 
+* `config.active_record.error_on_ignored_order_or_limit` specifies if an error should be raised if the order or limit of a query is ignored during a batch query. The options are true (raise error) or false (warn). Default is false.
+
 * `config.active_record.timestamped_migrations` controls whether migrations are numbered with serial integers or with timestamps. The default is true, to use timestamps, which are preferred if there are multiple developers working on the same application.
 
 * `config.active_record.lock_optimistically` controls whether Active Record will use optimistic locking and is true by default.


### PR DESCRIPTION
Right now find in batches logs a warning if the scoped order or limit is ignored. This makes sense, but in some applications it is preferred to fix these general cases as the ignoring of the limit or ordering could have substantial consequences.

This adds an active_record.error_on_ignored_order_or_limit config option to allow globally erroring on ignores. It also adds a per-method call config option error_on_ignore which can be specified for each call.

This is my first PR, so feedback is very welcome. I threw together some basic tests which I am still working on running locally. I just wanted to get this proof of concept out there for feedback.
