### PR TITLE
Log to stdout by default

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -13,7 +13,7 @@ module Rails
 
         option_parser(options).parse! args
 
-        options[:log_stdout] = options[:daemonize].blank? && (options[:environment] || Rails.env) == "development"
+        options[:log_stdout] = options[:daemonize].blank?
         options[:server]     = args.shift
         options
       end

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -80,7 +80,7 @@ class Rails::ServerTest < ActiveSupport::TestCase
 
         args    = ["-e", "production"]
         options = Rails::Server::Options.new.parse!(args)
-        assert_equal false, options[:log_stdout]
+        assert_equal true, options[:log_stdout]
 
         with_rack_env 'development' do
           args    = []
@@ -91,7 +91,7 @@ class Rails::ServerTest < ActiveSupport::TestCase
         with_rack_env 'production' do
           args    = []
           options = Rails::Server::Options.new.parse!(args)
-          assert_equal false, options[:log_stdout]
+          assert_equal true, options[:log_stdout]
         end
 
         with_rails_env 'development' do
@@ -103,7 +103,7 @@ class Rails::ServerTest < ActiveSupport::TestCase
         with_rails_env 'production' do
           args    = []
           options = Rails::Server::Options.new.parse!(args)
-          assert_equal false, options[:log_stdout]
+          assert_equal true, options[:log_stdout]
         end
       end
     end


### PR DESCRIPTION
Originally this logic was added by my PR https://github.com/rails/rails/pull/11060/files to only log to stdout in development mode. This was to prevent double logging when STDOUT was already being set as a logger. Since the introduction of the ability to detect logging to STDOUT in https://github.com/rails/rails/pull/22933 we can inspect the destination of logs directly, this brings better dev/prod parity with logging behavior.
