### PR TITLE
Added log "Rendering ...", when starting to render a template

### DIFF
--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -22,6 +22,15 @@ module ActionView
     alias :render_partial :render_template
     alias :render_collection :render_template
 
+
+    def start_rendering(event)
+      info do
+        message = "Rendering #{from_rails_root(event.payload[:identifier])}"
+        message << " within #{from_rails_root(event.payload[:layout])}" if event.payload[:layout]
+        message
+      end
+    end
+
     def logger
       ActionView::Base.logger
     end

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -50,6 +50,7 @@ module ActionView
       view, locals = @view, locals || {}
 
       render_with_layout(layout_name, locals) do |layout|
+        ActiveSupport::Notifications.instrument("start_rendering.action_view", identifier: template.identifier, layout: layout.try(:virtual_path))
         instrument(:template, :identifier => template.identifier, :layout => layout.try(:virtual_path)) do
           template.render(view, locals) { |*name| view._layout_for(*name) }
         end

--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -35,7 +35,8 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
       @view.render(:file => "test/hello_world")
       wait
 
-      assert_equal 1, @logger.logged(:info).size
+      assert_equal 2, @logger.logged(:info).size
+      assert_match(/Rendering test\/hello_world\.erb/, @logger.logged(:info).first)
       assert_match(/Rendered test\/hello_world\.erb/, @logger.logged(:info).last)
     end
   end
@@ -45,7 +46,8 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
       @view.render(:text => "TEXT")
       wait
 
-      assert_equal 1, @logger.logged(:info).size
+      assert_equal 2, @logger.logged(:info).size
+      assert_match(/Rendering text template/, @logger.logged(:info).first)
       assert_match(/Rendered text template/, @logger.logged(:info).last)
     end
   end
@@ -55,7 +57,8 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
       @view.render(:inline => "<%= 'TEXT' %>")
       wait
 
-      assert_equal 1, @logger.logged(:info).size
+      assert_equal 2, @logger.logged(:info).size
+      assert_match(/Rendering inline template/, @logger.logged(:info).first)
       assert_match(/Rendered inline template/, @logger.logged(:info).last)
     end
   end


### PR DESCRIPTION
Added log "Rendering ...", when starting to render a template, to log that we have started to render something, at the very beginning.

This helps to easily identify queries from controller vs views

Fixes #23710

r? @dhh 
