### PR TITLE
Fix `ActiveSupport::Reloader.check!`

### DIFF
--- a/activesupport/lib/active_support/reloader.rb
+++ b/activesupport/lib/active_support/reloader.rb
@@ -65,10 +65,9 @@ module ActiveSupport
       end
     end
 
-    class << self
-      attr_accessor :executor
-      attr_accessor :check
-    end
+    class_attribute :executor
+    class_attribute :check
+
     self.executor = Executor
     self.check = lambda { false }
 


### PR DESCRIPTION
The test failure in `bug_report_templates/action_controller_master.rb`
is due to `app.reloader.check` is `nil`.
