### PR TITLE
Dump `bigint` instead of `integer` with `limit: 8` for schema dumper

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -57,11 +57,15 @@ module ActiveRecord
       private
 
       def schema_type(column)
-        column.type
+        if column.bigint?
+          :bigint
+        else
+          column.type
+        end
       end
 
       def schema_limit(column)
-        limit = column.limit
+        limit = column.limit unless column.bigint?
         limit.inspect if limit && limit != native_database_types[column.type][:limit]
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -41,10 +41,6 @@ module ActiveRecord
           end
         end
 
-        def schema_limit(column)
-          super unless schema_type(column) == :bigserial
-        end
-
         def schema_expression(column)
           super unless column.serial?
         end

--- a/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
@@ -58,7 +58,7 @@ class Mysql2UnsignedTypeTest < ActiveRecord::Mysql2TestCase
   test "schema dump includes unsigned option" do
     schema = dump_table_schema "unsigned_types"
     assert_match %r{t.integer\s+"unsigned_integer",\s+unsigned: true$}, schema
-    assert_match %r{t.integer\s+"unsigned_bigint",\s+limit: 8,\s+unsigned: true$}, schema
+    assert_match %r{t.bigint\s+"unsigned_bigint",\s+unsigned: true$}, schema
     assert_match %r{t.float\s+"unsigned_float",\s+limit: 24,\s+unsigned: true$}, schema
     assert_match %r{t.decimal\s+"unsigned_decimal",\s+precision: 10,\s+scale: 2,\s+unsigned: true$}, schema
   end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -147,10 +147,10 @@ class SchemaDumperTest < ActiveRecord::TestCase
       assert_match %r{c_int_7.*limit: 7}, output
       assert_match %r{c_int_8.*limit: 8}, output
     else
-      assert_match %r{c_int_5.*limit: 8}, output
-      assert_match %r{c_int_6.*limit: 8}, output
-      assert_match %r{c_int_7.*limit: 8}, output
-      assert_match %r{c_int_8.*limit: 8}, output
+      assert_match %r{t\.bigint\s+"c_int_5"$}, output
+      assert_match %r{t\.bigint\s+"c_int_6"$}, output
+      assert_match %r{t\.bigint\s+"c_int_7"$}, output
+      assert_match %r{t\.bigint\s+"c_int_8"$}, output
     end
   end
 
@@ -248,12 +248,12 @@ class SchemaDumperTest < ActiveRecord::TestCase
   if current_adapter?(:PostgreSQLAdapter)
     def test_schema_dump_includes_bigint_default
       output = standard_dump
-      assert_match %r{t\.integer\s+"bigint_default",\s+limit: 8,\s+default: 0}, output
+      assert_match %r{t\.bigint\s+"bigint_default",\s+default: 0}, output
     end
 
     def test_schema_dump_includes_limit_on_array_type
       output = standard_dump
-      assert_match %r{t\.integer\s+"big_int_data_points\",\s+limit: 8,\s+array: true}, output
+      assert_match %r{t\.bigint\s+"big_int_data_points\",\s+array: true}, output
     end
 
     def test_schema_dump_allows_array_of_decimal_defaults


### PR DESCRIPTION
Before:

``` ruby
create_table "big_numbers", force: :cascade do |t|
  t.integer "bigint_column", limit: 8
end
```

After:

``` ruby
create_table "big_numbers", force: :cascade do |t|
  t.bigint "bigint_column"
end
```
