### PR TITLE
Do not duplicate join records for has_and_belong_to_many associations

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -388,8 +388,10 @@ module ActiveRecord
               records -= records_to_destroy
             end
 
+            is_habtm = (reflection.parent_reflection && reflection.parent_reflection.macro == :has_and_belongs_to_many)
+
             records.each do |record|
-              next if record.destroyed?
+              next if record.destroyed? || (is_habtm && record.persisted? && !record.changed?)
 
               saved = true
 

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -29,6 +29,9 @@ require 'models/publisher'
 require 'models/publisher/article'
 require 'models/publisher/magazine'
 require 'active_support/core_ext/string/conversions'
+require 'models/organization'
+require 'models/organizer'
+require 'models/genre'
 
 class ProjectWithAfterCreateHook < ActiveRecord::Base
   self.table_name = 'projects'
@@ -994,5 +997,14 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_difference "Project.first.developers_required_by_default.size", 1 do
       Project.first.developers_required_by_default.create!(name: "Sean", salary: 50000)
     end
+  end
+
+  def test_habtm_associations_does_not_duplicate_join_records
+    organizer = Organizer.new
+    organizer.organization = Organization.new
+    organizer.genres << Genre.new(name: 'R&B')
+    organizer.save!
+
+    assert_equal 1, organizer.reload.genres.count
   end
 end

--- a/activerecord/test/models/genre.rb
+++ b/activerecord/test/models/genre.rb
@@ -1,0 +1,3 @@
+class Genre < ActiveRecord::Base
+  has_and_belongs_to_many :organizers
+end

--- a/activerecord/test/models/organization.rb
+++ b/activerecord/test/models/organization.rb
@@ -10,5 +10,7 @@ class Organization < ActiveRecord::Base
 
   has_many :posts, :through => :author, :source => :posts
 
+  has_one :organizer
+
   scope :clubs, -> { from('clubs') }
 end

--- a/activerecord/test/models/organizer.rb
+++ b/activerecord/test/models/organizer.rb
@@ -1,0 +1,4 @@
+class Organizer < ActiveRecord::Base
+  has_and_belongs_to_many :genres
+  belongs_to :organization
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -343,6 +343,15 @@ ActiveRecord::Schema.define do
     t.integer :follower_id
   end
 
+  create_table :genres_organizers, id: false, force: true do |t|
+    t.integer :genre_id
+    t.integer :organizer_id
+  end
+
+  create_table :genres, force: true do |t|
+    t.string :name
+  end
+
   create_table :goofy_string_id, force: true, id: false do |t|
     t.string :id, null: false
     t.string :info
@@ -529,6 +538,11 @@ ActiveRecord::Schema.define do
 
   create_table :organizations, force: true do |t|
     t.string :name
+  end
+
+  create_table :organizers, force: true do |t|
+    t.string :name
+    t.integer :organization_id
   end
 
   create_table :owners, primary_key: :owner_id, force: true do |t|


### PR DESCRIPTION
Detailed information about current wrong behaviour is described in #24032 with reproduction script. Briefly Active Record creates unnecessary join records for has_and_belongs_to_many associations in some cases depending on the order of `ActiveRecord::Associations` class methods(has_one, has_many, etc.). The purpose of this pull request is fixing this issue.

Closes #24032
