### PR TITLE
Action Cable: client side 💅

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.coffee.erb
+++ b/actioncable/app/assets/javascripts/action_cable.coffee.erb
@@ -5,7 +5,7 @@
   INTERNAL: <%= ActionCable::INTERNAL.to_json %>
 
   createConsumer: (url) ->
-    url ?= @getConfig("url") ? "/cable"
+    url ?= @getConfig("url") ? @INTERNAL.default_mount_path
     new ActionCable.Consumer @createWebSocketURL(url)
 
   getConfig: (name) ->

--- a/actioncable/app/assets/javascripts/action_cable.coffee.erb
+++ b/actioncable/app/assets/javascripts/action_cable.coffee.erb
@@ -4,12 +4,13 @@
 @ActionCable =
   INTERNAL: <%= ActionCable::INTERNAL.to_json %>
 
-  createConsumer: (url = @getConfig("url")) ->
+  createConsumer: (url) ->
+    url ?= @getConfig("url") ? "/cable"
     new ActionCable.Consumer @createWebSocketURL(url)
 
   getConfig: (name) ->
     element = document.head.querySelector("meta[name='action-cable-#{name}']")
-    element?.getAttribute("content") ? '/cable'
+    element?.getAttribute("content")
 
   createWebSocketURL: (url) ->
     if url and not /^wss?:/i.test(url)

--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -8,6 +8,7 @@ class ActionCable.Connection
   @reopenDelay: 500
 
   constructor: (@consumer) ->
+    {@subscriptions} = @consumer
     @monitor = new ActionCable.ConnectionMonitor this
 
   send: (data) ->
@@ -80,16 +81,16 @@ class ActionCable.Connection
         when message_types.ping
           @monitor.recordPing()
         when message_types.confirmation
-          @consumer.subscriptions.notify(identifier, "connected")
+          @subscriptions.notify(identifier, "connected")
         when message_types.rejection
-          @consumer.subscriptions.reject(identifier)
+          @subscriptions.reject(identifier)
         else
-          @consumer.subscriptions.notify(identifier, "received", message)
+          @subscriptions.notify(identifier, "received", message)
 
     open: ->
       ActionCable.log("WebSocket onopen event")
       @disconnected = false
-      @consumer.subscriptions.reload()
+      @subscriptions.reload()
 
     close: ->
       ActionCable.log("WebSocket onclose event")
@@ -102,5 +103,5 @@ class ActionCable.Connection
   disconnect: ->
     return if @disconnected
     @disconnected = true
-    @consumer.subscriptions.notifyAll("disconnected")
+    @subscriptions.notifyAll("disconnected")
     @monitor.recordDisconnect()

--- a/actioncable/app/assets/javascripts/action_cable/subscription.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/subscription.coffee
@@ -1,5 +1,5 @@
-# A new subscription is created through the ActionCable.Subscriptions instance available on the consumer. 
-# It provides a number of callbacks and a method for calling remote procedure calls on the corresponding 
+# A new subscription is created through the ActionCable.Subscriptions instance available on the consumer.
+# It provides a number of callbacks and a method for calling remote procedure calls on the corresponding
 # Channel instance on the server side.
 #
 # An example demonstrates the basic functionality:
@@ -7,13 +7,13 @@
 #   App.appearance = App.cable.subscriptions.create "AppearanceChannel",
 #     connected: ->
 #       # Called once the subscription has been successfully completed
-#   
+#
 #     appear: ->
 #       @perform 'appear', appearing_on: @appearingOn()
-#   
+#
 #     away: ->
 #       @perform 'away'
-#   
+#
 #     appearingOn: ->
 #       $('main').data 'appearing-on'
 #
@@ -27,15 +27,15 @@
 #     def subscribed
 #       current_user.appear
 #     end
-#   
+#
 #     def unsubscribed
 #       current_user.disappear
 #     end
-#   
+#
 #     def appear(data)
 #       current_user.appear on: data['appearing_on']
 #     end
-#   
+#
 #     def away
 #       current_user.away
 #     end
@@ -44,11 +44,9 @@
 # The "AppearanceChannel" name is automatically mapped between the client-side subscription creation and the server-side Ruby class name.
 # The AppearanceChannel#appear/away public methods are exposed automatically to client-side invocation through the @perform method.
 class ActionCable.Subscription
-  constructor: (@subscriptions, params = {}, mixin) ->
+  constructor: (@consumer, params = {}, mixin) ->
     @identifier = JSON.stringify(params)
     extend(this, mixin)
-    @subscriptions.add(this)
-    @consumer = @subscriptions.consumer
 
   # Perform a channel action with the optional data passed as an attribute
   perform: (action, data = {}) ->
@@ -59,7 +57,7 @@ class ActionCable.Subscription
     @consumer.send(command: "message", identifier: @identifier, data: JSON.stringify(data))
 
   unsubscribe: ->
-    @subscriptions.remove(this)
+    @consumer.subscriptions.remove(this)
 
   extend = (object, properties) ->
     if properties?

--- a/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
@@ -13,7 +13,8 @@ class ActionCable.Subscriptions
   create: (channelName, mixin) ->
     channel = channelName
     params = if typeof channel is "object" then channel else {channel}
-    new ActionCable.Subscription this, params, mixin
+    subscription = new ActionCable.Subscription @consumer, params, mixin
+    @add(subscription)
 
   # Private
 

--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -34,7 +34,8 @@ module ActionCable
       ping: 'ping'.freeze,
       confirmation: 'confirm_subscription'.freeze,
       rejection: 'reject_subscription'.freeze
-    }
+    },
+    default_mount_path: '/cable'.freeze
   }
 
   # Singleton instance of the server

--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/hash/indifferent_access"
 module ActionCable
   class Railtie < Rails::Engine # :nodoc:
     config.action_cable = ActiveSupport::OrderedOptions.new
-    config.action_cable.mount_path = '/cable'
+    config.action_cable.mount_path = ActionCable::INTERNAL[:default_mount_path]
 
     config.eager_load_namespaces << ActionCable
 


### PR DESCRIPTION
- Moves the default mount path to `ActionCable::INTERNAL` to ensure it stays synced with `action_cable.js` (via `action_cable.coffee.erb`)
- Restores `ActionCable#getConfig` to its original, intended design for reading _any_ `action-cable-*` meta tag
- Minor internal refactoring for clarity and convenience

/cc @maclover7, @jeremy  
