### PR TITLE
Require enumerable module when using #sum

### DIFF
--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -1,4 +1,5 @@
 require 'rails/code_statistics_calculator'
+require 'active_support/core_ext/enumerable'
 
 class CodeStatistics #:nodoc:
 


### PR DESCRIPTION
In dfa48f2, a call to `#sum` was added. For that to always work, we need to require the core_ext/enumerable module.

r? @amatsuda 
