### PR TITLE
Friendly error message if missing `listen` development dependency

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -21,7 +21,13 @@ module ActiveSupport
         # Loading listen triggers warnings. These are originated by a legit
         # usage of attr_* macros for private attributes, but adds a lot of noise
         # to our test suite. Thus, we lazy load it and disable warnings locally.
-        silence_warnings { require 'listen' }
+        silence_warnings do
+          begin
+            require 'listen'
+          rescue LoadError => e
+            raise LoadError, "Could not load the 'listen' gem. Add `gem 'listen'` to the development group of your Gemfile", e.backtrace
+          end
+        end
         Listen.to(*dtw, &method(:changed)).start
       end
     end


### PR DESCRIPTION
### Summary

This PR is a follow up to https://github.com/rails/rails/pull/24066. It prints a better error message for users who upgrade from a previous version of Rails and forget to specify or accidentally remove the `listen` gem.

cc @dewski @rafaelfranca @arthurnn
