### PR TITLE
Turbolinks 5 compatibility changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,9 +28,9 @@ GIT
 
 GIT
   remote: git://github.com/turbolinks/turbolinks-rails.git
-  revision: 1604dcd7bad911f1471d65e4f47cd19d844354f1
+  revision: 65884729016dbb4d032f12bb01b7e7c1ddeb68ac
   specs:
-    turbolinks (5.0.0.beta1)
+    turbolinks (5.0.0.beta2)
       turbolinks-source
 
 PATH
@@ -252,7 +252,7 @@ GEM
     thor (0.19.1)
     thread (0.1.7)
     thread_safe (0.3.5)
-    turbolinks-source (5.0.0.beta1.1)
+    turbolinks-source (5.0.0.beta2)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     tzinfo-data (1.2015.7)

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -335,8 +335,8 @@ include the 'data-turbolinks-track' option which causes turbolinks to check if
 an asset has been updated and if so loads it into the page:
 
 ```erb
-<%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track" => true %>
-<%= javascript_include_tag "application", "data-turbolinks-track" => true %>
+<%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track" => "reload" %>
+<%= javascript_include_tag "application", "data-turbolinks-track" => "reload" %>
 ```
 
 In regular views you can access images in the `public/assets/images` directory

--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -350,8 +350,8 @@ $("<%= escape_javascript(render @user) %>").appendTo("#users");
 Turbolinks
 ----------
 
-Rails 4 ships with the [Turbolinks gem](https://github.com/turbolinks/turbolinks).
-This gem uses Ajax to speed up page rendering in most applications.
+Rails ships with the [Turbolinks library](https://github.com/turbolinks/turbolinks),
+which uses Ajax to speed up page rendering in most applications.
 
 ### How Turbolinks Works
 
@@ -364,14 +364,14 @@ will then use PushState to change the URL to the correct one, preserving
 refresh semantics and giving you pretty URLs.
 
 The only thing you have to do to enable Turbolinks is have it in your Gemfile,
-and put `//= require turbolinks` in your CoffeeScript manifest, which is usually
+and put `//= require turbolinks` in your JavaScript manifest, which is usually
 `app/assets/javascripts/application.js`.
 
-If you want to disable Turbolinks for certain links, add a `data-no-turbolink`
+If you want to disable Turbolinks for certain links, add a `data-turbolinks="false"`
 attribute to the tag:
 
 ```html
-<a href="..." data-no-turbolink>No turbolinks here</a>.
+<a href="..." data-turbolinks="false">No turbolinks here</a>.
 ```
 
 ### Page Change Events
@@ -389,7 +389,7 @@ event that this relies on will not be fired. If you have code that looks like
 this, you must change your code to do this instead:
 
 ```coffeescript
-$(document).on "page:change", ->
+$(document).on "turbolinks:load", ->
   alert "page has loaded!"
 ```
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -328,8 +328,8 @@ module Rails
                                        "Use #{options[:javascript]} as the JavaScript library")
 
           unless options[:skip_turbolinks]
-            gems << GemfileEntry.version("turbolinks", nil,
-             "Turbolinks makes following links in your web application faster. Read more: https://github.com/turbolinks/turbolinks")
+            gems << GemfileEntry.version("turbolinks", "~> 5.0.0.beta",
+             "Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks")
           end
 
           gems

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -11,8 +11,8 @@
     <%%= stylesheet_link_tag    'application', media: 'all' %>
     <%- else -%>
       <%- if gemfile_entries.any? { |m| m.name == 'turbolinks' } -%>
-    <%%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-    <%%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+    <%%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => 'reload' %>
+    <%%= javascript_include_tag 'application', 'data-turbolinks-track' => 'reload' %>
       <%- else -%>
     <%%= stylesheet_link_tag    'application', media: 'all' %>
     <%%= javascript_include_tag 'application' %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -64,8 +64,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_assets
     run_generator
 
-    assert_file("app/views/layouts/application.html.erb", /stylesheet_link_tag\s+'application', media: 'all', 'data-turbolinks-track' => true/)
-    assert_file("app/views/layouts/application.html.erb", /javascript_include_tag\s+'application', 'data-turbolinks-track' => true/)
+    assert_file("app/views/layouts/application.html.erb", /stylesheet_link_tag\s+'application', media: 'all', 'data-turbolinks-track' => 'reload'/)
+    assert_file("app/views/layouts/application.html.erb", /javascript_include_tag\s+'application', 'data-turbolinks-track' => 'reload'/)
     assert_file("app/assets/stylesheets/application.css")
     assert_file("app/assets/javascripts/application.js")
   end


### PR DESCRIPTION
- Replaces `data-turbolinks-track="true"` with Turbolinks 5’s `data-turbolinks-track="reload"`
- Updates the app generator to use Turbolinks 5 beta gems
- Updates the Rails JavaScript guide for Turbolinks 5
