### PR TITLE
use consistent quoting in select_tag

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -136,16 +136,16 @@ module ActionView
           include_blank = options.delete(:include_blank)
 
           if include_blank == true
-            include_blank = ''
+            include_blank = ""
           end
 
           if include_blank
-            option_tags = content_tag("option".freeze, include_blank, value: '').safe_concat(option_tags)
+            option_tags = content_tag("option".freeze, include_blank, value: "").safe_concat(option_tags)
           end
         end
 
         if prompt = options.delete(:prompt)
-          option_tags = content_tag("option".freeze, prompt, value: '').safe_concat(option_tags)
+          option_tags = content_tag("option".freeze, prompt, value: "").safe_concat(option_tags)
         end
 
         content_tag "select".freeze, option_tags, { "name" => html_name, "id" => sanitize_to_id(name) }.update(options.stringify_keys)


### PR DESCRIPTION
### Problem

The [comments](https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/form_tag_helper.rb#L89-L130) and [documentation](http://apidock.com/rails/ActionView/Helpers/FormTagHelper/select_tag) indicate that the select tag should be returned in this format:

```
<select id="people" name="people"><option value=""></option><option value="1">David</option></select>
```

However, the select tag is actually returned in this format:

```
<select id="people" name="people"><option value=""></option><option value='1'>David</option></select>
```

The `value` is wrapped in a single quote instead of a double quote.
### Solution

This change modifies the `select_tag` method to return everything wrapped in double quotes, to match the documentation.
