### PR TITLE
[ci skip] Fix the FinderMethods#find document

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -42,10 +42,10 @@ module ActiveRecord
     #   Person.find_by(name: 'Spartacus', rating: 4)
     #   # returns the first item or nil.
     #
-    #   Person.where(name: 'Spartacus', rating: 4).first_or_initialize
+    #   Person.find_or_initialize_by(name: 'Spartacus', rating: 4)
     #   # returns the first item or returns a new instance (requires you call .save to persist against the database).
     #
-    #   Person.where(name: 'Spartacus', rating: 4).first_or_create
+    #   Person.find_or_create_by(name: 'Spartacus', rating: 4)
     #   # returns the first item or creates it and returns it.
     #
     # ==== Alternatives for #find


### PR DESCRIPTION
related to https://github.com/rails/rails/commit/0096f53b25e68c3fc79429253f816fff4a4ee596

We should use `#find_or_initialize_by` and `#find_or_create_by` because `#first_or_initialize` and `#first_or_create` methods are not the public API
