### PR TITLE
Fixes #24239

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Adds support for including ActionController::Cookies in API controllers.
+    Previously, including the module would raise when trying to define
+    a `cookies` helper method. Skip calling #helper_method if it is not
+    defined -- if we don't have helpers, we needn't define one.
+
+    Fixes #24304
+
+    *Ryan T. Hosford*
+
 *   ETags: Introduce `Response#strong_etag=` and `#weak_etag=` and analogous
     options for `fresh_when` and `stale?`. `Response#etag=` sets a weak ETag.
 

--- a/actionpack/lib/action_controller/metal/cookies.rb
+++ b/actionpack/lib/action_controller/metal/cookies.rb
@@ -3,7 +3,7 @@ module ActionController #:nodoc:
     extend ActiveSupport::Concern
 
     included do
-      helper_method :cookies
+      helper_method :cookies if defined?(helper_method)
     end
 
     private

--- a/actionpack/test/controller/api/with_cookies_test.rb
+++ b/actionpack/test/controller/api/with_cookies_test.rb
@@ -1,0 +1,21 @@
+require 'abstract_unit'
+
+class WithCookiesController < ActionController::API
+  include ActionController::Cookies
+
+  def with_cookies
+    render plain: cookies[:foobar]
+  end
+end
+
+class WithCookiesTest < ActionController::TestCase
+  tests WithCookiesController
+
+  def test_with_cookies
+    request.cookies[:foobar] = 'bazbang'
+
+    get :with_cookies
+
+    assert_equal 'bazbang', response.body
+  end
+end


### PR DESCRIPTION
The guides claim you should be able to include AC modules in your controllers, but, as reported in #24239, it's currently not possible to include ActionController::Cookies in controllers inheriting from ActionController::API.

> All Action Controller modules know about their dependent modules, so you can feel free to include any modules into your controllers, and all dependencies will be included and set up as well.

To fix this we'll simply skip calling `#helper_method` if it's not defined: if we don't have helpers, we needn't define one.

The reproduction script from the parent issue: https://gist.github.com/tenshilg/056076c0507709c587b7

@matthewd 
