### PR TITLE
Specify plaform: :mri for byebug

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -26,7 +26,7 @@ source 'https://rubygems.org'
 <% if RUBY_ENGINE == 'ruby' -%>
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug'
+  gem 'byebug', platform: :mri
 end
 
 group :development do


### PR DESCRIPTION
### Summary

This PR specifies a platform for `byebug`. Since it only works with MRI, let's specify that It. It makes it easier to try out new platforms. It has the side benefit of exposing users to the `platform` option in a Gemfile.
