### PR TITLE
No need to specify Ruby patch version on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
-  - 2.2.4
-  - 2.3.0
+  - 2.2
+  - 2.3
   - ruby-head
 matrix:
   allow_failures:


### PR DESCRIPTION
Travis CI now select the latest patch version of Ruby automatically when given MAJOR.MINOR version string.

This is for `4-2-stable`.
