### PR TITLE
test writes session cookie if session is accessed

### DIFF
--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -173,6 +173,19 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_writes_session_cookie_if_nonempty_session_is_accessed
+    with_test_route_set do
+      get '/get_session_value'
+      assert_response :success
+      assert_equal nil, headers['Set-Cookie']
+
+      cookies[SessionKey] = SignedBar
+      get '/get_session_value'
+      assert_response :success
+      assert headers['Set-Cookie']
+    end
+  end
+
   def test_doesnt_write_session_cookie_if_session_is_unchanged
     with_test_route_set do
       cookies[SessionKey] = "BAh7BjoIZm9vIghiYXI%3D--" +


### PR DESCRIPTION
Accessing `session` causes a `Set-Cookie` header to be sent. If this is intended behavior here is a test to make it clear. If not i could change the test to a failing one.

``` ruby
  def test_doesnt_write_session_cookie_if_signed_session_is_unchanged
    with_test_route_set do
      cookies[SessionKey] = SignedBar
      get '/get_session_value'
      assert_response :success
      assert_equal nil, headers['Set-Cookie']
    end
  end
```

If this behavior is intended for cachebusting why dosn't it create a session. Like it is now a request without session could be cached preventing requests with a session to operate like intended.
