### PR TITLE
Prevent dirty checks from affecting original after #dup

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix regression in dirty attribute tracking after #dup.  Changes to the
+    clone no longer show as changed attributes in the original object.
+
+    *Dominic Cleal*
+
 *   Fix regression when loading fixture files with symbol keys.
 
     Closes #22584.

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -40,6 +40,7 @@ module ActiveRecord
 
       def initialize_dup(other) # :nodoc:
         super
+        @original_raw_attributes = nil
         calculate_changes_from_defaults
       end
 

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -757,6 +757,16 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal "arr", pirate.catchphrase
   end
 
+  test "cloning and modifying an object in-place only registers changes on the new object" do
+    pirate = Pirate.create!(catchphrase: "arrrr")
+    assert_equal({}, pirate.changed_attributes)
+    pirate_clone = pirate.dup
+    assert_equal({"catchphrase" => nil}, pirate_clone.changed_attributes)
+    pirate_clone.catchphrase = "arrrr matey!"
+    assert_equal({}, pirate.changed_attributes)
+    assert_equal({"catchphrase" => nil}, pirate_clone.changed_attributes)
+  end
+
   private
     def with_partial_writes(klass, on = true)
       old = klass.partial_writes?


### PR DESCRIPTION
When a record is cloned via #dup, the `@original_raw_attributes` cache
must also be reset, else the same hash is referenced on both the
original and newly cloned object.  Further changes to the clone cause
attributes to show as dirty on the original.

This seems to have been introduced with in-place dirty checking in 4.2,
and master is unaffected due to refactorings and better encapsulation.

---

Standalone test at https://gist.github.com/domcleal/cfacb1ac5aaf4e5fc553 which passes on master and 4.1.x.  I can resubmit the dirty_test.rb test case to master if desired to prevent any future regressions - it passes for me there.
