### PR TITLE
fix 'method redefined' warnings

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -17,6 +17,7 @@ module ActionController
     # the database on the main thread, so they could open a txn, then the
     # controller thread will open a new connection and try to access data
     # that's only visible to the main thread's txn.  This is the problem in #23483
+    remove_method :new_controller_thread
     def new_controller_thread # :nodoc:
       yield
     end


### PR DESCRIPTION
Turns out the fix for #23483 introduced some warnings:

```
./Users/bronson/rails/actionpack/lib/action_controller/test_case.rb:20: warning: method redefined; discarding old new_controller_thread
/Users/bronson/rails/actionpack/lib/action_controller/metal/live.rb:276: warning: previous definition of new_controller_thread was here
```

In 2005 Matz said that removing the method before redefining it is a good solution: https://groups.google.com/forum/#!topic/comp.lang.ruby/H0Tu7vYlt_Q
