### PR TITLE
Fix formatting in Action Cable guide [ci skip]

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -582,6 +582,7 @@ run ActionCable.server
 ```
 
 Then you start the server using a binstub in bin/cable ala:
+
 ```
 #!/bin/bash
 bundle exec puma -p 28080 cable/config.ru


### PR DESCRIPTION
Before:

![ruby on rails guides 2016-02-28 20-50-25](https://cloud.githubusercontent.com/assets/621238/13380022/fa19be56-de5c-11e5-841f-6bf858e56f73.jpg)

After:

![ruby on rails guides 2016-02-28 20-50-41](https://cloud.githubusercontent.com/assets/621238/13380024/082aa762-de5d-11e5-875f-194e3ed30b97.jpg)
