### PR TITLE
remove `active_support.test_order` from environment file

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -35,9 +35,6 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
   <%- end -%>
 
-  # Randomize the order test cases are executed.
-  config.active_support.test_order = :random
-
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 


### PR DESCRIPTION
The default test order has been changed to `:random` in 5f777e4b5ee2e3e8e6fd0e2a208ec2a4d25a960d.
Therefore, it is no more need to be specified in the environment file.
