### PR TITLE
Cable message encoding

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,11 +1,16 @@
-*  Add ActiveSupport::Notifications to ActionCable::Channel.
+*   Pubsub: automatic stream decoding.
 
-   *Matthew Wear*
+        stream_for @room, coder: ActiveSupport::JSON do |message|
+          # `message` is a Ruby hash here instead of a JSON string
 
-*   Allow channel identifiers with no backslahes/escaping to be accepted
-    by the subscription storer.
+    The `coder` must respond to `#decode`. Defaults to `coder: nil`
+    which skips decoding entirely.
 
-    *Jon Moss*
+    *Jeremy Daer*
+
+*   Add ActiveSupport::Notifications to ActionCable::Channel.
+
+    *Matthew Wear*
 
 *   Safely support autoloading and class unloading, by preventing concurrent
     loads, and disconnecting all cables during reload.

--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -198,7 +198,7 @@ module ActionCable
 
           payload = { channel_class: self.class.name, data: data, via: via }
           ActiveSupport::Notifications.instrument("transmit.action_cable", payload) do
-            connection.transmit ActiveSupport::JSON.encode(identifier: @identifier, message: data)
+            connection.transmit identifier: @identifier, message: data
           end
         end
 
@@ -274,7 +274,7 @@ module ActionCable
             logger.info "#{self.class.name} is transmitting the subscription confirmation"
 
             ActiveSupport::Notifications.instrument("transmit_subscription_confirmation.action_cable", channel_class: self.class.name) do
-              connection.transmit ActiveSupport::JSON.encode(identifier: @identifier, type: ActionCable::INTERNAL[:message_types][:confirmation])
+              connection.transmit identifier: @identifier, type: ActionCable::INTERNAL[:message_types][:confirmation]
               @subscription_confirmation_sent = true
             end
           end
@@ -289,7 +289,7 @@ module ActionCable
           logger.info "#{self.class.name} is transmitting the subscription rejection"
 
           ActiveSupport::Notifications.instrument("transmit_subscription_rejection.action_cable", channel_class: self.class.name) do
-            connection.transmit ActiveSupport::JSON.encode(identifier: @identifier, type: ActionCable::INTERNAL[:message_types][:rejection])
+            connection.transmit identifier: @identifier, type: ActionCable::INTERNAL[:message_types][:rejection]
           end
         end
     end

--- a/actioncable/lib/action_cable/connection/internal_channel.rb
+++ b/actioncable/lib/action_cable/connection/internal_channel.rb
@@ -11,7 +11,7 @@ module ActionCable
 
         def subscribe_to_internal_channel
           if connection_identifier.present?
-            callback = -> (message) { process_internal_message(message) }
+            callback = -> (message) { process_internal_message decode(message) }
             @_internal_subscriptions ||= []
             @_internal_subscriptions << [ internal_channel, callback ]
 
@@ -27,8 +27,6 @@ module ActionCable
         end
 
         def process_internal_message(message)
-          message = ActiveSupport::JSON.decode(message)
-
           case message['type']
           when 'disconnect'
             logger.info "Removing connection (#{connection_identifier})"

--- a/actioncable/lib/action_cable/connection/message_buffer.rb
+++ b/actioncable/lib/action_cable/connection/message_buffer.rb
@@ -30,7 +30,7 @@ module ActionCable
 
       protected
         attr_reader :connection
-        attr_accessor :buffered_messages
+        attr_reader :buffered_messages
 
       private
         def valid?(message)
@@ -38,7 +38,7 @@ module ActionCable
         end
 
         def receive(message)
-          connection.send_async :receive, message
+          connection.receive message
         end
 
         def buffer(message)

--- a/actioncable/lib/action_cable/server/broadcasting.rb
+++ b/actioncable/lib/action_cable/server/broadcasting.rb
@@ -19,27 +19,28 @@ module ActionCable
     #       new Notification data['title'], body: data['body']
     module Broadcasting
       # Broadcast a hash directly to a named <tt>broadcasting</tt>. This will later be JSON encoded.
-      def broadcast(broadcasting, message)
-        broadcaster_for(broadcasting).broadcast(message)
+      def broadcast(broadcasting, message, coder: ActiveSupport::JSON)
+        broadcaster_for(broadcasting, coder: coder).broadcast(message)
       end
 
       # Returns a broadcaster for a named <tt>broadcasting</tt> that can be reused. Useful when you have an object that
       # may need multiple spots to transmit to a specific broadcasting over and over.
-      def broadcaster_for(broadcasting)
-        Broadcaster.new(self, String(broadcasting))
+      def broadcaster_for(broadcasting, coder: ActiveSupport::JSON)
+        Broadcaster.new(self, String(broadcasting), coder: coder)
       end
 
       private
         class Broadcaster
-          attr_reader :server, :broadcasting
+          attr_reader :server, :broadcasting, :coder
 
-          def initialize(server, broadcasting)
-            @server, @broadcasting = server, broadcasting
+          def initialize(server, broadcasting, coder:)
+            @server, @broadcasting, @coder = server, broadcasting, coder
           end
 
           def broadcast(message)
-            server.logger.info "[ActionCable] Broadcasting to #{broadcasting}: #{message}"
-            server.pubsub.broadcast broadcasting, ActiveSupport::JSON.encode(message)
+            server.logger.info "[ActionCable] Broadcasting to #{broadcasting}: #{message.inspect}"
+            encoded = coder ? coder.encode(message) : message
+            server.pubsub.broadcast broadcasting, encoded
           end
         end
     end

--- a/actioncable/test/channel/base_test.rb
+++ b/actioncable/test/channel/base_test.rb
@@ -146,12 +146,12 @@ class ActionCable::Channel::BaseTest < ActiveSupport::TestCase
   test "transmitting data" do
     @channel.perform_action 'action' => :get_latest
 
-    expected = ActiveSupport::JSON.encode "identifier" => "{id: 1}", "message" => { "data" => "latest" }
+    expected = { "identifier" => "{id: 1}", "message" => { "data" => "latest" }}
     assert_equal expected, @connection.last_transmission
   end
 
   test "subscription confirmation" do
-    expected = ActiveSupport::JSON.encode "identifier" => "{id: 1}", "type" => "confirm_subscription"
+    expected = { "identifier" => "{id: 1}", "type" => "confirm_subscription" }
     assert_equal expected, @connection.last_transmission
   end
 

--- a/actioncable/test/channel/rejection_test.rb
+++ b/actioncable/test/channel/rejection_test.rb
@@ -18,7 +18,7 @@ class ActionCable::Channel::RejectionTest < ActiveSupport::TestCase
     @connection.expects(:subscriptions).returns mock().tap { |m| m.expects(:remove_subscription).with instance_of(SecretChannel) }
     @channel = SecretChannel.new @connection, "{id: 1}", { id: 1 }
 
-    expected = ActiveSupport::JSON.encode "identifier" => "{id: 1}", "type" => "reject_subscription"
+    expected = { "identifier" => "{id: 1}", "type" => "reject_subscription" }
     assert_equal expected, @connection.last_transmission
   end
 

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -2,18 +2,43 @@ require 'test_helper'
 require 'stubs/test_connection'
 require 'stubs/room'
 
-class ActionCable::Channel::StreamTest < ActionCable::TestCase
+module ActionCable::StreamTests
+  class Connection < ActionCable::Connection::Base
+    attr_reader :websocket
+
+    def send_async(method, *args)
+      send method, *args
+    end
+  end
+
   class ChatChannel < ActionCable::Channel::Base
     def subscribed
       if params[:id]
         @room = Room.new params[:id]
-        stream_from "test_room_#{@room.id}"
+        stream_from "test_room_#{@room.id}", coder: pick_coder(params[:coder])
       end
     end
 
     def send_confirmation
       transmit_subscription_confirmation
     end
+
+    private def pick_coder(coder)
+      case coder
+      when nil, 'json'
+        ActiveSupport::JSON
+      when 'custom'
+        DummyEncoder
+      when 'none'
+        nil
+      end
+    end
+  end
+
+  module DummyEncoder
+    extend self
+    def encode(*) '{ "foo": "encoded" }' end
+    def decode(*) { foo: 'decoded' } end
   end
 
   class SymbolChannel < ActionCable::Channel::Base
@@ -22,69 +47,114 @@ class ActionCable::Channel::StreamTest < ActionCable::TestCase
     end
   end
 
-  test "streaming start and stop" do
-    run_in_eventmachine do
-      connection = TestConnection.new
-      connection.expects(:pubsub).returns mock().tap { |m| m.expects(:subscribe).with("test_room_1", kind_of(Proc), kind_of(Proc)).returns stub_everything(:pubsub) }
-      channel = ChatChannel.new connection, "{id: 1}", { id: 1 }
+  class StreamTest < ActionCable::TestCase
+    test "streaming start and stop" do
+      run_in_eventmachine do
+        connection = TestConnection.new
+        connection.expects(:pubsub).returns mock().tap { |m| m.expects(:subscribe).with("test_room_1", kind_of(Proc), kind_of(Proc)).returns stub_everything(:pubsub) }
+        channel = ChatChannel.new connection, "{id: 1}", { id: 1 }
 
-      connection.expects(:pubsub).returns mock().tap { |m| m.expects(:unsubscribe) }
-      channel.unsubscribe_from_channel
+        connection.expects(:pubsub).returns mock().tap { |m| m.expects(:unsubscribe) }
+        channel.unsubscribe_from_channel
+      end
+    end
+
+    test "stream from non-string channel" do
+      run_in_eventmachine do
+        connection = TestConnection.new
+        connection.expects(:pubsub).returns mock().tap { |m| m.expects(:subscribe).with("channel", kind_of(Proc), kind_of(Proc)).returns stub_everything(:pubsub) }
+        channel = SymbolChannel.new connection, ""
+
+        connection.expects(:pubsub).returns mock().tap { |m| m.expects(:unsubscribe) }
+        channel.unsubscribe_from_channel
+      end
+    end
+
+    test "stream_for" do
+      run_in_eventmachine do
+        connection = TestConnection.new
+        connection.expects(:pubsub).returns mock().tap { |m| m.expects(:subscribe).with("action_cable:stream_tests:chat:Room#1-Campfire", kind_of(Proc), kind_of(Proc)).returns stub_everything(:pubsub) }
+
+        channel = ChatChannel.new connection, ""
+        channel.stream_for Room.new(1)
+      end
+    end
+
+    test "stream_from subscription confirmation" do
+      run_in_eventmachine do
+        connection = TestConnection.new
+
+        ChatChannel.new connection, "{id: 1}", { id: 1 }
+        assert_nil connection.last_transmission
+
+        wait_for_async
+
+        confirmation = { "identifier" => "{id: 1}", "type" => "confirm_subscription" }
+        connection.transmit(confirmation)
+
+        assert_equal confirmation, connection.last_transmission, "Did not receive subscription confirmation within 0.1s"
+      end
+    end
+
+    test "subscription confirmation should only be sent out once" do
+      run_in_eventmachine do
+        connection = TestConnection.new
+
+        channel = ChatChannel.new connection, "test_channel"
+        channel.send_confirmation
+        channel.send_confirmation
+
+        wait_for_async
+
+        expected = { "identifier" => "test_channel", "type" => "confirm_subscription" }
+        assert_equal expected, connection.last_transmission, "Did not receive subscription confirmation"
+
+        assert_equal 1, connection.transmissions.size
+      end
     end
   end
 
-  test "stream from non-string channel" do
-    run_in_eventmachine do
-      connection = TestConnection.new
-      connection.expects(:pubsub).returns mock().tap { |m| m.expects(:subscribe).with("channel", kind_of(Proc), kind_of(Proc)).returns stub_everything(:pubsub) }
-      channel = SymbolChannel.new connection, ""
+  require 'action_cable/subscription_adapter/inline'
 
-      connection.expects(:pubsub).returns mock().tap { |m| m.expects(:unsubscribe) }
-      channel.unsubscribe_from_channel
+  class StreamEncodingTest < ActionCable::TestCase
+    setup do
+      @server = TestServer.new(subscription_adapter: ActionCable::SubscriptionAdapter::Inline)
+      @server.config.allowed_request_origins = %w( http://rubyonrails.com )
+      @server.stubs(:channel_classes).returns(ChatChannel.name => ChatChannel)
     end
-  end
 
-  test "stream_for" do
-    run_in_eventmachine do
-      connection = TestConnection.new
-      connection.expects(:pubsub).returns mock().tap { |m| m.expects(:subscribe).with("action_cable:channel:stream_test:chat:Room#1-Campfire", kind_of(Proc), kind_of(Proc)).returns stub_everything(:pubsub) }
+    test 'custom encoder' do
+      run_in_eventmachine do
+        connection = open_connection
+        subscribe_to connection, identifiers: { id: 1 }
 
-      channel = ChatChannel.new connection, ""
-      channel.stream_for Room.new(1)
+        connection.websocket.expects(:transmit)
+        @server.broadcast 'test_room_1', { foo: 'bar' }, coder: DummyEncoder
+        wait_for_async
+      end
     end
+
+    private
+      def subscribe_to(connection, identifiers:)
+        receive connection, command: 'subscribe', identifiers: identifiers
+      end
+
+      def open_connection
+        env = Rack::MockRequest.env_for '/test', 'HTTP_HOST' => 'localhost', 'HTTP_CONNECTION' => 'upgrade', 'HTTP_UPGRADE' => 'websocket', 'HTTP_ORIGIN' => 'http://rubyonrails.com'
+
+        Connection.new(@server, env).tap do |connection|
+          connection.process
+          assert connection.websocket.possible?
+
+          wait_for_async
+          assert connection.websocket.alive?
+        end
+      end
+
+      def receive(connection, command:, identifiers:)
+        identifier = JSON.generate(channel: 'ActionCable::StreamTests::ChatChannel', **identifiers)
+        connection.dispatch_websocket_message JSON.generate(command: command, identifier: identifier)
+        wait_for_async
+      end
   end
-
-  test "stream_from subscription confirmation" do
-    run_in_eventmachine do
-      connection = TestConnection.new
-
-      ChatChannel.new connection, "{id: 1}", { id: 1 }
-      assert_nil connection.last_transmission
-
-      wait_for_async
-
-      expected = ActiveSupport::JSON.encode "identifier" => "{id: 1}", "type" => "confirm_subscription"
-      connection.transmit(expected)
-
-      assert_equal expected, connection.last_transmission, "Did not receive subscription confirmation within 0.1s"
-    end
-  end
-
-  test "subscription confirmation should only be sent out once" do
-    run_in_eventmachine do
-      connection = TestConnection.new
-
-      channel = ChatChannel.new connection, "test_channel"
-      channel.send_confirmation
-      channel.send_confirmation
-
-      wait_for_async
-
-      expected = ActiveSupport::JSON.encode "identifier" => "test_channel", "type" => "confirm_subscription"
-      assert_equal expected, connection.last_transmission, "Did not receive subscription confirmation"
-
-      assert_equal 1, connection.transmissions.size
-    end
-  end
-
 end

--- a/actioncable/test/connection/identifier_test.rb
+++ b/actioncable/test/connection/identifier_test.rb
@@ -40,8 +40,7 @@ class ActionCable::Connection::IdentifierTest < ActionCable::TestCase
       open_connection_with_stubbed_pubsub
 
       @connection.websocket.expects(:close)
-      message = ActiveSupport::JSON.encode('type' => 'disconnect')
-      @connection.process_internal_message message
+      @connection.process_internal_message 'type' => 'disconnect'
     end
   end
 
@@ -50,8 +49,7 @@ class ActionCable::Connection::IdentifierTest < ActionCable::TestCase
       open_connection_with_stubbed_pubsub
 
       @connection.websocket.expects(:close).never
-      message = ActiveSupport::JSON.encode('type' => 'unknown')
-      @connection.process_internal_message message
+      @connection.process_internal_message 'type' => 'unknown'
     end
   end
 

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -88,7 +88,7 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
 
       channel1 = subscribe_to_chat_channel
 
-      channel2_id = ActiveSupport::JSON.encode({ id: 2, channel: 'ActionCable::Connection::SubscriptionsTest::ChatChannel' })
+      channel2_id = ActiveSupport::JSON.encode(id: 2, channel: 'ActionCable::Connection::SubscriptionsTest::ChatChannel')
       channel2 = subscribe_to_chat_channel(channel2_id)
 
       channel1.expects(:unsubscribe_from_channel)

--- a/actioncable/test/stubs/test_connection.rb
+++ b/actioncable/test/stubs/test_connection.rb
@@ -3,24 +3,31 @@ require 'stubs/user'
 class TestConnection
   attr_reader :identifiers, :logger, :current_user, :server, :transmissions
 
-  def initialize(user = User.new("lifo"))
+  delegate :pubsub, to: :server
+
+  def initialize(user = User.new("lifo"), coder: ActiveSupport::JSON, subscription_adapter: SuccessAdapter)
+    @coder = coder
     @identifiers = [ :current_user ]
 
     @current_user = user
     @logger = ActiveSupport::TaggedLogging.new ActiveSupport::Logger.new(StringIO.new)
-    @server = TestServer.new
+    @server = TestServer.new(subscription_adapter: subscription_adapter)
     @transmissions = []
   end
 
-  def pubsub
-    SuccessAdapter.new(server)
-  end
-
-  def transmit(data)
-    @transmissions << data
+  def transmit(cable_message)
+    @transmissions << encode(cable_message)
   end
 
   def last_transmission
-    @transmissions.last
+    decode @transmissions.last if @transmissions.any?
+  end
+
+  def decode(websocket_message)
+    @coder.decode websocket_message
+  end
+
+  def encode(cable_message)
+    @coder.encode cable_message
   end
 end

--- a/actioncable/test/stubs/test_server.rb
+++ b/actioncable/test/stubs/test_server.rb
@@ -2,22 +2,26 @@ require 'ostruct'
 
 class TestServer
   include ActionCable::Server::Connections
+  include ActionCable::Server::Broadcasting
 
-  attr_reader :logger, :config
+  attr_reader :logger, :config, :mutex
 
-  def initialize
+  def initialize(subscription_adapter: SuccessAdapter)
     @logger = ActiveSupport::TaggedLogging.new ActiveSupport::Logger.new(StringIO.new)
-    @config = OpenStruct.new(log_tags: [], subscription_adapter: SuccessAdapter)
+
+    @config = OpenStruct.new(log_tags: [], subscription_adapter: subscription_adapter)
     @config.use_faye = ENV['FAYE'].present?
     @config.client_socket_class = if @config.use_faye
                                     ActionCable::Connection::FayeClientSocket
                                   else
                                     ActionCable::Connection::ClientSocket
                                   end
+
+     @mutex = Monitor.new
   end
 
   def pubsub
-    @config.subscription_adapter.new(self)
+    @pubsub ||= @config.subscription_adapter.new(self)
   end
 
   def event_loop

--- a/actioncable/test/subscription_adapter/common.rb
+++ b/actioncable/test/subscription_adapter/common.rb
@@ -20,8 +20,7 @@ module CommonSubscriptionAdapterTest
   end
 
   def teardown
-    @tx_adapter.shutdown if @tx_adapter && @tx_adapter != @rx_adapter
-    @rx_adapter.shutdown if @rx_adapter
+    [@rx_adapter, @tx_adapter].uniq.each(&:shutdown)
   end
 
 

--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -2,11 +2,13 @@ require 'action_cable'
 require 'active_support/testing/autorun'
 
 require 'puma'
-
 require 'mocha/setup'
-
 require 'rack/mock'
-require 'active_support/core_ext/hash/indifferent_access'
+
+begin
+  require 'byebug'
+rescue LoadError
+end
 
 # Require all the stubs and models
 Dir[File.dirname(__FILE__) + '/stubs/*.rb'].each {|file| require file }


### PR DESCRIPTION
- Introduce a connection coder responsible for encoding Cable messages
  as WebSocket messages, defaulting to `ActiveSupport::JSON` and duck-typing to any object responding to `#encode` and `#decode`.
- Consolidate encoding responsibility to the connection. No longer
  explicitly JSON-encode from channels or other sources. Pass Cable
  messages as Hashes to `#transmit` and rely on it to encode.
- Introduce stream encoders responsible for decoding pubsub messages.
  Preserve the currently raw encoding, but make it easy to use JSON.
  Same duck type as the connection encoder.
- Revert recent data normalization/quoting (#23649) which treated
  `identifier` and `data` values as nested JSON objects rather than as
  opaque JSON-encoded strings. That dealt us an awkward hand where we'd
  decode JSON strings… or not, but always encode as JSON. Embedding
  JSON object values directly is preferably, no extra JSON encoding,
  but that should be a purposeful protocol version change rather than
  ambiguously, inadvertently supporting multiple message formats.
