### PR TITLE
fix `as_json()` when passing hashes to 'include' array

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -177,7 +177,7 @@ module ActiveModel
         return unless includes = options[:include]
 
         unless includes.is_a?(Hash)
-          includes = Hash[Array(includes).map { |n| n.is_a?(Hash) ? n.to_a.first : [n, {}] }]
+          includes = Array(includes).each_with_object({}) { |n, hash| n.is_a?(Hash) ? hash.merge!(n) : hash[n] = {} }
         end
 
         includes.each do |association, opts|

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -138,6 +138,14 @@ class SerializationTest < ActiveModel::TestCase
     assert_equal expected, @user.serializable_hash(include: [:address, :friends])
   end
 
+  def test_multiple_includes_with_empty_hash
+    expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
+                "address"=>{"street"=>"123 Lane", "city"=>"Springfield", "state"=>"CA", "zip"=>11111},
+                "friends"=>[{"name"=>'Joe', "email"=>'joe@example.com', "gender"=>'male'},
+                            {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female'}]}
+    assert_equal expected, @user.serializable_hash(include: [address: {}, friends: {}])
+  end
+
   def test_include_with_options
     expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David",
                 "address"=>{"street"=>"123 Lane"}}


### PR DESCRIPTION
### Summary

As noticed by kenaniah in https://github.com/rails/rails/issues/22563
there is a bug in `as_json()` that prevents proper serialization

```
MyModel.first.as_json(include: [
    :tags,
    user: {
        only: [:first_name, :last_name]
    }, # BUG: rails doesn't return anything after the first hash config
    card: {
        only: [:name, :rp_name]
    }
])
```

This is due to the fact that `user` and `card` are merged to a single hash.
The workaround is to wrap them in `{}` like this:

```
MyModel.first.as_json(include: [
    :tags,
    {
        user: {
            only: [:first_name, :last_name]
        }
    }, 
    {
        card: {
            only: [:name, :rp_name]
        }
    }
])
```

With this PR the workaround is not needed.
