### PR TITLE
Fix logger silencing for broadcasted loggers

### DIFF
--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -1,8 +1,10 @@
 require 'active_support/logger_silence'
+require 'active_support/logger_thread_safe_level'
 require 'logger'
 
 module ActiveSupport
   class Logger < ::Logger
+    include ActiveSupport::LoggerThreadSafeLevel
     include LoggerSilence
 
     # Returns true if the logger destination matches one of the sources
@@ -47,6 +49,11 @@ module ActiveSupport
         define_method(:level=) do |level|
           logger.level = level
           super(level)
+        end
+
+        define_method(:local_level=) do |level|
+          logger.local_level = level if logger.respond_to?(:local_level=)
+          super(level) if respond_to?(:local_level=)
         end
       end
     end

--- a/activesupport/lib/active_support/logger_silence.rb
+++ b/activesupport/lib/active_support/logger_silence.rb
@@ -7,36 +7,19 @@ module LoggerSilence
 
   included do
     cattr_accessor :silencer
-    attr_reader :local_levels
     self.silencer = true
-  end
-
-  def after_initialize
-    @local_levels = Concurrent::Map.new(:initial_capacity => 2)
-  end
-
-  def local_log_id
-    Thread.current.__id__
-  end
-
-  def level
-    local_levels[local_log_id] || super
   end
 
   # Silences the logger for the duration of the block.
   def silence(temporary_level = Logger::ERROR)
     if silencer
       begin
-        old_local_level            = local_levels[local_log_id]
-        local_levels[local_log_id] = temporary_level
+        old_local_level            = local_level
+        self.local_level           = temporary_level
 
         yield self
       ensure
-        if old_local_level
-          local_levels[local_log_id] = old_local_level
-        else
-          local_levels.delete(local_log_id)
-        end
+        self.local_level = old_local_level
       end
     else
       yield self

--- a/activesupport/lib/active_support/logger_thread_safe_level.rb
+++ b/activesupport/lib/active_support/logger_thread_safe_level.rb
@@ -1,0 +1,31 @@
+require 'active_support/concern'
+
+module ActiveSupport
+  module LoggerThreadSafeLevel
+    extend ActiveSupport::Concern
+
+    def after_initialize
+      @local_levels = Concurrent::Map.new(:initial_capacity => 2)
+    end
+
+    def local_log_id
+      Thread.current.__id__
+    end
+
+    def local_level
+      @local_levels[local_log_id]
+    end
+
+    def local_level=(level)
+      if level
+        @local_levels[local_log_id] = level
+      else
+        @local_levels.delete(local_log_id)
+      end
+    end
+
+    def level
+      local_level || super
+    end
+  end
+end


### PR DESCRIPTION
Fix #23609

Commit 629efb6 introduced thread safety to logger silencing but it
didn't take into account the fact that the logger can be extended with
broadcasting to other logger.

This commit introduces local_level to broadcasting Module which enables
broadcasted loggers to be properly silenced.
