### PR TITLE
Remove `alias exec_without_stmt exec_query`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -134,8 +134,6 @@ module ActiveRecord
         ActiveRecord::Result.new(result.fields, result.to_a)
       end
 
-      alias exec_without_stmt exec_query
-
       def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
         execute to_sql(sql, binds), name
       end


### PR DESCRIPTION
This alias was for compatibility with legacy mysql adapter.
But the return value of both methods is already inconsistent.

`exec_query` returns `ActiveRecord::Result` instance.
But `exec_without_stmt` returns `[result_set, affected_rows]`

https://github.com/rails/rails/blob/v4.2.5.1/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb#L335-L364

Legacy mysql adapter was already removed in Rails 5.0.
I think we can remove this inconsistent alias.
