### PR TITLE
Add missing module for ActionController::API

### DIFF
--- a/actionpack/lib/action_controller/api.rb
+++ b/actionpack/lib/action_controller/api.rb
@@ -110,6 +110,7 @@ module ActionController
     MODULES = [
       AbstractController::Rendering,
 
+      Helpers,
       UrlFor,
       Redirecting,
       ApiRendering,


### PR DESCRIPTION
### Summary

When using rails 5 in api mode you can't include **ActionController::Cookies** into your application controller, this PR fixes it by adding missing module into **ActionController::API**

It should fix #24239 
