### PR TITLE
set `skip_listen` option to dummy appplication

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -90,6 +90,7 @@ task default: :test
       opts[:force] = force
       opts[:skip_bundle] = true
       opts[:api] = options.api?
+      opts[:skip_listen] = true
 
       invoke Rails::Generators::AppGenerator,
         [ File.expand_path(dummy_path, destination_root) ], opts

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -444,6 +444,14 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_dummy_appplication_skip_listen_by_default
+    run_generator
+
+    assert_file 'test/dummy/config/environments/development.rb' do |contents|
+      assert_match(/^\s*# config.file_watcher = ActiveSupport::EventedFileUpdateChecker/, contents)
+    end
+  end
+
   def test_ensure_that_gitignore_can_be_generated_from_a_template_for_dummy_path
     FileUtils.cd(Rails.root)
     run_generator([destination_root, "--dummy_path", "spec/dummy", "--skip-test"])


### PR DESCRIPTION
If you want to use `EventedFileUpdateChecker`, need to specify `listen` to plugin's gemspec.
However, because the default in the `listen` is not specified in plugin's gemspec,
`EventedFileUpdateChecker` should be disabled.
