### PR TITLE
Add update_gemfile in rails:update Rake task

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -239,6 +239,10 @@ module Rails
       end
       remove_task :update_config_files
 
+      def update_gemfile
+        build(:gemfile)
+      end
+
       def create_boot_file
         template "config/boot.rb"
       end

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -60,6 +60,7 @@ namespace :app do
     task :configs do
       RailsUpdate.invoke_from_app_generator :create_boot_file
       RailsUpdate.invoke_from_app_generator :update_config_files
+      RailsUpdate.invoke_from_app_generator :update_gemfile
     end
 
     # desc "Adds new executables to the application bin/ directory"


### PR DESCRIPTION
Rails 5 introduces a new `ActiveSupport::EventedFileUpdateChecker` class which is conditionally injected into existing Rails application configuration files from the `bin/rake app:update` task. During this upgrade process Rails checks to see if the `listen` library is required. If `listen` is required `ActiveSupport::EventedFileUpdateChecker` is added to the bottom of `config/environments/development.rb` as:

``` ruby
config.file_watcher = ActiveSupport::EventedFileUpdateChecker
```

The check for the `listen` library requirement is performed on a fresh installation of a Rails 5 project which is why this is a non-issue for fresh Rails projects using beta 3. It is expected that if the `listen` library is required the `listen` and `spring-watcher-listen` gems are present in the `:development` group of the Gemfile. That same requirement check is not happening during the upgrade process for the Gemfile which produces the error raised in #24063.

This change to the `app:upgrade` task upgrades the project’s existing Gemfile to include the new development dependencies introduced by Rails 5.

/cc @sadinie @maclover7 @rafaelfranca @fxn
