### PR TITLE
raise ActionView::MissingTemplate errors when a template cannot be found for a regular browser request

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   When responding to regular browser requests for actions with no 
+*   When responding to HTML, non-XHR browser requests for actions with no 
     corresponding templates, raise `ActionView::MissingTemplate` errors 
     rather than rendering `head :no_content`. That way the browser
     refreshes with a traditional, helpful error message.

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   When responding to regular browser requests for actions with no 
+    corresponding templates, raise `ActionView::MissingTemplate` errors 
+    rather than rendering `head :no_content`. That way the browser
+    refreshes with a traditional, helpful error message.
+
+    Fixes #23077.
+
+    *Mike Clark*
+
 *   Add image/svg+xml as a default mime type.
 
     *DHH*

--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -17,7 +17,7 @@ module ActionController
     #   default_render do
     #     head 404 # No template was found
     #   end
-    def default_render(*args) 
+    def default_render(*args)
       if template_exists?(action_name.to_s, _prefixes, variants: request.variant)
         render(*args)
       else

--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -8,9 +8,6 @@ module ActionController
     # For example, the "new" action with an HTML format and variant "phone" 
     # would try to render the <tt>new.html+phone.erb</tt> template.
     #
-    # If no template is found for a regular browser request, 
-    # <tt>ActionView::MissingTemplate</tt> is raised.
-    #
     # If no template is found and a block is passed, then the block is called 
     # to allow the caller to handle the missing template. If no block is passed 
     # and it's an HTML, non-XHR (interactive browser) request, then 

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -615,7 +615,7 @@ class RespondToControllerTest < ActionController::TestCase
     end
   end
 
-  def test_invalid_variant_for_regular_browser_request
+  def test_invalid_variant_for_interactive_browser_request
     assert_raises(ActionView::MissingTemplate) do
       get :variant_with_implicit_rendering, params: { v: :invalid }
     end
@@ -632,7 +632,7 @@ class RespondToControllerTest < ActionController::TestCase
     ActionController::Base.logger = old_logger
   end
 
-  def test_variant_not_set_template_missing_for_regular_browser_request
+  def test_variant_not_set_template_missing_for_interactive_browser_request
     assert_raises(ActionView::MissingTemplate) do
       get :variant_with_implicit_rendering
     end
@@ -643,7 +643,7 @@ class RespondToControllerTest < ActionController::TestCase
     assert_response :no_content
   end
 
-  def test_variant_with_implicit_rendering_for_regular_browser_request
+  def test_variant_with_implicit_rendering_for_interactive_browser_request
     assert_raises(ActionView::MissingTemplate) do
       get :variant_with_implicit_rendering, params: { v: :implicit }
     end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -537,7 +537,7 @@ end
 class ImplicitRenderTest < ActionController::TestCase
   tests ImplicitRenderTestController
 
-  def test_implicit_missing_template_error_for_regular_browser_request
+  def test_implicit_missing_template_error_for_interactive_browser_request
     assert_raises(ActionView::MissingTemplate) do
       get :empty_action
     end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -537,8 +537,19 @@ end
 class ImplicitRenderTest < ActionController::TestCase
   tests ImplicitRenderTestController
 
-  def test_implicit_no_content_response
-    get :empty_action
+  def test_implicit_missing_template_error_for_regular_browser_request
+    assert_raises(ActionView::MissingTemplate) do
+      get :empty_action
+    end
+  end
+
+  def test_implicit_no_content_response_for_xhr_request
+    get :empty_action, xhr: true
+    assert_response :no_content
+  end
+
+  def test_implicit_no_content_response_for_api_request
+    get :empty_action, format: 'json'
     assert_response :no_content
   end
 end


### PR DESCRIPTION
Proposal to fix #23077. This works, but I'm not thrilled with the implementation of `default_render`. My intent was to keep the code explicit (i.e.. not introduce more indirection) with minimal changes. Unfortunately,  `default_render` now has two paths for handling missing templates: raising an exception for regular browser requests and returning `head :no_content` for all other request types. That's the intended behavior, but I welcome any feedback/help on improving the code structure. For example, I'm not totally clear on the intent behind `BasicImplicitRender` and `ImplicitRender`, so there may be a way to structure better around their intended use. 
