### PR TITLE
Prevent not-intended loading of `ActionDispatch::IntegrationTest`

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -45,9 +45,9 @@ module ActionMailer
         register_observers(options.delete(:observers))
 
         options.each { |k,v| send("#{k}=", v) }
-
-        ActionDispatch::IntegrationTest.send :include, ActionMailer::TestCase::ClearTestDeliveries
       end
+
+      ActiveSupport.on_load(:action_dispatch_integration_test) { include ActionMailer::TestCase::ClearTestDeliveries }
     end
 
     initializer "action_mailer.compile_config_methods" do

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `ActiveSupport.run_load_hooks` to `ActionDispatch::IntegrationTest`
+    with `action_dispatch_integration_test` name.
+
+    *Yuichiro Kaneko*
+
 *   Update default rendering policies when the controller action did
     not explicitly indicate a response.
 

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -764,5 +764,7 @@ module ActionDispatch
     def self.register_encoder(*args)
       Integration::Session::RequestEncoder.register_encoder(*args)
     end
+
+    ActiveSupport.run_load_hooks(:action_dispatch_integration_test, self)
   end
 end


### PR DESCRIPTION
After 9d378747326d26cf1afdac4433ead22967af0984 `ActionDispatch::IntegrationTest`
class is loaded and defined in all Rails environments, not only test but also
production. This is not-intended loading of a class which is only used in
test environment.
