### PR TITLE
Add a note about downcasing submit tag

### DIFF
--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -294,6 +294,9 @@ Please refer to the [Changelog][action-view] for detailed changes.
     button on submit to prevent double submits.
     ([Pull Request](https://github.com/rails/rails/pull/21135))
 
+*   Downcase model name in form submit tags rather than humanize.
+    ([Pull Request](https://github.com/rails/rails/pull/22764))
+
 
 Action Mailer
 -------------


### PR DESCRIPTION
This is a notable change since this will cause confusing test failures for tests relying on the old naming scheme.
