### PR TITLE
Adjust to indifferent access around some ActiveModel::Errors methods

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow indifferent access in `ActiveModel::Errors`.
+
+    `#include?`, `#has_key?`, `#key?`, `#delete` and `#full_messages_for`.
+
+    *Kenichi Kamiya*
+
 *   Removed deprecated `:tokenizer` in the length validator.
 
     *Rafael Mendonça França*

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -110,6 +110,7 @@ module ActiveModel
     #   person.errors.include?(:name) # => true
     #   person.errors.include?(:age)  # => false
     def include?(attribute)
+      attribute = attribute.to_sym
       messages.key?(attribute) && messages[attribute].present?
     end
     alias :has_key? :include?
@@ -121,8 +122,9 @@ module ActiveModel
     #   person.errors.delete(:name) # => ["cannot be nil"]
     #   person.errors[:name]        # => []
     def delete(key)
-      details.delete(key)
-      messages.delete(key)
+      attribute = key.to_sym
+      details.delete(attribute)
+      messages.delete(attribute)
     end
 
     # When passed a symbol or a name of a method, returns an array of errors
@@ -342,6 +344,7 @@ module ActiveModel
     #   person.errors.full_messages_for(:name)
     #   # => ["Name is too short (minimum is 5 characters)", "Name can't be blank"]
     def full_messages_for(attribute)
+      attribute = attribute.to_sym
       messages[attribute].map { |message| full_message(attribute, message) }
     end
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -30,7 +30,7 @@ class ErrorsTest < ActiveModel::TestCase
   def test_delete
     errors = ActiveModel::Errors.new(self)
     errors[:foo] << "omg"
-    errors.delete(:foo)
+    errors.delete("foo")
     assert_empty errors[:foo]
   end
 
@@ -38,6 +38,7 @@ class ErrorsTest < ActiveModel::TestCase
     errors = ActiveModel::Errors.new(self)
     errors[:foo] << "omg"
     assert_includes errors, :foo, "errors should include :foo"
+    assert_includes errors, "foo", "errors should include 'foo' as :foo"
   end
 
   def test_dup
@@ -52,6 +53,7 @@ class ErrorsTest < ActiveModel::TestCase
     errors = ActiveModel::Errors.new(self)
     errors[:foo] << "omg"
     assert_equal true, errors.has_key?(:foo), "errors should have key :foo"
+    assert_equal true, errors.has_key?("foo"), "errors should have key 'foo' as :foo"
   end
 
   def test_has_no_key
@@ -63,6 +65,7 @@ class ErrorsTest < ActiveModel::TestCase
     errors = ActiveModel::Errors.new(self)
     errors[:foo] << "omg"
     assert_equal true, errors.key?(:foo), "errors should have key :foo"
+    assert_equal true, errors.key?("foo"), "errors should have key 'foo' as :foo"
   end
 
   def test_no_key
@@ -150,10 +153,11 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["cannot be blank"], person.errors[:name]
   end
 
-  test "added? detects if a specific error was added to the object" do
+  test "added? detects indifferent if a specific error was added to the object" do
     person = Person.new
     person.errors.add(:name, "cannot be blank")
     assert person.errors.added?(:name, "cannot be blank")
+    assert person.errors.added?("name", "cannot be blank")
   end
 
   test "added? handles symbol message" do
@@ -241,7 +245,7 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["name cannot be blank", "name cannot be nil"], person.errors.full_messages
   end
 
-  test "full_messages_for contains all the error messages for the given attribute" do
+  test "full_messages_for contains all the error messages for the given attribute indifferent" do
     person = Person.new
     person.errors.add(:name, "cannot be blank")
     person.errors.add(:name, "cannot be nil")
@@ -253,6 +257,7 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors.add(:name, "cannot be blank")
     person.errors.add(:email, "cannot be blank")
     assert_equal ["name cannot be blank"], person.errors.full_messages_for(:name)
+    assert_equal ["name cannot be blank"], person.errors.full_messages_for("name")
   end
 
   test "full_messages_for returns an empty list in case there are no errors for the given attribute" do


### PR DESCRIPTION
Adjusted to https://github.com/rails/rails/blob/6f8f2a2017e09d8d94c70761c70007ce72b984e7/activemodel/test/cases/errors_test.rb#L100-L105
