### PR TITLE
Brush up error message of `ActiveRecord::Migration.[]`

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -527,8 +527,8 @@ module ActiveRecord
       version = version.to_s
       name = "V#{version.tr('.', '_')}"
       unless Compatibility.const_defined?(name)
-        versions = Compatibility.constants.grep(/\AV[0-9_]+\z/).map { |s| s.to_s.delete('V').tr('_', '.').inspect }
-        raise ArgumentError, "Unknown migration version #{version.inspect}; expected one of #{versions.sort.join(', ')}"
+        versions = Compatibility.constants.grep(/\AV[0-9_]+\z/).map { |s| s.to_s.delete('V').tr('_', '.') }
+        raise ArgumentError, "Unknown migration version #{version}; expected one of #{versions.sort.join(', ')}"
       end
       Compatibility.const_get(name)
     end


### PR DESCRIPTION
[Before]
`ArgumentError: Unknown migration version "1.0"; expected one of "4.2", "5.0"`

[After]
`ArgumentError: Unknown migration version 1.0; expected one of 4.2, 5.0`
