### PR TITLE
Enable to set 'accept-charset' for a form

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Enable to set 'accept-charset' for a form.
+
+    *Yuichiro Kaneko*
+
 *   Add `srcset` option to `image_tag` helper.
 
     *Roberto Miranda*

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -444,6 +444,7 @@ module ActionView
         html_options[:remote] = options.delete(:remote) if options.has_key?(:remote)
         html_options[:method] = options.delete(:method) if options.has_key?(:method)
         html_options[:enforce_utf8] = options.delete(:enforce_utf8) if options.has_key?(:enforce_utf8)
+        html_options[:charset] = options.delete(:charset) if options.has_key?(:charset)
         html_options[:authenticity_token] = options.delete(:authenticity_token)
 
         builder = instantiate_builder(object_name, object, options)

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -824,7 +824,12 @@ module ActionView
             # The following URL is unescaped, this is just a hash of options, and it is the
             # responsibility of the caller to escape all the values.
             html_options["action"]  = url_for(url_for_options)
-            html_options["accept-charset"] = "UTF-8"
+
+            if (html_options["enforce_utf8"] == false && html_options["charset"])
+              html_options["accept-charset"] = html_options.delete("charset")
+            else
+              html_options["accept-charset"] = "UTF-8"
+            end
 
             html_options["data-remote"] = true if html_options.delete("remote")
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1927,6 +1927,18 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_for_enforce_utf8_false_with_accept_charset
+    form_for(:post, enforce_utf8: false, charset: "Shift_JIS") do |f|
+      concat f.text_field(:title)
+    end
+
+    expected = whole_form("/", nil, nil, enforce_utf8: false, charset: "Shift_JIS") do
+      "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_for_with_remote_in_html
     form_for(@post, url: "/", html: { remote: true, id: "create-post", method: :patch }) do |f|
       concat f.text_field(:title)
@@ -3458,8 +3470,10 @@ class FormHelperTest < ActionView::TestCase
       txt
     end
 
-    def form_text(action = "/", id = nil, html_class = nil, remote = nil, multipart = nil, method = nil)
-      txt =  %{<form accept-charset="UTF-8" action="#{action}"}.dup
+    def form_text(action = "/", id = nil, html_class = nil, remote = nil, multipart = nil, method = nil, accept_charset = nil)
+      accept_charset ||= "UTF-8"
+
+      txt =  %{<form accept-charset="#{accept_charset}" action="#{action}"}.dup
       txt << %{ enctype="multipart/form-data"} if multipart
       txt << %{ data-remote="true"} if remote
       txt << %{ class="#{html_class}"} if html_class
@@ -3471,9 +3485,9 @@ class FormHelperTest < ActionView::TestCase
     def whole_form(action = "/", id = nil, html_class = nil, options = {})
       contents = block_given? ? yield : ""
 
-      method, remote, multipart = options.values_at(:method, :remote, :multipart)
+      method, remote, multipart, accept_charset = options.values_at(:method, :remote, :multipart, :charset)
 
-      form_text(action, id, html_class, remote, multipart, method) + hidden_fields(options.slice :method, :enforce_utf8) + contents + "</form>"
+      form_text(action, id, html_class, remote, multipart, method, accept_charset) + hidden_fields(options.slice :method, :enforce_utf8) + contents + "</form>"
     end
 
     def protect_against_forgery?

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -26,11 +26,12 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def form_text(action = "http://www.example.com", options = {})
-    remote, enctype, html_class, id, method = options.values_at(:remote, :enctype, :html_class, :id, :method)
+    remote, enctype, html_class, id, method, accept_charset = options.values_at(:remote, :enctype, :html_class, :id, :method, :charset)
 
     method = method.to_s == "get" ? "get" : "post"
+    accept_charset ||= "UTF-8"
 
-    txt =  %{<form accept-charset="UTF-8" action="#{action}"}.dup
+    txt =  %{<form accept-charset="#{accept_charset}" action="#{action}"}.dup
     txt << %{ enctype="multipart/form-data"} if enctype
     txt << %{ data-remote="true"} if remote
     txt << %{ class="#{html_class}"} if html_class
@@ -136,6 +137,13 @@ class FormTagHelperTest < ActionView::TestCase
   def test_form_tag_enforce_utf8_false
     actual = form_tag({}, enforce_utf8: false)
     expected = whole_form("http://www.example.com", enforce_utf8: false)
+    assert_dom_equal expected, actual
+    assert actual.html_safe?
+  end
+
+  def test_form_tag_enforce_utf8_false_with_accept_charset
+    actual = form_tag({}, enforce_utf8: false, charset: "Shift_JIS")
+    expected = whole_form("http://www.example.com", enforce_utf8: false, charset: "Shift_JIS")
     assert_dom_equal expected, actual
     assert actual.html_safe?
   end


### PR DESCRIPTION
Before this commit developers can not set 'accept-charset' for
a form generated by `#form_for` or `#form_tag`
(always 'accept-charset' is set to 'UTF-8').
But sometimes developers want to create forms whose character encoding
is not 'UTF-8' (e.g. 'Windows-31J').
This commit enable us to set 'accept-charset' if `enforce_utf8` is false
and a `:charset` option is given.
