### PR TITLE
ActiveRecord: limit() and primary_key

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Don't impose primary key order if limit() has already been supplied.
+
+    Fixes #23607
+
+    *Brian Christian*
+
 *   Add environment & load_config dependency to `bin/rake db:seed` to enable
     seed load in environments without Rails and custom DB configuration
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -550,7 +550,7 @@ module ActiveRecord
       end
 
       def ordered_relation
-        if order_values.empty? && primary_key
+        if order_values.empty? && primary_key && limit_value.blank?
           order(arel_attribute(primary_key).asc)
         else
           self

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1265,6 +1265,21 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_first_and_last_with_limit_for_order_without_primary_key
+    # While Topic.first should impose an ordering by primary key,
+    # Topic.limit(n).first should not
+
+    Topic.first.touch # PostgreSQL changes the default order if no order clause is used
+
+    assert_equal Topic.limit(1).to_a.first, Topic.limit(1).first
+    assert_equal Topic.limit(2).to_a.first, Topic.limit(2).first
+    assert_equal Topic.limit(2).to_a.first(2), Topic.limit(2).first(2)
+
+    assert_equal Topic.limit(1).to_a.last, Topic.limit(1).last
+    assert_equal Topic.limit(2).to_a.last, Topic.limit(2).last
+    assert_equal Topic.limit(2).to_a.last(2), Topic.limit(2).last(2)
+  end
+
   def test_finder_with_offset_string
     assert_nothing_raised { Topic.offset("3").to_a }
   end


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/23607.

As discussed in https://github.com/rails/rails/issues/23607, there was an inconsistency between the `first` and `last` ActiveRecord finder methods, in that `limit(1).first` would impose primary key order if no order was specified, whereas `limit(1).last` would not.

Discussion with Rails community members in the issue thread as well as DHH's remarks in https://github.com/rails/rails/pull/23598#issuecomment-189675440 point to the behavior of `last` in this case as being the correct behavior -- that is, that it should not impose primary key order when `limit` has been defined.

This PR includes a test suite for this issue, and simply adds a check for `limit_value.blank?` before imposing primary key ordering by default. This brings the `first` and `last` finder methods into consistent agreement in their behavior on this issue.
