### PR TITLE
Adjust Puma default config to use a minimum of 1 thread, instead of 5

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb
@@ -1,8 +1,8 @@
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
-# the maximum value specified for Puma. Default is set to 5 threads for minimum
-# and maximum, this matches the default thread size of Active Record.
+# the maximum value specified for Puma. Active Record has a default
+# thread count of 5, so the Puma default maximum is set to match that.
 #
 min_threads = ENV.fetch("RAILS_MIN_THREADS") { 1 }.to_i
 max_threads = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i

--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb
@@ -4,8 +4,9 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
-threads threads_count, threads_count
+min_threads = ENV.fetch("RAILS_MIN_THREADS") { 1 }.to_i
+max_threads = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
+threads min_threads, max_threads
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.
 #


### PR DESCRIPTION
Re @schneems default Puma config introduced in 5563c329eee5febc22a3330e16fe8a6899d42fe2, this change would lower the default minimum thread count from `5` to `1` and also introduce a new `ENV` variable to make this easy to adjust without editing the config file. 

I found the config file a bit confusing and wondered why it was using the same value for the minimum and maximum thread count. It appears that Puma automatically scales the number of threads (https://github.com/puma/puma#thread-pool) and in the interest of keeping memory usage low on VPS servers etc, I thought it may be smart to default to a lower thread count so that people are more likely to be happy with the default config. 

I also tweaked the inline documentation to clarify what was going on. 

I'm new to Puma, so forgive me if I'm misunderstanding something. Thank you!
