### PR TITLE
Missing documentation about hash algorithm option for MessageVerifier

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -24,6 +24,12 @@ module ActiveSupport
   # hash upon initialization:
   #
   #   @verifier = ActiveSupport::MessageVerifier.new('s3Krit', serializer: YAML)
+  #
+  # +MessageVerifier+ creates HMAC signatures using SHA1 hash algorithm by default.
+  # If you want to use a different hash algorithm, you can change it by providing
+  # `:digest` key as an option while initializing the verifier:
+  #
+  #   @verifier = ActiveSupport::MessageVerifier.new('s3Krit', digest: 'SHA256')
   class MessageVerifier
     class InvalidSignature < StandardError; end
 


### PR DESCRIPTION
This is important because SHA1 algorithm is deprecated on major platforms and there is no documentation about what is used under the hood. Also it would be great to deprecate usage of SHA1 as well. WDYT about deprecating it?
