### PR TITLE
[FEATURE] Add Time#use_offset to wrap around the time zone offsets

### DIFF
--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -45,6 +45,30 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_raise(ArgumentError) { @twz.in_time_zone(Object.new) }
   end
 
+  def test_use_offset
+    Time.use_offset(-32400) do
+      assert_equal ActiveSupport::TimeWithZone.new(@utc, ActiveSupport::TimeZone['Alaska']), @twz.in_time_zone
+    end
+
+    Time.use_offset(0) do
+      assert_equal ActiveSupport::TimeWithZone.new(@utc, ActiveSupport::TimeZone['Casablanca']), @twz.in_time_zone
+    end
+
+    Time.use_zone(19800) do
+      assert_equal ActiveSupport::TimeWithZone.new(@utc, ActiveSupport::TimeZone['Kolkata']), @twz.in_time_zone
+    end
+  end
+
+  def test_use_offset_with_bad_argument
+    msg = assert_raise(ArgumentError) { Time.use_offset(nil) }
+    assert_equal 'Invalid Offset.', msg.to_s
+  end
+
+  def test_use_offset_with_no_mapping
+    msg = assert_raise(ArgumentError) { Time.use_offset(1234) }
+    assert_equal 'Invalid Offset: 1234', msg.to_s
+  end
+
   def test_localtime
     assert_equal @twz.localtime, @twz.utc.getlocal
   end


### PR DESCRIPTION
We have been with the time zones a lot in our codebase, plus we have to deal a number of places which are sending in the data from the same timezones, but we have to deal with the cases where the timezone offset have been provided instead of the plain old timezone string. 

This PR is a small attempt to solve this problem. I am open to suggestions and criticism...:)
