### PR TITLE
ConnectionMonitor is once again notified of disconnect (#2)

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -101,4 +101,5 @@ class ActionCable.Connection
   disconnect: ->
     return if @disconnected
     @disconnected = true
+    @consumer.connectionMonitor.disconnected()
     @consumer.subscriptions.notifyAll("disconnected")

--- a/actioncable/app/assets/javascripts/action_cable/connection_monitor.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection_monitor.coffee
@@ -18,6 +18,7 @@ class ActionCable.ConnectionMonitor
 
   disconnected: ->
     @disconnectedAt = now()
+    ActionCable.log("ConnectionMonitor disconnected")
 
   ping: ->
     @pingedAt = now()


### PR DESCRIPTION
### Summary

This is to fix an issue in ActionCable which @javan pointed out in reference to #23976 where on the client side `ConnectionMonitor.disconnected()` was not being called when there was a disconnect.

(Sorry this is the same PR as #24006 but the branch got messed up in a rebase).
