### PR TITLE
Update the rake file that needs to be loaded

### DIFF
--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -59,7 +59,7 @@ module ActionView
 
     rake_tasks do |app|
       unless app.config.api_only
-        load "action_view/tasks/dependencies.rake"
+        load "action_view/tasks/cache_digests.rake"
       end
     end
   end


### PR DESCRIPTION
#24125 pull request renames the dependencies.rake to cache_digests.rake

Updating the railtie.rb to be in sync with that change
