### PR TITLE
Remove unused dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,6 @@ PATH
     activesupport (5.0.0.beta2)
       concurrent-ruby (~> 1.0)
       i18n (~> 0.7)
-      method_source
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     rails (5.0.0.beta2)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'tzinfo',     '~> 1.1'
   s.add_dependency 'minitest',   '~> 5.1'
   s.add_dependency 'concurrent-ruby', '~> 1.0'
-  s.add_dependency 'method_source'
 end


### PR DESCRIPTION
railties uses method_source, activesupport does not.  I assume code was refactored and the dependency wasn't removed.
