### PR TITLE
Remove json gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,6 @@ platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
 end
 
 platforms :jruby do
-  gem 'json'
   if ENV['AR_JDBC']
     gem 'activerecord-jdbcsqlite3-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: 'master'
     group :db do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,6 @@ PATH
     activesupport (5.0.0.beta2)
       concurrent-ruby (~> 1.0)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       method_source
       minitest (~> 5.1)
       tzinfo (~> 1.1)
@@ -287,7 +286,6 @@ DEPENDENCIES
   faye-websocket
   hiredis
   jquery-rails
-  json
   kindlerb (= 0.1.1)
   listen (~> 3.0.5)
   minitest (< 5.3.4)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.rdoc_options.concat ['--encoding',  'UTF-8']
 
   s.add_dependency 'i18n',       '~> 0.7'
-  s.add_dependency 'json',       '~> 1.7', '>= 1.7.7'
   s.add_dependency 'tzinfo',     '~> 1.1'
   s.add_dependency 'minitest',   '~> 5.1'
   s.add_dependency 'concurrent-ruby', '~> 1.0'


### PR DESCRIPTION
All modern Rubies ship JSON as part of stdlib.  Using the gem actually hurts multi-platform support due to build difficulties on Windows.
