### PR TITLE
Use a URL instead of an URL everywhere

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -289,7 +289,7 @@ module ActionDispatch
                           if last.permitted?
                             args.pop.to_h
                           else
-                            raise ArgumentError, "Generating an URL from non sanitized request parameters is insecure!"
+                            raise ArgumentError, "Generating a URL from non sanitized request parameters is insecure!"
                           end
                         end
               helper.call self, args, options

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -173,7 +173,7 @@ module ActionDispatch
                          route_name)
         when ActionController::Parameters
           unless options.permitted?
-            raise ArgumentError.new("Generating an URL from non sanitized request parameters is insecure!")
+            raise ArgumentError.new("Generating a URL from non sanitized request parameters is insecure!")
           end
           route_name = options.delete :use_route
           _routes.url_for(options.to_h.symbolize_keys.

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -310,7 +310,7 @@ class RedirectTest < ActionController::TestCase
     error = assert_raise(ArgumentError) do
       get :redirect_to_params
     end
-    assert_equal "Generating an URL from non sanitized request parameters is insecure!", error.message
+    assert_equal "Generating a URL from non sanitized request parameters is insecure!", error.message
   end
 
   def test_redirect_to_with_block


### PR DESCRIPTION
'URL' is pronounced as 'you-are-ell'. So 'a URL' should be used instead of 'an URL'.
