### PR TITLE
Add methods back to array delegation from ActiveRecord::Relation

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -37,7 +37,8 @@ module ActiveRecord
     # for each different klass, and the delegations are compiled into that subclass only.
 
     delegate :to_xml, :to_yaml, :length, :collect, :map, :each, :all?, :include?, :to_ary, :join,
-      :[], :&, :|, :+, :-, :sample, :shuffle, :reverse, :compact, to: :to_a
+             :[], :&, :|, :+, :-, :sample, :reverse, :compact, :in_groups, :in_groups_of,
+             :shuffle, :split, to: :to_a
 
     delegate :table_name, :quoted_table_name, :primary_key, :quoted_primary_key,
              :connection, :columns_hash, :to => :klass


### PR DESCRIPTION
### Summary

As of Rails 5.0.0.beta2, certain `Array` methods are no longer being delegated from `ActiveRecord::Relation`.   This PR adds back support for delegating  `#in_groups`, `#in_groups_of`, `#shuffle` and `#split`.

Steps to reproduce can be found here: https://gist.github.com/kdough/37ae37e80d29989a192c
### Changes

Delegation of some `Array` methods was removed in commit 9d79334. That change did add explicit delegation of a few methods that `Array` has but which aren't on `Enumerable`.  However, a few non-mutation methods were omitted.  This adds `Array` delegation of `#in_groups`, `#in_groups_of`,
`#shuffle` and `#split`.  This allows things like `MyThing.all.in_groups_of(3) { ... }` to continue working as they did before commit 9d79334.
### Notes
- A temporary workaround is to explicitly call `#to_a` on a relation before something like `#in_groups_of` as this performs as expected
- Thanks to matthewd and radar in #rubyonrails for pointing me in the right direction
