### PR TITLE
Update dalli gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.0)
     connection_pool (2.2.0)
-    dalli (2.7.5)
+    dalli (2.7.6)
     dante (0.2.0)
     delayed_job (4.1.1)
       activesupport (>= 3.0, < 5.0)


### PR DESCRIPTION
dalli 2.7.6 fixed deprecation warning caused by using
`Rack::Session::Abstract::ID`.
This commit suppress warnings on ActionPack tests.

See:
https://github.com/petergoldstein/dalli/commit/9874a7c3ad67eb1e31cafba0a51966db4f0c7e42
