### PR TITLE
actionview simple_format does not always marks input as html_safe

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -312,9 +312,11 @@ module ActionView
         if paragraphs.empty?
           content_tag(wrapper_tag, nil, html_options)
         else
-          paragraphs.map! { |paragraph|
+          html = paragraphs.map! { |paragraph|
             content_tag(wrapper_tag, raw(paragraph), html_options)
-          }.join("\n\n").html_safe
+          }.join("\n\n")
+          html = html.html_safe if text.html_safe?
+          html
         end
       end
 

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -55,6 +55,11 @@ class TextHelperTest < ActionView::TestCase
     assert_equal "<p><b> test with unsafe string </b><script>code!</script></p>", simple_format("<b> test with unsafe string </b><script>code!</script>", {}, :sanitize => false)
   end
 
+  def test_simple_format_should_not_be_html_safe_when_sanitize_option_is_false
+    unsane_input = "<script>alert('all your base are belong to us');</script>"
+    refute simple_format(unsane_input, {}, { sanitize: false }).html_safe?
+  end
+
   def test_simple_format_with_custom_wrapper
     assert_equal "<div></div>", simple_format(nil, {}, :wrapper_tag => "div")
   end


### PR DESCRIPTION
### before

``` ruby
(irb) > include ActionView::Helpers::TextHelper
(irb) > unsane_string = "<script>alert('all your base are belong to us');</script>"
(irb) > simple_format(unsane_string, {}, { sanitize: false }).html_safe?
=> true
```
### after

``` ruby
(irb) > include ActionView::Helpers::TextHelper
(irb) > unsane_string = "<script>alert('all your base are belong to us');</script>"
(irb) > simple_format(unsane_string, {}, { sanitize: false }).html_safe?
=> false
```
