### PR TITLE
[ci skip] Shouldn't the around filter example use rescue instead of ensure?

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -722,7 +722,7 @@ class ChangesController < ApplicationController
     ActiveRecord::Base.transaction do
       begin
         yield
-      ensure
+      rescue
         raise ActiveRecord::Rollback
       end
     end


### PR DESCRIPTION
### Summary

When reading the **Action Controller Overview** guide in the _Filters_->_After Filters and Around Filters_ section, I noticed that the example for an around filter uses an `ensure` block, which raises an ActiveRecord Rollback error. Won't this always rollback the transaction? I'm thinking that `rescue` was actually intended here.
