### PR TITLE
Revert "Correct command for generating secret_key_base"  [ci skip]

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -417,7 +417,7 @@ secrets, you need to:
 
 3. Remove the `secret_token.rb` initializer.
 
-4. Use `rake secret` to generate new keys for the `development` and `test` sections.
+4. Use `rails secret` to generate new keys for the `development` and `test` sections.
 
 5. Restart your server.
 


### PR DESCRIPTION
### Summary

This reverts commit 36ea7bcc702940c2392ddcd50084b5bbc369e51f merged in #24188

It seems both `rails secret` and `rake secret` are available for Edge Rails so probably better to revert this. 
