### PR TITLE
sort templates after looking them up in the from the paths cache

### DIFF
--- a/actionview/lib/action_view/dependency_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker.rb
@@ -153,11 +153,11 @@ module ActionView
         def resolve_directories(wildcard_dependencies)
           return [] unless @view_paths
 
-          wildcard_dependencies.each_with_object([]) do |query, templates|
-            @view_paths.find_all_with_query(query).each do |template|
-              templates << "#{File.dirname(query)}/#{File.basename(template).split('.').first}"
+          wildcard_dependencies.flat_map { |query, templates|
+            @view_paths.find_all_with_query(query).map do |template|
+              "#{File.dirname(query)}/#{File.basename(template).split('.').first}"
             end
-          end
+          }.sort
         end
 
         def explicit_dependencies


### PR DESCRIPTION
The view paths cache will eventually query the filesystem when looking
up templates:

  https://github.com/rails/rails/blob/2db347bebc9d3f39b3c5e274b7c9beecfce73913/actionview/lib/action_view/template/resolver.rb#L224-L230

The order in which files are returned is file system dependent.  Since
the template digest [depends on its children](https://github.com/rails/rails/blob/2db347bebc9d3f39b3c5e274b7c9beecfce73913/actionview/lib/action_view/digestor.rb#L109-L115), the order of the dependencies will impact the fingerprint.
This commit sorts the wildcard dependencies so that we get a consistent
hash.

Fixes #23592

@dhh do you mind trying this?  Out of curiosity, does it matter that the digest differs from machine to machine?  Are you serializing the cache?
