### PR TITLE
Possible local_levels still nil when initilize.

### DIFF
--- a/activesupport/lib/active_support/logger_silence.rb
+++ b/activesupport/lib/active_support/logger_silence.rb
@@ -20,7 +20,7 @@ module LoggerSilence
   end
 
   def level
-    local_levels[local_log_id] || super
+    local_levels && local_levels[local_log_id] || super
   end
 
   # Silences the logger for the duration of the block.


### PR DESCRIPTION
Seems after_initialize not running, very strange, but anyway this will fix.

``` ruby
  def after_initialize
    @local_levels = ThreadSafe::Cache.new(:initial_capacity => 2)
  end
```

To reproduce: https://github.com/Eric-Guo/ember-tutorial

``` bat
C:\git\emberjs\ember-tutorial>rails s
=> Booting WEBrick
=> Rails 4.1.15 application starting in development on http://0.0.0.0:3000
=> Run `rails server -h` for more startup options
=> Notice: server is listening on all interfaces (0.0.0.0). Consider using 127.0.0.1 (--binding option)
=> Ctrl-C to shutdown server
Exiting
C:/Ruby22/lib/ruby/gems/2.2.0/gems/activesupport-4.1.15/lib/active_support/logger_silence.rb:23:in `level': undefined me
thod `[]' for nil:NilClass (NoMethodError)
        from C:/Ruby22/lib/ruby/gems/2.2.0/gems/railties-4.1.15/lib/rails/commands/server.rb:134:in `log_to_stdout'
        from C:/Ruby22/lib/ruby/gems/2.2.0/gems/railties-4.1.15/lib/rails/commands/server.rb:67:in `start'
        from C:/Ruby22/lib/ruby/gems/2.2.0/gems/railties-4.1.15/lib/rails/commands/commands_tasks.rb:81:in `block in server'
        from C:/Ruby22/lib/ruby/gems/2.2.0/gems/railties-4.1.15/lib/rails/commands/commands_tasks.rb:76:in `tap'
        from C:/Ruby22/lib/ruby/gems/2.2.0/gems/railties-4.1.15/lib/rails/commands/commands_tasks.rb:76:in `server'
        from C:/Ruby22/lib/ruby/gems/2.2.0/gems/railties-4.1.15/lib/rails/commands/commands_tasks.rb:40:in `run_command!'
        from C:/Ruby22/lib/ruby/gems/2.2.0/gems/railties-4.1.15/lib/rails/commands.rb:17:in `<top (required)>'
        from bin/rails:4:in `require'
        from bin/rails:4:in `<main>'
```
