### PR TITLE
ActiveRecord find_nth finder respects limit()

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Fixed an issue where using `first(n)` or `second` (etc.) after a `limit()`
+    would ignore the limit. (E.g., `limit(1).first(3).size == 3`.)
+    This had resulted in inconsistencies between `first(n)` and `last(n)`,
+    because `last(n)` did respect the `limit()` (e.g.,
+    `limit(1).first(3).size == 1`). The `first` finder is now fixed
+    to correctly respect the `limit()`, making it consistent with `last(n)`.
+
+    Fixes #23979.
+
+    *Brian Christian*
+
 *   Execute default_scope defined by abstract class in the context of subclass.
 
     Fixes #23413 & #10658

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -586,7 +586,15 @@ module ActiveRecord
       if loaded?
         @records[index, limit]
       else
+        # determine the appropriate size of the record set to return,
+        # based on the pre-existing limit_value
+        if limit_value.present?
+          limit = [limit_value, index + limit].min - index
+          limit = [0, limit].max
+        end
+
         index += offset
+        return [] if limit <= 0
         find_nth_with_limit(index, limit)
       end
     end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -412,6 +412,18 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal expected, Topic.second
   end
 
+  def test_second_with_limit
+    assert_equal nil, Topic.limit(1).second
+    assert_equal topics(:second), Topic.limit(2).second
+    assert_equal topics(:second), Topic.limit(3).second
+  end
+
+  def test_second_with_offset_and_limit
+    assert_equal nil, Topic.offset(1).limit(1).second
+    assert_equal topics(:third), Topic.offset(1).limit(2).second
+    assert_equal topics(:fourth), Topic.offset(2).limit(3).second
+  end
+
   def test_model_class_responds_to_second_bang
     assert Topic.second!
     Topic.delete_all
@@ -432,6 +444,20 @@ class FinderTest < ActiveRecord::TestCase
     expected = topics(:third)
     expected.touch # PostgreSQL changes the default order if no order clause is used
     assert_equal expected, Topic.third
+  end
+
+  def test_third_with_limit
+    assert_equal nil, Topic.limit(1).third
+    assert_equal nil, Topic.limit(2).third
+    assert_equal topics(:third), Topic.limit(3).third
+    assert_equal topics(:third), Topic.limit(4).third
+  end
+
+  def test_third_with_offset_and_limit
+    assert_equal nil, Topic.offset(1).limit(1).third
+    assert_equal nil, Topic.offset(1).limit(2).third
+    assert_equal topics(:fourth), Topic.offset(1).limit(3).third
+    assert_equal topics(:fifth), Topic.offset(2).limit(4).third
   end
 
   def test_model_class_responds_to_third_bang
@@ -456,6 +482,22 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal expected, Topic.fourth
   end
 
+  def test_fourth_with_limit
+    assert_equal nil, Topic.limit(1).fourth
+    assert_equal nil, Topic.limit(2).fourth
+    assert_equal nil, Topic.limit(3).fourth
+    assert_equal topics(:fourth), Topic.limit(4).fourth
+    assert_equal topics(:fourth), Topic.limit(5).fourth
+  end
+
+  def test_fourth_with_offset_and_limit
+    assert_equal nil, Topic.offset(1).limit(1).fourth
+    assert_equal nil, Topic.offset(1).limit(2).fourth
+    assert_equal nil, Topic.offset(1).limit(3).fourth
+    assert_equal topics(:fifth), Topic.offset(1).limit(4).fourth
+    assert_equal nil, Topic.offset(2).limit(5).fourth
+  end
+
   def test_model_class_responds_to_fourth_bang
     assert Topic.fourth!
     Topic.delete_all
@@ -478,6 +520,23 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal expected, Topic.fifth
   end
 
+  def test_fifth_with_limit
+    assert_equal nil, Topic.limit(1).fifth
+    assert_equal nil, Topic.limit(2).fifth
+    assert_equal nil, Topic.limit(3).fifth
+    assert_equal nil, Topic.limit(4).fifth
+    assert_equal topics(:fifth), Topic.limit(5).fifth
+  end
+  
+  def test_fifth_with_offset_and_limit
+    assert_equal nil, Topic.offset(1).limit(1).fifth
+    assert_equal nil, Topic.offset(1).limit(2).fifth
+    assert_equal nil, Topic.offset(1).limit(3).fifth
+    assert_equal nil, Topic.offset(1).limit(4).fifth
+    assert_equal nil, Topic.offset(1).limit(5).fifth
+    assert_equal nil, Topic.offset(2).limit(6).fifth
+  end
+  
   def test_model_class_responds_to_fifth_bang
     assert Topic.fifth!
     Topic.delete_all

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -390,6 +390,20 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal expected, Topic.first
   end
 
+  def test_first_nth_with_limit
+    assert_equal 1, Topic.limit(1).first(1).size
+    assert_equal 2, Topic.limit(2).first(2).size
+    assert_equal 2, Topic.limit(2).first(3).size
+    assert_equal Topic.limit(1).first(2).size, Topic.limit(1).last(2).size
+    assert_equal Topic.limit(2).first(3).size, Topic.limit(2).last(3).size
+  end
+
+  def test_first_nth_with_offset_and_limit
+    assert_equal topics(:second), Topic.offset(1).limit(2).first(3).first
+    assert_equal topics(:third), Topic.offset(1).limit(2).first(3).second
+    assert_equal nil, Topic.offset(1).limit(2).first(3).third
+  end
+
   def test_model_class_responds_to_first_bang
     assert Topic.first!
     Topic.delete_all


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/23979.

Issue https://github.com/rails/rails/issues/23979 describes behavior where the ActiveRecord `first` and `last` would behave differently following a `limit()`, and DHH's comment in https://github.com/rails/rails/pull/23598#issuecomment-189675440 pointed to the `first` method being the one that was behaving incorrectly.

Specifically, `limit(1).first(2)` would return a set of size 2 (incorrect), while `limit(1).last(2)` would return a record set of size 1 (correct).

This PR introduces a test suite to capture the interrelationships between `limit` and the finder methods (both `first(n)` as well as `second`, `third`, and so on).

It also adjusts those finder methods to make the test suite pass: making them respect the `limit` and making them consistent with the behavior of the `last` finders.
