### PR TITLE
Ability to set ActiveSupport::JSON::Decoding.with_indifferent_access

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Ability to set ActiveSupport::JSON::Decoding.with_indifferent_access = true
+    to convert all hashes of decoding result to ActiveSupport::HashWithIndifferentAccess
+    and therefore, access them by string or symbol keys indifferently.
+
+    *Andrey Voronkov*
+
 *   Prevent `Marshal.load` from looping infinitely when trying to autoload a constant
     which resolves to a different name.
 

--- a/activesupport/test/json/decoding_test.rb
+++ b/activesupport/test/json/decoding_test.rb
@@ -88,6 +88,18 @@ class TestJSONDecoding < ActiveSupport::TestCase
     end
   end
 
+  test "json decodes all hashes with indifferent access" do
+    begin
+      prev = ActiveSupport::JSON::Decoding.with_indifferent_access
+      ActiveSupport::JSON::Decoding.with_indifferent_access = true
+      decoded = ActiveSupport::JSON.decode(%({ "array": [1, null, false, true, { "hash": { "a": 5 } } ] }))
+      assert_equal 5, decoded[:array].last[:hash][:a]
+      assert_equal 5, decoded['array'].last['hash']['a']
+    ensure
+      ActiveSupport::JSON::Decoding.with_indifferent_access = prev
+    end
+  end
+
   def test_failed_json_decoding
     assert_raise(ActiveSupport::JSON.parse_error) { ActiveSupport::JSON.decode(%(undefined)) }
     assert_raise(ActiveSupport::JSON.parse_error) { ActiveSupport::JSON.decode(%({a: 1})) }


### PR DESCRIPTION
### Summary

Ability to set ActiveSupport::JSON::Decoding.with_indifferent_access = true
to convert all hashes of decoding result to ActiveSupport::HashWithIndifferentAccess
and therefore, access them by string or symbol keys indifferently.

This feature is extremely useful when you move your serialized data from text to
json/jsonb column format in PostgreSQL and have symbol setters and getters all around the code.
### application.rb

Can be set globally in config/application.rb

```
module YourApp
  class Application < Rails::Application
    ...    
    ActiveSupport::JSON::Decoding.with_indifferent_access = true
    ...
  end
end
```
### Rails 4.2.x

Please backport if possible. Need this feature in current project =)
