### PR TITLE
Match hash styles in migration.rb

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1247,7 +1247,7 @@ module ActiveRecord
     def record_version_state_after_migrating(version)
       if down?
         migrated.delete(version)
-        ActiveRecord::SchemaMigration.where(:version => version.to_s).delete_all
+        ActiveRecord::SchemaMigration.where(version: version.to_s).delete_all
       else
         migrated << version
         ActiveRecord::SchemaMigration.create!(version: version.to_s)


### PR DESCRIPTION
Whether we write ':version =>' or 'version:', it will not be a big problem. 
However, having both styles nearby, in this case line 1250 and line 1253, lacks consistency and should be avoided.
