### PR TITLE
Silence deprecation message on action_view test cases

### DIFF
--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -93,12 +93,14 @@ module ActionDispatch
       super
       return if DrawOnce.drew
 
-      SharedTestRoutes.draw do
-        get ':controller(/:action)'
-      end
+      ActiveSupport::Deprecation.silence do
+        SharedTestRoutes.draw do
+          get ':controller(/:action)'
+        end
 
-      ActionDispatch::IntegrationTest.app.routes.draw do
-        get ':controller(/:action)'
+        ActionDispatch::IntegrationTest.app.routes.draw do
+          get ':controller(/:action)'
+        end
       end
 
       DrawOnce.drew = true


### PR DESCRIPTION
Silence deprecation message for dynamic controller and actions on action_view test cases

Follow up to #23980.
