### PR TITLE
generate mailer views in Rails API

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -105,7 +105,7 @@ module Rails
 
     # Configure generators for API only applications. It basically hides
     # everything that is usually browser related, such as assets and session
-    # migration generators, and completely disable views, helpers and assets
+    # migration generators, and completely disable helpers and assets
     # so generators such as scaffold won't create them.
     def self.api_only!
       hide_namespaces "assets", "helper", "css", "js"
@@ -116,6 +116,10 @@ module Rails
         helper: false,
         template_engine: nil
       )
+
+      if ARGV.first == 'mailer'
+        options[:rails].merge!(template_engine: :erb)
+      end
     end
 
     # Remove the color from output.

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -276,9 +276,9 @@ module Rails
         end
       end
 
-      def delete_app_views_if_api_option
+      def delete_application_layout_file_if_api_option
         if options[:api]
-          remove_dir 'app/views'
+          remove_file 'app/views/layouts/application.html.erb'
         end
       end
 

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -160,5 +160,15 @@ module ApplicationTests
       assert Rails::Generators.options[:rails][:helper]
       assert_equal :my_template, Rails::Generators.options[:rails][:template_engine]
     end
+
+    test "api only generator generate mailer views" do
+      add_to_config <<-RUBY
+        config.api_only = true
+      RUBY
+
+      FileUtils.cd(rails_root){ `bin/rails generate mailer notifier foo` }
+      assert File.exist?(File.join(rails_root, "app/views/notifier_mailer/foo.text.erb"))
+      assert File.exist?(File.join(rails_root, "app/views/notifier_mailer/foo.html.erb"))
+    end
   end
 end

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -73,6 +73,8 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
       app/controllers
       app/mailers
       app/models
+      app/views/layouts/mailer.html.erb
+      app/views/layouts/mailer.text.erb
       config/environments
       config/initializers
       config/locales
@@ -94,7 +96,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
   def skipped_files
     %w(app/assets
        app/helpers
-       app/views
+       app/views/layouts/application.html.erb
        config/initializers/assets.rb
        config/initializers/cookies_serializer.rb
        config/initializers/session_store.rb


### PR DESCRIPTION
View files is necessary to send mail, it should be generated even Rails API.
Fixes #23617
