### PR TITLE
don’t explicitly mention EventMachine [ci skip]

### DIFF
--- a/actioncable/lib/rails/generators/channel/templates/channel.rb
+++ b/actioncable/lib/rails/generators/channel/templates/channel.rb
@@ -1,4 +1,4 @@
-# Be sure to restart your server when you modify this file. Action Cable runs in an EventMachine loop that does not support auto reloading.
+# Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto reloading.
 <% module_namespacing do -%>
 class <%= class_name %>Channel < ApplicationCable::Channel
   def subscribed


### PR DESCRIPTION
Follow up to 6accef4e11b0c793e1c085536b5ed27f32b6a0c3
