### PR TITLE
Remove extra spaces in the session file

### DIFF
--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -9,7 +9,7 @@ module ActionDispatch
 
       # Singleton object used to determine if an optional param wasn't specified
       Unspecified = Object.new
-      
+
       # Creates a session hash, merging the properties of the previous session if any
       def self.create(store, req, default_options)
         session_was = find req


### PR DESCRIPTION
Remove extra spaces in the actionpack/lib/action_dispatch/request/session.rb file
