### PR TITLE
Dependencies clean up

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -145,9 +145,9 @@ module ActiveSupport #:nodoc:
           # Get a list of the constants that were added
           new_constants = mod.local_constants - original_constants
 
-          # self[namespace] returns an Array of the constants that are being evaluated
+          # @stack[namespace] returns an Array of the constants that are being evaluated
           # for that namespace. For instance, if parent.rb requires child.rb, the first
-          # element of self[Object] will be an Array of the constants that were present
+          # element of @stack[Object] will be an Array of the constants that were present
           # before parent.rb was required. The second element will be an Array of the
           # constants that were present before child.rb was required.
           @stack[namespace].each do |namespace_constants|
@@ -262,7 +262,7 @@ module ActiveSupport #:nodoc:
       end
 
       def load_dependency(file)
-        if Dependencies.load? && ActiveSupport::Dependencies.constant_watch_stack.watching?
+        if Dependencies.load? && Dependencies.constant_watch_stack.watching?
           Dependencies.new_constants_in(Object) { yield }
         else
           yield

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -76,6 +76,7 @@ class DependenciesTest < ActiveSupport::TestCase
   def test_dependency_which_raises_exception_isnt_added_to_loaded_set
     with_loading do
       filename = 'dependencies/raises_exception'
+      expanded = File.expand_path(filename)
       $raises_exception_load_count = 0
 
       5.times do |count|
@@ -86,8 +87,8 @@ class DependenciesTest < ActiveSupport::TestCase
         assert_equal 'Loading me failed, so do not add to loaded or history.', e.message
         assert_equal count + 1, $raises_exception_load_count
 
-        assert_not ActiveSupport::Dependencies.loaded.include?(filename)
-        assert_not ActiveSupport::Dependencies.history.include?(filename)
+        assert_not ActiveSupport::Dependencies.loaded.include?(expanded)
+        assert_not ActiveSupport::Dependencies.history.include?(expanded)
       end
     end
   end
@@ -1044,14 +1045,6 @@ class DependenciesTest < ActiveSupport::TestCase
 
     assert Object.private_methods.include?(:load)
     assert Object.private_methods.include?(:require)
-  ensure
-    ActiveSupport::Dependencies.hook!
-  end
-
-  def test_unhook
-    ActiveSupport::Dependencies.unhook!
-    assert !Module.new.respond_to?(:const_missing_without_dependencies)
-    assert !Module.new.respond_to?(:load_without_new_constant_marking)
   ensure
     ActiveSupport::Dependencies.hook!
   end


### PR DESCRIPTION
This is my first Rails pull request. Kinda nervous/excited. Thanks for having a look.
I was reading through the `ActiveSupport::Dependencies` code and found four things that I thought could be enhanced. Two are in the test file, one is documentation, and the last one might be considered cosmetic. I'd be happy to remove it if you'd like.
I've explained the reasons for all of the changes in detail in the commit description.
Thanks!
