### PR TITLE
Remove the confusing comment

### DIFF
--- a/railties/lib/rails/cli.rb
+++ b/railties/lib/rails/cli.rb
@@ -1,7 +1,5 @@
 require 'rails/app_loader'
 
-# If we are inside a Rails application this method performs an exec and thus
-# the rest of this script is not run.
 Rails::AppLoader.exec_app
 
 require 'rails/ruby_version_check'


### PR DESCRIPTION
1. This comment just cover one case that is `exec` is performed
2. Even we are inside a Rails application with a `bin/rails` script
   if without `APP_PATH` be setup, the code will not be executed also
