### PR TITLE
generate ApplicationJob if it does not already exist

### DIFF
--- a/activejob/lib/rails/generators/job/job_generator.rb
+++ b/activejob/lib/rails/generators/job/job_generator.rb
@@ -17,7 +17,22 @@ module Rails # :nodoc:
 
       def create_job_file
         template 'job.rb', File.join('app/jobs', class_path, "#{file_name}_job.rb")
+
+        in_root do
+          if self.behavior == :invoke && !File.exist?(application_job_file_name)
+            template 'application_job.rb', application_job_file_name
+          end
+        end
       end
+
+      private
+        def application_job_file_name
+           @application_job_file_name ||= if mountable_engine?
+             "app/jobs/#{namespaced_path}/application_job.rb"
+           else
+             'app/jobs/application_job.rb'
+           end
+        end
     end
   end
 end

--- a/activejob/lib/rails/generators/job/templates/application_job.rb
+++ b/activejob/lib/rails/generators/job/templates/application_job.rb
@@ -1,0 +1,4 @@
+<% module_namespacing do -%>
+class ApplicationJob < ActiveJob::Base
+end
+<% end -%>

--- a/railties/test/generators/job_generator_test.rb
+++ b/railties/test/generators/job_generator_test.rb
@@ -26,4 +26,11 @@ class JobGeneratorTest < Rails::Generators::TestCase
       assert_match(/queue_as :admin/, job)
     end
   end
+
+  def test_application_job_skeleton_is_created
+    run_generator ["refresh_counters"]
+    assert_file "app/jobs/application_job.rb" do |job|
+      assert_match(/class ApplicationJob < ActiveJob::Base/, job)
+    end
+  end
 end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -669,6 +669,19 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_generate_application_job_when_does_not_exist_in_mountable_engine
+    run_generator [destination_root, '--mountable']
+    FileUtils.rm "#{destination_root}/app/jobs/bukkits/application_job.rb"
+    capture(:stdout) do
+      `#{destination_root}/bin/rails g job refresh_counters`
+    end
+
+    assert_file "#{destination_root}/app/jobs/bukkits/application_job.rb" do |record|
+      assert_match(/module Bukkits/, record)
+      assert_match(/class ApplicationJob < ActiveJob::Base/, record)
+    end
+  end
+
   def test_after_bundle_callback
     path = 'http://example.org/rails_template'
     template = %{ after_bundle { run 'echo ran after_bundle' } }


### PR DESCRIPTION
ActiveJob jobs now inherit from ApplicationJob by default.
However, when updating to Rails 5 from the old Rails,
since there is a possibility that ApplicationJob does not exist.
