### PR TITLE
Dont call each when calling body on response to fix #23964

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -163,14 +163,6 @@ module ActionController
         end
       end
 
-      def each
-        @response.sending!
-        while str = @buf.pop
-          yield str
-        end
-        @response.sent!
-      end
-
       # Write a 'close' event to the buffer; the producer/writing thread
       # uses this to notify us that it's finished supplying content.
       #
@@ -210,6 +202,14 @@ module ActionController
       def call_on_error
         @error_callback.call
       end
+
+      private
+
+        def each_chunk(&block)
+          while str = @buf.pop
+            yield str
+          end
+        end
     end
 
     class Response < ActionDispatch::Response #:nodoc: all

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -554,6 +554,8 @@ module ActionController
         end
         @request.query_string = ''
 
+        @response.sent!
+
         @response
       end
 

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -246,7 +246,8 @@ module ActionController
 
     def assert_stream_closed
       assert response.stream.closed?, 'stream should be closed'
-      assert response.sent?, 'stream should be sent'
+      assert response.committed?,     'response should be committed'
+      assert response.sent?,          'response should be sent'
     end
 
     def capture_log_output

--- a/actionpack/test/dispatch/live_response_test.rb
+++ b/actionpack/test/dispatch/live_response_test.rb
@@ -65,7 +65,7 @@ module ActionController
         latch = Concurrent::CountDownLatch.new
 
         t = Thread.new {
-          @response.stream.each do
+          @response.each do
             latch.count_down
           end
         }


### PR DESCRIPTION
- Adds `#each_chunk` to ActionDispatch::Response. It's a method which will be called by `ActionDispatch::Response#each`.
- Make `Response#each` a proper method instead of delegating to `@stream`
- In Live, instead of overriding `#each`, override `#each_chunk`.
- `#each` should just spit out `@str_body` if it's already set.
- Adds `#test_set_header_after_read_body_during_action` to prove this fixes #23964.
- Adds `#test_each_isnt_called_if_str_body_is_written` to ensure `#each` is not called when `@str_body` is available.
- Call `@response.sent!` in AC::TestCase's `#perform` so a test response acts a bit more like a real response. This makes tests that call  `#assert_stream_closed` pass again.
- Additionally, assert `#committed?` in `#assert_stream_closed`.
- Make test that was calling `@response.stream.each` pass again by calling `@response.each` instead.
