### PR TITLE
chage `date_time` type ` to `datetime`

### DIFF
--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -61,7 +61,7 @@ module ActiveRecord
     register(:binary, Type::Binary, override: false)
     register(:boolean, Type::Boolean, override: false)
     register(:date, Type::Date, override: false)
-    register(:date_time, Type::DateTime, override: false)
+    register(:datetime, Type::DateTime, override: false)
     register(:decimal, Type::Decimal, override: false)
     register(:float, Type::Float, override: false)
     register(:integer, Type::Integer, override: false)


### PR DESCRIPTION
Since we are using `datetime` in migration, better to use `datetime` is I think that confusion is less.
