### PR TITLE
Initialize `column.table_name` immediately for `column.serial?` correctly working

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -5,7 +5,7 @@ module ActiveRecord
   module ConnectionAdapters
     # An abstract definition of a column in a table.
     class Column
-      attr_reader :name, :null, :sql_type_metadata, :default, :default_function, :collation
+      attr_reader :name, :default, :sql_type_metadata, :null, :table_name, :default_function, :collation
 
       delegate :precision, :scale, :limit, :type, :sql_type, to: :sql_type_metadata, allow_nil: true
 
@@ -54,7 +54,7 @@ module ActiveRecord
       protected
 
       def attributes_for_hash
-        [self.class, name, default, sql_type_metadata, null, default_function, collation]
+        [self.class, name, default, sql_type_metadata, null, table_name, default_function, collation]
       end
     end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -43,7 +43,7 @@ module ActiveRecord
         end
 
         def schema_collation(column)
-          if column.collation && table_name = column.instance_variable_get(:@table_name)
+          if column.collation && table_name = column.table_name
             @table_collation_cache ||= {}
             @table_collation_cache[table_name] ||= select_one("SHOW TABLE STATUS LIKE '#{table_name}'")["Collation"]
             column.collation.inspect if column.collation != @table_collation_cache[table_name]

--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -8,7 +8,6 @@ module ActiveRecord
       def serial?
         return unless default_function
 
-        table_name = @table_name || '(?<table_name>.+)'
         %r{\Anextval\('"?#{table_name}_#{name}_seq"?'::regclass\)\z} === default_function
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -213,14 +213,17 @@ module ActiveRecord
         end
 
         # Returns the list of all column definitions for a table.
-        def columns(table_name)
+        def columns(table_name) # :nodoc:
+          table_name = table_name.to_s
           column_definitions(table_name).map do |column_name, type, default, notnull, oid, fmod, collation|
             oid = oid.to_i
             fmod = fmod.to_i
             type_metadata = fetch_type_metadata(column_name, type, oid, fmod)
             default_value = extract_value_from_default(default)
             default_function = extract_default_function(default_value, default)
-            new_column(column_name, default_value, type_metadata, !notnull, default_function, collation)
+            new_column(column_name, default_value, type_metadata, !notnull, default_function, collation).tap do |column|
+              column.instance_variable_set(:@table_name, table_name)
+            end
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -337,7 +337,8 @@ module ActiveRecord
       end
 
       # Returns an array of +Column+ objects for the table specified by +table_name+.
-      def columns(table_name) #:nodoc:
+      def columns(table_name) # :nodoc:
+        table_name = table_name.to_s
         table_structure(table_name).map do |field|
           case field["dflt_value"]
           when /^null$/i
@@ -351,7 +352,9 @@ module ActiveRecord
           collation = field['collation']
           sql_type = field['type']
           type_metadata = fetch_type_metadata(sql_type)
-          new_column(field['name'], field['dflt_value'], type_metadata, field['notnull'].to_i == 0, nil, collation)
+          new_column(field['name'], field['dflt_value'], type_metadata, field['notnull'].to_i == 0, nil, collation).tap do |column|
+            column.instance_variable_set(:@table_name, table_name)
+          end
         end
       end
 

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -104,10 +104,7 @@ HEADER
       end
 
       def table(table, stream)
-        columns = @connection.columns(table).map do |column|
-          column.instance_variable_set(:@table_name, table)
-          column
-        end
+        columns = @connection.columns(table)
         begin
           tbl = StringIO.new
 

--- a/activerecord/test/cases/adapters/postgresql/serial_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/serial_test.rb
@@ -10,6 +10,7 @@ class PostgresqlSerialTest < ActiveRecord::PostgreSQLTestCase
     @connection = ActiveRecord::Base.connection
     @connection.create_table "postgresql_serials", force: true do |t|
       t.serial :seq
+      t.integer :serials_id, default: -> { "nextval('postgresql_serials_id_seq')" }
     end
   end
 
@@ -24,9 +25,21 @@ class PostgresqlSerialTest < ActiveRecord::PostgreSQLTestCase
     assert column.serial?
   end
 
+  def test_not_serial_column
+    column = PostgresqlSerial.columns_hash["serials_id"]
+    assert_equal :integer, column.type
+    assert_equal "integer", column.sql_type
+    assert_not column.serial?
+  end
+
   def test_schema_dump_with_shorthand
     output = dump_table_schema "postgresql_serials"
     assert_match %r{t\.serial\s+"seq"}, output
+  end
+
+  def test_schema_dump_with_not_serial
+    output = dump_table_schema "postgresql_serials"
+    assert_match %r{t\.integer\s+"serials_id",\s+default: -> \{ "nextval\('postgresql_serials_id_seq'::regclass\)" \}$}, output
   end
 end
 
@@ -39,6 +52,7 @@ class PostgresqlBigSerialTest < ActiveRecord::PostgreSQLTestCase
     @connection = ActiveRecord::Base.connection
     @connection.create_table "postgresql_big_serials", force: true do |t|
       t.bigserial :seq
+      t.bigint :serials_id, default: -> { "nextval('postgresql_big_serials_id_seq')" }
     end
   end
 
@@ -53,8 +67,20 @@ class PostgresqlBigSerialTest < ActiveRecord::PostgreSQLTestCase
     assert column.serial?
   end
 
+  def test_not_bigserial_column
+    column = PostgresqlBigSerial.columns_hash["serials_id"]
+    assert_equal :integer, column.type
+    assert_equal "bigint", column.sql_type
+    assert_not column.serial?
+  end
+
   def test_schema_dump_with_shorthand
     output = dump_table_schema "postgresql_big_serials"
     assert_match %r{t\.bigserial\s+"seq"}, output
+  end
+
+  def test_schema_dump_with_not_bigserial
+    output = dump_table_schema "postgresql_big_serials"
+    assert_match %r{t\.integer\s+"serials_id",\s+limit: 8,\s+default: -> \{ "nextval\('postgresql_big_serials_id_seq'::regclass\)" \}$}, output
   end
 end


### PR DESCRIPTION
Currently the results of `column.serial?` is not correct. For
`column.serial?` correctly working, initialize `column.table_name`
immediately.
