### PR TITLE
UniquenessValidator exclude itself when PK changed, 4.2 backport #23581, fix #23399

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   UniquenessValidator correctly excludes itself when PK changed
+
+    Closes #23399.
+
+    *Diego Silva*
+
 *   Bust Model.attribute_names cache when resetting column information
     
     *James Coleman*

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -19,7 +19,7 @@ module ActiveRecord
           relation = build_relation(finder_class, table, attribute, value)
           if record.persisted?
             if finder_class.primary_key
-              relation = relation.and(table[finder_class.primary_key.to_sym].not_eq(record.id))
+              relation = relation.and(table[finder_class.primary_key.to_sym].not_eq(record.id_was || record.id))
             else
               raise UnknownPrimaryKey.new(finder_class, "Can not validate uniqueness for persisted record without primary key.")
             end

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -54,6 +54,15 @@ class BigIntReverseTest < ActiveRecord::Base
   validates :engines_count, uniqueness: true
 end
 
+class TopicWithAfterCreate < Topic
+  after_create :set_author
+
+  def set_author
+    update_attributes!(:author_name => "#{title} #{id}")
+  end
+end
+
+
 class UniquenessValidationTest < ActiveRecord::TestCase
   INT_MAX_VALUE = 2147483647
 
@@ -450,5 +459,26 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     end
     assert_match(/\AUnknown primary key for table dashboards in model/, e.message)
     assert_match(/Can not validate uniqueness for persisted record without primary key.\z/, e.message)
+  end
+
+  def test_validate_uniqueness_ignores_itself_when_primary_key_changed
+    Topic.validates_uniqueness_of(:title)
+
+    t = Topic.new("title" => "This is a unique title")
+    assert t.save, "Should save t as unique"
+
+    t.id += 1
+    assert t.valid?, "Should be valid"
+    assert t.save, "Should still save t as unique"
+  end
+
+  def test_validate_uniqueness_with_after_create_performing_save
+    TopicWithAfterCreate.validates_uniqueness_of(:title)
+    topic = TopicWithAfterCreate.create!(:title => "Title1")
+    assert topic.author_name.start_with?("Title1")
+
+    topic2 = TopicWithAfterCreate.new(:title => "Title1")
+    refute topic2.valid?
+    assert_equal(["has already been taken"], topic2.errors[:title])
   end
 end


### PR DESCRIPTION
This is a backport from PR #23581 that fixes the issue reported on #23399 for Rails 4.2.

> When changing the PK for a record which has a uniqueness validation on
> some other attribute, Active Record should exclude itself from the
> validation based on the PK value stored on the DB (id_was) instead of
> its new value (id).
