### PR TITLE
Do not create a hash key when calling ActiveModel::Errors#include?

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -110,7 +110,7 @@ module ActiveModel
     #   person.errors.include?(:name) # => true
     #   person.errors.include?(:age)  # => false
     def include?(attribute)
-      messages[attribute].present?
+      messages.key?(attribute) && messages[attribute].present?
     end
     alias :has_key? :include?
     alias :key? :include?

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -128,6 +128,13 @@ class ErrorsTest < ActiveModel::TestCase
     assert !person.errors.include?(:foo)
   end
 
+  test "include? does not add a key to messages hash" do
+    person = Person.new
+    person.errors.include?(:foo)
+
+    assert_not person.errors.messages.key?(:foo)
+  end
+
   test "adding errors using conditionals with Person#validate!" do
     person = Person.new
     person.validate!


### PR DESCRIPTION
### Summary

From: https://github.com/rails/rails/issues/24279

When doing `record.errors.include? :foo`, it adds a new key to the
@messages hash that defaults to an empty array.

This happens because of a combination of these 2 commits:
https://github.com/rails/rails/commit/b97035df64f5b2f912425c4a7fcb6e6bb3ddab8d
(Added in Rails 4.1)
and
https://github.com/rails/rails/commit/6ec8ba16d85d5feaccb993c9756c1edcbbf0ba13#diff-fdcf8b65b5fb954372c6fe1ddf284c78R76
(Rails 5.0)

By adding the default proc that returns an array for non-existing keys,
ruby adds that key to the hash.

This commit changes `#include?` to check with `has_key?` and then check if that value is
`present?`.
