### PR TITLE
Advertise the console web-console feature

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -31,7 +31,7 @@ end
 
 group :development do
 <%- unless options.api? -%>
-  # Access an IRB console on exception pages or by using <%%= console %> in views
+  # Access an IRB console on exception pages or by using <%%= console %> anywhere in the code.
   <%- if options.dev? || options.edge? -%>
   gem 'web-console', github: 'rails/web-console'
   <%- else -%>


### PR DESCRIPTION
In the latest version of Web Console, you can call `console` anywhere in
your application and get a console with that binding in it. I think this
is worth advertising, as it may be useful to do outside of controllers
and views. Say in models, or anywhere in `app/` code.

[ci skip]
