### PR TITLE
Deprecate :controller and :action path parameters

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -513,6 +513,15 @@ module ActionDispatch
 
         route = @set.add_route(name, mapping)
         named_routes[name] = route if name
+
+        if route.segment_keys.include?(:controller)
+          ActiveSupport::Deprecation.warn("Using a dynamic :controller segment in a route is deprecated and will be remove in Rails 5.1")
+        end
+
+        if route.segment_keys.include?(:action)
+          ActiveSupport::Deprecation.warn("Using a dynamic :action segment in a route is deprecated and will be remove in Rails 5.1")
+        end
+
         route
       end
 

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -69,7 +69,9 @@ FIXTURE_LOAD_PATH = File.join(File.dirname(__FILE__), 'fixtures')
 SharedTestRoutes = ActionDispatch::Routing::RouteSet.new
 
 SharedTestRoutes.draw do
-  get ':controller(/:action)'
+  ActiveSupport::Deprecation.silence do
+    get ':controller(/:action)'
+  end
 end
 
 module ActionDispatch
@@ -118,7 +120,9 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
   self.app = build_app
 
   app.routes.draw do
-    get ':controller(/:action)'
+    ActiveSupport::Deprecation.silence do
+      get ':controller(/:action)'
+    end
   end
 
   class DeadEndRoutes < ActionDispatch::Routing::RouteSet

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -177,7 +177,10 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
       set.draw do
         get 'route_one', :to => 'action_pack_assertions#nothing', :as => :route_one
         get 'route_two', :to => 'action_pack_assertions#nothing', :id => 'two', :as => :route_two
-        get ':controller/:action'
+
+        ActiveSupport::Deprecation.silence do
+          get ':controller/:action'
+        end
       end
       process :redirect_to_named_route
       assert_raise(ActiveSupport::TestCase::Assertion) do
@@ -201,7 +204,10 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
     with_routing do |set|
       set.draw do
         get 'admin/inner_module', :to => 'admin/inner_module#index', :as => :admin_inner_module
-        get ':controller/:action'
+
+        ActiveSupport::Deprecation.silence do
+          get ':controller/:action'
+        end
       end
       process :redirect_to_index
       # redirection is <{"action"=>"index", "controller"=>"admin/admin/inner_module"}>
@@ -215,7 +221,10 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
     with_routing do |set|
       set.draw do
         get '/action_pack_assertions/:id', :to => 'action_pack_assertions#index', :as => :top_level
-        get ':controller/:action'
+
+        ActiveSupport::Deprecation.silence do
+          get ':controller/:action'
+        end
       end
       process :redirect_to_top_level_named_route
       # assert_redirected_to "http://test.host/action_pack_assertions/foo" would pass because of exact match early return
@@ -231,7 +240,10 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
       set.draw do
         # this controller exists in the admin namespace as well which is the only difference from previous test
         get '/user/:id', :to => 'user#index', :as => :top_level
-        get ':controller/:action'
+
+        ActiveSupport::Deprecation.silence do
+          get ':controller/:action'
+        end
       end
       process :redirect_to_top_level_named_route
       # assert_redirected_to top_level_url('foo') would pass because of exact match early return

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -175,7 +175,10 @@ class UrlOptionsTest < ActionController::TestCase
     with_routing do |set|
       set.draw do
         get 'from_view', :to => 'url_options#from_view', :as => :from_view
-        get ':controller/:action'
+
+        ActiveSupport::Deprecation.silence do
+          get ':controller/:action'
+        end
       end
 
       get :from_view, params: { route: "from_view_url" }
@@ -209,7 +212,10 @@ class DefaultUrlOptionsTest < ActionController::TestCase
     with_routing do |set|
       set.draw do
         get 'from_view', :to => 'default_url_options#from_view', :as => :from_view
-        get ':controller/:action'
+
+        ActiveSupport::Deprecation.silence do
+          get ':controller/:action'
+        end
       end
 
       get :from_view, params: { route: "from_view_url" }
@@ -226,7 +232,10 @@ class DefaultUrlOptionsTest < ActionController::TestCase
         scope("/:locale") do
           resources :descriptions
         end
-        get ':controller/:action'
+
+        ActiveSupport::Deprecation.silence do
+          get ':controller/:action'
+        end
       end
 
       get :from_view, params: { route: "description_path(1)" }

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -323,7 +323,9 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
     def with_test_route_set
       with_routing do |set|
         set.draw do
-          get ':action', :to => FlashIntegrationTest::TestController
+          ActiveSupport::Deprecation.silence do
+            get ':action', :to => FlashIntegrationTest::TestController
+          end
         end
 
         @app = self.class.build_app(set) do |middleware|

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -730,8 +730,10 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
         set.draw do
           get 'moved' => redirect('/method')
 
-          match ':action', :to => controller, :via => [:get, :post], :as => :action
-          get 'get/:action', :to => controller, :as => :get_action
+          ActiveSupport::Deprecation.silence do
+            match ':action', :to => controller, :via => [:get, :post], :as => :action
+            get 'get/:action', :to => controller, :as => :get_action
+          end
         end
 
         self.singleton_class.include(set.url_helpers)
@@ -1105,7 +1107,12 @@ class IntegrationRequestsWithoutSetup < ActionDispatch::IntegrationTest
 
   def test_request
     with_routing do |routes|
-      routes.draw { get ':action' => FooController }
+      routes.draw do
+        ActiveSupport::Deprecation.silence do
+          get ':action' => FooController
+        end
+      end
+
       get '/ok'
 
       assert_response 200
@@ -1173,7 +1180,11 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
 
   def test_parsed_body_without_as_option
     with_routing do |routes|
-      routes.draw { get ':action' => FooController }
+      routes.draw do
+        ActiveSupport::Deprecation.silence do
+          get ':action' => FooController
+        end
+      end
 
       get '/foos_json.json', params: { foo: 'heyo' }
 
@@ -1184,7 +1195,11 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
   private
     def post_to_foos(as:)
       with_routing do |routes|
-        routes.draw { post ':action' => FooController }
+        routes.draw do
+          ActiveSupport::Deprecation.silence do
+            post ':action' => FooController
+          end
+        end
 
         post "/foos_#{as}", params: { foo: 'fighters' }, as: as
 

--- a/actionpack/test/controller/new_base/content_type_test.rb
+++ b/actionpack/test/controller/new_base/content_type_test.rb
@@ -43,7 +43,9 @@ module ContentType
     test "default response is text/plain and UTF8" do
       with_routing do |set|
         set.draw do
-          get ':controller', :action => 'index'
+          ActiveSupport::Deprecation.silence do
+            get ':controller', :action => 'index'
+          end
         end
 
         get "/content_type/base"

--- a/actionpack/test/controller/new_base/render_body_test.rb
+++ b/actionpack/test/controller/new_base/render_body_test.rb
@@ -85,7 +85,7 @@ module RenderBody
 
     test "rendering body from an action with default options renders the body with the layout" do
       with_routing do |set|
-        set.draw { get ':controller', action: 'index' }
+        set.draw { ActiveSupport::Deprecation.silence { get ':controller', action: 'index' } }
 
         get "/render_body/simple"
         assert_body "hello david"
@@ -95,7 +95,7 @@ module RenderBody
 
     test "rendering body from an action with default options renders the body without the layout" do
       with_routing do |set|
-        set.draw { get ':controller', action: 'index' }
+        set.draw { ActiveSupport::Deprecation.silence { get ':controller', action: 'index' } }
 
         get "/render_body/with_layout"
 

--- a/actionpack/test/controller/new_base/render_html_test.rb
+++ b/actionpack/test/controller/new_base/render_html_test.rb
@@ -88,7 +88,7 @@ module RenderHtml
 
     test "rendering text from an action with default options renders the text with the layout" do
       with_routing do |set|
-        set.draw { get ':controller', action: 'index' }
+        set.draw { ActiveSupport::Deprecation.silence { get ':controller', action: 'index' } }
 
         get "/render_html/simple"
         assert_body "hello david"
@@ -98,7 +98,7 @@ module RenderHtml
 
     test "rendering text from an action with default options renders the text without the layout" do
       with_routing do |set|
-        set.draw { get ':controller', action: 'index' }
+        set.draw { ActiveSupport::Deprecation.silence { get ':controller', action: 'index' } }
 
         get "/render_html/with_layout"
 

--- a/actionpack/test/controller/new_base/render_plain_test.rb
+++ b/actionpack/test/controller/new_base/render_plain_test.rb
@@ -80,7 +80,7 @@ module RenderPlain
 
     test "rendering text from an action with default options renders the text with the layout" do
       with_routing do |set|
-        set.draw { get ':controller', action: 'index' }
+        set.draw { ActiveSupport::Deprecation.silence { get ':controller', action: 'index' } }
 
         get "/render_plain/simple"
         assert_body "hello david"
@@ -90,7 +90,7 @@ module RenderPlain
 
     test "rendering text from an action with default options renders the text without the layout" do
       with_routing do |set|
-        set.draw { get ':controller', action: 'index' }
+        set.draw { ActiveSupport::Deprecation.silence { get ':controller', action: 'index' } }
 
         get "/render_plain/with_layout"
 

--- a/actionpack/test/controller/new_base/render_template_test.rb
+++ b/actionpack/test/controller/new_base/render_template_test.rb
@@ -177,7 +177,7 @@ module RenderTemplate
   class TestWithLayout < Rack::TestCase
     test "rendering with implicit layout" do
       with_routing do |set|
-        set.draw { get ':controller', :action => :index }
+        set.draw { ActiveSupport::Deprecation.silence { get ':controller', :action => :index } }
 
         get "/render_template/with_layout"
 

--- a/actionpack/test/controller/new_base/render_test.rb
+++ b/actionpack/test/controller/new_base/render_test.rb
@@ -57,7 +57,9 @@ module Render
     test "render with blank" do
       with_routing do |set|
         set.draw do
-          get ":controller", :action => 'index'
+          ActiveSupport::Deprecation.silence do
+            get ":controller", :action => 'index'
+          end
         end
 
         get "/render/blank_render"
@@ -70,7 +72,9 @@ module Render
     test "rendering more than once raises an exception" do
       with_routing do |set|
         set.draw do
-          get ":controller", :action => 'index'
+          ActiveSupport::Deprecation.silence do
+            get ":controller", :action => 'index'
+          end
         end
 
         assert_raises(AbstractController::DoubleRenderError) do

--- a/actionpack/test/controller/new_base/render_text_test.rb
+++ b/actionpack/test/controller/new_base/render_text_test.rb
@@ -83,7 +83,7 @@ module RenderText
 
     test "rendering text from an action with default options renders the text with the layout" do
       with_routing do |set|
-        set.draw { get ':controller', action: 'index' }
+        set.draw { ActiveSupport::Deprecation.silence { get ':controller', action: 'index' } }
 
         ActiveSupport::Deprecation.silence do
           get "/render_text/simple"
@@ -96,7 +96,7 @@ module RenderText
 
     test "rendering text from an action with default options renders the text without the layout" do
       with_routing do |set|
-        set.draw { get ':controller', action: 'index' }
+        set.draw { ActiveSupport::Deprecation.silence { get ':controller', action: 'index' } }
 
         ActiveSupport::Deprecation.silence do
           get "/render_text/with_layout"

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -286,7 +286,10 @@ class RedirectTest < ActionController::TestCase
     with_routing do |set|
       set.draw do
         resources :workshops
-        get ':controller/:action'
+
+        ActiveSupport::Deprecation.silence do
+          get ':controller/:action'
+        end
       end
 
       get :redirect_to_existing_record
@@ -328,7 +331,9 @@ class RedirectTest < ActionController::TestCase
   def test_redirect_to_with_block_and_accepted_options
     with_routing do |set|
       set.draw do
-        get ':controller/:action'
+        ActiveSupport::Deprecation.silence do
+          get ':controller/:action'
+        end
       end
 
       get :redirect_to_with_block_and_options

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -615,7 +615,10 @@ class HeadRenderTest < ActionController::TestCase
     with_routing do |set|
       set.draw do
         resources :customers
-        get ':controller/:action'
+
+        ActiveSupport::Deprecation.silence do
+          get ':controller/:action'
+        end
       end
 
       get :head_with_location_object

--- a/actionpack/test/controller/render_xml_test.rb
+++ b/actionpack/test/controller/render_xml_test.rb
@@ -72,7 +72,10 @@ class RenderXmlTest < ActionController::TestCase
     with_routing do |set|
       set.draw do
         resources :customers
-        get ':controller/:action'
+
+        ActiveSupport::Deprecation.silence do
+          get ':controller/:action'
+        end
       end
 
       get :render_with_object_location

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -15,7 +15,9 @@ class UriReservedCharactersRoutingTest < ActiveSupport::TestCase
   def setup
     @set = ActionDispatch::Routing::RouteSet.new
     @set.draw do
-      get ':controller/:action/:variable/*additional'
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:variable/*additional'
+      end
     end
 
     safe, unsafe = %w(: @ & = + $ , ;), %w(^ ? # [ ])
@@ -300,7 +302,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   end
 
   def test_default_setup
-    rs.draw { get '/:controller(/:action(/:id))' }
+    rs.draw { ActiveSupport::Deprecation.silence { get '/:controller(/:action(/:id))' } }
     assert_equal({:controller => "content", :action => 'index'}, rs.recognize_path("/content"))
     assert_equal({:controller => "content", :action => 'list'},  rs.recognize_path("/content/list"))
     assert_equal({:controller => "content", :action => 'show', :id => '10'}, rs.recognize_path("/content/show/10"))
@@ -323,7 +325,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_route_with_colon_first
     rs.draw do
-      get '/:controller/:action/:id', action: 'index', id: nil
+      ActiveSupport::Deprecation.silence do
+        get '/:controller/:action/:id', action: 'index', id: nil
+      end
+
       get ':url', controller: 'content', action: 'translate'
     end
 
@@ -331,7 +336,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   end
 
   def test_route_with_regexp_for_action
-    rs.draw { get '/:controller/:action', action: /auth[-|_].+/ }
+    rs.draw { ActiveSupport::Deprecation.silence { get '/:controller/:action', action: /auth[-|_].+/ } }
 
     assert_equal({ action: 'auth_google', controller: 'content' }, rs.recognize_path('/content/auth_google'))
     assert_equal({ action: 'auth-facebook', controller: 'content' }, rs.recognize_path('/content/auth-facebook'))
@@ -342,8 +347,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_route_with_regexp_for_controller
     rs.draw do
-      get ':controller/:admintoken(/:action(/:id))', :controller => /admin\/.+/
-      get '/:controller(/:action(/:id))'
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:admintoken(/:action(/:id))', :controller => /admin\/.+/
+        get '/:controller(/:action(/:id))'
+      end
     end
 
     assert_equal({:controller => "admin/user", :admintoken => "foo", :action => "index"},
@@ -357,7 +364,9 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_route_with_regexp_and_captures_for_controller
     rs.draw do
-      get '/:controller(/:action(/:id))', :controller => /admin\/(accounts|users)/
+      ActiveSupport::Deprecation.silence do
+        get '/:controller(/:action(/:id))', :controller => /admin\/(accounts|users)/
+      end
     end
     assert_equal({:controller => "admin/accounts", :action => "index"}, rs.recognize_path("/admin/accounts"))
     assert_equal({:controller => "admin/users", :action => "index"}, rs.recognize_path("/admin/users"))
@@ -366,11 +375,13 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_route_with_regexp_and_dot
     rs.draw do
-      get ':controller/:action/:file',
-                :controller => /admin|user/,
-                :action => /upload|download/,
-                :defaults => {:file => nil},
-                :constraints => {:file => %r{[^/]+(\.[^/]+)?}}
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:file',
+                  :controller => /admin|user/,
+                  :action => /upload|download/,
+                  :defaults => {:file => nil},
+                  :constraints => {:file => %r{[^/]+(\.[^/]+)?}}
+      end
     end
     # Without a file extension
     assert_equal '/user/download/file',
@@ -457,7 +468,9 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_named_route_without_hash
     rs.draw do
-      get ':controller/:action/:id', :as => 'normal'
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id', :as => 'normal'
+      end
     end
   end
 
@@ -509,7 +522,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     rs.draw do
       get 'page/:year/:month/:day/:title' => 'page#show', :as => 'article',
         :year => /\d+/, :month => /\d+/, :day => /\d+/
-      get ':controller/:action/:id'
+
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id'
+      end
     end
 
     routes = setup_for_named_route
@@ -519,7 +535,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   end
 
   def test_changing_controller
-    rs.draw { get ':controller/:action/:id' }
+    rs.draw { ActiveSupport::Deprecation.silence { get ':controller/:action/:id' } }
 
     get URI('http://test.host/admin/user/index/10')
 
@@ -530,7 +546,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   def test_paths_escaped
     rs.draw do
       get 'file/*path' => 'content#show_file', :as => 'path'
-      get ':controller/:action/:id'
+
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id'
+      end
     end
 
     # No + to space in URI escaping, only for query params.
@@ -555,7 +574,9 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_non_controllers_cannot_be_matched
     rs.draw do
-      get ':controller/:action/:id'
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id'
+      end
     end
     assert_raise(ActionController::RoutingError) { rs.recognize_path("/not_a/show/10") }
   end
@@ -593,8 +614,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_backwards
     rs.draw do
-      get 'page/:id(/:action)' => 'pages#show'
-      get ':controller(/:action(/:id))'
+      ActiveSupport::Deprecation.silence do
+        get 'page/:id(/:action)' => 'pages#show'
+        get ':controller(/:action(/:id))'
+      end
     end
 
     get URI('http://test.host/pages/show')
@@ -606,7 +629,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   def test_route_with_fixnum_default
     rs.draw do
       get 'page(/:id)' => 'content#show_page', :id => 1
-      get ':controller/:action/:id'
+
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id'
+      end
     end
 
     assert_equal '/page',    url_for(rs, { :controller => 'content', :action => 'show_page' })
@@ -623,7 +649,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   def test_route_with_text_default
     rs.draw do
       get 'page/:id' => 'content#show_page', :id => 1
-      get ':controller/:action/:id'
+
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id'
+      end
     end
 
     assert_equal '/page/foo', url_for(rs, { :controller => 'content', :action => 'show_page', :id => 'foo' })
@@ -638,7 +667,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   end
 
   def test_action_expiry
-    rs.draw { get ':controller(/:action(/:id))' }
+    rs.draw { ActiveSupport::Deprecation.silence { get ':controller(/:action(/:id))' } }
     get URI('http://test.host/content/show')
     assert_equal '/content', controller.url_for(:controller => 'content', :only_path => true)
   end
@@ -661,7 +690,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
         :defaults => { :year => nil },
         :constraints => { :year => /\d{4}/ }
       )
-      get ':controller/:action/:id'
+
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id'
+      end
     end
 
     assert_equal '/test', url_for(rs, { :controller => 'post', :action => 'show' })
@@ -673,7 +705,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   def test_set_to_nil_forgets
     rs.draw do
       get 'pages(/:year(/:month(/:day)))' => 'content#list_pages', :month => nil, :day => nil
-      get ':controller/:action/:id'
+
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id'
+      end
     end
 
     assert_equal '/pages/2005',
@@ -720,7 +755,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   def test_named_route_method
     rs.draw do
       get 'categories' => 'content#categories', :as => 'categories'
-      get ':controller(/:action(/:id))'
+
+      ActiveSupport::Deprecation.silence do
+        get ':controller(/:action(/:id))'
+      end
     end
 
     assert_equal '/categories', url_for(rs, { :controller => 'content', :action => 'categories' })
@@ -736,7 +774,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     rs.draw do
       get 'journal' => 'content#list_journal',
         :date => nil, :user_id => nil
-      get ':controller/:action/:id'
+
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id'
+      end
     end
 
     assert_equal '/journal', url_for(rs, {
@@ -776,10 +817,12 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_subpath_recognized
     rs.draw do
-      get '/books/:id/edit'    => 'subpath_books#edit'
-      get '/items/:id/:action' => 'subpath_books'
-      get '/posts/new/:action' => 'subpath_books'
-      get '/posts/:id'         => 'subpath_books#show'
+      ActiveSupport::Deprecation.silence do
+        get '/books/:id/edit'    => 'subpath_books#edit'
+        get '/items/:id/:action' => 'subpath_books'
+        get '/posts/new/:action' => 'subpath_books'
+        get '/posts/:id'         => 'subpath_books#show'
+      end
     end
 
     hash = rs.recognize_path "/books/17/edit"
@@ -801,9 +844,11 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_subpath_generated
     rs.draw do
-      get '/books/:id/edit'    => 'subpath_books#edit'
-      get '/items/:id/:action' => 'subpath_books'
-      get '/posts/new/:action' => 'subpath_books'
+      ActiveSupport::Deprecation.silence do
+        get '/books/:id/edit'    => 'subpath_books#edit'
+        get '/items/:id/:action' => 'subpath_books'
+        get '/posts/new/:action' => 'subpath_books'
+      end
     end
 
     assert_equal "/books/7/edit",      url_for(rs, { :controller => "subpath_books", :id => 7, :action => "edit" })
@@ -827,8 +872,11 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
       get 'ca' => 'ca#aa'
       get 'cb' => 'cb#ab'
       get 'cc' => 'cc#ac'
-      get ':controller/:action/:id'
-      get ':controller/:action/:id.:format'
+
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id'
+        get ':controller/:action/:id.:format'
+      end
     end
 
     hash = rs.recognize_path "/cc"
@@ -839,8 +887,11 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     rs.draw do
       get 'cb' => 'cb#ab'
       get 'cc' => 'cc#ac'
-      get ':controller/:action/:id'
-      get ':controller/:action/:id.:format'
+
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id'
+        get ':controller/:action/:id.:format'
+      end
     end
 
     hash = rs.recognize_path "/cc"
@@ -871,29 +922,34 @@ class RouteSetTest < ActiveSupport::TestCase
     @default_route_set ||= begin
       set = ActionDispatch::Routing::RouteSet.new
       set.draw do
-        get '/:controller(/:action(/:id))'
+
+        ActiveSupport::Deprecation.silence do
+          get '/:controller(/:action(/:id))'
+        end
       end
       set
     end
   end
 
   def test_generate_extras
-    set.draw { get ':controller/(:action(/:id))' }
+    set.draw { ActiveSupport::Deprecation.silence { get ':controller/(:action(/:id))' } }
     path, extras = set.generate_extras(:controller => "foo", :action => "bar", :id => 15, :this => "hello", :that => "world")
     assert_equal "/foo/bar/15", path
     assert_equal %w(that this), extras.map(&:to_s).sort
   end
 
   def test_extra_keys
-    set.draw { get ':controller/:action/:id' }
+    set.draw { ActiveSupport::Deprecation.silence { get ':controller/:action/:id' } }
     extras = set.extra_keys(:controller => "foo", :action => "bar", :id => 15, :this => "hello", :that => "world")
     assert_equal %w(that this), extras.map(&:to_s).sort
   end
 
   def test_generate_extras_not_first
     set.draw do
-      get ':controller/:action/:id.:format'
-      get ':controller/:action/:id'
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id.:format'
+        get ':controller/:action/:id'
+      end
     end
     path, extras = set.generate_extras(:controller => "foo", :action => "bar", :id => 15, :this => "hello", :that => "world")
     assert_equal "/foo/bar/15", path
@@ -902,8 +958,10 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_generate_not_first
     set.draw do
-      get ':controller/:action/:id.:format'
-      get ':controller/:action/:id'
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id.:format'
+        get ':controller/:action/:id'
+      end
     end
     assert_equal "/foo/bar/15?this=hello",
         url_for(set, { :controller => "foo", :action => "bar", :id => 15, :this => "hello" })
@@ -911,8 +969,10 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_extra_keys_not_first
     set.draw do
-      get ':controller/:action/:id.:format'
-      get ':controller/:action/:id'
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id.:format'
+        get ':controller/:action/:id'
+      end
     end
     extras = set.extra_keys(:controller => "foo", :action => "bar", :id => 15, :this => "hello", :that => "world")
     assert_equal %w(that this), extras.map(&:to_s).sort
@@ -1044,7 +1104,9 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_draw_default_route
     set.draw do
-      get '/:controller/:action/:id'
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id'
+      end
     end
 
     assert_equal 1, set.routes.size
@@ -1059,7 +1121,10 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_route_with_parameter_shell
     set.draw do
       get 'page/:id' => 'pages#show', :id => /\d+/
-      get '/:controller(/:action(/:id))'
+
+      ActiveSupport::Deprecation.silence do
+        get '/:controller(/:action(/:id))'
+      end
     end
 
     assert_equal({:controller => 'pages', :action => 'index'}, request_path_params('/pages'))
@@ -1314,7 +1379,9 @@ class RouteSetTest < ActiveSupport::TestCase
     @set = make_set false
 
     set.draw do
-      get ':controller/:id/:action'
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:id/:action'
+      end
     end
 
     get URI('http://test.host/people/7/show')
@@ -1327,7 +1394,10 @@ class RouteSetTest < ActiveSupport::TestCase
 
     set.draw do
       get 'about' => "welcome#about"
-      get ':controller/:action/:id'
+
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:id/:action'
+      end
     end
 
     get URI('http://test.host/welcom/get/7')
@@ -1338,7 +1408,7 @@ class RouteSetTest < ActiveSupport::TestCase
   end
 
   def test_generate
-    set.draw { get ':controller/:action/:id' }
+    set.draw { ActiveSupport::Deprecation.silence { get ':controller/:action/:id' } }
 
     args = { :controller => "foo", :action => "bar", :id => "7", :x => "y" }
     assert_equal "/foo/bar/7?x=y",     url_for(set, args)
@@ -1349,7 +1419,9 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_generate_with_path_prefix
     set.draw do
       scope "my" do
-        get ':controller(/:action(/:id))'
+        ActiveSupport::Deprecation.silence do
+          get ':controller(/:action(/:id))'
+        end
       end
     end
 
@@ -1360,7 +1432,9 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_generate_with_blank_path_prefix
     set.draw do
       scope "" do
-        get ':controller(/:action(/:id))'
+        ActiveSupport::Deprecation.silence do
+          get ':controller(/:action(/:id))'
+        end
       end
     end
 
@@ -1372,9 +1446,11 @@ class RouteSetTest < ActiveSupport::TestCase
     @set = make_set false
 
     set.draw do
-      get "/connection/manage(/:action)" => 'connection/manage#index'
-      get "/connection/connection" => "connection/connection#index"
-      get '/connection' => 'connection#index', :as => 'family_connection'
+      ActiveSupport::Deprecation.silence do
+        get "/connection/manage(/:action)" => 'connection/manage#index'
+        get "/connection/connection" => "connection/connection#index"
+        get '/connection' => 'connection#index', :as => 'family_connection'
+      end
     end
 
     assert_equal({ :controller => 'connection/manage',
@@ -1392,7 +1468,9 @@ class RouteSetTest < ActiveSupport::TestCase
     @set = make_set false
 
     set.draw do
-      get ':controller(/:action(/:id))'
+      ActiveSupport::Deprecation.silence do
+        get ':controller(/:action(/:id))'
+      end
     end
 
     get URI('http://test.host/books/show/10')
@@ -1407,7 +1485,10 @@ class RouteSetTest < ActiveSupport::TestCase
 
     set.draw do
       get 'show_weblog/:parameter' => 'weblog#show'
-      get ':controller(/:action(/:id))'
+
+      ActiveSupport::Deprecation.silence do
+        get ':controller(/:action(/:id))'
+      end
     end
 
     get URI('http://test.host/weblog/show/1')
@@ -1435,7 +1516,7 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_expiry_determination_should_consider_values_with_to_param
     @set = make_set false
 
-    set.draw { get 'projects/:project_id/:controller/:action' }
+    set.draw { ActiveSupport::Deprecation.silence { get 'projects/:project_id/:controller/:action' } }
 
     get URI('http://test.host/projects/1/weblog/show')
 
@@ -1612,7 +1693,9 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_assign_route_options_with_anchor_chars
     set.draw do
-      get '/cars/:action/:person/:car/', :controller => 'cars'
+      ActiveSupport::Deprecation.silence do
+        get '/cars/:action/:person/:car/', :controller => 'cars'
+      end
     end
 
     assert_equal '/cars/buy/1/2', url_for(set, { :controller => 'cars', :action => 'buy', :person => '1', :car => '2' })
@@ -1622,7 +1705,9 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_segmentation_of_dot_path
     set.draw do
-      get '/books/:action.rss', :controller => 'books'
+      ActiveSupport::Deprecation.silence do
+        get '/books/:action.rss', :controller => 'books'
+      end
     end
 
     assert_equal '/books/list.rss', url_for(set, { :controller => 'books', :action => 'list' })
@@ -1632,7 +1717,9 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_segmentation_of_dynamic_dot_path
     set.draw do
-      get '/books(/:action(.:format))', :controller => 'books'
+      ActiveSupport::Deprecation.silence do
+        get '/books(/:action(.:format))', :controller => 'books'
+      end
     end
 
     assert_equal '/books/list.rss', url_for(set, { :controller => 'books', :action => 'list', :format => 'rss' })
@@ -1647,7 +1734,7 @@ class RouteSetTest < ActiveSupport::TestCase
   end
 
   def test_slashes_are_implied
-    set.draw { get("/:controller(/:action(/:id))") }
+    set.draw { ActiveSupport::Deprecation.silence { get("/:controller(/:action(/:id))") } }
 
     assert_equal '/content',        url_for(set, { :controller => 'content', :action => 'index' })
     assert_equal '/content/list',   url_for(set, { :controller => 'content', :action => 'list' })
@@ -1738,7 +1825,9 @@ class RouteSetTest < ActiveSupport::TestCase
                              :constraints => { :page => /\d+/ },
                              :defaults => { :page => 1 }
 
-      get ':controller/:action/:id'
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/:id'
+      end
     end
 
     assert_equal '/ibocorp', url_for(set, { :controller => 'ibocorp', :action => "show", :page => 1 })
@@ -1761,7 +1850,11 @@ class RouteSetTest < ActiveSupport::TestCase
             :day => nil, :month => nil
 
       get "blog/show/:id", :controller => "blog", :action => "show", :id => /\d+/
-      get "blog/:controller/:action(/:id)"
+
+      ActiveSupport::Deprecation.silence do
+        get "blog/:controller/:action(/:id)"
+      end
+
       get "*anything", :controller => "blog", :action => "unknown_request"
     end
 
@@ -1850,13 +1943,20 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
 
     get 'news(.:format)' => "news#index"
 
-    get 'comment/:id(/:action)' => "comments#show"
-    get 'ws/:controller(/:action(/:id))', :ws => true
-    get 'account(/:action)' => "account#subscription"
-    get 'pages/:page_id/:controller(/:action(/:id))'
-    get ':controller/ping', :action => 'ping'
+    ActiveSupport::Deprecation.silence do
+      get 'comment/:id(/:action)' => "comments#show"
+      get 'ws/:controller(/:action(/:id))', :ws => true
+      get 'account(/:action)' => "account#subscription"
+      get 'pages/:page_id/:controller(/:action(/:id))'
+      get ':controller/ping', :action => 'ping'
+    end
+
     get 'こんにちは/世界', :controller => 'news', :action => 'index'
-    match ':controller(/:action(/:id))(.:format)', :via => :all
+
+    ActiveSupport::Deprecation.silence do
+      match ':controller(/:action(/:id))(.:format)', :via => :all
+    end
+
     root :to => "news#index"
   }
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -167,7 +167,9 @@ XML
     @request.delete_header 'PATH_INFO'
     @routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
       r.draw do
-        get ':controller(/:action(/:id))'
+        ActiveSupport::Deprecation.silence do
+          get ':controller(/:action(/:id))'
+        end
       end
     end
   end
@@ -672,7 +674,10 @@ XML
     with_routing do |set|
       set.draw do
         get 'file/*path', to: 'test_case_test/test#test_params'
-        get ':controller/:action'
+
+        ActiveSupport::Deprecation.silence do
+          get ':controller/:action'
+        end
       end
 
       get :test_params, params: { path: ['hello', 'world'] }
@@ -1008,7 +1013,9 @@ class ResponseDefaultHeadersTest < ActionController::TestCase
     @request.env['PATH_INFO'] = nil
     @routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
       r.draw do
-        get ':controller(/:action(/:id))'
+        ActiveSupport::Deprecation.silence do
+          get ':controller(/:action(/:id))'
+        end
       end
     end
   end
@@ -1135,7 +1142,9 @@ class AnonymousControllerTest < ActionController::TestCase
 
     @routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
       r.draw do
-        get ':controller(/:action(/:id))'
+        ActiveSupport::Deprecation.silence do
+          get ':controller(/:action(/:id))'
+        end
       end
     end
   end

--- a/actionpack/test/controller/url_for_integration_test.rb
+++ b/actionpack/test/controller/url_for_integration_test.rb
@@ -52,12 +52,15 @@ module ActionPack
 
       get 'news(.:format)' => "news#index"
 
-      get 'comment/:id(/:action)' => "comments#show"
-      get 'ws/:controller(/:action(/:id))', :ws => true
-      get 'account(/:action)' => "account#subscription"
-      get 'pages/:page_id/:controller(/:action(/:id))'
-      get ':controller/ping', :action => 'ping'
-      get ':controller(/:action(/:id))(.:format)'
+      ActiveSupport::Deprecation.silence {
+        get 'comment/:id(/:action)' => "comments#show"
+        get 'ws/:controller(/:action(/:id))', :ws => true
+        get 'account(/:action)' => "account#subscription"
+        get 'pages/:page_id/:controller(/:action(/:id))'
+        get ':controller/ping', :action => 'ping'
+        get ':controller(/:action(/:id))(.:format)'
+      }
+
       root :to => "news#index"
     }
 

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -4,7 +4,13 @@ module AbstractController
   module Testing
     class UrlForTest < ActionController::TestCase
       class W
-        include ActionDispatch::Routing::RouteSet.new.tap { |r| r.draw { get ':controller(/:action(/:id(.:format)))' } }.url_helpers
+        include ActionDispatch::Routing::RouteSet.new.tap { |r|
+          r.draw {
+            ActiveSupport::Deprecation.silence {
+              get ':controller(/:action(/:id(.:format)))'
+            }
+          }
+        }.url_helpers
       end
 
       def teardown
@@ -260,7 +266,7 @@ module AbstractController
         w = Class.new {
           config = ActionDispatch::Routing::RouteSet::Config.new '/subdir'
           r = ActionDispatch::Routing::RouteSet.new(config)
-          r.draw { get ':controller(/:action(/:id(.:format)))' }
+          r.draw { ActiveSupport::Deprecation.silence { get ':controller(/:action(/:id(.:format)))' } }
           include r.url_helpers
         }
         add_host!(w)
@@ -315,7 +321,10 @@ module AbstractController
         with_routing do |set|
           set.draw do
             get 'home/sweet/home/:user', :to => 'home#index', :as => :home
-            get ':controller/:action/:id'
+
+            ActiveSupport::Deprecation.silence do
+              get ':controller/:action/:id'
+            end
           end
 
           # We need to create a new class in order to install the new named route.

--- a/actionpack/test/controller/url_rewriter_test.rb
+++ b/actionpack/test/controller/url_rewriter_test.rb
@@ -20,7 +20,9 @@ class UrlRewriterTests < ActionController::TestCase
     @rewriter = Rewriter.new(@request) #.new(@request, @params)
     @routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
       r.draw do
-        get ':controller(/:action(/:id))'
+        ActiveSupport::Deprecation.silence do
+          get ':controller(/:action(/:id))'
+        end
       end
     end
   end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -103,7 +103,9 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     def with_test_routing
       with_routing do |set|
         set.draw do
-          post ':action', :to => ::JsonParamsParsingTest::TestController
+          ActiveSupport::Deprecation.silence do
+            post ':action', :to => ::JsonParamsParsingTest::TestController
+          end
         end
         yield
       end
@@ -191,7 +193,9 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
     def with_test_routing(controller)
       with_routing do |set|
         set.draw do
-          post ':action', :to => controller
+          ActiveSupport::Deprecation.silence do
+            post ':action', :to => controller
+          end
         end
         yield
       end

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -159,7 +159,9 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
   test "does not raise EOFError on GET request with multipart content-type" do
     with_routing do |set|
       set.draw do
-        get ':action', controller: 'multipart_params_parsing_test/test'
+        ActiveSupport::Deprecation.silence do
+          get ':action', controller: 'multipart_params_parsing_test/test'
+        end
       end
       headers = { "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x" }
       get "/parse", headers: headers
@@ -188,7 +190,9 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
     def with_test_routing
       with_routing do |set|
         set.draw do
-          post ':action', :controller => 'multipart_params_parsing_test/test'
+          ActiveSupport::Deprecation.silence do
+            post ':action', :controller => 'multipart_params_parsing_test/test'
+          end
         end
         yield
       end

--- a/actionpack/test/dispatch/request/query_string_parsing_test.rb
+++ b/actionpack/test/dispatch/request/query_string_parsing_test.rb
@@ -144,7 +144,9 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
   test "ambiguous query string returns a bad request" do
     with_routing do |set|
       set.draw do
-        get ':action', :to => ::QueryStringParsingTest::TestController
+        ActiveSupport::Deprecation.silence do
+          get ':action', :to => ::QueryStringParsingTest::TestController
+        end
       end
 
       get "/parse", headers: { "QUERY_STRING" => "foo[]=bar&foo[4]=bar" }
@@ -156,7 +158,9 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
     def assert_parses(expected, actual)
       with_routing do |set|
         set.draw do
-          get ':action', :to => ::QueryStringParsingTest::TestController
+          ActiveSupport::Deprecation.silence do
+            get ':action', :to => ::QueryStringParsingTest::TestController
+          end
         end
         @app = self.class.build_app(set) do |middleware|
           middleware.use(EarlyParse)

--- a/actionpack/test/dispatch/request/url_encoded_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/url_encoded_params_parsing_test.rb
@@ -140,7 +140,9 @@ class UrlEncodedParamsParsingTest < ActionDispatch::IntegrationTest
     def with_test_routing
       with_routing do |set|
         set.draw do
-          post ':action', to: ::UrlEncodedParamsParsingTest::TestController
+          ActiveSupport::Deprecation.silence do
+            post ':action', to: ::UrlEncodedParamsParsingTest::TestController
+          end
         end
         yield
       end

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -133,7 +133,9 @@ module ActionDispatch
 
       def test_inspect_routes_shows_dynamic_action_route
         output = draw do
-          get 'api/:action' => 'api'
+          ActiveSupport::Deprecation.silence do
+            get 'api/:action' => 'api'
+          end
         end
 
         assert_equal [
@@ -144,7 +146,9 @@ module ActionDispatch
 
       def test_inspect_routes_shows_controller_and_action_only_route
         output = draw do
-          get ':controller/:action'
+          ActiveSupport::Deprecation.silence do
+            get ':controller/:action'
+          end
         end
 
         assert_equal [
@@ -155,7 +159,9 @@ module ActionDispatch
 
       def test_inspect_routes_shows_controller_and_action_route_with_constraints
         output = draw do
-          get ':controller(/:action(/:id))', :id => /\d+/
+          ActiveSupport::Deprecation.silence do
+            get ':controller(/:action(/:id))', :id => /\d+/
+          end
         end
 
         assert_equal [
@@ -335,7 +341,9 @@ module ActionDispatch
 
       def test_regression_route_with_controller_regexp
         output = draw do
-          get ':controller(/:action)', controller: /api\/[^\/]+/, format: false
+          ActiveSupport::Deprecation.silence do
+            get ':controller(/:action)', controller: /api\/[^\/]+/, format: false
+          end
         end
 
         assert_equal ["Prefix Verb URI Pattern            Controller#Action",

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -116,7 +116,9 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_raise(ArgumentError) do
       draw do
         namespace :admin do
-          get '/:controller(/:action(/:id(.:format)))'
+          ActiveSupport::Deprecation.silence do
+            get '/:controller(/:action(/:id(.:format)))'
+          end
         end
       end
     end
@@ -125,7 +127,9 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   def test_namespace_without_controller_segment
     draw do
       namespace :admin do
-        get 'hello/:controllers/:action'
+        ActiveSupport::Deprecation.silence do
+          get 'hello/:controllers/:action'
+        end
       end
     end
     get '/admin/hello/foo/new'
@@ -427,7 +431,10 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
         get 'global/hide_notice'
         get 'global/export',      :action => :export, :as => :export_request
         get '/export/:id/:file',  :action => :export, :as => :export_download, :constraints => { :file => /.*/ }
-        get 'global/:action'
+
+        ActiveSupport::Deprecation.silence do
+          get 'global/:action'
+        end
       end
     end
 
@@ -450,7 +457,9 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_local
     draw do
-      get "/local/:action", :controller => "local"
+      ActiveSupport::Deprecation.silence do
+        get "/local/:action", :controller => "local"
+      end
     end
 
     get '/local/dashboard'
@@ -1506,7 +1515,9 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_not_matching_shorthand_with_dynamic_parameters
     draw do
-      get ':controller/:action/admin'
+      ActiveSupport::Deprecation.silence do
+        get ':controller/:action/admin'
+      end
     end
 
     get '/finances/overview/admin'
@@ -1542,7 +1553,9 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   def test_scoped_controller_with_namespace_and_action
     draw do
       namespace :account do
-        get ':action/callback', :action => /twitter|github/, :controller => "callbacks", :as => :callback
+        ActiveSupport::Deprecation.silence do
+          get ':action/callback', :action => /twitter|github/, :controller => "callbacks", :as => :callback
+        end
       end
     end
 
@@ -1837,7 +1850,9 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_url_generator_for_generic_route
     draw do
-      get "whatever/:controller(/:action(/:id))"
+      ActiveSupport::Deprecation.silence do
+        get "whatever/:controller(/:action(/:id))"
+      end
     end
 
     get '/whatever/foo/bar'
@@ -1849,7 +1864,9 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_url_generator_for_namespaced_generic_route
     draw do
-      get "whatever/:controller(/:action(/:id))", :id => /\d+/
+      ActiveSupport::Deprecation.silence do
+        get "whatever/:controller(/:action(/:id))", :id => /\d+/
+      end
     end
 
     get '/whatever/foo/bar/show'
@@ -3125,12 +3142,6 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     assert_raise(ArgumentError) do
-      assert_deprecated do
-        draw { controller("/feeds") { get '/feeds/:service', :to => :show } }
-      end
-    end
-
-    assert_raise(ArgumentError) do
       draw { resources :feeds, :controller => '/feeds' }
     end
   end
@@ -3597,6 +3608,22 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     params.permit!
 
     assert_equal '/?id=1', root_path(params)
+  end
+
+  def test_dynamic_controller_segments_are_deprecated
+    assert_deprecated do
+      draw do
+        get '/:controller', action: 'index'
+      end
+    end
+  end
+
+  def test_dynamic_action_segments_are_deprecated
+    assert_deprecated do
+      draw do
+        get '/pages/:action', controller: 'pages'
+      end
+    end
   end
 
 private
@@ -4122,7 +4149,11 @@ class TestOptimizedNamedRoutes < ActionDispatch::IntegrationTest
     app.draw do
       ok = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, []] }
       get '/foo' => ok, as: :foo
-      get '/post(/:action(/:id))' => ok, as: :posts
+
+      ActiveSupport::Deprecation.silence do
+        get '/post(/:action(/:id))' => ok, as: :posts
+      end
+
       get '/:foo/:foo_type/bars/:id' => ok, as: :bar
       get '/projects/:id.:format' => ok, as: :project
       get '/pages/:id' => ok, as: :page
@@ -4292,11 +4323,16 @@ class TestInvalidUrls < ActionDispatch::IntegrationTest
 
   test "invalid UTF-8 encoding returns a 400 Bad Request" do
     with_routing do |set|
-      set.draw do
-        get "/bar/:id", :to => redirect("/foo/show/%{id}")
-        get "/foo/show(/:id)", :to => "test_invalid_urls/foo#show"
-        get "/foo(/:action(/:id))", :controller => "test_invalid_urls/foo"
-        get "/:controller(/:action(/:id))"
+      ActiveSupport::Deprecation.silence do
+        set.draw do
+          get "/bar/:id", :to => redirect("/foo/show/%{id}")
+          get "/foo/show(/:id)", :to => "test_invalid_urls/foo#show"
+
+          ActiveSupport::Deprecation.silence do
+            get "/foo(/:action(/:id))", :controller => "test_invalid_urls/foo"
+            get "/:controller(/:action(/:id))"
+          end
+        end
       end
 
       get "/%E2%EF%BF%BD%A6"
@@ -4627,7 +4663,9 @@ class TestErrorsInController < ActionDispatch::IntegrationTest
 
   Routes = ActionDispatch::Routing::RouteSet.new
   Routes.draw do
-    get '/:controller(/:action)'
+    ActiveSupport::Deprecation.silence do
+      get '/:controller(/:action)'
+    end
   end
 
   APP = build_app Routes

--- a/actionpack/test/dispatch/session/cache_store_test.rb
+++ b/actionpack/test/dispatch/session/cache_store_test.rb
@@ -164,7 +164,9 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
     def with_test_route_set
       with_routing do |set|
         set.draw do
-          get ':action', :to => ::CacheStoreTest::TestController
+          ActiveSupport::Deprecation.silence do
+            get ':action', :to => ::CacheStoreTest::TestController
+          end
         end
 
         @app = self.class.build_app(set) do |middleware|

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -345,7 +345,9 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
     def with_test_route_set(options = {})
       with_routing do |set|
         set.draw do
-          get ':action', :to => ::CookieStoreTest::TestController
+          ActiveSupport::Deprecation.silence do
+            get ':action', :to => ::CookieStoreTest::TestController
+          end
         end
 
         options = { :key => SessionKey }.merge!(options)

--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -187,7 +187,9 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
     def with_test_route_set
       with_routing do |set|
         set.draw do
-          get ':action', :to => ::MemCacheStoreTest::TestController
+          ActiveSupport::Deprecation.silence do
+            get ':action', :to => ::MemCacheStoreTest::TestController
+          end
         end
 
         @app = self.class.build_app(set) do |middleware|

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -124,7 +124,7 @@ module TestHelpers
       routes = File.read("#{app_path}/config/routes.rb")
       if routes =~ /(\n\s*end\s*)\Z/
         File.open("#{app_path}/config/routes.rb", 'w') do |f|
-          f.puts $` + "\nmatch ':controller(/:action(/:id))(.:format)', via: :all\n" + $1
+          f.puts $` + "\nActiveSupport::Deprecation.silence { match ':controller(/:action(/:id))(.:format)', via: :all }\n" + $1
         end
       end
 


### PR DESCRIPTION
Allowing :controller and :action values to be specified via the path in config/routes.rb has been an underlying cause of a number of issues in Rails that have resulted in security releases. In light of this it's
better that controllers and actions are explicitly whitelisted rather than trying to blacklist or sanitize 'bad' values.

WDYT? @dhh @rafaelfranca @tenderlove 
