### PR TITLE
Let t.foreign_key use the same `to_table` twice

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix a bug where using `t.foreign_key` twice with the same `to_table` within
+    the same table definition would only create one foreign key.
+
+    *George Millo*
+
 *   Rework `ActiveRecord::Relation#last` 
     
     1. Never perform additional SQL on loaded relation

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -212,7 +212,7 @@ module ActiveRecord
       def initialize(name, temporary, options, as = nil)
         @columns_hash = {}
         @indexes = {}
-        @foreign_keys = {}
+        @foreign_keys = []
         @primary_keys = nil
         @temporary = temporary
         @options = options
@@ -330,7 +330,7 @@ module ActiveRecord
       end
 
       def foreign_key(table_name, options = {}) # :nodoc:
-        foreign_keys[table_name] = options
+        foreign_keys.push([table_name, options])
       end
 
       # Appends <tt>:datetime</tt> columns <tt>:created_at</tt> and

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -144,6 +144,26 @@ module ActiveRecord
           @connection.drop_table "testing", if_exists: true
         end
       end
+
+      test "multiple foreign keys can be added to the same table" do
+        @connection.create_table :testings do |t|
+          t.integer :col_1
+          t.integer :col_2
+
+          t.foreign_key :testing_parents, column: :col_1
+          t.foreign_key :testing_parents, column: :col_2
+        end
+
+        fks = @connection.foreign_keys("testings")
+
+        assert_equal fks.length, 2
+        assert_equal "testings",        fks[0].from_table
+        assert_equal "testing_parents", fks[0].to_table
+        assert_equal "col_1",           fks[0].column
+        assert_equal "testings",        fks[1].from_table
+        assert_equal "testing_parents", fks[1].to_table
+        assert_equal "col_2",           fks[1].column
+      end
     end
   end
 end


### PR DESCRIPTION
I just discovered this issue with migrations in Rails 5 beta 2. Say I want to create a table with multiple foreign keys pointing to the _same_ table:

```
def change
  create_table :flights do |t|
    t.integer :from_id, index: true, null: false
    t.integer :to_id,   index: true, null: false

    t.foreign_key :airports, column: :from_id
    t.foreign_key :airports, column: :to_id
  end
end
```

The problem is that this only creates the _last_ foreign key (in this case the one on `to_id`) and ignores any previous foreign keys. From the source it's easy to see why:

```
def foreign_key(table_name, options = {}) # :nodoc:
  foreign_keys[table_name] = options
end
```

The hash keys are being re-used, so later definitions will overwrite previous ones.

This PR contains a simple fix, by turning `foreign_keys[table_name]` into an Array and allowing multiple definitions to be made for the same `to_table`.
