### PR TITLE
[ci skip] Fix Rails.groups method description

### DIFF
--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -86,8 +86,8 @@ module Rails
     #   groups assets: [:development, :test]
     #
     #   # Returns
-    #   # => [:default, :development, :assets] for Rails.env == "development"
-    #   # => [:default, :production]           for Rails.env == "production"
+    #   # => [:default, :development] for Rails.env == "development"
+    #   # => [:default, :production]  for Rails.env == "production"
     def groups(*groups)
       hash = groups.extract_options!
       env = Rails.env


### PR DESCRIPTION
Playing with this method I noticed that docs are not up to date. When in development it doesn't return :assets in array results.

<img width="447" alt="img" src="https://cloud.githubusercontent.com/assets/7427365/12950083/a747cf74-d00b-11e5-9b7c-63c8c99edf3b.png">
