### PR TITLE
Fix `NoMethodError: undefined method `preparable'`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -65,7 +65,7 @@ module ActiveRecord
         if @query_cache_enabled && !locked?(arel)
           arel, binds = binds_from_relation arel, binds
           sql = to_sql(arel, binds)
-          cache_sql(sql, binds) { super(sql, name, binds, preparable: visitor.preparable) }
+          cache_sql(sql, binds) { super(sql, name, binds, preparable: preparable) }
         else
           super
         end


### PR DESCRIPTION
The error occurs with `prepared_statements: false`:

```
$ ARCONN=postgresql bundle exec ruby -w -Itest test/cases/associations_test.rb
Using postgresql
Run options: --seed 27753

...E....................................

Finished in 0.713115s, 56.0919 runs/s, 91.1494 assertions/s.

  1) Error:
AssociationsTest#test_force_reload_is_uncached:
NoMethodError: undefined method `preparable' for #<Arel::Visitors::PostgreSQL:0x007f8699702570>
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:68:in `block in select_all'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:83:in `cache_sql'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:68:in `select_all'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/querying.rb:39:in `find_by_sql'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:699:in `exec_queries'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/association_relation.rb:32:in `exec_queries'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:580:in `load'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:260:in `records'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:256:in `to_a'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/associations/collection_association.rb:458:in `get_records'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/associations/collection_association.rb:473:in `find_target'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/associations/collection_association.rb:412:in `load_target'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/associations/collection_proxy.rb:45:in `load_target'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/associations/collection_proxy.rb:983:in `records'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/relation/delegation.rb:39:in `each'
    test/cases/associations_test.rb:116:in `block (2 levels) in test_force_reload_is_uncached'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:32:in `cache'
    /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/query_cache.rb:9:in `cache'
    test/cases/associations_test.rb:115:in `block in test_force_reload_is_uncached'
    /Users/kamipo/src/github.com/rails/rails/activesupport/lib/active_support/deprecation/reporting.rb:36:in `silence'
    /Users/kamipo/src/github.com/rails/rails/activesupport/lib/active_support/deprecation/instance_delegator.rb:19:in `silence'
    test/cases/associations_test.rb:114:in `test_force_reload_is_uncached'
```
