### PR TITLE
Use || instead of `or` as preferred in rails code conventions

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup
@@ -15,7 +15,7 @@ chdir APP_ROOT do
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
-  system('bundle check') or system!('bundle install')
+  system('bundle check') || system!('bundle install')
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')

--- a/railties/lib/rails/generators/rails/app/templates/bin/update
+++ b/railties/lib/rails/generators/rails/app/templates/bin/update
@@ -15,7 +15,7 @@ chdir APP_ROOT do
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
-  system 'bundle check' or system! 'bundle install'
+  system 'bundle check' || system! 'bundle install'
 
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'


### PR DESCRIPTION
These are two lines in new generated rails application which don't follow this convention.
[Rails coding conventions](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions)

Also I was considering add/remove parenthesis in affected lines as they are identical but couldn't decide which direction to take. Will be happy do so if someone can help with the decision?  
