### PR TITLE
Add config/initializers/time_zone_aware_types.rb

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `config/initializers/time_zone_aware_types.rb`.
+
+    Newly generated Rails apps have a new initializer called
+    `time_zone_aware_types.rb` which adds `:time` to  the values included in
+    `ActiveRecord::Base.time_zone_aware_types`.
+
+    As a result, in new Rails apps, any `Time` column is stored by ActiveRecord
+    as "time zone aware", meaning that the time zone will also be stored.
+
+    The terminator is *not* added when running `rake rails:update`, so old apps
+    ported to Rails 5 will not store `Time` columns as time zone aware and will
+    displaying a deprecation warning to prompt users to update their code.
+
+    *claudiob*
+
 *   The application generator writes a new file `config/spring.rb`, which tells
     Spring to watch additional common files.
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -96,6 +96,7 @@ module Rails
       ssl_options_exist = File.exist?('config/initializers/ssl_options.rb')
       rack_cors_config_exist = File.exist?('config/initializers/cors.rb')
       development_config_exist = File.exist?('config/environments/development.rb')
+      time_zone_aware_types_config_exist = File.exist?('config/initializers/time_zone_aware_types.rb')
 
       config
 
@@ -125,6 +126,10 @@ module Rails
 
       unless rack_cors_config_exist
         remove_file 'config/initializers/cors.rb'
+      end
+
+      unless time_zone_aware_types_config_exist
+        remove_file 'config/initializers/time_zone_aware_types.rb'
       end
     end
 
@@ -332,6 +337,7 @@ module Rails
       def delete_active_record_initializers_skipping_active_record
         if options[:skip_active_record]
           remove_file 'config/initializers/active_record_belongs_to_required_by_default.rb'
+          remove_file 'config/initializers/time_zone_aware_types.rb'
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/time_zone_aware_types.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/time_zone_aware_types.rb
@@ -1,0 +1,8 @@
+# Be sure to restart your server when you modify this file.
+
+# Store `Time` columns as time zone aware: if `config.time_zone` is set to a
+# value other than `'UTC'`, `Time` columns will be treated as in that time zone.
+# This is a new Rails 5.0 default, so it is introduced as a configuration option
+# to ensure that apps made with earlier versions of Rails are not affected when
+# upgrading.
+Rails.application.config.active_record.time_zone_aware_types = [:datetime, :time]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -200,6 +200,34 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_rails_update_does_not_create_time_zone_aware_initializer
+    app_root = File.join(destination_root, 'myapp')
+    run_generator [app_root]
+
+    FileUtils.rm("#{app_root}/config/initializers/time_zone_aware_types.rb")
+
+    stub_rails_application(app_root) do
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
+      generator.send(:app_const)
+      quietly { generator.send(:update_config_files) }
+      assert_no_file "#{app_root}/config/initializers/time_zone_aware_types.rb"
+    end
+  end
+
+  def test_rails_update_does_not_remove_time_zone_aware_initializer_if_already_present
+    app_root = File.join(destination_root, 'myapp')
+    run_generator [app_root]
+
+    FileUtils.touch("#{app_root}/config/initializers/time_zone_aware_types.rb")
+
+    stub_rails_application(app_root) do
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
+      generator.send(:app_const)
+      quietly { generator.send(:update_config_files) }
+      assert_file "#{app_root}/config/initializers/time_zone_aware_types.rb"
+    end
+  end
+
   def test_rails_update_set_the_cookie_serializer_to_marshal_if_it_is_not_already_configured
     app_root = File.join(destination_root, 'myapp')
     run_generator [app_root]


### PR DESCRIPTION
This PR integrates #15726, under which `Time` columns should support time
zone aware attributes.

In order for this to be the **default behavior** on brand new Rails 5.0 apps,
an initializer is required. Without it, even brand new Rails 5.0 apps would be
showing the following deprecation warning, which should be reserved to apps
_ported_ to Rails 5.0 from an older version:

```
Time columns will become time zone aware in Rails 5.1. This
still causes `String`s to be parsed as if they were in `Time.zone`,
and `Time`s to be converted to `Time.zone`.
To keep the old behavior, you must add the following to your initializer:
    config.active_record.time_zone_aware_types = [:datetime]
To silence this deprecation warning, add the following:
    config.active_record.time_zone_aware_types << :time
```

@sgrif Is the above correct?
