### PR TITLE
Fix Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,7 @@ DEPENDENCIES
   rake (>= 10.3)
   redcarpet (~> 3.2.3)
   redis
-  resque
+  resque (< 1.26)
   resque-scheduler
   sass!
   sdoc (~> 0.4.0)


### PR DESCRIPTION
### Summary
- Resque version was locked to < 1.26 in 92f869a0c85268 but
  Gemfile.lock was not updated.

r? @rafaelfranca 
