### PR TITLE
Revise #23717 (Add "Rendering ..." message) using proper ActiveSupport::LogSubscriber#start

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*  Added log "Rendering ...", when starting to render a template to log that
+   we have started rendering something. This helps to easily identify the origin
+   of queries in the log whether they came from controller or views.
+
+   *Vipul A M and Prem Sichanugrist*
+
 ## Rails 5.0.0.beta3 (February 24, 2016) ##
 
 *   Collection rendering can cache and fetch multiple partials at once.

--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -30,13 +30,12 @@ module ActionView
       end
     end
 
-
-    def start_rendering(event)
-      info do
-        message = "Rendering #{from_rails_root(event.payload[:identifier])}"
-        message << " within #{from_rails_root(event.payload[:layout])}" if event.payload[:layout]
-        message
+    def start(name, id, payload)
+      if name == "render_template.action_view"
+        log_rendering_start(payload)
       end
+
+      super
     end
 
     def logger
@@ -61,6 +60,16 @@ module ActionView
         "[#{payload[:cache_hits]} / #{payload[:count]} cache hits]"
       else
         "[#{payload[:count]} times]"
+      end
+    end
+
+  private
+
+    def log_rendering_start(payload)
+      info do
+        message = "  Rendering #{from_rails_root(payload[:identifier])}"
+        message << " within #{from_rails_root(payload[:layout])}" if payload[:layout]
+        message
       end
     end
   end

--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -30,6 +30,15 @@ module ActionView
       end
     end
 
+
+    def start_rendering(event)
+      info do
+        message = "Rendering #{from_rails_root(event.payload[:identifier])}"
+        message << " within #{from_rails_root(event.payload[:layout])}" if event.payload[:layout]
+        message
+      end
+    end
+
     def logger
       ActionView::Base.logger
     end

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -50,7 +50,6 @@ module ActionView
       view, locals = @view, locals || {}
 
       render_with_layout(layout_name, locals) do |layout|
-        ActiveSupport::Notifications.instrument("start_rendering.action_view", identifier: template.identifier, layout: layout.try(:virtual_path))
         instrument(:template, :identifier => template.identifier, :layout => layout.try(:virtual_path)) do
           template.render(view, locals) { |*name| view._layout_for(*name) }
         end

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -50,6 +50,7 @@ module ActionView
       view, locals = @view, locals || {}
 
       render_with_layout(layout_name, locals) do |layout|
+        ActiveSupport::Notifications.instrument("start_rendering.action_view", identifier: template.identifier, layout: layout.try(:virtual_path))
         instrument(:template, :identifier => template.identifier, :layout => layout.try(:virtual_path)) do
           template.render(view, locals) { |*name| view._layout_for(*name) }
         end

--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -35,7 +35,8 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
       @view.render(:file => "test/hello_world")
       wait
 
-      assert_equal 1, @logger.logged(:info).size
+      assert_equal 2, @logger.logged(:info).size
+      assert_match(/Rendering test\/hello_world\.erb/, @logger.logged(:info).first)
       assert_match(/Rendered test\/hello_world\.erb/, @logger.logged(:info).last)
     end
   end
@@ -45,7 +46,8 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
       @view.render(:text => "TEXT")
       wait
 
-      assert_equal 1, @logger.logged(:info).size
+      assert_equal 2, @logger.logged(:info).size
+      assert_match(/Rendering text template/, @logger.logged(:info).first)
       assert_match(/Rendered text template/, @logger.logged(:info).last)
     end
   end
@@ -55,7 +57,8 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
       @view.render(:inline => "<%= 'TEXT' %>")
       wait
 
-      assert_equal 1, @logger.logged(:info).size
+      assert_equal 2, @logger.logged(:info).size
+      assert_match(/Rendering inline template/, @logger.logged(:info).first)
       assert_match(/Rendered inline template/, @logger.logged(:info).last)
     end
   end


### PR DESCRIPTION
I revise #23717 by defining `#start` method instead of instrument another event.

r? @rafaelfranca 
