### PR TITLE
Replace old Rails greeting references

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ and may also be used independently outside Rails.
    Run with `--help` or `-h` for options.
 
 4. Using a browser, go to `http://localhost:3000` and you'll see:
-"Welcome aboard: You're riding Ruby on Rails!"
+"Yay! You’re on Rails!"
 
 5. Follow the guidelines to start developing your application. You may find
    the following resources handy:

--- a/railties/RDOC_MAIN.rdoc
+++ b/railties/RDOC_MAIN.rdoc
@@ -51,7 +51,7 @@ can read more about Action Pack in its {README}[link:files/actionpack/README_rdo
 
 4. Go to http://localhost:3000 and you'll see:
 
-    "Welcome aboard: You're riding Ruby on Rails!"
+    "Yay! You’re on Rails!"
 
 5. Follow the guidelines to start developing your application. You may find the following resources handy:
 


### PR DESCRIPTION
A couple of the READMEs were still referring the old welcome page. This
is a small change that goes over them.
