### PR TITLE
changed default value of `caching` option to `nil`

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -93,7 +93,7 @@ module Rails
         DoNotReverseLookup: true,
         environment:        (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || "development").dup,
         daemonize:          false,
-        caching:            false,
+        caching:            nil,
         pid:                Options::DEFAULT_PID_PATH
       })
     end

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -54,7 +54,8 @@ class Rails::ServerTest < ActiveSupport::TestCase
   def test_caching_without_option
     args = []
     options = Rails::Server::Options.new.parse!(args)
-    assert_equal nil, options[:caching]
+    merged_options = Rails::Server.new.default_options.merge(options)
+    assert_equal nil, merged_options[:caching]
   end
 
   def test_caching_with_option


### PR DESCRIPTION
The default is that's false, caching even if you do not specify the caching option is determined not to use,
and `tmp/caching-dev.txt` will be deleted.
If it is this, regardless of whether or not there is `tmp/caching-dev.txt`, be sure to order would be necessary to specify the caching option,
I think that in than good to so as not to do anything by default.
