### PR TITLE
Fix routes to match verb and URL path with -g option also.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -84,14 +84,15 @@ module ActionDispatch
         if filter.is_a?(Hash) && filter[:controller]
           { controller: /#{filter[:controller].downcase.sub(/_?controller\z/, '').sub('::', '/')}/ }
         elsif filter
-          { controller: /#{filter}/, action: /#{filter}/ }
+          { controller: /#{filter}/, action: /#{filter}/, verb: /#{filter}/, name: /#{filter}/, path: /#{filter}/ }
         end
       end
 
       def filter_routes(filter)
         if filter
           @routes.select do |route|
-            filter.any? { |default, value| route.defaults[default] =~ value }
+            route_wrapper = RouteWrapper.new(route)
+            filter.any? { |default, value| route_wrapper.send(default) =~ value }
           end
         else
           @routes

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -179,12 +179,20 @@ module ApplicationTests
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
           get '/cart', to: 'cart#show'
-          get '/basketball', to: 'basketball#index'
+          post '/cart', to: 'cart#create'
+          get '/basketballs', to: 'basketball#index'
         end
       RUBY
 
       output = Dir.chdir(app_path){ `bin/rails routes -g show` }
       assert_equal "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n", output
+
+      output = Dir.chdir(app_path){ `bin/rails routes -g POST` }
+      assert_equal "Prefix Verb URI Pattern     Controller#Action\n       POST /cart(.:format) cart#create\n", output
+
+      output = Dir.chdir(app_path){ `bin/rails routes -g basketballs` }
+      assert_equal "     Prefix Verb URI Pattern            Controller#Action\n" \
+                   "basketballs GET  /basketballs(.:format) basketball#index\n", output
     end
 
     def test_rake_routes_with_controller_search_key


### PR DESCRIPTION
Docs have mentioned that by  `-g` option, it matches the URL helper method name, the HTTP verb, or the URL path. But, as I can see it does not search on Verb/path mentioned(which it should).

```
$ rails routes | grep POST
              POST   /users(.:format)              users#create
              POST   /products(.:format)           products#create
              POST   /cart(.:format)               cart#create
```

But with `-g` option

```
$ rails routes -g POST
No routes were found for this controller
```

This PR includes Prefix, HTTP Verb and URL path to match with filter.
