### PR TITLE
Add accidentally removed `#` [ci skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -5,12 +5,12 @@
     Example:
 
         PriceEstimate.where(estimate_of: [Treasure.find(1), Car.find(2)])
-        => SELECT "price_estimates".* FROM "price_estimates"
-           WHERE (("price_estimates"."estimate_of_type" = 'Treasure' AND "price_estimates"."estimate_of_id" = 1)
-           OR ("price_estimates"."estimate_of_type" = 'Car' AND "price_estimates"."estimate_of_id" = 2))
+        # => SELECT "price_estimates".* FROM "price_estimates"
+             WHERE (("price_estimates"."estimate_of_type" = 'Treasure' AND "price_estimates"."estimate_of_id" = 1)
+             OR ("price_estimates"."estimate_of_type" = 'Car' AND "price_estimates"."estimate_of_id" = 2))
 
     *Philippe Huibonhoa*
-    
+
 *   Fix a bug where using `t.foreign_key` twice with the same `to_table` within
     the same table definition would only create one foreign key.
 
@@ -23,7 +23,7 @@
 
     *Bogdan Gusiev*, *Jon Hinson*
 
-*   Rework `ActiveRecord::Relation#last`
+*   Rework `ActiveRecord::Relation#last`.
 
     1. Never perform additional SQL on loaded relation
     2. Use SQL reverse order instead of loading relation if relation doesn't have limit
@@ -46,7 +46,7 @@
 
 *   Allow `joins` to be unscoped.
 
-    Closes #13775.
+    Fixes #13775.
 
     *Takashi Kokubun*
 


### PR DESCRIPTION
`#` was removed at f57092a but this `#` is intentional.
e.g. https://github.com/rails/rails/blame/v5.0.0.beta2/activerecord/CHANGELOG.md#L1423-L1426
