### PR TITLE
Added proper test for new attribute not reflecting previous change.

### DIFF
--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -137,7 +137,12 @@ class DirtyTest < ActiveModel::TestCase
     assert_equal [nil, "Jericho Cane"], @model.previous_changes['name']
   end
 
-  test "setting new attributes should not affect previous changes" do
+  test "setting new attribute should not affect previous changes" do
+    @model.name = "Jericho Cane"
+    assert_equal nil, @model.name_previous_change
+  end
+
+  test "setting new attributes should be reflected in previous change" do
     @model.name = "Jericho Cane"
     @model.save
     @model.name = "DudeFella ManGuy"


### PR DESCRIPTION
- The existing test description said previous change should not be affected but the assertion had previous changes value compared.
- Added new test case that supports existing test case's description.
