### PR TITLE
set https to default_url_options as default when force_ssl is true

### DIFF
--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -39,6 +39,11 @@ module ActionDispatch
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie
 
+      if app.config.force_ssl
+        app.routes.default_url_options ||= {}
+        app.routes.default_url_options[:protocol] ||= 'https'
+      end
+
       ActionDispatch::Reloader.default_reloader = app.reloader
 
       ActionDispatch.test_app = app

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -60,6 +60,17 @@ module ApplicationTests
       assert_equal "https", ActionMailer::Base.default_url_options[:protocol]
     end
 
+    test "Default to HTTPS for routes URLs when force_ssl is on" do
+      app_file "config/environments/development.rb", <<-RUBY
+        Rails.application.configure do
+          config.force_ssl = true
+        end
+      RUBY
+
+      require "#{app_path}/config/environment"
+      assert_equal "https", Rails.application.routes.default_url_options[:protocol]
+    end
+
     test "includes url helpers as action methods" do
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do


### PR DESCRIPTION
I expect `_url` methods return url that contain https without  protocol option when `config.force_ssl = true`
like ActionMailer dose.

Does it make sense?

ex)

```
# when config.force_ssl = true

products_url(host: 'www.example.com')
#=> before: http://www.example.com/products
#=> after: https://www.example.com/products
```
