### PR TITLE
Improve Action Cable message encoding + decoding

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -192,7 +192,7 @@ module ActionCable
         # the proper channel identifier marked as the recipient.
         def transmit(data, via: nil)
           logger.info "#{self.class.name} transmitting #{data.inspect.truncate(300)}".tap { |m| m << " (via #{via})" if via }
-          connection.transmit ActiveSupport::JSON.encode(identifier: @identifier, message: data)
+          connection.transmit({ identifier: @identifier, message: data })
         end
 
         def defer_subscription_confirmation!

--- a/actioncable/lib/action_cable/connection.rb
+++ b/actioncable/lib/action_cable/connection.rb
@@ -15,6 +15,7 @@ module ActionCable
       autoload :StreamEventLoop
       autoload :Subscriptions
       autoload :TaggedLoggerProxy
+      autoload :Utils
       autoload :WebSocket
     end
   end

--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -5,6 +5,8 @@ module ActionCable
     # Collection class for all the channel subscriptions established on a given connection. Responsible for routing incoming commands that arrive on
     # the connection to the proper channel.
     class Subscriptions # :nodoc:
+      include Utils
+
       def initialize(connection)
         @connection = connection
         @subscriptions = {}
@@ -23,13 +25,13 @@ module ActionCable
       end
 
       def add(data)
-        id_options = decode_hash(data['identifier'])
-        identifier = normalize_identifier(id_options)
+        id_key = data['identifier']
+        id_options = json_to_hash(data['identifier'])
 
         subscription_klass = connection.server.channel_classes[id_options[:channel]]
 
         if subscription_klass
-          subscriptions[identifier] ||= subscription_klass.new(connection, identifier, id_options)
+          subscriptions[id_key] ||= subscription_klass.new(connection, id_key, id_options)
         else
           logger.error "Subscription class not found (#{data.inspect})"
         end
@@ -37,7 +39,7 @@ module ActionCable
 
       def remove(data)
         logger.info "Unsubscribing from channel: #{data['identifier']}"
-        remove_subscription subscriptions[normalize_identifier(data['identifier'])]
+        remove_subscription subscriptions[data['identifier']]
       end
 
       def remove_subscription(subscription)
@@ -46,7 +48,7 @@ module ActionCable
       end
 
       def perform_action(data)
-        find(data).perform_action(decode_hash(data['data']))
+        find(data).perform_action(data['data'])
       end
 
       def identifiers
@@ -63,21 +65,8 @@ module ActionCable
       private
         delegate :logger, to: :connection
 
-        def normalize_identifier(identifier)
-          identifier = ActiveSupport::JSON.encode(identifier) if identifier.is_a?(Hash)
-          identifier
-        end
-
-        # If `data` is a Hash, this means that the original JSON
-        # sent by the client had no backslashes in it, and does
-        # not need to be decoded again.
-        def decode_hash(data)
-          data = ActiveSupport::JSON.decode(data) unless data.is_a?(Hash)
-          data.with_indifferent_access
-        end
-
         def find(data)
-          if subscription = subscriptions[normalize_identifier(data['identifier'])]
+          if subscription = subscriptions[data['identifier']]
             subscription
           else
             raise "Unable to find subscription with identifier: #{data['identifier']}"

--- a/actioncable/lib/action_cable/connection/utils.rb
+++ b/actioncable/lib/action_cable/connection/utils.rb
@@ -1,0 +1,29 @@
+module ActionCable
+  module Connection
+    module Utils # :nodoc:
+      extend ActiveSupport::Concern
+
+      # Parse the subscription's identifier, as well as
+      # the connection's message data
+      def parsed_json_data(json_data)
+        data = json_to_hash(json_data)
+
+        data['identifier'] = hash_to_json(data['identifier'])
+        data['data'] = json_to_hash(data['data'])
+        data
+      end
+
+      def hash_to_json(data)
+        return unless data
+        data = ActiveSupport::JSON.encode(data) if data.is_a?(Hash)
+        data
+      end
+
+      def json_to_hash(data)
+        return unless data
+        data = ActiveSupport::JSON.decode(data) unless data.is_a?(Hash)
+        data.with_indifferent_access
+      end
+    end
+  end
+end

--- a/actioncable/lib/action_cable/connection/web_socket.rb
+++ b/actioncable/lib/action_cable/connection/web_socket.rb
@@ -4,6 +4,8 @@ module ActionCable
   module Connection
     # Wrap the real socket to minimize the externally-presented API
     class WebSocket
+      include Utils
+
       def initialize(env, event_target, event_loop, client_socket_class)
         @websocket = ::WebSocket::Driver.websocket?(env) ? client_socket_class.new(env, event_target, event_loop) : nil
       end
@@ -17,7 +19,7 @@ module ActionCable
       end
 
       def transmit(data)
-        websocket.transmit data
+        websocket.transmit hash_to_json(data)
       end
 
       def close

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -27,7 +27,10 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
     @server.stubs(:channel_classes).returns(ChatChannel.name => ChatChannel)
 
     @chat_identifier = ActiveSupport::JSON.encode(id: 1, channel: 'ActionCable::Connection::SubscriptionsTest::ChatChannel')
+    @chat_no_slash_identifier = '{"id": "1", "channel":"ActionCable::Connection::SubscriptionsTest::ChatChannel"}'
   end
+
+  include ActionCable::Connection::Utils
 
   test "subscribe command" do
     run_in_eventmachine do
@@ -61,6 +64,21 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
     end
   end
 
+  test "unsubscribe command with JSON with no backslahes" do
+    run_in_eventmachine do
+      setup_connection
+      subscribe_to_chat_channel(@chat_no_slash_identifier)
+
+      channel = subscribe_to_chat_channel(@chat_no_slash_identifier)
+      channel.expects(:unsubscribe_from_channel)
+
+      command = { 'command' => 'unsubscribe', 'identifier' => @chat_no_slash_identifier }
+      @subscriptions.execute_command parsed_json_data(command)
+
+      assert @subscriptions.identifiers.empty?
+    end
+  end
+
   test "unsubscribe command without an identifier" do
     run_in_eventmachine do
       setup_connection
@@ -76,9 +94,23 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
       channel = subscribe_to_chat_channel
 
       data = { 'content' => 'Hello World!', 'action' => 'speak' }
-      @subscriptions.execute_command 'command' => 'message', 'identifier' => @chat_identifier, 'data' => ActiveSupport::JSON.encode(data)
+      command = { 'command' => 'message', 'identifier' => @chat_identifier, 'data' => ActiveSupport::JSON.encode(data) }
+      @subscriptions.execute_command parsed_json_data(command)
 
       assert_equal [ data ], channel.lines
+    end
+  end
+
+  test "message command with JSON with no backslahes" do
+    run_in_eventmachine do
+      setup_connection
+      channel = subscribe_to_chat_channel(@chat_no_slash_identifier)
+
+      data = '{"content": "Hello World!", "action":"speak"}'
+      command = { 'command' => 'message', 'identifier' => @chat_no_slash_identifier, 'data' => data }
+      @subscriptions.execute_command parsed_json_data(command)
+
+      assert_equal [{"content"=>"Hello World!", "action"=>"speak"}], channel.lines
     end
   end
 

--- a/actioncable/test/stubs/test_connection.rb
+++ b/actioncable/test/stubs/test_connection.rb
@@ -1,6 +1,8 @@
 require 'stubs/user'
 
 class TestConnection
+  include ActionCable::Connection::Utils
+
   attr_reader :identifiers, :logger, :current_user, :server, :transmissions
 
   def initialize(user = User.new("lifo"))
@@ -17,7 +19,7 @@ class TestConnection
   end
 
   def transmit(data)
-    @transmissions << data
+    @transmissions << hash_to_json(data)
   end
 
   def last_transmission

--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -6,7 +6,6 @@ require 'puma'
 require 'mocha/setup'
 
 require 'rack/mock'
-require 'active_support/core_ext/hash/indifferent_access'
 
 # Require all the stubs and models
 Dir[File.dirname(__FILE__) + '/stubs/*.rb'].each {|file| require file }


### PR DESCRIPTION
- This centralizes all parsing and processing methods in
  a `ActionCable::Connection::Utils` concern, which is then `include`d for
  use within the library.
- All payload parsing/processing is done immediately in
  `ActionCable::Connection::Base#receive`
- `ActionCable::Connection::Subscriptions` once again uses `id_key` as
  the identifier for subscriptions within the global hash. This was only
  changed in the first place to accomodate payload parsing/processing.

See #23649 and #24040 for previous discussion regarding this.

Likely still more work to be done with this, but this is a start at
trying to organize this logic in a way that is easier to understand.
