### PR TITLE
Add `Hash#force_compact`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added `Hash#force_compact` to return a hash with non blank values.
+
+    *Yoshiyuki Hirano*
+
 *  Fix regression in `Hash#dig` for HashWithIndifferentAccess.
    *Jon Moss*
 

--- a/activesupport/lib/active_support/core_ext/hash/compact.rb
+++ b/activesupport/lib/active_support/core_ext/hash/compact.rb
@@ -17,4 +17,23 @@ class Hash
   def compact!
     self.reject! { |_, value| value.nil? }
   end
+
+  # Returns a hash with non +blank+ values.
+  #
+  #   hash = { a: true, b: false, c: nil, d: [], e: {}, f: ''}
+  #   hash.force_compact # => { a: true}
+  #   hash # => { a: true, b: false, c: nil, d: [], e: {}, f: ''}
+  #   { b: false, c: nil, d: [], e: {}, f: '' }.force_compact # => {}
+  def force_compact
+    self.select { |_, value| !value.blank? }
+  end
+
+  # Replaces current hash with non +blank+ values.
+  #
+  #   hash = { a: true, b: false, c: nil, d: [], e: {}, f: ''}
+  #   hash.force_compact! # => { a: true}
+  #   hash # => { a: true}
+  def force_compact!
+    self.reject! { |_, value| value.blank? }
+  end
 end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -70,6 +70,8 @@ class HashExtTest < ActiveSupport::TestCase
     assert_respond_to h, :to_options!
     assert_respond_to h, :compact
     assert_respond_to h, :compact!
+    assert_respond_to h, :force_compact
+    assert_respond_to h, :force_compact!
     assert_respond_to h, :except
     assert_respond_to h, :except!
   end
@@ -1011,6 +1013,32 @@ class HashExtTest < ActiveSupport::TestCase
 
     h = hash_with_only_nil_values.dup
     assert_equal({}, h.compact!)
+    assert_equal({}, h)
+  end
+
+  def test_force_compact
+    hash_contain_blank_value = @symbols.merge(v: false, w: nil, x: [], y: {}, z: '')
+    hash_with_only_blank_values = { a: false, b: nil, c: [], d: {}, e: '' }
+
+    h = hash_contain_blank_value.dup
+    assert_equal(@symbols, h.force_compact)
+    assert_equal(hash_contain_blank_value, h)
+
+    h = hash_with_only_blank_values.dup
+    assert_equal({}, h.force_compact)
+    assert_equal(hash_with_only_blank_values, h)
+  end
+
+  def test_force_compact!
+    hash_contain_blank_value = @symbols.merge(v: false, w: nil, x: [], y: {}, z: '')
+    hash_with_only_blank_values = { a: false, b: nil, c: [], d: {}, e: '' }
+
+    h = hash_contain_blank_value.dup
+    assert_equal(@symbols, h.force_compact!)
+    assert_equal(@symbols, h)
+
+    h = hash_with_only_blank_values.dup
+    assert_equal({}, h.force_compact!)
     assert_equal({}, h)
   end
 


### PR DESCRIPTION
`Hash#force_compact` returns a hash with non blank values.

example:

``` ruby
hash = { a: true, b: false, c: nil, d: [], e: {}, f: ''}
hash.force_compact # => { a: true}
hash # => { a: true, b: false, c: nil, d: [], e: {}, f: ''}
{ b: false, c: nil, d: [], e: {}, f: '' }.force_compact # => {}
```
