### PR TITLE
Fix `request.ssl?` bug with Action Cable

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -403,6 +403,10 @@ module ActionDispatch
     def commit_flash
     end
 
+    def ssl?
+      super || scheme == 'wss'.freeze
+    end
+
     private
       def check_method(name)
         HTTP_METHOD_LOOKUP[name] || raise(ActionController::UnknownHttpMethod, "#{name}, accepted HTTP methods are #{HTTP_METHODS[0...-1].join(', ')}, and #{HTTP_METHODS[-1]}")

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -322,3 +322,12 @@ class RedirectToSSLTest < ActionController::TestCase
     assert_equal 'ihaz', response.body
   end
 end
+
+class ForceSSLControllerLevelTest < ActionController::TestCase
+  def test_no_redirect_websocket_ssl_request
+    request.env['rack.url_scheme'] = 'wss'
+    request.env['Upgrade'] = 'websocket'
+    get :cheeseburger
+    assert_response 200
+  end
+end


### PR DESCRIPTION
This bug affects `wss://` requests when running Action Cable in-app.
Fixes #23620.
