### PR TITLE
application/gzip added as default mime type into mime type list

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add application/gzip as a default mime type.
+
+    *Mehmet Emin İNAÇ*
+
 *   Add request encoding and response parsing to integration tests.
 
     What previously was:

--- a/actionpack/lib/action_dispatch/http/mime_types.rb
+++ b/actionpack/lib/action_dispatch/http/mime_types.rb
@@ -32,3 +32,4 @@ Mime::Type.register "application/json", :json, %w( text/x-json application/jsonr
 
 Mime::Type.register "application/pdf", :pdf, [], %w(pdf)
 Mime::Type.register "application/zip", :zip, [], %w(zip)
+Mime::Type.register "application/gzip", :gzip, %w(application/x-gzip), %w(gz)

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -49,7 +49,7 @@ class MimeTypeTest < ActiveSupport::TestCase
 
   test "parse application with trailing star" do
     accept = "application/*"
-    expect = [Mime[:html], Mime[:js], Mime[:xml], Mime[:rss], Mime[:atom], Mime[:yaml], Mime[:url_encoded_form], Mime[:json], Mime[:pdf], Mime[:zip]]
+    expect = [Mime[:html], Mime[:js], Mime[:xml], Mime[:rss], Mime[:atom], Mime[:yaml], Mime[:url_encoded_form], Mime[:json], Mime[:pdf], Mime[:zip], Mime[:gzip]]
     parsed = Mime::Type.parse(accept)
     assert_equal expect, parsed
   end


### PR DESCRIPTION
I'm really surprised that gzip is not in the list.
There are other alias mime types like `application/gzipped`, `application/gzip-compressed` but i don't think they are widely used. If you think we need to add them as alias please let me know.
