### PR TITLE
Add Ruby formatting to CHANGELOG entry

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## Rails 5.0.0.beta3 (February 24, 2016) ##
 
-*  Added ActionCable::SubscriptionAdapter::EventedRedis.em_redis_connector/redis_connector and
-   ActionCable::SubscriptionAdapter::Redis.redis_connector factory methods for redis connections, 
-   so you can overwrite with your own initializers. This is used when you want to use different-than-standard Redis adapters,
-   like for Makara distributed Redis.
+*  Added `em_redis_connector` and `redis_connector` to
+  `ActionCable::SubscriptionAdapter::EventedRedis` and added `redis_connector`
+   to `ActionCable::SubscriptionAdapter::Redis`, so you can overwrite with your
+   own initializers. This is used when you want to use different-than-standard
+   Redis adapters, like for Makara distributed Redis.
 
    *DHH*
 


### PR DESCRIPTION
[ci skip]

From this:
<img width="923" alt="old" src="https://cloud.githubusercontent.com/assets/10076/13293308/04d05f4e-dad4-11e5-913f-2045f2a5e071.png">

To this:
<img width="904" alt="new" src="https://cloud.githubusercontent.com/assets/10076/13293307/04b173d6-dad4-11e5-8671-25e02789f3eb.png">
