### PR TITLE
Ensure #pluck behaves consistently across types

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -87,15 +87,7 @@ module Enumerable
     entries.flatten!
   end
 
-  # Queries an object (in particular, an ActiveRecord model, Hash, or Struct)
-  # for a particular value using #[], #fetch, or #send, as appropriate,
-  # returning nil if the value is not found.
-  #
-  #   pluck_single({ name: "David" }, :name)
-  #     => "David"
-  #
-  #   pluck_single({ name: "David" }, :email)
-  #     => nil
+  # :nodoc:
   def pluck_single(element, key)
     if element.respond_to?(:has_attribute?) # AR
       element[key]

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -87,6 +87,15 @@ module Enumerable
     entries.flatten!
   end
 
+  # Queries an object (in particular, an ActiveRecord model, Hash, or Struct)
+  # for a particular value using #[], #fetch, or #send, as appropriate,
+  # returning nil if the value is not found.
+  #
+  #   pluck_single({ name: "David" }, :name)
+  #     => "David"
+  #
+  #   pluck_single({ name: "David" }, :email)
+  #     => nil
   def pluck_single(element, key)
     if element.respond_to?(:has_attribute?) # AR
       element[key]

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -116,12 +116,40 @@ class EnumerableTests < ActiveSupport::TestCase
   def test_pluck
     payments = GenericEnumerable.new([ Payment.new(5), Payment.new(15), Payment.new(10) ])
     assert_equal [5, 15, 10], payments.pluck(:price)
+  end
 
+  def test_pluck_with_key_not_present
+    payments = GenericEnumerable.new([ Payment.new(5), Payment.new(15), Payment.new(10) ])
+    assert_equal [nil, nil, nil], payments.pluck(:cents)
+  end
+
+  def test_pluck_with_many_keys
     payments = GenericEnumerable.new([
       ExpandedPayment.new(5, 99),
       ExpandedPayment.new(15, 0),
       ExpandedPayment.new(10, 50)
     ])
     assert_equal [[5, 99], [15, 0], [10, 50]], payments.pluck(:dollars, :cents)
+  end
+
+  def test_pluck_with_many_keys_some_not_present
+    payments = GenericEnumerable.new([
+      ExpandedPayment.new(5, 99),
+      ExpandedPayment.new(15, 0),
+      ExpandedPayment.new(10, 50)
+    ])
+    assert_equal [[5, nil], [15, nil], [10, nil]], payments.pluck(:dollars, :pennies)
+  end
+
+
+  def test_pluck_works_with_non_nil_default
+    entries = [5, 15, 10].map do |n|
+      hsh = Hash.new('!!!')
+      hsh.merge(price: n)
+    end
+
+    payments = GenericEnumerable.new(entries)
+
+    assert_equal [nil, nil, nil], payments.pluck(:dollars)
   end
 end

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -141,7 +141,6 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal [[5, nil], [15, nil], [10, nil]], payments.pluck(:dollars, :pennies)
   end
 
-
   def test_pluck_works_with_non_nil_default
     entries = [5, 15, 10].map do |n|
       hsh = Hash.new('!!!')


### PR DESCRIPTION
### Summary

As it's currently written, Enumerable#pluck behaves inconsistently when
working with Hashes (as in the method's documentation), with Structs
(which are used in the method's tests), and with ActiveRecord models
(Enumerable#pluck is meant to emulate ActiveRecord::Calculations#pluck) 
when a given key is not present or, in the case of a Hash, when `nil` is not the 
Hash's default value.

Per @dhh's notes on Issue #20339, I take the return behavior of
`ActiveRecord::Base#[]` as the reference behavior: namely, a key not
present in an element should return `nil` rather than raising an
exception (as occurs when calling #pluck with an unfamiliar attribute on
an AR relation):

```
[38] pry(main)> users.pluck(:names)
# . . .
PG::UndefinedColumn: ERROR:  column "names" does not exist
```

```
[52] pry(main)> user.class
=> User(id: integer, email: string...
[51] pry(main)> user[:names]
=> nil
```

```
[3] pry(main)> user = Hash.new('!'); user[:email] = 'email@example.com'
[6] pry(main)> user[:names]
"!"
```

```
[59] pry(main)> User = Struct.new(:email)
[60] pry(main)> User.new('user@example.com')
[63] pry(main)> user[:names]
NameError: no member 'names' in struct
        from: (pry):63:in `[]'
```

This patch makes the method's behavior consistent across types,
normalizing on the behavior of `ActiveRecord::Base#[]` while adding
two further benefits:
1. Makes it robust to Hash objects with non-nil default values
2. Enables it to work on mixed collections

Related: 
[Issue #20339](https://github.com/rails/rails/issues/20339)
[PR #20350](https://github.com/rails/rails/pull/20350)
