### PR TITLE
Simply use `select_value` in `show_variable`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -585,8 +585,7 @@ module ActiveRecord
 
       # SHOW VARIABLES LIKE 'name'
       def show_variable(name)
-        variables = select_all("select @@#{name} as 'Value'", 'SCHEMA')
-        variables.first['Value'] unless variables.empty?
+        select_value("SELECT @@#{name}", 'SCHEMA')
       rescue ActiveRecord::StatementInvalid
         nil
       end


### PR DESCRIPTION
`SELECT @@name` statement returns only single row or `StatementInvalid`.

```
root@localhost [activerecord_unittest] > SELECT @@version;
+-----------+
| @@version |
+-----------+
| 5.7.9-log |
+-----------+
1 row in set (0.00 sec)

root@localhost [activerecord_unittest] > SELECT @@unknown_variable;
ERROR 1193 (HY000): Unknown system variable 'unknown_variable'
```
