### PR TITLE
prevent adding template dependencies when using "render" in HTML tags

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Rails 6.0.0.alpha (Unreleased) ##
 
+*   Fix finding dependencies for templates. No longer find dependencies inside
+    of HTML tags and also calls to render that include a instantiating an object.
+
+    Fixes #21951 and #23536
+
+    *Daniel Fox*
+
 *   Change translation key of `submit_tag` from `module_name_class_name` to `module_name/class_name`.
 
     *Rui Onodera*


### PR DESCRIPTION
This fixes issues #23536 and #21951.

This occurs because of how the dependency tracker looks for render calls
in templates.

I ran into this bug when I was using a decorator object that defined
`to_partial_path`. I had in my view a render call like this
`<%= render MyDecorator.new(model_object) %>`
and I also had calls to the cache helper in the same template. When
the cache helper was getting the dependencies to use for digesting,
I saw in the log "Couldn't find template for digesting: news/new".
I was able to track this down to how the dependency tracker finds
render calls and then processes them. The relevant code is here
[https://github.com/rails/rails/blob/v5.0.0.beta2/actionview/lib/action_view/dependency_tracker.rb#L118](https://github.com/rails/rails/blob/v5.0.0.beta2/actionview/lib/action_view/dependency_tracker.rb#L118).

I believe issue #21951 is related and is also will be fixed by this.

If this is present in a view template:

``` erb
<script>
  var render = document.getElementById('#render');
  render(data.autokinds);
</script>

<div id="render" data-auto_kinds="value">
  <h1>hello</h1>
</div>

<%= render ApplicationHelper::ClassWithPartialPath.new %>
<%= render ClassWithPartialPath.new %>
<%= render ApplicationHelper::employee %>
```

Then running
`bundle exec rake cache_digests:dependencies TEMPLATE=that_template_name`
will produce the following list:

``` ruby
=> [
  "autokinds/autokind",
  "static/ data-auto_kinds=", # static is the name of controller I chose
  "ApplicationHelpers/ApplicationHelper",
  "news/new"
]
```

After the fix, running the cache_digests command on the same template
will produce:

``` ruby
=> [
  "employees/employee"
]
```

This is matching the last render call, the scoped access of a record
in the ApplicationHelper. I'm not sure that anyone actually uses that
but it is a side-effect fix to prevent the 3rd dependency,
"ApplicationHelpers/ApplicationHelper", from showing as a dependency.
