### PR TITLE
Make sure the parameter parsers register API work with overidden mime types.

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -52,7 +52,7 @@ module ActionController
       self.session = session
       self.session_options = TestSession::DEFAULT_OPTIONS
       @custom_param_parsers = {
-        Mime[:xml] => lambda { |raw_post| Hash.from_xml(raw_post)['hash'] }
+        xml: lambda { |raw_post| Hash.from_xml(raw_post)['hash'] }
       }
     end
 
@@ -105,7 +105,7 @@ module ActionController
           when :url_encoded_form
             data = non_path_parameters.to_query
           else
-            @custom_param_parsers[content_mime_type] = ->(_) { non_path_parameters }
+            @custom_param_parsers[content_mime_type.symbol] = ->(_) { non_path_parameters }
             data = non_path_parameters.to_query
           end
         end

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -4,7 +4,7 @@ module ActionDispatch
       PARAMETERS_KEY = 'action_dispatch.request.path_parameters'
 
       DEFAULT_PARSERS = {
-        Mime[:json] => lambda { |raw_post|
+        Mime[:json].symbol => -> (raw_post) {
           data = ActiveSupport::JSON.decode(raw_post)
           data.is_a?(Hash) ? data : {:_json => data}
         }
@@ -51,7 +51,7 @@ module ActionDispatch
       def parse_formatted_parameters(parsers)
         return yield if content_length.zero?
 
-        strategy = parsers.fetch(content_mime_type) { return yield }
+        strategy = parsers.fetch(content_mime_type.symbol) { return yield }
 
         begin
           strategy.call(raw_post)

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -1,6 +1,8 @@
 module ActionDispatch
   module Http
     module Parameters
+      extend ActiveSupport::Concern
+
       PARAMETERS_KEY = 'action_dispatch.request.path_parameters'
 
       DEFAULT_PARSERS = {
@@ -10,13 +12,20 @@ module ActionDispatch
         }
       }
 
-      def self.included(klass)
-        class << klass
-          attr_accessor :parameter_parsers
+      included do
+        class << self
+          attr_reader :parameter_parsers
         end
 
-        klass.parameter_parsers = DEFAULT_PARSERS
+        self.parameter_parsers = DEFAULT_PARSERS
       end
+
+      module ClassMethods
+        def parameter_parsers=(parsers) # :nodoc:
+          @parameter_parsers = parsers.transform_keys { |key| key.respond_to?(:symbol) ? key.symbol : key }
+        end
+      end
+
       # Returns both GET and POST \parameters in a single hash.
       def parameters
         params = get_header("action_dispatch.request.parameters")

--- a/actionpack/lib/action_dispatch/middleware/params_parser.rb
+++ b/actionpack/lib/action_dispatch/middleware/params_parser.rb
@@ -37,6 +37,7 @@ module ActionDispatch
     # The +parsers+ argument can take Hash of parsers where key is identifying
     # content mime type, and value is a lambda that is going to process data.
     def self.new(app, parsers = {})
+      parsers = parsers.transform_keys { |key| key.respond_to?(:symbol) ? key.symbol : key }
       ActionDispatch::Request.parameter_parsers = ActionDispatch::Request::DEFAULT_PARSERS.merge(parsers)
       app
     end

--- a/actionpack/test/controller/webservice_test.rb
+++ b/actionpack/test/controller/webservice_test.rb
@@ -65,7 +65,7 @@ class WebServiceTest < ActionDispatch::IntegrationTest
 
   def test_register_and_use_json_simple
     with_test_route_set do
-      with_params_parsers Mime[:json] => Proc.new { |data| ActiveSupport::JSON.decode(data)['request'].with_indifferent_access } do
+      with_params_parsers json: Proc.new { |data| ActiveSupport::JSON.decode(data)['request'].with_indifferent_access } do
         post "/",
           params: '{"request":{"summary":"content...","title":"JSON"}}',
           headers: { 'CONTENT_TYPE' => 'application/json' }
@@ -99,7 +99,7 @@ class WebServiceTest < ActionDispatch::IntegrationTest
   def test_parsing_json_doesnot_rescue_exception
     req = Class.new(ActionDispatch::Request) do
       def params_parsers
-        { Mime[:json] => Proc.new { |data| raise Interrupt } }
+        { json: Proc.new { |data| raise Interrupt } }
       end
 
       def content_length; get_header('rack.input').length; end

--- a/actionpack/test/controller/webservice_test.rb
+++ b/actionpack/test/controller/webservice_test.rb
@@ -65,7 +65,7 @@ class WebServiceTest < ActionDispatch::IntegrationTest
 
   def test_register_and_use_json_simple
     with_test_route_set do
-      with_params_parsers json: Proc.new { |data| ActiveSupport::JSON.decode(data)['request'].with_indifferent_access } do
+      with_params_parsers Mime[:json] => Proc.new { |data| ActiveSupport::JSON.decode(data)['request'].with_indifferent_access } do
         post "/",
           params: '{"request":{"summary":"content...","title":"JSON"}}',
           headers: { 'CONTENT_TYPE' => 'application/json' }

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -151,19 +151,31 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
   end
 
   test "parses json params after custom json mime type registered" do
-    Mime::Type.register "application/json", :json, %w(application/vnd.api+json)
-    assert_parses(
-      {"user" => {"username" => "meinac"}, "username" => "meinac"},
-      "{\"username\": \"meinac\"}", { 'CONTENT_TYPE' => 'application/json' }
-    )
+    begin
+      Mime::Type.unregister :json
+      Mime::Type.register "application/json", :json, %w(application/vnd.api+json)
+      assert_parses(
+        {"user" => {"username" => "meinac"}, "username" => "meinac"},
+        "{\"username\": \"meinac\"}", { 'CONTENT_TYPE' => 'application/json' }
+      )
+    ensure
+      Mime::Type.unregister :json
+      Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest )
+    end
   end
 
   test "parses json params after custom json mime type registered with synonym" do
-    Mime::Type.register "application/json", :json, %w(application/vnd.api+json)
-    assert_parses(
-      {"user" => {"username" => "meinac"}, "username" => "meinac"},
-      "{\"username\": \"meinac\"}", { 'CONTENT_TYPE' => 'application/vnd.api+json' }
-    )
+    begin
+      Mime::Type.unregister :json
+      Mime::Type.register "application/json", :json, %w(application/vnd.api+json)
+      assert_parses(
+        {"user" => {"username" => "meinac"}, "username" => "meinac"},
+        "{\"username\": \"meinac\"}", { 'CONTENT_TYPE' => 'application/vnd.api+json' }
+      )
+    ensure
+      Mime::Type.unregister :json
+      Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest )
+    end
   end
 
   private

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -150,6 +150,22 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
+  test "parses json params after custom json mime type registered" do
+    Mime::Type.register "application/json", :json, %w(application/vnd.api+json)
+    assert_parses(
+      {"user" => {"username" => "meinac"}, "username" => "meinac"},
+      "{\"username\": \"meinac\"}", { 'CONTENT_TYPE' => 'application/json' }
+    )
+  end
+
+  test "parses json params after custom json mime type registered with synonym" do
+    Mime::Type.register "application/json", :json, %w(application/vnd.api+json)
+    assert_parses(
+      {"user" => {"username" => "meinac"}, "username" => "meinac"},
+      "{\"username\": \"meinac\"}", { 'CONTENT_TYPE' => 'application/vnd.api+json' }
+    )
+  end
+
   private
     def assert_parses(expected, actual, headers = {})
       with_test_routing(UsersController) do


### PR DESCRIPTION
Currently if you want to add a new mime type to an existing type like `application/vnd.api+json` it will not use the JSON parameter parser.

The reason is that we use the `Mime::Type` object as the key of the parameter parser hash.

Here is an example of how an application use this behavior.

``` ruby
Mime::Type.unregister :json
Mime::Type.register "application/json", :json, %w(text/x-json application/jsonrequest application/vnd.api+json)
```

To fix it we changed the parameter parsers internal representation to use the `Mime::Type`'s `symbol` method.

To not break the existing API, when instantiating the `ActionDispatch::ParamsParser` we accept `Mime::Type` instances but we change them to symbols.
