### PR TITLE
Remove the assumption of schema in DATABASE_URL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -33,7 +33,7 @@ module ActiveRecord
         def initialize(url)
           raise "Database URL cannot be empty" if url.blank?
           @uri     = uri_parser.parse(url)
-          @adapter = @uri.scheme.tr('-', '_')
+          @adapter = @uri.scheme && @uri.scheme.tr('-', '_')
           @adapter = "postgresql" if @adapter == "postgres"
 
           if @uri.opaque

--- a/activerecord/test/cases/connection_adapters/connection_specification_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_specification_test.rb
@@ -7,6 +7,11 @@ module ActiveRecord
         spec = ConnectionSpecification.new({ :a => :b }, "bar")
         assert_not_equal(spec.config.object_id, spec.dup.config.object_id)
       end
+
+      def test_handle_missing_scheme
+        spec = ConnectionSpecification.new({ :url => 'testing' }, "bar")
+        assert_not_equal(spec.config.object_id, spec.dup.config.object_id)
+      end
     end
   end
 end

--- a/activerecord/test/cases/connection_adapters/connection_specification_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_specification_test.rb
@@ -7,11 +7,6 @@ module ActiveRecord
         spec = ConnectionSpecification.new({ :a => :b }, "bar")
         assert_not_equal(spec.config.object_id, spec.dup.config.object_id)
       end
-
-      def test_handle_missing_scheme
-        spec = ConnectionSpecification.new({ :url => 'testing' }, "bar")
-        assert_not_equal(spec.config.object_id, spec.dup.config.object_id)
-      end
     end
   end
 end

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -57,6 +57,12 @@ module ActiveRecord
             "encoding" => "utf8" }, spec)
         end
 
+        def test_url_missing_scheme
+          spec = resolve 'foo'
+          assert_equal({
+            "database" => "foo" }, spec)
+        end
+
         def test_url_host_db
           spec = resolve 'abstract://foo/bar?encoding=utf8'
           assert_equal({


### PR DESCRIPTION
If you set the DATABASE_URL environment variable to `mydatabase` by accident, you end up getting a series of errors that are hard to trace. For example: 

```
warning: already initialized constant ActiveRecord::Base::OrmAdapter
```

Turns out the cascade of errors is due to the error raised by `.tr` being called on `nil`.

This commit makes sure that `scheme` is set before calling `.tr` on it. My previous iteration used `@uri.scheme.try(:tr, '-', '_')` but using the `&&` logical operator is a fair bit faster: http://stackoverflow.com/questions/26655032/try-vs-performance

With this change, the error message becomes much more understandable:

```
FATAL:  database "mydatabase" does not exist (ActiveRecord::NoDatabaseError)
```
