### PR TITLE
`schema_type` returns symbol rather than string

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
       def column_spec_for_primary_key(column)
         return if column.type == :integer
-        spec = { id: column.type.inspect }
+        spec = { id: schema_type(column).inspect }
         spec.merge!(prepare_column_options(column).delete_if { |key, _| [:name, :type].include?(key) })
       end
 
@@ -24,7 +24,7 @@ module ActiveRecord
       def prepare_column_options(column)
         spec = {}
         spec[:name]      = column.name.inspect
-        spec[:type]      = schema_type(column)
+        spec[:type]      = schema_type(column).to_s
         spec[:null]      = 'false' unless column.null
 
         if limit = schema_limit(column)
@@ -57,7 +57,7 @@ module ActiveRecord
       private
 
       def schema_type(column)
-        column.type.to_s
+        column.type
       end
 
       def schema_limit(column)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -12,7 +12,7 @@ module ActiveRecord
             spec[:unsigned] = 'true' if column.unsigned?
             return if spec.empty?
           else
-            spec[:id] = column.type.inspect
+            spec[:id] = schema_type(column).inspect
             spec.merge!(prepare_column_options(column).delete_if { |key, _| [:name, :type, :null].include?(key) })
           end
           spec
@@ -32,7 +32,7 @@ module ActiveRecord
 
         def schema_type(column)
           if column.sql_type == 'tinyblob'
-            'blob'
+            :blob
           else
             super
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -11,7 +11,7 @@ module ActiveRecord
             spec[:id] = ':uuid'
             spec[:default] = schema_default(column) || 'nil'
           else
-            spec[:id] = column.type.inspect
+            spec[:id] = schema_type(column).inspect
             spec.merge!(prepare_column_options(column).delete_if { |key, _| [:name, :type, :null].include?(key) })
           end
           spec
@@ -35,9 +35,9 @@ module ActiveRecord
           return super unless column.serial?
 
           if column.bigint?
-            'bigserial'
+            :bigserial
           else
-            'serial'
+            :serial
           end
         end
 


### PR DESCRIPTION
A return value of `schema_type` is used by:
1. primary key type: using as `symbol.inspect`
2. normal column type: using as `symbol.to_s`

It is better to return symbol.
