### PR TITLE
Add tests to make sure find_by methods are case sensitive.

### DIFF
--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -540,7 +540,7 @@ class FinderTest < ActiveRecord::TestCase
     assert_deprecated do
       Topic.order("coalesce(author_name, title)").last
     end
-  end  
+  end
 
   def test_last_on_relation_with_limit_and_offset
     post = posts('sti_comments')
@@ -921,6 +921,22 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_find_by_two_attributes_but_passing_only_one
     assert_raise(ArgumentError) { Topic.find_by_title_and_author_name("The First Topic") }
+  end
+
+  def test_find_by_case_sensitive_consistency_with_dyanmic_matcher
+    author = authors(:david)
+
+    # MySQL queries are not case sensitive by default
+    if ARTest.connection_name =~ /mysql/
+      assert_equal(author, Author.find_by_name("david"))
+      assert_equal(author, Author.find_by(name: 'david'))
+    else
+      assert_equal(nil, Author.find_by_name("david"))
+      assert_equal(nil, Author.find_by(name: 'david'))
+    end
+
+    assert_equal(author, Author.find_by_name("David"))
+    assert_equal(author, Author.find_by(name: 'David'))
   end
 
   def test_find_last_with_offset


### PR DESCRIPTION
In Rails 4.2.5.1, I get 

``` ruby
User.create!(username: 'tgx')

User.find_by_username('tgx') # Returns record
User.find_by_username('TGX') # Returns record

User.find_by(username: 'tgx') # Returns record
User.find_by(username: 'TGX') # Returns nil 
```

Tests are according to the current behavior in Rails 5
