### PR TITLE
stop overriding allowed_request_origins if set with ActionCable.server.config

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -22,15 +22,15 @@ module ActionCable
 
     initializer "action_cable.set_configs" do |app|
       options = app.config.action_cable
-      if ::Rails.env.development? && !ActionCable.server.config.allowed_request_origins
-        options.allowed_request_origins ||= "http://localhost:3000"
-      end
 
       app.paths.add "config/cable", with: "config/cable.yml"
 
       ActiveSupport.on_load(:action_cable) do
         if (config_path = Pathname.new(app.config.paths["config/cable"].first)).exist?
           self.cable = Rails.application.config_for(config_path).with_indifferent_access
+        end
+        if ::Rails.env.development? && !ActionCable.server.config.allowed_request_origins
+          options.allowed_request_origins ||= "http://localhost:3000"
         end
 
         options.each { |k,v| send("#{k}=", v) }

--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -22,7 +22,9 @@ module ActionCable
 
     initializer "action_cable.set_configs" do |app|
       options = app.config.action_cable
-      options.allowed_request_origins ||= "http://localhost:3000" if ::Rails.env.development?
+      if ::Rails.env.development? && !ActionCable.server.config.allowed_request_origins
+        options.allowed_request_origins ||= "http://localhost:3000"
+      end
 
       app.paths.add "config/cable", with: "config/cable.yml"
 


### PR DESCRIPTION
Currently, if you set ActionCable.server.config.allowed_request_origins in say an initializer it will be overridden by the development default value when initialized in the ActionCable Engine. This patch fixes that by requiring that ActionCable.server.config not be set in order to assign the default value in development of "http://localhost:3000".
