### PR TITLE
use method provided by minitest

### DIFF
--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -18,7 +18,7 @@ module Rails
       if output_inline? && result.failure && (!result.skipped? || options[:verbose])
         io.puts
         io.puts
-        io.puts format_failures(result).map { |line| color_output(line, by: result) }
+        io.puts color_output(result, by: result)
         io.puts
         io.puts format_rerun_snippet(result)
         io.puts
@@ -64,12 +64,6 @@ module Rails
 
       def format_line(result)
         "%s#%s = %.2f s = %s" % [result.class, result.name, result.time, result.result_code]
-      end
-
-      def format_failures(result)
-        result.failures.map do |failure|
-          "#{failure.result_label}:\n#{result.location}:\n#{failure.message}\n"
-        end
       end
 
       def format_rerun_snippet(result)


### PR DESCRIPTION
The process of converting `Test` to `String` is already defined in minitest.
I think it is better to use that for the consistency of output content.

ref: https://github.com/seattlerb/minitest/blob/master/lib/minitest/test.rb#L261..L267
