### PR TITLE
Converting backtrace to strings before calling set_backtrace

### DIFF
--- a/activesupport/lib/active_support/deprecation/behaviors.rb
+++ b/activesupport/lib/active_support/deprecation/behaviors.rb
@@ -11,7 +11,7 @@ module ActiveSupport
     DEFAULT_BEHAVIORS = {
       raise: ->(message, callstack) {
         e = DeprecationException.new(message)
-        e.set_backtrace(callstack)
+        e.set_backtrace(callstack.map(&:to_s))
         raise e
       },
 

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -105,13 +105,13 @@ class DeprecationTest < ActiveSupport::TestCase
     ActiveSupport::Deprecation.behavior = :raise
 
     message   = 'Revise this deprecated stuff now!'
-    callstack = %w(foo bar baz)
+    callstack = caller_locations
 
     e = assert_raise ActiveSupport::DeprecationException do
       ActiveSupport::Deprecation.behavior.first.call(message, callstack)
     end
     assert_equal message, e.message
-    assert_equal callstack, e.backtrace
+    assert_equal callstack.map(&:to_s), e.backtrace.map(&:to_s)
   end
 
   def test_default_stderr_behavior


### PR DESCRIPTION
Fixes #23058
