### PR TITLE
Don't publicize Kernel core extensions

### DIFF
--- a/activesupport/lib/active_support/core_ext/kernel/concern.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/concern.rb
@@ -1,6 +1,8 @@
 require 'active_support/core_ext/module/concerning'
 
 module Kernel
+  module_function
+
   # A shortcut to define a toplevel concern, not within a module.
   #
   # See Module::Concerning for more.

--- a/activesupport/lib/active_support/core_ext/kernel/reporting.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/reporting.rb
@@ -1,4 +1,6 @@
 module Kernel
+  module_function
+
   # Sets $VERBOSE to nil for the duration of the block and back to its original
   # value afterwards.
   #


### PR DESCRIPTION
This is a reaction to a [bug](https://github.com/rails/web-console/issues/184) we hit in web-console. The cause of it was
a `Kernel` extension called `#console` that was public and was fighting
over Railties with console block to be run on `rails console`. We solved
it by making the method private. We did that through `module_function`
so `::Kernel.console` can be invoked even in `BasicObject`.

I'm proposing to make most of the core Active Support `Kernel`
extensions `module_function` as well. Those are currently public and we
are polluting every `Object` public interface with them.

``` ruby
>> Object.new.respond_to? :silence_warnings
=> true

>> Object.new.respond_to? :with_warnings
=> true

>> Object.new.respond_to? :enable_warnings
=> true

>> Object.new.respond_to? :suppress
=> true
```

Some extensions like `Kernel#class_eval` should be public, but most of
them don't really need to be.
