### PR TITLE
[ci skip] Add small Action Cable documentation fixes

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -339,21 +339,21 @@ Rails.application.config.action_cable.disable_request_forgery_protection = true
 
 ### Consumer Configuration
 
-Once you have decided how to run your cable server (see below), you must provide the server url (or path) to your client-side setup.
+Once you have decided how to run your cable server (see below), you must provide the server URL (or path) to your client-side setup.
 There are two ways you can do this.
 
 The first is to simply pass it in when creating your consumer. For a standalone server,
 this would be something like: `App.cable = ActionCable.createConsumer("ws://example.com:28080")`, and for an in-app server,
 something like: `App.cable = ActionCable.createConsumer("/cable")`.
 
-The second option is to pass the server url through the `action_cable_meta_tag` in your layout.
-This uses a url or path typically set via `config.action_cable.url` in the environment configuration files, or defaults to "/cable".
+The second option is to pass the server URL through the `action_cable_meta_tag` in your layout.
+This uses a URL or path typically set via `config.action_cable.url` in the environment configuration files, or defaults to "/cable".
 
-This method is especially useful if your WebSocket url might change between environments. If you host your production server via https, you will need to use the wss scheme
+This method is especially useful if your WebSocket URL might change between environments. If you host your production server via https, you will need to use the wss scheme
 for your Action Cable server, but development might remain http and use the ws scheme. You might use localhost in development and your
 domain in production.
 
-In any case, to vary the WebSocket url between environments, add the following configuration to each environment:
+In any case, to vary the WebSocket URL between environments, add the following configuration to each environment:
 
 ```ruby
 config.action_cable.url = "ws://example.com:28080"

--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -166,7 +166,7 @@ module ActionCable
         end
       end
 
-      # Called by the cable connection when its cut, so the channel has a chance to cleanup with callbacks.
+      # Called by the cable connection when it's cut, so the channel has a chance to cleanup with callbacks.
       # This method is not intended to be called directly by the user. Instead, overwrite the #unsubscribed callback.
       def unsubscribe_from_channel # :nodoc:
         run_callbacks :unsubscribe do

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -1,6 +1,6 @@
 module ActionCable
   module Channel
-    # Streams allow channels to route broadcastings to the subscriber. A broadcasting is, as discussed elsewhere, a pub/sub queue where any data
+    # Streams allow channels to route broadcastings to the subscriber. A broadcasting is, as discussed elsewhere, a pubsub queue where any data
     # placed into it is automatically sent to the clients that are connected at that time. It's purely an online queue, though. If you're not
     # streaming a broadcasting at the very moment it sends out an update, you will not get that update, if you connect after it has been sent.
     #

--- a/actioncable/lib/action_cable/helpers/action_cable_helper.rb
+++ b/actioncable/lib/action_cable/helpers/action_cable_helper.rb
@@ -1,24 +1,24 @@
 module ActionCable
   module Helpers
     module ActionCableHelper
-      # Returns an "action-cable-url" meta tag with the value of the url specified in your
-      # configuration. Ensure this is above your javascript tag:
+      # Returns an "action-cable-url" meta tag with the value of the URL specified in your
+      # configuration. Ensure this is above your JavaScript tag:
       #
       #   <head>
       #     <%= action_cable_meta_tag %>
       #     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
       #   </head>
       #
-      # This is then used by Action Cable to determine the url of your WebSocket server.
+      # This is then used by Action Cable to determine the URL of your WebSocket server.
       # Your CoffeeScript can then connect to the server without needing to specify the
-      # url directly:
+      # URL directly:
       #
       #   #= require cable
       #   @App = {}
       #   App.cable = Cable.createConsumer()
       #
-      # Make sure to specify the correct server location in each of your environments
-      # config file:
+      # Make sure to specify the correct server location in each of your environment
+      # config files:
       #
       #   config.action_cable.mount_path = "/cable123"
       #   <%= action_cable_meta_tag %> would render:

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -622,8 +622,8 @@ There are a few configuration options available in Active Support:
 if you are running Action Cable servers that are separated from your
 main application.
 * `config.action_cable.mount_path` accepts a string for where to mount Action
-  Cable, as apart of the main server process. Defaults to `/cable`.
-You can set this as nil to not mount Action Cable as apart of your
+  Cable, as part of the main server process. Defaults to `/cable`.
+You can set this as nil to not mount Action Cable as part of your
 normal Rails server.
 
 ### Configuring a Database


### PR DESCRIPTION
### Summary
- Fix typos/grammar errors
- Make capitalization/naming consistent
