### PR TITLE
Reject empty messages from ActiveModel::Errors#{keys,values}

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -223,7 +223,7 @@ module ActiveModel
     #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
     #   person.errors.values   # => [["cannot be nil", "must be specified"]]
     def values
-      messages.values
+      messages.values.reject { |value| value == [] }
     end
 
     # Returns all message keys.
@@ -231,7 +231,7 @@ module ActiveModel
     #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
     #   person.errors.keys     # => [:name]
     def keys
-      messages.keys
+      messages.reject { |_, value| value == [] }.keys
     end
 
     # Returns +true+ if no errors are found, +false+ otherwise.

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -107,17 +107,19 @@ class ErrorsTest < ActiveModel::TestCase
   test "values returns an array of messages" do
     errors = ActiveModel::Errors.new(self)
     errors.messages[:foo] = "omg"
-    errors.messages[:baz] = "zomg"
+    errors.messages[:bar] = ""
+    errors.key?(:baz)
 
-    assert_equal ["omg", "zomg"], errors.values
+    assert_equal ["omg", ""], errors.values
   end
 
   test "keys returns the error keys" do
     errors = ActiveModel::Errors.new(self)
     errors.messages[:foo] << "omg"
-    errors.messages[:baz] << "zomg"
+    errors.messages[:bar] << ""
+    errors.key?(:baz)
 
-    assert_equal [:foo, :baz], errors.keys
+    assert_equal [:foo, :bar], errors.keys
   end
 
   test "detecting whether there are errors with empty?, blank?, include?" do
@@ -215,7 +217,9 @@ class ErrorsTest < ActiveModel::TestCase
   test "size calculates the number of error messages" do
     person = Person.new
     person.errors.add(:name, "cannot be blank")
-    assert_equal 1, person.errors.size
+    person.errors.add(:email, "")
+    person.errors.key?(:age)
+    assert_equal 2, person.errors.size
   end
 
   test "count calculates the number of error messages" do


### PR DESCRIPTION
I don't have confident to handle empty strings as these... But I couldn't guess `errors.key?` modifies `errors.keys` and `errors.values` is a spec.
