### PR TITLE
Update deprecation message shown when tasks from rails namespace are run

### DIFF
--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -73,8 +73,8 @@ namespace :rails do
   %i(update template templates:copy update:configs update:bin).each do |task_name|
     task "#{task_name}" do
       ActiveSupport::Deprecation.warn(<<-MSG.squish)
-        Running #{task_name} with the rails: namespace is deprecated in favor of app.
-        Run e.g. bin/rails app:#{task_name} instead."
+        Running #{task_name} with the rails: namespace is deprecated in favor of app: namespace.
+        Run bin/rails app:#{task_name} instead.
       MSG
       Rake.application.invoke_task("app:#{task_name}")
     end


### PR DESCRIPTION
### Summary

Improved the deprecation message show when tasks under `rails:` namespace are run.

r? @kaspth 
