### PR TITLE
Fix `thread_mattr_accessor` thread-local variable naming

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
@@ -47,7 +47,7 @@ class Module
       unless options[:instance_reader] == false || options[:instance_accessor] == false
         class_eval(<<-EOS, __FILE__, __LINE__ + 1)
           def #{sym}
-            Thread.current[:"attr_#{self.class.name}_#{sym}"]
+            Thread.current[:"attr_#{name}_#{sym}"]
           end
         EOS
       end
@@ -86,7 +86,7 @@ class Module
       unless options[:instance_writer] == false || options[:instance_accessor] == false
         class_eval(<<-EOS, __FILE__, __LINE__ + 1)
           def #{sym}=(obj)
-            Thread.current[:"attr_#{self.class.name}_#{sym}"] = obj
+            Thread.current[:"attr_#{name}_#{sym}"] = obj
           end
         EOS
       end

--- a/activesupport/test/core_ext/module/attribute_accessor_per_thread_test.rb
+++ b/activesupport/test/core_ext/module/attribute_accessor_per_thread_test.rb
@@ -106,4 +106,10 @@ class ModuleAttributeAccessorPerThreadTest < ActiveSupport::TestCase
     end
     assert_equal "invalid attribute name: 2valid_part", exception.message
   end
+
+  def test_should_return_same_value_by_class_or_instance_accessor
+    @class.foo = 'fries'
+
+    assert_equal @class.foo, @object.foo
+  end
 end


### PR DESCRIPTION
I believe there's an oopsie in the current implentation of `thread_mattr_accessor`, which is setting differently-named thread variables when defining class and instance writer methods, so the method isn't working as documented:

```
    Account.user = "DHH"
    Account.user # => "DHH"
    Account.new.user # => nil
    a = Account.new
    a.user = "ABC" # => "ABC"
    a.class.user # => "DHH"
```

At this point `:attr_Account_user` and `:attr_Class_user` thread-local variables have been created. This change modifies the reader and writer methods to use the class name, instead of 'Class'.

A comparison test has been added (we're already testing the setters above), and all AS tests are passing.

Please scrutinize. :)
