### PR TITLE
Action Cable: Return subscription object(s) when updating the collection

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
@@ -16,8 +16,6 @@ class ActionCable.Subscriptions
     subscription = new ActionCable.Subscription @consumer, params, mixin
     @add(subscription)
 
-    subscription
-
   # Private
 
   add: (subscription) ->
@@ -25,20 +23,23 @@ class ActionCable.Subscriptions
     @consumer.ensureActiveConnection()
     @notify(subscription, "initialized")
     @sendCommand(subscription, "subscribe")
+    subscription
 
   remove: (subscription) ->
     @forget(subscription)
-
     unless @findAll(subscription.identifier).length
       @sendCommand(subscription, "unsubscribe")
+    subscription
 
   reject: (identifier) ->
     for subscription in @findAll(identifier)
       @forget(subscription)
       @notify(subscription, "rejected")
+      subscription
 
   forget: (subscription) ->
     @subscriptions = (s for s in @subscriptions when s isnt subscription)
+    subscription
 
   findAll: (identifier) ->
     s for s in @subscriptions when s.identifier is identifier


### PR DESCRIPTION
Re: https://github.com/rails/rails/commit/f1c93ed82802776c1be94fd8488257acaa253bd7#commitcomment-16501663

> I think ActionCable.Subscriptions#create should always return the Subscription object. We expect that in our apps as well.

Slightly improved version of 9ce6fe439ad58cb44f25d7ec785e9f04da83becd

/cc @lifo @jeremy 
