### PR TITLE
Make collection caching explicit.

### DIFF
--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -381,19 +381,14 @@ class CollectionCacheController < ActionController::Base
     render 'index'
   end
 
-  def index_explicit_render
+  def index_explicit_render_in_controller
     @customers = [Customer.new('david', 1)]
-    render partial: 'customers/customer', collection: @customers
+    render partial: 'customers/customer', collection: @customers, cached: true
   end
 
   def index_with_comment
     @customers = [Customer.new('david', 1)]
-    render partial: 'customers/commented_customer', collection: @customers, as: :customer
-  end
-
-  def index_with_callable_cache_key
-    @customers = [Customer.new('david', 1)]
-    render @customers, cache: -> customer { 'cached_david' }
+    render partial: 'customers/commented_customer', collection: @customers, as: :customer, cached: true
   end
 end
 
@@ -404,7 +399,7 @@ class AutomaticCollectionCacheTest < ActionController::TestCase
     @controller.perform_caching = true
     @controller.partial_rendered_times = 0
     @controller.cache_store = ActiveSupport::Cache::MemoryStore.new
-    ActionView::PartialRenderer.collection_cache = @controller.cache_store
+    ActionView::PartialRenderer.collection_cache = ActiveSupport::Cache::MemoryStore.new
   end
 
   def test_collection_fetches_cached_views
@@ -427,7 +422,7 @@ class AutomaticCollectionCacheTest < ActionController::TestCase
   end
 
   def test_explicit_render_call_with_options
-    get :index_explicit_render
+    get :index_explicit_render_in_controller
 
     assert_select ':root', "david, 1"
   end
@@ -438,12 +433,6 @@ class AutomaticCollectionCacheTest < ActionController::TestCase
 
     get :index_with_comment
     assert_equal 1, @controller.partial_rendered_times
-  end
-
-  def test_caching_with_callable_cache_key
-    get :index_with_callable_cache_key
-    assert_customer_cached 'cached_david', 'david, 1'
-    assert_customer_cached 'david/1', 'david, 1'
   end
 
   private

--- a/actionpack/test/fixtures/collection_cache/index.html.erb
+++ b/actionpack/test/fixtures/collection_cache/index.html.erb
@@ -1,1 +1,1 @@
-<%= render @customers %>
+<%= render partial: 'customers/customer', collection: @customers, cached: true %>

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -126,44 +126,16 @@ module ActionView
       #
       # Now all you have to do is change that timestamp when the helper method changes.
       #
-      # === Automatic Collection Caching
+      # === Collection Caching
       #
-      # When rendering collections such as:
+      # When rendering a collection of objects that each use the same partial, a `cached`
+      # option can be passed.
+      # For collections rendered such:
       #
-      #   <%= render @notifications %>
-      #   <%= render partial: 'notifications/notification', collection: @notifications %>
+      #   <%= render partial: 'notifications/notification', collection: @notifications, cached: true %>
       #
-      # If the notifications/_notification partial starts with a cache call as:
-      #
-      #   <% cache notification do %>
-      #     <%= notification.name %>
-      #   <% end %>
-      #
-      # The collection can then automatically use any cached renders for that
-      # template by reading them at once instead of one by one.
-      #
-      # See ActionView::Template::Handlers::ERB.resource_cache_call_pattern for
-      # more information on what cache calls make a template eligible for this
-      # collection caching.
-      #
-      # The automatic cache multi read can be turned off like so:
-      #
-      #   <%= render @notifications, cache: false %>
-      #
-      # === Explicit Collection Caching
-      #
-      # If the partial template doesn't start with a clean cache call as
-      # mentioned above, you can still benefit from collection caching by
-      # adding a special comment format anywhere in the template, like:
-      #
-      #   <%# Template Collection: notification %>
-      #   <% my_helper_that_calls_cache(some_arg, notification) do %>
-      #     <%= notification.name %>
-      #   <% end %>
-      #
-      # The pattern used to match these is <tt>/# Template Collection: (\S+)/</tt>,
-      # so it's important that you type it out just so.
-      # You can only declare one collection in a partial template file.
+      # The `cached: true` will make Action Views rendering issue a `read_multi` to
+      # the cache store instead of reading from it for every partial.
       def cache(name = {}, options = {}, &block)
         if controller.respond_to?(:perform_caching) && controller.perform_caching
           name_options = options.slice(:skip_digest, :virtual_path)

--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -20,7 +20,15 @@ module ActionView
       end
     end
     alias :render_partial :render_template
-    alias :render_collection :render_template
+
+    def render_collection(event)
+      identifier = event.payload[:identifier] || 'templates'
+
+      info do
+        "  Rendered collection of #{from_rails_root(identifier)}" \
+        " #{render_count(event.payload)} (#{event.duration.round(1)}ms)"
+      end
+    end
 
     def logger
       ActionView::Base.logger
@@ -37,6 +45,14 @@ module ActionView
 
     def rails_root
       @root ||= "#{Rails.root}/"
+    end
+
+    def render_count(payload)
+      if payload[:cache_hits]
+        "[#{payload[:cache_hits]} / #{payload[:count]} cache hits]"
+      else
+        "[#{payload[:count]} times]"
+      end
     end
   end
 end

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -35,8 +35,12 @@ module ActionView
       end
     end
 
-    def instrument(name, options={})
-      ActiveSupport::Notifications.instrument("render_#{name}.action_view", options){ yield }
+    def instrument(name, **options)
+      options[:identifier] ||= (@template && @template.identifier) || @path
+
+      ActiveSupport::Notifications.instrument("render_#{name}.action_view", options) do |payload|
+        yield payload
+      end
     end
 
     def prepend_formats(formats)

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -428,8 +428,6 @@ module ActionView
         layout = find_template(layout, @template_keys)
       end
 
-      collection_cache_eligible = automatic_cache_eligible?
-
       partial_iteration = PartialIteration.new(@collection.size)
       locals[iteration] = partial_iteration
 
@@ -438,11 +436,6 @@ module ActionView
         locals[counter]   = partial_iteration.index
 
         content = template.render(view, locals)
-
-        if collection_cache_eligible
-          collection_cache_rendered_partial(content, object)
-        end
-
         content = layout.render(view, locals) { content } if layout
         partial_iteration.iterate!
         content

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -9,11 +9,12 @@ module ActionView
     end
 
     private
-      def cache_collection_render
+      def cache_collection_render(instrumentation_payload)
         return yield unless @options[:cached]
 
         keyed_collection = collection_by_cache_keys
-        cached_partials = collection_cache.read_multi(*keyed_collection.keys)
+        cached_partials  = collection_cache.read_multi(*keyed_collection.keys)
+        instrumentation_payload[:cache_hits] = cached_partials.size
 
         @collection = keyed_collection.reject { |key, _| cached_partials.key?(key) }.values
         rendered_partials = @collection.empty? ? [] : yield

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -130,7 +130,6 @@ module ActionView
       @source            = source
       @identifier        = identifier
       @handler           = handler
-      @cache_name        = extract_resource_cache_name
       @compiled          = false
       @original_encoding = nil
       @locals            = details[:locals] || []
@@ -164,10 +163,6 @@ module ActionView
 
     def type
       @type ||= Types[@formats.first] if @formats.first
-    end
-
-    def eligible_for_collection_caching?(as: nil)
-      @cache_name == (as || inferred_cache_name).to_s
     end
 
     # Receives a view object and return a template similar to self by using @virtual_path.
@@ -354,24 +349,6 @@ module ActionView
         else
           ActiveSupport::Notifications.instrument("#{action}.action_view".freeze, payload, &block)
         end
-      end
-
-      EXPLICIT_COLLECTION = /# Template Collection: (?<resource_name>\w+)/
-
-      def extract_resource_cache_name
-        if match = @source.match(EXPLICIT_COLLECTION) || resource_cache_call_match
-          match[:resource_name]
-        end
-      end
-
-      def resource_cache_call_match
-        if @handler.respond_to?(:resource_cache_call_pattern)
-          @source.match(@handler.resource_cache_call_pattern)
-        end
-      end
-
-      def inferred_cache_name
-        @inferred_cache_name ||= @virtual_path.split('/'.freeze).last.sub('_'.freeze, ''.freeze)
       end
   end
 end

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -123,31 +123,6 @@ module ActionView
           ).src
         end
 
-        # Returns Regexp to extract a cached resource's name from a cache call at the
-        # first line of a template.
-        # The extracted cache name is captured as :resource_name.
-        #
-        #   <% cache notification do %> # => notification
-        #
-        # The pattern should support templates with a beginning comment:
-        #
-        #   <%# Still extractable even though there's a comment %>
-        #   <% cache notification do %> # => notification
-        #
-        # But fail to extract a name if a resource association is cached.
-        #
-        #   <% cache notification.event do %> # => nil
-        def resource_cache_call_pattern
-          /\A
-            (?:<%\#.*%>)*                 # optional initial comment
-            \s*                           # followed by optional spaces or newlines
-            <%\s*cache[\(\s]              # followed by an ERB call to cache
-            \s*                           # followed by optional spaces or newlines
-            (?<resource_name>\w+)         # capture the cache call argument as :resource_name
-            [\s\)]                        # followed by a space or close paren
-          /xm
-        end
-
       private
 
         def valid_encoding(string, encoding)

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -192,38 +192,6 @@ class TestERBTemplate < ActiveSupport::TestCase
     assert_match(/\xFC/, e.message)
   end
 
-  def test_not_eligible_for_collection_caching_without_cache_call
-    [
-      "<%= 'Hello' %>",
-      "<% cache_customer = 42 %>",
-      "<% cache customer.name do %><% end %>",
-      "<% my_cache customer do %><% end %>"
-    ].each do |body|
-      template = new_template(body, virtual_path: "test/foo/_customer")
-      assert_not template.eligible_for_collection_caching?, "Template #{body.inspect} should not be eligible for collection caching"
-    end
-  end
-
-  def test_eligible_for_collection_caching_with_cache_call_or_explicit
-    [
-      "<% cache customer do %><% end %>",
-      "<% cache(customer) do %><% end %>",
-      "<% cache( customer) do %><% end %>",
-      "<% cache( customer ) do %><% end %>",
-      "<%cache customer do %><% end %>",
-      "<%   cache   customer    do %><% end %>",
-      "  <% cache customer do %>\n<% end %>\n",
-      "<%# comment %><% cache customer do %><% end %>",
-      "<%# comment %>\n<% cache customer do %><% end %>",
-      "<%# comment\n line 2\n line 3 %>\n<% cache customer do %><% end %>",
-      "<%# comment 1 %>\n<%# comment 2 %>\n<% cache customer do %><% end %>",
-      "<%# comment 1 %>\n<%# Template Collection: customer %>\n<% my_cache customer do %><% end %>"
-    ].each do |body|
-      template = new_template(body, virtual_path: "test/foo/_customer")
-      assert template.eligible_for_collection_caching?, "Template #{body.inspect} should be eligible for collection caching"
-    end
-  end
-
   def with_external_encoding(encoding)
     old = Encoding.default_external
     Encoding::Converter.new old, encoding if old != encoding

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -333,21 +333,19 @@ module ActiveSupport
         options = names.extract_options!
         options = merged_options(options)
 
-        instrument_multi(:read, names, options) do |payload|
-          results = {}
-          names.each do |name|
-            key = normalize_key(name, options)
-            entry = read_entry(key, options)
-            if entry
-              if entry.expired?
-                delete_entry(key, options)
-              else
-                results[name] = entry.value
-              end
+        results = {}
+        names.each do |name|
+          key = normalize_key(name, options)
+          entry = read_entry(key, options)
+          if entry
+            if entry.expired?
+              delete_entry(key, options)
+            else
+              results[name] = entry.value
             end
           end
-          results
         end
+        results
       end
 
       # Fetches data from the cache, using the given keys. If there is data in
@@ -553,17 +551,6 @@ module ActiveSupport
           payload = { :key => key }
           payload.merge!(options) if options.is_a?(Hash)
           ActiveSupport::Notifications.instrument("cache_#{operation}.active_support", payload){ yield(payload) }
-        end
-
-        def instrument_multi(operation, keys, options = nil)
-          log do
-            formatted_keys = keys.map { |k| "- #{k}" }.join("\n")
-            "Caches multi #{operation}:\n#{formatted_keys}#{options.blank? ? "" : " (#{options.inspect})"}"
-          end
-
-          payload = { key: keys }
-          payload.merge!(options) if options.is_a?(Hash)
-          ActiveSupport::Notifications.instrument("cache_#{operation}_multi.active_support", payload) { yield(payload) }
         end
 
         def log

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -96,16 +96,14 @@ module ActiveSupport
         options = names.extract_options!
         options = merged_options(options)
 
-        instrument_multi(:read, names, options) do
-          keys_to_names = Hash[names.map{|name| [normalize_key(name, options), name]}]
-          raw_values = @data.get_multi(keys_to_names.keys, :raw => true)
-          values = {}
-          raw_values.each do |key, value|
-            entry = deserialize_entry(value)
-            values[keys_to_names[key]] = entry.value unless entry.expired?
-          end
-          values
+        keys_to_names = Hash[names.map{|name| [normalize_key(name, options), name]}]
+        raw_values = @data.get_multi(keys_to_names.keys, :raw => true)
+        values = {}
+        raw_values.each do |key, value|
+          entry = deserialize_entry(value)
+          values[keys_to_names[key]] = entry.value unless entry.expired?
         end
+        values
       end
 
       # Increment a cached value. This method uses the memcached incr atomic

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -1151,15 +1151,6 @@ class CacheStoreLoggerTest < ActiveSupport::TestCase
     @cache.mute { @cache.fetch('foo') { 'bar' } }
     assert @buffer.string.blank?
   end
-
-  def test_multi_read_loggin
-    @cache.write 'hello', 'goodbye'
-    @cache.write 'world', 'earth'
-
-    @cache.read_multi('hello', 'world')
-
-    assert_match "Caches multi read:\n- hello\n- world", @buffer.string
-  end
 end
 
 class CacheEntryTest < ActiveSupport::TestCase

--- a/railties/test/application/per_request_digest_cache_test.rb
+++ b/railties/test/application/per_request_digest_cache_test.rb
@@ -29,6 +29,8 @@ class PerRequestDigestCacheTest < ActiveSupport::TestCase
 
     app_file 'app/controllers/customers_controller.rb', <<-RUBY
       class CustomersController < ApplicationController
+        self.perform_caching = true
+
         def index
           render [ Customer.new('david', 1), Customer.new('dingus', 2) ]
         end


### PR DESCRIPTION
Having collection caching that wraps templates and automatically tries
to infer if they are cachable proved to be too much of a hassle.

We'd rather have it be something you explicitly turn on.

This removes much of the code and docs to explain the previous automatic
behavior.

This change also removes scoped cache keys and passing cache_options.

cc @dhh
