### PR TITLE
i18n fallbacks test fixes

### DIFF
--- a/railties/test/application/initializers/i18n_test.rb
+++ b/railties/test/application/initializers/i18n_test.rb
@@ -245,7 +245,7 @@ fr:
       assert_fallbacks de: [:de, :'en-US', :en]
     end
 
-    test "[shortcut] config.i18n.fallbacks = [{ :ca => :'es-ES' }] initializes fallbacks with a mapping de-AT => de-DE" do
+    test "[shortcut] config.i18n.fallbacks = [{ :ca => :'es-ES' }] initializes fallbacks with a mapping ca => es-ES" do
       I18n::Railtie.config.i18n.fallbacks.map = { :ca => :'es-ES' }
       load_app
       assert_fallbacks ca: [:ca, :"es-ES", :es, :en]
@@ -255,6 +255,12 @@ fr:
       I18n::Railtie.config.i18n.fallbacks = [:'en-US', { :ca => :'es-ES' }]
       load_app
       assert_fallbacks ca: [:ca, :"es-ES", :es, :'en-US', :en]
+    end
+
+    test "[shortcut] config.i18n.fallbacks = { ca: :en } initializes fallbacks with a mapping ca => :en" do
+      I18n::Railtie.config.i18n.fallbacks = { ca: :en }
+      load_app
+      assert_fallbacks ca: [:ca, :en]
     end
 
     test "disable config.i18n.enforce_available_locales" do


### PR DESCRIPTION
- Added i18n test to verify assigning hash directly to fallbacks instead of using map
- Fixed test name for setting fallbacks to config.i18n.fallbacks = [{ :ca => :'es-ES' }]
