### PR TITLE
Backport MySQL 5.7 support

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -710,11 +710,12 @@ module ActiveRecord
       end
 
       # Given a set of columns and an ORDER BY clause, returns the columns for a SELECT DISTINCT.
-      # Both PostgreSQL and Oracle overrides this for custom DISTINCT syntax - they
+      # PostgreSQL, MySQL, and Oracle overrides this for custom DISTINCT syntax - they
       # require the order columns appear in the SELECT.
       #
       #   columns_for_distinct("posts.id", ["posts.created_at desc"])
-      def columns_for_distinct(columns, orders) #:nodoc:
+      #
+      def columns_for_distinct(columns, orders) # :nodoc:
         columns
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -567,8 +567,12 @@ module ActiveRecord
 
       # SHOW VARIABLES LIKE 'name'
       def show_variable(name)
-        variables = select_all("SHOW VARIABLES LIKE '#{name}'", 'SCHEMA')
-        variables.first['Value'] unless variables.empty?
+        begin
+          variables = select_all("select @@#{name} as 'Value'", 'SCHEMA')
+          variables.first['Value'] unless variables.empty?
+        rescue ActiveRecord::StatementInvalid => _e
+          nil
+        end
       end
 
       # Returns a table's primary key and belonging sequence.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -604,6 +604,21 @@ module ActiveRecord
         end
       end
 
+      # In MySQL 5.7.5 and up, ONLY_FULL_GROUP_BY affects handling of queries that use
+      # DISTINCT and ORDER BY. It requires the ORDER BY columns in the select list for
+      # distinct queries, and requires that the ORDER BY include the distinct column.
+      # See https://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html
+      def columns_for_distinct(columns, orders) # :nodoc:
+        order_columns = orders.reject(&:blank?).map { |s|
+          # Convert Arel node to string
+          s = s.to_sql unless s.is_a?(String)
+          # Remove any ASC/DESC modifiers
+          s.gsub(/\s+(?:ASC|DESC)\b/i, '')
+        }.reject(&:blank?).map.with_index { |column, i| "#{column} AS alias_#{i}" }
+
+        [super, *order_columns].join(', ')
+      end
+
       def limited_update_conditions(where_sql, quoted_table_name, quoted_primary_key)
         where_sql
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -624,7 +624,9 @@ module ActiveRecord
 
         subselect = Arel::SelectManager.new(select.engine)
         subselect.project Arel.sql(key.name)
-        subselect.from subsubselect.as('__active_record_temp')
+        # Materialized subquery by adding distinct
+        # to work with MySQL 5.7.6 which sets optimizer_switch='derived_merge=on'
+        subselect.from subsubselect.distinct.as('__active_record_temp')
       end
 
       def add_index_length(option_strings, column_names, options = {})

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -624,11 +624,13 @@ module ActiveRecord
         subsubselect = select.clone
         subsubselect.projections = [key]
 
+        # Materialize subquery by adding distinct
+        # to work with MySQL 5.7.6 which sets optimizer_switch='derived_merge=on'
+        subsubselect.distinct unless select.limit || select.offset || select.orders.any?
+
         subselect = Arel::SelectManager.new(select.engine)
         subselect.project Arel.sql(key.name)
-        # Materialized subquery by adding distinct
-        # to work with MySQL 5.7.6 which sets optimizer_switch='derived_merge=on'
-        subselect.from subsubselect.distinct.as('__active_record_temp')
+        subselect.from subsubselect.as('__active_record_temp')
       end
 
       def add_index_length(option_strings, column_names, options = {})

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -567,12 +567,10 @@ module ActiveRecord
 
       # SHOW VARIABLES LIKE 'name'
       def show_variable(name)
-        begin
-          variables = select_all("select @@#{name} as 'Value'", 'SCHEMA')
-          variables.first['Value'] unless variables.empty?
-        rescue ActiveRecord::StatementInvalid => _e
-          nil
-        end
+        variables = select_all("select @@#{name} as 'Value'", 'SCHEMA')
+        variables.first['Value'] unless variables.empty?
+      rescue ActiveRecord::StatementInvalid
+        nil
       end
 
       # Returns a table's primary key and belonging sequence.

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -273,7 +273,7 @@ module ActiveRecord
         return @client_encoding if @client_encoding
 
         result = exec_query(
-          "SHOW VARIABLES WHERE Variable_name = 'character_set_client'",
+          "select @@character_set_client",
           'SCHEMA')
         @client_encoding = ENCODINGS[result.rows.last.last]
       end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -1,0 +1,44 @@
+require "cases/helper"
+
+class Mysql2AdapterTest < ActiveRecord::TestCase
+  def setup
+    @conn = ActiveRecord::Base.connection
+  end
+
+  def test_columns_for_distinct_zero_orders
+    assert_equal "posts.id",
+      @conn.columns_for_distinct("posts.id", [])
+  end
+
+  def test_columns_for_distinct_one_order
+    assert_equal "posts.id, posts.created_at AS alias_0",
+      @conn.columns_for_distinct("posts.id", ["posts.created_at desc"])
+  end
+
+  def test_columns_for_distinct_few_orders
+    assert_equal "posts.id, posts.created_at AS alias_0, posts.position AS alias_1",
+      @conn.columns_for_distinct("posts.id", ["posts.created_at desc", "posts.position asc"])
+  end
+
+  def test_columns_for_distinct_with_case
+    assert_equal(
+      'posts.id, CASE WHEN author.is_active THEN UPPER(author.name) ELSE UPPER(author.email) END AS alias_0',
+      @conn.columns_for_distinct('posts.id',
+        ["CASE WHEN author.is_active THEN UPPER(author.name) ELSE UPPER(author.email) END"])
+    )
+  end
+
+  def test_columns_for_distinct_blank_not_nil_orders
+    assert_equal "posts.id, posts.created_at AS alias_0",
+      @conn.columns_for_distinct("posts.id", ["posts.created_at desc", "", "   "])
+  end
+
+  def test_columns_for_distinct_with_arel_order
+    order = Object.new
+    def order.to_sql
+      "posts.created_at desc"
+    end
+    assert_equal "posts.id, posts.created_at AS alias_0",
+      @conn.columns_for_distinct("posts.id", [order])
+  end
+end


### PR DESCRIPTION
### Summary

This is a backport of #22383 and #22864, adding additional support for MySQL 5.7.
### Other Information

I encountered an `ActiveRecord::StatementInvalid: Mysql2::Error` (in Rails 4.0.0), summarized by:
http://stackoverflow.com/questions/32528773/mysql-5-5-to-5-7-you-cant-specify-target-table-for-update-in-from-clause-sa

As far as I understand, the PRs above fixed the problem in Rails 4.2 and 5.0. I'm proposing to apply these changes to Rails 4.1.

After several attempts at running `rake test:mysql`, `rake test:mysql2`, and `rake test:postgresql`, I've given up and thought it'd be best to ask for feedback before continuing.
