### PR TITLE
[ci skip] Add `bundle exec` for ActiveRecord unit tests

### DIFF
--- a/activerecord/RUNNING_UNIT_TESTS.rdoc
+++ b/activerecord/RUNNING_UNIT_TESTS.rdoc
@@ -7,11 +7,11 @@ http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#setting-up-
 
 To run a specific test:
 
-  $ ruby -Itest test/cases/base_test.rb -n method_name
+  $ bundle exec ruby -Itest test/cases/base_test.rb -n method_name
 
 To run a set of tests:
 
-  $ ruby -Itest test/cases/base_test.rb
+  $ bundle exec ruby -Itest test/cases/base_test.rb
 
 You can also run tests that depend upon a specific database backend. For
 example:
@@ -41,7 +41,7 @@ parameters in +test/config.example.yml+ are.
 You can override the +connections:+ parameter in either file using the +ARCONN+
 (Active Record CONNection) environment variable:
 
-  $ ARCONN=postgresql ruby -Itest test/cases/base_test.rb
+  $ ARCONN=postgresql bundle exec ruby -Itest test/cases/base_test.rb
 
 You can specify a custom location for the config file using the +ARCONFIG+
 environment variable.


### PR DESCRIPTION
This pull request update how to execute ActiveRecord unit test by adding `bundle exec` as discussed in #24008.
