### PR TITLE
Correct command for generating secret_key_base [ci skip]

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -417,7 +417,7 @@ secrets, you need to:
 
 3. Remove the `secret_token.rb` initializer.
 
-4. Use `rails secret` to generate new keys for the `development` and `test` sections.
+4. Use `rake secret` to generate new keys for the `development` and `test` sections.
 
 5. Restart your server.
 


### PR DESCRIPTION
### Summary

The upgrade section currently displays the incorrect command for generating a new secret_key_base. This fixes it.
