### PR TITLE
The minimum supported version of PostgreSQL is now >= 9.1

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Bumped the minimum supported version of PostgreSQL to >= 9.1.
+    Both PG 9.0 and 8.4 are past their end of life date:
+    http://www.postgresql.org/support/versioning/
+
+    *Remo Mueller*
+
 ## Rails 5.0.0.beta2 (February 01, 2016) ##
 
 *   `ActiveRecord::Relation#reverse_order` throws `ActiveRecord::IrreversibleOrderError`

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -214,7 +214,7 @@ module ActiveRecord
         @statements = StatementPool.new @connection,
                                         self.class.type_cast_config_to_integer(config.fetch(:statement_limit) { 1000 })
 
-        if postgresql_version < 80200
+        if postgresql_version < 90100
           raise "Your version of PostgreSQL (#{postgresql_version}) is too old, please upgrade!"
         end
 
@@ -297,9 +297,8 @@ module ActiveRecord
         true
       end
 
-      # Returns true if pg > 9.1
       def supports_extensions?
-        postgresql_version >= 90100
+        true
       end
 
       # Range datatypes weren't introduced until PostgreSQL 9.2


### PR DESCRIPTION
Both PG 9.0 and 8.4 are past their end of life date:
http://www.postgresql.org/support/versioning/
