### PR TITLE
Handle circular references in Object#as_json

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -51,7 +51,7 @@ class Object
     else
       instance_values.as_json(options)
     end
-  rescue SystemStackError => e
+  rescue SystemStackError
     raise JSON::GeneratorError.new('source contains circular reference')
   end
 end

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -51,6 +51,8 @@ class Object
     else
       instance_values.as_json(options)
     end
+  rescue SystemStackError => e
+    raise JSON::GeneratorError.new('source contains circular reference')
   end
 end
 

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -141,6 +141,15 @@ class TestJSONEncoding < ActiveSupport::TestCase
     assert_equal({"foo"=>"hello"}, JSON.parse(json))
   end
 
+  def test_object_to_json_with_circular_reference
+    obj1 = Object.new
+    obj2 = Object.new
+    obj1.instance_variable_set :@foo, obj2
+    obj2.instance_variable_set :@foo, obj1
+
+    assert_raises(JSON::GeneratorError) { obj1.as_json }
+  end
+
   def test_struct_to_json_with_options
     struct = Struct.new(:foo, :bar).new
     struct.foo = "hello"


### PR DESCRIPTION
Calling `as_json` on an object with circular references via instance variables (e.g. `REXML::Element` with a parent) will cause infinite recursion. Since `ActiveSupport` implements all the `as_json` methods, it might not be a bad idea to catch that error and provide more meaningful feedback about what's happening (also since stack level too deep errors are difficult to trace). I believe ruby 2.2 fixes stack traces for that exception, but it still might not be a bad idea to throw a better error.
