### PR TITLE
Speed up ActionDispatch::Reloader for static assets. Fix #23510

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/reloader.rb
+++ b/actionpack/lib/action_dispatch/middleware/reloader.rb
@@ -65,13 +65,17 @@ module ActionDispatch
     end
 
     def call(env)
-      @validated = @condition.call
-      prepare!
+      if env['PATH_INFO'].include?(Rails.application.config.assets.prefix)
+        @app.call(env)
+      else
+        @validated = @condition.call
+        prepare!
 
-      response = @app.call(env)
-      response[2] = ::Rack::BodyProxy.new(response[2]) { cleanup! }
+        response = @app.call(env)
+        response[2] = ::Rack::BodyProxy.new(response[2]) { cleanup! }
 
-      response
+        response
+      end
     rescue Exception
       cleanup!
       raise


### PR DESCRIPTION
Bypass ActionDispatch::Reloader middleware for non-Ruby code and serve assets in O(1) time regardless of application size (LOC and gems set), helpful mostly in development mode.
