### PR TITLE
Fix argument passing to rake routes

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -42,8 +42,7 @@
 
 ## Rails 5.0.0.beta2 (February 01, 2016) ##
 
-*   Add `-g` and `-c` (short for _grep_ and _controller_ respectively) options
-    to `bin/rake routes`. These options return the url `name`, `verb` and
+*   Add `-g` and `-c` options to `bin/rake routes`. These options return the url `name`, `verb` and
     `path` field that match the pattern or match a specific controller.
 
     Deprecate `CONTROLLER` env variable in `bin/rake routes`.

--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -239,8 +239,7 @@ module ActionDispatch
   #
   #   rails routes
   #
-  # Target specific controllers by prefixing the command with <tt>--controller</tt> option
-  # - or its <tt>-c</tt> shorthand.
+  # Target specific controllers by prefixing the command with <tt>-c</tt> option.
   #
   module Routing
     extend ActiveSupport::Autoload

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -1136,19 +1136,19 @@ For example, here's a small section of the `rails routes` output for a RESTful r
 edit_user GET    /users/:id/edit(.:format) users#edit
 ```
 
-You can search through your routes with the --grep option (-g for short). This outputs any routes that partially match the URL helper method name, the HTTP verb, or the URL path.
+You can search through your routes with the grep option: -g. This outputs any routes that partially match the URL helper method name, the HTTP verb, or the URL path.
 
 ```
-$ bin/rails routes --grep new_comment
+$ bin/rails routes -g new_comment
 $ bin/rails routes -g POST
 $ bin/rails routes -g admin
 ```
 
-If you only want to see the routes that map to a specific controller, there's the --controller option (-c for short).
+If you only want to see the routes that map to a specific controller, there's the -c option.
 
 ```
-$ bin/rails routes --controller users
-$ bin/rails routes --controller admin/users
+$ bin/rails routes -c users
+$ bin/rails routes -c admin/users
 $ bin/rails routes -c Comments
 $ bin/rails routes -c Articles::CommentsController
 ```

--- a/railties/lib/rails/tasks/routes.rake
+++ b/railties/lib/rails/tasks/routes.rake
@@ -2,7 +2,7 @@ require 'active_support/deprecation'
 require 'active_support/core_ext/string/strip' # for strip_heredoc
 require 'optparse'
 
-desc 'Print out all defined routes in match order, with names. Target specific controller with --controller option - or its -c shorthand.'
+desc 'Print out all defined routes in match order, with names. Target specific controller with -c option, or grep routes using -g option'
 task routes: :environment do
   all_routes = Rails.application.routes.routes
   require 'action_dispatch/routing/inspector'
@@ -19,11 +19,11 @@ task routes: :environment do
 
   OptionParser.new do |opts|
     opts.banner = "Usage: rails routes [options]"
-    opts.on("-c", "--controller [CONTROLLER]") do |controller|
+    opts.on("-c CONTROLLER") do |controller|
       routes_filter = { controller: controller }
     end
 
-    opts.on("-g", "--grep [PATTERN]") do |pattern|
+    opts.on("-g PATTERN") do |pattern|
       routes_filter = pattern
     end
 


### PR DESCRIPTION
- rake tasks need to be prepended with -- , so as to make sure they are not parsed by rake.
- Fixes routes task to take a note of this and parse arguments accordingly
- Fixed related documentation and usage all around

Fixes #23561
