### PR TITLE
After callbacks in regular order and around have separate order context

### DIFF
--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -113,7 +113,7 @@ module ActionMailer
         end
     end
 
-    include Behavior
     include ClearTestDeliveries
+    include Behavior
   end
 end

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -547,12 +547,6 @@ class FilterTest < ActionController::TestCase
     end
   end
 
-  def test_after_actions_are_not_run_if_around_action_does_not_yield
-    controller = NonYieldingAroundFilterController.new
-    test_process(controller, "index")
-    assert_equal ["filter_one", "it didn't yield"], controller.instance_variable_get(:@filters)
-  end
-
   def test_added_action_to_inheritance_graph
     assert_equal [ :ensure_login ], TestController.before_actions
   end
@@ -706,8 +700,8 @@ class FilterTest < ActionController::TestCase
 
   def test_prepending_and_appending_around_action
     test_process(MixedFilterController)
-    assert_equal " before aroundfilter  before procfilter  before appended aroundfilter " +
-                 " after appended aroundfilter  after procfilter  after aroundfilter ",
+    assert_equal " before procfilter  before aroundfilter  before appended aroundfilter " +
+                 " after appended aroundfilter  after aroundfilter  after procfilter ",
                  MixedFilterController.execution_log
   end
 
@@ -1020,7 +1014,7 @@ class YieldingAroundFiltersTest < ActionController::TestCase
 
   def test_action_order_with_all_action_types
     test_process(ControllerWithAllTypesOfFilters,'no_raise')
-    assert_equal 'before around (before yield) around_again (before yield) around_again (after yield) after around (after yield)', @controller.instance_variable_get(:@ran_filter).join(' ')
+    assert_equal 'before around (before yield) around_again (before yield) around_again (after yield) around (after yield) after', @controller.instance_variable_get(:@ran_filter).join(' ')
   end
 
   def test_action_order_with_skip_action_method

--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -137,7 +137,11 @@ module ActiveModel
     def _define_after_model_callback(klass, callback) #:nodoc:
       klass.define_singleton_method("after_#{callback}") do |*args, &block|
         options = args.extract_options!
-        options[:prepend] = true
+
+        unless ActiveSupport::Callbacks.use_simple_callbacks_order
+          options[:prepend] = true
+        end
+
         conditional = ActiveSupport::Callbacks::Conditionals::Value.new { |v|
           v != false
         }

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -94,7 +94,11 @@ module ActiveModel
         #   person.status # => true
         def after_validation(*args, &block)
           options = args.extract_options!
-          options[:prepend] = true
+
+          unless ActiveSupport::Callbacks.use_simple_callbacks_order
+            options[:prepend] = true
+          end
+
           options[:if] = Array(options[:if])
           if options[:on]
             options[:on] = Array(options[:on])

--- a/activemodel/test/cases/callbacks_test.rb
+++ b/activemodel/test/cases/callbacks_test.rb
@@ -128,8 +128,33 @@ class CallbacksTest < ActiveModel::TestCase
   test "after_create callbacks with both callbacks declared in one line" do
     assert_equal ["callback1", "callback2"], Violin1.new.create.history
   end
+
   test "after_create callbacks with both callbacks declared in different lines" do
     assert_equal ["callback1", "callback2"], Violin2.new.create.history
+  end
+
+  test "after_create callbacks work in simple order even if legacy order of ActiveSupport callbacks is chosen" do
+    begin
+      ActiveSupport::Callbacks.use_simple_callbacks_order = false
+
+      class Violin3 < Violin
+        after_create :callback1
+        after_create :callback2
+      end
+
+      assert_equal ["callback1", "callback2"], Violin3.new.create.history
+
+      ActiveSupport::Callbacks.use_simple_callbacks_order = true
+
+      class Violin4 < Violin
+        after_create :callback1
+        after_create :callback2
+      end
+
+      assert_equal ["callback1", "callback2"], Violin4.new.create.history
+    ensure
+      ActiveSupport::Callbacks.use_simple_callbacks_order = true
+    end
   end
 
 end

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -289,11 +289,11 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :after_save,                  :proc   ],
       [ :after_save,                  :object ],
       [ :after_save,                  :block  ],
-      [ :after_commit,                :block  ],
-      [ :after_commit,                :object ],
-      [ :after_commit,                :proc   ],
+      [ :after_commit,                :method ],
       [ :after_commit,                :string ],
-      [ :after_commit,                :method ]
+      [ :after_commit,                :proc   ],
+      [ :after_commit,                :object ],
+      [ :after_commit,                :block  ]
     ], david.history
   end
 
@@ -315,7 +315,7 @@ class CallbacksTest < ActiveRecord::TestCase
       :before_validation_on_create,
       :validate,
       :after_validation,
-      :after_validation_on_create
+      :after_validation_on_create,
     ], david.history
   end
 
@@ -363,11 +363,11 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :after_save,                  :proc   ],
       [ :after_save,                  :object ],
       [ :after_save,                  :block  ],
-      [ :after_commit,                :block  ],
-      [ :after_commit,                :object ],
-      [ :after_commit,                :proc   ],
+      [ :after_commit,                :method ],
       [ :after_commit,                :string ],
-      [ :after_commit,                :method ]
+      [ :after_commit,                :proc   ],
+      [ :after_commit,                :object ],
+      [ :after_commit,                :block  ]
     ], david.history
   end
 
@@ -419,11 +419,11 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :after_destroy,               :proc   ],
       [ :after_destroy,               :object ],
       [ :after_destroy,               :block  ],
-      [ :after_commit,                :block  ],
-      [ :after_commit,                :object ],
-      [ :after_commit,                :proc   ],
+      [ :after_commit,                :method ],
       [ :after_commit,                :string ],
-      [ :after_commit,                :method ]
+      [ :after_commit,                :proc   ],
+      [ :after_commit,                :object ],
+      [ :after_commit,                :block  ]
     ], david.history
   end
 
@@ -585,11 +585,11 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :before_validation,           :object ],
       [ :before_validation,           :block  ],
       [ :before_validation, :returning_false  ],
-      [ :after_rollback, :block  ],
-      [ :after_rollback, :object ],
-      [ :after_rollback, :proc   ],
-      [ :after_rollback, :string ],
       [ :after_rollback, :method ],
+      [ :after_rollback, :string ],
+      [ :after_rollback, :proc   ],
+      [ :after_rollback, :object ],
+      [ :after_rollback, :block  ],
     ], david.history
   end
 
@@ -613,11 +613,11 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :before_validation, :object ],
       [ :before_validation, :block  ],
       [ :before_validation, :throwing_abort ],
-      [ :after_rollback,    :block  ],
-      [ :after_rollback,    :object ],
-      [ :after_rollback,    :proc   ],
-      [ :after_rollback,    :string ],
       [ :after_rollback,    :method ],
+      [ :after_rollback,    :string ],
+      [ :after_rollback,    :proc   ],
+      [ :after_rollback,    :object ],
+      [ :after_rollback,    :block  ],
     ], david.history
   end
 

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -419,16 +419,16 @@ class CallbacksOnMultipleActionsTest < ActiveRecord::TestCase
   def test_after_commit_on_multiple_actions
     topic = TopicWithCallbacksOnMultipleActions.new
     topic.save
-    assert_equal [:create_and_update, :create_and_destroy], topic.history
+    assert_equal [:create_and_destroy, :create_and_update], topic.history
 
     topic.clear_history
     topic.approved = true
     topic.save
-    assert_equal [:update_and_destroy, :create_and_update], topic.history
+    assert_equal [:create_and_update, :update_and_destroy], topic.history
 
     topic.clear_history
     topic.destroy
-    assert_equal [:update_and_destroy, :create_and_destroy], topic.history
+    assert_equal [:create_and_destroy, :update_and_destroy ], topic.history
   end
 
   def test_before_commit_actions
@@ -436,7 +436,7 @@ class CallbacksOnMultipleActionsTest < ActiveRecord::TestCase
     topic.save_before_commit_history = true
     topic.save
 
-    assert_equal [:before_commit, :create_and_update, :create_and_destroy], topic.history
+    assert_equal [:before_commit, :create_and_destroy, :create_and_update], topic.history
   end
 
   def test_before_commit_update_in_same_transaction

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Run callbacks in simple order
+
+    All callbacks are run in order of definition respectively for given callback type.
+    Callback types are run in simple order before, around, after.
+
+    This behavior can be switched back to old order of callbacks by setting
+    ActiveSupport::Callbacks.use_simple_callbacks_order = false
+
+    *Piotr Jakubowski*
+
 ## Rails 5.0.0.beta3 (February 24, 2016) ##
 
 *   Deprecate arguments on `assert_nothing_raised`.

--- a/activesupport/test/callback_inheritance_test.rb
+++ b/activesupport/test/callback_inheritance_test.rb
@@ -116,11 +116,11 @@ class BasicCallbacksTest < ActiveSupport::TestCase
   end
 
   def test_basic_conditional_callback2
-    assert_equal %w(before1 before2 update after2 after1), @update.log
+    assert_equal %w(before1 before2 update after1 after2), @update.log
   end
 
   def test_basic_conditional_callback3
-    assert_equal %w(delete after2 after1), @delete.log
+    assert_equal %w(delete after1 after2), @delete.log
   end
 end
 
@@ -140,7 +140,7 @@ class InheritedCallbacksTest < ActiveSupport::TestCase
   end
 
   def test_partially_excluded
-    assert_equal %w(delete after2 after1), @delete.log
+    assert_equal %w(delete after1 after2), @delete.log
   end
 end
 
@@ -151,11 +151,11 @@ class InheritedCallbacksTest2 < ActiveSupport::TestCase
   end
 
   def test_crazy_mix_on
-    assert_equal %w(before1 update after2 after1), @update1.log
+    assert_equal %w(before1 update after1 after2), @update1.log
   end
 
   def test_crazy_mix_off
-    assert_equal %w(before1 before2 update after2 after1), @update2.log
+    assert_equal %w(before1 before2 update after1 after2), @update2.log
   end
 end
 

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -171,13 +171,39 @@ module CallbacksTest
   end
 
   class AfterSaveConditionalPersonCallbackTest < ActiveSupport::TestCase
-    def test_after_save_runs_in_the_reverse_order
+    def test_after_save_runs_in_simple_order
       person = AfterSaveConditionalPerson.new
       person.save
       assert_equal [
-        [:after_save, :string2],
-        [:after_save, :string1]
+        [:after_save, :string1],
+        [:after_save, :string2]
       ], person.history
+    end
+
+    def test_after_save_runs_in_reverse_order_if_option_chosen
+      begin
+        ActiveSupport::Callbacks.use_simple_callbacks_order = false
+
+        AfterSaveConditionalPerson.send(:get_callbacks, :save).instance_variable_set(:@callbacks, nil)
+        person = AfterSaveConditionalPerson.new
+        person.save
+        assert_equal [
+          [:after_save, :string2],
+          [:after_save, :string1]
+        ], person.history
+
+        ActiveSupport::Callbacks.use_simple_callbacks_order = true
+        AfterSaveConditionalPerson.send(:get_callbacks, :save).instance_variable_set(:@callbacks, nil)
+        person = AfterSaveConditionalPerson.new
+        person.save
+        assert_equal [
+          [:after_save, :string1],
+          [:after_save, :string2]
+        ], person.history
+      ensure
+        ActiveSupport::Callbacks.use_simple_callbacks_order = true
+        AfterSaveConditionalPerson.send(:get_callbacks, :save).instance_variable_set(:@callbacks, nil)
+      end
     end
   end
 
@@ -423,12 +449,12 @@ module CallbacksTest
         [:before_save, :proc],
         [:before_save, :object],
         [:before_save, :block],
-        [:after_save, :block],
-        [:after_save, :class],
-        [:after_save, :object],
-        [:after_save, :proc],
+        [:after_save, :symbol],
         [:after_save, :string],
-        [:after_save, :symbol]
+        [:after_save, :proc],
+        [:after_save, :object],
+        [:after_save, :class],
+        [:after_save, :block]
       ], person.history
     end
 
@@ -442,12 +468,12 @@ module CallbacksTest
       assert_equal [], person.history
       person.save
       assert_equal [
-        [:after_save, :block],
-        [:after_save, :class],
-        [:after_save, :object],
-        [:after_save, :proc],
+        [:after_save, :symbol],
         [:after_save, :string],
-        [:after_save, :symbol]
+        [:after_save, :proc],
+        [:after_save, :object],
+        [:after_save, :class],
+        [:after_save, :block]
       ], person.history
     end
   end
@@ -465,12 +491,12 @@ module CallbacksTest
         [:before_save, :object],
         [:before_save, :class],
         [:before_save, :block],
-        [:after_save, :block],
-        [:after_save, :class],
-        [:after_save, :object],
-        [:after_save, :proc],
+        [:after_save, :symbol],
         [:after_save, :string],
-        [:after_save, :symbol]
+        [:after_save, :proc],
+        [:after_save, :object],
+        [:after_save, :class],
+        [:after_save, :block]
       ], person.history
     end
   end
@@ -721,7 +747,7 @@ module CallbacksTest
     def test_termination_skips_following_before_and_around_callbacks
       terminator = CallbackTerminator.new
       terminator.save
-      assert_equal ["first", "second", "third", "first"], terminator.history
+      assert_equal ["first", "second", "first", "third"], terminator.history
     end
 
     def test_termination_invokes_hook
@@ -749,7 +775,7 @@ module CallbacksTest
     def test_default_termination
       terminator = CallbackDefaultTerminator.new
       terminator.save
-      assert_equal ["first", "second", "third", "first"], terminator.history
+      assert_equal ["first", "second", "first", "third"], terminator.history
     end
 
     def test_default_termination_invokes_hook
@@ -826,12 +852,12 @@ module CallbacksTest
         [:before_save, :object],
         [:before_save, :class],
         [:before_save, :block],
-        [:after_save, :block],
-        [:after_save, :class],
-        [:after_save, :object],
-        [:after_save, :proc],
+        [:after_save, :symbol],
         [:after_save, :string],
-        [:after_save, :symbol]
+        [:after_save, :proc],
+        [:after_save, :object],
+        [:after_save, :class],
+        [:after_save, :block]
       ], writer.history
     end
   end

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -144,18 +144,18 @@ class SetupAndTeardownTest < ActiveSupport::TestCase
     end
 
     def sentinel
-      assert_equal [:foo], @called_back
+      assert_equal [:foo, :foo], @called_back
     end
 end
 
 class SubclassSetupAndTeardownTest < SetupAndTeardownTest
   setup :bar
-  teardown :bar
+  teardown :bar, :subsentinel
 
   def test_inherited_setup_callbacks
     assert_equal [:reset_callback_record, :foo, :bar], self.class._setup_callbacks.map(&:raw_filter)
     assert_equal [:foo, :bar], @called_back
-    assert_equal [:foo, :sentinel, :bar], self.class._teardown_callbacks.map(&:raw_filter)
+    assert_equal [:foo, :sentinel, :bar, :subsentinel], self.class._teardown_callbacks.map(&:raw_filter)
   end
 
   protected
@@ -164,7 +164,11 @@ class SubclassSetupAndTeardownTest < SetupAndTeardownTest
     end
 
     def sentinel
-      assert_equal [:foo, :bar, :bar], @called_back
+      assert_equal [:foo, :bar, :foo], @called_back
+    end
+
+    def subsentinel
+      assert_equal [:foo, :bar, :foo, :bar], @called_back
     end
 end
 


### PR DESCRIPTION
Different, and in my opinion better approach of fixing the problem
stated in #15106. This commit changes the underlying implementation of
all callbacks in Rails - ActiveSupport::Callbacks.

Existing implementation of callbacks have 2 quirks:
1. After callbacks are being run in reverse order
2. Around callback completely changes the ordering context

So let's say we have following case

```
class CallbacksOrWhat
  include ActiveSupport::Callbacks

  define_callbacks :run

  set_callback :run, :before, :before_a
  set_callback :run, :after, :after_a
  set_callback :run, :around, :around_a
  set_callback :run, :after, :after_b
  set_callback :run, :after, :after_c
  set_callback :run, :around, :around_b
  set_callback :run, :after, :after_d
  set_callback :run, :before, :before_b

  def before_a; puts "before a"; end
  def before_b; puts "before b"; end
  def after_a; puts "after a"; end
  def after_b; puts "after b"; end
  def after_c; puts "after c"; end
  def after_d; puts "after d"; end

  def around_a
    puts "around before a"
    yield
    puts "around after a"
  end

  def around_b
    puts "around before b"
    yield
    puts "around after b"
  end

  def run
    run_callbacks :run do
      puts "Running"
    end
  end
end

CallbacksOrWhat.new.run
```

The result would be

```
before a
around before a
around before b
before b
Running
after d
around after b
after c
after b
around after a
after a
```

So the after callbacks are actually run before the "after" part of the
around filter that are defined before them and so on.

The consequences of that are following:
- ActiveModel and ActiveRecord sprinkle some options[:prepend] = true
  around to get rid of the reverse ordering of after callbacks.
- Documentation of ActiveSupport claims:
  
  > Calls the before and around callbacks in the order they were set,
  > yields the block (if given one), and then runs the after callbacks in
  > reverse order.
  
  But since definition of around callback kind of changes the context of
  execution that's not exactly what's happening.
- The around this is pretty hard to grasp and it's hard to figure out
  jus by looking at code what's the exact order of execution>

I would expect something more along the lines:
1. Run all before callbacks in order of definition
2. Run all around callbacks as a stack that has the first defined on
  top, last defined on almost bottom and the method the block they
  are surrounding at the very bottom.
3. Run all after callbacks

So something like this:

```
before a
before b
around before a
around before b
Running
around after b
around after a
after a
after b
after c
after d
```

This seems way more consistent, and frees ActiveRecord and ActiveModel
from hacking prepend (which in the end makes the prepend option unusable
for the end user).
