### PR TITLE
Move sequence value methods to Model level

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -231,6 +231,18 @@ module ActiveRecord
         @explicit_sequence_name = true
       end
 
+      # Determines if the primary key values should be selected from their
+      # corresponding sequence before the insert statement.
+      def prefetch_primary_key?
+        connection.prefetch_primary_key?(table_name)
+      end
+
+      # Returns the next value that will be used as the primary key on
+      # an insert statment.
+      def next_sequence_value
+        connection.next_sequence_value(sequence_name)
+      end
+
       # Indicates whether the table associated with this class exists
       def table_exists?
         connection.schema_cache.data_source_exists?(table_name)

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -45,8 +45,8 @@ module ActiveRecord
           k.name == primary_key
         }]
 
-        if !primary_key_value && connection.prefetch_primary_key?(klass.table_name)
-          primary_key_value = connection.next_sequence_value(klass.sequence_name)
+        if !primary_key_value && klass.prefetch_primary_key?
+          primary_key_value = klass.next_sequence_value
           values[arel_attribute(klass.primary_key)] = primary_key_value
         end
       end


### PR DESCRIPTION
### Summary

`prefetch_primary_key?` and `next_sequence_value` methods live in the
connection level at the moment, that make sense when you are generating
the sequence from the database, in the same connection. Which is the use
case today at the Oracle and Postgres adapters.
However if you have an service that generates IDs, that has nothing to
do with the database connection, and should not be fetched from there.
Another use case, is if you want to use another connection to fetch IDs,
that would not be possible with the current implementation, however when
we move those methods to the model level, you can use a new connection
there.

Also this makes easier for gems to add behavior on those methods.

review @jeremy @sgrif @rafaelfranca 
cc @jesseplusplus
