### PR TITLE
speed up string xor operation and reduce object allocations again

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -379,7 +379,7 @@ module ActionController #:nodoc:
 
       def xor_byte_strings(s1, s2)
         s2_bytes = s2.bytes
-        s1.bytes.map.with_index { |c1, i| c1 ^ s2_bytes[i] }.pack('c*')
+        s1.bytes.each_with_index { |c1, i| c1 ^ s2_bytes[i] }.pack('c*')
       end
 
       # The form's authenticity parameter. Override to provide your own.


### PR DESCRIPTION
```
╰─$ cat xor.rb
a = "\x14b\"\xB4P8\x05\x8D\xC74\xC3\xEC}\xFDf\x8E!h\xCF^\xBF\xA5%\xC6\xF0\xA9\xF9x\x04\xFA\xF1\x82"
b = "O.\xF7\x01\xA9D\xA3\xE1D\x7FU\x85\xFC\x8Ak\e\x04\x8A\x97\x91\xD01\x02\xA4G\x1EIf:Y\x0F@"

def xor_byte_strings(s1, s2)
  s2_bytes = s2.bytes
  s1.bytes.map.with_index { |c1, i| c1 ^ s2_bytes[i] }.pack('c*')
end

def xor_byte_strings2(s1, s2)
  s2_bytes = s2.bytes
  s1.bytes.each_with_index { |c1, i| c1 ^ s2_bytes[i] }.pack('c*')
end

require 'benchmark/ips'
require 'allocation_tracer'

Benchmark.ips do |x|
  x.report 'xor_byte_strings' do
    xor_byte_strings a, b
  end

  x.report 'xor_byte_strings2' do
    xor_byte_strings2 a, b
  end
end

ObjectSpace::AllocationTracer.setup(%i{type})
result = ObjectSpace::AllocationTracer.trace do
  xor_byte_strings a, b
end
p :xor_byte_strings => result
ObjectSpace::AllocationTracer.clear
result = ObjectSpace::AllocationTracer.trace do
  xor_byte_strings2 a, b
end
p :xor_byte_strings2 => result

╰─$ ruby xor.rb
Warming up --------------------------------------
    xor_byte_strings    10.295k i/100ms
   xor_byte_strings2    12.048k i/100ms
Calculating -------------------------------------
    xor_byte_strings    109.263k (± 2.7%) i/s -    555.930k
   xor_byte_strings2    123.155k (± 9.1%) i/s -    614.448k
{:xor_byte_strings=>{[:T_ARRAY]=>[3, 0, 0, 0, 0, 0], [:T_DATA]=>[1, 0, 0, 0, 0, 0], [:T_NODE]=>[2, 0, 0, 0, 0, 0], [:T_STRING]=>[2, 0, 0, 0, 0, 0]}}
{:xor_byte_strings2=>{[:T_ARRAY]=>[2, 0, 0, 0, 0, 0], [:T_NODE]=>[2, 0, 0, 0, 0, 0], [:T_STRING]=>[2, 0, 0, 0, 0, 0]}}
```
