### PR TITLE
Refactor AV <=> AP interdependence

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -24,7 +24,7 @@ module AbstractController
       options = _normalize_render(*args, &block)
       rendered_body = render_to_body(options)
       if options[:html]
-        _set_html_content_type
+        set_html_content_type
       else
         _set_rendered_content_type rendered_format
       end
@@ -68,10 +68,9 @@ module AbstractController
     # You can overwrite this configuration per controller.
     # :api: public
     def view_assigns
-      protected_vars = _protected_ivars
-      variables      = instance_variables
+      variables = instance_variables
 
-      variables.reject! { |s| protected_vars.include? s }
+      variables.reject! { |s| DEFAULT_PROTECTED_INSTANCE_VARIABLES.include? s }
       variables.each_with_object({}) { |name, hash|
         hash[name.slice(1, name.length)] = instance_variable_get(name)
       }
@@ -107,31 +106,24 @@ module AbstractController
       options
     end
 
-    # Process the rendered format.
-    # :api: private
-    def _process_format(format)
-    end
-
-    def _set_html_content_type # :nodoc:
-    end
-
-    def _set_rendered_content_type(format) # :nodoc:
-    end
-
-    # Normalize args and options.
-    # :api: private
-    def _normalize_render(*args, &block)
-      options = _normalize_args(*args, &block)
-      #TODO: remove defined? when we restore AP <=> AV dependency
-      if defined?(request) && request.variant.present?
-        options[:variant] = request.variant
+    private
+      def set_html_content_type # :nodoc:
+        self.content_type = Mime[:html].to_s
       end
-      _normalize_options(options)
-      options
-    end
 
-    def _protected_ivars # :nodoc:
-      DEFAULT_PROTECTED_INSTANCE_VARIABLES
-    end
+      def _set_rendered_content_type(format) # :nodoc:
+      end
+
+      # Normalize args and options.
+      # :api: private
+      def _normalize_render(*args, &block)
+        options = _normalize_args(*args, &block)
+        #TODO: remove defined? when we restore AP <=> AV dependency
+        if defined?(request) && request.variant.present?
+          options[:variant] = request.variant
+        end
+        _normalize_options(options)
+        options
+      end
   end
 end

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -155,6 +155,7 @@ module ActionController
       nil
     end
 
+    # Load in the default renderers -- <tt>:json</tt>, <tt>:js</tt>, and <tt>:xml</tt>.
     add :json do |json, options|
       json = json.to_json(options) unless json.kind_of?(String)
 

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -62,10 +62,6 @@ module ActionController
       nil
     end
 
-    def _set_html_content_type
-      self.content_type = Mime[:html].to_s
-    end
-
     def _set_rendered_content_type(format)
       unless response.content_type
         self.content_type = format.to_s

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -105,7 +105,6 @@ module ActionView
 
       # Assign the rendered format to look up context.
       def _process_format(format) #:nodoc:
-        super
         lookup_context.formats = [format.to_sym]
         lookup_context.rendered_format = lookup_context.formats.first
       end

--- a/actionview/lib/action_view/routing_url_for.rb
+++ b/actionview/lib/action_view/routing_url_for.rb
@@ -1,3 +1,6 @@
+gem 'actionpack', ActionView::VERSION::STRING
+require 'action_pack'
+
 require 'action_dispatch/routing/polymorphic_routes'
 
 module ActionView


### PR DESCRIPTION
This commit helps to alleviate coupling between the `ActionController`,
`AbstractController`, and `ActionView` rendering stack. There were
multiple private methods that were only declared so that way the could
be overriden, there was one case in ActionView where `super` was called,
and it was assumed that Action View was operating within the
Action Pack rendering stack. This is despite the fact that Action Pack
is only a development dependency of Action View.

As well, a few methods that were previously `:nodoc:`'d were made
private methods, but this isn't a breaking change, because methods with
a `:nodoc:` comment means that they are not public API, and no end users
should be depending on them.
