### PR TITLE
Use `start_with?` for simpler env scrubbing

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -611,10 +611,7 @@ module ActionController
       private
 
       def scrub_env!(env)
-        env.delete_if { |k, v| k =~ /^(action_dispatch|rack)\.request/ }
-        env.delete_if { |k, v| k =~ /^action_dispatch\.rescue/ }
-        env.delete 'action_dispatch.request.query_parameters'
-        env.delete 'action_dispatch.request.request_parameters'
+        env.delete_if { |k, v| k.start_with?("action_dispatch.request", "rack.request", "action_dispatch.rescue") }
         env
       end
 


### PR DESCRIPTION
The deletion of `'action_dispatch.request.query_parameters'` and `'action_dispatch.request.request_parameters'` are already covered by the regex `/^(action_dispatch|rack)\.request/`.

Using `start_with?` instead of regular expressions because it is easier to read. And probably faster, too -- although it probably doesn't matter in this case.

This PR doesn’t fix any bugs or make anything noticably faster. But encountering this line when stepping with the debugger (as I did), it should now be easier to figure out what’s being removed from `env`.

I think the last commits to touch this code were f65fd25f0491919ef9db6e79be43f5d6f518374a, 394b7be0368cdf992b29c40bf7f501418d630b64, c546a2b045600b6d700140adf2a4df666d6e08ce and 889a4a3da025e52d0f044d9b1b832a45fcc88c01.
