### PR TITLE
Remove requiring load_paths from tools/test.rb

### DIFF
--- a/tools/test.rb
+++ b/tools/test.rb
@@ -1,5 +1,8 @@
 $: << File.expand_path("test", COMPONENT_ROOT)
-require File.expand_path("../../load_paths", __FILE__)
+
+require 'bundler'
+Bundler.setup
+
 require "rails/test_unit/minitest_plugin"
 
 module Rails


### PR DESCRIPTION
- `tools/test.rb` is used internally from all `bin/test` scripts inside
  component gems.
- Followup of https://github.com/rails/rails/commit/2abcdfd978fdcd491576a237e8c6be04ddaf884d.

r? @arthurnn 
