### PR TITLE
fix typo

### DIFF
--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -146,7 +146,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, country.treaties.count
   end
 
-  def test_join_table_composit_primary_key_should_not_warn
+  def test_join_table_composite_primary_key_should_not_warn
     country = Country.new(:name => 'India')
     country.country_id = 'c1'
     country.save!


### PR DESCRIPTION
Fixing typo in [has_and_belongs_to_many_associations_test.rb](https://github.com/rails/rails/blob/2df891dccdcfbdfb176c55297589712ac379f87d/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb#L149).
