### PR TITLE
Add `parsed_body` to `ActionDispatch::TestResponse`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `parsed_body` to `ActionDispatch::TestResponse` to avoid
+    calling `JSON.parse` multiple times in tests.
+
+    *Jon Moss*
+
 *   Add image/svg+xml as a default mime type.
 
     *DHH*

--- a/actionpack/lib/action_dispatch/testing/test_response.rb
+++ b/actionpack/lib/action_dispatch/testing/test_response.rb
@@ -18,5 +18,14 @@ module ActionDispatch
 
     # Was there a server-side error?
     alias_method :error?, :server_error?
+
+    # Return a JSON parsed response body
+    def parsed_body
+      begin
+        JSON.parse(body)
+      rescue
+        nil
+      end
+    end
   end
 end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -150,6 +150,10 @@ XML
       render html: '<body class="foo"></body>'.html_safe
     end
 
+    def test_with_json
+      render json: { 'hi' => 'hi' }
+    end
+
     private
 
       def generate_url(opts)
@@ -965,6 +969,11 @@ XML
     assert_raise(ActiveSupport::TestCase::Assertion) do
       assert_redirected_to 'created resource'
     end
+  end
+
+  def test_parsed_body
+    post :test_with_json, params: { action: 'foobar' }
+    assert_equal({ 'hi' => 'hi' }, @response.parsed_body)
   end
 end
 


### PR DESCRIPTION
This will avoid users from calling `JSON.parse` multiple times in tests.
Fixes #23594 

r? @kaspth 
