### PR TITLE
Do not overwrite SQL mode only `STRICT_ALL_TABLES` in strict mode

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -859,6 +859,11 @@ module ActiveRecord
           else
             sql_mode -= ['STRICT_TRANS_TABLES']
           end
+          # Before 5.7.5, MySQL does not detect functional dependency and ONLY_FULL_GROUP_BY is not enabled by default.
+          # See https://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html
+          if version < '5.7.5'
+            sql_mode -= ['ONLY_FULL_GROUP_BY']
+          end
           variables['sql_mode'] = sql_mode.join(',')
         end
 


### PR DESCRIPTION
The default SQL mode in MySQL 5.7 includes these modes:

```
ONLY_FULL_GROUP_BY, STRICT_TRANS_TABLES, NO_ZERO_IN_DATE, NO_ZERO_DATE,
ERROR_FOR_DIVISION_BY_ZERO, NO_AUTO_CREATE_USER, and NO_ENGINE_SUBSTITUTION.
```

See https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-setting

But AR's strict mode overwrites SQL mode only `STRICT_ALL_TABLES`.
These default SQL modes are useful for compatibility with other RDBMS.
I think we should keep the default SQL mode.
