### PR TITLE
Version 3.1.11 of bcrypt gem works on Windows again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,13 +17,7 @@ gem 'turbolinks', github: 'turbolinks/turbolinks-rails'
 # require: false so bcrypt is loaded only when has_secure_password is used.
 # This is to avoid Active Model (and by extension the entire framework)
 # being dependent on a binary library.
-platforms :mingw, :x64_mingw, :mswin, :mswin64 do
-  gem 'bcrypt-ruby', '~> 3.0.0', require: false
-end
-
-platforms :ruby, :jruby, :rbx do
-  gem 'bcrypt', '~> 3.1.10', require: false
-end
+gem 'bcrypt', '~> 3.1.11', require: false
 
 # This needs to be with require false to avoid it being automatically loaded by
 # sprockets.


### PR DESCRIPTION
This undoes https://github.com/rails/rails/commit/7241498e51120b9847a8bc16cf48551db0f3e216 by @sgrif 

bcrypt versions less than 3.1.11 didn't work on Ruby 2.2 on Windows (see https://github.com/codahale/bcrypt-ruby/issues/116 and https://github.com/codahale/bcrypt-ruby/issues/128).

[Version 3.1.11 fixes Windows support](https://github.com/codahale/bcrypt-ruby/commit/fbbece54c6cb8b53db01132c7eeb58955944547d) and was pushed up on March 6th.
