### PR TITLE
Prevent `Marshal.load` from looping infinitely

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Prevent `Marshal.load` from looping infinitely when trying to autoload a constant
+    which resolves to a different name.
+
+    *Olek Janiszewski*
+
+
 ## Rails 4.2.6 (March 07, 2016) ##
 
 *   No changes.

--- a/activesupport/lib/active_support/core_ext/marshal.rb
+++ b/activesupport/lib/active_support/core_ext/marshal.rb
@@ -7,8 +7,11 @@ module Marshal
     rescue ArgumentError, NameError => exc
       if exc.message.match(%r|undefined class/module (.+)|)
         # try loading the class/module
-        $1.constantize
-        # if it is a IO we need to go back to read the object
+        loaded = $1.constantize
+
+        raise unless $1 == loaded.name
+
+        # if it is an IO we need to go back to read the object
         source.rewind if source.respond_to?(:rewind)
         retry
       else

--- a/activesupport/test/core_ext/marshal_test.rb
+++ b/activesupport/test/core_ext/marshal_test.rb
@@ -64,6 +64,17 @@ class MarshalTest < ActiveSupport::TestCase
     end
   end
 
+  test "when one constant resolves to another" do
+    class Parent; C = Class.new; end
+    class Child < Parent; C = Class.new; end
+
+    dump = Marshal.dump(Child::C.new)
+
+    Child.send(:remove_const, :C)
+
+    assert_raise(ArgumentError) { Marshal.load(dump) }
+  end
+
   test "that a real missing class is causing an exception" do
     dumped = nil
     with_autoloading_fixtures do


### PR DESCRIPTION
Fix a bug in `Marshal.load` that caused it to loop indefinitely when
trying to autoload a constant that resolved to a different name.

This could occur when marshalling an ActiveRecord 4.0 object (e.g. into
memcached) and then trying to unmarshal it with Rails 4.2. The
marshalled payload contains a reference to
`ActiveRecord::ConnectionAdapters::Mysql2Adapter::Column`, which in
Rails 4.2 resolves to
`ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::Column`.

This backports #24150 to 4-2-stable
