### PR TITLE
Improve Action Cable reconnection reliability

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.coffee.erb
+++ b/actioncable/app/assets/javascripts/action_cable.coffee.erb
@@ -21,3 +21,14 @@
       a.href
     else
       url
+
+  startDebugging: ->
+    @debugging = true
+
+  stopDebugging: ->
+    @debugging = null
+
+  log: (messages...) ->
+    if @debugging
+      messages.push(Date.now())
+      console.log("[ActionCable]", messages...)

--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -31,14 +31,16 @@ class ActionCable.Connection
 
   reopen: ->
     ActionCable.log("Reopening WebSocket, current state is #{@getState()}")
-    if @isClosed()
-      @open()
-    else
+    if @isAlive()
       try
         @close()
+      catch error
+        ActionCable.log("Failed to reopen WebSocket", error)
       finally
-        ActionCable.log("Failed to reopen WebSocket, retrying in #{@constructor.reopenDelay}ms")
+        ActionCable.log("Reopening WebSocket in #{@constructor.reopenDelay}ms")
         setTimeout(@open, @constructor.reopenDelay)
+    else
+      @open()
 
   isOpen: ->
     @isState("open")
@@ -46,7 +48,7 @@ class ActionCable.Connection
   # Private
 
   isAlive: ->
-    not @isState("closing", "closed")
+    @webSocket? and not @isState("closing", "closed")
 
   isState: (states...) ->
     @getState() in states

--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -21,6 +21,7 @@ class ActionCable.Connection
       throw new Error("Existing connection must be closed before opening")
     else
       console.log("[cable] Opening WebSocket, current state is #{@getState()}", Date.now())
+      @uninstallEventHandlers() if @webSocket?
       @webSocket = new WebSocket(@consumer.url)
       @installEventHandlers()
       true
@@ -58,6 +59,11 @@ class ActionCable.Connection
     for eventName of @events
       handler = @events[eventName].bind(this)
       @webSocket["on#{eventName}"] = handler
+    return
+
+  uninstallEventHandlers: ->
+    for eventName of @events
+      @webSocket["on#{eventName}"] = ->
     return
 
   events:

--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -17,8 +17,10 @@ class ActionCable.Connection
 
   open: =>
     if @webSocket and not @isState("closed")
+      console.log("[cable] Attemped to open WebSocket, but existing socket is #{@getState()}", Date.now())
       throw new Error("Existing connection must be closed before opening")
     else
+      console.log("[cable] Opening WebSocket", Date.now())
       @webSocket = new WebSocket(@consumer.url)
       @installEventHandlers()
       true
@@ -27,12 +29,14 @@ class ActionCable.Connection
     @webSocket?.close()
 
   reopen: ->
+    console.log("[cable] Reopening WebSocket, current state is #{@getState()}", Date.now())
     if @isState("closed")
       @open()
     else
       try
         @close()
       finally
+        console.log("[cable] Failed to reopen WebSocket, retrying in #{@constructor.reopenDelay}ms", Date.now())
         setTimeout(@open, @constructor.reopenDelay)
 
   isOpen: ->
@@ -66,13 +70,16 @@ class ActionCable.Connection
           @consumer.subscriptions.notify(identifier, "received", message)
 
     open: ->
+      console.log("[cable] WebSocket onopen event", Date.now())
       @disconnected = false
       @consumer.subscriptions.reload()
 
     close: ->
+      console.log("[cable] WebSocket onclose event", Date.now())
       @disconnect()
 
     error: ->
+      console.log("[cable] WebSocket onerror event", Date.now())
       @disconnect()
 
   disconnect: ->

--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -16,7 +16,7 @@ class ActionCable.Connection
       false
 
   open: =>
-    if @webSocket and not @isClosed()
+    if @isAlive()
       console.log("[cable] Attemped to open WebSocket, but existing socket is #{@getState()}", Date.now())
       throw new Error("Existing connection must be closed before opening")
     else
@@ -44,8 +44,8 @@ class ActionCable.Connection
 
   # Private
 
-  isClosed: ->
-    @isState("closing", "closed")
+  isAlive: ->
+    not @isState("closing", "closed")
 
   isState: (states...) ->
     @getState() in states

--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -17,10 +17,10 @@ class ActionCable.Connection
 
   open: =>
     if @isAlive()
-      console.log("[cable] Attemped to open WebSocket, but existing socket is #{@getState()}", Date.now())
+      ActionCable.log("Attemped to open WebSocket, but existing socket is #{@getState()}")
       throw new Error("Existing connection must be closed before opening")
     else
-      console.log("[cable] Opening WebSocket, current state is #{@getState()}", Date.now())
+      ActionCable.log("Opening WebSocket, current state is #{@getState()}")
       @uninstallEventHandlers() if @webSocket?
       @webSocket = new WebSocket(@consumer.url)
       @installEventHandlers()
@@ -30,14 +30,14 @@ class ActionCable.Connection
     @webSocket?.close()
 
   reopen: ->
-    console.log("[cable] Reopening WebSocket, current state is #{@getState()}", Date.now())
+    ActionCable.log("Reopening WebSocket, current state is #{@getState()}")
     if @isClosed()
       @open()
     else
       try
         @close()
       finally
-        console.log("[cable] Failed to reopen WebSocket, retrying in #{@constructor.reopenDelay}ms", Date.now())
+        ActionCable.log("Failed to reopen WebSocket, retrying in #{@constructor.reopenDelay}ms")
         setTimeout(@open, @constructor.reopenDelay)
 
   isOpen: ->
@@ -79,16 +79,16 @@ class ActionCable.Connection
           @consumer.subscriptions.notify(identifier, "received", message)
 
     open: ->
-      console.log("[cable] WebSocket onopen event", Date.now())
+      ActionCable.log("WebSocket onopen event")
       @disconnected = false
       @consumer.subscriptions.reload()
 
     close: ->
-      console.log("[cable] WebSocket onclose event", Date.now())
+      ActionCable.log("WebSocket onclose event")
       @disconnect()
 
     error: ->
-      console.log("[cable] WebSocket onerror event", Date.now())
+      ActionCable.log("WebSocket onerror event")
       @disconnect()
 
   disconnect: ->

--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -16,11 +16,11 @@ class ActionCable.Connection
       false
 
   open: =>
-    if @webSocket and not @isState("closed")
+    if @webSocket and not @isClosed()
       console.log("[cable] Attemped to open WebSocket, but existing socket is #{@getState()}", Date.now())
       throw new Error("Existing connection must be closed before opening")
     else
-      console.log("[cable] Opening WebSocket", Date.now())
+      console.log("[cable] Opening WebSocket, current state is #{@getState()}", Date.now())
       @webSocket = new WebSocket(@consumer.url)
       @installEventHandlers()
       true
@@ -30,7 +30,7 @@ class ActionCable.Connection
 
   reopen: ->
     console.log("[cable] Reopening WebSocket, current state is #{@getState()}", Date.now())
-    if @isState("closed")
+    if @isClosed()
       @open()
     else
       try
@@ -43,6 +43,9 @@ class ActionCable.Connection
     @isState("open")
 
   # Private
+
+  isClosed: ->
+    @isState("closing", "closed")
 
   isState: (states...) ->
     @getState() in states

--- a/actioncable/app/assets/javascripts/action_cable/connection_monitor.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection_monitor.coffee
@@ -33,10 +33,12 @@ class ActionCable.ConnectionMonitor
     @startedAt = now()
     @poll()
     document.addEventListener("visibilitychange", @visibilityDidChange)
+    console.log("[cable] ConnectionMonitor started, pollInterval is #{@getInterval()}ms", Date.now())
 
   stop: ->
     @stoppedAt = now()
     document.removeEventListener("visibilitychange", @visibilityDidChange)
+    console.log("[cable] ConnectionMonitor stopped", Date.now())
 
   poll: ->
     setTimeout =>
@@ -52,8 +54,12 @@ class ActionCable.ConnectionMonitor
 
   reconnectIfStale: ->
     if @connectionIsStale()
+      console.log("[cable] ConnectionMonitor detected stale connection, reconnectAttempts = #{@reconnectAttempts}", Date.now())
       @reconnectAttempts++
-      unless @disconnectedRecently()
+      if @disconnectedRecently()
+        console.log("[cable] ConnectionMonitor skipping repopen because recently disconnected at #{@disconnectedAt}", Date.now())
+      else
+        console.log("[cable] ConnectionMonitor reopening", Date.now())
         @consumer.connection.reopen()
 
   connectionIsStale: ->
@@ -66,6 +72,7 @@ class ActionCable.ConnectionMonitor
     if document.visibilityState is "visible"
       setTimeout =>
         if @connectionIsStale() or not @consumer.connection.isOpen()
+          console.log("[cable] ConnectionMonitor reopening stale connection after visibilitychange", Date.now())
           @consumer.connection.reopen()
       , 200
 

--- a/actioncable/app/assets/javascripts/action_cable/connection_monitor.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection_monitor.coffee
@@ -17,7 +17,7 @@ class ActionCable.ConnectionMonitor
     @reset()
     @pingedAt = now()
     delete @disconnectedAt
-    console.log("[cable] ConnectionMonitor connected", Date.now())
+    ActionCable.log("ConnectionMonitor connected")
 
   disconnected: ->
     @disconnectedAt = now()
@@ -34,12 +34,12 @@ class ActionCable.ConnectionMonitor
     @startedAt = now()
     @poll()
     document.addEventListener("visibilitychange", @visibilityDidChange)
-    console.log("[cable] ConnectionMonitor started, pollInterval is #{@getInterval()}ms", Date.now())
+    ActionCable.log("ConnectionMonitor started, pollInterval is #{@getInterval()}ms")
 
   stop: ->
     @stoppedAt = now()
     document.removeEventListener("visibilitychange", @visibilityDidChange)
-    console.log("[cable] ConnectionMonitor stopped", Date.now())
+    ActionCable.log("ConnectionMonitor stopped")
 
   poll: ->
     setTimeout =>
@@ -55,12 +55,12 @@ class ActionCable.ConnectionMonitor
 
   reconnectIfStale: ->
     if @connectionIsStale()
-      console.log("[cable] ConnectionMonitor detected stale connection, reconnectAttempts = #{@reconnectAttempts}", Date.now())
+      ActionCable.log("ConnectionMonitor detected stale connection, reconnectAttempts = #{@reconnectAttempts}")
       @reconnectAttempts++
       if @disconnectedRecently()
-        console.log("[cable] ConnectionMonitor skipping repopen because recently disconnected at #{@disconnectedAt}", Date.now())
+        ActionCable.log("ConnectionMonitor skipping reopen because recently disconnected at #{@disconnectedAt}")
       else
-        console.log("[cable] ConnectionMonitor reopening", Date.now())
+        ActionCable.log("ConnectionMonitor reopening")
         @consumer.connection.reopen()
 
   connectionIsStale: ->
@@ -73,7 +73,7 @@ class ActionCable.ConnectionMonitor
     if document.visibilityState is "visible"
       setTimeout =>
         if @connectionIsStale() or not @consumer.connection.isOpen()
-          console.log("[cable] ConnectionMonitor reopening stale connection after visibilitychange", Date.now())
+          ActionCable.log("ConnectionMonitor reopening stale connection after visibilitychange to #{document.visibilityState}")
           @consumer.connection.reopen()
       , 200
 

--- a/actioncable/app/assets/javascripts/action_cable/connection_monitor.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection_monitor.coffee
@@ -17,6 +17,7 @@ class ActionCable.ConnectionMonitor
     @reset()
     @pingedAt = now()
     delete @disconnectedAt
+    console.log("[cable] ConnectionMonitor connected", Date.now())
 
   disconnected: ->
     @disconnectedAt = now()

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -154,7 +154,7 @@ module ActionCable
         def handle_open
           connect if respond_to?(:connect)
           subscribe_to_internal_channel
-          beat
+          confirm_connection_monitor_subscription
 
           message_buffer.process!
           server.add_connection(self)
@@ -171,6 +171,13 @@ module ActionCable
           unsubscribe_from_internal_channel
 
           disconnect if respond_to?(:disconnect)
+        end
+
+        def confirm_connection_monitor_subscription
+          # Send confirmation message to the internal connection monitor channel.
+          # This ensures the connection monitor state is reset after a successful
+          # websocket connection.
+          transmit ActiveSupport::JSON.encode(identifier: ActionCable::INTERNAL[:identifiers][:ping], type: ActionCable::INTERNAL[:message_types][:confirmation])
         end
 
         def allow_request_origin?

--- a/actioncable/test/connection/base_test.rb
+++ b/actioncable/test/connection/base_test.rb
@@ -56,7 +56,7 @@ class ActionCable::Connection::BaseTest < ActionCable::TestCase
     run_in_eventmachine do
       connection = open_connection
 
-      connection.websocket.expects(:transmit).with(regexp_matches(/\_ping/))
+      connection.websocket.expects(:transmit).with({ identifier: "_ping", type: "confirm_subscription" }.to_json)
       connection.message_buffer.expects(:process!)
 
       connection.process


### PR DESCRIPTION
There three improvements here:
1. Treat "closing" state as "closed" when attempting to reconnect from the client side. We had tons of issues where websocket connections somehow get stuck in the "closing" state, which would prevent automatic reconnection and require a reload.
2. Add client side logging to make it easier to debug client side connection issues. This is turned off by default, but can be turned on with calling `ActionCable.startDebugging()` from inside your application's javascript.
3. Makes sure the client side `ActionCable.ConnectionMonitor#connected()` gets called upon successful websocket connection.
