### PR TITLE
Gracefully handle an invalid flash

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -90,6 +90,8 @@ module ActionDispatch
                 end
 
         flash.tap(&:sweep)
+      rescue ArgumentError
+        new
       end
       
       # Builds a hash containing the discarded values and the hashes
@@ -101,6 +103,8 @@ module ActionDispatch
       end
 
       def initialize(flashes = {}, discard = []) #:nodoc:
+        fail ArgumentError unless discard.respond_to?(:map)
+
         @discard = Set.new(stringify_array(discard))
         @flashes = flashes.stringify_keys
         @now     = nil

--- a/actionpack/test/controller/flash_hash_test.rb
+++ b/actionpack/test/controller/flash_hash_test.rb
@@ -86,6 +86,14 @@ module ActionDispatch
       assert_equal "hey you", hash["message"]
     end
 
+    def test_invalid_flash
+      decrypted_data = "{ \"session_id\":\"d98bdf6d129618fc2548c354c161cfb5\", \"flash\":{} }"
+      session = ActionDispatch::Cookies::JsonSerializer.load(decrypted_data)
+      hash = Flash::FlashHash.from_session_value(session['flash'])
+
+      assert_equal(nil, hash.to_session_value)
+    end
+
     def test_empty?
       assert @hash.empty?
       @hash['zomg'] = 'bears'


### PR DESCRIPTION
This is my first PR to Rails, so please forgive my ignorance.

I work on a high traffic site which occasionally throws a 500 error due to an invalid flash in the session.

Here's the stacktrace:

```
NoMethodError, undefined method `map' for nil:NilClass

gems/actionpack-4.2.5.1/lib/action_dispatch/middleware/flash.rb:249 in `stringify_array'
gems/actionpack-4.2.5.1/lib/action_dispatch/middleware/flash.rb:104 in `initialize'
gems/actionpack-4.2.5.1/lib/action_dispatch/middleware/flash.rb:87  in `new'
gems/actionpack-4.2.5.1/lib/action_dispatch/middleware/flash.rb:87  in `from_session_value'
gems/actionpack-4.2.5.1/lib/action_dispatch/middleware/flash.rb:9   in `flash'
gems/actionpack-4.2.5.1/lib/action_controller/metal/flash.rb:9   in `flash'
gems/actionview-4.2.5.1/lib/action_view/helpers/controller_helper.rb:10  in `flash'
```

Ideally, we'd return a 422, but that would take more work. This at least ensures we don't generate a 5xx exception.

I added a test that reproduces the exception, and some minimal code to address it.
