### PR TITLE
Backport to 4-1-stable "Fix typo `--ssl-cipher`"

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -139,7 +139,7 @@ IDENTIFIED BY '#{configuration['password']}' WITH GRANT OPTION;
           'sslca'     => '--ssl-ca',
           'sslcert'   => '--ssl-cert',
           'sslcapath' => '--ssl-capath',
-          'sslcipher' => '--ssh-cipher',
+          'sslcipher' => '--ssl-cipher',
           'sslkey'    => '--ssl-key'
         }.map { |opt, arg| "#{arg}=#{configuration[opt]}" if configuration[opt] }.compact
 


### PR DESCRIPTION
Backport #24082 for #23293.
