### PR TITLE
Creates development and test databases in db:migrate task

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -22,7 +22,7 @@ db_namespace = namespace :db do
     end
   end
 
-  desc 'Creates the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:create:all to create all databases in the config). Without RAILS_ENV, it defaults to creating the development and test databases.'
+  desc 'Creates the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:create:all to create all databases in the config). Without RAILS_ENV or when RAILS_ENV is development, it defaults to creating the development and test databases.'
   task :create => [:load_config] do
     ActiveRecord::Tasks::DatabaseTasks.create_current
   end
@@ -33,7 +33,7 @@ db_namespace = namespace :db do
     end
   end
 
-  desc 'Drops the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:drop:all to drop all databases in the config). Without RAILS_ENV, it defaults to dropping the development and test databases.'
+  desc 'Drops the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:drop:all to drop all databases in the config). Without RAILS_ENV or when RAILS_ENV is development, it defaults to dropping the development and test databases.'
   task :drop => [:load_config, :check_protected_environments] do
     db_namespace["drop:_unsafe"].invoke
   end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -282,8 +282,7 @@ module ActiveRecord
 
       def each_current_configuration(environment)
         environments = [environment]
-        # add test environment only if no RAILS_ENV was specified.
-        environments << 'test' if environment == 'development' && ENV['RAILS_ENV'].nil?
+        environments << 'test' if environment == 'development'
 
         configurations = ActiveRecord::Base.configurations.values_at(*environments)
         configurations.compact.each do |configuration|

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -161,21 +161,25 @@ module ActiveRecord
         with('database' => 'dev-db')
       ActiveRecord::Tasks::DatabaseTasks.expects(:create).
         with('database' => 'test-db')
-      ENV.expects(:[]).with('RAILS_ENV').returns(nil)
 
       ActiveRecord::Tasks::DatabaseTasks.create_current(
         ActiveSupport::StringInquirer.new('development')
       )
     end
 
-    def test_creates_only_development_database_when_rails_env_is_development
+    def test_creates_test_and_development_databases_when_rails_env_is_development
+      old_env = ENV['RAILS_ENV']
+      ENV['RAILS_ENV'] = 'development'
       ActiveRecord::Tasks::DatabaseTasks.expects(:create).
         with('database' => 'dev-db')
-      ENV.expects(:[]).with('RAILS_ENV').returns('development')
+      ActiveRecord::Tasks::DatabaseTasks.expects(:create).
+        with('database' => 'test-db')
 
       ActiveRecord::Tasks::DatabaseTasks.create_current(
         ActiveSupport::StringInquirer.new('development')
       )
+    ensure
+      ENV['RAILS_ENV'] = old_env
     end
 
     def test_establishes_connection_for_the_given_environment
@@ -282,21 +286,25 @@ module ActiveRecord
         with('database' => 'dev-db')
       ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
         with('database' => 'test-db')
-      ENV.expects(:[]).with('RAILS_ENV').returns(nil)
 
       ActiveRecord::Tasks::DatabaseTasks.drop_current(
         ActiveSupport::StringInquirer.new('development')
       )
     end
 
-    def test_drops_only_development_database_when_rails_env_is_development
+    def test_drops_testand_development_databases_when_rails_env_is_development
+      old_env = ENV['RAILS_ENV']
+      ENV['RAILS_ENV'] = 'development'
       ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
         with('database' => 'dev-db')
-      ENV.expects(:[]).with('RAILS_ENV').returns('development')
+      ActiveRecord::Tasks::DatabaseTasks.expects(:drop).
+        with('database' => 'test-db')
 
       ActiveRecord::Tasks::DatabaseTasks.drop_current(
         ActiveSupport::StringInquirer.new('development')
       )
+    ensure
+      ENV['RAILS_ENV'] = old_env
     end
   end
 


### PR DESCRIPTION
This reverts a334425caff9b2140d5e99fcfc2eb8c4ab10bdfa.

The main reason is that now the workflow is inconsistent when using spring.

When using spring `RAILS_ENV` is always set, so only one database is created.

This means that in development `bin/rake db:create` and `bundle exec rake db:create` have different results.

It also breaks the `bin/setup` script since `bin/rake db:setup db:test:prepare` will fail.

@schneems could you check if this would be a problem in the heroku setup?

cc @jeremy 
