### PR TITLE
Fix ActionView::Rendering include order with jbuilder

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix ActionView::Rendering include order for API only applications with jbuilder.
+
+    Fixes #23923
+
+    *Mehmet Emin İNAÇ*
+
 *   Add extension synonyms `yml` and `yaml` for MIME type `application/x-yaml`.
 
    *bogdanvlviv*

--- a/actionpack/lib/action_controller/api/api_rendering.rb
+++ b/actionpack/lib/action_controller/api/api_rendering.rb
@@ -4,6 +4,7 @@ module ActionController
 
     included do
       include Rendering
+      include ActionView::Rendering
     end
 
     def render_to_body(options = {})

--- a/actionpack/test/controller/api/renderers_test.rb
+++ b/actionpack/test/controller/api/renderers_test.rb
@@ -29,6 +29,14 @@ class RenderersApiController < ActionController::API
   end
 end
 
+class IncludeACRenderingController < ActionController::API
+  include ActionView::Rendering
+
+  def respond_with_json
+    render json: { foo: :bar }
+  end
+end
+
 class RenderersApiTest < ActionController::TestCase
   tests RenderersApiController
 
@@ -56,5 +64,15 @@ class RenderersApiTest < ActionController::TestCase
     end
     assert_response :internal_server_error
     assert_equal('Hi from text', @response.body)
+  end
+end
+
+class RenderersJSONApiTest < ActionController::TestCase
+  tests IncludeACRenderingController
+
+  def test_render_json
+    get :respond_with_json
+    assert_response :success
+    assert_equal({ foo: :bar }.to_json, @response.body)
   end
 end


### PR DESCRIPTION
Jbuilder includes `ActionView::Rendering` after ActionController loaded. This overrides `render_to_body` method which is defined by `ActionController::Renderers` and as a result of this you can't render json like `render json: { status: :ok }`.
This pull request fixes this misbehaviour. Also I'm going to open a pull request for jbuilder to remove module include statement from it.

I think @rafaelfranca or @spastorino may want to review this.

Closes #23923

r? @rafaelfranca
