### PR TITLE
Make verifier serializers in message encryptors customizable.

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -42,13 +42,18 @@ module ActiveSupport
     #   <tt>OpenSSL::Cipher.ciphers</tt>. Default is 'aes-256-cbc'.
     # * <tt>:digest</tt> - String of digest to use for signing. Default is +SHA1+.
     # * <tt>:serializer</tt> - Object serializer to use. Default is +Marshal+.
+    # * <tt>:verifier_serializer</tt> - Object serializer to be used by the
+    #   verifier. Default is +NullSerializer+. Use +Marshal+ for compatibility
+    #   with messages encrypted by Rails versions prior to 3.2.
+
     def initialize(secret, *signature_key_or_options)
       options = signature_key_or_options.extract_options!
       sign_secret = signature_key_or_options.first
       @secret = secret
       @sign_secret = sign_secret
       @cipher = options[:cipher] || 'aes-256-cbc'
-      @verifier = MessageVerifier.new(@sign_secret || @secret, digest: options[:digest] || 'SHA1', serializer: NullSerializer)
+      @verifier = MessageVerifier.new(@sign_secret || @secret, digest: options[:digest] || 'SHA1',
+                                      serializer: options[:verifier_serializer] || NullSerializer)
       @serializer = options[:serializer] || Marshal
     end
 

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -70,6 +70,13 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     assert_not_verified([iv,  message] * bad_encoding_characters)
   end
 
+  def test_legacy_deserialization
+    marshal_encryptor = ActiveSupport::MessageEncryptor.new(@secret, verifier_serializer: Marshal)
+    message = marshal_encryptor.encrypt_and_sign(@data)
+    assert_not_decrypted(message)
+    assert_equal(marshal_encryptor.decrypt_and_verify(message), @data)
+  end
+
   private
 
   def assert_not_decrypted(value)


### PR DESCRIPTION
### Summary

Prior to Rails 3.2, `MessageEncryptor` would use `MessageVerifier`'s default serializer (`Marshal`), which would result in double marshalling of the data. Rails 3.2 eliminated the redundant marshalling, but broke compatibility with previous versions. Upgrades required hacky workarounds, as reported by @bjeanes in #22195.

This PR adds a configuration option to use arbitrary verifier serializers.
### Other Information

I've decided against adding a graceful backwards-compatible `LegacySerializer` as suggested by @jeremy in the comments to the breaking commit. This is because a serializer's `dump` and `load` methods should be mathematical inverses of each other (i.e., their composition in either order should yield an identity), and such a serializer would violate this. Instead, the documentation suggests what to do with legacy encrypted messages.
