### PR TITLE
Fix request.reset_session for API controllers

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -337,7 +337,6 @@ module ActionDispatch
       else
         self.session = {}
       end
-      self.flash = nil
     end
 
     def session=(session) #:nodoc:

--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -70,6 +70,11 @@ module ActionDispatch
           session.delete('flash')
         end
       end
+
+      def reset_session # :nodoc
+        super
+        self.flash = nil
+      end
     end
 
     class FlashNow #:nodoc:

--- a/railties/test/application/middleware/flash_test.rb
+++ b/railties/test/application/middleware/flash_test.rb
@@ -1,0 +1,46 @@
+require 'isolation/abstract_unit'
+require 'rack/test'
+
+module ApplicationTests
+  class FlashTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include Rack::Test::Methods
+
+    def setup
+      build_app
+      boot_rails
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    test 'calling reset_session on request does not trigger an error for API apps' do
+      add_to_config 'config.api_only = true'
+
+      controller :test, <<-RUBY
+        class TestController < ApplicationController
+          def dump_flash
+            request.reset_session
+            render plain: 'It worked!'
+          end
+        end
+      RUBY
+
+      app_file 'config/routes.rb', <<-RUBY
+        Rails.application.routes.draw do
+          get '/dump_flash' => "test#dump_flash"
+        end
+      RUBY
+
+      app 'development'
+
+      get '/dump_flash'
+
+      assert_equal 200, last_response.status
+      assert_equal 'It worked!', last_response.body
+
+      refute Rails.application.middleware.include?(ActionDispatch::Flash)
+    end
+  end
+end


### PR DESCRIPTION
Due to that `ActionDispatch::Flash` (the flash API's middleware) is not
included for API controllers, the `request.reset_session` method, which
relies on there being a `flash=` method which is in fact defined by the
middleware, was previously breaking. Similarly to how
add46482a540b33184f3011c5c307f4b8e90c9cc created a method to be
overriden by the flash middleware in order to ensure non-breakage, this
is how flashes are now reset.

Fixes #24222
