### PR TITLE
Improve ActiveSupport::Dependencies code understanding

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -734,6 +734,7 @@ module ActiveSupport #:nodoc:
         begin
           constantized = parent.const_get(to_remove, false)
         rescue NameError
+          # Skip when const is unreachable.
           return
         else
           constantized.before_remove_const if constantized.respond_to?(:before_remove_const)
@@ -743,6 +744,7 @@ module ActiveSupport #:nodoc:
       begin
         parent.instance_eval { remove_const to_remove }
       rescue NameError
+        # Skip when const is unreachable.
       end
     end
   end


### PR DESCRIPTION
### Summary

In pull request #24198, I removed all log-related stuff in `ActiveSupport::Dependencies` as this was no longer useful. However, some of the log messages were still useful to understand the code. Therefore, in this patch, those messages are put back as comments.
### Other Information

Please have a look at pull request #24198 as reference. 

Looking forward to hearing from you :smile:  
