### PR TITLE
Removes potentially quadratic Regexp from ActiveRecord::LogSubscriber…

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -67,7 +67,7 @@ module ActiveRecord
       case sql
         when /\A\s*rollback/mi
           RED
-        when /\s*.*?select .*for update/mi, /\A\s*lock/mi
+        when /select .*for update/mi, /\A\s*lock/mi
           WHITE
         when /\A\s*select/i
           BLUE


### PR DESCRIPTION
### Summary

Simplifies a regexp that is used to colorize sql logs. Without some change to the regexp in question, it can take several seconds to colorize a single line. This PR doesn't include a test, although [the gist](https://gist.github.com/ctm/63e92e5dbc15e3574dec) that is linked in [the issue](https://github.com/rails/rails/issues/23947) has a messy test. I'm happy to adapt the test and include it in this PR if anyone thinks that's necessary.
