### PR TITLE
Ensure that Hash and ActionController::Parameters are equal both ways.

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -158,6 +158,17 @@ module ActionController
       end
     end
 
+    module HashEquality
+      def ==(other_hash)
+        if other_hash.is_a?(ActionController::Parameters)
+          other_hash == self
+        else
+          super
+        end
+      end
+    end
+    ::Hash.prepend(HashEquality)
+
     # Returns a safe <tt>ActiveSupport::HashWithIndifferentAccess</tt>
     # representation of this parameter with all unpermitted keys removed.
     #

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -133,5 +133,6 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     hash1 = { foo: :bar }
     params1 = ActionController::Parameters.new(hash1)
     assert(params1 == hash1)
+    assert(hash1 == params1)
   end
 end


### PR DESCRIPTION
Follow-up for #23167 by @maclover7 
It fixed `ActionController::Parameters == Hash` but not `Hash == ActionController::Parameters`.

I think that `a == b` should be the same as `b == a` so here's a fix.
The test failed without the `lib` change.
