### PR TITLE
Remove unused Journey code

### DIFF
--- a/actionpack/lib/action_dispatch/journey/backwards.rb
+++ b/actionpack/lib/action_dispatch/journey/backwards.rb
@@ -1,5 +1,0 @@
-module Rack # :nodoc:
-  Mount = ActionDispatch::Journey::Router
-  Mount::RouteSet = ActionDispatch::Journey::Router
-  Mount::RegexpWithNamedGroups = ActionDispatch::Journey::Path::Pattern
-end

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -16,9 +16,6 @@ module ActionDispatch
       class RoutingError < ::StandardError # :nodoc:
       end
 
-      # :nodoc:
-      VERSION = '2.0.0'
-
       attr_accessor :routes
 
       def initialize(routes)


### PR DESCRIPTION
- `VERSION` shouldn't be there anymore since Journey is technically part
  of Action Dispatch now (and thus Action Pack, and follows the normal
  Rails versioning scheme)
- `backwards.rb` was only in the file tree because early in the history
  or Journey (back in 2011!), it was moved from under the Rack namespace, to its own
  namespace, Journey! This file is no longer required, and is assigning
  constants that are no longer needed.
