### PR TITLE
Backports fix to issue #24235 to 4.2 stable

### DIFF
--- a/activerecord/test/cases/type/decimal_test.rb
+++ b/activerecord/test/cases/type/decimal_test.rb
@@ -55,8 +55,8 @@ module ActiveRecord
       def test_scale_is_applied_before_precision_to_prevent_rounding_errors
         type = Decimal.new(precision: 5, scale: 3)
 
-        assert_equal BigDecimal("1.250"), type.cast(1.250473853637869)
-        assert_equal BigDecimal("1.250"), type.cast("1.250473853637869")
+        assert_equal BigDecimal("1.250"), type.type_cast_from_user(1.250473853637869)
+        assert_equal BigDecimal("1.250"), type.type_cast_from_user("1.250473853637869")
       end
     end
   end


### PR DESCRIPTION
### Summary

This change backports the fix to 4.2 stable that applies scale before precision when coercing
floats to decimal. This was necessary to change manually due to changes from 4.2 to master that
moved decimal logic from activerecord to active model.

Fixes issue #24235 on 4-2-stable
