### PR TITLE
Implement ActionController::Parameters#inspect

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -109,7 +109,7 @@ module ActionController
     cattr_accessor :permit_all_parameters, instance_accessor: false
     cattr_accessor :action_on_unpermitted_parameters, instance_accessor: false
 
-    delegate :keys, :key?, :has_key?, :values, :has_value?, :value?, :empty?, :include?, :inspect,
+    delegate :keys, :key?, :has_key?, :values, :has_value?, :value?, :empty?, :include?,
       :as_json, to: :@parameters
 
     # By default, never raise an UnpermittedParameters exception if these
@@ -572,6 +572,10 @@ module ActionController
     # matter as we are using +HashWithIndifferentAccess+ internally.
     def stringify_keys # :nodoc:
       dup
+    end
+
+    def inspect
+      "<#{self.class} #{@parameters}>"
     end
 
     def method_missing(method_sym, *args, &block)

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -134,4 +134,13 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     params1 = ActionController::Parameters.new(hash1)
     assert(params1 == hash1)
   end
+
+  test "inspect shows both class name and parameters" do
+    assert_equal(
+      '<ActionController::Parameters {"person"=>{"age"=>"32", '\
+      '"name"=>{"first"=>"David", "last"=>"Heinemeier Hansson"}, ' \
+      '"addresses"=>[{"city"=>"Chicago", "state"=>"Illinois"}]}}>',
+      @params.inspect
+    )
+  end
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -988,7 +988,7 @@ module ApplicationTests
       app 'development'
 
       post "/posts.json", '{ "title": "foo", "name": "bar" }', "CONTENT_TYPE" => "application/json"
-      assert_equal '{"title"=>"foo"}', last_response.body
+      assert_equal '<ActionController::Parameters {"title"=>"foo"}>', last_response.body
     end
 
     test "config.action_controller.permit_all_parameters = true" do


### PR DESCRIPTION
Now that AC::Parameters is no longer a Hash, it shouldn't look like a Hash.

Here's an example from my RSpec output without this PR:

```
#<Foo:0x007f10be4aa4b8> received :bar with unexpected arguments
  expected: ({"x"=>"y"})
       got: ({"x"=>"y"})
Diff:

Please stub a default value first if message might be received with other args as well.
```

After this PR, the diff is much more useful:

```
#<Foo:0x007f5dc8799848> received :bar with unexpected arguments
  expected: ({"x"=>"y"})
       got: (<ActionController::Parameters {"x"=>"y"}>)
Diff:
@@ -1,2 +1,2 @@
-[{"x"=>"y"}]
+[<ActionController::Parameters {"x"=>"y"}>]

Please stub a default value first if message might be received with other args as well.
```
