### PR TITLE
AppGenerator: allow both 'rake' and 'rails'

### DIFF
--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -202,7 +202,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_rails_should_run_rake_command_with_default_env
-    assert_called_with(generator, :run, ["rails log:clear RAILS_ENV=development", verbose: false]) do
+    assert_called_with(generator, :run, ["rake log:clear RAILS_ENV=development", verbose: false]) do
       with_rails_env nil do
         action :rake, 'log:clear'
       end
@@ -210,13 +210,13 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_rails_with_env_option_should_run_rake_command_in_env
-    assert_called_with(generator, :run, ['rails log:clear RAILS_ENV=production', verbose: false]) do
+    assert_called_with(generator, :run, ['rake log:clear RAILS_ENV=production', verbose: false]) do
       action :rake, 'log:clear', env: 'production'
     end
   end
 
   test "rails command with RAILS_ENV variable should run rake command in env" do
-    assert_called_with(generator, :run, ['rails log:clear RAILS_ENV=production', verbose: false]) do
+    assert_called_with(generator, :run, ['rake log:clear RAILS_ENV=production', verbose: false]) do
       with_rails_env "production" do
         action :rake, 'log:clear'
       end
@@ -224,7 +224,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   test "env option should win over RAILS_ENV variable when running rake" do
-    assert_called_with(generator, :run, ['rails log:clear RAILS_ENV=production', verbose: false]) do
+    assert_called_with(generator, :run, ['rake log:clear RAILS_ENV=production', verbose: false]) do
       with_rails_env "staging" do
         action :rake, 'log:clear', env: 'production'
       end
@@ -232,7 +232,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   test "rails command with sudo option should run rake command with sudo" do
-    assert_called_with(generator, :run, ["sudo rails log:clear RAILS_ENV=development", verbose: false]) do
+    assert_called_with(generator, :run, ["sudo rake log:clear RAILS_ENV=development", verbose: false]) do
       with_rails_env nil do
         action :rake, 'log:clear', sudo: true
       end


### PR DESCRIPTION
This commit comes from the comments made by
- @matthewd at https://github.com/rails/rails/pull/23795/files#r54469637
- @rafaelfranca at https://github.com/rails/rails/pull/23795/files#r54609364

The idea is that if you type (for example) "rake db:migrate" in an AppGenerator,
then this should actually invoke `rake db:migrate` on the command line, whereas
if you type "rails_command db:migrate", this should invoke `rails db:migrate`.
