### PR TITLE
Add the missing author name [ci skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -2,6 +2,8 @@
 
     Closes #13775.
 
+    *Takashi Kokubun*
+
 *   Add ActiveRecord `#second_to_last` and `#third_to_last` methods.
 
     *Brian Christian*


### PR DESCRIPTION
The author name was lost in the merge commit 6fedc7d.
