### PR TITLE
Fix `assert_in_delta` test failure

### DIFF
--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -98,8 +98,11 @@ class TimestampTest < ActiveRecord::TestCase
     task = Task.first
     previous_value = task.ending
     task.touch(:ending)
+
+    now = Time.now.change(usec: 0)
+
     assert_not_equal previous_value, task.ending
-    assert_in_delta Time.now, task.ending, 1
+    assert_in_delta now, task.ending, 1
   end
 
   def test_touching_an_attribute_updates_timestamp_with_given_time
@@ -120,10 +123,12 @@ class TimestampTest < ActiveRecord::TestCase
     previous_ending = task.ending
     task.touch(:starting, :ending)
 
+    now = Time.now.change(usec: 0)
+
     assert_not_equal previous_starting, task.starting
     assert_not_equal previous_ending, task.ending
-    assert_in_delta Time.now, task.starting, 1
-    assert_in_delta Time.now, task.ending, 1
+    assert_in_delta now, task.starting, 1
+    assert_in_delta now, task.ending, 1
   end
 
   def test_touching_a_record_without_timestamps_is_unexceptional


### PR DESCRIPTION
`assert_in_delta` in `timestamp_test.rb` causes an intermittent test
failure. It looks like that caused by subseconds truncation in MySQL 5.5.

Example:

```
  1) Failure:
  TimestampTest#test_touching_many_attributes_updates_them [/home/travis/build/rails/rails/activerecord/test/cases/timestamp_test.rb:125]:
  Expected |2016-02-06 09:22:10 +0000 - 2016-02-06 09:22:09 UTC| (1.000837185) to be <= 1.
```

https://travis-ci.org/rails/rails/jobs/107415700#L447-L449
