### PR TITLE
No adapters uses `value.to_s` when `Type::Binary::Data` in `_quote`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -158,8 +158,10 @@ module ActiveRecord
 
       def _quote(value)
         case value
-        when String, ActiveSupport::Multibyte::Chars, Type::Binary::Data
+        when String, ActiveSupport::Multibyte::Chars
           "'#{quote_string(value.to_s)}'"
+        when Type::Binary::Data
+          "x'#{value.hex}'"
         when true       then quoted_true
         when false      then quoted_false
         when nil        then "NULL"

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -35,16 +35,6 @@ module ActiveRecord
             super.sub(/\.\d{6}\z/, '')
           end
         end
-
-        private
-
-        def _quote(value)
-          if value.is_a?(Type::Binary::Data)
-            "x'#{value.hex}'"
-          else
-            super
-          end
-        end
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -1,0 +1,51 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      module Quoting # :nodoc:
+        QUOTED_TRUE, QUOTED_FALSE = '1', '0'
+
+        def quote_column_name(name)
+          @quoted_column_names[name] ||= "`#{name.to_s.gsub('`', '``')}`"
+        end
+
+        def quote_table_name(name)
+          @quoted_table_names[name] ||= quote_column_name(name).gsub('.', '`.`')
+        end
+
+        def quoted_true
+          QUOTED_TRUE
+        end
+
+        def unquoted_true
+          1
+        end
+
+        def quoted_false
+          QUOTED_FALSE
+        end
+
+        def unquoted_false
+          0
+        end
+
+        def quoted_date(value)
+          if supports_datetime_with_precision?
+            super
+          else
+            super.sub(/\.\d{6}\z/, '')
+          end
+        end
+
+        private
+
+        def _quote(value)
+          if value.is_a?(Type::Binary::Data)
+            "x'#{value.hex}'"
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -1,0 +1,45 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      module Quoting # :nodoc:
+        def quote_string(s)
+          @connection.class.quote(s)
+        end
+
+        def quote_table_name_for_assignment(table, attr)
+          quote_column_name(attr)
+        end
+
+        def quote_column_name(name)
+          @quoted_column_names[name] ||= %Q("#{name.to_s.gsub('"', '""')}")
+        end
+
+        private
+
+        def _quote(value)
+          case value
+          when Type::Binary::Data
+            "x'#{value.hex}'"
+          else
+            super
+          end
+        end
+
+        def _type_cast(value)
+          case value
+          when BigDecimal
+            value.to_f
+          when String
+            if value.encoding == Encoding::ASCII_8BIT
+              super(value.encode(Encoding::UTF_8))
+            else
+              super
+            end
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -16,15 +16,6 @@ module ActiveRecord
 
         private
 
-        def _quote(value)
-          case value
-          when Type::Binary::Data
-            "x'#{value.hex}'"
-          else
-            super
-          end
-        end
-
         def _type_cast(value)
           case value
           when BigDecimal

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -1,6 +1,7 @@
 require 'active_record/connection_adapters/abstract_adapter'
 require 'active_record/connection_adapters/statement_pool'
 require 'active_record/connection_adapters/sqlite3/explain_pretty_printer'
+require 'active_record/connection_adapters/sqlite3/quoting'
 require 'active_record/connection_adapters/sqlite3/schema_creation'
 
 gem 'sqlite3', '~> 1.3.6'
@@ -49,6 +50,8 @@ module ActiveRecord
     # * <tt>:database</tt> - Path to the database file.
     class SQLite3Adapter < AbstractAdapter
       ADAPTER_NAME = 'SQLite'.freeze
+
+      include SQLite3::Quoting
       include Savepoints
 
       NATIVE_DATABASE_TYPES = {
@@ -172,44 +175,6 @@ module ActiveRecord
 
       def supports_explain?
         true
-      end
-
-      # QUOTING ==================================================
-
-      def _quote(value) # :nodoc:
-        case value
-        when Type::Binary::Data
-          "x'#{value.hex}'"
-        else
-          super
-        end
-      end
-
-      def _type_cast(value) # :nodoc:
-        case value
-        when BigDecimal
-          value.to_f
-        when String
-          if value.encoding == Encoding::ASCII_8BIT
-            super(value.encode(Encoding::UTF_8))
-          else
-            super
-          end
-        else
-          super
-        end
-      end
-
-      def quote_string(s) #:nodoc:
-        @connection.class.quote(s)
-      end
-
-      def quote_table_name_for_assignment(table, attr)
-        quote_column_name(attr)
-      end
-
-      def quote_column_name(name) #:nodoc:
-        @quoted_column_names[name] ||= %Q("#{name.to_s.gsub('"', '""')}")
       end
 
       #--


### PR DESCRIPTION
All adapters (postgresql, mysql2, sqlite3, sqlserver, oracle-enhanced)
does not use `value.to_s` when `Type::Binary::Data` in `_quote`.
