### PR TITLE
Drop support for passing an instance of `ActiveRecord::Base` to `find`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Drop support for passing an instance of `ActiveRecord::Base` to `find`
+
+    *Yuichiro Kaneko*
+
 *   Added `numeric` helper into migrations.
 
     Example:

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -426,8 +426,7 @@ module ActiveRecord
 
     def find_one(id)
       if ActiveRecord::Base === id
-        id = id.id
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        raise ArgumentError, <<-MSG.squish
           You are passing an instance of ActiveRecord::Base to `find`.
           Please pass the id of the object by calling `.id`
         MSG

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -117,8 +117,8 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal 'The Fourth Topic of the day', records[2].title
   end
 
-  def test_find_passing_active_record_object_is_deprecated
-    assert_deprecated do
+  def test_find_passing_active_record_object_raise_exception
+    assert_raises(ArgumentError) do
       Topic.find(Topic.last)
     end
   end


### PR DESCRIPTION
This deprecation was introduced on Rails 4.2.0
(see d35f0033c7dec2b8d8b52058fb8db495d49596f7).
Now we are arriving Rails 5, so drop support for
passing an instance of `ActiveRecord::Base` to `find`.
