### PR TITLE
Use || instead of `or` in bin/(update|setup) tpl as preferred by rails code convention

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup
@@ -15,7 +15,7 @@ chdir APP_ROOT do
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
-  system('bundle check') or system!('bundle install')
+  system('bundle check') || system!('bundle install')
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')

--- a/railties/lib/rails/generators/rails/app/templates/bin/update
+++ b/railties/lib/rails/generators/rails/app/templates/bin/update
@@ -15,7 +15,7 @@ chdir APP_ROOT do
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
-  system 'bundle check' or system! 'bundle install'
+  system('bundle check') || system!('bundle install')
 
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'


### PR DESCRIPTION
Replaces https://github.com/rails/rails/pull/24274 where @rafaelfranca correctly pointed out the operators precedence, which also answered my subquestion in body of PR.
