### PR TITLE
Remove needless `drop_table :test_limits`

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -587,7 +587,6 @@ class MigrationTest < ActiveRecord::TestCase
 
   if current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter)
     def test_out_of_range_limit_should_raise
-      Person.connection.drop_table :test_limits rescue nil
       e = assert_raise(ActiveRecord::ActiveRecordError, "integer limit didn't raise") do
         Person.connection.create_table :test_integer_limits, :force => true do |t|
           t.column :bigone, :integer, :limit => 10
@@ -603,8 +602,6 @@ class MigrationTest < ActiveRecord::TestCase
           end
         end
       end
-
-      Person.connection.drop_table :test_limits rescue nil
     end
   end
 


### PR DESCRIPTION
A `:test_limits` table has not been created.
