### PR TITLE
Fix 22675 b

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,9 @@
+* Allow channel identifiers with no backslahes/escapin to be accepted
+  by the subscription storer. Also, subscriptions are now identified
+by their _escaped_ JSON keys. For example, `"{\"channel\":\"RoomChannel\"}"` is now identified by `{"channel"=>"RoomChannel"}` in the global subscriptions hash.
+
+   *Jon Moss*
+
 *  Added ActionCable::SubscriptionAdapter::EventedRedis.em_redis_connector/redis_connector and
    ActionCable::SubscriptionAdapter::Redis.redis_connector factory methods for redis connections, 
    so you can overwrite with your own initializers. This is used when you want to use different-than-standard Redis adapters,

--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -24,12 +24,20 @@ module ActionCable
 
       def add(data)
         id_key = data['identifier']
-        id_options = ActiveSupport::JSON.decode(id_key).with_indifferent_access
+
+        # If `id_key` is a Hash, this means that the original JSON
+        # sent by the client had no backslashes in it, and does
+        # not need to be decoded again.
+        if id_key.is_a?(Hash)
+          id_options = id_key.with_indifferent_access
+        else
+          id_options = ActiveSupport::JSON.decode(id_key).with_indifferent_access
+        end
 
         subscription_klass = connection.server.channel_classes[id_options[:channel]]
 
         if subscription_klass
-          subscriptions[id_key] ||= subscription_klass.new(connection, id_key, id_options)
+          subscriptions[id_options] ||= subscription_klass.new(connection, id_key, id_options)
         else
           logger.error "Subscription class not found (#{data.inspect})"
         end
@@ -37,7 +45,7 @@ module ActionCable
 
       def remove(data)
         logger.info "Unsubscribing from channel: #{data['identifier']}"
-        remove_subscription subscriptions[data['identifier']]
+        remove_subscription subscriptions[decoded_identifier(data)]
       end
 
       def remove_subscription(subscription)
@@ -63,8 +71,12 @@ module ActionCable
       private
         delegate :logger, to: :connection
 
+        def decoded_identifier(data)
+          ActiveSupport::JSON.decode(data['identifier'])
+        end
+
         def find(data)
-          if subscription = subscriptions[data['identifier']]
+          if subscription = subscriptions[decoded_identifier(data)]
             subscription
           else
             raise "Unable to find subscription with identifier: #{data['identifier']}"

--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -54,7 +54,16 @@ module ActionCable
       end
 
       def perform_action(data)
-        find(data).perform_action ActiveSupport::JSON.decode(data['data'])
+        action = data['data']
+        # If `action` is a Hash, this means that the original JSON 
+        # sent by the client had no backslashes in it, and does 
+        # not need to be decoded again.
+        if action.is_a?(Hash)
+          find(data).perform_action action
+        else
+          find(data).perform_action ActiveSupport::JSON.decode(action)
+        end 
+        
       end
 
       def identifiers

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -26,7 +26,8 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
     @server = TestServer.new
     @server.stubs(:channel_classes).returns(ChatChannel.name => ChatChannel)
 
-    @chat_identifier = ActiveSupport::JSON.encode(id: 1, channel: 'ActionCable::Connection::SubscriptionsTest::ChatChannel')
+    @chat_identifier = { id: 1, channel: 'ActionCable::Connection::SubscriptionsTest::ChatChannel'}.with_indifferent_access
+    @chat_identifier_json = ActiveSupport::JSON.encode(@chat_identifier)
   end
 
   test "subscribe command" do
@@ -56,7 +57,7 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
       channel = subscribe_to_chat_channel
       channel.expects(:unsubscribe_from_channel)
 
-      @subscriptions.execute_command 'command' => 'unsubscribe', 'identifier' => @chat_identifier
+      @subscriptions.execute_command 'command' => 'unsubscribe', 'identifier' => @chat_identifier_json
       assert @subscriptions.identifiers.empty?
     end
   end
@@ -76,19 +77,18 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
       channel = subscribe_to_chat_channel
 
       data = { 'content' => 'Hello World!', 'action' => 'speak' }
-      @subscriptions.execute_command 'command' => 'message', 'identifier' => @chat_identifier, 'data' => ActiveSupport::JSON.encode(data)
-
+      @subscriptions.execute_command 'command' => 'message', 'identifier' => @chat_identifier_json, 'data' => ActiveSupport::JSON.encode(data)
       assert_equal [ data ], channel.lines
     end
   end
 
-  test "unsubscrib from all" do
+  test "unsubscribe from all" do
     run_in_eventmachine do
       setup_connection
 
       channel1 = subscribe_to_chat_channel
 
-      channel2_id = ActiveSupport::JSON.encode(id: 2, channel: 'ActionCable::Connection::SubscriptionsTest::ChatChannel')
+      channel2_id = ActiveSupport::JSON.encode({id: 2, channel: 'ActionCable::Connection::SubscriptionsTest::ChatChannel'})
       channel2 = subscribe_to_chat_channel(channel2_id)
 
       channel1.expects(:unsubscribe_from_channel)
@@ -101,9 +101,13 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
   private
     def subscribe_to_chat_channel(identifier = @chat_identifier)
       @subscriptions.execute_command 'command' => 'subscribe', 'identifier' => identifier
-      assert_equal identifier, @subscriptions.identifiers.last
 
-      @subscriptions.send :find, 'identifier' => identifier
+      if identifier.is_a?(String)
+        identifier = ActiveSupport::JSON.decode(identifier)
+      end
+
+      assert_equal identifier, @subscriptions.identifiers.last
+      @subscriptions.send :find, 'identifier' => ActiveSupport::JSON.encode(identifier)
     end
 
     def setup_connection

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -77,7 +77,8 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
       channel = subscribe_to_chat_channel
 
       data = { 'content' => 'Hello World!', 'action' => 'speak' }
-      @subscriptions.execute_command 'command' => 'message', 'identifier' => @chat_identifier_json, 'data' => ActiveSupport::JSON.encode(data)
+      # @subscriptions.execute_command 'command' => 'message', 'identifier' => @chat_identifier_json, 'data' => ActiveSupport::JSON.encode(data)
+      @subscriptions.execute_command 'command' => 'message', 'identifier' => @chat_identifier_json, 'data' => data
       assert_equal [ data ], channel.lines
     end
   end

--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -9,6 +9,7 @@ require 'puma'
 require 'mocha/setup'
 
 require 'rack/mock'
+require 'active_support/core_ext/hash/indifferent_access'
 
 # Require all the stubs and models
 Dir[File.dirname(__FILE__) + '/stubs/*.rb'].each {|file| require file }


### PR DESCRIPTION
Fixes #22675 

Builds on @maclover7 's patch for `identifier` hash to also allow `data` hash without backslash/escaping to be accepted
