### PR TITLE
Config ac per env

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -324,9 +324,10 @@ Rails.application.paths.add "config/cable", with: "somewhere/else/cable.yml"
 ### Allowed Request Origins
 
 Action Cable will only accept requests from specified origins, which are passed to the server config as an array. The origins can be instances of strings or regular expressions, against which a check for match will be performed.
+Edit or insert the following lines into your `config/environments/development.rb` and `config/environments/production.rb`.
 
 ```ruby
-Rails.application.config.action_cable.allowed_request_origins = ['http://rubyonrails.com', /http:\/\/ruby.*/]
+config.action_cable.allowed_request_origins = ['http://rubyonrails.com', /http:\/\/ruby.*/]
 ```
 
 When running in the development environment, this defaults to "http://localhost:3000".
@@ -334,7 +335,7 @@ When running in the development environment, this defaults to "http://localhost:
 To disable and allow requests from any origin:
 
 ```ruby
-Rails.application.config.action_cable.disable_request_forgery_protection = true
+config.action_cable.disable_request_forgery_protection = true
 ```
 
 ### Consumer Configuration

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -54,4 +54,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   <%= '# ' unless depend_on_listen? %>config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Uncomment if you wish to allow Action Cable access from any origin
+  # config.action_cable.disable_request_forgery_protection = true
 end


### PR DESCRIPTION
Developers getting started with Rails may be surprised to find that by default Action Cable will only work on their localhost.  Guide them on how to configure this per environment.  There already are comments in config/environments/production.rb, so point them there and add comments to config/environments/development.rb.
