### PR TITLE
Remove passing `with_dispatchers` to AppGenerator

### DIFF
--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -47,8 +47,9 @@ namespace :app do
         @app_generator ||= begin
           require 'rails/generators'
           require 'rails/generators/rails/app/app_generator'
-          gen = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true, api: !!Rails.application.config.api_only },
-            destination_root: Rails.root
+          gen = Rails::Generators::AppGenerator.new ["rails"],
+                                                    { api: !!Rails.application.config.api_only },
+                                                    destination_root: Rails.root
           File.exist?(Rails.root.join("config", "application.rb")) ?
             gen.send(:app_const) : gen.send(:valid_const?)
           gen

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -125,7 +125,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
         # make sure we are in correct dir
         FileUtils.cd(app_moved_root)
 
-        generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true },
+        generator = Rails::Generators::AppGenerator.new ["rails"], [],
                                                                    destination_root: app_moved_root, shell: @shell
         generator.send(:app_const)
         quietly { generator.send(:update_config_files) }
@@ -140,7 +140,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [app_root]
 
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
       generator.send(:app_const)
       quietly { generator.send(:update_config_files) }
       assert_file "myapp/config/initializers/session_store.rb", /_myapp_session/
@@ -164,7 +164,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [app_root]
 
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
       generator.send(:app_const)
       quietly { generator.send(:update_config_files) }
       assert_file("#{app_root}/config/initializers/cookies_serializer.rb", /Rails\.application\.config\.action_dispatch\.cookies_serializer = :json/)
@@ -178,7 +178,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     FileUtils.rm("#{app_root}/config/initializers/callback_terminator.rb")
 
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
       generator.send(:app_const)
       quietly { generator.send(:update_config_files) }
       assert_no_file "#{app_root}/config/initializers/callback_terminator.rb"
@@ -192,7 +192,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     FileUtils.touch("#{app_root}/config/initializers/callback_terminator.rb")
 
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
       generator.send(:app_const)
       quietly { generator.send(:update_config_files) }
       assert_file "#{app_root}/config/initializers/callback_terminator.rb"
@@ -206,7 +206,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     FileUtils.rm("#{app_root}/config/initializers/cookies_serializer.rb")
 
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
       generator.send(:app_const)
       quietly { generator.send(:update_config_files) }
       assert_file("#{app_root}/config/initializers/cookies_serializer.rb", /Rails\.application\.config\.action_dispatch\.cookies_serializer = :marshal/)
@@ -220,7 +220,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     FileUtils.rm("#{app_root}/config/initializers/active_record_belongs_to_required_by_default.rb")
 
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
       generator.send(:app_const)
       quietly { generator.send(:update_config_files) }
       assert_no_file "#{app_root}/config/initializers/active_record_belongs_to_required_by_default.rb"
@@ -234,7 +234,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     FileUtils.touch("#{app_root}/config/initializers/active_record_belongs_to_required_by_default.rb")
 
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
       generator.send(:app_const)
       quietly { generator.send(:update_config_files) }
       assert_file "#{app_root}/config/initializers/active_record_belongs_to_required_by_default.rb"
@@ -248,7 +248,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     FileUtils.rm("#{app_root}/config/initializers/ssl_options.rb")
 
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
       generator.send(:app_const)
       quietly { generator.send(:update_config_files) }
       assert_no_file "#{app_root}/config/initializers/ssl_options.rb"
@@ -262,7 +262,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     FileUtils.touch("#{app_root}/config/initializers/ssl_options.rb")
 
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
       generator.send(:app_const)
       quietly { generator.send(:update_config_files) }
       assert_file "#{app_root}/config/initializers/ssl_options.rb"
@@ -274,7 +274,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [app_root]
 
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
       generator.send(:app_const)
       quietly { generator.send(:update_config_files) }
       assert_no_file "#{app_root}/config/initializers/cors.rb"
@@ -288,7 +288,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     FileUtils.touch("#{app_root}/config/initializers/cors.rb")
 
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
       generator.send(:app_const)
       quietly { generator.send(:update_config_files) }
       assert_file "#{app_root}/config/initializers/cors.rb"


### PR DESCRIPTION
- While working on #22790 I found out
  that we pass `with_dispatchers: true` but it's not used at all by Rails.
- We were passing `with_dispatchers: true` in few tests too but again
  it's not used by Rails.

r? @rafaelfranca cc @senny 
