### PR TITLE
Fix undefined method `owners' for NullPreloader:Class

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -184,6 +184,7 @@ module ActiveRecord
         def self.new(klass, owners, reflection, preload_scope); self; end
         def self.run(preloader); end
         def self.preloaded_records; []; end
+        def self.owners; []; end
       end
 
       # Returns a class containing the logic needed to load preload the data

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1085,15 +1085,15 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_preloading_empty_through_with_polymorphic_source_association
-    owner = Owner.create!(:name => "Rainbow Unicat")
-    pet = Pet.create!(:owner => owner)
-    person = Person.create!(:first_name => "Gaga")
-    treasure = Treasure.create!(:looter => person)
+    owner = Owner.create!(name: "Rainbow Unicat")
+    pet = Pet.create!(owner: owner)
+    person = Person.create!(first_name: "Gaga")
+    treasure = Treasure.create!(looter: person)
     non_looted_treasure = Treasure.create!()
-    PetTreasure.create!(:pet => pet, :treasure => treasure, :rainbow_color => "Ultra violet indigo")
-    PetTreasure.create!(:pet => pet, :treasure => non_looted_treasure, :rainbow_color => "Ultra violet indigo")
+    PetTreasure.create!(pet: pet, treasure: treasure, rainbow_color: "Ultra violet indigo")
+    PetTreasure.create!(pet: pet, treasure: non_looted_treasure, rainbow_color: "Ultra violet indigo")
 
-    assert_equal [person], Owner.where(:name => "Rainbow Unicat").includes(:pets => :persons).first.persons.to_a
+    assert_equal [person], Owner.where(name: "Rainbow Unicat").includes(pets: :persons).first.persons.to_a
   end
 
   def test_explicitly_joining_join_table

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -11,7 +11,9 @@ require 'models/tagging'
 require 'models/author'
 require 'models/owner'
 require 'models/pet'
+require 'models/pet_treasure'
 require 'models/toy'
+require 'models/treasure'
 require 'models/contract'
 require 'models/company'
 require 'models/developer'
@@ -1080,6 +1082,18 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
     assert person.posts.loaded?, 'person.posts should be loaded'
     assert_equal [], person.posts
+  end
+
+  def test_preloading_empty_through_with_polymorphic_source_association
+    owner = Owner.create!(:name => "Rainbow Unicat")
+    pet = Pet.create!(:owner => owner)
+    person = Person.create!(:first_name => "Gaga")
+    treasure = Treasure.create!(:looter => person)
+    non_looted_treasure = Treasure.create!()
+    PetTreasure.create!(:pet => pet, :treasure => treasure, :rainbow_color => "Ultra violet indigo")
+    PetTreasure.create!(:pet => pet, :treasure => non_looted_treasure, :rainbow_color => "Ultra violet indigo")
+
+    assert_equal [person], Owner.where(:name => "Rainbow Unicat").includes(:pets => :persons).first.persons.to_a
   end
 
   def test_explicitly_joining_join_table

--- a/activerecord/test/models/owner.rb
+++ b/activerecord/test/models/owner.rb
@@ -1,8 +1,8 @@
 class Owner < ActiveRecord::Base
   self.primary_key = :owner_id
   has_many :pets, -> { order 'pets.name desc' }
-  has_many :toys, :through => :pets
-  has_many :persons, :through => :pets
+  has_many :toys, through: :pets
+  has_many :persons, through: :pets
 
   belongs_to :last_pet, class_name: 'Pet'
   scope :including_last_pet, -> {

--- a/activerecord/test/models/owner.rb
+++ b/activerecord/test/models/owner.rb
@@ -2,6 +2,7 @@ class Owner < ActiveRecord::Base
   self.primary_key = :owner_id
   has_many :pets, -> { order 'pets.name desc' }
   has_many :toys, :through => :pets
+  has_many :persons, :through => :pets
 
   belongs_to :last_pet, class_name: 'Pet'
   scope :including_last_pet, -> {

--- a/activerecord/test/models/pet.rb
+++ b/activerecord/test/models/pet.rb
@@ -4,6 +4,9 @@ class Pet < ActiveRecord::Base
   self.primary_key = :pet_id
   belongs_to :owner, :touch => true
   has_many :toys
+  has_many :pet_treasures
+  has_many :treasures, :through => :pet_treasures
+  has_many :persons, :through => :treasures, :source => :looter, :source_type => 'Person'
 
   class << self
     attr_accessor :after_destroy_output

--- a/activerecord/test/models/pet.rb
+++ b/activerecord/test/models/pet.rb
@@ -5,8 +5,8 @@ class Pet < ActiveRecord::Base
   belongs_to :owner, :touch => true
   has_many :toys
   has_many :pet_treasures
-  has_many :treasures, :through => :pet_treasures
-  has_many :persons, :through => :treasures, :source => :looter, :source_type => 'Person'
+  has_many :treasures, through: :pet_treasures
+  has_many :persons, through: :treasures, source: :looter, source_type: 'Person'
 
   class << self
     attr_accessor :after_destroy_output

--- a/activerecord/test/models/pet_treasure.rb
+++ b/activerecord/test/models/pet_treasure.rb
@@ -1,0 +1,6 @@
+class PetTreasure < ActiveRecord::Base
+  self.table_name = "pets_treasures"
+
+  belongs_to :pet
+  belongs_to :treasure
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -620,6 +620,12 @@ ActiveRecord::Schema.define do
     end
   end
 
+  create_table :pets_treasures, force: true do |t|
+    t.column :treasure_id, :integer
+    t.column :pet_id, :integer
+    t.column :rainbow_color, :string
+  end
+
   create_table :pirates, force: true do |t|
     t.column :catchphrase, :string
     t.column :parrot_id, :integer


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/24413
### Summary

Fixing undefined method `owners' for ActiveRecord::Associations::Preloader::NullPreloader:Class

This a building of a complex query with include, that is getting this result. The root of the problem is probably more :through relations, when one link of the chain is empty
### Other Information

This fix is probably not right, might be that ActiveRecord::Associations::Preloader::NullPreloader:Class should just have :owners method defined?
### Application specific details

This happen when I combine my 2 PRs:
https://github.com/ManageIQ/manageiq/pull/7033
https://github.com/ManageIQ/manageiq/pull/7237

This brings extra :through layer https://github.com/ManageIQ/manageiq/pull/7237, then I start to see this error

StackTrace of the ManageIQ app where this occurs:

```
[----] I, [2016-03-14T19:21:26.529830 #16851:41dc71c]  INFO -- : Started GET "/cloud_subnet/show_list" for ::1 at 2016-03-14 19:21:26 +0100
[----] I, [2016-03-14T19:21:27.254761 #16851:41dc71c]  INFO -- : Processing by CloudSubnetController#show_list as HTML
[----] F, [2016-03-14T19:21:31.411707 #16851:41dc71c] FATAL -- : Error caught: [NoMethodError] undefined method `owners' for ActiveRecord::Associations::Preloader::NullPreloader:Class
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader/through_association.rb:36:in `block in associated_records_by_owner'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader/through_association.rb:35:in `each'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader/through_association.rb:35:in `each_with_object'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader/through_association.rb:35:in `associated_records_by_owner'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader/has_many_through.rb:8:in `associated_records_by_owner'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader/collection_association.rb:8:in `preload'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader/association.rb:19:in `run'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:151:in `block (2 levels) in preloaders_for_one'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:149:in `each'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:149:in `map'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:149:in `block in preloaders_for_one'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:148:in `each'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:148:in `flat_map'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:148:in `preloaders_for_one'
/home/Ladas/Projects/cfme/manageiq/lib/extensions/ar_virtual.rb:263:in `preloaders_for_one'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:115:in `preloaders_on'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:102:in `block in preload'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:101:in `each'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:101:in `flat_map'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:101:in `preload'
/home/Ladas/Projects/cfme/manageiq/lib/extensions/ar_virtual.rb:258:in `block in preloaders_for_one'
/home/Ladas/Projects/cfme/manageiq/lib/extensions/ar_virtual.rb:256:in `each'
/home/Ladas/Projects/cfme/manageiq/lib/extensions/ar_virtual.rb:256:in `flat_map'
/home/Ladas/Projects/cfme/manageiq/lib/extensions/ar_virtual.rb:256:in `preloaders_for_one'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:125:in `block in preloaders_for_hash'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:124:in `each'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:124:in `flat_map'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:124:in `preloaders_for_hash'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:113:in `preloaders_on'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:102:in `block in preload'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:101:in `each'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:101:in `flat_map'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/associations/preloader.rb:101:in `preload'
/home/Ladas/Projects/cfme/manageiq/lib/miq_preloader.rb:4:in `preload'
/home/Ladas/Projects/cfme/manageiq/lib/extensions/ar_virtual.rb:289:in `find_with_associations'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/relation.rb:699:in `exec_queries'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/relation.rb:580:in `load'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/relation.rb:260:in `records'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/relation/delegation.rb:39:in `length'
/home/Ladas/Projects/cfme/manageiq/app/models/rbac.rb:292:in `find_targets_without_rbac'
/home/Ladas/Projects/cfme/manageiq/app/models/rbac.rb:287:in `find_targets_with_rbac'
/home/Ladas/Projects/cfme/manageiq/app/models/rbac.rb:507:in `search'
/home/Ladas/Projects/cfme/manageiq/app/models/miq_report/search.rb:109:in `paged_view_search'
/home/Ladas/Projects/cfme/manageiq/app/controllers/application_controller.rb:1771:in `get_view'
/home/Ladas/Projects/cfme/manageiq/app/controllers/application_controller/ci_processing.rb:1026:in `process_show_list'
/home/Ladas/Projects/cfme/manageiq/app/controllers/mixins/generic_list_mixin.rb:8:in `show_list'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/abstract_controller/base.rb:181:in `process_action'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_controller/metal/rendering.rb:30:in `process_action'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/abstract_controller/callbacks.rb:20:in `block in process_action'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/callbacks.rb:126:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/callbacks.rb:126:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/callbacks.rb:455:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/callbacks.rb:455:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/callbacks.rb:750:in `_run_process_action_callbacks'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/callbacks.rb:90:in `run_callbacks'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/abstract_controller/callbacks.rb:19:in `process_action'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_controller/metal/rescue.rb:31:in `process_action'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/notifications.rb:164:in `block in instrument'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/notifications.rb:164:in `instrument'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_controller/metal/instrumentation.rb:30:in `process_action'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_controller/metal/params_wrapper.rb:248:in `process_action'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activerecord/lib/active_record/railties/controller_runtime.rb:18:in `process_action'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/abstract_controller/base.rb:126:in `process'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionview/lib/action_view/rendering.rb:30:in `process'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_controller/metal.rb:190:in `dispatch'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_controller/metal.rb:262:in `dispatch'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/routing/route_set.rb:50:in `dispatch'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/routing/route_set.rb:32:in `serve'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/journey/router.rb:39:in `block in serve'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/journey/router.rb:26:in `each'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/journey/router.rb:26:in `serve'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/routing/route_set.rb:739:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/omniauth-1.3.1/lib/omniauth/strategy.rb:186:in `call!'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/omniauth-1.3.1/lib/omniauth/strategy.rb:164:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/omniauth-1.3.1/lib/omniauth/builder.rb:63:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/secure_headers-3.0.3/lib/secure_headers/middleware.rb:10:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionview/lib/action_view/digestor.rb:12:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/rack-2.0.0.alpha/lib/rack/etag.rb:25:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/rack-2.0.0.alpha/lib/rack/conditional_get.rb:25:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/rack-2.0.0.alpha/lib/rack/head.rb:12:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/rack-2.0.0.alpha/lib/rack/session/abstract/id.rb:220:in `context'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/rack-2.0.0.alpha/lib/rack/session/abstract/id.rb:214:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/middleware/cookies.rb:613:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/middleware/callbacks.rb:38:in `block in call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/callbacks.rb:750:in `_run_call_callbacks'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/callbacks.rb:90:in `run_callbacks'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/middleware/callbacks.rb:36:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/middleware/executor.rb:12:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/middleware/remote_ip.rb:79:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb:49:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/railties/lib/rails/rack/logger.rb:36:in `call_app'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/railties/lib/rails/rack/logger.rb:26:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/request_store-1.3.0/lib/request_store/middleware.rb:9:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/middleware/request_id.rb:24:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/rack-2.0.0.alpha/lib/rack/method_override.rb:22:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/rack-2.0.0.alpha/lib/rack/runtime.rb:22:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/activesupport/lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/middleware/executor.rb:12:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/actionpack/lib/action_dispatch/middleware/static.rb:136:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/rack-2.0.0.alpha/lib/rack/sendfile.rb:111:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/bundler/gems/rails-feef64cee449/railties/lib/rails/engine.rb:522:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/puma-2.16.0/lib/puma/server.rb:557:in `handle_request'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/puma-2.16.0/lib/puma/server.rb:404:in `process_client'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/puma-2.16.0/lib/puma/server.rb:270:in `block in run'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/puma-2.16.0/lib/puma/thread_pool.rb:106:in `call'
/home/Ladas/.rvm/gems/ruby-2.2.3/gems/puma-2.16.0/lib/puma/thread_pool.rb:106:in `block in spawn_thread'
[----] I, [2016-03-14T19:21:31.420386 #16851:41dc71c]  INFO -- :   Rendering layouts/exception.html.haml within layouts/application
[----] I, [2016-03-14T19:21:31.430582 #16851:41dc71c]  INFO -- :   Rendered layouts/_exception_contents.html.haml (5.0ms)
[----] I, [2016-03-14T19:21:31.430759 #16851:41dc71c]  INFO -- :   Rendered layouts/exception.html.haml within layouts/application (10.2ms)
[----] I, [2016-03-14T19:21:31.441036 #16851:41dc71c]  INFO -- :   Rendered layouts/_doctype.html.haml (1.7ms)
[----] I, [2016-03-14T19:21:34.194908 #16851:41dc71c]  INFO -- :   Rendered stylesheets/_template50.html.haml (2.3ms)
[----] I, [2016-03-14T19:21:35.033150 #16851:41dc71c]  INFO -- :   Rendered layouts/_i18n_js.html.haml (3.8ms)
[----] I, [2016-03-14T19:21:35.066909 #16851:41dc71c]  INFO -- :   Rendered layouts/_user_options.html.haml (13.9ms)
[----] I, [2016-03-14T19:21:35.092621 #16851:41dc71c]  INFO -- :   Rendered layouts/_page_header_navbar.html.haml (25.0ms)
[----] I, [2016-03-14T19:21:35.095483 #16851:41dc71c]  INFO -- :   Rendered layouts/_spinner.html.haml (2.2ms)
[----] I, [2016-03-14T19:21:35.097470 #16851:41dc71c]  INFO -- :   Rendered layouts/_lightbox_panel.html.haml (1.4ms)
[----] I, [2016-03-14T19:21:35.097624 #16851:41dc71c]  INFO -- :   Rendered layouts/_header.html.haml (63.7ms)
[----] I, [2016-03-14T19:21:35.115346 #16851:41dc71c]  INFO -- :   Rendered layouts/_breadcrumbs.html.haml (2.2ms)
[----] I, [2016-03-14T19:21:35.115658 #16851:41dc71c]  INFO -- :   Rendered layouts/_content.html.haml (17.4ms)
[----] I, [2016-03-14T19:21:35.123156 #16851:41dc71c]  INFO -- :   Rendered layouts/_adv_search.html.haml (4.7ms)
[----] I, [2016-03-14T19:21:35.123374 #16851:41dc71c]  INFO -- :   Rendered layouts/_footer.html.haml (7.1ms)
[----] I, [2016-03-14T19:21:35.123853 #16851:41dc71c]  INFO -- : Completed 500 Internal Server Error in 7869ms (Views: 3711.1ms | ActiveRecord: 0.0ms)
```
