### PR TITLE
Remove vestiges of 4.2.0 deprecation

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -458,10 +458,7 @@ module ActiveRecord
           scale = extract_scale(sql_type)
           precision = extract_precision(sql_type)
 
-          if scale == 0
-            # FIXME: Remove this class as well
-            Type::DecimalWithoutScale.new(precision: precision)
-          else
+          if !(scale == 0)
             Type::Decimal.new(precision: precision, scale: scale)
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -485,11 +485,7 @@ module ActiveRecord
             #
             # places after decimal  = fmod - 4 & 0xffff
             # places before decimal = (fmod - 4) >> 16 & 0xffff
-            if fmod && (fmod - 4 & 0xffff).zero?
-              # FIXME: Remove this class, and the second argument to
-              # lookups on PG
-              Type::DecimalWithoutScale.new(precision: precision)
-            else
+            if !(fmod && (fmod - 4 & 0xffff).zero?)
               OID::Decimal.new(precision: precision, scale: scale)
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -486,7 +486,7 @@ module ActiveRecord
             # places after decimal  = fmod - 4 & 0xffff
             # places before decimal = (fmod - 4) >> 16 & 0xffff
             if !(fmod && (fmod - 4 & 0xffff).zero?)
-              OID::Decimal.new(precision: precision, scale: scale)
+              OID::Decimal.new(precision: precision)
             end
           end
 

--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -49,7 +49,6 @@ module ActiveRecord
     Binary = ActiveModel::Type::Binary
     Boolean = ActiveModel::Type::Boolean
     Decimal = ActiveModel::Type::Decimal
-    DecimalWithoutScale = ActiveModel::Type::DecimalWithoutScale
     Float = ActiveModel::Type::Float
     Integer = ActiveModel::Type::Integer
     String = ActiveModel::Type::String


### PR DESCRIPTION
Added in #15295, removed in #15374, vestiges still lingering.

Deprecations introduced in 4.2 are due to be removed in 5.0, like how deprecations introduced in 5.0 are due to be removed in 5.1.

r? @sgrif - All of the tests that you changed to fit the new API are now failing, so I think something else on the internals of Active Record must have changed. Can you take a look -- I'm not really sure what's going on. Let me know if you want me to remove the underlying Active Model type class, as well.
