### PR TITLE
Do not destructively mutate passed options hash in route definitions

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1,4 +1,3 @@
-require 'active_support/core_ext/hash/reverse_merge'
 require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/enumerable'
 require 'active_support/core_ext/array/extract_options'
@@ -824,7 +823,7 @@ module ActionDispatch
               URL_OPTIONS.include?(k) && (v.is_a?(String) || v.is_a?(Fixnum))
             end
 
-            (options[:defaults] ||= {}).reverse_merge!(defaults)
+            options[:defaults] = defaults.merge(options[:defaults] || {})
           else
             block, options[:constraints] = options[:constraints], {}
           end

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -178,6 +178,19 @@ module ActionDispatch
           mapper.mount as: "exciting"
         end
       end
+
+      def test_scope_does_not_destructively_mutate_default_options
+        fakeset = FakeSet.new
+        mapper = Mapper.new fakeset
+
+        frozen = { foo: :bar }.freeze
+
+        assert_nothing_raised do
+          mapper.scope(defaults: frozen) do
+            # pass
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #24030

An example scope might be specified as such:

``` ruby
HTML = { constraints: { format: :html } }.freeze
scope HTML do
  get 'x'
end
```

This currently raises an error because the mapper attempts to
destructively modify the passed options hash. This is dangerous because
this options hash might even be shared with other scopes.

We should instead always instantiate a new object instead of modifying
the passed options.
