### PR TITLE
Removing unnecessary iteration on the dup object

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -272,8 +272,7 @@ module ActiveModel
 
       # Copy validators on inheritance.
       def inherited(base) #:nodoc:
-        dup = _validators.dup
-        base._validators = dup.each { |k, v| dup[k] = v.dup }
+        base._validators = _validators.dup
         super
       end
     end


### PR DESCRIPTION
There's no need for the `each` block on the duped object(hash). `object.dup` works fine even for nested hashes and arrays.
