### PR TITLE
AppGenerator: Replace 'rake' with 'rails_command'

### DIFF
--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -22,7 +22,7 @@ $ rails new blog -m ~/template.rb
 $ rails new blog -m http://example.com/template.rb
 ```
 
-You can use the rake task `rails:template` to apply templates to an existing Rails application. The location of the template needs to be passed in to an environment variable named LOCATION. Again, this can either be path to a file or a URL.
+You can use the task `rails:template` to apply templates to an existing Rails application. The location of the template needs to be passed in to an environment variable named LOCATION. Again, this can either be path to a file or a URL.
 
 ```bash
 $ bin/rails rails:template LOCATION=~/template.rb
@@ -38,7 +38,7 @@ The Rails templates API is easy to understand. Here's an example of a typical Ra
 # template.rb
 generate(:scaffold, "person name:string")
 route "root to: 'people#index'"
-rake("db:migrate")
+rails_command("db:migrate")
 
 after_bundle do
   git :init
@@ -175,18 +175,24 @@ Executes an arbitrary command. Just like the backticks. Let's say you want to re
 run "rm README.rdoc"
 ```
 
-### rake(command, options = {})
+### rails_command(command, options = {})
 
-Runs the supplied rake tasks in the Rails application. Let's say you want to migrate the database:
+Runs the supplied task in the Rails application. Let's say you want to migrate the database:
 
 ```ruby
-rake "db:migrate"
+rails_command "db:migrate"
 ```
 
-You can also run rake tasks with a different Rails environment:
+You can also run tasks with a different Rails environment:
 
 ```ruby
-rake "db:migrate", env: 'production'
+rails_command "db:migrate", env: 'production'
+```
+
+You can also run tasks as a super-user:
+
+```ruby
+rails_command "log:clear", sudo: true
 ```
 
 ### route(routing_code)
@@ -226,7 +232,7 @@ CODE
 These methods let you ask questions from templates and decide the flow based on the user's answer. Let's say you want to Freeze Rails only if the user wants to:
 
 ```ruby
-rake("rails:freeze:gems") if yes?("Freeze rails gems?")
+rails_command("rails:freeze:gems") if yes?("Freeze rails gems?")
 # no?(question) acts just the opposite.
 ```
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Alias `rake` with `rails_command` in the Rails Application Templates API
+    following Rails 5 convention of preferring "rails" to "rake" to run tasks.
+
+    *claudiob*
+
 *   Change fail fast of `bin/rails test` interrupts run on error.
 
     *Yuji Yaginuma*

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -216,7 +216,7 @@ module Rails
         log :rake, command
         env  = options[:env] || ENV["RAILS_ENV"] || 'development'
         sudo = options[:sudo] && RbConfig::CONFIG['host_os'] !~ /mswin|mingw/ ? 'sudo ' : ''
-        in_root { run("#{sudo}#{extify(:rake)} #{command} RAILS_ENV=#{env}", verbose: false) }
+        in_root { run("#{sudo}#{extify(:rails)} #{command} RAILS_ENV=#{env}", verbose: false) }
       end
       alias :rails_command :rake
 

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -218,6 +218,7 @@ module Rails
         sudo = options[:sudo] && RbConfig::CONFIG['host_os'] !~ /mswin|mingw/ ? 'sudo ' : ''
         in_root { run("#{sudo}#{extify(:rake)} #{command} RAILS_ENV=#{env}", verbose: false) }
       end
+      alias :rails_command :rake
 
       # Just run the capify command in root
       #

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -239,6 +239,44 @@ class ActionsTest < Rails::Generators::TestCase
     end
   end
 
+  def test_rails_command_should_run_rails_command_with_default_env
+    assert_called_with(generator, :run, ["rake log:clear RAILS_ENV=development", verbose: false]) do
+      with_rails_env nil do
+        action :rails_command, 'log:clear'
+      end
+    end
+  end
+
+  def test_rails_command_with_env_option_should_run_rails_command_in_env
+    assert_called_with(generator, :run, ['rake log:clear RAILS_ENV=production', verbose: false]) do
+      action :rails_command, 'log:clear', env: 'production'
+    end
+  end
+
+  def test_rails_command_with_rails_env_variable_should_run_rails_command_in_env
+    assert_called_with(generator, :run, ['rake log:clear RAILS_ENV=production', verbose: false]) do
+      with_rails_env "production" do
+        action :rails_command, 'log:clear'
+      end
+    end
+  end
+
+  def test_env_option_should_win_over_rails_env_variable_when_running_rails
+    assert_called_with(generator, :run, ['rake log:clear RAILS_ENV=production', verbose: false]) do
+      with_rails_env "staging" do
+        action :rails_command, 'log:clear', env: 'production'
+      end
+    end
+  end
+
+  def test_rails_command_with_sudo_option_should_run_rails_command_with_sudo
+    assert_called_with(generator, :run, ["sudo rake log:clear RAILS_ENV=development", verbose: false]) do
+      with_rails_env nil do
+        action :rails_command, 'log:clear', sudo: true
+      end
+    end
+  end
+
   def test_capify_should_run_the_capify_command
     assert_called_with(generator, :run, ['capify .', verbose: false]) do
       action :capify!

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -202,7 +202,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_rake_should_run_rake_command_with_default_env
-    assert_called_with(generator, :run, ["rake log:clear RAILS_ENV=development", verbose: false]) do
+    assert_called_with(generator, :run, ["rails log:clear RAILS_ENV=development", verbose: false]) do
       with_rails_env nil do
         action :rake, 'log:clear'
       end
@@ -210,13 +210,13 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_rake_with_env_option_should_run_rake_command_in_env
-    assert_called_with(generator, :run, ['rake log:clear RAILS_ENV=production', verbose: false]) do
+    assert_called_with(generator, :run, ['rails log:clear RAILS_ENV=production', verbose: false]) do
       action :rake, 'log:clear', env: 'production'
     end
   end
 
   def test_rake_with_rails_env_variable_should_run_rake_command_in_env
-    assert_called_with(generator, :run, ['rake log:clear RAILS_ENV=production', verbose: false]) do
+    assert_called_with(generator, :run, ['rails log:clear RAILS_ENV=production', verbose: false]) do
       with_rails_env "production" do
         action :rake, 'log:clear'
       end
@@ -224,7 +224,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_env_option_should_win_over_rails_env_variable_when_running_rake
-    assert_called_with(generator, :run, ['rake log:clear RAILS_ENV=production', verbose: false]) do
+    assert_called_with(generator, :run, ['rails log:clear RAILS_ENV=production', verbose: false]) do
       with_rails_env "staging" do
         action :rake, 'log:clear', env: 'production'
       end
@@ -232,7 +232,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_rake_with_sudo_option_should_run_rake_command_with_sudo
-    assert_called_with(generator, :run, ["sudo rake log:clear RAILS_ENV=development", verbose: false]) do
+    assert_called_with(generator, :run, ["sudo rails log:clear RAILS_ENV=development", verbose: false]) do
       with_rails_env nil do
         action :rake, 'log:clear', sudo: true
       end
@@ -240,7 +240,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_rails_command_should_run_rails_command_with_default_env
-    assert_called_with(generator, :run, ["rake log:clear RAILS_ENV=development", verbose: false]) do
+    assert_called_with(generator, :run, ["rails log:clear RAILS_ENV=development", verbose: false]) do
       with_rails_env nil do
         action :rails_command, 'log:clear'
       end
@@ -248,13 +248,13 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_rails_command_with_env_option_should_run_rails_command_in_env
-    assert_called_with(generator, :run, ['rake log:clear RAILS_ENV=production', verbose: false]) do
+    assert_called_with(generator, :run, ['rails log:clear RAILS_ENV=production', verbose: false]) do
       action :rails_command, 'log:clear', env: 'production'
     end
   end
 
   def test_rails_command_with_rails_env_variable_should_run_rails_command_in_env
-    assert_called_with(generator, :run, ['rake log:clear RAILS_ENV=production', verbose: false]) do
+    assert_called_with(generator, :run, ['rails log:clear RAILS_ENV=production', verbose: false]) do
       with_rails_env "production" do
         action :rails_command, 'log:clear'
       end
@@ -262,7 +262,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_env_option_should_win_over_rails_env_variable_when_running_rails
-    assert_called_with(generator, :run, ['rake log:clear RAILS_ENV=production', verbose: false]) do
+    assert_called_with(generator, :run, ['rails log:clear RAILS_ENV=production', verbose: false]) do
       with_rails_env "staging" do
         action :rails_command, 'log:clear', env: 'production'
       end
@@ -270,7 +270,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_rails_command_with_sudo_option_should_run_rails_command_with_sudo
-    assert_called_with(generator, :run, ["sudo rake log:clear RAILS_ENV=development", verbose: false]) do
+    assert_called_with(generator, :run, ["sudo rails log:clear RAILS_ENV=development", verbose: false]) do
       with_rails_env nil do
         action :rails_command, 'log:clear', sudo: true
       end


### PR DESCRIPTION
Since Rails 5.0 is switching the Rails command line from 'rake …' to 'rails …', it makes sense to also replace the `rake` method in the Rails templates API.

Based on feedback from @matthewd and @kaspth, I chose to replace `rake` with `rails_command`, which is less confusing than the alternatives `rails` or `command` or `rails_run` and is not Thor-reserved word like `task`.
