### PR TITLE
Array.second_to_last and Array.third_to_last access methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add ActiveRecord `#second_to_last` and `#third_to_last` methods.
+
+    *Brian Christian*
+
 *   Added `numeric` helper into migrations.
 
     Example:

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -136,12 +136,12 @@ module ActiveRecord
         first_nth_or_last(:forty_two, *args)
       end
 
-      def antepenultimate(*args)
-        first_nth_or_last(:antepenultimate, *args)
+      def third_to_last(*args)
+        first_nth_or_last(:third_to_last, *args)
       end
 
-      def penultimate(*args)
-        first_nth_or_last(:penultimate, *args)
+      def second_to_last(*args)
+        first_nth_or_last(:second_to_last, *args)
       end
 
       def last(*args)

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -136,6 +136,14 @@ module ActiveRecord
         first_nth_or_last(:forty_two, *args)
       end
 
+      def antepenultimate(*args)
+        first_nth_or_last(:antepenultimate, *args)
+      end
+
+      def penultimate(*args)
+        first_nth_or_last(:penultimate, *args)
+      end
+
       def last(*args)
         first_nth_or_last(:last, *args)
       end

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -198,13 +198,13 @@ module ActiveRecord
       end
 
       # Same as #first except returns only the third-to-last record.
-      def antepenultimate(*args)
-        @association.antepenultimate(*args)
+      def third_to_last(*args)
+        @association.third_to_last(*args)
       end
 
       # Same as #first except returns only the second-to-last record.
-      def penultimate(*args)
-        @association.penultimate(*args)
+      def second_to_last(*args)
+        @association.second_to_last(*args)
       end
 
       # Returns the last record, or the last +n+ records, from the collection.

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -197,6 +197,16 @@ module ActiveRecord
         @association.forty_two(*args)
       end
 
+      # Same as #first except returns only the third-to-last record.
+      def antepenultimate(*args)
+        @association.antepenultimate(*args)
+      end
+
+      # Same as #first except returns only the second-to-last record.
+      def penultimate(*args)
+        @association.penultimate(*args)
+      end
+
       # Returns the last record, or the last +n+ records, from the collection.
       # If the collection is empty, the first form returns +nil+, and the second
       # form returns an empty array.

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module Querying
     delegate :find, :take, :take!, :first, :first!, :last, :last!, :exists?, :any?, :many?, to: :all
-    delegate :second, :second!, :third, :third!, :fourth, :fourth!, :fifth, :fifth!, :forty_two, :forty_two!, :antepenultimate, :antepenultimate!, :penultimate, :penultimate!, to: :all
+    delegate :second, :second!, :third, :third!, :fourth, :fourth!, :fifth, :fifth!, :forty_two, :forty_two!, :third_to_last, :third_to_last!, :second_to_last, :second_to_last!, to: :all
     delegate :first_or_create, :first_or_create!, :first_or_initialize, to: :all
     delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, to: :all
     delegate :find_by, :find_by!, to: :all

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module Querying
     delegate :find, :take, :take!, :first, :first!, :last, :last!, :exists?, :any?, :many?, to: :all
-    delegate :second, :second!, :third, :third!, :fourth, :fourth!, :fifth, :fifth!, :forty_two, :forty_two!, to: :all
+    delegate :second, :second!, :third, :third!, :fourth, :fourth!, :fifth, :fifth!, :forty_two, :forty_two!, :antepenultimate, :antepenultimate!, :penultimate, :penultimate!, to: :all
     delegate :first_or_create, :first_or_create!, :first_or_initialize, to: :all
     delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, to: :all
     delegate :find_by, :find_by!, to: :all

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -245,32 +245,32 @@ module ActiveRecord
     # Find the third-to-last record.
     # If no order is defined it will order by primary key.
     #
-    #   Person.antepenultimate # returns the third-to-last object fetched by SELECT * FROM people
-    #   Person.offset(3).antepenultimate # returns the third-to-last object from OFFSET 3
-    #   Person.where(["user_name = :u", { u: user_name }]).antepenultimate
-    def antepenultimate
+    #   Person.third_to_last # returns the third-to-last object fetched by SELECT * FROM people
+    #   Person.offset(3).third_to_last # returns the third-to-last object from OFFSET 3
+    #   Person.where(["user_name = :u", { u: user_name }]).third_to_last
+    def third_to_last
       find_nth -3
     end
 
-    # Same as #antepenultimate but raises ActiveRecord::RecordNotFound if no record
+    # Same as #third_to_last but raises ActiveRecord::RecordNotFound if no record
     # is found.
-    def antepenultimate!
+    def third_to_last!
       find_nth! -3
     end
 
     # Find the second-to-last record.
     # If no order is defined it will order by primary key.
     #
-    #   Person.penultimate # returns the second-to-last object fetched by SELECT * FROM people
-    #   Person.offset(3).penultimate # returns the second-to-last object from OFFSET 3
-    #   Person.where(["user_name = :u", { u: user_name }]).penultimate
-    def penultimate
+    #   Person.second_to_last # returns the second-to-last object fetched by SELECT * FROM people
+    #   Person.offset(3).second_to_last # returns the second-to-last object from OFFSET 3
+    #   Person.where(["user_name = :u", { u: user_name }]).second_to_last
+    def second_to_last
       find_nth -2
     end
 
-    # Same as #penultimate but raises ActiveRecord::RecordNotFound if no record
+    # Same as #second_to_last but raises ActiveRecord::RecordNotFound if no record
     # is found.
-    def penultimate!
+    def second_to_last!
       find_nth! -2
     end
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -242,6 +242,38 @@ module ActiveRecord
       find_nth! 41
     end
 
+    # Find the third-to-last record.
+    # If no order is defined it will order by primary key.
+    #
+    #   Person.antepenultimate # returns the third-to-last object fetched by SELECT * FROM people
+    #   Person.offset(3).antepenultimate # returns the third-to-last object from OFFSET 3
+    #   Person.where(["user_name = :u", { u: user_name }]).antepenultimate
+    def antepenultimate
+      find_nth -3
+    end
+
+    # Same as #antepenultimate but raises ActiveRecord::RecordNotFound if no record
+    # is found.
+    def antepenultimate!
+      find_nth! -3
+    end
+
+    # Find the second-to-last record.
+    # If no order is defined it will order by primary key.
+    #
+    #   Person.penultimate # returns the second-to-last object fetched by SELECT * FROM people
+    #   Person.offset(3).penultimate # returns the second-to-last object from OFFSET 3
+    #   Person.where(["user_name = :u", { u: user_name }]).penultimate
+    def penultimate
+      find_nth -2
+    end
+
+    # Same as #penultimate but raises ActiveRecord::RecordNotFound if no record
+    # is found.
+    def penultimate!
+      find_nth! -2
+    end
+
     # Returns true if a record exists in the table that matches the +id+ or
     # conditions given, or false otherwise. The argument can take six forms:
     #

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -408,13 +408,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_no_queries do
-      bulbs.antepenultimate()
-      bulbs.antepenultimate({})
+      bulbs.third_to_last()
+      bulbs.third_to_last({})
     end
 
     assert_no_queries do
-      bulbs.penultimate()
-      bulbs.penultimate({})
+      bulbs.second_to_last()
+      bulbs.second_to_last({})
     end
 
     assert_no_queries do

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -408,6 +408,16 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_no_queries do
+      bulbs.antepenultimate()
+      bulbs.antepenultimate({})
+    end
+
+    assert_no_queries do
+      bulbs.penultimate()
+      bulbs.penultimate({})
+    end
+
+    assert_no_queries do
       bulbs.last()
       bulbs.last({})
     end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `Array#second_to_last` and `Array#third_to_last` methods.
+
+    *Brian Christian*
+
 *  Fix regression in `Hash#dig` for HashWithIndifferentAccess.
    *Jon Moss*
 

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -73,4 +73,18 @@ class Array
   def forty_two
     self[41]
   end
+
+  # Equal to <tt>self[-3]</tt>.
+  #
+  #   %w( a b c d e ).antepenultimate # => "c"
+  def antepenultimate
+    self[-3]
+  end
+
+  # Equal to <tt>self[-2]</tt>.
+  #
+  #   %w( a b c d e ).penultimate # => "d"
+  def penultimate
+    self[-2]
+  end
 end

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -76,15 +76,15 @@ class Array
 
   # Equal to <tt>self[-3]</tt>.
   #
-  #   %w( a b c d e ).antepenultimate # => "c"
-  def antepenultimate
+  #   %w( a b c d e ).third_to_last # => "c"
+  def third_to_last
     self[-3]
   end
 
   # Equal to <tt>self[-2]</tt>.
   #
-  #   %w( a b c d e ).penultimate # => "d"
-  def penultimate
+  #   %w( a b c d e ).second_to_last # => "d"
+  def second_to_last
     self[-2]
   end
 end

--- a/activesupport/test/core_ext/array/access_test.rb
+++ b/activesupport/test/core_ext/array/access_test.rb
@@ -26,8 +26,8 @@ class AccessTest < ActiveSupport::TestCase
     assert_equal array[3], array.fourth
     assert_equal array[4], array.fifth
     assert_equal array[41], array.forty_two
-    assert_equal array[-3], array.antepenultimate
-    assert_equal array[-2], array.penultimate
+    assert_equal array[-3], array.third_to_last
+    assert_equal array[-2], array.second_to_last
   end
 
   def test_without

--- a/activesupport/test/core_ext/array/access_test.rb
+++ b/activesupport/test/core_ext/array/access_test.rb
@@ -26,6 +26,8 @@ class AccessTest < ActiveSupport::TestCase
     assert_equal array[3], array.fourth
     assert_equal array[4], array.fifth
     assert_equal array[41], array.forty_two
+    assert_equal array[-3], array.antepenultimate
+    assert_equal array[-2], array.penultimate
   end
 
   def test_without

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2240,7 +2240,7 @@ Similarly, `from` returns the tail from the element at the passed index to the e
 [].from(0)           # => []
 ```
 
-The methods `second`, `third`, `fourth`, and `fifth` return the corresponding element (`first` is built-in), while `penultimate` and `antepenultimate` return the second-to-last and third-to-last elements, respectively. Thanks to social wisdom and positive constructiveness all around, `forty_two` is also available.
+The methods `second`, `third`, `fourth`, and `fifth` return the corresponding element, as do `second_to_last` and `third_to_last` (`first` and `last` are built-in). Thanks to social wisdom and positive constructiveness all around, `forty_two` is also available.
 
 ```ruby
 %w(a b c d).third # => "c"

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2240,7 +2240,7 @@ Similarly, `from` returns the tail from the element at the passed index to the e
 [].from(0)           # => []
 ```
 
-The methods `second`, `third`, `fourth`, and `fifth` return the corresponding element (`first` is built-in). Thanks to social wisdom and positive constructiveness all around, `forty_two` is also available.
+The methods `second`, `third`, `fourth`, and `fifth` return the corresponding element (`first` is built-in), while `penultimate` and `antepenultimate` return the second-to-last and third-to-last elements, respectively. Thanks to social wisdom and positive constructiveness all around, `forty_two` is also available.
 
 ```ruby
 %w(a b c d).third # => "c"


### PR DESCRIPTION
Reading @dhh's [Rails Doctrine](http://rubyonrails.org/doctrine/) essay got me thinking a lot about Rails' `second` and `fifth` accessor methods, which I (like DHH) love so much.

One of the things that has occurred to me about once every month or two since I began working with Rails (back in 2008) is that it'd be nice to have similarly natural ways of accessing the end of an array or relation. We have `last`, but it ends there. It's slightly jarring (for me anyway) to go from `x.last` to `x[-2]`.

So, here's a proposal to add `penultimate` and `antepenultimate` as well. Partly for the delight factor, partly because I think it would actually be useful. (At least, it would to me.)

If `next_to_last` / `second_to_last` and `third_to_last` are more natural, we can easily use those instead, or make them aliases.

This is my first Rails PR, so I've tried to include everything (tests, documentation), but I'm happy to make alterations if I've missed anything.
