### PR TITLE
Prevent invocation of channel action if rejected connection

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -247,7 +247,7 @@ module ActionCable
         end
 
         def processable_action?(action)
-          self.class.action_methods.include?(action.to_s)
+          self.class.action_methods.include?(action.to_s) unless subscription_rejected?
         end
 
         def dispatch_action(action, data)

--- a/actioncable/test/channel/rejection_test.rb
+++ b/actioncable/test/channel/rejection_test.rb
@@ -7,6 +7,9 @@ class ActionCable::Channel::RejectionTest < ActiveSupport::TestCase
     def subscribed
       reject if params[:id] > 0
     end
+
+    def secret_action
+    end
   end
 
   setup do
@@ -20,5 +23,17 @@ class ActionCable::Channel::RejectionTest < ActiveSupport::TestCase
 
     expected = { "identifier" => "{id: 1}", "type" => "reject_subscription" }
     assert_equal expected, @connection.last_transmission
+  end
+
+  test "does not execute action if subscription is rejected" do
+    @connection.expects(:subscriptions).returns mock().tap { |m| m.expects(:remove_subscription).with instance_of(SecretChannel) }
+    @channel = SecretChannel.new @connection, "{id: 1}", id: 1
+
+    expected = { "identifier" => "{id: 1}", "type" => "reject_subscription" }
+    assert_equal expected, @connection.last_transmission
+    assert_equal 1, @connection.transmissions.size
+
+    @channel.perform_action("action" => :secret_action)
+    assert_equal 1, @connection.transmissions.size
   end
 end


### PR DESCRIPTION
Fixes #23757.

Before this commit, even if `reject` was called in the `subscribe`
method for an Action Cable channel, all actions on that channel could
still be invoked. This calls a `return` if a rejected connection tries
to invoke any actions on the channel.
