### PR TITLE
Fix partial rendering with dot in filename

### DIFF
--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -521,7 +521,7 @@ module ActionView
     def retrieve_variable(path, as)
       variable = as || begin
         base = path[-1] == "/".freeze ? "".freeze : File.basename(path)
-        raise_invalid_identifier(path) unless base =~ /\A_?(.*)(?:\.\w+)*\z/
+        raise_invalid_identifier(path) unless base =~ /\A_?(.*?)(\.\w+)*\z/
         $1.to_sym
       end
       if @collection

--- a/actionview/test/fixtures/test/_customer.mobile.erb
+++ b/actionview/test/fixtures/test/_customer.mobile.erb
@@ -1,0 +1,1 @@
+Hello: <%= customer.name rescue "Anonymous" %>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -270,6 +270,11 @@ module RenderTestCases
     assert_equal "Hello: davidHello: mary", @view.render(:partial => "test/customer", :collection => [ Customer.new("david"), Customer.new("mary") ])
   end
 
+  def test_render_partial_collection_with_partial_name_containing_dot
+    assert_equal "Hello: davidHello: mary",
+      @view.render(:partial => "test/customer.mobile", :collection => [ Customer.new("david"), Customer.new("mary") ])
+  end
+
   def test_render_partial_collection_as_by_string
     assert_equal "david david davidmary mary mary",
       @view.render(:partial => "test/customer_with_var", :collection => [ Customer.new("david"), Customer.new("mary") ], :as => 'customer')


### PR DESCRIPTION
When rendering a collection with a partial whose filename contains a dot, e.g. "customer.mobile", we would set a `locals[:'customer.mobile']` variable instead of, as in earlier versions of Rails, `locals[:customer]`.

This bug was introduced in da9038eaa5d19c77c734a044c6b35d7bfac01104.
