### PR TITLE
Allow grouping by Arel::Nodes::NamedFunction

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -338,7 +338,7 @@ module ActiveRecord
 
         select_values.concat group_columns.map { |aliaz, field|
           if field.respond_to?(:as)
-            field.as(aliaz)
+            field.dup.as(aliaz)
           else
             "#{field} AS #{aliaz}"
           end
@@ -379,7 +379,7 @@ module ActiveRecord
       #   column_alias_for("count(distinct users.id)") # => "count_distinct_users_id"
       #   column_alias_for("count(*)")                 # => "count_all"
       def column_alias_for(keys)
-        if keys.respond_to? :name
+        if keys.respond_to?(:relation) && keys.respond_to?(:name)
           keys = "#{keys.relation.name}.#{keys.name}"
         end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -680,6 +680,12 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal 1, count["aaron"]
   end
 
+  def test_group_weirds_by_named_function
+    Weird.create("a$b" => "value", :from => "aaron")
+    count = Weird.group(Arel::Nodes::NamedFunction.new("COALESCE", [Weird.arel_table[:from], Weird.arel_table["a$b"]])).count
+    assert_equal 1, count["aaron"]
+  end
+
   def test_attributes_on_dummy_time
     # Oracle does not have a TIME datatype.
     return true if current_adapter?(:OracleAdapter)


### PR DESCRIPTION
This only fails because `Arel::Nodes::NamedFunction` responds to `name` (but not `relation`) and calling `as` modifies the node, resulting in `GROUP BY … AS …`, which is invalid SQL.

This is primarily being done to benefit Squeel. It used to work as it previously passed a `Squeel::Node::Function` that doesn't exhibit the above behaviour but that had other problems.
