### PR TITLE
Revert "No need to specify Ruby patch version on Travis CI"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ env:
     - "GEM=aj:integration"
     - "GEM=guides"
 rvm:
-  - 2.2
-  - 2.3
+  - 2.2.4
+  - 2.3.0
   - ruby-head
 matrix:
   allow_failures:


### PR DESCRIPTION
Reverts rails/rails#23502

Looks like test failures have been caused by this.
