### PR TITLE
Drop Action Controller require in ActionDispatch::ExceptionWrapper

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -1,4 +1,3 @@
-require 'action_controller/metal/exceptions'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'rack/utils'
 


### PR DESCRIPTION
We only reference the Action Controller error classes by name in
ActionDispatch::ExceptionWrapper, so there is no need to explicitly
require them.

It drops a tiny coupling between Action Dispatch and Action Controller,
so it makes me feel warm inside. We still have a lot of others AC
requires in the AD code base, but here, we can save it.
