### PR TITLE
Fix `warning: method redefined; discarding old female`

### DIFF
--- a/activerecord/test/models/cat.rb
+++ b/activerecord/test/models/cat.rb
@@ -3,9 +3,6 @@ class Cat < ActiveRecord::Base
 
   enum gender: [:female, :male]
 
-  scope :female, -> { where(gender: genders[:female]) }
-  scope :male, -> { where(gender: genders[:male]) }
-
   default_scope -> { where(is_vegetarian: false) }
 end
 


### PR DESCRIPTION
```
$ ARCONN=mysql2 be ruby -w -Itest test/cases/scoping/default_scoping_test.rb
Using mysql2
/Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/scoping/named.rb:158: warning: method redefined; discarding old female
/Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/scoping/named.rb:158: warning: previous definition of female was here
/Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/scoping/named.rb:158: warning: method redefined; discarding old male
/Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/scoping/named.rb:158: warning: previous definition of male was here
```
