### PR TITLE
Set database poolsize via rails_max_threads

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
@@ -19,7 +19,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: 5
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
   <<: *default


### PR DESCRIPTION
Introduced in #23057 was an environment variable `RAILS_MAX_THREADS` that is used to set the number of threads in puma, the default web server. The default value for this environment variable is `5` because that matches the default number of ActiveRecord threads. A mismatch between the database poolsize and the puma thread-count results in `ActiveRecord::ConnectionTimeoutError`.

This PR proposes to also reuse the `RAILS_MAX_THREADS` when setting the database pool size to better ensure that the values are in sync.
