### PR TITLE
Pass headers through to payload for logging.

### DIFF
--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -19,6 +19,7 @@ module ActionController
         :controller => self.class.name,
         :action     => self.action_name,
         :params     => request.filtered_parameters,
+        :headers    => request.headers,
         :format     => request.format.ref,
         :method     => request.request_method,
         :path       => request.fullpath

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -183,6 +183,12 @@ class ACLogSubscriberTest < ActionController::TestCase
     assert_equal "test_value", @controller.last_payload[:test_key]
   end
 
+  def test_process_action_headers
+    get :show
+    wait
+    assert_equal "Rails Testing", @controller.last_payload[:headers]['User-Agent']
+  end
+
   def test_process_action_with_filter_parameters
     @request.env["action_dispatch.parameter_filter"] = [:lifo, :amount]
 


### PR DESCRIPTION
### Summary

In attempting to log certain request headers the Rails way while still leveraging the output of `ActionController::LogSubscriber`'s `start_processing` method, we realized we'd love to have the request headers in the event payload. This allows us to add header logging like this:

```
Started POST "/create" for 127.0.0.1 at 2016-03-09 03:14:49 +0000
Processing by RailsController#create as JSON
  Parameters: {"param_1"=>"A", "param_2"=> "B"}
  Headers: {"X-Platform-Id"=>"1", "X-Request-Id"=>"2"}
Application logic logging.
More application model logging.
Completed 200 OK in 108ms (Views: 3.1ms | ActiveRecord: 0.0ms)
```

 via `OurLogSubscriber.attach_to :action_controller`.

Any other options I investigated involved completely replacing the default request logging.

@rafaelfranca 
