### PR TITLE
Changed behaviour of timestamps helper by create_table migration generator [ci skip]

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -287,7 +287,7 @@ class CreateProducts < ActiveRecord::Migration[5.0]
       t.string :name
       t.text :description
 
-      t.timestamps null: false
+      t.timestamps
     end
   end
 end


### PR DESCRIPTION
In case if you create a model with rails model generator like `rails new model Foo bar:string` command, brand new migration file look like this:

``` ruby
class CreateFoos < ActiveRecord::Migration[5.0]
  def change
    create_table :foos do |t|
      t.string :bar

      t.timestamps
    end
  end
end
```

It doesn't use `null: false` anymore.

Also in the `Column Modifiers` section the documentation says:

> index Adds an index for the column.

This is partially true because you can't use this option on `change_table` method. Maybe you want to have a look at [this one](https://github.com/rails/rails/pull/23593).
