### PR TITLE
remove unused method

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -287,10 +287,6 @@ task default: :test
 
     protected
 
-      def app_templates_dir
-        "../../app/templates"
-      end
-
       def create_dummy_app(path = nil)
         dummy_path(path) if path
 


### PR DESCRIPTION
`app_templates_dir` is unused since dc53fe9.
