### PR TITLE
respect `pride` option

### DIFF
--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -87,6 +87,8 @@ module Minitest
     self.reporter.reporters.delete_if { |reporter| reporter.kind_of?(SummaryReporter) || reporter.kind_of?(ProgressReporter) }
     self.reporter << SuppressedSummaryReporter.new(options[:io], options)
     self.reporter << ::Rails::TestUnitReporter.new(options[:io], options)
+
+    Minitest.plugin_pride_init(options) if Minitest::PrideIO.pride?
   end
 
   mattr_accessor(:run_with_autorun)         { false }

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -515,6 +515,12 @@ module ApplicationTests
       assert_match "ar_internal_metadata", output, "tables should be dumped"
     end
 
+    def test_pride_option
+      create_test_file :models, 'account'
+      output =  Dir.chdir(app_path) { `bin/rails test -p` }
+      assert_no_match 'Finished', output
+    end
+
     def test_rake_passes_TESTOPTS_to_minitest
       create_test_file :models, 'account'
       output =  Dir.chdir(app_path) { `bin/rake test TESTOPTS=-v` }


### PR DESCRIPTION
Because it removes the reporters after initialization process of pride extension, to use the pride extension, need to call initialization process of pride extension again.

Fixes #23994.
