### PR TITLE
Always use redis_connector to create redis connections 

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -33,7 +33,7 @@ module ActionCable
       end
 
       def redis_connection_for_subscriptions
-        ::Redis.new(@server.config.cable)
+        redis_connection
       end
 
       private
@@ -43,8 +43,12 @@ module ActionCable
 
         def redis_connection_for_broadcasts
           @redis_connection_for_broadcasts || @server.mutex.synchronize do
-            @redis_connection_for_broadcasts ||= self.class.redis_connector.call(@server.config.cable)
+            @redis_connection_for_broadcasts ||= redis_connection
           end
+        end
+
+        def redis_connection
+          self.class.redis_connector.call(@server.config.cable)
         end
 
         class Listener < SubscriberMap


### PR DESCRIPTION
Currently, `redis_connection_for_subscriptions` is bypassing the `redis_connector` in redis subscription adapter. This ensures we use the same redis connector for all the redis connections.
