### PR TITLE
Add singular resource support for `form_for`

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -454,6 +454,25 @@ module ActionView
         form_tag_with_body(html_options, output)
       end
 
+      def build_form_url(action, method, record, format = '', options)
+        # First, try and build the route normally
+        begin
+          path = polymorphic_path(record, { format: format })
+        # If a NoMethodError is raised, this means that the resource is singular.
+        rescue NoMethodError
+          path = if action == :edit
+                   edit_polymorphic_path(record, { format: format })
+                 elsif action == :new
+                   new_polymorphic_path(record, { format: format })
+                 else
+                   polymorphic_path(record, { format: format })
+                 end
+        end
+
+        path
+      end
+      private :build_form_url
+
       def apply_form_for_options!(record, object, options) #:nodoc:
         object = convert_to_model(object)
 
@@ -466,11 +485,7 @@ module ActionView
           method: method
         )
 
-        options[:url] ||= if options.key?(:format)
-                            polymorphic_path(record, format: options.delete(:format))
-                          else
-                            polymorphic_path(record, {})
-                          end
+        options[:url] ||= build_form_url(action, method, record, options.delete(:format), options)
       end
       private :apply_form_for_options!
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -148,6 +148,8 @@ class FormHelperTest < ActionView::TestCase
 
     get "/foo", to: "controller#action"
     root to: "main#index"
+
+    resource :comment
   end
 
   def _routes
@@ -3524,6 +3526,38 @@ class FormHelperTest < ActionView::TestCase
 
     form_for(@post, builder: builder_class) { }
     assert_equal 1, initialization_count, 'form builder instantiated more than once'
+  end
+
+  def test_form_for_with_new_singular_resource
+    form_for(Comment.new) {}
+    assert_dom_equal(
+      %{<form class="new_comment" id="new_comment" action="/comment/new" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /></form>},
+      output_buffer
+    )
+  end
+
+  def test_form_for_with_new_singular_resource_and_format
+    form_for(Comment.new, format: :json) {}
+    assert_dom_equal(
+      %{<form class="new_comment" id="new_comment" action="/comment/new.json" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /></form>},
+      output_buffer
+    )
+  end
+
+  def test_form_for_with_persisted_singular_resource
+    form_for(Comment.new(1)) {}
+    assert_dom_equal(
+      %{<form class="edit_comment" id="edit_comment_1" action="/comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="patch" /></form>},
+      output_buffer
+    )
+  end
+
+  def test_form_for_with_persisted_singular_resource_and_format
+    form_for(Comment.new(2), format: :json) {}
+    assert_dom_equal(
+      %{<form class="edit_comment" id="edit_comment_2" action="/comment.json" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="patch" /></form>},
+      output_buffer
+    )
   end
 
   protected


### PR DESCRIPTION
Fixes #1769.

cc @pixeltrix 

I'm not happy about checking for a `NoMethodError`, but the only better way to do this would be to use `ActionController::Routing::Routes#recognize_path`, but we can't use that, since it would add AC <=> AV dependence. :disappointed: 

Important/Random Links:
- https://github.com/rails/rails/issues/1769
- https://github.com/rails/rails/issues/1769#issuecomment-5506213
- https://github.com/rails/rails/pull/17066
- https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb#L119
