### PR TITLE
remove rack cors initializer when updating

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -93,6 +93,7 @@ module Rails
       active_record_belongs_to_required_by_default_config_exist = File.exist?('config/initializers/active_record_belongs_to_required_by_default.rb')
       action_cable_config_exist = File.exist?('config/cable.yml')
       ssl_options_exist = File.exist?('config/initializers/ssl_options.rb')
+      rack_cors_config_exist = File.exist?('config/initializers/cors.rb')
 
       config
 
@@ -114,6 +115,10 @@ module Rails
 
       unless ssl_options_exist
         remove_file 'config/initializers/ssl_options.rb'
+      end
+
+      unless rack_cors_config_exist
+        remove_file 'config/initializers/cors.rb'
       end
     end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -269,6 +269,32 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_rails_update_does_not_create_rack_cors
+    app_root = File.join(destination_root, 'myapp')
+    run_generator [app_root]
+
+    stub_rails_application(app_root) do
+      generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+      generator.send(:app_const)
+      quietly { generator.send(:update_config_files) }
+      assert_no_file "#{app_root}/config/initializers/cors.rb"
+    end
+  end
+
+  def test_rails_update_does_not_remove_rack_cors_if_already_present
+    app_root = File.join(destination_root, 'myapp')
+    run_generator [app_root]
+
+    FileUtils.touch("#{app_root}/config/initializers/cors.rb")
+
+    stub_rails_application(app_root) do
+      generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+      generator.send(:app_const)
+      quietly { generator.send(:update_config_files) }
+      assert_file "#{app_root}/config/initializers/cors.rb"
+    end
+  end
+
   def test_application_names_are_not_singularized
     run_generator [File.join(destination_root, "hats")]
     assert_file "hats/config/environment.rb", /Rails\.application\.initialize!/


### PR DESCRIPTION
Rack cors initializer is only necessary to API-only applications, for when the update is unnecessary.
