### PR TITLE
Update api_app.md to use "rake middleware" instead of "rails middleware"

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -228,7 +228,7 @@ building, and make sense in an API-only Rails application.
 You can get a list of all middleware in your application via:
 
 ```bash
-$ rails middleware
+$ rake middleware
 ```
 
 ### Using the Cache Middleware


### PR DESCRIPTION
### Summary

Simply updated "Using Rails for API-only Applications" to use the correct command for listing middleware. 
