### PR TITLE
Fix README heading according to Markdown conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Welcome to Rails
+# Welcome to Rails
 
 Rails is a web-application framework that includes everything needed to
 create database-backed web applications according to the

--- a/railties/lib/rails/generators/rails/app/templates/README.md
+++ b/railties/lib/rails/generators/rails/app/templates/README.md
@@ -1,4 +1,4 @@
-## README
+# README
 
 This README would normally document whatever steps are necessary to get the
 application up and running.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,4 +1,4 @@
-## Rails dev tools
+# Rails dev tools
 
 This is a collection of utilities used for Rails internal development.
 They aren't used by Rails apps directly.


### PR DESCRIPTION
In this patch I changed the heading of the main `README` and the automatically generated README by Railties. In my opinion the title of the README is of incorrect structure, because it uses a second level heading instead of a first level heading.
