### PR TITLE
Introduced AR::Relation more_than? and similar methods

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -179,6 +179,31 @@ module ActiveRecord
       pluck primary_key
     end
 
+    def more_than?(limit)
+      count_with_limit(limit + 1) > limit
+    end
+
+    def less_than?(limit)
+      count_with_limit(limit) < limit
+    end
+
+    def less_equal_than?(limit)
+      !more_than?(limit)
+    end
+
+    def more_equal_than?(limit)
+      !less_than?(limit)
+    end
+
+    private
+
+    def count_with_limit(limit)
+      if group_values.any?
+        raise ArgumentError, "can not perform limited count operation on the Relation with GROUP BY statement"
+      end
+      limit(limit).count
+    end
+
     private
 
     def has_include?(column_name)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -789,4 +789,33 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 50, result[1].credit_limit
     assert_equal 50, result[2].credit_limit
   end
+
+  def test_more_than
+    assert Topic.all.more_than?(0)
+    assert Topic.all.more_than?(1)
+    assert !Topic.all.more_than?(5)
+    assert !Topic.all.more_than?(6)
+  end
+
+  def test_less_than
+    assert !Topic.all.less_than?(0)
+    assert !Topic.all.less_than?(1)
+    assert !Topic.all.less_than?(5)
+    assert Topic.all.less_than?(6)
+  end
+
+  def test_more_equal_than
+    assert Topic.all.more_equal_than?(0)
+    assert Topic.all.more_equal_than?(1)
+    assert Topic.all.more_equal_than?(5)
+    assert !Topic.all.more_equal_than?(6)
+  end
+
+  def test_less_equal_than
+    assert !Topic.all.less_equal_than?(0)
+    assert !Topic.all.less_equal_than?(1)
+    assert Topic.all.less_equal_than?(5)
+    assert Topic.all.less_equal_than?(6)
+  end
+
 end


### PR DESCRIPTION
In the world of large data `Model.count` takes forever to finish.
There is no cheap solution to that other than do not display large counters
That is why we need a faster versions that do not calculate the whole result size but only if it is more than specified number.

Use cases:

``` haml
- if @assets.more_than?(20)
  = paginate @assets
```

``` haml
- if @assets.less_than?(10_000_000)
  Total found: #{@assets.size}
- else
  More than 10 000 000 records found
```

``` ruby
if @assets.less_than?(100)
  transaction { @assets.each(&:destroy) }
  # do not show an annoying progress bar that disappears in 0.1 second.
  redirect_to zzz
else
  MassAssetsDestroction.delete_asyncronosly(@assets.where_values)
  render_a_progress_bar
end
```

``` ruby
if @assets.more_than?(500_000)
  flash[:error] = "CSV export can not be performed for such a large dataset. Please export in chunks."
else
  ...
end
```

TODO:
- [ ] Changelog
- [ ] Documentation
