### PR TITLE
index option added for change_table migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Added `index` option for `change_table` migration helpers.
+    With this change you can create indexes while adding new
+    columns into the existing tables.
+
+    Example:
+
+        change_table(:languages) do |t|
+          t.string :country_code, index: true
+        end
+
+    *Mehmet Emin İNAÇ*
+
 *   Don't update counter cache unless the record is actually saved.
 
     Fixes #31493, #33113, #33117.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -527,7 +527,9 @@ module ActiveRecord
       #
       # See TableDefinition#column for details of the options you can use.
       def column(column_name, type, options = {})
+        index_options = options.delete(:index)
         @base.add_column(name, column_name, type, options)
+        index(column_name, index_options.is_a?(Hash) ? index_options : {}) if index_options
       end
 
       # Checks to see if a column exists.

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -164,6 +164,14 @@ module ActiveRecord
         end
       end
 
+      def test_column_creates_column_with_index
+        with_change_table do |t|
+          @connection.expect :add_column, nil, [:delete_me, :bar, :integer, {}]
+          @connection.expect :add_index, nil, [:delete_me, :bar, {}]
+          t.column :bar, :integer, index: true
+        end
+      end
+
       def test_index_creates_index
         with_change_table do |t|
           @connection.expect :add_index, nil, [:delete_me, :bar, {}]


### PR DESCRIPTION
In case if we want to add a column into the existing table
with index on it, we have to add column and index in two
seperate lines.
With this feature we don't need to write an extra line to
add index for column. We can just use `index` option.

Old behaviour in action:

```
  change_table(:languages) do |t|
    t.string :country_code
    t.index: :country_code
  end
```

New behaviour in action:

```
  change_table(:languages) do |t|
    t.string :country_code, index: true
  end
```

Exactly same behaviour is already exist for `create_table` migrations.
There was a [pull request](github.com/rails/rails/pull/20616) created by me which was about adding `index` option for `add_column` helper. I understand the concern behind closing it and it make sense but this addition is different from it. So I'm not pushing same idea again.
