### PR TITLE
Fix a tip in Active Record time attributes deprecation

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -104,7 +104,7 @@ module ActiveRecord
 
               To silence this deprecation warning, add the following:
 
-                  config.active_record.time_zone_aware_types << :time
+                  config.active_record.time_zone_aware_types = [:datetime, :time]
             MESSAGE
           end
 


### PR DESCRIPTION
I have hit this deprecation in a newly created Rails 5 application and
the suggested tip lead me to a `NoMethodError`.

It's not trivial to actually make the following work, because of the
`ActiveRecord::Base` class attributes setting dance in the Active Record
railtie.

```
config.active_record.time_zone_aware_types << :time
```

Decided to suggest setting it explicitly to the values we need.

[ci skip]
