### PR TITLE
Improve accuracy of request message timestamps

### DIFF
--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -217,7 +217,7 @@ module ActionCable
             request.filtered_path,
             websocket.possible? ? ' [WebSocket]' : '[non-WebSocket]',
             request.ip,
-            Time.now.to_s ]
+            Time.now.strftime('%Y-%m-%d %H:%M:%S.%4N %z') ]
         end
 
         def finished_request_message
@@ -225,7 +225,7 @@ module ActionCable
             request.filtered_path,
             websocket.possible? ? ' [WebSocket]' : '[non-WebSocket]',
             request.ip,
-            Time.now.to_s ]
+            Time.now.strftime('%Y-%m-%d %H:%M:%S.%4N %z') ]
         end
 
         def invalid_request_message

--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -49,7 +49,7 @@ module Rails
           request.request_method,
           request.filtered_path,
           request.ip,
-          Time.now.to_default_s ]
+          Time.now.strftime('%Y-%m-%d %H:%M:%S.%4N %z') ]
       end
 
       def compute_tags(request)


### PR DESCRIPTION
### Summary

Add microseconds precision to the server logs.

It would help to keep the proper order of requests when performing centralized logging(multi-servers environment).
### Other Information

From:
`Started GET "/home" for 127.0.0.1 at 2016-03-15 12:13:14 +0000`

To:
`Started GET "/home" for 127.0.0.1 at 2016-03-15 12:13:14.1234 +0000`

To the best of my knowledge, this still respect ISO8601 (decimal fractions). That being said, it might imply a breaking change for some third party log parsers who do not respect it.

I feel these should be from a constant(or a config), but I would really like to collect some thoughts first.
