### PR TITLE
Convert ping from an `identifier` to a `message_type`

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,8 @@
+* Convert ping from an `identifier` to a `message_type`, and remove
+  notion of internal identifiers.
+
+   *Jon Moss*
+
 *  Added ActionCable::SubscriptionAdapter::EventedRedis.em_redis_connector/redis_connector and
    ActionCable::SubscriptionAdapter::Redis.redis_connector factory methods for redis connections, 
    so you can overwrite with your own initializers. This is used when you want to use different-than-standard Redis adapters,

--- a/actioncable/app/assets/javascripts/action_cable/connection_monitor.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection_monitor.coffee
@@ -7,7 +7,7 @@ class ActionCable.ConnectionMonitor
 
   @staleThreshold: 6 # Server::Connections::BEAT_INTERVAL * 2 (missed two pings)
 
-  identifier: ActionCable.INTERNAL.identifiers.ping
+  identifier: ActionCable.INTERNAL.message_types.ping
 
   constructor: (@consumer) ->
     @consumer.subscriptions.add(this)

--- a/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
@@ -58,7 +58,7 @@ class ActionCable.Subscriptions
 
   sendCommand: (subscription, command) ->
     {identifier} = subscription
-    if identifier is ActionCable.INTERNAL.identifiers.ping
+    if identifier is ActionCable.INTERNAL.message_types.ping
       @consumer.connection.isOpen()
     else
       @consumer.send({command, identifier})

--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -29,11 +29,9 @@ module ActionCable
   extend ActiveSupport::Autoload
 
   INTERNAL = {
-    identifiers: {
-      ping: '_ping'.freeze
-    },
     message_types: {
       confirmation: 'confirm_subscription'.freeze,
+      ping: '_ping'.freeze,
       rejection: 'reject_subscription'.freeze
     }
   }

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -114,7 +114,7 @@ module ActionCable
       end
 
       def beat
-        transmit ActiveSupport::JSON.encode(identifier: ActionCable::INTERNAL[:identifiers][:ping], message: Time.now.to_i)
+        transmit ActiveSupport::JSON.encode(identifier: ActionCable::INTERNAL[:message_types][:ping], message: Time.now.to_i)
       end
 
       def on_open # :nodoc:


### PR DESCRIPTION
Removes notion of internal identifiers.
