### PR TITLE
The BINARY Operator is only needed for string columns

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -608,10 +608,10 @@ module ActiveRecord
       end
 
       def case_sensitive_comparison(table, attribute, column, value)
-        if value.nil? || column.case_sensitive?
-          super
-        else
+        if !value.nil? && column.collation && !column.case_sensitive?
           table[attribute].eq(Arel::Nodes::Bin.new(Arel::Nodes::BindParam.new))
+        else
+          super
         end
       end
 

--- a/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
@@ -51,4 +51,13 @@ class Mysql2CaseSensitivityTest < ActiveRecord::Mysql2TestCase
     cs_uniqueness_query = queries.detect { |q| q.match(/string_cs_column/) }
     assert_no_match(/binary/i, cs_uniqueness_query)
   end
+
+  def test_case_sensitive_comparison_for_binary_column
+    CollationTest.validates_uniqueness_of(:binary_column, case_sensitive: true)
+    CollationTest.create!(binary_column: 'A')
+    invalid = CollationTest.new(binary_column: 'A')
+    queries = assert_sql { invalid.save }
+    bin_uniqueness_query = queries.detect { |q| q.match(/binary_column/) }
+    assert_no_match(/\bBINARY\b/, bin_uniqueness_query)
+  end
 end

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define do
   create_table :collation_tests, id: false, force: true do |t|
     t.string :string_cs_column, limit: 1, collation: 'utf8_bin'
     t.string :string_ci_column, limit: 1, collation: 'utf8_general_ci'
+    t.binary :binary_column,    limit: 1
   end
 
   ActiveRecord::Base.connection.execute <<-SQL


### PR DESCRIPTION
Follow up to #13040.
