### PR TITLE
Allow http_cache_forever to be called without block

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -227,9 +227,11 @@ module ActionController
     def http_cache_forever(public: false, version: 'v1')
       expires_in 100.years, public: public
 
-      yield if stale?(etag: "#{version}-#{request.fullpath}",
-                      last_modified: Time.new(2011, 1, 1).utc,
-                      public: public)
+      if stale?(etag: "#{version}-#{request.fullpath}",
+                last_modified: Time.new(2011, 1, 1).utc,
+                public: public)
+        yield if block_given?
+      end
     end
 
     private

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -704,6 +704,10 @@ class HttpCacheForeverTest < ActionController::TestCase
         render plain: 'hello'
       end
     end
+
+    def cache_me_forever_without_block
+      http_cache_forever(public: params[:public], version: params[:version] || 'v1')
+    end
   end
 
   tests HttpCacheForeverController
@@ -746,6 +750,14 @@ class HttpCacheForeverTest < ActionController::TestCase
     @request.if_none_match = @response.etag
 
     get :cache_me_forever, params: {version: 'v2'}
+    assert_response :not_modified
+  end
+
+  def test_cache_forever_without_block
+    get :cache_me_forever_without_block
+    assert_response :success
+    @request.if_modified_since = @response.headers['Last-Modified']
+    get :cache_me_forever_without_block
     assert_response :not_modified
   end
 end

--- a/actionpack/test/fixtures/http_cache_forever_test/http_cache_forever/cache_me_forever_without_block.html.erb
+++ b/actionpack/test/fixtures/http_cache_forever_test/http_cache_forever/cache_me_forever_without_block.html.erb
@@ -1,0 +1,1 @@
+Hello, I am getting cached forever without any block!


### PR DESCRIPTION
- When using just a normal template without a rendering something inline,
  we still have to use empty block with http_cache_forever.

``` ruby
      def index
        # index.html.erb to be rendered.
        http_cache_forever(version: '1', public: true) {}
      end
```
- This commit allows it to be called without that empty block.

``` ruby
       def index
         # index.html.erb to be rendered.
         http_cache_forever(version: '1', public: true)
       end
```
