### PR TITLE
Accept sets as values in `where` conditions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `where` now accepts sets as values. 
+
+    Example:
+
+        User.where({ name: Set.new(["Alice", "Bob"]) })
+        # SELECT * FROM users WHERE name IN ('Alice', 'Bob')
+
+    *Fernando Tapia Rico*
+
 *   MySQL: strict mode respects other SQL modes rather than overwriting them.
     Setting `strict: true` adds `STRICT_ALL_TABLES` to `sql_mode`. Setting
     `strict: false` removes `STRICT_TRANS_TABLES`, `STRICT_ALL_TABLES`, and

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -6,8 +6,10 @@ module ActiveRecord
     require 'active_record/relation/predicate_builder/basic_object_handler'
     require 'active_record/relation/predicate_builder/class_handler'
     require 'active_record/relation/predicate_builder/polymorphic_array_handler'
+    require 'active_record/relation/predicate_builder/polymorphic_set_handler'
     require 'active_record/relation/predicate_builder/range_handler'
     require 'active_record/relation/predicate_builder/relation_handler'
+    require 'active_record/relation/predicate_builder/set_handler'
 
     delegate :resolve_column_aliases, to: :table
 
@@ -22,8 +24,10 @@ module ActiveRecord
       register_handler(RangeHandler::RangeWithBinds, RangeHandler.new(self))
       register_handler(Relation, RelationHandler.new)
       register_handler(Array, ArrayHandler.new(self))
+      register_handler(Set, SetHandler.new(self))
       register_handler(AssociationQueryValue, AssociationQueryHandler.new(self))
       register_handler(PolymorphicArrayValue, PolymorphicArrayHandler.new(self))
+      register_handler(PolymorphicSetValue, PolymorphicSetHandler.new(self))
     end
 
     def build_from_hash(attributes)

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
@@ -4,6 +4,8 @@ module ActiveRecord
       def self.value_for(table, column, value)
         klass = if table.associated_table(column).polymorphic_association? && ::Array === value && value.first.is_a?(Base)
           PolymorphicArrayValue
+        elsif table.associated_table(column).polymorphic_association? && ::Set === value && value.first.is_a?(Base)
+          PolymorphicSetValue
         else
           AssociationQueryValue
         end
@@ -69,6 +71,9 @@ module ActiveRecord
           value.klass.base_class
         when Array
           val = value.compact.first
+          val.class.base_class if val.is_a?(Base)
+        when Set
+          val = value.first
           val.class.base_class if val.is_a?(Base)
         when Base
           value.class.base_class

--- a/activerecord/lib/active_record/relation/predicate_builder/polymorphic_set_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/polymorphic_set_handler.rb
@@ -1,0 +1,6 @@
+module ActiveRecord
+  class PredicateBuilder
+    class PolymorphicSetHandler < PolymorphicArrayHandler; end # :nodoc:
+    class PolymorphicSetValue < PolymorphicArrayValue; end
+  end
+end

--- a/activerecord/lib/active_record/relation/predicate_builder/set_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/set_handler.rb
@@ -1,0 +1,5 @@
+module ActiveRecord
+  class PredicateBuilder
+    class SetHandler < ArrayHandler; end # :nodoc:
+  end
+end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -555,12 +555,15 @@ module ActiveRecord
     # #where will also accept a hash condition, in which the keys are fields and the values
     # are values to be searched for.
     #
-    # Fields can be symbols or strings. Values can be single values, arrays, or ranges.
+    # Fields can be symbols or strings. Values can be single values, arrays, sets, or ranges.
     #
     #    User.where({ name: "Joe", email: "joe@example.com" })
     #    # SELECT * FROM users WHERE name = 'Joe' AND email = 'joe@example.com'
     #
-    #    User.where({ name: ["Alice", "Bob"]})
+    #    User.where({ name: ["Alice", "Bob"] })
+    #    # SELECT * FROM users WHERE name IN ('Alice', 'Bob')
+    #
+    #    User.where({ name: Set.new(["Alice", "Bob"]) })
     #    # SELECT * FROM users WHERE name IN ('Alice', 'Bob')
     #
     #    User.where({ created_at: (Time.now.midnight - 1.day)..Time.now.midnight })


### PR DESCRIPTION
### Summary

Active Record currently allows to pass an `Array` as value in a `#where` condition, but it fails with `Set`s. With these changes, you can now do: 

``` ruby
User.where({ name: Set.new(["Alice", "Bob"]) })
# SELECT * FROM users WHERE name IN ('Alice', 'Bob')
```
