### PR TITLE
Have `image_tag` image location default to assets prefix

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/array/extract_options'
 require 'active_support/core_ext/hash/keys'
+require 'active_support/core_ext/hash/slice'
 require 'action_view/helpers/asset_url_helper'
 require 'action_view/helpers/tag_helper'
 
@@ -207,11 +208,15 @@ module ActionView
       #   # => <img alt="Icon" class="menu_icon" src="/icons/icon.gif" />
       #   image_tag("/icons/icon.gif", data: { title: 'Rails Application' })
       #   # => <img data-title="Rails Application" src="/icons/icon.gif" />
-      def image_tag(source, options={})
+      def image_tag(source, options = {})
         options = options.symbolize_keys
         check_for_image_tag_errors(options)
 
-        src = options[:src] = path_to_image(source)
+        if defined?(Rails) && defined?(Rails.application)
+          options[:storage_directory] = Rails.application.config.assets.prefix
+        end
+
+        src = options[:src] = path_to_image(source, options.extract!(:storage_directory))
 
         unless src =~ /^(?:cid|data):/ || src.blank?
           options[:alt] = options.fetch(:alt){ image_alt(src) }

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -199,7 +199,10 @@ module ActionView
       # extensions can override this method to point to custom assets
       # or generate digested paths or query strings.
       def compute_asset_path(source, options = {})
-        dir = ASSET_PUBLIC_DIRECTORIES[options[:type]] || ""
+        unless (dir = options[:storage_directory])
+          dir = ASSET_PUBLIC_DIRECTORIES[options[:type]] || ""
+        end
+
         File.join(dir, source)
       end
 


### PR DESCRIPTION
Fixes #7218.

Previously, if you had an image stored in `app/assets/images/`, and you
had a Helper that contained an `image_tag`, and you tried to test this
helper method, this would cause a test failure.

The test would fail like so:

```
-"<img src=\"/assets/3020626.png\" alt=\"3020626\" />"
+"<img src=\"/images/3020626.png\" alt=\"3020626\" />"
```

This is unexpected behavior -- ActionView should assume all assets are
inside `/assets` (or whatever the Sprockets assets route prefix is)
unless told otherwise. The assumption of public directory location is
instilled in the constant located [here](https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/asset_url_helper.rb#L188-L196).

I agree it isn't great to introduce coupling like this, but I also think
it's :-1: to introduce unexpected behavior.
