### PR TITLE
Dup sql before sending to instrumentation.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -76,9 +76,10 @@ module ActiveRecord
       def cache_sql(sql, binds)
         result =
           if @query_cache[sql].key?(binds)
+            entry = @query_cache[sql][binds]
             ActiveSupport::Notifications.instrument("sql.active_record",
-              :sql => sql.freeze, :binds => binds.freeze, :name => "CACHE", :connection_id => object_id)
-            @query_cache[sql][binds]
+              :sql => sql, :binds => binds, :name => "CACHE", :connection_id => object_id)
+            entry
           else
             @query_cache[sql][binds] = yield
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -77,7 +77,7 @@ module ActiveRecord
         result =
           if @query_cache[sql].key?(binds)
             ActiveSupport::Notifications.instrument("sql.active_record",
-              :sql => sql, :binds => binds, :name => "CACHE", :connection_id => object_id)
+              :sql => sql.freeze, :binds => binds.freeze, :name => "CACHE", :connection_id => object_id)
             @query_cache[sql][binds]
           else
             @query_cache[sql][binds] = yield

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -524,7 +524,7 @@ module ActiveRecord
           :name           => name,
           :connection_id  => object_id,
           :statement_name => statement_name,
-          :binds          => binds) { yield }
+          :binds          => binds.freeze) { yield }
       rescue => e
         raise translate_exception_class(e, sql)
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -520,11 +520,11 @@ module ActiveRecord
       def log(sql, name = "SQL", binds = [], statement_name = nil)
         @instrumenter.instrument(
           "sql.active_record",
-          :sql            => sql.freeze,
+          :sql            => sql.dup,
           :name           => name,
           :connection_id  => object_id,
           :statement_name => statement_name,
-          :binds          => binds.freeze) { yield }
+          :binds          => binds.dup) { yield }
       rescue => e
         raise translate_exception_class(e, sql)
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -520,7 +520,7 @@ module ActiveRecord
       def log(sql, name = "SQL", binds = [], statement_name = nil)
         @instrumenter.instrument(
           "sql.active_record",
-          :sql            => sql,
+          :sql            => sql.freeze,
           :name           => name,
           :connection_id  => object_id,
           :statement_name => statement_name,

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -245,12 +245,10 @@ class QueryCacheTest < ActiveRecord::TestCase
     end
   end
 
-  def test_query_cache_freezes_they_key
+  def test_query_cache_works_when_mutating_payload
     callback = Proc.new do |*args, payload|
-      e = assert_raises(RuntimeError) do
-        payload[:sql].gsub!("*", "* ")
-      end
-      assert_equal "can't modify frozen String", e.message
+      payload[:sql].gsub!("*", "* ")
+      payload[:binds].clear
     end
 
     ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do


### PR DESCRIPTION
We should not allow a subscriber to mutate the query to be executed.

I found this because we had some bad code that were doing a `gsub!` in place for check some things on the query, however the query was been mutated and been pushed as a wrong key to the cache.

thoughts @rafaelfranca @matthewd @sgrif 

Not sure if I should write a regression test somewhere else too? maybe the subscriber?
