### PR TITLE
enhance ActiveRecord#substitute_values to loop values just once

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -94,12 +94,12 @@ module ActiveRecord
     end
 
     def substitute_values(values) # :nodoc:
-      binds = values.map do |arel_attr, value|
-        QueryAttribute.new(arel_attr.name, value, klass.type_for_attribute(arel_attr.name))
-      end
+      binds = []
+      substitutes = []
 
-      substitutes = values.map do |(arel_attr, _)|
-        [arel_attr, Arel::Nodes::BindParam.new]
+      values.each do |arel_attr, value|
+        binds.push QueryAttribute.new(arel_attr.name, value, klass.type_for_attribute(arel_attr.name))
+        substitutes.push [arel_attr, Arel::Nodes::BindParam.new]
       end
 
       [substitutes, binds]


### PR DESCRIPTION
### Summary

`ActiveRecord#substitute_values` loops values twice with two "map".
In fact, we only need to loop it once and it can enhance the performance a little bit.

Below shows the performance change with 50000 calls to this function. Line 2 in each benchmark testing is with the code change.

```
irb(main):001:0> load './a.rb'
Rehearsal --------------------------------------------
existing   0.260000   0.000000   0.260000 (  0.266588)
enhanced   0.210000   0.010000   0.220000 (  0.214615)
----------------------------------- total: 0.480000sec

               user     system      total        real
existing   0.250000   0.000000   0.250000 (  0.253279)
enhanced   0.210000   0.000000   0.210000 (  0.209324)
=> true
irb(main):002:0> load './a.rb'
Rehearsal --------------------------------------------
existing   0.270000   0.010000   0.280000 (  0.284093)
enhanced   0.200000   0.000000   0.200000 (  0.208968)
----------------------------------- total: 0.480000sec

               user     system      total        real
existing   0.260000   0.000000   0.260000 (  0.264996)
enhanced   0.200000   0.000000   0.200000 (  0.212814)
=> true
irb(main):003:0> load './a.rb'
Rehearsal --------------------------------------------
existing   0.270000   0.010000   0.280000 (  0.279593)
enhanced   0.210000   0.000000   0.210000 (  0.221941)
----------------------------------- total: 0.490000sec

               user     system      total        real
existing   0.260000   0.000000   0.260000 (  0.267670)
enhanced   0.210000   0.000000   0.210000 (  0.215447)
=> true

```
