### PR TITLE
Make ActionDispatch::Resquest#xml_http_request? actually return a boolean.

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -249,7 +249,7 @@ module ActionDispatch
     # (case-insensitive), which may need to be manually added depending on the
     # choice of JavaScript libraries and frameworks.
     def xml_http_request?
-      get_header('HTTP_X_REQUESTED_WITH') =~ /XMLHttpRequest/i
+      !!(get_header('HTTP_X_REQUESTED_WITH') =~ /XMLHttpRequest/i)
     end
     alias :xhr? :xml_http_request?
 


### PR DESCRIPTION
This improves method naming and value parity convention
