### PR TITLE
Fix Postgres Array issue

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -18,7 +18,7 @@ module ActiveRecord
 
           def deserialize(value)
             if value.is_a?(::String)
-              type_cast_array(@pg_decoder.decode(value), :deserialize)
+              type_cast_array(@pg_decoder.decode(value.encode!(__ENCODING__)), :deserialize)
             else
               super
             end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -300,6 +300,28 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
     assert_equal ["has already been taken"], e2.errors[:tags], "Should have uniqueness message for tags"
   end
 
+  def test_change_of_unicode_string_within_array
+    x = PgArray.create!(tags: ['nový'])
+    x.reload
+
+    assert_equal(false, x.changed?)
+    assert_equal(x.tags, ['nový'])
+
+    x.attributes = { tags: ['nový'] }
+
+    assert_equal(false, x.changed?)
+
+    x.reload
+    x.tags << 'modrý'
+
+    assert_equal(x.tags, ['nový', 'modrý'])
+    assert_equal(true, x.changed?)
+
+    x.save!
+
+    assert_equal(false, x.changed?)
+  end
+
   private
   def assert_cycle field, array
     # test creation


### PR DESCRIPTION
Fixes #22730. Change is based on recommendation made [here](https://bitbucket.org/ged/ruby-pg/issues/230/pg-textencoder-array-doesnt-properly).
