### PR TITLE
Drop the explicit version requirements for web-console

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -35,7 +35,7 @@ group :development do
   <%- if options.dev? || options.edge? -%>
   gem 'web-console', github: 'rails/web-console'
   <%- else -%>
-  gem 'web-console', '~> 3.0'
+  gem 'web-console'
   <%- end -%>
 <%- end -%>
 <% if depend_on_listen? -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -632,7 +632,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_match(/gem 'web-console',\s+github: 'rails\/web-console'/, content)
-      assert_no_match(/gem 'web-console', '~> 3.0'/, content)
+      assert_no_match(/gem 'web-console'/, content)
     end
   end
 
@@ -641,7 +641,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_match(/gem 'web-console',\s+github: 'rails\/web-console'/, content)
-      assert_no_match(/gem 'web-console', '~> 3.0'/, content)
+      assert_no_match(/gem 'web-console'/, content)
     end
   end
 


### PR DESCRIPTION
Between major versions 2 and 3, we hit a bug. It's fixed in version 3,
however, the explicit 2.x requirement of `~> '2.0'` will prevent people
from getting the fix with `bundle update` and they would have to
explicitly set the constraint to `~> '3.0'`.

For more information see: rails/web-console#178.

I propose we drop the explicit version constraints in the Gemfile. Web
Console has been relatively stable for the past couple of years, and I
don't anticipate any major alterations, like we saw between major
versions 1 and 2.
