### PR TITLE
Dynamically show available sql types [ci skip]

### DIFF
--- a/railties/lib/rails/generators/rails/model/USAGE
+++ b/railties/lib/rails/generators/rails/model/USAGE
@@ -35,17 +35,7 @@ Available field types:
     type. If no type is specified the string type will be used by default.
     You can use the following types:
 
-        integer
-        primary_key
-        decimal
-        float
-        boolean
-        binary
-        string
-        text
-        date
-        time
-        datetime
+        <%= ActiveRecord::Base.connection.native_database_types.keys.join("\n\t") %>
 
     You can also consider `references` as a kind of type. For instance, if you run:
 


### PR DESCRIPTION
Dynamically list available sql data types based on current database adapter.
While I was working on another issue I've noticed that there are some missing data types `bigint`, `numeric` and `timestamp`. This datatypes are available in abstract adapter so they are available for sqlite3, mysql2 and postgresql adapters. After adding this types into the list I thought that in case if I use postgresql as database adapter the help message wont show all available postgresql datatypes like `money`, `inet` etc. It would be great to see all available data types for current adapter in help message and I've prepared this pr for this purpose.
