### PR TITLE
UniquenessValidator exclude itself when PK changed, 4.1 backport #23581

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   UniquenessValidator correctly excludes itself when PK changed
+
+    Closes #23399.
+
+    *Diego Silva*
+
 ## Rails 4.1.16 (July 12, 2016) ##
 
 *   Correctly pass MySQL options when using structure_dump or structure_load

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -17,7 +17,7 @@ module ActiveRecord
         value = deserialize_attribute(record, attribute, value)
 
         relation = build_relation(finder_class, table, attribute, value)
-        relation = relation.and(table[finder_class.primary_key.to_sym].not_eq(record.id)) if record.persisted?
+        relation = relation.and(table[finder_class.primary_key.to_sym].not_eq(record.id_was || record.id)) if record.persisted?
         relation = scope_relation(record, table, relation)
         relation = finder_class.unscoped.where(relation)
         relation = relation.merge(options[:conditions]) if options[:conditions]


### PR DESCRIPTION
This is a backport from PR #23581 that fixes the issue reported on #23399 for Rails 4.1.

> When changing the PK for a record which has a uniqueness validation on
> some other attribute, Active Record should exclude itself from the
> validation based on the PK value stored on the DB (id_was) instead of
> its new value (id).

r? @sgrif 
