### PR TITLE
Inject Rails related configuration through Railtie

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -31,6 +31,8 @@ module ActionCable
           self.cable = Rails.application.config_for(config_path).with_indifferent_access
         end
 
+        self.channel_paths = Rails.application.paths['app/channels'].existent
+
         options.each { |k,v| send("#{k}=", v) }
       end
     end

--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -31,6 +31,10 @@ module ActionCable
           self.cable = Rails.application.config_for(config_path).with_indifferent_access
         end
 
+        if 'ApplicationCable::Connection'.safe_constantize
+          self.connection_class = ApplicationCable::Connection
+        end
+
         self.channel_paths = Rails.application.paths['app/channels'].existent
 
         options.each { |k,v| send("#{k}=", v) }

--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -5,9 +5,10 @@ module ActionCable
     class Configuration
       attr_accessor :logger, :log_tags
       attr_accessor :connection_class, :worker_pool_size
-      attr_accessor :channel_load_paths
       attr_accessor :disable_request_forgery_protection, :allowed_request_origins
       attr_accessor :cable, :url
+
+      attr_accessor :channel_paths # :nodoc:
 
       def initialize
         @log_tags = []
@@ -15,15 +16,7 @@ module ActionCable
         @connection_class  = ApplicationCable::Connection
         @worker_pool_size  = 100
 
-        @channel_load_paths = [Rails.root.join('app/channels')]
-
         @disable_request_forgery_protection = false
-      end
-
-      def channel_paths
-        @channel_paths ||= channel_load_paths.flat_map do |path|
-          Dir["#{path}/**/*_channel.rb"]
-        end
       end
 
       def channel_class_names

--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -13,8 +13,8 @@ module ActionCable
       def initialize
         @log_tags = []
 
-        @connection_class  = ApplicationCable::Connection
-        @worker_pool_size  = 100
+        @connection_class = ActionCable::Connection::Base
+        @worker_pool_size = 100
 
         @disable_request_forgery_protection = false
       end

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -12,11 +12,9 @@ class ClientTest < ActionCable::TestCase
   WAIT_WHEN_NOT_EXPECTING_EVENT = 0.2
 
   def setup
-    # TODO: ActionCable requires a *lot* of setup at the moment...
     ActionCable.instance_variable_set(:@server, nil)
     server = ActionCable.server
-    inner_logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
-    server.config.logger = ActionCable::Connection::TaggedLoggerProxy.new(inner_logger, tags: [])
+    server.config.logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
 
     server.config.cable = { adapter: 'async' }.with_indifferent_access
 

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -13,9 +13,6 @@ class ClientTest < ActionCable::TestCase
 
   def setup
     # TODO: ActionCable requires a *lot* of setup at the moment...
-    ::Object.const_set(:ApplicationCable, Module.new)
-    ::ApplicationCable.const_set(:Connection, Class.new(ActionCable::Connection::Base))
-
     ActionCable.instance_variable_set(:@server, nil)
     server = ActionCable.server
     inner_logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
@@ -36,11 +33,6 @@ class ClientTest < ActionCable::TestCase
 
   def teardown
     $VERBOSE = @previous_verbose
-
-    begin
-      ::Object.send(:remove_const, :ApplicationCable)
-    rescue NameError
-    end
   end
 
   def with_puma_server(rack_app = ActionCable.server, port = 3099)

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -16,12 +16,8 @@ class ClientTest < ActionCable::TestCase
     ::Object.const_set(:ApplicationCable, Module.new)
     ::ApplicationCable.const_set(:Connection, Class.new(ActionCable::Connection::Base))
 
-    ::Object.const_set(:Rails, Module.new)
-    ::Rails.singleton_class.send(:define_method, :root) { Pathname.new(__dir__) }
-
     ActionCable.instance_variable_set(:@server, nil)
     server = ActionCable.server
-    server.config = ActionCable::Server::Configuration.new
     inner_logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
     server.config.logger = ActionCable::Connection::TaggedLoggerProxy.new(inner_logger, tags: [])
 
@@ -29,7 +25,7 @@ class ClientTest < ActionCable::TestCase
 
     # and now the "real" setup for our test:
     server.config.disable_request_forgery_protection = true
-    server.config.channel_load_paths = [File.expand_path('client', __dir__)]
+    server.config.channel_paths = [ File.expand_path('client/echo_channel.rb', __dir__) ]
 
     Thread.new { EventMachine.run } unless EventMachine.reactor_running?
     Thread.pass until EventMachine.reactor_running?
@@ -43,10 +39,6 @@ class ClientTest < ActionCable::TestCase
 
     begin
       ::Object.send(:remove_const, :ApplicationCable)
-    rescue NameError
-    end
-    begin
-      ::Object.send(:remove_const, :Rails)
     rescue NameError
     end
   end

--- a/actioncable/test/subscription_adapter/common.rb
+++ b/actioncable/test/subscription_adapter/common.rb
@@ -9,13 +9,7 @@ module CommonSubscriptionAdapterTest
   WAIT_WHEN_NOT_EXPECTING_EVENT = 0.2
 
   def setup
-    # TODO: ActionCable requires a *lot* of setup at the moment...
     server = ActionCable::Server::Base.new
-    inner_logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
-    server.config.logger = ActionCable::Connection::TaggedLoggerProxy.new(inner_logger, tags: [])
-
-
-    # and now the "real" setup for our test:
     server.config.cable = cable_config.with_indifferent_access
 
     adapter_klass = server.config.pubsub_adapter

--- a/actioncable/test/subscription_adapter/common.rb
+++ b/actioncable/test/subscription_adapter/common.rb
@@ -13,11 +13,7 @@ module CommonSubscriptionAdapterTest
     ::Object.const_set(:ApplicationCable, Module.new)
     ::ApplicationCable.const_set(:Connection, Class.new(ActionCable::Connection::Base))
 
-    ::Object.const_set(:Rails, Module.new)
-    ::Rails.singleton_class.send(:define_method, :root) { Pathname.new(__dir__) }
-
     server = ActionCable::Server::Base.new
-    server.config = ActionCable::Server::Configuration.new
     inner_logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
     server.config.logger = ActionCable::Connection::TaggedLoggerProxy.new(inner_logger, tags: [])
 
@@ -37,10 +33,6 @@ module CommonSubscriptionAdapterTest
 
     begin
       ::Object.send(:remove_const, :ApplicationCable)
-    rescue NameError
-    end
-    begin
-      ::Object.send(:remove_const, :Rails)
     rescue NameError
     end
   end

--- a/actioncable/test/subscription_adapter/common.rb
+++ b/actioncable/test/subscription_adapter/common.rb
@@ -10,9 +10,6 @@ module CommonSubscriptionAdapterTest
 
   def setup
     # TODO: ActionCable requires a *lot* of setup at the moment...
-    ::Object.const_set(:ApplicationCable, Module.new)
-    ::ApplicationCable.const_set(:Connection, Class.new(ActionCable::Connection::Base))
-
     server = ActionCable::Server::Base.new
     inner_logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
     server.config.logger = ActionCable::Connection::TaggedLoggerProxy.new(inner_logger, tags: [])
@@ -30,11 +27,6 @@ module CommonSubscriptionAdapterTest
   def teardown
     @tx_adapter.shutdown if @tx_adapter && @tx_adapter != @rx_adapter
     @rx_adapter.shutdown if @rx_adapter
-
-    begin
-      ::Object.send(:remove_const, :ApplicationCable)
-    rescue NameError
-    end
   end
 
 

--- a/actioncable/test/worker_test.rb
+++ b/actioncable/test/worker_test.rb
@@ -17,7 +17,9 @@ class WorkerTest < ActiveSupport::TestCase
     end
 
     def logger
-      ActionCable.server.logger
+      # Impersonating a connection requires a TaggedLoggerProxy'ied logger.
+      inner_logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
+      ActionCable::Connection::TaggedLoggerProxy.new(inner_logger, tags: [])
     end
   end
 

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -39,6 +39,7 @@ module Rails
           paths.add "app",                 eager_load: true, glob: "{*,*/concerns}"
           paths.add "app/assets",          glob: "*"
           paths.add "app/controllers",     eager_load: true
+          paths.add "app/channels",        eager_load: true, glob: "**/*_channel.rb"
           paths.add "app/helpers",         eager_load: true
           paths.add "app/models",          eager_load: true
           paths.add "app/mailers",         eager_load: true


### PR DESCRIPTION
Instead of direct coupling we can inject configuration. This also spares us some setup in tests.

Work in progress. Need to consider better error messages, better docs, tests.

Would also like to tackle the `inner_logger` + `TaggedLoggerProxy.new` test setup, but unsure what to do there at the moment. Maybe we can move `new_tagged_logger` to the server?

cc @rafaelfranca @matthewd 
