### PR TITLE
Exclude `:name` and `:type` from `prepare_column_options`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -13,7 +13,7 @@ module ActiveRecord
             return if spec.empty?
           else
             spec[:id] = schema_type(column).inspect
-            spec.merge!(prepare_column_options(column).delete_if { |key, _| [:name, :type, :null].include?(key) })
+            spec.merge!(prepare_column_options(column).delete_if { |key, _| key == :null })
           end
           spec
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -12,7 +12,7 @@ module ActiveRecord
             spec[:default] = schema_default(column) || 'nil'
           else
             spec[:id] = schema_type(column).inspect
-            spec.merge!(prepare_column_options(column).delete_if { |key, _| [:name, :type, :null].include?(key) })
+            spec.merge!(prepare_column_options(column).delete_if { |key, _| key == :null })
           end
           spec
         end


### PR DESCRIPTION
Actually `:name` and `:type` are not column options.
