### PR TITLE
Update assertion on redis in generated Gemfile

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -415,7 +415,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_action_cable_redis_gems
     run_generator
-    assert_gem 'redis'
+    assert_file "Gemfile", /^# gem 'redis'/
   end
 
   def test_inclusion_of_javascript_runtime


### PR DESCRIPTION
Redis now included in Gemfile but commented out. This change was made in 91864439c7aebb6ca710831aac6781903a433904 and is causing the test failure.

See https://travis-ci.org/rails/rails/jobs/106994913#L1025
