### PR TITLE
ActionCable: Add a "welcome" and "ping" message type

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -73,10 +73,11 @@ class ActionCable.Connection
   events:
     message: (event) ->
       {identifier, message, type} = JSON.parse(event.data)
-
       switch type
         when message_types.welcome
-          @consumer.subscriptions.notify(@consumer.connectionMonitor, "connected")
+          @consumer.connectionMonitor.connected()
+        when message_types.ping
+          @consumer.connectionMonitor.ping()
         when message_types.confirmation
           @consumer.subscriptions.notify(identifier, "connected")
         when message_types.rejection

--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -75,6 +75,8 @@ class ActionCable.Connection
       {identifier, message, type} = JSON.parse(event.data)
 
       switch type
+        when message_types.welcome
+          @consumer.subscriptions.notify(@consumer.connectionMonitor, "connected")
         when message_types.confirmation
           @consumer.subscriptions.notify(identifier, "connected")
         when message_types.rejection

--- a/actioncable/app/assets/javascripts/action_cable/connection_monitor.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection_monitor.coffee
@@ -7,10 +7,7 @@ class ActionCable.ConnectionMonitor
 
   @staleThreshold: 6 # Server::Connections::BEAT_INTERVAL * 2 (missed two pings)
 
-  identifier: ActionCable.INTERNAL.identifiers.ping
-
   constructor: (@consumer) ->
-    @consumer.subscriptions.add(this)
     @start()
 
   connected: ->
@@ -22,11 +19,12 @@ class ActionCable.ConnectionMonitor
   disconnected: ->
     @disconnectedAt = now()
 
-  received: ->
+  ping: ->
     @pingedAt = now()
 
   reset: ->
     @reconnectAttempts = 0
+    @consumer.connection.isOpen()
 
   start: ->
     @reset()

--- a/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
@@ -58,7 +58,5 @@ class ActionCable.Subscriptions
 
   sendCommand: (subscription, command) ->
     {identifier} = subscription
-    if identifier is ActionCable.INTERNAL.identifiers.ping
-      @consumer.connection.isOpen()
-    else
-      @consumer.send({command, identifier})
+    @consumer.send({command, identifier})
+      

--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -29,11 +29,9 @@ module ActionCable
   extend ActiveSupport::Autoload
 
   INTERNAL = {
-    identifiers: {
-      ping: '_ping'.freeze
-    },
     message_types: {
       welcome: 'welcome'.freeze,
+      ping: 'ping'.freeze,
       confirmation: 'confirm_subscription'.freeze,
       rejection: 'reject_subscription'.freeze
     }

--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -33,6 +33,7 @@ module ActionCable
       ping: '_ping'.freeze
     },
     message_types: {
+      welcome: 'welcome'.freeze,
       confirmation: 'confirm_subscription'.freeze,
       rejection: 'reject_subscription'.freeze
     }

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -154,7 +154,7 @@ module ActionCable
         def handle_open
           connect if respond_to?(:connect)
           subscribe_to_internal_channel
-          confirm_connection_monitor_subscription
+          send_welcome_message
 
           message_buffer.process!
           server.add_connection(self)
@@ -173,11 +173,11 @@ module ActionCable
           disconnect if respond_to?(:disconnect)
         end
 
-        def confirm_connection_monitor_subscription
-          # Send confirmation message to the internal connection monitor channel.
+        def send_welcome_message
+          # Send welcome message to the internal connection monitor channel.
           # This ensures the connection monitor state is reset after a successful
           # websocket connection.
-          transmit ActiveSupport::JSON.encode(identifier: ActionCable::INTERNAL[:identifiers][:ping], type: ActionCable::INTERNAL[:message_types][:confirmation])
+          transmit ActiveSupport::JSON.encode(type: ActionCable::INTERNAL[:message_types][:welcome])
         end
 
         def allow_request_origin?

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -114,7 +114,7 @@ module ActionCable
       end
 
       def beat
-        transmit ActiveSupport::JSON.encode(identifier: ActionCable::INTERNAL[:identifiers][:ping], message: Time.now.to_i)
+        transmit ActiveSupport::JSON.encode(type: ActionCable::INTERNAL[:message_types][:ping], message: Time.now.to_i)
       end
 
       def on_open # :nodoc:

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -75,7 +75,7 @@ class ClientTest < ActionCable::TestCase
 
       @ws.on(:message) do |event|
         hash = JSON.parse(event.data)
-        if hash['identifier'] == '_ping'
+        if hash['type'] == 'ping'
           @pings += 1
         else
           @messages << hash

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -138,6 +138,7 @@ class ClientTest < ActionCable::TestCase
   def test_single_client
     with_puma_server do |port|
       c = faye_client(port)
+      assert_equal({"type" => "welcome"}, c.read_message)  # pop the first welcome message off the stack
       c.send_message command: 'subscribe', identifier: JSON.dump(channel: 'EchoChannel')
       assert_equal({"identifier"=>"{\"channel\":\"EchoChannel\"}", "type"=>"confirm_subscription"}, c.read_message)
       c.send_message command: 'message', identifier: JSON.dump(channel: 'EchoChannel'), data: JSON.dump(action: 'ding', message: 'hello')
@@ -154,6 +155,7 @@ class ClientTest < ActionCable::TestCase
       barrier_2 = Concurrent::CyclicBarrier.new(clients.size)
 
       clients.map {|c| Concurrent::Future.execute {
+        assert_equal({"type" => "welcome"}, c.read_message)  # pop the first welcome message off the stack
         c.send_message command: 'subscribe', identifier: JSON.dump(channel: 'EchoChannel')
         assert_equal({"identifier"=>'{"channel":"EchoChannel"}', "type"=>"confirm_subscription"}, c.read_message)
         c.send_message command: 'message', identifier: JSON.dump(channel: 'EchoChannel'), data: JSON.dump(action: 'ding', message: 'hello')
@@ -173,6 +175,7 @@ class ClientTest < ActionCable::TestCase
       clients = 100.times.map { faye_client(port) }
 
       clients.map {|c| Concurrent::Future.execute {
+        assert_equal({"type" => "welcome"}, c.read_message)  # pop the first welcome message off the stack
         c.send_message command: 'subscribe', identifier: JSON.dump(channel: 'EchoChannel')
         assert_equal({"identifier"=>'{"channel":"EchoChannel"}', "type"=>"confirm_subscription"}, c.read_message)
         c.send_message command: 'message', identifier: JSON.dump(channel: 'EchoChannel'), data: JSON.dump(action: 'ding', message: 'hello')
@@ -186,12 +189,14 @@ class ClientTest < ActionCable::TestCase
   def test_disappearing_client
     with_puma_server do |port|
       c = faye_client(port)
+      assert_equal({"type" => "welcome"}, c.read_message)  # pop the first welcome message off the stack
       c.send_message command: 'subscribe', identifier: JSON.dump(channel: 'EchoChannel')
       assert_equal({"identifier"=>"{\"channel\":\"EchoChannel\"}", "type"=>"confirm_subscription"}, c.read_message)
       c.send_message command: 'message', identifier: JSON.dump(channel: 'EchoChannel'), data: JSON.dump(action: 'delay', message: 'hello')
       c.close # disappear before write
 
       c = faye_client(port)
+      assert_equal({"type" => "welcome"}, c.read_message) # pop the first welcome message off the stack
       c.send_message command: 'subscribe', identifier: JSON.dump(channel: 'EchoChannel')
       assert_equal({"identifier"=>"{\"channel\":\"EchoChannel\"}", "type"=>"confirm_subscription"}, c.read_message)
       c.send_message command: 'message', identifier: JSON.dump(channel: 'EchoChannel'), data: JSON.dump(action: 'ding', message: 'hello')
@@ -206,6 +211,7 @@ class ClientTest < ActionCable::TestCase
       identifier = JSON.dump(channel: 'EchoChannel')
 
       c = faye_client(port)
+      assert_equal({"type" => "welcome"}, c.read_message)
       c.send_message command: 'subscribe', identifier: identifier
       assert_equal({"identifier"=>"{\"channel\":\"EchoChannel\"}", "type"=>"confirm_subscription"}, c.read_message)
       assert_equal(1, app.connections.count)

--- a/actioncable/test/connection/base_test.rb
+++ b/actioncable/test/connection/base_test.rb
@@ -56,7 +56,7 @@ class ActionCable::Connection::BaseTest < ActionCable::TestCase
     run_in_eventmachine do
       connection = open_connection
 
-      connection.websocket.expects(:transmit).with({ identifier: "_ping", type: "confirm_subscription" }.to_json)
+      connection.websocket.expects(:transmit).with({ type: "welcome" }.to_json)
       connection.message_buffer.expects(:process!)
 
       connection.process


### PR DESCRIPTION
### Summary

This pull request does three things:
1. Fixes inconsistencies in the ActionCable protocol between server and client in regards to the `ping` message by making ping a message type instead of an `identifier`.
2. Adds a `welcome` message type, which signals to clients the server is ready or has re-opened the connection.
3. Removes `ConnectionMonitor` as a subscriber, as this is no longer necessary when pings and welcome messages can be identified separately.
### Other Information

The `ping` message was being sent looking like:
`{"identifier": "_ping", "message": "3939939393"}`
whereas other messages were being sent to look like:
`{"type": "confirm_subscription" ...}`
Now the ping looks like:
`{"type": "ping", "message": "3939939393"}`

Consequently, this enabled some code to trick the client and tests to be removed and for some clean up in how the ConnectionMonitor works.
