### PR TITLE
move `test_generator_if_skip_action_cable_is_given_for_an_api_app` to the appropriate file

### DIFF
--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -52,6 +52,16 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     assert_file "app/controllers/application_controller.rb", /ActionController::API/
   end
 
+  def test_generator_if_skip_action_cable_is_given
+    run_generator [destination_root, "--skip-action-cable"]
+    assert_file "config/application.rb", /#\s+require\s+["']action_cable\/engine["']/
+    assert_no_file "config/cable.yml"
+    assert_no_file "app/channels"
+    assert_file "Gemfile" do |content|
+      assert_no_match(/redis/, content)
+    end
+  end
+
   private
 
   def default_files

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -413,17 +413,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_generator_if_skip_action_cable_is_given_for_an_api_app
-    run_generator [destination_root, "--skip-action-cable", "--api"]
-    assert_file "config/application.rb", /#\s+require\s+["']action_cable\/engine["']/
-    assert_no_file "config/cable.yml"
-    assert_no_file "app/assets/javascripts/cable.coffee"
-    assert_no_file "app/channels"
-    assert_file "Gemfile" do |content|
-      assert_no_match(/redis/, content)
-    end
-  end
-
   def test_action_cable_redis_gems
     run_generator
     assert_gem 'redis'


### PR DESCRIPTION
Test of Rails API should be in `api_app_generator_test.rb`.
