### PR TITLE
Use the most highest priority exception handler when cause is set

### DIFF
--- a/actionpack/lib/action_controller/metal/rescue.rb
+++ b/actionpack/lib/action_controller/metal/rescue.rb
@@ -8,9 +8,9 @@ module ActionController #:nodoc:
 
     def rescue_with_handler(exception)
       if exception.cause
-        handler_index = index_of_handler_for_rescue(exception)
+        handler_index = index_of_handler_for_rescue(exception) || Float::INFINITY
         cause_handler_index = index_of_handler_for_rescue(exception.cause)
-        if handler_index && cause_handler_index && cause_handler_index <= handler_index
+        if cause_handler_index && cause_handler_index <= handler_index
           exception = exception.cause
         end
       end

--- a/actionpack/lib/action_controller/metal/rescue.rb
+++ b/actionpack/lib/action_controller/metal/rescue.rb
@@ -7,8 +7,12 @@ module ActionController #:nodoc:
     include ActiveSupport::Rescuable
 
     def rescue_with_handler(exception)
-      if exception.cause && handler_for_rescue(exception.cause)
-        exception = exception.cause
+      if exception.cause
+        handler_index = index_of_handler_for_rescue(exception)
+        cause_handler_index = index_of_handler_for_rescue(exception.cause)
+        if handler_index && cause_handler_index && cause_handler_index <= handler_index
+          exception = exception.cause
+        end
       end
       super(exception)
     end

--- a/actionpack/test/controller/rescue_test.rb
+++ b/actionpack/test/controller/rescue_test.rb
@@ -159,6 +159,12 @@ class RescueController < ActionController::Base
     raise RecordInvalid
   end
 
+  def exception_with_no_handler_for_wrapper
+    raise RecordInvalid
+  rescue
+    raise RangeError
+  end
+
   protected
     def deny_access
       head :forbidden
@@ -321,6 +327,11 @@ class RescueControllerTest < ActionController::TestCase
 
   test 'rescue when cause has more specific handler than wrapper' do
     get :exception_with_more_specific_handler_for_cause
+    assert_response :unprocessable_entity
+  end
+
+  test 'rescue when cause has handler, but wrapper doesnt' do
+    get :exception_with_no_handler_for_wrapper
     assert_response :unprocessable_entity
   end
 end

--- a/actionpack/test/controller/rescue_test.rb
+++ b/actionpack/test/controller/rescue_test.rb
@@ -147,6 +147,18 @@ class RescueController < ActionController::Base
     end
   end
 
+  def exception_with_more_specific_handler_for_wrapper
+    raise RecordInvalid
+  rescue
+    raise NotAuthorized
+  end
+
+  def exception_with_more_specific_handler_for_cause
+    raise NotAuthorized
+  rescue
+    raise RecordInvalid
+  end
+
   protected
     def deny_access
       head :forbidden
@@ -300,6 +312,16 @@ class RescueControllerTest < ActionController::TestCase
   def test_block_rescue_handler_with_argument_as_string
     get :resource_unavailable_raise_as_string
     assert_equal "RescueController::ResourceUnavailableToRescueAsString", @response.body
+  end
+
+  test 'rescue when wrapper has more specific handler than cause' do
+    get :exception_with_more_specific_handler_for_wrapper
+    assert_response :unprocessable_entity
+  end
+
+  test 'rescue when cause has more specific handler than wrapper' do
+    get :exception_with_more_specific_handler_for_cause
+    assert_response :unprocessable_entity
   end
 end
 

--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -115,5 +115,15 @@ module ActiveSupport
         end
       end
     end
+
+    def index_of_handler_for_rescue(exception)
+      handlers = self.class.rescue_handlers.reverse_each.with_index
+      _, index = handlers.detect do |(klass_name, _), _|
+        klass = self.class.const_get(klass_name) rescue nil
+        klass ||= (klass_name.constantize rescue nil)
+        klass === exception if klass
+      end
+      index
+    end
   end
 end


### PR DESCRIPTION
There was some subtle breakage caused by #18774, when we removed
`#original_exception` in favor of `#cause`. However, `#cause` is
automatically set by Ruby when raising an exception from a rescue block.
With this change, we will use whichever handler has the highest priority
(whichever call to `rescue_from` came last). In cases where the outer
has lower precidence than the cause, but the outer is what should be
handled, cause will need to be explicitly unset.

Fixes #23925
