### PR TITLE
Add singular resource support to `polymorphic_path`

### DIFF
--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -146,6 +146,8 @@ class FormHelperTest < ActionView::TestCase
       end
     end
 
+    resource :comment
+
     get "/foo", to: "controller#action"
     root to: "main#index"
   end
@@ -3524,6 +3526,38 @@ class FormHelperTest < ActionView::TestCase
 
     form_for(@post, builder: builder_class) { }
     assert_equal 1, initialization_count, 'form builder instantiated more than once'
+  end
+
+  def test_form_for_with_new_singular_resource
+    form_for(Comment.new) {}
+    assert_dom_equal(
+      %{<form class="new_comment" id="new_comment" action="/comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /></form>},
+      output_buffer
+    )
+  end
+
+  def test_form_for_with_new_singular_resource_and_format
+    form_for(Comment.new, format: :json) {}
+    assert_dom_equal(
+      %{<form class="new_comment" id="new_comment" action="/comment.json" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /></form>},
+      output_buffer
+    )
+  end
+
+  def test_form_for_with_persisted_singular_resource
+    form_for(Comment.new(1)) {}
+    assert_dom_equal(
+      %{<form class="edit_comment" id="edit_comment_1" action="/comment" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="patch" /></form>},
+      output_buffer
+    )
+  end
+
+  def test_form_for_with_persisted_singular_resource_and_format
+    form_for(Comment.new(2), format: :json) {}
+    assert_dom_equal(
+      %{<form class="edit_comment" id="edit_comment_2" action="/comment.json" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="patch" /></form>},
+      output_buffer
+    )
   end
 
   protected


### PR DESCRIPTION
A somewhat less invasive redo to #23535. The problem that makes #1769 so
hard to solve, is that `polymorphic_path` is only provided with an
database object, so this makes it hard to reinvent the routing tree.
This is the best solution I could come up with.

Will update documentation if this is merged.

r? @pixeltrix 
