### PR TITLE
Primary key should be `NOT NULL`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -16,7 +16,7 @@ module ActiveRecord
       def column_spec_for_primary_key(column)
         return {} if default_primary_key?(column)
         spec = { id: schema_type(column).inspect }
-        spec.merge!(prepare_column_options(column))
+        spec.merge!(prepare_column_options(column).except!(:null))
       end
 
       # This can be overridden on an Adapter level basis to support other

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -7,7 +7,7 @@ module ActiveRecord
             spec = { id: :bigint.inspect }
             spec[:default] = schema_default(column) || 'nil' unless column.auto_increment?
           else
-            spec = super.except!(:null)
+            spec = super
           end
           spec[:unsigned] = 'true' if column.unsigned?
           spec

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     module PostgreSQL
       module ColumnDumper
         def column_spec_for_primary_key(column)
-          spec = super.except!(:null)
+          spec = super
           if schema_type(column) == :uuid
             spec[:default] ||= 'nil'
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_creation.rb
@@ -3,6 +3,13 @@ module ActiveRecord
     module SQLite3
       class SchemaCreation < AbstractAdapter::SchemaCreation
         private
+
+          def column_options(o)
+            options = super
+            options[:null] = false if o.primary_key
+            options
+          end
+
           def add_column_options!(sql, options)
             if options[:collation]
               sql << " COLLATE \"#{options[:collation]}\""

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -229,7 +229,7 @@ class PrimaryKeyAnyTypeTest < ActiveRecord::TestCase
     assert_equal "code", Barcode.primary_key
 
     column = Barcode.column_for_attribute(Barcode.primary_key)
-    assert_not column.null unless current_adapter?(:SQLite3Adapter)
+    assert_not column.null
     assert_equal :string, column.type
     assert_equal 42, column.limit
   end


### PR DESCRIPTION
Follow up to #18228.

In MySQL and PostgreSQL, primary key is to be `NOT NULL` implicitly.
But in SQLite it must be specified `NOT NULL` explicitly.

[lib/active_record/connection_adapters/sqlite3_adapter.rb#L56](https://github.com/rails/rails/blob/v5.0.0.beta2/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L56)
