### PR TITLE
set in no more used in ActionView::Template::Types

### DIFF
--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -1,4 +1,3 @@
-require 'set'
 require 'active_support/core_ext/module/attribute_accessors'
 
 module ActionView


### PR DESCRIPTION
initially set is used for template type https://github.com/rails/rails/commit/67f55e28

after this commit https://github.com/rails/rails/commit/91f2ad36 it’s not require
