### PR TITLE
Fix bug in JSON deserialization when column default is an empty string

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Handle JSON deserialization correctly if the column default from database
+    adapter returns `''` instead of `nil`.
+
+    *Johannes Opper*
+
 *   Ensure that mutations of the array returned from `ActiveRecord::Relation#to_a`
     do not affect the original relation, by returning a duplicate array each time.
 

--- a/activerecord/lib/active_record/coders/json.rb
+++ b/activerecord/lib/active_record/coders/json.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       end
 
       def self.load(json)
-        ActiveSupport::JSON.decode(json) unless json.nil?
+        ActiveSupport::JSON.decode(json) unless json.blank?
       end
     end
   end

--- a/activerecord/test/cases/coders/json_test.rb
+++ b/activerecord/test/cases/coders/json_test.rb
@@ -1,0 +1,15 @@
+require "cases/helper"
+
+module ActiveRecord
+  module Coders
+    class JSONTest < ActiveRecord::TestCase
+      def test_returns_nil_if_empty_string_given
+        assert_nil JSON.load("")
+      end
+
+      def test_returns_nil_if_nil_given
+        assert_nil JSON.load(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When `ActiveRecord::Coders::JSON` serialization is used and the default of the column returns `''` it raises the following error:

```
JSON::ParserError: A JSON text must at least contain two octets!
```

If MySQL is running in non-strict mode, it returns an empty string as column default for a text column:

``` ruby
def extract_default
  if blob_or_text_column?
    @default = null || strict ? nil : ''
  end
end
```

Since `''` is invalid JSON, there shouldn't be an attempt to parse it, it should be treated like nil.
ActiveRecord::Coders::JSON should behave consistently for all possible non-user-set column default values.
