### PR TITLE
Raise IrreversibleOrderError when reversing an offset

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fixed an issue when using `last()` with `offset()` where
+    offsets could end up applied to the end of a record set
+    rather than the beginning, resulting in inconsistent behavior.
+    Because SQL queries with offsets cannot be easily reversed,
+    using `last()` and `reverse_order` with `offset()` is deprecated.
+
+    Fixes #23829.
+
+    *Brian Christian*
+
 *   Fix an issue when preloading associations with extensions.
     Previously every association with extension methods was transformed into an
     instance dependent scope. This is no longer the case.

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -152,6 +152,13 @@ module ActiveRecord
 
       result = limit(limit || 1)
       result.order!(arel_attribute(primary_key)) if order_values.empty? && primary_key
+
+      # raise an IrreversibleOrderError if there is an offset already applied, which
+      # will be caught by the rescue block below.
+      # Reverse_order will itself raise an IrreverisbleOrderError with an offset
+      # in Rails 5.1, at which time this can be removed.
+      raise ActiveRecord::IrreversibleOrderError if offset_index != 0
+
       result = result.reverse_order!
 
       limit ? result.reverse : result.first

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -155,7 +155,7 @@ module ActiveRecord
 
       # raise an IrreversibleOrderError if there is an offset already applied, which
       # will be caught by the rescue block below.
-      # Reverse_order will itself raise an IrreverisbleOrderError with an offset
+      # reverse_order will itself raise an IrreverisbleOrderError with an offset
       # in Rails 5.1, at which time this can be removed.
       raise ActiveRecord::IrreversibleOrderError if offset_index != 0
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -135,6 +135,9 @@ module ActiveRecord
     #   Person.last # returns the last object fetched by SELECT * FROM people
     #   Person.where(["user_name = ?", user_name]).last
     #   Person.order("created_on DESC").offset(5).last # returns the last object (or nil if Person.all.size <= 5)
+    #
+    #  Note that the use of offset with last is deprecated, because relations with an offset cannot be automatically reversed.
+    #
     #   Person.last(3) # returns the last three objects fetched by SELECT * FROM people.
     #
     # Take note that in that last case, the results are sorted in ascending order:

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -134,7 +134,7 @@ module ActiveRecord
     #
     #   Person.last # returns the last object fetched by SELECT * FROM people
     #   Person.where(["user_name = ?", user_name]).last
-    #   Person.order("created_on DESC").offset(5).last
+    #   Person.order("created_on DESC").offset(5).last # returns the last object (or nil if Person.all.size <= 5)
     #   Person.last(3) # returns the last three objects fetched by SELECT * FROM people.
     #
     # Take note that in that last case, the results are sorted in ascending order:

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -153,11 +153,18 @@ module ActiveRecord
       result = limit(limit || 1)
       result.order!(arel_attribute(primary_key)) if order_values.empty? && primary_key
 
-      # raise an IrreversibleOrderError if there is an offset already applied, which
-      # will be caught by the rescue block below.
+      # Raise a deprecation warning if there is an offset already applied.
       # reverse_order will itself raise an IrreverisbleOrderError with an offset
       # in Rails 5.1, at which time this can be removed.
-      raise ActiveRecord::IrreversibleOrderError if offset_index != 0
+      if offset_index != 0
+        ActiveSupport::Deprecation.warn(<<-WARNING.squish)
+            Finding a last element by loading the relation with an offset
+            applied is deprecated.
+            Rails 5.1 will raise ActiveRecord::IrreversibleOrderError in this case.
+            Please call `to_a.last` if you still want to load the relation.
+        WARNING
+        return find_last(limit)
+      end
 
       result = result.reverse_order!
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1108,6 +1108,10 @@ module ActiveRecord
     end
 
     def reverse_sql_order(order_query)
+      if offset_index != 0
+        raise IrreversibleOrderError, "Relations with offset cannot be reversed automatically."
+      end
+      
       if order_query.empty?
         return [arel_attribute(primary_key).desc] if primary_key
         raise IrreversibleOrderError,

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1109,7 +1109,14 @@ module ActiveRecord
 
     def reverse_sql_order(order_query)
       if offset_index != 0
-        raise IrreversibleOrderError, "Relations with offset cannot be reversed automatically."
+        ActiveSupport::Deprecation.warn(<<-WARNING.squish)
+            Finding a last element by loading the relation when SQL ORDER
+            cannot be reversed (such as when an offset is applied) is deprecated.
+            Rails 5.1 will raise ActiveRecord::IrreversibleOrderError in this case.
+            Please call `reverse` if you still want to reverse the relation.
+        WARNING
+        # TODO: In Rails 5.1, replace Deprecation above with the below or similar:
+        # raise IrreversibleOrderError, "Relations with offset cannot be reversed automatically."
       end
       
       if order_query.empty?

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1110,8 +1110,7 @@ module ActiveRecord
     def reverse_sql_order(order_query)
       if offset_index != 0
         ActiveSupport::Deprecation.warn(<<-WARNING.squish)
-            Finding a last element by loading the relation when SQL ORDER
-            cannot be reversed (such as when an offset is applied) is deprecated.
+            Reversing the SQL ORDER of a relation with offset applied is deprecated.
             Rails 5.1 will raise ActiveRecord::IrreversibleOrderError in this case.
             Please call `reverse` if you still want to reverse the relation.
         WARNING

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -572,6 +572,20 @@ class FinderTest < ActiveRecord::TestCase
     assert_sql(/LIMIT|ROWNUM <=/) { Topic.last(5).entries }
   end
 
+  def test_last_with_offset
+    topic = Topic.order(:id)
+    assert_equal topic.to_a.last, topic.last
+    assert_equal topic.offset(1).to_a.last, topic.offset(1).last
+    assert_equal topic.last, topic.offset(4).last
+  end
+
+  def test_last_with_integer_and_offset
+    topic = Topic.order(:id)
+    assert_equal topic.to_a.last(2), topic.last(2)
+    assert_equal topic.offset(1).to_a.last(2), topic.offset(1).last(2)
+    assert_equal topic.last(1), topic.offset(4).last(2)
+  end
+
   def test_last_with_integer_and_order_should_keep_the_order
     assert_equal Topic.order("title").to_a.last(2), Topic.order("title").last(2)
   end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -987,7 +987,8 @@ class FinderTest < ActiveRecord::TestCase
     devs = Developer.order('id')
 
     assert_equal devs[2], Developer.offset(2).first
-    assert_equal devs[-1], Developer.offset(2).last
+    assert_equal devs[-1], Developer.offset(2).last # note that this behavior is deprecated and will raise an exception in Rails 5.1
+    assert_raise(ActiveRecord::IrreversibleOrderError) { Developer.offset(1).reverse_order }
     assert_equal devs[-3], Developer.offset(2).order('id DESC').first
   end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -987,7 +987,7 @@ class FinderTest < ActiveRecord::TestCase
     devs = Developer.order('id')
 
     assert_equal devs[2], Developer.offset(2).first
-    assert_equal devs[-3], Developer.offset(2).last
+    assert_equal devs[-1], Developer.offset(2).last
     assert_equal devs[-3], Developer.offset(2).order('id DESC').first
   end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -988,7 +988,6 @@ class FinderTest < ActiveRecord::TestCase
 
     assert_equal devs[2], Developer.offset(2).first
     assert_equal devs[-3], Developer.offset(2).last
-    assert_equal devs[-3], Developer.offset(2).last
     assert_equal devs[-3], Developer.offset(2).order('id DESC').first
   end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1002,7 +1002,8 @@ class FinderTest < ActiveRecord::TestCase
 
     assert_equal devs[2], Developer.offset(2).first
     assert_equal devs[-1], Developer.offset(2).last # note that this behavior is deprecated and will raise an exception in Rails 5.1
-    assert_raise(ActiveRecord::IrreversibleOrderError) { Developer.offset(1).reverse_order }
+    # assert_raise(ActiveRecord::IrreversibleOrderError) { Developer.offset(2).last } # Rails >= 5.1
+    # assert_raise(ActiveRecord::IrreversibleOrderError) { Developer.offset(1).reverse_order } # Rails >= 5.1
     assert_equal devs[-3], Developer.offset(2).order('id DESC').first
   end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1001,8 +1001,10 @@ class FinderTest < ActiveRecord::TestCase
     devs = Developer.order('id')
 
     assert_equal devs[2], Developer.offset(2).first
-    assert_equal devs[-1], Developer.offset(2).last # note that this behavior is deprecated and will raise an exception in Rails 5.1
+    assert_equal devs[-1], Developer.offset(2).last
+    assert_deprecated { Developer.offset(2).last }
     # assert_raise(ActiveRecord::IrreversibleOrderError) { Developer.offset(2).last } # Rails >= 5.1
+    assert_deprecated { Developer.offset(1).reverse_order }
     # assert_raise(ActiveRecord::IrreversibleOrderError) { Developer.offset(1).reverse_order } # Rails >= 5.1
     assert_equal devs[-3], Developer.offset(2).order('id DESC').first
   end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1004,9 +1004,12 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal devs[-1], Developer.offset(2).last
     assert_deprecated { Developer.offset(2).last }
     # assert_raise(ActiveRecord::IrreversibleOrderError) { Developer.offset(2).last } # Rails >= 5.1
+    assert_equal devs[-3], Developer.offset(2).order('id DESC').first
+  end
+
+  def reverse_order_with_offset
     assert_deprecated { Developer.offset(1).reverse_order }
     # assert_raise(ActiveRecord::IrreversibleOrderError) { Developer.offset(1).reverse_order } # Rails >= 5.1
-    assert_equal devs[-3], Developer.offset(2).order('id DESC').first
   end
 
   def test_find_by_nil_attribute


### PR DESCRIPTION
### Summary

I noticed that in the `master` branch, the AR finder method `last` is designed to catch `ActiveRecord::IrreversibleOrderError` and fall back on `to_a.last` in that case. It occurred to me that this can be used to address some of the issues relating to the use of `last` with `offset`.

I have documented a number of complex issues arising from the mixing of `offset` and `last`, for example in https://github.com/rails/rails/issues/23829.

This PR is designed to address this behavior by raising an `IrreversibleOrderError` when `reverse_order` is called on an AR Relation that has an offset.
### Other Information

This PR involved changing the expectation for one current Rails test, from

``` ruby
assert_equal devs[-3], Developer.offset(2).last
```

to

``` ruby
assert_equal devs[-1], Developer.offset(2).last
```

This change is in line with DHH's discussion about how `last` and `offset` should behave together in  https://github.com/rails/rails/pull/23598#issuecomment-189675440.

Because `Developer.offset(2).last` will raise an `ActiveSupport::Deprecation.warn`, I think users are reasonably well protected from this change affecting any application logic that relies on chaining these two finder methods together.

I noticed that the interaction between offset and last is not fully covered in the documentation, so I am adding that as well.
