### PR TITLE
Comment out config.file_watcher during Rails upgrade process

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -95,8 +95,13 @@ module Rails
       action_cable_config_exist = File.exist?('config/cable.yml')
       ssl_options_exist = File.exist?('config/initializers/ssl_options.rb')
       rack_cors_config_exist = File.exist?('config/initializers/cors.rb')
+      development_config_exist = File.exist?('config/environments/development.rb')
 
       config
+
+      if development_config_exist
+        gsub_file 'config/environments/development.rb', /^(\s+)config\.file_watcher/, '\1# config.file_watcher'
+      end
 
       unless callback_terminator_config_exist
         remove_file 'config/initializers/callback_terminator.rb'


### PR DESCRIPTION
This PR is a follow up to the feedback received in #24066 trying to fix the issue raised in #24063. 

Rails 5 introduces a new `ActiveSupport::EventedFileUpdateChecker` class which is conditionally injected into existing Rails application configuration files from the `bin/rails app:update` task. During this upgrade process Rails checks to see if the `listen` library is required. If `listen` is required `ActiveSupport::EventedFileUpdateChecker` is added to the bottom of `config/environments/development.rb` as:

``` ruby
config.file_watcher = ActiveSupport::EventedFileUpdateChecker
```

Per @rafaelfranca's [comments](https://github.com/rails/rails/pull/24066#issuecomment-192503172), the upgrade task should not require the installation of any new gems. Modifying the app generator to comment out the `config.file_watcher` line by default resolves the issue.

I've stored the full terminal output verifying the behavior [here in a gist](https://gist.github.com/dewski/2d63cca145bfa28a7305).

/cc @arthurnn @sadinie @maclover7 @rafaelfranca @fxn
