### PR TITLE
Freeze some defined strings.

### DIFF
--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -9,8 +9,8 @@ module AbstractController
     # to translate many keys within the same controller / action and gives you a
     # simple framework for scoping them consistently.
     def translate(key, options = {})
-      if key.to_s.first == '.'
-        path = controller_path.tr('/', '.')
+      if key.to_s.first == '.'.freeze
+        path = controller_path.tr('/', '.'.freeze)
         defaults = [:"#{path}#{key}"]
         defaults << options[:default] if options[:default]
         options[:default] = defaults


### PR DESCRIPTION
- Freeze some defined strings so that every `translate` call will not
  create new strings objects for those defined strings.
