### PR TITLE
Remove the method already overridden by private method

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -561,19 +561,6 @@ module ActiveRecord
       relation.limit(limit).to_a
     end
 
-    def find_last
-      if loaded?
-        @records.last
-      else
-        @last ||=
-          if limit_value
-            to_a.last
-          else
-            reverse_order.limit(1).to_a.first
-          end
-      end
-    end
-
     private
 
     def find_nth_with_limit_and_offset(index, limit, offset:) # :nodoc:


### PR DESCRIPTION
This method is overridden by a private method with this [pr](https://github.com/rails/rails/pull/23377). I think that @bogdan went out of sync because @sgrif [revert](https://github.com/rails/rails/commit/0cbcae59) the first pr about same change and this problem happened.
