### PR TITLE
[ci skip] Fix enqueuing spelling to maintain consistency

### DIFF
--- a/activejob/lib/active_job/async_job.rb
+++ b/activejob/lib/active_job/async_job.rb
@@ -6,7 +6,7 @@ require 'concurrent/utility/processor_counter'
 module ActiveJob
   # == Active Job Async Job
   #
-  # When enqueueing jobs with Async Job each job will be executed asynchronously
+  # When enqueuing jobs with Async Job each job will be executed asynchronously
   # on a +concurrent-ruby+ thread pool. All job data is retained in memory.
   # Because job data is not saved to a persistent datastore there is no
   # additional infrastructure needed and jobs process quickly. The lack of

--- a/activejob/lib/active_job/queue_adapters/async_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/async_adapter.rb
@@ -4,7 +4,7 @@ module ActiveJob
   module QueueAdapters
     # == Active Job Async adapter
     #
-    # When enqueueing jobs with the Async adapter the job will be executed
+    # When enqueuing jobs with the Async adapter the job will be executed
     # asynchronously using {AsyncJob}[http://api.rubyonrails.org/classes/ActiveJob/AsyncJob.html].
     #
     # To use +AsyncJob+ set the queue_adapter config to +:async+.

--- a/activejob/lib/active_job/queue_adapters/inline_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/inline_adapter.rb
@@ -2,7 +2,7 @@ module ActiveJob
   module QueueAdapters
     # == Active Job Inline adapter
     #
-    # When enqueueing jobs with the Inline adapter the job will be executed
+    # When enqueuing jobs with the Inline adapter the job will be executed
     # immediately.
     #
     # To use the Inline set the queue_adapter config to +:inline+.


### PR DESCRIPTION
'enqueueing' and 'enqueuing' seems to be alternate forms:
https://en.wiktionary.org/wiki/enqueuing

But, just to maintain consistency over its usage where we have Enqueuing as module a also -
https://github.com/rails/rails/blob/master/activejob/lib/active_job/enqueuing.rb#L5 and at many other places.
