### PR TITLE
Fix #23964 with response.body(should_send)

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -163,12 +163,16 @@ module ActionController
         end
       end
 
-      def each
-        @response.sending!
+      def body(*args)
+        super(sending: true)
+      end
+
+      def each(sending: true)
+        @response.sending! if sending
         while str = @buf.pop
           yield str
         end
-        @response.sent!
+        @response.sent! if sending
       end
 
       # Write a 'close' event to the buffer; the producer/writing thread

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -95,10 +95,10 @@ module ActionDispatch # :nodoc:
         @str_body = nil
       end
 
-      def body
+      def body(sending: true)
         @str_body ||= begin
                         buf = ''
-                        each { |chunk| buf << chunk }
+                        each(sending: sending) { |chunk| buf << chunk }
                         buf
                       end
       end
@@ -111,10 +111,10 @@ module ActionDispatch # :nodoc:
         @buf.push string
       end
 
-      def each(&block)
-        @response.sending!
+      def each(sending: true, &block)
+        @response.sending! if sending
         x = @buf.each(&block)
-        @response.sent!
+        @response.sent! if sending
         x
       end
 
@@ -279,8 +279,8 @@ module ActionDispatch # :nodoc:
 
     # Returns the content of the response as a string. This contains the contents
     # of any calls to <tt>render</tt>.
-    def body
-      @stream.body
+    def body(sending: false)
+      @stream.body(sending: sending)
     end
 
     def write(string)
@@ -308,7 +308,7 @@ module ActionDispatch # :nodoc:
         @to_path = path
       end
 
-      def body
+      def body(*args)
         File.binread(to_path)
       end
 

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -46,11 +46,14 @@ class ResponseTest < ActiveSupport::TestCase
     # after the action reads back @response.body,
     assert_equal "Hello, World!", @response.body
 
+    @response['x-header'] = "Best of all possible worlds."
+
     # the response can be built.
     status, headers, body = @response.to_a
     assert_equal 200, status
     assert_equal({
-      "Content-Type" => "text/html; charset=utf-8"
+      "Content-Type" => "text/html; charset=utf-8",
+      "x-header"     => "Best of all possible worlds."
     }, headers)
 
     parts = []


### PR DESCRIPTION
### Summary

A developer might need to access `response.body` before actually sending the response. Currently, a side effect of accessing `response.body` is the raising of some flags (`@sending == @sent == @committed == true`) and freezing of response headers. For a user to access `request.body` as he/she normally would, the default behavior should be to not raise those flags and to not freeze the headers.
### Other Information
- defaults to false (don't send) for regular requests so user's can continue using
  response.body... 
- for live streams, this should default to true
- response.body(sending: false) allows users to read the
  response body without raising the sending, sent, committed flags
  and without freezing the response headers
- regular requests should call response.body(should_send: true) when they're actually sent

Fixes #23964
