### PR TITLE
Fix ActionCable.Subscriptions#create

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
@@ -16,6 +16,8 @@ class ActionCable.Subscriptions
     subscription = new ActionCable.Subscription @consumer, params, mixin
     @add(subscription)
 
+    subscription
+
   # Private
 
   add: (subscription) ->


### PR DESCRIPTION
This makes sure `ActionCable.Subscriptions#create` always returns the newly created `ActionCable.Subscription` object.
