### PR TITLE
use rails instead of rake [ci skip]

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -42,10 +42,10 @@
 
 ## Rails 5.0.0.beta2 (February 01, 2016) ##
 
-*   Add `-g` and `-c` options to `bin/rake routes`. These options return the url `name`, `verb` and
+*   Add `-g` and `-c` options to `bin/rails routes`. These options return the url `name`, `verb` and
     `path` field that match the pattern or match a specific controller.
 
-    Deprecate `CONTROLLER` env variable in `bin/rake routes`.
+    Deprecate `CONTROLLER` env variable in `bin/rails routes`.
 
     See #18902.
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -620,7 +620,7 @@
 
     *Ben Murphy*, *Matthew Draper*
 
-*   `bin/rake db:migrate` uses
+*   `bin/rails db:migrate` uses
     `ActiveRecord::Tasks::DatabaseTasks.migrations_paths` instead of
     `Migrator.migrations_paths`.
 


### PR DESCRIPTION
since starting with Rails 5.x(beta) we prefer to use rails as the replacement of rake commands, may be change log will be the same
