### PR TITLE
Remove not needed `exec_insert` in mysql2 adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -134,10 +134,6 @@ module ActiveRecord
         ActiveRecord::Result.new(result.fields, result.to_a) if result
       end
 
-      def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
-        execute to_sql(sql, binds), name
-      end
-
       def exec_delete(sql, name, binds)
         execute to_sql(sql, binds), name
         @connection.affected_rows


### PR DESCRIPTION
Simply it is sufficient to use the method in the super class.
