### PR TITLE
set association name to generated fixtures if attribute is reference

### DIFF
--- a/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
+++ b/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml
@@ -6,7 +6,7 @@
   <%- if attribute.password_digest? -%>
   password_digest: <%%= BCrypt::Password.create('secret') %>
   <%- elsif attribute.reference? -%>
-  <%= yaml_key_value(attribute.column_name.sub(/_id$/, ''), attribute.default) %>
+  <%= yaml_key_value(attribute.column_name.sub(/_id$/, ''), attribute.default || name) %>
   <%- else -%>
   <%= yaml_key_value(attribute.column_name, attribute.default) %>
   <%- end -%>

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -291,12 +291,11 @@ module ApplicationTests
       assert_no_match(/Errors running/, output)
     end
 
-    def test_scaffold_with_references_columns_tests_pass_when_belongs_to_is_optional
-      app_file "config/initializers/active_record_belongs_to_required_by_default.rb",
-        "Rails.application.config.active_record.belongs_to_required_by_default = false"
-
+    def test_scaffold_with_references_columns_tests_pass_by_default
       output = Dir.chdir(app_path) do
-        `bin/rails generate scaffold LineItems product:references cart:belongs_to;
+        `bin/rails generate model Product;
+         bin/rails generate model Cart;
+         bin/rails generate scaffold LineItems product:references cart:belongs_to;
          RAILS_ENV=test bin/rails db:migrate test`
       end
 

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -298,18 +298,18 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   def test_fixtures_use_the_references_ids
     run_generator ["LineItem", "product:references", "cart:belongs_to"]
 
-    assert_file "test/fixtures/line_items.yml", /product: \n  cart: /
+    assert_file "test/fixtures/line_items.yml", /product: one\n  cart: one/
     assert_generated_fixture("test/fixtures/line_items.yml",
-                             {"one"=>{"product"=>nil, "cart"=>nil}, "two"=>{"product"=>nil, "cart"=>nil}})
+                             {"one"=>{"product"=>"one", "cart"=>"one"}, "two"=>{"product"=>"two", "cart"=>"two"}})
   end
 
   def test_fixtures_use_the_references_ids_and_type
     run_generator ["LineItem", "product:references{polymorphic}", "cart:belongs_to"]
 
-    assert_file "test/fixtures/line_items.yml", /product: \n  product_type: Product\n  cart: /
+    assert_file "test/fixtures/line_items.yml", /product: one\n  product_type: Product\n  cart: one/
     assert_generated_fixture("test/fixtures/line_items.yml",
-                             {"one"=>{"product"=>nil, "product_type"=>"Product", "cart"=>nil},
-                              "two"=>{"product"=>nil, "product_type"=>"Product", "cart"=>nil}})
+                             {"one"=>{"product"=>"one", "product_type"=>"Product", "cart"=>"one"},
+                              "two"=>{"product"=>"two", "product_type"=>"Product", "cart"=>"two"}})
   end
 
   def test_fixtures_respect_reserved_yml_keywords


### PR DESCRIPTION
It has been changed to require `belongs_to` by default in Rails 5.
Therefore in order to pass the controller test, have association of set to fixtures.

Fixes #23384
