### PR TITLE
The JSON API media type should only work with a JSON API handler

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_types.rb
+++ b/actionpack/lib/action_dispatch/http/mime_types.rb
@@ -28,7 +28,7 @@ Mime::Type.register "application/x-www-form-urlencoded", :url_encoded_form
 
 # http://www.ietf.org/rfc/rfc4627.txt
 # http://www.json.org/JSONRequest.html
-Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest application/vnd.api+json )
+Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest )
 
 Mime::Type.register "application/pdf", :pdf, [], %w(pdf)
 Mime::Type.register "application/zip", :zip, [], %w(zip)

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -37,9 +37,9 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
-  test "parses json params for application/vnd.api+json" do
+  test "does not parses unregistered media types such as application/vnd.api+json" do
     assert_parses(
-      {"person" => {"name" => "David"}},
+      {},
       "{\"person\": {\"name\": \"David\"}}", { 'CONTENT_TYPE' => 'application/vnd.api+json' }
     )
   end
@@ -140,13 +140,6 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
     assert_parses(
       {"user" => {"username" => "sikachu"}, "username" => "sikachu"},
       "{\"username\": \"sikachu\"}", { 'CONTENT_TYPE' => 'application/jsonrequest' }
-    )
-  end
-
-  test "parses json params for application/vnd.api+json" do
-    assert_parses(
-      {"user" => {"username" => "sikachu"}, "username" => "sikachu"},
-      "{\"username\": \"sikachu\"}", { 'CONTENT_TYPE' => 'application/vnd.api+json' }
     )
   end
 


### PR DESCRIPTION
Revises behavior introduced in #20329 #21251

Since the media type 'application/vnd.api+json' is a spec,
it is inappropriate to handle it with the JSON renderer.
## Updated Description per [discussion](https://github.com/rails/rails/pull/23712#issuecomment-184977238)

>  Let's remove it and introduce back only when we have defined the proper API for the handlers.

This PR removes support for the JSON API media type.

We recommend the media type be registered on its own as `jsonapi` when a jsonapi Renderer and deserializer (Http::Parameters::DEFAULT_PARSERS) are added.
## Original Description

[This PR](https://github.com/rails/rails/commit/6f73b1906fea9ac29f257e8e0c88c117901bbb9e#diff-6a80fa5836403509e86a81c2117af391R12) adds support for a JSON API media type.
- [ ] It does not currently include a JSON API renderer, but I could add that
  here.
- [ ] The JSON being parsed in the tests is invalid JSON API, but I
  retained the example for test continuity.  I'd like to change that as
  well.

I've chosen to register JSON API as `api_json` per
[JSONAPI-resources](https://github.com/cerebris/jsonapi-resources/blob/v0.7.0/lib/jsonapi/mime_types.rb),
one of the more mature Rails+JSON API gems out there.  An alternate name
could be `jsonapi`. In both cases, I would recommend the renderer be
named after the registered mime type.

Is related to work in https://github.com/rails/rails/pull/21496

cc @dgeb
