### PR TITLE
doc changes to clarify asset pipeline

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -21,6 +21,9 @@ What is the Asset Pipeline?
 The asset pipeline provides a framework to concatenate and minify or compress
 JavaScript and CSS assets. It also adds the ability to write these assets in
 other languages and pre-processors such as CoffeeScript, Sass and ERB.
+It allows assets in your application to be automatically combined with assets 
+from other gems. For example, jquery-rails includes a copy of jquery.js
+and enables AJAX features in Rails.
 
 The asset pipeline is technically no longer a core feature of Rails 4, it has
 been extracted out of the framework into the
@@ -45,7 +48,7 @@ gem 'coffee-rails'
 ```
 
 Using the `--skip-sprockets` option will prevent Rails 4 from adding
-`sass-rails` and `uglifier` to your Gemfile, so if you later want to enable
+them to your Gemfile, so if you later want to enable
 the asset pipeline you will have to add those gems to your Gemfile. Also,
 creating an application with the `--skip-sprockets` option will generate
 a slightly different `config/application.rb` file, with a require statement

--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -148,10 +148,10 @@ and Rails has got your back in those cases.
 Because of Unobtrusive JavaScript, the Rails "Ajax helpers" are actually in two
 parts: the JavaScript half and the Ruby half.
 
+Unless you have disabled the Asset Pipeline,
 [rails.js](https://github.com/rails/jquery-ujs/blob/master/src/rails.js)
 provides the JavaScript half, and the regular Ruby view helpers add appropriate
-tags to your DOM. The CoffeeScript in rails.js then listens for these
-attributes, and attaches appropriate handlers.
+tags to your DOM.
 
 ### form_for
 


### PR DESCRIPTION
for rails/rails#23431

```
   modified:   guides/source/asset_pipeline.md
```
- description of asset combination from apps and gems, e.g. jquery-rails
- note that asset pipeline is required for normal operation
- after @vipulnsward's related change rails/rails#23479
  correction: --skip-sprockets will prevent all of these gems, not just sass-rails and uglifier
  
  ```
   modified:   guides/source/working_with_javascript_in_rails.md
  ```
- noted that helpers require the asset pipeline
