### PR TITLE
Use Range#cover? for Date inclusion validator

### DIFF
--- a/activemodel/lib/active_model/validations/clusivity.rb
+++ b/activemodel/lib/active_model/validations/clusivity.rb
@@ -30,14 +30,15 @@ module ActiveModel
         @delimiter ||= options[:in] || options[:within]
       end
 
-      # In Ruby 1.9 <tt>Range#include?</tt> on non-number-or-time-ish ranges checks all
+      # In Ruby 2.2 <tt>Range#include?</tt> on non-number-or-time-ish ranges checks all
       # possible values in the range for equality, which is slower but more accurate.
       # <tt>Range#cover?</tt> uses the previous logic of comparing a value with the range
-      # endpoints, which is fast but is only accurate on Numeric, Time, or DateTime ranges.
+      # endpoints, which is fast but is only accurate on Numeric, Time, Date,
+      # or DateTime ranges.
       def inclusion_method(enumerable)
         if enumerable.is_a? Range
           case enumerable.first
-          when Numeric, Time, DateTime
+          when Numeric, Time, DateTime, Date
             :cover?
           else
             :include?

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -21,24 +21,38 @@ class InclusionValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_inclusion_of_time_range
-    Topic.validates_inclusion_of(:created_at, in: 1.year.ago..Time.now)
+    range_begin = 1.year.ago
+    range_end = Time.now
+    Topic.validates_inclusion_of(:created_at, in: range_begin..range_end)
     assert Topic.new(title: 'aaa', created_at: 2.years.ago).invalid?
     assert Topic.new(title: 'aaa', created_at: 3.months.ago).valid?
     assert Topic.new(title: 'aaa', created_at: 37.weeks.from_now).invalid?
+    assert Topic.new(title: 'aaa', created_at: range_begin).valid?
+    assert Topic.new(title: 'aaa', created_at: range_end).valid?
   end
 
   def test_validates_inclusion_of_date_range
-    Topic.validates_inclusion_of(:created_at, in: 1.year.until(Date.today)..Date.today)
+    range_begin = 1.year.until(Date.today)
+    range_end = Date.today
+    Topic.validates_inclusion_of(:created_at, in: range_begin..range_end)
     assert Topic.new(title: 'aaa', created_at: 2.years.until(Date.today)).invalid?
     assert Topic.new(title: 'aaa', created_at: 3.months.until(Date.today)).valid?
     assert Topic.new(title: 'aaa', created_at: 37.weeks.since(Date.today)).invalid?
+    assert Topic.new(title: 'aaa', created_at: 1.year.until(Date.today)).valid?
+    assert Topic.new(title: 'aaa', created_at: Date.today).valid?
+    assert Topic.new(title: 'aaa', created_at: range_begin).valid?
+    assert Topic.new(title: 'aaa', created_at: range_end).valid?
   end
 
   def test_validates_inclusion_of_date_time_range
-    Topic.validates_inclusion_of(:created_at, in: 1.year.until(DateTime.current)..DateTime.current)
+    range_begin = 1.year.until(DateTime.current)
+    range_end = DateTime.current
+    Topic.validates_inclusion_of(:created_at, in: range_begin..range_end)
     assert Topic.new(title: 'aaa', created_at: 2.years.until(DateTime.current)).invalid?
     assert Topic.new(title: 'aaa', created_at: 3.months.until(DateTime.current)).valid?
     assert Topic.new(title: 'aaa', created_at: 37.weeks.since(DateTime.current)).invalid?
+    assert Topic.new(title: 'aaa', created_at: range_begin).valid?
+    assert Topic.new(title: 'aaa', created_at: range_end).valid?
   end
 
   def test_validates_inclusion_of


### PR DESCRIPTION
AFAICS Range#cover? works just fine for Date in ruby-2.2/2.3, jruby-9k & rbx, so let's use it.
Please advise if I'm missing something.
