### PR TITLE
Job payload should be symmetric across JSON dump/load

### DIFF
--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -79,7 +79,7 @@ module ActiveJob
         'queue_name' => queue_name,
         'priority'   => priority,
         'arguments'  => serialize_arguments(arguments),
-        'locale'     => I18n.locale
+        'locale'     => I18n.locale.to_s
       }
     end
 

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -108,7 +108,7 @@ module ActiveJob
       self.queue_name           = job_data['queue_name']
       self.priority             = job_data['priority']
       self.serialized_arguments = job_data['arguments']
-      self.locale               = job_data['locale'] || I18n.locale
+      self.locale               = job_data['locale'] || I18n.locale.to_s
     end
 
     private

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -2,6 +2,7 @@ require 'helper'
 require 'jobs/gid_job'
 require 'jobs/hello_job'
 require 'models/person'
+require 'json'
 
 class JobSerializationTest < ActiveSupport::TestCase
   setup do
@@ -18,6 +19,20 @@ class JobSerializationTest < ActiveSupport::TestCase
     assert_equal 'en', HelloJob.new.serialize['locale']
   end
 
+  test 'serialize and deserialize are symmetric' do
+    # Round trip a job in memory only
+    h1 = HelloJob.new
+    h1.deserialize(h1.serialize)
+
+    # Now verify it's identical to a JSON round trip.
+    # We don't want any non-native JSON elements in the job hash,
+    # like symbols.
+    payload = JSON.dump(h1.serialize)
+    h2 = HelloJob.new
+    h2.deserialize(JSON.load(payload))
+    assert_equal h1.serialize, h2.serialize
+  end
+
   test 'deserialize sets locale' do
     job = HelloJob.new
     job.deserialize 'locale' => 'es'
@@ -27,6 +42,6 @@ class JobSerializationTest < ActiveSupport::TestCase
   test 'deserialize sets default locale' do
     job = HelloJob.new
     job.deserialize({})
-    assert_equal :en, job.locale
+    assert_equal 'en', job.locale
   end
 end

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -15,13 +15,13 @@ class JobSerializationTest < ActiveSupport::TestCase
   end
 
   test 'serialize includes current locale' do
-    assert_equal :en, HelloJob.new.serialize['locale']
+    assert_equal 'en', HelloJob.new.serialize['locale']
   end
 
   test 'deserialize sets locale' do
     job = HelloJob.new
-    job.deserialize 'locale' => :es
-    assert_equal :es, job.locale
+    job.deserialize 'locale' => 'es'
+    assert_equal 'es', job.locale
   end
 
   test 'deserialize sets default locale' do


### PR DESCRIPTION
Placing non-native JSON data types, like symbols, in the hash to serialize means that the deserialize method will return something different from what was serialized, a common bug and source of frustration for devs.  This matters to Resque, Sidekiq and any other systems using JSON for their data format.

Without this change, I can't add a runtime check `JSON.load(JSON.dump(args)) == args` because it fails for every ActiveJob, due to the locale symbol.
