### PR TITLE
Improve the performance of string xor operation

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -379,7 +379,8 @@ module ActionController #:nodoc:
 
       def xor_byte_strings(s1, s2)
         s2_bytes = s2.bytes
-        s1.bytes.map.with_index { |c1, i| c1 ^ s2_bytes[i] }.pack('c*')
+        s1.each_byte.with_index { |c1, i| s2_bytes[i] ^= c1 }
+        s2_bytes.pack('C*')
       end
 
       # The form's authenticity parameter. Override to provide your own.


### PR DESCRIPTION
Use `each_byte` instead of `bytes` to speed up string xor operation and
reduce object allocations.

Inspired by commit 02c3867882d6d23b10df262a6db5f937ca69fb53.

I saw that commit from the blog post [Ruby on Rails, with love since 2005](http://weblog.rubyonrails.org/2016/2/12/this-week-in-rails-ruby-on-rails-with-love-since-2005/) :smiley_cat: 

``` ruby
require 'benchmark/ips'
require 'allocation_tracer'

a = 32.times.map { rand(256) }.pack('C*')
b = 32.times.map { rand(256) }.pack('C*')

def xor_byte_strings1(s1, s2)
  s1.bytes.zip(s2.bytes).map { |(c1,c2)| c1 ^ c2 }.pack('c*')
end

def xor_byte_strings2(s1, s2)
  s2_bytes = s2.bytes
  s1.bytes.map.with_index { |c1, i| c1 ^ s2_bytes[i] }.pack('c*')
end

def xor_byte_strings3(s1, s2)
  s2_bytes = s2.bytes
  s1.each_byte.with_index { |c1, i| s2_bytes[i] ^= c1 }
  s2_bytes.pack('C*')
end

fail if xor_byte_strings1(a, b) != xor_byte_strings2(a, b)
fail if xor_byte_strings1(a, b) != xor_byte_strings3(a, b)

Benchmark.ips do |x|
  x.report('xor_byte_strings1') { xor_byte_strings1(a, b) }
  x.report('xor_byte_strings2') { xor_byte_strings2(a, b) }
  x.report('xor_byte_strings3') { xor_byte_strings3(a, b) }
  x.compare!
end

Tracer = ObjectSpace::AllocationTracer
Tracer.setup(%i{type})
p xor_byte_strings1: Tracer.trace { xor_byte_strings1(a, b) }
p xor_byte_strings2: Tracer.trace { xor_byte_strings2(a, b) }
p xor_byte_strings3: Tracer.trace { xor_byte_strings3(a, b) }
```

```
Warming up --------------------------------------
   xor_byte_strings1    10.668k i/100ms
   xor_byte_strings2    11.814k i/100ms
   xor_byte_strings3    13.139k i/100ms
Calculating -------------------------------------
   xor_byte_strings1    116.667k (± 3.1%) i/s -    586.740k
   xor_byte_strings2    129.932k (± 4.3%) i/s -    649.770k
   xor_byte_strings3    142.506k (± 4.2%) i/s -    722.645k

Comparison:
   xor_byte_strings3:   142506.3 i/s
   xor_byte_strings2:   129932.4 i/s - 1.10x slower
   xor_byte_strings1:   116666.8 i/s - 1.22x slower

{:xor_byte_strings1=>{[:T_ARRAY]=>[38, 0, 0, 0, 0, 0], [:T_STRING]=>[2, 0, 0, 0, 0, 0]}}
{:xor_byte_strings2=>{[:T_ARRAY]=>[3, 0, 0, 0, 0, 0], [:T_DATA]=>[1, 0, 0, 0, 0, 0], [:T_IMEMO]=>[2, 0, 0, 0, 0, 0], [:T_STRING]=>[2, 0, 0, 0, 0, 0]}}
{:xor_byte_strings3=>{[:T_ARRAY]=>[1, 0, 0, 0, 0, 0], [:T_DATA]=>[1, 0, 0, 0, 0, 0], [:T_IMEMO]=>[2, 0, 0, 0, 0, 0], [:T_STRING]=>[2, 0, 0, 0, 0, 0]}}
```
