### PR TITLE
Change for `ActiveRecord::Migration.[]` to raise `ArgumentError` inst…

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -528,7 +528,7 @@ module ActiveRecord
       name = "V#{version.tr('.', '_')}"
       unless Compatibility.const_defined?(name)
         versions = Compatibility.constants.grep(/\AV[0-9_]+\z/).map { |s| s.to_s.delete('V').tr('_', '.').inspect }
-        raise "Unknown migration version #{version.inspect}; expected one of #{versions.sort.join(', ')}"
+        raise ArgumentError, "Unknown migration version #{version.inspect}; expected one of #{versions.sort.join(', ')}"
       end
       Compatibility.const_get(name)
     end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1107,4 +1107,7 @@ class CopyMigrationsTest < ActiveRecord::TestCase
     ActiveRecord::Base.logger = old
   end
 
+  def test_unknown_migration_version_should_raise_an_argument_error
+    assert_raise(ArgumentError) { ActiveRecord::Migration[1.0] }
+  end
 end


### PR DESCRIPTION
…ead of `RuntimeError`

The error is raised because user passed invalid version number to a public api of
`ActiveRecord`, so `ArgumentError` is more suitable.
And add a test case checking if an error is raised when unknown migration version
is passed, because these test cases are not implemented.
