### PR TITLE
Improve String#demodulize method

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/inflections'
 
 module ActiveSupport
@@ -204,12 +206,7 @@ module ActiveSupport
     #
     # See also #deconstantize.
     def demodulize(path)
-      path = path.to_s
-      if i = path.rindex('::')
-        path[(i+2)..-1]
-      else
-        path
-      end
+      (i = path.rindex('::')) ? path[(i + 2)..-1] : path
     end
 
     # Removes the rightmost segment from the constant expression in the string.

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -206,6 +206,7 @@ module ActiveSupport
     #
     # See also #deconstantize.
     def demodulize(path)
+      path = deprecate_symbol(path)
       (i = path.rindex('::')) ? path[(i + 2)..-1] : path
     end
 
@@ -382,6 +383,18 @@ module ActiveSupport
         rules.each { |(rule, replacement)| break if result.sub!(rule, replacement) }
         result
       end
+    end
+
+    def deprecate_symbol(symbol)
+      if symbol.is_a?(Symbol)
+        symbol = symbol.to_s
+
+        ActiveSupport::Deprecation.warn(
+          'Using symbols in inflections is deprecated. Please use #to_s'
+        )
+      end
+
+      symbol
     end
   end
 end

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -534,4 +534,10 @@ class InflectorTest < ActiveSupport::TestCase
 
     assert_equal "HTTP", ActiveSupport::Inflector.pluralize("HTTP")
   end
+
+  def test_demodulize_with_symbol_deprecated
+    assert_deprecated(/Using symbols in inflections is deprecated/) do
+      ActiveSupport::Inflector.demodulize(:'Foo::Bar')
+    end
+  end
 end


### PR DESCRIPTION
### Benchmark

Using: **ruby 2.3.0**

``` ruby
# frozen_string_literal: true

require 'benchmark'

class Inflector
  def self.original_demodulize(path)
    path = path.to_s
    if i = path.rindex('::')
      path[(i+2)..-1]
    else
      path
    end
  end

  def self.new_demodulize(path)
    (i = path.rindex('::')) ? path[i + 2..-1] : path
  end
end

n = 1_000_000
path = 'String::Inflections'

Benchmark.bmbm do |x|
  x.report('.original_demodulize') do
    n.times { Inflector.original_demodulize(path) }
  end

  x.report('.new_demodulize') do
    n.times { Inflector.new_demodulize(path)  }
  end
end
```
#### Worst case

When `path` contains `::` (e.g: `'String::Inflections'`)

```
Rehearsal --------------------------------------------------------
#original_demodulize   0.320000   0.000000   0.320000 (  0.326918)
#new_demodulize        0.300000   0.000000   0.300000 (  0.295983)
----------------------------------------------- total: 0.620000sec

                           user     system      total        real
#original_demodulize   0.320000   0.000000   0.320000 (  0.321361)
#new_demodulize        0.270000   0.000000   0.270000 (  0.271659)
```

**Improvement**: _~15.62%_
#### Best case

When `path` does not contain `::` (e.g: `''`)

```
Rehearsal --------------------------------------------------------
#original_demodulize   0.140000   0.000000   0.140000 (  0.145417)
#new_demodulize        0.120000   0.000000   0.120000 (  0.115560)
----------------------------------------------- total: 0.260000sec

                           user     system      total        real
#original_demodulize   0.150000   0.000000   0.150000 (  0.145593)
#new_demodulize        0.110000   0.000000   0.110000 (  0.113746)
```

**Improvement**: _~26.67%_
