### PR TITLE
Fix a small template misrender in ActiveRecord::Persistence

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -61,7 +61,7 @@ module ActiveRecord
       # +instantiate+ instead of +new+, finder methods ensure they get new
       # instances of the appropriate class for each record.
       #
-      # See +ActiveRecord::Inheritance#discriminate_class_for_record+ to see
+      # See <tt>ActiveRecord::Inheritance#discriminate_class_for_record</tt> to see
       # how this "single-table" inheritance mapping is implemented.
       def instantiate(attributes, column_types = {})
         klass = discriminate_class_for_record(attributes)


### PR DESCRIPTION
See the end of [this](http://edgeapi.rubyonrails.org/classes/ActiveRecord/Persistence/ClassMethods.html#method-i-create) page.

[ci skip]
