### PR TITLE
Deprecate `Module.local_constants`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `Module.local_constants`. Please use `Module.constants(false)` instead.
+
+    *Yuichiro Kaneko*
+
 ## Rails 5.0.0.beta3 (February 24, 2016) ##
 
 *   Deprecate arguments on `assert_nothing_raised`.

--- a/activesupport/lib/active_support/core_ext/module/introspection.rb
+++ b/activesupport/lib/active_support/core_ext/module/introspection.rb
@@ -57,6 +57,10 @@ class Module
   end
 
   def local_constants #:nodoc:
+    ActiveSupport::Deprecation.warn(<<-MSG.squish)
+      Module#local_constants is deprecated and will be removed in Rails 5.1.
+      Use Module#constants(false) instead.
+    MSG
     constants(false)
   end
 end

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -143,7 +143,7 @@ module ActiveSupport #:nodoc:
           next unless mod.is_a?(Module)
 
           # Get a list of the constants that were added
-          new_constants = mod.local_constants - original_constants
+          new_constants = mod.constants(false) - original_constants
 
           # @stack[namespace] returns an Array of the constants that are being evaluated
           # for that namespace. For instance, if parent.rb requires child.rb, the first
@@ -171,7 +171,7 @@ module ActiveSupport #:nodoc:
         @watching << namespaces.map do |namespace|
           module_name = Dependencies.to_constant_name(namespace)
           original_constants = Dependencies.qualified_const_defined?(module_name) ?
-            Inflector.constantize(module_name).local_constants : []
+            Inflector.constantize(module_name).constants(false) : []
 
           @stack[module_name] << original_constants
           module_name

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -328,7 +328,13 @@ class ModuleTest < ActiveSupport::TestCase
   end
 
   def test_local_constants
-    assert_equal %w(Constant1 Constant3), Ab.local_constants.sort.map(&:to_s)
+    ActiveSupport::Deprecation.silence do
+      assert_equal %w(Constant1 Constant3), Ab.local_constants.sort.map(&:to_s)
+    end
+  end
+
+  def test_test_local_constants_is_deprecated
+    assert_deprecated { Ab.local_constants.sort.map(&:to_s) }
   end
 end
 

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -709,29 +709,6 @@ M.parents       # => [X::Y, X, Object]
 
 NOTE: Defined in `active_support/core_ext/module/introspection.rb`.
 
-### Constants
-
-The method `local_constants` returns the names of the constants that have been
-defined in the receiver module:
-
-```ruby
-module X
-  X1 = 1
-  X2 = 2
-  module Y
-    Y1 = :y1
-    X1 = :overrides_X1_above
-  end
-end
-
-X.local_constants    # => [:X1, :X2, :Y]
-X::Y.local_constants # => [:Y1, :X1]
-```
-
-The names are returned as symbols.
-
-NOTE: Defined in `active_support/core_ext/module/introspection.rb`.
-
 #### Qualified Constant Names
 
 The standard methods `const_defined?`, `const_get`, and `const_set` accept


### PR DESCRIPTION
`Module.local_constants` is treated as public API in 'Constans' session
of Rails guide active_support_core_extensions. So it is better to remove
`#:nodoc:`.
