### PR TITLE
convert cable.coffee to cable.js

### DIFF
--- a/actioncable/lib/rails/generators/channel/USAGE
+++ b/actioncable/lib/rails/generators/channel/USAGE
@@ -3,7 +3,7 @@ Description:
     Stubs out a new cable channel for the server (in Ruby) and client (in CoffeeScript).
     Pass the channel name, either CamelCased or under_scored, and an optional list of channel actions as arguments.
 
-    Note: Turn on the cable connection in app/assets/javascript/cable.coffee after generating any channels.
+    Note: Turn on the cable connection in app/assets/javascript/cable.js after generating any channels.
 
 Example:
 ========

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -332,7 +332,7 @@ module Rails
       def delete_action_cable_files_skipping_action_cable
         if options[:skip_action_cable]
           remove_file 'config/cable.yml'
-          remove_file 'app/assets/javascripts/cable.coffee'
+          remove_file 'app/assets/javascripts/cable.js'
           remove_dir 'app/channels'
         end
       end

--- a/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/cable.coffee
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/cable.coffee
@@ -1,9 +1,0 @@
-# Action Cable provides the framework to deal with WebSockets in Rails.
-# You can generate new channels where WebSocket features live using the rails generate channel command.
-#
-#= require action_cable
-#= require_self
-#= require_tree ./channels
-
-@App ||= {}
-App.cable = ActionCable.createConsumer()

--- a/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/cable.js
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/cable.js
@@ -1,0 +1,13 @@
+// Action Cable provides the framework to deal with WebSockets in Rails.
+// You can generate new channels where WebSocket features live using the rails generate channel command.
+//
+//= require action_cable
+//= require_self
+//= require_tree ./channels
+
+(function() {
+  this.App || (this.App = {});
+
+  App.cable = ActionCable.createConsumer();
+
+}).call(this);

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -118,7 +118,7 @@ module ApplicationTests
     end
 
     def test_code_statistics_sanity
-      assert_match "Code LOC: 16     Test LOC: 0     Code to Test Ratio: 1:0.0",
+      assert_match "Code LOC: 18     Test LOC: 0     Code to Test Ratio: 1:0.0",
         Dir.chdir(app_path){ `bin/rails stats` }
     end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -463,7 +463,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--skip-action-cable"]
     assert_file "config/application.rb", /#\s+require\s+["']action_cable\/engine["']/
     assert_no_file "config/cable.yml"
-    assert_no_file "app/assets/javascripts/cable.coffee"
+    assert_no_file "app/assets/javascripts/cable.js"
     assert_no_file "app/channels"
     assert_file "Gemfile" do |content|
       assert_no_match(/redis/, content)


### PR DESCRIPTION
### Summary

I created a new mountable engine in Rails 5.0.0.beta3, to create a scaffold, but ran the test failed.

```
$ bin/rails plugin new blorgh --mountable
$ bin/rails g scaffold user email:string
$ bin/rails db:migrate
$ bin/rails t
Run options: --seed 59074

# Running:

E

Error:
Blorgh::UsersControllerTest#test_should_get_index:
LoadError: cannot load such file -- coffee_script



bin/rails test test/controllers/blorgh/users_controller_test.rb:11

E

Error:
Blorgh::UsersControllerTest#test_should_get_edit:
LoadError: cannot load such file -- coffee_script
```

Dependecy on CoffeeScript by `cable.coffee` which is generated by default will occur, it has become an error. 
In order to eliminate the dependence on CoffeeScript, `cable.coffee` is I think it is better in which was JavaScript, How about?
