### PR TITLE
Fix ActiveRecord's 'first' method with 'limit'. Fixes #23979

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix `first` method while using it with `limit`.
+    When `first` method gets used with `limit`, it was overriding limit value.
+    Now added a private method 'find_first' which helps to fetch the correct
+    record(s). GH#23979
+
+    *Santosh Wadghule*
+
 *   PostgreSQL array columns will now respect the encoding of strings contained
     in the array.
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -116,6 +116,8 @@ module ActiveRecord
     #   Person.first(3) # returns the first three objects fetched by SELECT * FROM people ORDER BY people.id LIMIT 3
     #
     def first(limit = nil)
+      return find_first(limit) if loaded? || limit_value
+
       if limit
         find_nth_with_limit(0, limit)
       else
@@ -576,6 +578,10 @@ module ActiveRecord
 
       def find_last(limit)
         limit ? records.last(limit) : records.last
+      end
+
+      def find_first(limit)
+        limit ? records.first(limit) : records.first
       end
   end
 end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -385,6 +385,17 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal expected, Topic.first
   end
 
+  def test_first_with_limit
+    assert_equal Topic.limit(1).first(2).size, 1
+    assert_equal Topic.limit(1).first, Topic.first
+    assert_equal Topic.limit(2).first(2), Topic.first(2)
+  end
+
+  def test_result_of_first_and_last_with_respect_to_limit
+    assert_equal Topic.limit(1).first, Topic.limit(1).last
+    assert_equal Topic.limit(1).first(2).size, Topic.limit(1).last(2).size
+  end
+
   def test_model_class_responds_to_first_bang
     assert Topic.first!
     Topic.delete_all


### PR DESCRIPTION
- When 'first' method gets used with 'limit', it was overriding limit value.
- Added a new private method 'find_first' which helps to fetch the correct record(s).
- Added tests for the same.
- Fixes #23979
