### PR TITLE
Do not bind Arel attributes

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -14,6 +14,7 @@ module ActiveRecord
       register_handler(Relation, RelationHandler.new)
       register_handler(Array, ArrayHandler.new(self))
       register_handler(Set, ArrayHandler.new(self))
+      register_handler(Arel::Attributes::Attribute, ArelHandler.new)
     end
 
     def build_from_hash(attributes)
@@ -135,6 +136,7 @@ module ActiveRecord
   end
 end
 
+require "active_record/relation/predicate_builder/arel_handler"
 require "active_record/relation/predicate_builder/array_handler"
 require "active_record/relation/predicate_builder/base_handler"
 require "active_record/relation/predicate_builder/basic_object_handler"

--- a/activerecord/lib/active_record/relation/predicate_builder/arel_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/arel_handler.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class PredicateBuilder
+    class ArelHandler # :nodoc:
+      def call(attribute, value)
+        attribute.eq(value)
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1001,6 +1001,12 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_condition_arel_attribute
+    relation = Company.where(name: Company.arel_table[:name])
+    assert_sql(/\bname\b.*=.*\bname\b/) { relation.first }
+    assert_equal Company.count, relation.count
+  end
+
   def test_bind_variables
     assert_kind_of Firm, Company.where(["name = ?", "37signals"]).first
     assert_nil Company.where(["name = ?", "37signals!"]).first


### PR DESCRIPTION
This (slightly convoluted example) used to work but no longer does.

``` ruby
Company.where(:name => Company.arel_table[:name])
```

This is especially useful when eager loading associations with scopes containing additional where conditions.
