### PR TITLE
Remove unused private method

### DIFF
--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -72,10 +72,6 @@ module Rails
         instrumenter.finish 'request.action_dispatch', request: request
       end
 
-      def development?
-        Rails.env.development?
-      end
-
       def logger
         Rails.logger
       end


### PR DESCRIPTION
After #23220, the `#development?` method is no longer being used.
