### PR TITLE
When generating a mailer, you must specify Mailer in the class name

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -13,7 +13,7 @@ module ActionMailer
   #
   # To use Action Mailer, you need to create a mailer model.
   #
-  #   $ rails generate mailer Notifier
+  #   $ rails generate mailer NotifierMailer
   #
   # The generated model inherits from <tt>ApplicationMailer</tt> which in turn
   # inherits from <tt>ActionMailer::Base</tt>. A mailer model defines methods

--- a/actionmailer/lib/rails/generators/mailer/USAGE
+++ b/actionmailer/lib/rails/generators/mailer/USAGE
@@ -8,7 +8,7 @@ Description:
 
 Example:
 ========
-    rails generate mailer Notifications signup forgot_password invoice
+    rails generate mailer NotificationsMailer signup forgot_password invoice
 
     creates a Notifications mailer class, views, and test:
         Mailer:     app/mailers/notifications_mailer.rb


### PR DESCRIPTION
The usage docs for generating a mailer are missing Mailer in the name of the mailer.  If you don't add Mailer to the name, your views and tests are generated incorrectly.

Based on the existing docs, if you do this:
`rails generate mailer School welcome`
The views will be put in app/views/school and the tests will refer to a School class.

You must run the generator like this:
`rails generate mailer SchoolMailer welcome`

These comment and usage changes reflect this requirement.
