### PR TITLE
Make ActiveRecord::Base.clear_cache! clear all model caches

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -123,7 +123,9 @@ module ActiveRecord
     end
 
     def clear_cache! # :nodoc:
-      connection.schema_cache.clear!
+      direct_descendants.each do |descendant|
+        descendant.send(:reset_column_information)
+      end
     end
 
     delegate :clear_active_connections!, :clear_reloadable_connections!,

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -19,6 +19,8 @@ require 'models/comment'
 require 'models/minimalistic'
 require 'models/warehouse_thing'
 require 'models/parrot'
+require 'models/pirate'
+require 'models/treasure'
 require 'models/person'
 require 'models/edge'
 require 'models/joke'
@@ -1261,13 +1263,20 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_clear_cache!
     # preheat cache
-    c1 = Post.connection.schema_cache.columns('posts')
+    schema_columns_before = Post.connection.schema_cache.columns('posts')
+    model_columns_before  = Post.columns
     ActiveRecord::Base.clear_cache!
-    c2 = Post.connection.schema_cache.columns('posts')
-    c1.each_with_index do |v, i|
-      assert_not_same v, c2[i]
+    schema_columns_after = Post.connection.schema_cache.columns('posts')
+    model_columns_after  = Post.columns
+
+    schema_columns_before.each_with_index do |c, i|
+      assert_not_same c, schema_columns_after[i]
     end
-    assert_equal c1, c2
+    model_columns_before.each_with_index do |c, i|
+      assert_not_same c, model_columns_after[i]
+    end
+    assert_equal schema_columns_before, schema_columns_after
+    assert_equal model_columns_before,  model_columns_after
   end
 
   def test_current_scope_is_reset


### PR DESCRIPTION
**Note: This PR is currently not mergeable as it breaks the test suite due to connection clearing where we are currently mocking a connection.** I was asked to open this PR early for more open discussion as changes progress. 
### Summary

Fixes #24273, potentially

~~This PR does two things:~~
- Changes `ActiveRecord::Base.clear_cache!` to _also_ clear model caches, which have drifted separately from the db adapter's schema cache. (See related Issue for an example of why that's bad. TLDR: clearing the schema cache does not clear columns on models)
- ~~With all caches being properly cleared, calls `clear_cache!` at the end of the `migrate` task. This removes the unfortunate fact that after migrations, seeding (in the same process) would now have models with inaccurate `columns` (be it from column removals, whatever). Related: https://github.com/ManageIQ/manageiq/pull/7476~~
