### PR TITLE
Fix `NoMethodError: undefined method `fields' for nil:NilClass`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -131,7 +131,7 @@ module ActiveRecord
       def exec_query(sql, name = 'SQL', binds = [], prepare: false)
         result = execute(sql, name)
         @connection.next_result while @connection.more_results?
-        ActiveRecord::Result.new(result.fields, result.to_a)
+        ActiveRecord::Result.new(result.fields, result.to_a) if result
       end
 
       def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -1,8 +1,20 @@
 require "cases/helper"
+require "support/ddl_helper"
 
 class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
+  include DdlHelper
+
   def setup
     @conn = ActiveRecord::Base.connection
+  end
+
+  def test_exec_query_nothing_raises_with_no_result_queries
+    assert_nothing_raised do
+      with_example_table do
+        @conn.exec_query('INSERT INTO ex (number) VALUES (1)')
+        @conn.exec_query('DELETE FROM ex WHERE number = 1')
+      end
+    end
   end
 
   def test_columns_for_distinct_zero_orders
@@ -40,5 +52,11 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     end
     assert_equal "posts.id, posts.created_at AS alias_0",
       @conn.columns_for_distinct("posts.id", [order])
+  end
+
+  private
+
+  def with_example_table(definition = 'id int auto_increment primary key, number int, data varchar(255)', &block)
+    super(@conn, 'ex', definition, &block)
   end
 end


### PR DESCRIPTION
Currently `exec_query` raises `NoMethodError` when executing no result
queries (`INSERT`, `UPDATE`, `DELETE`, and all DDL) in mysql2 adapter.

```
irb(main):002:0> conn.execute("create table t(a int)")
   (43.3ms)  create table t(a int)
=> nil
irb(main):003:0> conn.execute("insert into t values (1)")
   (19.3ms)  insert into t values (1)
=> nil
irb(main):004:0> conn.exec_query("insert into t values (1)")
  SQL (28.6ms)  insert into t values (1)
NoMethodError: undefined method `fields' for nil:NilClass
```
