### PR TITLE
Automatically guess the inverse associations for STI

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Automatically guess the inverse associations for STI.
+
+    *Yuichiro Kaneko*
+
 *   Ensure `sum` honors `distinct` on `has_many :through` associations
 
     Fixes #16791.

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -657,7 +657,7 @@ module ActiveRecord
         # from calling +klass+, +reflection+ will already be set to false.
         def valid_inverse_reflection?(reflection)
           reflection &&
-            klass.name == reflection.active_record.name &&
+            klass <= reflection.active_record &&
             can_find_inverse_of_automatically?(reflection)
         end
 


### PR DESCRIPTION
ActiveRecord associations automatically guess the inverse associations.
But this feature does not work correctly on assoctions for STI.
For example, before this commit

```
class Post < ActiveRecord::Base
  belongs_to :author
end

class SpecialPost < Post; end

class Author < ActiveRecord::Base
  has_many :posts
  has_many :special_posts
end
```

`author.posts.first.author` works correctly, but
`author.special_posts.first.author` does not work correctly.
