### PR TITLE
UniquenessValidator exclude itself when PK changed

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -19,7 +19,7 @@ module ActiveRecord
         relation = build_relation(finder_class, table, attribute, value)
         if record.persisted? && finder_class.primary_key.to_s != attribute.to_s
           if finder_class.primary_key
-            relation = relation.where.not(finder_class.primary_key => record.id)
+            relation = relation.where.not(finder_class.primary_key => record.id_was)
           else
             raise UnknownPrimaryKey.new(finder_class, "Can not validate uniqueness for persisted record without primary key.")
           end

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -469,4 +469,15 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert_match(/\AUnknown primary key for table dashboards in model/, e.message)
     assert_match(/Can not validate uniqueness for persisted record without primary key.\z/, e.message)
   end
+
+  def test_validate_uniqueness_ignores_itself_when_primary_key_changed
+    Topic.validates_uniqueness_of(:title)
+
+    t = Topic.new("title" => "This is a unique title")
+    assert t.save, "Should save t as unique"
+
+    t.id += 1
+    assert t.valid?, "Should be valid"
+    assert t.save, "Should still save t as unique"
+  end
 end


### PR DESCRIPTION
When changing the PK for a record which has a uniqueness validation on some other attribute, Active Record should exclude itself from the validation based on the PK value stored on the DB (`id_was`) instead of its new value (`id`).

This PR fixes the issue reported at #23399.

I've included a simple test that fails with the current `master` branch.
It should be noted that without this fix a PK update will never work on models that have a uniqueness validation.

This fix applies to Rails 5.0, but I think it should be backported to other stable versions.
