### PR TITLE
Set time_zone_aware_types on Active Record configuration

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -61,10 +61,11 @@ module ActiveRecord
       require "active_record/base"
     end
 
-    initializer "active_record.initialize_timezone" do
+    initializer "active_record.initialize_timezone" do |app|
       ActiveSupport.on_load(:active_record) do
         self.time_zone_aware_attributes = true
         self.default_timezone = :utc
+        app.config.active_record.time_zone_aware_types = ActiveRecord::Base.time_zone_aware_types
       end
     end
 


### PR DESCRIPTION
- Earlier it was set on ActiveRecord::Base itself in
  https://github.com/rails/rails/commit/43ccebc1db072ba0c96a67de0b3db78fd8fd0973.
- Then it was reverted in
  https://github.com/rails/rails/commit/520e81ba5d2d510517bfe7b72ec2104b32c40dfa.
- But now it is set up correctly on `config.active_record`.

r? @rafaelfranca 
