### PR TITLE
Remove redundant regexp escapes in generators

### DIFF
--- a/actioncable/lib/rails/generators/channel/channel_generator.rb
+++ b/actioncable/lib/rails/generators/channel/channel_generator.rb
@@ -21,7 +21,7 @@ module Rails
 
       protected
         def file_name
-          @_file_name ||= super.gsub(/\_channel/i, '')
+          @_file_name ||= super.gsub(/_channel/i, '')
         end
 
         # FIXME: Change these files to symlinks once RubyGems 2.5.0 is required.

--- a/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
+++ b/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
@@ -15,7 +15,7 @@ module Rails
 
       protected
         def file_name
-          @_file_name ||= super.gsub(/\_mailer/i, '')
+          @_file_name ||= super.gsub(/_mailer/i, '')
         end
     end
   end

--- a/railties/lib/rails/generators/erb/mailer/mailer_generator.rb
+++ b/railties/lib/rails/generators/erb/mailer/mailer_generator.rb
@@ -26,7 +26,7 @@ module Erb # :nodoc:
       end
 
       def file_name
-        @_file_name ||= super.gsub(/\_mailer/i, '')
+        @_file_name ||= super.gsub(/_mailer/i, '')
       end
     end
   end

--- a/railties/lib/rails/generators/test_unit/mailer/mailer_generator.rb
+++ b/railties/lib/rails/generators/test_unit/mailer/mailer_generator.rb
@@ -19,7 +19,7 @@ module TestUnit # :nodoc:
 
       protected
         def file_name
-          @_file_name ||= super.gsub(/\_mailer/i, '')
+          @_file_name ||= super.gsub(/_mailer/i, '')
         end
     end
   end


### PR DESCRIPTION
### Summary

Remove some redundant regexp escapes in generators, since `_` is not a special character and can be used directly.
