### PR TITLE
Document and Match the Rails logger interface

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -55,14 +55,6 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
-  end
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
@@ -86,6 +78,16 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+
+  # Use a different logger for distributed setups.
+  # require 'syslog/logger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
   <%- unless options.skip_active_record? -%>
 
   # Do not dump schema after migrations.


### PR DESCRIPTION
The logger interface to get all Rails features is not obvious. This change adds documentation on how to assign a logger that will use all Rails features.

We are also matching the stdout logging interface to the default logger in bootstrap https://github.com/rails/rails/blob/f5a5988352b165143f0f9d622707c351c1470882/railties/lib/rails/application/bootstrap.rb#L42-L45.
