### PR TITLE
Add html_safe support to ActionView Array#OutputSafetyHelper

### DIFF
--- a/actionview/lib/action_view/helpers/output_safety_helper.rb
+++ b/actionview/lib/action_view/helpers/output_safety_helper.rb
@@ -33,6 +33,36 @@ module ActionView #:nodoc:
 
         array.flatten.map! { |i| ERB::Util.unwrapped_html_escape(i) }.join(sep).html_safe
       end
+
+      # Converts the array to a comma-separated sentence where the last element is
+      # joined by the connector word. This is the html_safe-aware version of
+      # ActiveSupport's {Array#to_sentence}[http://api.rubyonrails.org/classes/Array.html#method-i-to_sentence].
+      #
+      def to_sentence(array, options = {})
+        options.assert_valid_keys(:words_connector, :two_words_connector, :last_word_connector, :locale)
+
+        default_connectors = {
+          :words_connector     => ', ',
+          :two_words_connector => ' and ',
+          :last_word_connector => ', and '
+        }
+        if defined?(I18n)
+          i18n_connectors = I18n.translate(:'support.array', locale: options[:locale], default: {})
+          default_connectors.merge!(i18n_connectors)
+        end
+        options = default_connectors.merge!(options)
+
+        case array.length
+        when 0
+          ''.html_safe
+        when 1
+          ERB::Util.html_escape(array[0])
+        when 2
+          safe_join([array[0], array[1]], options[:two_words_connector])
+        else
+          safe_join([safe_join(array[0...-1], options[:words_connector]), options[:last_word_connector], array[-1]])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I realize there are a few incredibly objectionable proposals in this PR and my commits are not squashed, but I was hoping to open the discussion which might point me in a better direction. I beg you to first consider the concept of the change and not the implementation.

`Array#to_sentence` is not `html_safe`-aware. This can lead to `html_safe` calls in applications. When this pops up, many people are under the assumption that `to_sentence` is `html_safe`-aware.

We have a general feeling that `html_safe` should rarely if ever appear in application code and that the various helpers provided by rails should be able to provide `html_safe`-aware APIs. We even have a lint test to ensure that `html_safe` is not introduced in new code, and frequently the cause of the `html_safe` is a call to `to_sentence`.

[This require_relative](https://github.com/rails/rails/compare/master...oreoshake:to-sentence-html-safety?expand=1#diff-c065bec6b41f0b6ceeeeed9ddeae1dd6R6) is a pretty stinky code smell.

I wasn't sure what to do [here](https://github.com/rails/rails/compare/master...oreoshake:to-sentence-html-safety?expand=1#diff-c065bec6b41f0b6ceeeeed9ddeae1dd6R85) with the value previously wrapped in a string interpolation.

/cc @mastahyeti @ptoomey3 @gregose @aroben @nakajima
