### PR TITLE
Correct SQL in a test case

### DIFF
--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -127,7 +127,7 @@ class FinderTest < ActiveRecord::TestCase
     gc_disabled = GC.disable
     Post.where("author_id" => nil)  # warm up
     x = Symbol.all_symbols.count
-    Post.where("title" => {"xxxqqqq" => "bar"})
+    Post.where("title" => "xxxqqqq")
     assert_equal x, Symbol.all_symbols.count
   ensure
     GC.enable if gc_disabled == false


### PR DESCRIPTION
Executing a query generated by `Post.where("title" => {"xxxqqqq" => "bar"})`
causes an error.

"Unknown column 'title.xxxqqqq' in 'where clause': SELECT `posts`.*
 FROM `posts` WHERE `title`.`xxxqqqq` = 'bar'"

Sure this test case does not execute a query, but it is good to
use valid code example.
