### PR TITLE
Assorted Railties generators work

### DIFF
--- a/actioncable/lib/rails/generators/channel/channel_generator.rb
+++ b/actioncable/lib/rails/generators/channel/channel_generator.rb
@@ -24,6 +24,7 @@ module Rails
           @_file_name ||= super.gsub(/\_channel/i, '')
         end
 
+        # FIXME: Change these files to symlinks once RubyGems 2.5.0 is required.
         def generate_application_cable_files
           return if self.behavior != :invoke
 

--- a/actioncable/lib/rails/generators/channel/channel_generator.rb
+++ b/actioncable/lib/rails/generators/channel/channel_generator.rb
@@ -15,11 +15,27 @@ module Rails
         if options[:assets]
           template "assets/channel.coffee", File.join('app/assets/javascripts/channels', class_path, "#{file_name}.coffee")
         end
+
+        generate_application_cable_files
       end
 
       protected
         def file_name
           @_file_name ||= super.gsub(/\_channel/i, '')
+        end
+
+        def generate_application_cable_files
+          return if self.behavior != :invoke
+
+          files = [
+            'application_cable/channel.rb',
+            'application_cable/connection.rb'
+          ]
+
+          files.each do |name|
+            path = File.join('app/channels/', name)
+            template(name, path) if !File.exist?(path)
+          end
         end
     end
   end

--- a/actioncable/lib/rails/generators/channel/templates/application_cable/channel.rb
+++ b/actioncable/lib/rails/generators/channel/templates/application_cable/channel.rb
@@ -1,0 +1,5 @@
+# Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto reloading.
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/actioncable/lib/rails/generators/channel/templates/application_cable/connection.rb
+++ b/actioncable/lib/rails/generators/channel/templates/application_cable/connection.rb
@@ -1,0 +1,5 @@
+# Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto reloading.
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+  end
+end

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -39,6 +39,7 @@ module ActiveRecord
           attributes.select { |a| !a.reference? && a.has_index? }
         end
 
+        # FIXME: Change this file to a symlink once RubyGems 2.5.0 is required.
         def generate_application_record
           if self.behavior == :invoke && !File.exist?('app/models/application_record.rb')
             template 'application_record.rb', 'app/models/application_record.rb'

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -22,11 +22,13 @@ module ActiveRecord
 
       def create_model_file
         template 'model.rb', File.join('app/models', class_path, "#{file_name}.rb")
+        generate_application_record
       end
 
       def create_module_file
         return if regular_class_path.empty?
         template 'module.rb', File.join('app/models', "#{class_path.join('/')}.rb") if behavior == :invoke
+        generate_application_record
       end
 
       hook_for :test_framework
@@ -35,6 +37,12 @@ module ActiveRecord
 
         def attributes_with_index
           attributes.select { |a| !a.reference? && a.has_index? }
+        end
+
+        def generate_application_record
+          if self.behavior == :invoke && !File.exist?('app/models/application_record.rb')
+            template 'application_record.rb', 'app/models/application_record.rb'
+          end
         end
 
         # Used by the migration template to determine the parent name of the model

--- a/activerecord/lib/rails/generators/active_record/model/templates/application_record.rb
+++ b/activerecord/lib/rails/generators/active_record/model/templates/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -91,6 +91,7 @@ module Rails
       cookie_serializer_config_exist = File.exist?('config/initializers/cookies_serializer.rb')
       callback_terminator_config_exist = File.exist?('config/initializers/callback_terminator.rb')
       active_record_belongs_to_required_by_default_config_exist = File.exist?('config/initializers/active_record_belongs_to_required_by_default.rb')
+      action_cable_config_exist = File.exist?('config/cable.yml')
 
       config
 
@@ -104,6 +105,10 @@ module Rails
 
       unless active_record_belongs_to_required_by_default_config_exist
         remove_file 'config/initializers/active_record_belongs_to_required_by_default.rb'
+      end
+
+      unless action_cable_config_exist
+        template 'config/cable.yml'
       end
     end
 

--- a/railties/test/generators/channel_generator_test.rb
+++ b/railties/test/generators/channel_generator_test.rb
@@ -5,6 +5,18 @@ class ChannelGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
   tests Rails::Generators::ChannelGenerator
 
+  def test_application_cable_skeleton_is_created
+     run_generator ['books']
+
+     assert_file "app/channels/application_cable/channel.rb" do |cable|
+       assert_match(/module ApplicationCable\n  class Channel < ActionCable::Channel::Base\n/, cable)
+     end
+
+     assert_file "app/channels/application_cable/connection.rb" do |cable|
+       assert_match(/module ApplicationCable\n  class Connection < ActionCable::Connection::Base\n/, cable)
+     end
+   end
+
   def test_channel_is_created
     run_generator ['chat']
 

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -6,6 +6,14 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
   arguments %w(Account name:string age:integer)
 
+   def test_application_record_skeleton_is_created
+     run_generator
+     assert_file "app/models/application_record.rb" do |record|
+       assert_match(/class ApplicationRecord < ActiveRecord::Base/, record)
+       assert_match(/self.abstract_class = true/, record)
+     end
+   end
+
   def test_help_shows_invoked_generators_options
     content = run_generator ["--help"]
     assert_match(/ActiveRecord options:/, content)


### PR DESCRIPTION
In this PR...
- Generate `config/cable.yml` in `rails:update` command for Rails apps that are upgrading, and want to take advantage of Action Cable
- Generate `ApplicationRecord` if it does not already exist, in the `ActiveRecord` model generator
- Generate `ApplicationCable::Channel` and `ApplicationCable::Connection` if it does not already exist, in the `ActionCable` channel generator
