### PR TITLE
Removing reference to config option debug_exception_response format from general configuring doc

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -98,8 +98,6 @@ application. Accepts a valid week day symbol (e.g. `:monday`).
 
 * `config.exceptions_app` sets the exceptions application invoked by the ShowException middleware when an exception happens. Defaults to `ActionDispatch::PublicExceptions.new(Rails.public_path)`.
 
-* `config.debug_exception_response_format` sets the format used in responses when errors occur in development mode.
-
 * `config.file_watcher` is the class used to detect file updates in the file system when `config.reload_classes_only_on_change` is true. Rails ships with `ActiveSupport::FileUpdateChecker`, the default, and `ActiveSupport::EventedFileUpdateChecker` (this one depends on the [listen](https://github.com/guard/listen) gem). Custom classes must conform to the `ActiveSupport::FileUpdateChecker` API.
 
 * `config.filter_parameters` used for filtering out the parameters that


### PR DESCRIPTION
### Summary
- Config debug_exception_response_format is effective with api_only applications.

[ci skip]

r? @rafaelfranca 
