### PR TITLE
Clean up dead links in guides header

### DIFF
--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -30,11 +30,8 @@
       </span>
       <ul class="more-info-links s-hidden">
         <li class="more-info"><a href="http://rubyonrails.org/">Overview</a></li>
-        <li class="more-info"><a href="http://rubyonrails.org/download">Download</a></li>
-        <li class="more-info"><a href="http://rubyonrails.org/deploy">Deploy</a></li>
         <li class="more-info"><a href="https://github.com/rails/rails">Code</a></li>
-        <li class="more-info"><a href="http://rubyonrails.org/screencasts">Screencasts</a></li>
-        <li class="more-info"><a href="http://rubyonrails.org/documentation">Documentation</a></li>
+        <li class="more-info"><a href="http://api.rubyonrails.org/">Documentation</a></li>
         <li class="more-info"><a href="http://rubyonrails.org/community">Community</a></li>
         <li class="more-info"><a href="http://weblog.rubyonrails.org/">Blog</a></li>
       </ul>


### PR DESCRIPTION
Since the redesign of rubyonrails.org, some links from the guides page header are directing to missing pages. It’s already cleaned up on edgeguides, but not on the current live page.
