### PR TITLE
Don't unnecessarily load a belongs_to when saving.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Remove unnecessarily association load when a `belongs_to` association has already been
+    loaded then the foreign key is changed directly and the record saved.
+
+    *James Coleman*
+
 *   Remove standardized column types/arguments spaces in schema dump.
 
     *Tim Petricola*

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -457,7 +457,9 @@ module ActiveRecord
       # In addition, it will destroy the association if it was marked for destruction.
       def save_belongs_to_association(reflection)
         association = association_instance_get(reflection.name)
-        record      = association && association.load_target
+        return unless association && association.loaded? && !association.stale_target?
+
+        record = association.load_target
         if record && !record.destroyed?
           autosave = reflection.options[:autosave]
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -626,6 +626,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_queries(0) { tagging.super_tag }
   end
 
+  def test_dont_find_target_when_saving_foreign_key_after_stale_association_loaded
+    client = Client.create!(name: "Test client", firm_with_basic_id: Firm.find(1))
+    client.firm_id = Firm.create!(name: "Test firm").id
+    assert_queries(1) { client.save! }
+  end
+
   def test_field_name_same_as_foreign_key
     computer = Computer.find(1)
     assert_not_nil computer.developer, ":foreign key == attribute didn't lock up" # '


### PR DESCRIPTION
Previously, if the the association was previously loaded and then
the foreign key changed by itself, a #save call would trigger a
load of the new associated record during autosave. This is unnecessary
and the autosave code (in that case) didn't use the loaded record
anyways.
