### PR TITLE
Action Cable payload parsing cleanup

### DIFF
--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -6,7 +6,6 @@ require 'puma'
 require 'mocha/setup'
 
 require 'rack/mock'
-require 'active_support/core_ext/hash/indifferent_access'
 
 # Require all the stubs and models
 Dir[File.dirname(__FILE__) + '/stubs/*.rb'].each {|file| require file }


### PR DESCRIPTION
This centralizes all parsing and processing done on Action Cable
payloads, within `ActionCable::Connection::Subscriptions`. Previously,
the parsing and processing was spread throughout the file, but now
everything is centralized in one main `normalize_data` method.

Follow-up to #23649.
