### PR TITLE
Ensure actioncable behaves as expected with non-string queues

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Ensure ActionCable behaves correctly for non-string queue names.
+
+  *Jay Hayes*
+
 ## Rails 5.0.0.beta3 (February 24, 2016) ##
 
 *  Added `em_redis_connector` and `redis_connector` to

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -72,6 +72,7 @@ module ActionCable
       # Start streaming from the named <tt>broadcasting</tt> pubsub queue. Optionally, you can pass a <tt>callback</tt> that'll be used
       # instead of the default of just transmitting the updates straight to the subscriber.
       def stream_from(broadcasting, callback = nil)
+        broadcasting = String(broadcasting)
         # Don't send the confirmation until pubsub#subscribe is successful
         defer_subscription_confirmation!
 

--- a/actioncable/lib/action_cable/server/broadcasting.rb
+++ b/actioncable/lib/action_cable/server/broadcasting.rb
@@ -26,7 +26,7 @@ module ActionCable
       # Returns a broadcaster for a named <tt>broadcasting</tt> that can be reused. Useful when you have an object that
       # may need multiple spots to transmit to a specific broadcasting over and over.
       def broadcaster_for(broadcasting)
-        Broadcaster.new(self, broadcasting)
+        Broadcaster.new(self, String(broadcasting))
       end
 
       private

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -16,11 +16,28 @@ class ActionCable::Channel::StreamTest < ActionCable::TestCase
     end
   end
 
+  class SymbolChannel < ActionCable::Channel::Base
+    def subscribed
+      stream_from :channel
+    end
+  end
+
   test "streaming start and stop" do
     run_in_eventmachine do
       connection = TestConnection.new
       connection.expects(:pubsub).returns mock().tap { |m| m.expects(:subscribe).with("test_room_1", kind_of(Proc), kind_of(Proc)).returns stub_everything(:pubsub) }
       channel = ChatChannel.new connection, "{id: 1}", { id: 1 }
+
+      connection.expects(:pubsub).returns mock().tap { |m| m.expects(:unsubscribe) }
+      channel.unsubscribe_from_channel
+    end
+  end
+
+  test "stream from non-string channel" do
+    run_in_eventmachine do
+      connection = TestConnection.new
+      connection.expects(:pubsub).returns mock().tap { |m| m.expects(:subscribe).with("channel", kind_of(Proc), kind_of(Proc)).returns stub_everything(:pubsub) }
+      channel = SymbolChannel.new connection, ""
 
       connection.expects(:pubsub).returns mock().tap { |m| m.expects(:unsubscribe) }
       channel.unsubscribe_from_channel

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -14,7 +14,6 @@ class ActionCable::Channel::StreamTest < ActionCable::TestCase
     def send_confirmation
       transmit_subscription_confirmation
     end
-
   end
 
   test "streaming start and stop" do

--- a/actioncable/test/server/broadcasting_test.rb
+++ b/actioncable/test/server/broadcasting_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class BroadcastingTest < ActiveSupport::TestCase
+  class TestServer
+    include ActionCable::Server::Broadcasting
+  end
+
+  test "fetching a broadcaster converts the broadcasting queue to a string" do
+    broadcasting = :test_queue
+    server = TestServer.new
+    broadcaster = server.broadcaster_for(broadcasting)
+
+    assert_equal "test_queue", broadcaster.broadcasting
+  end
+end


### PR DESCRIPTION
# The problem

Using a non-string value for the queue name in ActionCable leads to baffling behavior. In my case, everything worked as expected locally (using the async adapter). When I delivered the app to prod (using the redis adapter), I was able to see heartbeat messages, but none of the application messages arrived. There were no errors in the logs.

After some debugging, I realized that the problem was the datatype of the queue used in my messages.

```
ActionCable.server.broadcast(:foos, foo: :bar)
```

Perhaps using a symbol as a queue name doesn't make sense, but for whatever reason it was my default behavior.

The error was more apparent with the PostgreSQL adapter as it's call to [`escape_identifier`](https://github.com/rails/rails/blob/c57e7239a8b82957bcb07534cb7c1a3dcef71864/actioncable/lib/action_cable/subscription_adapter/postgresql.rb#L15) fails for non-string types.
# The fix

I saw two options.
1. Reject non-string values
2. Convert values to string

I tend to think the former might be more desirable, namely "tell the user that there is a problem" vs. "it's wrong, but try to make it right". In this case, the implementation was the former was a bit simpler, so I opted to propose that change for feedback. As always, I'm happen to restructure in any way needed to help out.

Thanks :heart: 
