### PR TITLE
Rubocop fails at the long line

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Rakefile
+++ b/railties/lib/rails/generators/rails/app/templates/Rakefile
@@ -1,5 +1,6 @@
-# Add your own tasks in files placed in lib/tasks ending in .rake,
-# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+# Add your own tasks in files placed in lib/tasks ending in .rake.
+# For example lib/tasks/capistrano.rake 
+# and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
 


### PR DESCRIPTION
### Summary

Rubocop gem which is used for code quality metrics is throwing an offense at the long line in the template, this change removes the issue 

![image](https://cloud.githubusercontent.com/assets/12704422/13621591/7d396d08-e54d-11e5-8620-a18be1322024.png)
