### PR TITLE
Remove `const_missing` which fallback to deprecated `NEVER_UNPERMITTED_PARAMS`

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -122,16 +122,6 @@ module ActionController
     cattr_accessor :always_permitted_parameters
     self.always_permitted_parameters = %w( controller action )
 
-    def self.const_missing(const_name)
-      return super unless const_name == :NEVER_UNPERMITTED_PARAMS
-      ActiveSupport::Deprecation.warn(<<-MSG.squish)
-        `ActionController::Parameters::NEVER_UNPERMITTED_PARAMS` has been deprecated.
-        Use `ActionController::Parameters.always_permitted_parameters` instead.
-      MSG
-
-      always_permitted_parameters
-    end
-
     # Returns a new instance of <tt>ActionController::Parameters</tt>.
     # Also, sets the +permitted+ attribute to the default value of
     # <tt>ActionController::Parameters.permit_all_parameters</tt>.

--- a/actionpack/test/controller/parameters/always_permitted_parameters_test.rb
+++ b/actionpack/test/controller/parameters/always_permitted_parameters_test.rb
@@ -12,12 +12,6 @@ class AlwaysPermittedParametersTest < ActiveSupport::TestCase
     ActionController::Parameters.always_permitted_parameters = %w( controller action )
   end
 
-  test "shows deprecations warning on NEVER_UNPERMITTED_PARAMS" do
-    assert_deprecated do
-      ActionController::Parameters::NEVER_UNPERMITTED_PARAMS
-    end
-  end
-
   test "returns super on missing constant other than NEVER_UNPERMITTED_PARAMS" do
     ActionController::Parameters.superclass.stub :const_missing, "super" do
       assert_equal "super", ActionController::Parameters::NON_EXISTING_CONSTANT


### PR DESCRIPTION
`NEVER_UNPERMITTED_PARAMS` is deprecated in Rails 4.2. See #15933.
