### PR TITLE
Make ActionCable logging less verbose in development

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -191,7 +191,7 @@ module ActionCable
         # Transmit a hash of data to the subscriber. The hash will automatically be wrapped in a JSON envelope with
         # the proper channel identifier marked as the recipient.
         def transmit(data, via: nil)
-          logger.info "#{self.class.name} transmitting #{data.inspect}".tap { |m| m << " (via #{via})" if via }
+          logger.info "#{self.class.name} transmitting #{data.inspect.truncate(300)}".tap { |m| m << " (via #{via})" if via }
           connection.transmit ActiveSupport::JSON.encode(identifier: @identifier, message: data)
         end
 


### PR DESCRIPTION
When running the ActionCable server in development I get a lot of log messages, even when I set the application log level to `config.log_level = :info`. ~~With this commit I move the level for ActionCable to `debug` which is more appropriate in my opinion.~~ With this commit I truncate the log message as proposed by @dhh in https://github.com/rails/rails/pull/23709#issuecomment-185260388.

Example of my current output to illustrate the problem: 

![image](https://cloud.githubusercontent.com/assets/167882/13077891/f83dba42-d4bb-11e5-939f-384bfffd10bd.png)
