### PR TITLE
fix the language for simple and proper understanding

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -402,7 +402,7 @@ module Blorgh
 end
 ```
 
-NOTE: The `ApplicationController` class being inherited from here is the
+NOTE: The `ArticlesController` class inherits from
 `Blorgh::ApplicationController`, not an application's `ApplicationController`.
 
 The helper inside `app/helpers/blorgh/articles_helper.rb` is also namespaced:

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -403,7 +403,7 @@ end
 ```
 
 NOTE: The `ArticlesController` class inherits from
-`Blorgh::ApplicationController`, not an application's `ApplicationController`.
+`Blorgh::ApplicationController`, not the application's `ApplicationController`.
 
 The helper inside `app/helpers/blorgh/articles_helper.rb` is also namespaced:
 


### PR DESCRIPTION
It fixes the language for simple and proper understanding in engines section in Rails guide 

http://guides.rubyonrails.org/engines.html#generating-an-article-resource
