### PR TITLE
Mutating the result of Relation#to_a should not affect the relation

### DIFF
--- a/activerecord/lib/active_record/association_relation.rb
+++ b/activerecord/lib/active_record/association_relation.rb
@@ -10,7 +10,7 @@ module ActiveRecord
     end
 
     def ==(other)
-      other == to_a
+      other == records
     end
 
     def build(*args, &block)

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -979,6 +979,10 @@ module ActiveRecord
       end
       alias_method :to_a, :to_ary
 
+      def records # :nodoc:
+        load_target
+      end
+
       # Adds one or more +records+ to the collection by setting their foreign keys
       # to the association's primary key. Returns +self+, so several appends may be
       # chained together.

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -45,7 +45,7 @@ module ActiveRecord
         end
 
         def get_records
-          return scope.limit(1).to_a if skip_statement_cache?
+          return scope.limit(1).records if skip_statement_cache?
 
           conn = klass.connection
           sc = reflection.association_scope_cache(conn, owner) do

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module NullRelation # :nodoc:
     def exec_queries
-      @records = []
+      @records = [].freeze
     end
 
     def pluck(*column_names)

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -187,7 +187,7 @@ module ActiveRecord
 
       loop do
         if load
-          records = batch_relation.to_a
+          records = batch_relation.records
           ids = records.map(&:id)
           yielded_relation = self.where(primary_key => ids)
           yielded_relation.load_records(records)

--- a/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
@@ -35,7 +35,7 @@ module ActiveRecord
         return to_enum(:each_record) unless block_given?
 
         @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, load: true).each do |relation|
-          relation.to_a.each { |record| yield record }
+          relation.records.each { |record| yield record }
         end
       end
 

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -38,7 +38,7 @@ module ActiveRecord
 
     delegate :to_xml, :to_yaml, :length, :collect, :map, :each, :all?, :include?, :to_ary, :join,
              :[], :&, :|, :+, :-, :sample, :reverse, :compact, :in_groups, :in_groups_of,
-             :shuffle, :split, to: :to_a
+             :shuffle, :split, to: :records
 
     delegate :table_name, :quoted_table_name, :primary_key, :quoted_primary_key,
              :connection, :columns_hash, :to => :klass

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -506,7 +506,7 @@ module ActiveRecord
     def find_some_ordered(ids)
       ids = ids.slice(offset_value || 0, limit_value || ids.size) || []
 
-      result = except(:limit, :offset).where(primary_key => ids).to_a
+      result = except(:limit, :offset).where(primary_key => ids).records
 
       if result.size == ids.size
         pk_type = @klass.type_for_attribute(primary_key)
@@ -522,7 +522,7 @@ module ActiveRecord
       if loaded?
         @records.first
       else
-        @take ||= limit(1).to_a.first
+        @take ||= limit(1).records.first
       end
     end
 
@@ -573,7 +573,7 @@ module ActiveRecord
     end
 
     def find_last(limit)
-      limit ? to_a.last(limit) : to_a.last
+      limit ? records.last(limit) : records.last
     end
   end
 end

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -29,7 +29,7 @@ module ActiveRecord
     # This is mainly intended for sharing common conditions between multiple associations.
     def merge(other)
       if other.is_a?(Array)
-        to_a & other
+        records & other
       elsif other
         spawn.merge!(other)
       else

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1273,6 +1273,16 @@ class RelationTest < ActiveRecord::TestCase
     assert posts.loaded?
   end
 
+  def test_to_a_should_dup_target
+    posts = Post.all
+
+    original_size = posts.size
+    removed = posts.to_a.pop
+
+    assert_equal original_size, posts.size
+    assert_includes posts.to_a, removed
+  end
+
   def test_build
     posts = Post.all
 


### PR DESCRIPTION
Clarifying this separation and enforcing relation immutability is the culmination of the previous efforts to remove the mutator method delegations.
