### PR TITLE
Adds a test that fails for 2286fa9 regression

### DIFF
--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -635,6 +635,13 @@ class CachedCollectionViewRenderTest < CachedViewRenderTest
     ActionView::PartialRenderer.collection_cache.clear
   end
 
+  test "with falsy value for custom key" do
+    key = cache_key([false, 'falsy_value_key'], "test/_customer")
+
+    assert_equal "Hello",
+      @view.render(partial: "test/customer", collection: [false], cache: ->(item) { [item, 'falsy_value_key'] })
+  end
+
   test "with custom key" do
     customer = Customer.new("david")
     key = cache_key([customer, 'key'], "test/_customer")


### PR DESCRIPTION
2286fa9 causes a bit of a regression when the cached collection contains falsy values.

This test shows the regression. Reverting 2286fa9 makes the test turn green.
