### PR TITLE
Addresses #23568, Incorrect error message with accepts_nested_attributes_for / has_many & has_one

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -29,14 +29,6 @@ module ActiveRecord
       assign_multiparameter_attributes(multi_parameter_attributes) unless multi_parameter_attributes.empty?
     end
 
-    # Tries to assign given value to given attribute.
-    # In case of an error, re-raises with the ActiveRecord constant.
-    def _assign_attribute(k, v) # :nodoc:
-      super
-    rescue ActiveModel::UnknownAttributeError
-      raise UnknownAttributeError.new(self, k)
-    end
-
     # Assign any deferred nested attributes after the base attributes have been set.
     def assign_nested_parameter_attributes(pairs)
       pairs.each { |k, v| _assign_attribute(k, v) }

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -61,6 +61,13 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     assert_equal "No association found for name `honesty'. Has it been defined yet?", exception.message
   end
 
+  def test_should_raise_an_UnknownAttributeError_for_non_existing_nested_attributes
+    exception = assert_raise ActiveModel::UnknownAttributeError do
+      Pirate.new(:ship_attributes => { :sail => true })
+    end
+    assert_equal "unknown attribute 'sail' for Ship.", exception.message
+  end
+
   def test_should_disable_allow_destroy_by_default
     Pirate.accepts_nested_attributes_for :ship
 
@@ -580,6 +587,13 @@ end
 module NestedAttributesOnACollectionAssociationTests
   def test_should_define_an_attribute_writer_method_for_the_association
     assert_respond_to @pirate, association_setter
+  end
+
+  def test_should_raise_an_UnknownAttributeError_for_non_existing_nested_attributes_for_has_many
+    exception = assert_raise ActiveModel::UnknownAttributeError do
+      @pirate.parrots_attributes = [{ peg_leg: true }]
+    end
+    assert_equal "unknown attribute 'peg_leg' for Parrot.", exception.message
   end
 
   def test_should_save_only_one_association_on_create


### PR DESCRIPTION
- Corrects an incorrect exception message when using accepts_nested_attributes_for
- Removes rescue/reraise behavior introduced in #19077
- Adds a test case that would fail without this patch

Fixes #23568
