### PR TITLE
Introduce Module#delegate_missing_to

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,50 @@
+*   Introduce Module#delegate_missing_to
+
+    When building a decorator, a common pattern emerges:
+
+        class Partition
+          def initialize(first_event)
+            @events = [ first_event ]
+          end
+
+          def people
+            if @events.first.detail.people.any?
+              @events.collect { |e| Array(e.detail.people) }.flatten.uniq
+            else
+              @events.collect(&:creator).uniq
+            end
+          end
+
+          private
+            def respond_to_missing?(name, include_private = false)
+              @events.respond_to?(name, include_private)
+            end
+
+            def method_missing(method, *args, &block)
+              @events.send(method, *args, &block)
+            end
+        end
+
+    With `Module#delegate_missing_to`, the above is condensed to:
+
+        class Partition
+          delegate_missing_to :@events
+
+          def initialize(first_event)
+            @events = [ first_event ]
+          end
+
+          def people
+            if @events.first.detail.people.any?
+              @events.collect { |e| Array(e.detail.people) }.flatten.uniq
+            else
+              @events.collect(&:creator).uniq
+            end
+          end
+        end
+
+    *Genadi Samokovarov*, *DHH*
+
 ## Rails 5.0.0.beta3 (February 24, 2016) ##
 
 *   Deprecate arguments on `assert_nothing_raised`.

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -148,7 +148,6 @@ class Module
   #   Foo.new("Bar").name # raises NoMethodError: undefined method `name'
   #
   # The target method must be public, otherwise it will raise +NoMethodError+.
-  #
   def delegate(*methods)
     options = methods.pop
     unless options.is_a?(Hash) && to = options[:to]
@@ -214,5 +213,65 @@ class Module
 
       module_eval(method_def, file, line)
     end
+  end
+
+  # When building decorators, a common pattern may emerge:
+  #
+  #   class Partition
+  #     def initialize(first_event)
+  #       @events = [ first_event ]
+  #     end
+  #
+  #     def people
+  #       if @events.first.detail.people.any?
+  #         @events.collect { |e| Array(e.detail.people) }.flatten.uniq
+  #       else
+  #         @events.collect(&:creator).uniq
+  #       end
+  #     end
+  #
+  #     private
+  #       def respond_to_missing?(name, include_private = false)
+  #         @events.respond_to?(name, include_private)
+  #       end
+  #
+  #       def method_missing(method, *args, &block)
+  #         @events.send(method, *args, &block)
+  #       end
+  #   end
+  #
+  # With `Module#delegate_missing_to`, the above is condensed to:
+  #
+  #   class Partition
+  #     delegate_missing_to :@events
+  #
+  #     def initialize(first_event)
+  #       @events = [ first_event ]
+  #     end
+  #
+  #     def people
+  #       if @events.first.detail.people.any?
+  #         @events.collect { |e| Array(e.detail.people) }.flatten.uniq
+  #       else
+  #         @events.collect(&:creator).uniq
+  #       end
+  #     end
+  #   end
+  #
+  # The target can be anything callable withing the object. E.g. instance
+  # variables, methods, constants ant the likes.
+  def delegate_missing_to(target)
+    target = target.to_s
+    target = "self.#{target}" if DELEGATION_RESERVED_METHOD_NAMES.include?(target)
+
+    module_eval <<-RUBY, __FILE__, __LINE__ + 1
+      def respond_to_missing?(name, include_private = false)
+        #{target}.respond_to?(name, include_private)
+      end
+
+      def method_missing(method, *args, &block)
+        #{target}.send(method, *args, &block)
+      end
+    RUBY
   end
 end

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -83,6 +83,20 @@ Product = Struct.new(:name) do
   end
 end
 
+DecoratedTester = Struct.new(:client) do
+  delegate_missing_to :client
+end
+
+class DecoratedReserved
+  delegate_missing_to :case
+
+  attr_reader :case
+
+  def initialize(kase)
+    @case = kase
+  end
+end
+
 class Block
   def hello?
     true
@@ -314,6 +328,14 @@ class ModuleTest < ActiveSupport::TestCase
   def test_delegation_with_method_arguments
     has_block = HasBlock.new(Block.new)
     assert has_block.hello?
+  end
+
+  def test_delegate_to_missing_with_method
+    assert_equal "David", DecoratedTester.new(@david).name
+  end
+
+  def test_delegate_to_missing_with_reserved_methods
+    assert_equal "David", DecoratedReserved.new(@david).name
   end
 
   def test_parent


### PR DESCRIPTION
When building decorators, a common pattern may emerge:

```
class Partition
  def initialize(first_event)
    @events = [ first_event ]
  end

  def people
    if @events.first.detail.people.any?
      @events.collect { |e| Array(e.detail.people) }.flatten.uniq
    else
      @events.collect(&:creator).uniq
    end
  end

  private
    def respond_to_missing?(name, include_private = false)
      @events.respond_to?(name, include_private)
    end

    def method_missing(method, *args, &block)
      @events.send(method, *args, &block)
    end
end
```

With `Module#delegate_missing_to`, the above is condensed to:

```
class Partition
  delegate_missing_to :@events

  def initialize(first_event)
    @events = [ first_event ]
  end

  def people
    if @events.first.detail.people.any?
      @events.collect { |e| Array(e.detail.people) }.flatten.uniq
    else
      @events.collect(&:creator).uniq
    end
  end
end
```

David suggested it in #23824.
