### PR TITLE
Change default value for ActionCable prod config

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/cable.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/cable.yml
@@ -1,7 +1,7 @@
 # Action Cable uses Redis by default to administer connections, channels, and sending/receiving messages over the WebSocket.
 production:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: <%= ENV["REDIS_URL"] %>
 
 development:
   adapter: async


### PR DESCRIPTION
# What

Change the default ActionCable Redis production URL to be fetched from the environment.
# Why

Values such as this are often [configured in the environment](http://12factor.net/config). For example, it is very common to have a `DATABASE_URL` environment variable for the primary database configuration. So much so that this is currently the default in a new Rails application. As such, let's do the same for ActionCable's Redis configuration.
## What have I done?

I briefly looked for a commit explaining the purpose for this value as is and didn't immediately see anything compelling. I'm sorry if there are specific reasons and this is a waste of time. I was compelled to submit a PR as it caused me some brief confusion as I attempted to deploy an ActionCable app to production.

Also FWIW, there have been a few other head scratcher so far. Having to go find all the things throughout that must be uncommented was a little weird, but I don't feel like I have enough understanding to make any reasonable suggestions about that yet.
