### PR TITLE
Adds tests for Digestor#nested_dependencies

### DIFF
--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -81,7 +81,7 @@ module ActionView
     def nested_dependencies
       dependencies.collect do |dependency|
         dependencies = PartialDigestor.new(dependency, finder).nested_dependencies
-        dependencies.any? ? { dependency => dependencies } : dependency
+        dependencies.empty? ? dependency : { dependency => dependencies }
       end
     end
 

--- a/actionview/test/fixtures/digestor/messages/peek.html.erb
+++ b/actionview/test/fixtures/digestor/messages/peek.html.erb
@@ -1,0 +1,2 @@
+<%# Template Dependency: messages/message %>
+<%= render "comments/comments" %>

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -130,6 +130,16 @@ class TemplateDigestorTest < ActionView::TestCase
     end
   end
 
+  def test_getting_of_singly_nested_dependencies
+    singly_nested_dependencies = ["messages/header", "messages/form", "messages/message", "events/event", "comments/comment"]
+    assert_equal singly_nested_dependencies, nested_dependencies('messages/edit')
+  end
+
+  def test_getting_of_doubly_nested_dependencies
+    doubly_nested = [{"comments/comments"=>["comments/comment"]}, "messages/message"]
+    assert_equal doubly_nested, nested_dependencies('messages/peek')
+  end
+
   def test_nested_template_directory
     assert_digest_difference("messages/show") do
       change_template("messages/actions/_move")


### PR DESCRIPTION
I spotted in 2286fa94716b138a7763e95ade87a7582864bb42 a preference for using #empty? over #any? and so I looked around for other occurrences.

Before this change, we'd enumerate the collection twice per recursion.  I noticed the line I was changing didn't appear to be covered by any of the tests, so I added some.
