### PR TITLE
Action Cable: Establish WebSocket connection when first subscription is created

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -8,9 +8,6 @@ class ActionCable.Connection
   constructor: (@consumer) ->
 
   send: (data) ->
-    unless @isOpen()
-      @open()
-
     if @isOpen()
       @webSocket.send(JSON.stringify(data))
       true
@@ -18,7 +15,7 @@ class ActionCable.Connection
       false
 
   open: =>
-    if @isAlive()
+    if @isActive()
       ActionCable.log("Attemped to open WebSocket, but existing socket is #{@getState()}")
       throw new Error("Existing connection must be closed before opening")
     else
@@ -33,7 +30,7 @@ class ActionCable.Connection
 
   reopen: ->
     ActionCable.log("Reopening WebSocket, current state is #{@getState()}")
-    if @isAlive()
+    if @isActive()
       try
         @close()
       catch error
@@ -47,10 +44,10 @@ class ActionCable.Connection
   isOpen: ->
     @isState("open")
 
-  # Private
+  isActive: ->
+    @isState("open", "connecting")
 
-  isAlive: ->
-    @webSocket? and not @isState("closing", "closed")
+  # Private
 
   isState: (states...) ->
     @getState() in states

--- a/actioncable/app/assets/javascripts/action_cable/consumer.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/consumer.coffee
@@ -23,3 +23,7 @@ class ActionCable.Consumer
 
   send: (data) ->
     @connection.send(data)
+
+  ensureActiveConnection: ->
+    unless @connection.isActive()
+      @connection.open()

--- a/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
@@ -19,6 +19,7 @@ class ActionCable.Subscriptions
 
   add: (subscription) ->
     @subscriptions.push(subscription)
+    @consumer.ensureActiveConnection()
     @notify(subscription, "initialized")
     @sendCommand(subscription, "subscribe")
 
@@ -59,4 +60,3 @@ class ActionCable.Subscriptions
   sendCommand: (subscription, command) ->
     {identifier} = subscription
     @consumer.send({command, identifier})
-      


### PR DESCRIPTION
Re: https://github.com/rails/rails/issues/24026
- More intention revealing than connecting on the first call to Connection#send
- Fixes that calls to Connection#send would attempt to open a connection when the WebSocket's state is CONNECTING
