### PR TITLE
Fix tests failure with `prepared_statements: false`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -65,7 +65,7 @@ module ActiveRecord
         if @query_cache_enabled && !locked?(arel)
           arel, binds = binds_from_relation arel, binds
           sql = to_sql(arel, binds)
-          cache_sql(sql, binds) { super(sql, name, binds, preparable: visitor.preparable) }
+          cache_sql(sql, binds) { super(sql, name, binds, preparable: preparable) }
         else
           super
         end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -11,7 +11,8 @@ module ActiveRecord
 
     ##
     # PostgreSQL does not support null bytes in strings
-    unless current_adapter?(:PostgreSQLAdapter)
+    unless current_adapter?(:PostgreSQLAdapter) ||
+        (current_adapter?(:SQLite3Adapter) && !ActiveRecord::Base.connection.prepared_statements)
       def test_update_prepared_statement
         b = Book.create(name: "my \x00 book")
         b.reload

--- a/activerecord/test/cases/adapters/mysql2/explain_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/explain_test.rb
@@ -2,26 +2,20 @@ require "cases/helper"
 require 'models/developer'
 require 'models/computer'
 
-module ActiveRecord
-  module ConnectionAdapters
-    class Mysql2Adapter
-      class ExplainTest < ActiveRecord::Mysql2TestCase
-        fixtures :developers
+class Mysql2ExplainTest < ActiveRecord::Mysql2TestCase
+  fixtures :developers
 
-        def test_explain_for_one_query
-          explain = Developer.where(:id => 1).explain
-          assert_match %(EXPLAIN for: SELECT `developers`.* FROM `developers` WHERE `developers`.`id` = 1), explain
-          assert_match %r(developers |.* const), explain
-        end
+  def test_explain_for_one_query
+    explain = Developer.where(id: 1).explain
+    assert_match %(EXPLAIN for: SELECT `developers`.* FROM `developers` WHERE `developers`.`id` = 1), explain
+    assert_match %r(developers |.* const), explain
+  end
 
-        def test_explain_with_eager_loading
-          explain = Developer.where(:id => 1).includes(:audit_logs).explain
-          assert_match %(EXPLAIN for: SELECT `developers`.* FROM `developers` WHERE `developers`.`id` = 1), explain
-          assert_match %r(developers |.* const), explain
-          assert_match %(EXPLAIN for: SELECT `audit_logs`.* FROM `audit_logs` WHERE `audit_logs`.`developer_id` = 1), explain
-          assert_match %r(audit_logs |.* ALL), explain
-        end
-      end
-    end
+  def test_explain_with_eager_loading
+    explain = Developer.where(id: 1).includes(:audit_logs).explain
+    assert_match %(EXPLAIN for: SELECT `developers`.* FROM `developers` WHERE `developers`.`id` = 1), explain
+    assert_match %r(developers |.* const), explain
+    assert_match %(EXPLAIN for: SELECT `audit_logs`.* FROM `audit_logs` WHERE `audit_logs`.`developer_id` = 1), explain
+    assert_match %r(audit_logs |.* ALL), explain
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
@@ -57,9 +57,11 @@ class PostgresqlBitStringTest < ActiveRecord::PostgreSQLTestCase
     assert_match %r{t\.bit_varying\s+"a_bit_varying",\s+limit: 4,\s+default: "0011"$}, output
   end
 
-  def test_assigning_invalid_hex_string_raises_exception
-    assert_raises(ActiveRecord::StatementInvalid) { PostgresqlBitString.create! a_bit: "FF" }
-    assert_raises(ActiveRecord::StatementInvalid) { PostgresqlBitString.create! a_bit_varying: "FF" }
+  if ActiveRecord::Base.connection.prepared_statements
+    def test_assigning_invalid_hex_string_raises_exception
+      assert_raises(ActiveRecord::StatementInvalid) { PostgresqlBitString.create! a_bit: "FF" }
+      assert_raises(ActiveRecord::StatementInvalid) { PostgresqlBitString.create! a_bit_varying: "F" }
+    end
   end
 
   def test_roundtrip

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -125,14 +125,16 @@ module ActiveRecord
       assert_equal 'SCHEMA', @subscriber.logged[0][1]
     end
 
-    def test_statement_key_is_logged
-      bind = Relation::QueryAttribute.new(nil, 1, Type::Value.new)
-      @connection.exec_query('SELECT $1::integer', 'SQL', [bind], prepare: true)
-      name = @subscriber.payloads.last[:statement_name]
-      assert name
-      res = @connection.exec_query("EXPLAIN (FORMAT JSON) EXECUTE #{name}(1)")
-      plan = res.column_types['QUERY PLAN'].deserialize res.rows.first.first
-      assert_operator plan.length, :>, 0
+    if ActiveRecord::Base.connection.prepared_statements
+      def test_statement_key_is_logged
+        bind = Relation::QueryAttribute.new(nil, 1, Type::Value.new)
+        @connection.exec_query('SELECT $1::integer', 'SQL', [bind], prepare: true)
+        name = @subscriber.payloads.last[:statement_name]
+        assert name
+        res = @connection.exec_query("EXPLAIN (FORMAT JSON) EXECUTE #{name}(1)")
+        plan = res.column_types['QUERY PLAN'].deserialize res.rows.first.first
+        assert_operator plan.length, :>, 0
+      end
     end
 
     # Must have PostgreSQL >= 9.2, or with_manual_interventions set to

--- a/activerecord/test/cases/adapters/postgresql/explain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/explain_test.rb
@@ -7,14 +7,14 @@ class PostgreSQLExplainTest < ActiveRecord::PostgreSQLTestCase
 
   def test_explain_for_one_query
     explain = Developer.where(:id => 1).explain
-    assert_match %(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = $1), explain
+    assert_match %r(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = \$?1), explain
     assert_match %(QUERY PLAN), explain
   end
 
   def test_explain_with_eager_loading
     explain = Developer.where(:id => 1).includes(:audit_logs).explain
     assert_match %(QUERY PLAN), explain
-    assert_match %(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = $1), explain
+    assert_match %r(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = \$?1), explain
     assert_match %(EXPLAIN for: SELECT "audit_logs".* FROM "audit_logs" WHERE "audit_logs"."developer_id" = 1), explain
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/explain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/explain_test.rb
@@ -6,13 +6,13 @@ class PostgreSQLExplainTest < ActiveRecord::PostgreSQLTestCase
   fixtures :developers
 
   def test_explain_for_one_query
-    explain = Developer.where(:id => 1).explain
+    explain = Developer.where(id: 1).explain
     assert_match %r(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = \$?1), explain
     assert_match %(QUERY PLAN), explain
   end
 
   def test_explain_with_eager_loading
-    explain = Developer.where(:id => 1).includes(:audit_logs).explain
+    explain = Developer.where(id: 1).includes(:audit_logs).explain
     assert_match %(QUERY PLAN), explain
     assert_match %r(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = \$?1), explain
     assert_match %(EXPLAIN for: SELECT "audit_logs".* FROM "audit_logs" WHERE "audit_logs"."developer_id" = 1), explain

--- a/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
@@ -55,20 +55,22 @@ class SchemaAuthorizationTest < ActiveRecord::PostgreSQLTestCase
       set_session_auth
       USERS.each do |u|
         set_session_auth u
-        assert_equal u, @connection.exec_query("SELECT name FROM #{TABLE_NAME} WHERE id = $1", 'SQL', [bind_param(1)]).first['name']
+        assert_equal u, @connection.select_value("SELECT name FROM #{TABLE_NAME} WHERE id = 1")
         set_session_auth
       end
     end
   end
 
-  def test_auth_with_bind
-    assert_nothing_raised do
-      set_session_auth
-      USERS.each do |u|
-        @connection.clear_cache!
-        set_session_auth u
-        assert_equal u, @connection.exec_query("SELECT name FROM #{TABLE_NAME} WHERE id = $1", 'SQL', [bind_param(1)]).first['name']
+  if ActiveRecord::Base.connection.prepared_statements
+    def test_auth_with_bind
+      assert_nothing_raised do
         set_session_auth
+        USERS.each do |u|
+          @connection.clear_cache!
+          set_session_auth u
+          assert_equal u, @connection.select_value("SELECT name FROM #{TABLE_NAME} WHERE id = $1", 'SQL', [bind_param(1)])
+          set_session_auth
+        end
       end
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -172,16 +172,18 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
-  def test_schema_change_with_prepared_stmt
-    altered = false
-    @connection.exec_query "select * from developers where id = $1", 'sql', [bind_param(1)]
-    @connection.exec_query "alter table developers add column zomg int", 'sql', []
-    altered = true
-    @connection.exec_query "select * from developers where id = $1", 'sql', [bind_param(1)]
-  ensure
-    # We are not using DROP COLUMN IF EXISTS because that syntax is only
-    # supported by pg 9.X
-    @connection.exec_query("alter table developers drop column zomg", 'sql', []) if altered
+  if ActiveRecord::Base.connection.prepared_statements
+    def test_schema_change_with_prepared_stmt
+      altered = false
+      @connection.exec_query "select * from developers where id = $1", 'sql', [bind_param(1)]
+      @connection.exec_query "alter table developers add column zomg int", 'sql', []
+      altered = true
+      @connection.exec_query "select * from developers where id = $1", 'sql', [bind_param(1)]
+    ensure
+      # We are not using DROP COLUMN IF EXISTS because that syntax is only
+      # supported by pg 9.X
+      @connection.exec_query("alter table developers drop column zomg", 'sql', []) if altered
+    end
   end
 
   def test_data_source_exists?

--- a/activerecord/test/cases/adapters/sqlite3/explain_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/explain_test.rb
@@ -10,13 +10,13 @@ module ActiveRecord
 
         def test_explain_for_one_query
           explain = Developer.where(:id => 1).explain
-          assert_match %(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = ?), explain
+          assert_match %r(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = (?:\?|1)), explain
           assert_match(/(SEARCH )?TABLE developers USING (INTEGER )?PRIMARY KEY/, explain)
         end
 
         def test_explain_with_eager_loading
           explain = Developer.where(:id => 1).includes(:audit_logs).explain
-          assert_match %(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = ?), explain
+          assert_match %r(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = (?:\?|1)), explain
           assert_match(/(SEARCH )?TABLE developers USING (INTEGER )?PRIMARY KEY/, explain)
           assert_match %(EXPLAIN for: SELECT "audit_logs".* FROM "audit_logs" WHERE "audit_logs"."developer_id" = 1), explain
           assert_match(/(SCAN )?TABLE audit_logs/, explain)

--- a/activerecord/test/cases/adapters/sqlite3/explain_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/explain_test.rb
@@ -2,26 +2,20 @@ require "cases/helper"
 require 'models/developer'
 require 'models/computer'
 
-module ActiveRecord
-  module ConnectionAdapters
-    class SQLite3Adapter
-      class ExplainTest < ActiveRecord::SQLite3TestCase
-        fixtures :developers
+class SQLite3ExplainTest < ActiveRecord::SQLite3TestCase
+  fixtures :developers
 
-        def test_explain_for_one_query
-          explain = Developer.where(:id => 1).explain
-          assert_match %r(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = (?:\?|1)), explain
-          assert_match(/(SEARCH )?TABLE developers USING (INTEGER )?PRIMARY KEY/, explain)
-        end
+  def test_explain_for_one_query
+    explain = Developer.where(id: 1).explain
+    assert_match %r(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = (?:\?|1)), explain
+    assert_match(/(SEARCH )?TABLE developers USING (INTEGER )?PRIMARY KEY/, explain)
+  end
 
-        def test_explain_with_eager_loading
-          explain = Developer.where(:id => 1).includes(:audit_logs).explain
-          assert_match %r(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = (?:\?|1)), explain
-          assert_match(/(SEARCH )?TABLE developers USING (INTEGER )?PRIMARY KEY/, explain)
-          assert_match %(EXPLAIN for: SELECT "audit_logs".* FROM "audit_logs" WHERE "audit_logs"."developer_id" = 1), explain
-          assert_match(/(SCAN )?TABLE audit_logs/, explain)
-        end
-      end
-    end
+  def test_explain_with_eager_loading
+    explain = Developer.where(id: 1).includes(:audit_logs).explain
+    assert_match %r(EXPLAIN for: SELECT "developers".* FROM "developers" WHERE "developers"."id" = (?:\?|1)), explain
+    assert_match(/(SEARCH )?TABLE developers USING (INTEGER )?PRIMARY KEY/, explain)
+    assert_match %(EXPLAIN for: SELECT "audit_logs".* FROM "audit_logs" WHERE "audit_logs"."developer_id" = 1), explain
+    assert_match(/(SCAN )?TABLE audit_logs/, explain)
   end
 end

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -31,7 +31,8 @@ module ActiveRecord
       ActiveSupport::Notifications.unsubscribe(@subscription)
     end
 
-    if ActiveRecord::Base.connection.supports_statement_cache?
+    if ActiveRecord::Base.connection.supports_statement_cache? &&
+       ActiveRecord::Base.connection.prepared_statements
       def test_bind_from_join_in_subquery
         subquery = Author.joins(:thinking_posts).where(name: 'David')
         scope = Author.from(subquery, 'authors').where(id: 1)

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -441,7 +441,7 @@ unless in_memory_db?
       def test_lock_sending_custom_lock_statement
         Person.transaction do
           person = Person.find(1)
-          assert_sql(/LIMIT \$\d FOR SHARE NOWAIT/) do
+          assert_sql(/LIMIT \$?\d FOR SHARE NOWAIT/) do
             person.lock!('FOR SHARE NOWAIT')
           end
         end


### PR DESCRIPTION
Some tests does not work for unprepared statements.
Add `if ActiveRecord::Base.connection.prepared_statements` and fix a
regex for fix tests failure with `prepared_statements: false`.
