### PR TITLE
add inherit_validation_context flag to AssociatedValidator

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   AssociatedValidator accepts `inherit_validation_context` 
+ 
+    When enabled context passed to validation <tt>parent.valid?(:custom_context)</tt> gets inherited by AssociatedValidator
+
+    *Rafał Brize*
+
 *   Deprecate `rails db:structure:{load, dump}` tasks and extend
     `rails db:schema:{load, dump}` tasks to work with either `:ruby` or `:sql` format,
     depending on `config.active_record.schema_format` configuration value.

--- a/activerecord/test/cases/validations/association_validation_test.rb
+++ b/activerecord/test/cases/validations/association_validation_test.rb
@@ -49,7 +49,7 @@ class AssociationValidationTest < ActiveRecord::TestCase
 
   def test_validates_associated_without_marked_for_destruction
     reply = Class.new do
-      def valid?
+      def valid?(context = nil)
         true
       end
     end
@@ -95,5 +95,15 @@ class AssociationValidationTest < ActiveRecord::TestCase
       interest = human.interests.build(topic: "Airplanes")
       assert interest.valid?, "Expected interest to be valid, but was not. Interest should have a human object associated"
     end
+  end
+
+  def test_passes_down_validation_context
+    Reply.validates :topic, associated: { inherit_validation_context: true }
+    Topic.validates_presence_of(:content, on: :my_context)
+    r = Reply.create("title" => "A reply", "content" => "with content!")
+    r.topic = Topic.create("title" => "uhohuhoh")
+
+    assert r.valid?
+    assert_not r.valid?(:my_context)
   end
 end


### PR DESCRIPTION
### Summary

This PR comes as a result of a research done to solve issue https://github.com/rails/rails/issues/23261.
This allows to pass a forward_validation_context flag to `AssociatedValidator` so that writing `parent.valid?(:custom_context)` will pass that `:custom_context` down to child validation.
This is consistent with what `:autosave` does as a default behavior https://github.com/rails/rails/blob/master/activerecord/lib/active_record/autosave_association.rb#L328. Doing that a default behavior for `AssociatedValidator` would be a breaking change.
