### PR TITLE
Add #dig to ActionDispatch::Request::Session

### DIFF
--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -91,6 +91,13 @@ module ActionDispatch
         @delegate[key]
       end
 
+      # Returns the nested value specified by the sequence of key, returning
+      # nil if any intermediate step is nil.
+      def dig(*keys)
+        load_for_read!
+        @delegate.dig(*keys)
+      end
+
       # Returns true if the session has the given key or false.
       def has_key?(key)
         load_for_read!

--- a/actionpack/test/dispatch/request/session_test.rb
+++ b/actionpack/test/dispatch/request/session_test.rb
@@ -105,6 +105,17 @@ module ActionDispatch
         end
       end
 
+      def test_dig
+        session = Session.create(store, req, {})
+        session['one'] = {'two': '3'}
+
+        assert_equal '3', session.dig('one', 'two')
+        assert_equal '3', session.dig(:one, :two)
+
+        assert_nil session.dig('three', 'two')
+        assert_nil session.dig('one', 'four')
+      end
+
       def test_indifferent_access
         s = Session.create(store, req, {})
 


### PR DESCRIPTION
The `session` object is not a real Hash but responds to many methods of Hash
such as `[]`, `[]`, `fetch`, `has_key?`.

Since Ruby 2.3, Hash also supports a `dig` method.

This commit adds a `dig` method to `ActionDispatch::Request::Session` with the
same behavior as `Hash#dig`.

This is useful if you store a hash in your session, such as:

``` ruby
session[:user] = {'id': 1, 'avatar_url': 'http://example.org/nyancat.jpg'}
```

Then you can shorten your code from `session[:user][:avatar_url]` to `session.dig :user, :avatar_url`.
