### PR TITLE
Abstract option added for Active Record model generator

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Added `--abstract` option to generate abstract models via CLI.
+
+    Example:
+
+        rails g model account --abstract
+
+    The above command will generate following class without migration and fixtures files.
+
+        class Account < ActiveRecord::Base
+          self.abstract_class = true
+        end
+
+    *Mehmet Emin İNAÇ*
+
 *   Fix a bug where using `t.foreign_key` twice with the same `to_table` within
     the same table definition would only create one foreign key.
 

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -12,10 +12,11 @@ module ActiveRecord
       class_option :parent, type: :string, desc: "The parent class for the generated model"
       class_option :indexes, type: :boolean, default: true, desc: "Add indexes for references and belongs_to columns"
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
+      class_option :abstract, type: :boolean, default: false, desc: "Create model as abstract class"
 
       # creates the migration file for the model.
       def create_migration_file
-        return unless options[:migration] && options[:parent].nil?
+        return unless options[:migration] && options[:parent].nil? && !abstract?
         attributes.each { |a| a.attr_options.delete(:index) if a.reference? && !a.has_index? } if options[:indexes] == false
         migration_template "../../migration/templates/create_table_migration.rb", "db/migrate/create_#{table_name}.rb"
       end
@@ -27,6 +28,10 @@ module ActiveRecord
       def create_module_file
         return if regular_class_path.empty?
         template 'module.rb', File.join('app/models', "#{class_path.join('/')}.rb") if behavior == :invoke
+      end
+
+      def abstract?
+        options[:abstract]
       end
 
       hook_for :test_framework

--- a/activerecord/lib/rails/generators/active_record/model/templates/model.rb
+++ b/activerecord/lib/rails/generators/active_record/model/templates/model.rb
@@ -1,5 +1,8 @@
 <% module_namespacing do -%>
 class <%= class_name %> < <%= parent_class_name.classify %>
+<% if abstract? -%>
+  self.abstract_class = true
+<% end -%>
 <% attributes.select(&:reference?).each do |attribute| -%>
   belongs_to :<%= attribute.name %><%= ', polymorphic: true' if attribute.polymorphic? %><%= ', required: true' if attribute.required? %>
 <% end -%>

--- a/railties/lib/rails/generators/test_unit/model/model_generator.rb
+++ b/railties/lib/rails/generators/test_unit/model/model_generator.rb
@@ -18,7 +18,7 @@ module TestUnit # :nodoc:
       hook_for :fixture_replacement
 
       def create_fixture_file
-        if options[:fixture] && options[:fixture_replacement].nil?
+        if options[:fixture] && options[:fixture_replacement].nil? && !parent_options[:abstract]
           template 'fixtures.yml', File.join('test/fixtures', class_path, "#{fixture_file_name}.yml")
         end
       end

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -35,6 +35,13 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_no_migration "db/migrate/create_accounts.rb"
   end
 
+  def test_model_with_abstract_option
+    run_generator ["account", "--abstract"]
+    assert_file "app/models/account.rb", /self.abstract_class = true/
+    assert_no_migration "db/migrate/create_accounts.rb"
+    assert_no_file "test/fixtures/accounts.yml"
+  end
+
   def test_model_with_existent_application_record
     mkdir_p "#{destination_root}/app/models"
     touch "#{destination_root}/app/models/application_record.rb"


### PR DESCRIPTION
`--abstract` option added for Active Record model generator to create abstract Active Record classes from CLI.

Usage:

```
rails g model account --abstract
```

This will generate following class without migration and fixtures:

```
class Account < ActiveRecord::Base
  self.abstract_class = true
end
```
