### PR TITLE
Bugfix: ActionCable not loaded when generating plugin without ActiveRecord

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb
@@ -6,10 +6,12 @@ require 'rails/all'
 # Pick the frameworks you want:
 <%= comment_if :skip_active_record %>require "active_record/railtie"
 require "action_controller/railtie"
-<%= comment_if :skip_action_mailer %>require "action_mailer/railtie"
 require "action_view/railtie"
-<%= comment_if :skip_sprockets %>require "sprockets/railtie"
+<%= comment_if :skip_action_mailer %>require "action_mailer/railtie"
+require "active_job/railtie"
+<%= comment_if :skip_action_cable %>require "action_cable/engine"
 <%= comment_if :skip_test %>require "rails/test_unit/railtie"
+<%= comment_if :skip_sprockets %>require "sprockets/railtie"
 <% end -%>
 
 Bundler.require(*Rails.groups)


### PR DESCRIPTION
When generating a plugin _without_ ActiveRecord, the dummy application fails on not being able to find the `action_cable` asset.

```
couldn't find file 'action_cable' with type 'application/javascript'
```

I'm not sure why the problem doesn't occur when I generate with AR, but I figure AC is included somewhere in the AR code. 

Adding the `require` statement to the `application.rb` works in both cases.
