### PR TITLE
Fix HABTM associations join table resolver bug on constants and symbols

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -28,7 +28,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
           class_name = options.fetch(:class_name) {
             name.to_s.camelize.singularize
           }
-          KnownClass.new lhs_class, class_name
+          KnownClass.new lhs_class, class_name.to_s
         end
       end
     end

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -86,6 +86,10 @@ class DeveloperWithSymbolClassName < Developer
   has_and_belongs_to_many :projects, class_name: :ProjectWithSymbolsForKeys
 end
 
+class DeveloperWithConstantClassName < Developer
+  has_and_belongs_to_many :projects, class_name: ProjectWithSymbolsForKeys
+end
+
 class DeveloperWithExtendOption < Developer
   module NamedExtension
     def category
@@ -939,7 +943,15 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
   def test_with_symbol_class_name
     assert_nothing_raised do
-      DeveloperWithSymbolClassName.new
+      developer = DeveloperWithSymbolClassName.new
+      developer.projects
+    end
+  end
+
+  def test_with_constant_class_name
+    assert_nothing_raised do
+      developer = DeveloperWithConstantClassName.new
+      developer.projects
     end
   end
 


### PR DESCRIPTION
Using Constant and symbol class_name option for associations are valid but raises exception on HABTM associations.
There was a test case which tries to cover symbol class_name usage but doesn't cover correctly. Fixed both symbol usage and constant usage as well.

These are all working as expected now;

```
  has_and_belongs_to_many :foos, class_name: 'Foo'
  has_and_belongs_to_many :foos, class_name: :Foo
  has_and_belongs_to_many :foos, class_name: Foo
```

Closes #23767
