### PR TITLE
Drop support for passing an instance of ActiveRecord::Base to `exists?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Drop support for passing an instance of `ActiveRecord::Base` to `exists?`
+
+    *Yuichiro Kaneko*
+
 *   Added `numeric` helper into migrations.
 
     Example:

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -271,8 +271,7 @@ module ActiveRecord
     #   Person.exists?
     def exists?(conditions = :none)
       if Base === conditions
-        conditions = conditions.id
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        raise ArgumentError, <<-MSG.squish
           You are passing an instance of ActiveRecord::Base to `exists?`.
           Please pass the id of the object by calling `.id`
         MSG

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -167,8 +167,8 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal false, relation.exists?(false)
   end
 
-  def test_exists_passing_active_record_object_is_deprecated
-    assert_deprecated do
+  def test_exists_passing_active_record_object_raise_exception
+    assert_raise(ArgumentError) do
       Topic.exists?(Topic.new)
     end
   end


### PR DESCRIPTION
This deprecation was introduced on Rails 4.2.0
(see d92ae6ccca3bcfd73546d612efaea011270bd270).
Now we are arriving Rails 5, so drop support for
passing an instance of ActiveRecord::Base to `exists?`.
