### PR TITLE
Remove load_paths file

### DIFF
--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -1,8 +1,5 @@
-require File.expand_path('../../../load_paths', __FILE__)
-
 require 'action_cable'
 require 'active_support/testing/autorun'
-
 
 require 'puma'
 

--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../load_paths', __FILE__)
 require 'active_support/core_ext/kernel/reporting'
 
 # These are the normal settings that will be set up by Railties

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -1,5 +1,3 @@
-require File.expand_path('../../../load_paths', __FILE__)
-
 $:.unshift(File.dirname(__FILE__) + '/lib')
 $:.unshift(File.dirname(__FILE__) + '/fixtures/helpers')
 $:.unshift(File.dirname(__FILE__) + '/fixtures/alternate_helpers')

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -1,5 +1,3 @@
-require File.expand_path('../../../load_paths', __FILE__)
-
 $:.unshift(File.dirname(__FILE__) + '/lib')
 $:.unshift(File.dirname(__FILE__) + '/fixtures/helpers')
 $:.unshift(File.dirname(__FILE__) + '/fixtures/alternate_helpers')

--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -1,5 +1,3 @@
-require File.expand_path('../../../load_paths', __FILE__)
-
 require 'active_job'
 require 'support/job_buffer'
 

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -1,5 +1,3 @@
-require File.expand_path('../../../../load_paths', __FILE__)
-
 require 'active_model'
 require 'active_support/core_ext/string/access'
 

--- a/activerecord/examples/performance.rb
+++ b/activerecord/examples/performance.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../load_paths', __FILE__)
 require "active_record"
 require 'benchmark/ips'
 

--- a/activerecord/examples/simple.rb
+++ b/activerecord/examples/simple.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../load_paths', __FILE__)
 require 'active_record'
 
 class Person < ActiveRecord::Base

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -1,5 +1,3 @@
-require File.expand_path('../../../../load_paths', __FILE__)
-
 require 'config'
 
 require 'active_support/testing/autorun'

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -1,12 +1,5 @@
 ORIG_ARGV = ARGV.dup
 
-begin
-  old, $VERBOSE = $VERBOSE, nil
-  require File.expand_path('../../../load_paths', __FILE__)
-ensure
-  $VERBOSE = old
-end
-
 require 'active_support/core_ext/kernel/reporting'
 
 silence_warnings do

--- a/load_paths.rb
+++ b/load_paths.rb
@@ -1,3 +1,0 @@
-# bust gem prelude
-require 'bundler'
-Bundler.setup

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -1,7 +1,5 @@
 ENV["RAILS_ENV"] ||= "test"
 
-require File.expand_path("../../../load_paths", __FILE__)
-
 require 'stringio'
 require 'active_support/testing/autorun'
 require 'active_support/testing/stream'

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -311,10 +311,6 @@ module TestHelpers
     end
 
     def boot_rails
-      # FIXME: shush Sass warning spam, not relevant to testing Railties
-      Kernel.silence_warnings do
-        require File.expand_path('../../../../load_paths', __FILE__)
-      end
     end
   end
 end
@@ -336,12 +332,8 @@ Module.new do
   FileUtils.rm_rf(app_template_path)
   FileUtils.mkdir(app_template_path)
 
-  environment = File.expand_path('../../../../load_paths', __FILE__)
-  require_environment = "-r #{environment}"
-
-  `#{Gem.ruby} #{require_environment} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails new #{app_template_path} --skip-gemfile --skip-listen --no-rc`
+  `#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails new #{app_template_path} --skip-gemfile --skip-listen --no-rc`
   File.open("#{app_template_path}/config/boot.rb", 'w') do |f|
-    f.puts "require '#{environment}'"
     f.puts "require 'rails/all'"
   end
 end unless defined?(RAILS_ISOLATED_ENGINE)

--- a/railties/test/railties/generators_test.rb
+++ b/railties/test/railties/generators_test.rb
@@ -26,11 +26,7 @@ module RailtiesTests
     end
 
     def rails(cmd)
-      environment = File.expand_path('../../../../load_paths', __FILE__)
-      if File.exist?("#{environment}.rb")
-        require_environment = "-r #{environment}"
-      end
-      `#{Gem.ruby} #{require_environment} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails #{cmd}`
+      `#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails #{cmd}`
     end
 
     def build_engine(is_mountable=false)

--- a/tools/console
+++ b/tools/console
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
-require File.expand_path('../../load_paths', __FILE__)
+require 'bundler'
+Bundler.setup
+
 require 'rails/all'
 require 'active_support/all'
 require 'irb'


### PR DESCRIPTION
### Summary

Was looking at the load_paths.rb file this Saturday morning. And notices that file wasn't updated since 2012. I saw we were setting update bundler there, however It occurred to me that on our new binstubs we do that already, and in our internal tests we require the things we need. 

Wanted to test it out, to see if we really need this file or not. Running a few tests locally everything passed. Lets see what CI says.

thoughts @tenderlove @rafaelfranca @kaspth 
