### PR TITLE
[ci skip] Improve the readability of documents of nested_attributes

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -195,15 +195,23 @@ module ActiveRecord
     # Nested attributes for an associated collection can also be passed in
     # the form of a hash of hashes instead of an array of hashes:
     #
-    #   Member.create(name:             'joe',
-    #                 posts_attributes: { first:  { title: 'Foo' },
-    #                                     second: { title: 'Bar' } })
+    #   Member.create(
+    #     name: 'joe',
+    #     posts_attributes: {
+    #       first:  { title: 'Foo' },
+    #       second: { title: 'Bar' }
+    #     }
+    #   )
     #
     # has the same effect as
     #
-    #   Member.create(name:             'joe',
-    #                 posts_attributes: [ { title: 'Foo' },
-    #                                     { title: 'Bar' } ])
+    #   Member.create(
+    #     name: 'joe',
+    #     posts_attributes: [
+    #       { title: 'Foo' },
+    #       { title: 'Bar' }
+    #     ]
+    #   )
     #
     # The keys of the hash which is the value for +:posts_attributes+ are
     # ignored in this case.


### PR DESCRIPTION
http://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html

Before

<img width="826" alt="2016-02-24 10 27 41" src="https://cloud.githubusercontent.com/assets/5356517/13272693/544e0960-dae1-11e5-84eb-5f879c8d612f.png">

After

<img width="776" alt="2016-02-24 10 27 53" src="https://cloud.githubusercontent.com/assets/5356517/13272698/5910e800-dae1-11e5-914e-420a120f2948.png">
