### PR TITLE
Remove needless `case_insensitive_comparison` in mysql2 adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -398,7 +398,7 @@ module ActiveRecord
         if can_perform_case_insensitive_comparison_for?(column)
           table[attribute].lower.eq(table.lower(Arel::Nodes::BindParam.new))
         else
-          case_sensitive_comparison(table, attribute, column, value)
+          table[attribute].eq(Arel::Nodes::BindParam.new)
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -615,13 +615,10 @@ module ActiveRecord
         end
       end
 
-      def case_insensitive_comparison(table, attribute, column, value)
-        if column.case_sensitive?
-          super
-        else
-          table[attribute].eq(Arel::Nodes::BindParam.new)
-        end
+      def can_perform_case_insensitive_comparison_for?(column)
+        column.case_sensitive?
       end
+      private :can_perform_case_insensitive_comparison_for?
 
       # In MySQL 5.7.5 and up, ONLY_FULL_GROUP_BY affects handling of queries that use
       # DISTINCT and ORDER BY. It requires the ORDER BY columns in the select list for


### PR DESCRIPTION
Simply it is sufficient to override `can_perform_case_insensitive_comparison_for?`.
