### PR TITLE
Use Rails.configuration instead of Rails.application.config in initializers

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/active_record_belongs_to_required_by_default.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/active_record_belongs_to_required_by_default.rb
@@ -3,4 +3,4 @@
 # Require `belongs_to` associations by default. This is a new Rails 5.0
 # default, so it is introduced as a configuration option to ensure that apps
 # made on earlier versions of Rails are not affected when upgrading.
-Rails.application.config.active_record.belongs_to_required_by_default = true
+Rails.configuration.active_record.belongs_to_required_by_default = true

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
@@ -1,11 +1,11 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.configuration.assets.version = '1.0'
 
 # Add additional assets to the asset load path
-# Rails.application.config.assets.paths << Emoji.images_path
+# Rails.configuration.assets.paths << Emoji.images_path
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+# Rails.configuration.assets.precompile += %w( search.js )

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/cookies_serializer.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json
+Rails.configuration.action_dispatch.cookies_serializer = :json

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb
@@ -5,7 +5,7 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
+# Rails.configuration.middleware.insert_before 0, Rack::Cors do
 #   allow do
 #     origins 'example.com'
 #

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.configuration.filter_parameters += [:password]

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/per_form_csrf_tokens.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/per_form_csrf_tokens.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Enable per-form CSRF tokens.
-Rails.application.config.action_controller.per_form_csrf_tokens = true
+Rails.configuration.action_controller.per_form_csrf_tokens = true

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/request_forgery_protection.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/request_forgery_protection.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Enable origin-checking CSRF mitigation.
-Rails.application.config.action_controller.forgery_protection_origin_check = true
+Rails.configuration.action_controller.forgery_protection_origin_check = true

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: <%= "'_#{app_name}_session'" %>
+Rails.configuration.session_store :cookie_store, key: <%= "'_#{app_name}_session'" %>

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/ssl_options.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/ssl_options.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure SSL options to enable HSTS with subdomains.
-Rails.application.config.ssl_options = { hsts: { subdomains: true } }
+Rails.configuration.ssl_options = { hsts: { subdomains: true } }


### PR DESCRIPTION
Given that there's no difference between `Rails.configuration` and `Rails.application.config`, surely it is better to use the one that is more concise and aesthetically pleasing?
