### PR TITLE
Add prefix and length options to has_secure_token

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add prefix and length options to has_secure_token.
+
+    *Abdulaziz Alshetwi*
+
 *   Fix a bug where using `t.foreign_key` twice with the same `to_table` within
     the same table definition would only create one foreign key.
 

--- a/activerecord/lib/active_record/secure_token.rb
+++ b/activerecord/lib/active_record/secure_token.rb
@@ -5,16 +5,18 @@ module ActiveRecord
     module ClassMethods
       # Example using #has_secure_token
       #
-      #   # Schema: User(token:string, auth_token:string)
+      #   # Schema: User(token:string, auth_token:string, api_key:string)
       #   class User < ActiveRecord::Base
       #     has_secure_token
-      #     has_secure_token :auth_token
+      #     has_secure_token :auth_token, prefix: 'ut_'
+      #     has_secure_token :api_key,    prefix: 'ak_', length: 42
       #   end
       #
       #   user = User.new
       #   user.save
       #   user.token # => "pX27zsMN2ViQKta1bGfLmVJE"
       #   user.auth_token # => "77TMHrHJFvFDwodq8w7Ev2m7"
+      #   user.api_key # => "ak_1wkenr7vcAb9tH1jyQzvBdxBg8jC2bSv8ySM335"
       #   user.regenerate_token # => true
       #   user.regenerate_auth_token # => true
       #
@@ -23,15 +25,16 @@ module ActiveRecord
       # Note that it's still possible to generate a race condition in the database in the same way that
       # {validates_uniqueness_of}[rdoc-ref:Validations::ClassMethods#validates_uniqueness_of] can.
       # You're encouraged to add a unique index in the database to deal with this even more unlikely scenario.
-      def has_secure_token(attribute = :token)
+      def has_secure_token(attribute = :token, length: 24, prefix: '')
         # Load securerandom only when has_secure_token is used.
         require 'active_support/core_ext/securerandom'
-        define_method("regenerate_#{attribute}") { update! attribute => self.class.generate_unique_secure_token }
-        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token) unless self.send("#{attribute}?")}
+        define_method("regenerate_#{attribute}") { update! attribute => self.class.generate_unique_secure_token(length, prefix) }
+        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token(length, prefix)) unless self.send("#{attribute}?")}
       end
 
-      def generate_unique_secure_token
-        SecureRandom.base58(24)
+      def generate_unique_secure_token(length, prefix)
+        token_length = length - prefix.length
+        prefix + SecureRandom.base58(token_length)
       end
     end
   end

--- a/activerecord/test/cases/secure_token_test.rb
+++ b/activerecord/test/cases/secure_token_test.rb
@@ -29,4 +29,34 @@ class SecureTokenTest < ActiveRecord::TestCase
 
     assert_equal @user.token, "custom-secure-token"
   end
+
+  def test_token_value_default_length_is_24
+    default_length = 24
+    @user.save
+    
+    assert_equal default_length, @user.token.length
+    assert_equal default_length, @user.auth_token.length
+    assert_not_equal default_length, @user.api_key.length
+  end
+
+  def test_token_length_option_change_token_length
+    @user.save
+    
+    assert_equal 42, @user.api_key.length
+  end
+  
+  def test_regenerating_token_with_same_length
+    @user.save
+    @user.regenerate_api_key
+    
+    assert_equal 24, @user.token.length
+    assert_equal 24, @user.auth_token.length
+    assert_equal 42, @user.api_key.length
+  end
+  
+  def test_prefix_prepend_in_token
+    @user.save
+    
+    assert @user.api_key.start_with?("ak_")
+  end
 end

--- a/activerecord/test/models/user.rb
+++ b/activerecord/test/models/user.rb
@@ -1,6 +1,7 @@
 class User < ActiveRecord::Base
   has_secure_token
-  has_secure_token :auth_token
+  has_secure_token :auth_token, prefix: 'ut_'
+  has_secure_token :api_key, prefix: 'ak_', length: 42
 end
 
 class UserWithNotification < User

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1009,6 +1009,7 @@ ActiveRecord::Schema.define do
   create_table :users, force: true do |t|
     t.string :token
     t.string :auth_token
+    t.string :api_key
   end
 
   create_table :test_with_keyword_column_name, force: true do |t|


### PR DESCRIPTION
This PR add prefix and length options to has_secure_token. This will be very helpful when you have multiple keys with different use and want to clarify every type of them (public key and private key). Also if you have multiple tokens in different models and you pass this token as an identifier.

```
has_secure_token
has_secure_token :secret_key, prefix: 'sk_', length: 64
has_secure_token :public_key, prefix: 'pk_'
```
