### PR TITLE
Deprecate AC::Parameters#== with Hash

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -144,16 +144,21 @@ module ActionController
     end
 
     # Returns true if another +Parameters+ object contains the same content and
-    # permitted flag, or other Hash-like object contains the same content.
-    def ==(other_hash)
-      if other_hash.respond_to?(:permitted?)
-        self.permitted? == other_hash.permitted? && self.parameters == other_hash.parameters
+    # permitted flag.
+    def ==(other)
+      if other.respond_to?(:permitted?)
+        self.permitted? == other.permitted? && self.parameters == other.parameters
+      elsif other.is_a?(Hash)
+        ActiveSupport::Deprecation.warn <<-WARNING.squish
+          Comparing equality between `ActionController::Parameters` and a
+          `Hash` is deprecated and will be removed in Rails 5.1. Please only do
+          comparisons between instances of `ActionController::Parameters`. If
+          you need to compare to a hash, first convert it using
+          `ActionController::Parameters#new`.
+        WARNING
+        @parameters == other.with_indifferent_access
       else
-        if other_hash.is_a?(Hash)
-          @parameters == other_hash.with_indifferent_access
-        else
-          @parameters == other_hash
-        end
+        @parameters == other
       end
     end
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -144,11 +144,10 @@ module ActionController
     end
 
     # Returns true if another +Parameters+ object contains the same content and
-    # permitted flag, or other Hash-like object contains the same content. This
-    # override is in place so you can perform a comparison with `Hash`.
+    # permitted flag, or other Hash-like object contains the same content.
     def ==(other_hash)
       if other_hash.respond_to?(:permitted?)
-        super
+        self.permitted? == other_hash.permitted? && self.parameters == other_hash.parameters
       else
         if other_hash.is_a?(Hash)
           @parameters == other_hash.with_indifferent_access
@@ -597,6 +596,8 @@ module ActionController
     end
 
     protected
+      attr_reader :parameters
+
       def permitted=(new_permitted)
         @permitted = new_permitted
       end

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -135,6 +135,12 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert(params1 == hash1)
   end
 
+  test "equality with simple types works" do
+    assert(@params != 'Hello')
+    assert(@params != 42)
+    assert(@params != false)
+  end
+
   test "inspect shows both class name and parameters" do
     assert_equal(
       '<ActionController::Parameters {"person"=>{"age"=>"32", '\

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -129,10 +129,12 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_not @params[:person].values_at(:name).first.permitted?
   end
 
-  test "equality with another hash works" do
+  test "equality with a hash is deprecated" do
     hash1 = { foo: :bar }
     params1 = ActionController::Parameters.new(hash1)
-    assert(params1 == hash1)
+    assert_deprecated("will be removed in Rails 5.1") do
+      assert(params1 == hash1)
+    end
   end
 
   test "is equal to Parameters instance with same params" do

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -135,6 +135,39 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert(params1 == hash1)
   end
 
+  test "is equal to Parameters instance with same params" do
+    params1 = ActionController::Parameters.new(a: 1, b: 2)
+    params2 = ActionController::Parameters.new(a: 1, b: 2)
+    assert(params1 == params2)
+  end
+
+  test "is equal to Parameters instance with same permitted params" do
+    params1 = ActionController::Parameters.new(a: 1, b: 2).permit(:a)
+    params2 = ActionController::Parameters.new(a: 1, b: 2).permit(:a)
+    assert(params1 == params2)
+  end
+
+  test "is equal to Parameters instance with same different source params, but same permitted params" do
+    params1 = ActionController::Parameters.new(a: 1, b: 2).permit(:a)
+    params2 = ActionController::Parameters.new(a: 1, c: 3).permit(:a)
+    assert(params1 == params2)
+    assert(params2 == params1)
+  end
+
+  test 'is not equal to an unpermitted Parameters instance with same params' do
+    params1 = ActionController::Parameters.new(a: 1).permit(:a)
+    params2 = ActionController::Parameters.new(a: 1)
+    assert(params1 != params2)
+    assert(params2 != params1)
+  end
+
+  test "is not equal to Parameters instance with different permitted params" do
+    params1 = ActionController::Parameters.new(a: 1, b: 2).permit(:a, :b)
+    params2 = ActionController::Parameters.new(a: 1, b: 2).permit(:a)
+    assert(params1 != params2)
+    assert(params2 != params1)
+  end
+
   test "equality with simple types works" do
     assert(@params != 'Hello')
     assert(@params != 42)


### PR DESCRIPTION
As @schneems mentioned in #23711: “ActionController::Parameters is not a hash, so we should not expect it to be equal to one.” I think it would be best to deprecate that behavior before Rails 5 is released.

This also fixes #22820 – comparison between AC::Parameters instances.
