### PR TITLE
Allow passing record being validated to error message generator

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Allow passing record being validated to the message proc to generate
+    customized error messages for that object using I18n helper.
+
+    *Prathamesh Sonpatki*
+
 ## Rails 5.0.0.beta3 (February 24, 2016) ##
 
 *   No changes.

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -486,7 +486,8 @@ module ActiveModel
         default: defaults,
         model: @base.model_name.human,
         attribute: @base.class.human_attribute_name(attribute),
-        value: value
+        value: value,
+        object: @base
       }.merge!(options)
 
       I18n.translate(key, options)

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -444,4 +444,12 @@ class ValidationsTest < ActiveModel::TestCase
     assert topic.invalid?
     assert duped.valid?
   end
+
+  def test_validation_with_message_as_proc_that_takes_a_record_as_a_parameter
+    Topic.validates_presence_of(:title, message: proc { |record| "You have failed me for the last time, #{record.author_name}." })
+
+    t = Topic.new(author_name: 'Admiral')
+    assert t.invalid?
+    assert_equal ["You have failed me for the last time, Admiral."], t.errors[:title]
+  end
 end


### PR DESCRIPTION
- Pass object to I18n helper so that when calling message proc, it will
  pass that object as argument to the proc and we can generate custom
  error messages based on current record being validated.
- Based on https://github.com/rails/rails/issues/856.

r? @rafaelfranca 

I used different approach from #856 by passing required object to I18n so that it can call proc with correct argument.  Let me know if this is right approach or not. I will add CHANGELOG and documentation after getting some ideas about this approach.
