### PR TITLE
Un-hide helper and assets options for controller generator

### DIFF
--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -19,8 +19,7 @@ module Rails
         end
       end
 
-      hook_for :template_engine, :test_framework
-      hook_for :helper, :assets, hide: true
+      hook_for :template_engine, :test_framework, :helper, :assets
 
       private
 


### PR DESCRIPTION
These options were hidden via 9b36cf0fa4cbdcb2e2072ef1b8179a98b13efce3,
but these options have tests written for them, and I believe that they
are supposed to be public API.

Fixes #24168.
