### PR TITLE
Preserve readonly flag only for readonly association

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -274,7 +274,9 @@ module ActiveRecord
             construct(model, node, row, rs, seen, model_cache, aliases)
           else
             model = construct_model(ar_parent, node, row, model_cache, id, aliases)
-            model.readonly!
+            if node.reflection.scope_for(node.base_klass).readonly_value
+              model.readonly!
+            end
             seen[ar_parent.object_id][node.base_klass][id] = model
             construct(model, node, row, rs, seen, model_cache, aliases)
           end

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -113,7 +113,7 @@ module ActiveRecord
         end
 
         def reflection_scope
-          @reflection_scope ||= reflection.scope ? klass.unscoped.instance_exec(nil, &reflection.scope) : klass.unscoped
+          @reflection_scope ||= reflection.scope_for(klass)
         end
 
         def build_scope

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -311,6 +311,10 @@ module ActiveRecord
           active_record == other_aggregation.active_record
       end
 
+      def scope_for(klass)
+        scope ? klass.unscoped.instance_exec(nil, &scope) : klass.unscoped
+      end
+
       private
         def derive_class_name
           name.to_s.camelize

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1424,6 +1424,24 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert david.readonly_comments.first.readonly?
   end
 
+  test "eager-loading non-readonly association" do
+    # has_one
+    firm = Firm.where(id: "1").eager_load(:account).first!
+    assert_not firm.account.readonly?
+
+    # has_and_belongs_to_many
+    project = Project.where(id: "2").eager_load(:developers).first!
+    assert_not project.developers.first.readonly?
+
+    # has_many :through
+    david = Author.where(id: "1").eager_load(:comments).first!
+    assert_not david.comments.first.readonly?
+
+    # belongs_to
+    post = Post.where(id: "1").eager_load(:author).first!
+    assert_not post.author.readonly?
+  end
+
   test "eager-loading readonly association" do
     # has-one
     firm = Firm.where(id: "1").eager_load(:readonly_account).first!
@@ -1438,8 +1456,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert david.readonly_comments.first.readonly?
 
     # belongs_to
-    post = Post.where(id: "1").eager_load(:author).first!
-    assert post.author.readonly?
+    post = Post.where(id: "1").eager_load(:readonly_author).first!
+    assert post.readonly_author.readonly?
   end
 
   test "preloading a polymorphic association with references to the associated table" do

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -24,6 +24,7 @@ class Post < ActiveRecord::Base
   scope :limit_by, lambda {|l| limit(l) }
 
   belongs_to :author
+  belongs_to :readonly_author, -> { readonly }, class_name: 'Author', foreign_key: :author_id
 
   belongs_to :author_with_posts, -> { includes(:posts) }, :class_name => "Author", :foreign_key => :author_id
   belongs_to :author_with_address, -> { includes(:author_address) }, :class_name => "Author", :foreign_key => :author_id


### PR DESCRIPTION
### Summary

I fixed a bug in https://github.com/rails/rails/pull/18097. See  #24093 for detail.
In this patch, I made eager-loaded association readonly only when it was specified as readonly.

Fixes #24093
