### PR TITLE
Prefer `public_send` in `ActiveRecord::AttributeMethods::Query`

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       end
 
       def query_attribute(attr_name)
-        value = self[attr_name]
+        value = public_send(attr_name)
 
         case value
         when true        then true


### PR DESCRIPTION
Replace `self.[]` which does not work with custom attributes or `ActiveRecord::Store` generated methods.

Related to #16704 (see discussion)
@rafaelfranca 
