### PR TITLE
Test parent local_stored_attributes isn't modified

### DIFF
--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -177,6 +177,7 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal [:color], first_model.stored_attributes[:data]
     assert_equal [:color, :width, :height], second_model.stored_attributes[:data]
     assert_equal [:color, :area, :volume], third_model.stored_attributes[:data]
+    assert_equal [:color], first_model.stored_attributes[:data]
   end
 
   test "YAML coder initializes the store when a Nil value is given" do


### PR DESCRIPTION
Saw the `merge!` and had to prove to myself that the parent model's local_stored_attributes was not being changed when stored_attributes is called on a child model. Proved to be working as expected but this test is probably still useful to keep around.
