### PR TITLE
Fix behavior of JSON encoding for Exception

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix behavior of JSON encoding for `Exception`.
+
+    *namusyaka*
+
 *   Make `number_to_phone` format number with regexp pattern.
 
         number_to_phone(18812345678, pattern: /(\d{3})(\d{4})(\d{4})/)

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -197,3 +197,9 @@ class Process::Status #:nodoc:
     { :exitstatus => exitstatus, :pid => pid }
   end
 end
+
+class Exception
+  def as_json(options = nil)
+    to_s
+  end
+end

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -422,6 +422,11 @@ EXPECTED
     assert_equal '"1999-12-31T19:00:00.000-05:00"', ActiveSupport::JSON.encode(time)
   end
 
+  def test_exception_to_json
+    exception = Exception.new("foo")
+    assert_equal '"foo"', ActiveSupport::JSON.encode(exception)
+  end
+
   protected
 
     def object_keys(json_object)


### PR DESCRIPTION
Currently, the behavior of `ActiveSupport::JSON.encode` is incorrect.

``` ruby
require 'json'
puts Exception.new("hoge").to_json #=> "hoge"
```

``` ruby
require 'active_support/json'
require 'active_support/core_ext/object/json'

puts Exception.new("hoge").to_json #=> {}
```
