### PR TITLE
Revert "When generating a mailer, you must specify Mailer in the class name in"

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -13,7 +13,7 @@ module ActionMailer
   #
   # To use Action Mailer, you need to create a mailer model.
   #
-  #   $ rails generate mailer NotifierMailer
+  #   $ rails generate mailer Notifier
   #
   # The generated model inherits from <tt>ApplicationMailer</tt> which in turn
   # inherits from <tt>ActionMailer::Base</tt>. A mailer model defines methods

--- a/actionmailer/lib/rails/generators/mailer/USAGE
+++ b/actionmailer/lib/rails/generators/mailer/USAGE
@@ -8,7 +8,7 @@ Description:
 
 Example:
 ========
-    rails generate mailer NotificationsMailer signup forgot_password invoice
+    rails generate mailer Notifications signup forgot_password invoice
 
     creates a Notifications mailer class, views, and test:
         Mailer:     app/mailers/notifications_mailer.rb


### PR DESCRIPTION
This reverts commit 8417d967e016f0219cc4ec30bf0d3908ce6cd29b.

In 5697bdb and af3eb59, add mailer suffix to generated files and classes.
Therefore, no longer need to specify `Mailer` to class name. [ci skip]
