### PR TITLE
Show proper error message when a non-relation object is passed to AR::Relation#or

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -655,6 +655,10 @@ module ActiveRecord
     #    # SELECT `posts`.* FROM `posts`  WHERE (('id = 1' OR 'author_id = 3'))
     #
     def or(other)
+      unless other.is_a? Relation
+        raise ArgumentError, "You have passed #{other.class.name} object to #or. Pass an ActiveRecord::Relation object instead."
+      end
+
       spawn.or!(other)
     end
 

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -82,5 +82,11 @@ module ActiveRecord
       assert_equal p.loaded?, true
       assert_equal expected, p.or(Post.where('id = 2')).to_a
     end
+
+    def test_or_with_non_relation_object_raises_error
+      assert_raises ArgumentError do
+        Post.where(id: [1, 2, 3]).or(title: 'Rails')
+      end
+    end
   end
 end


### PR DESCRIPTION
- Previously it used to show error message
  <"undefined method `limit_value' for {:title=>\"Rails\"}:Hash">
- Now it shows following error message.
  
  > > Post.where.not(name: 'DHH').or(name: 'Tenderlove')
  > > ArgumentError: You have passed Hash object to #or. Pass an ActiveRecord::Relation object instead.
- Fixes #23714.
