### PR TITLE
No need to specify Ruby patch version on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ env:
     - "GEM=aj:integration"
     - "GEM=guides"
 rvm:
-  - 2.2.4
-  - 2.3.0
+  - 2.2
+  - 2.3
   - ruby-head
 matrix:
   allow_failures:


### PR DESCRIPTION
Travis CI now select the latest patch version of Ruby automatically when given MAJOR.MINOR version string.
