### PR TITLE
Add SimpleCov to measure code coverage of Action Mailer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ pkg
 /railties/doc
 /railties/tmp
 /guides/output
+coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ group :test do
   end
 
   gem 'benchmark-ips'
+  gem 'simplecov', require: false
 end
 
 platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
     delayed_job_active_record (4.1.0)
       activerecord (>= 3.0, < 5)
       delayed_job (>= 3.0, < 5)
+    docile (1.1.5)
     em-hiredis (0.3.1)
       eventmachine (~> 1.0)
       hiredis (~> 0.6.0)
@@ -229,6 +230,11 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       redis (~> 3.2, >= 3.2.1)
     sigdump (0.2.3)
+    simplecov (0.11.2)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     sinatra (1.0)
       rack (>= 1.0)
     sneakers (2.3.5)
@@ -315,6 +321,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   sequel
   sidekiq
+  simplecov
   sneakers
   sqlite3 (~> 1.3.6)
   stackprof

--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -22,3 +22,9 @@ namespace :test do
     end or raise "Failures"
   end
 end
+
+task :coverage do
+  ENV['COVERAGE'] = 'true'
+  Rake::Task['test'].execute
+  ENV.delete('COVERAGE')
+end

--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -1,5 +1,10 @@
 require 'active_support/core_ext/kernel/reporting'
 
+if ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.start
+end
+
 # These are the normal settings that will be set up by Railties
 # TODO: Have these tests support other combinations of these values
 silence_warnings do


### PR DESCRIPTION
### Summary

Currently, Ruby on Rails does not measure code coverage, which can be a useful tool to see what is or is not tested. Therefore, in this patch, we propose the addition of SimpleCov. With SimpleCov, we can easily get an overview of the coverage for each file. Furthermore, we have tried to make it as elegant as possible by defining a Rake task, such that we can get the coverage data by running the following command from the Action Mailer directory: `bundle exec rake coverage`. The code coverage analysis results will be placed in a `coverage` directory, which will be created in the root of the Action Mailer module.
### Other information

We, @ValMai, @vliegenthart, @basvijzendoorn, and myself, think it would be a nice addition to Rails to use a code coverage analysis tool. We would like to discuss with you what you think of this proposal.

Furthermore, we have made some changes to show a possible integration of a code coverage analysis tool, namely [SimpleCov](https://github.com/colszowka/simplecov). Ultimately, we would like to implement SimpleCov, such that code coverage analysis results are generated during the build and test process by Travis CI.

We are looking forward to hearing from you :smile: 
