### PR TITLE
Move `@quoted_{column|table}_names` cache up to the abstract adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -82,7 +82,7 @@ module ActiveRecord
 
       # Quotes the column name. Defaults to no quoting.
       def quote_column_name(column_name)
-        column_name
+        column_name.to_s
       end
 
       # Quotes the table name. Defaults to column name quoting.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -106,6 +106,7 @@ module ActiveRecord
         @schema_cache        = SchemaCache.new self
         @visitor             = nil
         @prepared_statements = false
+        @quoted_column_names, @quoted_table_names = {}, {}
       end
 
       class Version

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -56,7 +56,6 @@ module ActiveRecord
 
       def initialize(connection, logger, connection_options, config)
         super(connection, logger, config)
-        @quoted_column_names, @quoted_table_names = {}, {}
 
         @visitor = Arel::Visitors::MySQL.new self
 
@@ -165,15 +164,9 @@ module ActiveRecord
         raise NotImplementedError
       end
 
+      #--
       # QUOTING ==================================================
-
-      def quote_column_name(name) #:nodoc:
-        @quoted_column_names[name] ||= "`#{name.to_s.gsub('`', '``')}`"
-      end
-
-      def quote_table_name(name) #:nodoc:
-        @quoted_table_names[name] ||= quote_column_name(name).gsub('.', '`.`')
-      end
+      #++
 
       def quoted_true
         QUOTED_TRUE

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -2,6 +2,14 @@ module ActiveRecord
   module ConnectionAdapters
     module MySQL
       module Quoting # :nodoc:
+        def quote_column_name(name)
+          @quoted_column_names[name] ||= "`#{super.gsub('`', '``')}`"
+        end
+
+        def quote_table_name(name)
+          @quoted_table_names[name] ||= super.gsub('.', '`.`')
+        end
+
         private
 
         def _quote(value)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -27,8 +27,8 @@ module ActiveRecord
         # - schema_name."table.name"
         # - "schema.name".table_name
         # - "schema.name"."table.name"
-        def quote_table_name(name)
-          Utils.extract_schema_qualified_name(name.to_s).quoted
+        def quote_table_name(name) # :nodoc:
+          @quoted_table_names[name] ||= Utils.extract_schema_qualified_name(name.to_s).quoted
         end
 
         # Quotes schema names for use in SQL queries.
@@ -41,8 +41,8 @@ module ActiveRecord
         end
 
         # Quotes column names for use in SQL queries.
-        def quote_column_name(name) #:nodoc:
-          PGconn.quote_ident(name.to_s)
+        def quote_column_name(name) # :nodoc:
+          @quoted_column_names[name] ||= PGconn.quote_ident(super)
         end
 
         # Quote date/time values for use in SQL input.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -2,6 +2,10 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLite3
       module Quoting # :nodoc:
+        def quote_column_name(name)
+          @quoted_column_names[name] ||= %Q("#{super.gsub('"', '""')}")
+        end
+
         private
 
         def _quote(value)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -87,7 +87,6 @@ module ActiveRecord
         @statements = StatementPool.new(self.class.type_cast_config_to_integer(config.fetch(:statement_limit) { 1000 }))
 
         @visitor = Arel::Visitors::SQLite.new self
-        @quoted_column_names = {}
 
         if self.class.type_cast_config_to_boolean(config.fetch(:prepared_statements) { true })
           @prepared_statements = true
@@ -185,10 +184,6 @@ module ActiveRecord
 
       def quote_table_name_for_assignment(table, attr)
         quote_column_name(attr)
-      end
-
-      def quote_column_name(name) #:nodoc:
-        @quoted_column_names[name] ||= %Q("#{name.to_s.gsub('"', '""')}")
       end
 
       #--


### PR DESCRIPTION
MySQL and SQLite3 adapters caches quoting results in `@quoted_{column|table}_names` but PG adapter is not so. This PR ensures caching quoting results for all adapters.
