### PR TITLE
remove needless `debug_exception_response_format` config [ci skip]

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -166,14 +166,6 @@ class definition:
 config.api_only = true
 ```
 
-Optionally, in `config/environments/development.rb` add the following line
-to render error responses using the API format (JSON by default) when it
-is a local request:
-
-```ruby
-config.debug_exception_response_format = :api
-```
-
 Finally, inside `app/controllers/application_controller.rb`, instead of:
 
 ```ruby


### PR DESCRIPTION
Since a0343d11f1bf80a79e273c1d0cf9934ef2601e98, `debug_exception_response_format` config depends on `api_only`.
Therefore, if set the `api_only`, need to specify `debug_exception_response_format` is not.
