### PR TITLE
Fix description in cookies_serializer.rb being corrupted by gsub when updating

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -103,7 +103,7 @@ module Rails
       end
 
       unless cookie_serializer_config_exist
-        gsub_file 'config/initializers/cookies_serializer.rb', /json/, 'marshal'
+        gsub_file 'config/initializers/cookies_serializer.rb', /json(?!,)/, 'marshal'
       end
 
       unless active_record_belongs_to_required_by_default_config_exist

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -210,7 +210,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
       generator = Rails::Generators::AppGenerator.new ["rails"], { with_dispatchers: true }, destination_root: app_root, shell: @shell
       generator.send(:app_const)
       quietly { generator.send(:update_config_files) }
-      assert_file("#{app_root}/config/initializers/cookies_serializer.rb", /Rails\.application\.config\.action_dispatch\.cookies_serializer = :marshal/)
+      assert_file("#{app_root}/config/initializers/cookies_serializer.rb",
+                  /Valid options are :json, :marshal, and :hybrid\.\nRails\.application\.config\.action_dispatch\.cookies_serializer = :marshal/)
     end
   end
 


### PR DESCRIPTION
### Summary

When updating Rails, a generator creates `cookies_serializer.rb` and replaces `json` in its content with `marshal`. However, since there is `json` in the description comment, it is also replaced like this.

``` ruby
# Valid options are :marshal, :marshal, and :hybrid.
Rails.application.config.action_dispatch.cookies_serializer = :marshal
```

I've fixed this by changing the providing regexp for `gsub_file`.
