### PR TITLE
Don't inherit from Concurrent::CountDownLatch

### DIFF
--- a/activesupport/lib/active_support/concurrency/latch.rb
+++ b/activesupport/lib/active_support/concurrency/latch.rb
@@ -2,17 +2,24 @@ require 'concurrent/atomic/count_down_latch'
 
 module ActiveSupport
   module Concurrency
-    class Latch < Concurrent::CountDownLatch
+    class Latch
 
       def initialize(count = 1)
-        ActiveSupport::Deprecation.warn("ActiveSupport::Concurrency::Latch is deprecated. Please use Concurrent::CountDownLatch instead.")
-        super(count)
+        if count == 1
+          ActiveSupport::Deprecation.warn("ActiveSupport::Concurrency::Latch is deprecated. Please use Concurrent::Event instead.")
+        else
+          ActiveSupport::Deprecation.warn("ActiveSupport::Concurrency::Latch is deprecated. Please use Concurrent::CountDownLatch instead.")
+        end
+
+        @inner = Concurrent::CountDownLatch.new(count)
       end
 
-      alias_method :release, :count_down
+      def release
+        @inner.count_down
+      end
 
       def await
-        wait(nil)
+        @inner.wait(nil)
       end
     end
   end


### PR DESCRIPTION
That class mangles .new, which interferes with our deprecation warning.

More generally, it suggests we shouldn't be subclassing without a very good reason, and avoiding one allocation doesn't seem to meet that criteria.

In passing, recommend the simpler Concurrent::Event for the common count=1 case.

cc @jdantonio
