### PR TITLE
Fix bigserial appears with limit 8 for schema dumper

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -41,6 +41,10 @@ module ActiveRecord
           end
         end
 
+        def schema_limit(column)
+          super unless schema_type(column) == :bigserial
+        end
+
         def schema_expression(column)
           super unless column.serial?
         end

--- a/activerecord/test/cases/adapters/postgresql/serial_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/serial_test.rb
@@ -26,7 +26,7 @@ class PostgresqlSerialTest < ActiveRecord::PostgreSQLTestCase
 
   def test_schema_dump_with_shorthand
     output = dump_table_schema "postgresql_serials"
-    assert_match %r{t\.serial\s+"seq"}, output
+    assert_match %r{t\.serial\s+"seq",\s+null: false$}, output
   end
 end
 
@@ -55,6 +55,6 @@ class PostgresqlBigSerialTest < ActiveRecord::PostgreSQLTestCase
 
   def test_schema_dump_with_shorthand
     output = dump_table_schema "postgresql_big_serials"
-    assert_match %r{t\.bigserial\s+"seq"}, output
+    assert_match %r{t\.bigserial\s+"seq",\s+null: false$}, output
   end
 end


### PR DESCRIPTION
Before:

``` ruby
create_table "postgresql_big_serials", force: :cascade do |t|
  t.bigserial "seq", limit: 8, null: false
end
```

After:

``` ruby
create_table "postgresql_big_serials", force: :cascade do |t|
  t.bigserial "seq", null: false
end
```
