### PR TITLE
Fix `assert_nothing_raised` deprecation warning format

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -76,8 +76,9 @@ module ActiveSupport
     #   end
     def assert_nothing_raised(*args)
       if args.present?
-      ActiveSupport::Deprecation.warn("Passing arguments to assert_nothing_raised
-        is deprecated and will be removed in Rails 5.1.")
+        ActiveSupport::Deprecation.warn(
+          "Passing arguments to assert_nothing_raised " \
+          "is deprecated and will be removed in Rails 5.1.")
       end
       yield
     end


### PR DESCRIPTION
Before:

```
DEPRECATION WARNING: Passing arguments to assert_nothing_raised
        is deprecated and will be removed in Rails 5.1.
```

After:

```
DEPRECATION WARNING: Passing arguments to assert_nothing_raised is deprecated and will be removed in Rails 5.1.
```
