### PR TITLE
Fix issue #23625

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -17,7 +17,7 @@ module ActiveRecord
         value = map_enum_attribute(finder_class, attribute, value)
 
         relation = build_relation(finder_class, table, attribute, value)
-        if record.persisted? && finder_class.primary_key.to_s != attribute.to_s
+        if record.persisted?
           if finder_class.primary_key
             relation = relation.where.not(finder_class.primary_key => record.id_was)
           else

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -5,6 +5,7 @@ require 'models/warehouse_thing'
 require 'models/guid'
 require 'models/event'
 require 'models/dashboard'
+require 'models/uuid_item'
 
 class Wizard < ActiveRecord::Base
   self.abstract_class = true
@@ -46,6 +47,10 @@ class BigIntReverseTest < ActiveRecord::Base
   self.table_name = 'cars'
   validates :engines_count, inclusion: { in: 0..INT_MAX_VALUE }
   validates :engines_count, uniqueness: true
+end
+
+class CoolTopic < Topic
+  validates_uniqueness_of :id
 end
 
 class UniquenessValidationTest < ActiveRecord::TestCase
@@ -479,5 +484,26 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     t.id += 1
     assert t.valid?, "Should be valid"
     assert t.save, "Should still save t as unique"
+  end
+
+  def test_validate_uniqueness_uuid
+    skip unless current_adapter?(:PostgreSQLAdapter)
+    item = UuidItem.create!(uuid: SecureRandom.uuid, title: 'item1')
+    item.update(title: 'item1-title2')
+    assert_empty item.errors
+
+    item2 = UuidValidatingItem.create!(uuid: SecureRandom.uuid, title: 'item2')
+    item2.update(title: 'item2-title2')
+    assert_empty item2.errors
+  end
+
+  def test_validate_uniqueness_regular_id
+    item = CoolTopic.create!(title: 'MyItem')
+    assert_empty item.errors
+
+    item2 = CoolTopic.new(id: item.id, title: 'MyItem2')
+    refute item2.valid?
+
+    assert_equal(["has already been taken"], item2.errors[:id])
   end
 end

--- a/activerecord/test/models/uuid_item.rb
+++ b/activerecord/test/models/uuid_item.rb
@@ -1,0 +1,6 @@
+class UuidItem < ActiveRecord::Base
+end
+
+class UuidValidatingItem < UuidItem
+  validates_uniqueness_of :uuid
+end

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -106,4 +106,9 @@ _SQL
     t.integer :big_int_data_points, limit: 8, array: true
     t.decimal :decimal_array_default, array: true, default: [1.23, 3.45]
   end
+
+  create_table :uuid_items, force: true, id: false do |t|
+    t.uuid :uuid, primary_key: true
+    t.string :title
+  end
 end


### PR DESCRIPTION
This resolves a bug where if the primary key used is not `id` (ex:
`uuid`), and has a `validates_uniqueness_of` in the model, a uniqueness error
would be raised. This is a partial revert of commit 119b9181ece399c67213543fb5227b82688b536f, which introduced this behavior.
