### PR TITLE
Address ruby warnings

### DIFF
--- a/railties/test/application/integration_test_case_test.rb
+++ b/railties/test/application/integration_test_case_test.rb
@@ -40,7 +40,7 @@ module ApplicationTests
 
       output = Dir.chdir(app_path) { `bin/rails test 2>&1` }
       assert_equal 0, $?.to_i, output
-      assert_match /0 failures, 0 errors/, output
+      assert_match(/0 failures, 0 errors/, output)
     end
   end
 end

--- a/railties/test/generators/channel_generator_test.rb
+++ b/railties/test/generators/channel_generator_test.rb
@@ -6,16 +6,16 @@ class ChannelGeneratorTest < Rails::Generators::TestCase
   tests Rails::Generators::ChannelGenerator
 
   def test_application_cable_skeleton_is_created
-     run_generator ['books']
+    run_generator ['books']
 
-     assert_file "app/channels/application_cable/channel.rb" do |cable|
-       assert_match(/module ApplicationCable\n  class Channel < ActionCable::Channel::Base\n/, cable)
-     end
+    assert_file "app/channels/application_cable/channel.rb" do |cable|
+      assert_match(/module ApplicationCable\n  class Channel < ActionCable::Channel::Base\n/, cable)
+    end
 
-     assert_file "app/channels/application_cable/connection.rb" do |cable|
-       assert_match(/module ApplicationCable\n  class Connection < ActionCable::Connection::Base\n/, cable)
-     end
-   end
+    assert_file "app/channels/application_cable/connection.rb" do |cable|
+      assert_match(/module ApplicationCable\n  class Connection < ActionCable::Connection::Base\n/, cable)
+    end
+  end
 
   def test_channel_is_created
     run_generator ['chat']


### PR DESCRIPTION
- Ambiguous first argument
- Mismatched indentation
