### PR TITLE
Add Puerto Rico time zone to TimeZone::MAPPING

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -48,6 +48,7 @@ module ActiveSupport
       "Central America"              => "America/Guatemala",
       "Eastern Time (US & Canada)"   => "America/New_York",
       "Indiana (East)"               => "America/Indiana/Indianapolis",
+      "Puerto Rico"                  => "America/Puerto_Rico",
       "Bogota"                       => "America/Bogota",
       "Lima"                         => "America/Lima",
       "Quito"                        => "America/Lima",


### PR DESCRIPTION
America/Puerto_Rico is a TZInfo time zone and was missing from the list. America/New_York cannot be used because Puerto Rico is in the Atlantic time zone and does not have daylight savings.
