### PR TITLE
clarify that helper_method makes both methods available in the view [ci skip]

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -38,7 +38,8 @@ module AbstractController
       end
 
       # Declare a controller method as a helper. For example, the following
-      # makes the +current_user+ controller method available to the view:
+      # makes the +current_user+ and +logged_in?+ controller methods available
+      # to the view:
       #   class ApplicationController < ActionController::Base
       #     helper_method :current_user, :logged_in?
       #


### PR DESCRIPTION
### Summary

It's probably obvious to most, but clarify that `:helper_method` will make both
of these methods available to the view.
