### PR TITLE
Remove reference to unmaintained plugin/gem in Security guide

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -160,7 +160,7 @@ The most effective countermeasure is to _issue a new session identifier_ and dec
 reset_session
 ```
 
-If you use the popular RestfulAuthentication plugin for user management, add reset_session to the SessionsController#create action. Note that this removes any value from the session, _you have to transfer them to the new session_.
+If you use the popular [Devise](https://rubygems.org/gems/devise) gem for user management, it will automatically expire sessions on sign in and sign out for you. If you roll your own, remember to expire the session after your sign in action (when the session is created). This will remove values from the session, therefore _you will have to transfer them to the new session_.
 
 Another countermeasure is to _save user-specific properties in the session_, verify them every time a request comes in, and deny access, if the information does not match. Such properties could be the remote IP address or the user agent (the web browser name), though the latter is less user-specific. When saving the IP address, you have to bear in mind that there are Internet service providers or large organizations that put their users behind proxies. _These might change over the course of a session_, so these users will not be able to use your application, or only in a limited way.
 


### PR DESCRIPTION
We're advising people to use the "Restful Authentication plugin". The restful-authentication gem hasn't been updated since September 2012.

I've updated the guide to reference Devise instead, which solves the session fixation issue by default with the [`expire_data_after_sign_in!` method](https://github.com/plataformatec/devise/blob/7df57d5081f9884849ca15e4fde179ef164a575f/lib/devise/controllers/sign_in_out.rb#L85-L91).

This should obviously be reviewed by security-minded people like @tenderlove and @josevalim since he last touched that Devise method and is likely familiar with it.
