### PR TITLE
add `queue_classic` to list of provide `provider_job_id` [ci skip]

### DIFF
--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -621,10 +621,11 @@ Please refer to the [Changelog][active-job] for detailed changes.
 *   A generated job now inherits from `app/jobs/application_job.rb` by default.
     ([Pull Request](https://github.com/rails/rails/pull/19034))
 
-*   Allow `DelayedJob`, `Sidekiq`, `qu`, and `que` to report the job id back to
-    `ActiveJob::Base` as `provider_job_id`.
+*   Allow `DelayedJob`, `Sidekiq`, `qu`, `que`, and `queue_classic` to report
+    the job id back to `ActiveJob::Base` as `provider_job_id`.
     ([Pull Request](https://github.com/rails/rails/pull/20064),
-     [Pull Request](https://github.com/rails/rails/pull/20056))
+     [Pull Request](https://github.com/rails/rails/pull/20056),
+     [commit](https://github.com/rails/rails/commit/68e3279163d06e6b04e043f91c9470e9259bbbe0))
 
 *   Implement a simple `AsyncJob` processor and associated `AsyncAdapter` that
     queue jobs to a `concurrent-ruby` thread pool.


### PR DESCRIPTION
`queue_classic` also supports the `provider_job_id`. 
Ref: 68e3279163d06e6b04e043f91c9470e9259bbbe0
