### PR TITLE
Put some space for non-assets requests in development mode

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -26,6 +26,8 @@ module ActionController
         end
         message = "Completed #{status} #{Rack::Utils::HTTP_STATUS_CODES[status]} in #{event.duration.round}ms"
         message << " (#{additions.join(" | ".freeze)})" unless additions.blank?
+        message << "\n\n" if Rails.env.development?
+
         message
       end
     end


### PR DESCRIPTION
- Fixes #23428.

r? @dhh 

Here is the sample output on an app created from rails master with this change - https://gist.github.com/prathamesh-sonpatki/ca9dbc32bcbae9066562

~~EDIT: Updated gist with Kasper's suggestion of printing a line before starting assets request - https://gist.github.com/prathamesh-sonpatki/c9075f78ac6f1f372c7c~~
