### PR TITLE
adds missing tests for Digestor#nested_dependencies

### DIFF
--- a/actionview/test/fixtures/digestor/messages/peek.html.erb
+++ b/actionview/test/fixtures/digestor/messages/peek.html.erb
@@ -1,0 +1,2 @@
+<%# Template Dependency: messages/message %>
+<%= render "comments/comments" %>

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -130,6 +130,16 @@ class TemplateDigestorTest < ActionView::TestCase
     end
   end
 
+  def test_getting_of_singly_nested_dependencies
+    singly_nested_dependencies = ["messages/header", "messages/form", "messages/message", "events/event", "comments/comment"]
+    assert_equal singly_nested_dependencies, nested_dependencies('messages/edit')
+  end
+
+  def test_getting_of_doubly_nested_dependencies
+    doubly_nested = [{"comments/comments"=>["comments/comment"]}, "messages/message"]
+    assert_equal doubly_nested, nested_dependencies('messages/peek')
+  end
+
   def test_nested_template_directory
     assert_digest_difference("messages/show") do
       change_template("messages/actions/_move")


### PR DESCRIPTION
I realized the tests were missing when I made an intentionally breaking change to [ActionView::Digestor#nested_dependencies](https://github.com/rails/rails/blob/master/actionview/lib/action_view/digestor.rb#L84):

```
-        dependencies.empty? ? dependency : { dependency => dependencies }
+        dependencies.any? ? dependency : { dependency => dependencies }
```

That change, while obviously breaking, did not result in any test breakage.
I've added the two test cases that should have broken... My intentional breakage causes the tests added here to fail as follows:

```
  1) Failure:
TemplateDigestorTest#test_getting_of_doubly_nested_dependencies [/home/rth/Software/rails/actionview/test/template/digestor_test.rb:140]:
--- expected
+++ actual
@@ -1 +1 @@
-[{"comments/comments"=>["comments/comment"]}, "messages/message"]
+["comments/comments", {"messages/message"=>[]}]



  2) Failure:
TemplateDigestorTest#test_getting_of_singly_nested_dependencies [/home/rth/Software/rails/actionview/test/template/digestor_test.rb:135]:
--- expected
+++ actual
@@ -1 +1 @@
-["messages/header", "messages/form", "messages/message", "events/event", "comments/comment"]
+[{"messages/header"=>[]}, {"messages/form"=>[]}, {"messages/message"=>[]}, {"events/event"=>[]}, {"comments/comment"=>[]}]
```
