### PR TITLE
Allow generating channel.js (instead of channel.coffee)

### DIFF
--- a/actioncable/lib/rails/generators/channel/channel_generator.rb
+++ b/actioncable/lib/rails/generators/channel/channel_generator.rb
@@ -6,6 +6,7 @@ module Rails
       argument :actions, type: :array, default: [], banner: "method method"
 
       class_option :assets, type: :boolean
+      class_option :javascript, type: :boolean
 
       check_class_collision suffix: "Channel"
 
@@ -13,13 +14,29 @@ module Rails
         template "channel.rb", File.join('app/channels', class_path, "#{file_name}_channel.rb")
 
         if options[:assets]
-          template "assets/channel.coffee", File.join('app/assets/javascripts/channels', class_path, "#{file_name}.coffee")
+          if options[:javascript]
+            template("assets/channel.coffee", file_path("js")) do |content|
+              require "coffee-script"
+              CoffeeScript.compile(content)
+            end
+          else
+            template("assets/channel.coffee", file_path("coffee"))
+          end
         end
 
         generate_application_cable_files
       end
 
       protected
+
+        def file_path(extension)
+          File.join(
+            'app/assets/javascripts/channels',
+            class_path,
+            "#{file_name}.#{extension}"
+          )
+        end
+
         def file_name
           @_file_name ||= super.gsub(/_channel/i, '')
         end

--- a/railties/test/generators/channel_generator_test.rb
+++ b/railties/test/generators/channel_generator_test.rb
@@ -38,4 +38,18 @@ class ChannelGeneratorTest < Rails::Generators::TestCase
 
     assert_no_file "app/assets/javascripts/channels/chat.coffee"
   end
+
+  def test_channel_is_created_with_javascript_instead_of_coffee
+    run_generator ['chat', '--javascript']
+
+    assert_file "app/channels/chat_channel.rb" do |channel|
+      assert_match(/class ChatChannel < ApplicationCable::Channel/, channel)
+    end
+
+    assert_no_file "app/assets/javascripts/channels/chat.coffee"
+
+    assert_file "app/assets/javascripts/channels/chat.js" do |channel|
+      assert_match(/App.chat = App.cable.subscriptions.create\("ChatChannel", /, channel)
+    end
+  end
 end


### PR DESCRIPTION
I'd like to use ActionCable but don't want to write CoffeeScript. 

I understand ActionCable itself is written in CoffeeScript, so `coffee-rails` is still needed.

This PR generates the CoffeeScript, then converts it to JavaScript, using the `coffee-script` gem (a dependency of `coffee-rails`). This avoids the need to maintain two templates, and since `coffee-rails` is needed anyway, we might as well leverage.

A few things might need to be done:
1. Add a note if the `require "coffee-script"` fails, to help the user.
2. Honor `config.generators`'s `javascript_engine :js`option.
3. Update documentation.

Here's what the generated JS looks like, after running `rails generate channel chat --javascript`.

```
(function() {
  App.chat = App.cable.subscriptions.create("ChatChannel", {
    connected: function() {},
    disconnected: function() {},
    received: function(data) {}
  });

}).call(this);
```

Happy to do the rest of that work, just want to make sure it's something y'all are interested in before continuing.
