### PR TITLE
Reorder paragraphs in the Routing API docs

### DIFF
--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -73,13 +73,13 @@ module ActionDispatch
   #   get 'post/:id' => 'posts#show'
   #   post 'post/:id' => 'posts#create_comment'
   #
+  # Now, if you POST to <tt>/posts/:id</tt>, it will route to the <tt>create_comment</tt> action. A GET on the same
+  # URL will route to the <tt>show</tt> action.
+  #
   # If your route needs to respond to more than one HTTP method (or all methods) then using the
   # <tt>:via</tt> option on <tt>match</tt> is preferable.
   #
   #   match 'post/:id' => 'posts#show', via: [:get, :post]
-  #
-  # Now, if you POST to <tt>/posts/:id</tt>, it will route to the <tt>create_comment</tt> action. A GET on the same
-  # URL will route to the <tt>show</tt> action.
   #
   # == Named routes
   #


### PR DESCRIPTION
### Summary

A minor documentation change to remove an ambiguity.
### Other Information

The previous order made sense [when `match` was used twice to point to two different actions](7305ef8). In this case the note was misleading as posting to `/posts/:id` would still route to the `show` action.
