### PR TITLE
Remove http_cache_forever's version parameter

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -222,12 +222,10 @@ module ActionController
     # * +public+: By default, HTTP responses are private, cached only on the
     #   user's web browser. To allow proxies to cache the response, set +true+ to
     #   indicate that they can serve the cached response to all users.
-    #
-    # * +version+: the version passed as a key for the cache.
-    def http_cache_forever(public: false, version: 'v1')
+    def http_cache_forever(public: false)
       expires_in 100.years, public: public
 
-      yield if stale?(etag: "#{version}-#{request.fullpath}",
+      yield if stale?(etag: request.fullpath,
                       last_modified: Time.new(2011, 1, 1).utc,
                       public: public)
     end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -703,7 +703,7 @@ end
 class HttpCacheForeverTest < ActionController::TestCase
   class HttpCacheForeverController < ActionController::Base
     def cache_me_forever
-      http_cache_forever(public: params[:public], version: params[:version] || 'v1') do
+      http_cache_forever(public: params[:public]) do
         render plain: 'hello'
       end
     end
@@ -742,13 +742,5 @@ class HttpCacheForeverTest < ActionController::TestCase
     assert_response :not_modified
     @request.if_modified_since = @response.headers['Last-Modified']
     @request.if_none_match = @response.etag
-
-    get :cache_me_forever, params: {version: 'v2'}
-    assert_response :success
-    @request.if_modified_since = @response.headers['Last-Modified']
-    @request.if_none_match = @response.etag
-
-    get :cache_me_forever, params: {version: 'v2'}
-    assert_response :not_modified
   end
 end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/18394
### Summary

After a discussion with @jeremy and @rafaelfranca it seems we agree that the version parameter doesn't serve a real purpose and might actually mislead developers into thinking they can wipe the cache by bumping the version.
### Context

Since `expires_in 100.years` sets a `Cache-Control: max-age=3155760000` response header, browsers and / or proxy won't revalidate the resource back to the server unless they do a force-reload (`Cache-Control: max-age=0` request header). In which case the browser will receive the changed resource wether or not the ETag changed.

If developers wish to wipe such cache, they will have to change the resource URL with a query parameter or similar.

cc @arthurnn 
