### PR TITLE
ActionCable action params passed in as hash with indifferent access

### DIFF
--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -46,7 +46,15 @@ module ActionCable
       end
 
       def perform_action(data)
-        find(data).perform_action ActiveSupport::JSON.decode(data['data'])
+        if (data['data'].present? && data['data'].is_a?(String))
+          params = ActiveSupport::JSON.decode(data['data'])
+        elsif data['data'].present?
+          params = data['data']
+        end
+
+        params = params.with_indifferent_access if params.is_a?(Hash)
+
+        find(data).perform_action params
       end
 
       def identifiers

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -82,6 +82,18 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
     end
   end
 
+  test "message command with raw" do
+    run_in_eventmachine do
+      setup_connection
+      channel = subscribe_to_chat_channel
+
+      data = { 'content' => 'Hello World!', 'action' => 'speak' }
+      @subscriptions.execute_command 'command' => 'message', 'identifier' => @chat_identifier, 'data' => data
+
+      assert_equal [ data ], channel.lines
+    end
+  end
+
   test "unsubscrib from all" do
     run_in_eventmachine do
       setup_connection


### PR DESCRIPTION
### Summary

This pull request makes two changes:
1. Calls `with_indifferent_access` on any `Hash` that is passed back to the target action on an ActionCable channel. This makes it fall in line with what is expected from `params` in an `ActionController`.
2. Does not attempt to JSON decode an object that is not a `String`. This means that the incoming JSON can be `{... "data": {"hello": "world"}}` as well as working with what it had to be before: `{... "data": "{\"hello\": \"world\"}"}`. The result is the same, but the protocol between server and client is changed (is this documented anywhere?)
### Other Information

Added a test to make sure the second point above has an associated test with the changed behavior.
