### PR TITLE
Fix Model.limit(1).last doesn't order on the primary key. Fixes #23607.

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -145,7 +145,7 @@ module ActiveRecord
     #
     #   [#<Person id:4>, #<Person id:3>, #<Person id:2>]
     def last(limit = nil)
-      return find_last(limit) if loaded? || limit_value
+      return find_last(limit) if loaded?
 
       result = limit(limit || 1)
       result.order!(arel_attribute(primary_key)) if order_values.empty? && primary_key

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -606,14 +606,22 @@ class FinderTest < ActiveRecord::TestCase
     post = posts('sti_comments')
 
     comments = post.comments.order(id: :asc)
-    assert_equal comments.limit(2).to_a.last, comments.limit(2).last
-    assert_equal comments.limit(2).to_a.last(2), comments.limit(2).last(2)
-    assert_equal comments.limit(2).to_a.last(3), comments.limit(2).last(3)
+    comment_ids = comments.pluck(:id)
+
+    assert_equal comment_ids.last, comments.limit(2).last.id
+    assert_equal comment_ids.last(2), comments.limit(2).last(2).pluck(:id)
+    assert_equal comment_ids.last(3), comments.limit(2).last(3).pluck(:id)
 
     comments = comments.offset(1)
-    assert_equal comments.limit(2).to_a.last, comments.limit(2).last
-    assert_equal comments.limit(2).to_a.last(2), comments.limit(2).last(2)
-    assert_equal comments.limit(2).to_a.last(3), comments.limit(2).last(3)
+
+    assert_equal comment_ids[-2], comments.limit(2).last.id
+    assert_equal comment_ids[2,2], comments.limit(2).last(2).pluck(:id)
+    assert_equal comment_ids[1,3], comments.limit(2).last(3).pluck(:id)
+  end
+
+  def test_last_with_limit
+    assert_equal Post.last, Post.limit(1).last
+    assert_equal Post.last(2), Post.limit(2).last(2)
   end
 
   def test_take_and_first_and_last_with_integer_should_return_an_array


### PR DESCRIPTION
- Fixes #23607
- Removed unwanted check for 'limit_value' from the given condition
  which was causing the issue for the unloaded record. Unloaded record
  with limit was getting evaluated without checking its 'order'.
- Added required tests for this fix.
