### PR TITLE
[close #23681] Use puma 3.0.0+

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -181,7 +181,7 @@ module Rails
       def webserver_gemfile_entry
         return [] if options[:skip_puma]
         comment = 'Use Puma as the app server'
-        GemfileEntry.new('puma', nil, comment)
+        GemfileEntry.new('puma', '~> 3.0', comment)
       end
 
       def include_all_railties?

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -366,6 +366,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_generator_defaults_to_puma_version
+    run_generator [destination_root]
+    assert_gem "puma", "'~> 3.0'"
+  end
+
   def test_generator_if_skip_puma_is_given
     run_generator [destination_root, "--skip-puma"]
     assert_no_file "config/puma.rb"


### PR DESCRIPTION
Puma 3.0 and up introduced compatibility to read from `config/puma.rb` when booting from the command `$ rails server`https://github.com/puma/puma/pull/856.
