### PR TITLE
fix engine routes file example code

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -95,7 +95,7 @@ that provides the following:
   * A `config/routes.rb` file:
 
     ```ruby
-    Rails.application.routes.draw do
+    Blorgh::Engine.routes.draw do
     end
     ```
 


### PR DESCRIPTION
The guide has `Rails.application.routes.draw do` as the example for `config/routes.rb`, but the generated code is `Blorgh::Engine.routes.draw do`.
