### PR TITLE
Add test cases about MySQL ORDER BY FIELD()

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -358,6 +358,12 @@ class RelationTest < ActiveRecord::TestCase
   def test_finding_with_sanitized_order
     query = Tag.order(["field(id, ?)", [1,3,2]]).to_sql
     assert_match(/field\(id, 1,3,2\)/, query)
+
+    query = Tag.order(["field(id, ?)", []]).to_sql
+    assert_match(/field\(id, NULL\)/, query)
+
+    query = Tag.order(["field(id, ?)", nil]).to_sql
+    assert_match(/field\(id, NULL\)/, query)
   end
 
   def test_finding_with_order_limit_and_offset


### PR DESCRIPTION
These assertions examine the sanitization of `ORDER BY FIELD()` with empty data on MySQL appropriately.

``` ruby
  Tag.order(['field(id, ?)', []]).to_sql
  # => SELECT "tags".* FROM "tags" ORDER BY field(id, NULL)

  Tag.order(['field(id, ?)', nil]).to_sql
  # => SELECT "tags".* FROM "tags" ORDER BY field(id, NULL)
```
