### PR TITLE
Don't put config.action_mailer.perform_caching entry twice in development.rb

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -16,10 +16,6 @@ Rails.application.configure do
   if Rails.root.join('tmp/caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 
-    <%- unless options.skip_action_mailer? -%>
-    config.action_mailer.perform_caching = false
-    <%- end -%>
-
     config.cache_store = :memory_store
     config.public_file_server.headers = {
       'Cache-Control' => 'public, max-age=172800'
@@ -27,16 +23,14 @@ Rails.application.configure do
   else
     config.action_controller.perform_caching = false
 
-    <%- unless options.skip_action_mailer? -%>
-    config.action_mailer.perform_caching = false
-    <%- end -%>
-
     config.cache_store = :null_store
   end
   <%- unless options.skip_action_mailer? -%>
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
+
+  config.action_mailer.perform_caching = false
   <%- end -%>
 
   # Print deprecation notices to the Rails logger.


### PR DESCRIPTION
Not sure this was intentional to duplicate but just noticed it while upgrading to beta3.

r? @rafaelfranca 
