### PR TITLE
Command correction for api_app.md

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -220,7 +220,7 @@ building, and make sense in an API-only Rails application.
 You can get a list of all middleware in your application via:
 
 ```bash
-$ rails middleware
+$ rake middleware
 ```
 
 ### Using the Cache Middleware


### PR DESCRIPTION
Currently, the command specified to get the list of middleware in your rails app is listed as 'rails middleware' instead of 'rake middleware' in the "Using Rails for API-only Applications" guide. 
