### PR TITLE
Alternative to #23638 log to STDOUT via env var

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -60,6 +60,10 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  end
+
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -348,6 +348,17 @@ module ApplicationTests
       end
     end
 
+    test "In production mode, STDOUT logging is enabled when RAILS_LOG_TO_STDOUT is set" do
+      restore_default_config
+
+      with_rails_env "production" do
+        switch_env "RAILS_LOG_TO_STDOUT", "1" do
+          app 'production'
+          assert ActiveSupport::Logger.logger_outputs_to?(app.config.logger, STDOUT)
+        end
+      end
+    end
+
     test "In production mode, config.public_file_server.enabled is disabled when RAILS_SERVE_STATIC_FILES is blank" do
       restore_default_config
 


### PR DESCRIPTION
People who deploy to containers or other places where they might have some sort of a log wrapping service use stdout. With this change new rails apps can be configured to output to STDOUT via setting `RAILS_LOG_TO_STDOUT` to any value. This allows container images or services to set the value for all apps without having to modify configuration for each application. If an app wants to opt out, they can either delete from the env hash, or remove that configuration. 

cc/ @rafaelfranca
