### PR TITLE
Prevent ActionMailer initializer from triggering load of ActionMailer

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -45,13 +45,6 @@ module ActionMailer
 
         options.each { |k,v| send("#{k}=", v) }
 
-        if options.show_previews
-          app.routes.prepend do
-            get '/rails/mailers'         => "rails/mailers#index", internal: true
-            get '/rails/mailers/*path'   => "rails/mailers#preview", internal: true
-          end
-        end
-
         ActionDispatch::IntegrationTest.send :include, ActionMailer::TestCase::ClearTestDeliveries
       end
     end
@@ -62,9 +55,18 @@ module ActionMailer
       end
     end
 
-    config.after_initialize do
-      if ActionMailer::Base.preview_path
-        ActiveSupport::Dependencies.autoload_paths << ActionMailer::Base.preview_path
+    config.after_initialize do |app|
+      options = app.config.action_mailer
+
+      if options.show_previews
+        app.routes.prepend do
+          get '/rails/mailers'         => "rails/mailers#index", internal: true
+          get '/rails/mailers/*path'   => "rails/mailers#preview", internal: true
+        end
+
+        if options.preview_path
+          ActiveSupport::Dependencies.autoload_paths << options.preview_path
+        end
       end
     end
   end


### PR DESCRIPTION
The ActionMailer railtie includes a reference to `ActionMailer::Base` in an `after_initialize` block. This causes ActionMailer to be loaded rather than lazily loaded when needed.

The `after_initialize` block has been changed to use the **configuration** from `config.action_mailer` rather than `ActionMailer::Base` so that action mailer is not loaded before it is necessary.

Also, the mailer preview routes setup have been moved out of an `on_load(:action_mailer)` block. Now that ActionMailer is correctly lazy-loading, the on_load may not fire during app configuration.
