### PR TITLE
Added numeric helper into `SchemaStatements` for MySQL and PostgreSQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Added `numeric` helper into migrations.
+
+    Example:
+
+        create_table(:numeric_types) do |t|
+          t.numeric :numeric_type, precision: 10, scale: 2
+        end
+
+    *Mehmet Emin İNAÇ*
+
 *   Bumped the minimum supported version of PostgreSQL to >= 9.1.
     Both PG 9.0 and 8.4 are past their end of life date:
     http://www.postgresql.org/support/versioning/

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -182,6 +182,7 @@ module ActiveRecord
           end
         CODE
       end
+      alias_method :numeric, :decimal
     end
 
     # Represents the schema of an SQL table in an abstract way. This class
@@ -436,6 +437,7 @@ module ActiveRecord
     #     t.bigint
     #     t.float
     #     t.decimal
+    #     t.numeric
     #     t.datetime
     #     t.timestamp
     #     t.time


### PR DESCRIPTION
With this addition, you can add a column into the table like:

```
  create_table(:numeric_types) do |t|
    t.numeric :foo, precision: 10, scale: 2, default: 2.0
  end
```

This migration creates a `numeric` column for PostgreSQL and `decimal` column for MySQL. The result of the migration above is same with:

```
  create_table(:numeric_types) do |t|
    t.decimal :foo, precision: 10, scale: 2, default: 2.0
  end
```

In PostgreSQL decimal and numeric types are same. Decimal is alias for numeric. For more information about numeric types in PostgreSQL see http://www.postgresql.org/docs/current/interactive/datatype-numeric.html
In MySQL decimal and numeric types are same. Numeric is alias for decimal. For more information about fixed point types in MySQL see http://dev.mysql.com/doc/refman/5.7/en/fixed-point-types.html
