### PR TITLE
Remove unused parameter from ActionCable::Channel::Base#transmit

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -190,8 +190,8 @@ module ActionCable
 
         # Transmit a hash of data to the subscriber. The hash will automatically be wrapped in a JSON envelope with
         # the proper channel identifier marked as the recipient.
-        def transmit(data, via: nil)
-          logger.info "#{self.class.name} transmitting #{data.inspect.truncate(300)}".tap { |m| m << " (via #{via})" if via }
+        def transmit(data)
+          logger.info "#{self.class.name} transmitting #{data.inspect.truncate(300)}"
           connection.transmit ActiveSupport::JSON.encode(identifier: @identifier, message: data)
         end
 

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -110,7 +110,7 @@ module ActionCable
 
         def default_stream_callback(broadcasting)
           -> (message) do
-            transmit ActiveSupport::JSON.decode(message), via: "streamed from #{broadcasting}"
+            transmit ActiveSupport::JSON.decode(message)
           end
         end
     end


### PR DESCRIPTION
The via parameter in ActionCable::Channel::Base#transmit appears to only be used for logging. It should probably be removed unless this is intentional or further implementation is expected.
