### PR TITLE
modify to `error` also abort when specify fail fast option

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Change fail fast of `bin/rails test` interrupts run on error.
+
+    *Yuji Yaginuma*
+
 *   The application generator supports `--skip-listen` to opt-out of features
     that depend on the listen gem. As of this writing they are the evented file
     system monitor and the async plugin for spring.

--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -42,7 +42,7 @@ module Minitest
     end
 
     opts.on("-f", "--fail-fast",
-            "Abort test run on first failure") do
+            "Abort test run on first failure or error") do
       options[:fail_fast] = true
     end
 

--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -24,7 +24,7 @@ module Rails
         io.puts
       end
 
-      if fail_fast? && result.failure && !result.error? && !result.skipped?
+      if fail_fast? && result.failure && !result.skipped?
         raise Interrupt
       end
     end

--- a/railties/test/test_unit/reporter_test.rb
+++ b/railties/test/test_unit/reporter_test.rb
@@ -104,11 +104,22 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     end
   end
 
-  test "fail fast does not interrupt run errors or skips" do
+  test "fail fast interrupts run on error" do
     fail_fast = Rails::TestUnitReporter.new @output, fail_fast: true
+    interrupt_raised = false
 
-    fail_fast.record(errored_test)
-    assert_no_match 'Failed tests:', @output.string
+    # Minitest passes through Interrupt, catch it manually.
+    begin
+      fail_fast.record(errored_test)
+    rescue Interrupt
+      interrupt_raised = true
+    ensure
+      assert interrupt_raised, 'Expected Interrupt to be raised.'
+    end
+  end
+
+  test "fail fast does not interrupt run skips" do
+    fail_fast = Rails::TestUnitReporter.new @output, fail_fast: true
 
     fail_fast.record(skipped_test)
     assert_no_match 'Failed tests:', @output.string


### PR DESCRIPTION
Since the `error` also state that as the test has failed, I think that in the case of error may be got to stop the execution of the test. How about?
