### PR TITLE
create_join_table should work with uuid

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -329,12 +329,13 @@ module ActiveRecord
 
         column_options = options.delete(:column_options) || {}
         column_options.reverse_merge!(null: false)
+        type = column_options.delete(:type) || :integer
 
         t1_column, t2_column = [table_1, table_2].map{ |t| t.to_s.singularize.foreign_key }
 
         create_table(join_table_name, options.merge!(id: false)) do |td|
-          td.integer t1_column, column_options
-          td.integer t2_column, column_options
+          td.send type, t1_column, column_options
+          td.send type, t2_column, column_options
           yield td if block_given?
         end
       end

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -132,6 +132,13 @@ module ActiveRecord
         end
       end
 
+      if current_adapter?(:PostgreSQLAdapter)
+        def test_create_join_table_with_uuid
+          connection.create_join_table :artists, :musics, column_options: { type: :uuid }
+          assert_equal [:uuid, :uuid], connection.columns(:artists_musics).map(&:type)
+        end
+      end
+
       private
 
         def with_table_cleanup


### PR DESCRIPTION
`create_join_table` had integers hardcoded for the column type, but I think it should support other column types such as `uuid` too. 
