### PR TITLE
Delegate some additional methods in querying.rb

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Delegate `empty?`, `none?` and `one?`. Now they can be invoked as model class methods.
+
+    Example:
+
+        # When no record is found on the table
+        Topic.empty? # => true
+        Topic.none?  # => true
+
+        # When only one record is found on the table
+        Topic.one?   # => true
+
+    *Kenta Shirai*
+
 *   The form builder now properly displays values when passing a proc form
     default to the attributes API.
 

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -1,6 +1,6 @@
 module ActiveRecord
   module Querying
-    delegate :find, :take, :take!, :first, :first!, :last, :last!, :exists?, :any?, :many?, to: :all
+    delegate :find, :take, :take!, :first, :first!, :last, :last!, :exists?, :any?, :many?, :empty?, :none?, :one?, to: :all
     delegate :second, :second!, :third, :third!, :fourth, :fourth!, :fifth, :fifth!, :forty_two, :forty_two!, :third_to_last, :third_to_last!, :second_to_last, :second_to_last!, to: :all
     delegate :first_or_create, :first_or_create!, :first_or_initialize, to: :all
     delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, to: :all

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -544,4 +544,24 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert_equal 1, SpecialComment.where(body: 'go crazy').created.count
   end
 
+  def test_model_class_should_respond_to_empty
+    assert !Topic.empty?
+    Topic.delete_all
+    assert Topic.empty?
+  end
+
+  def test_model_class_should_respond_to_none
+    assert !Topic.none?
+    Topic.delete_all
+    assert Topic.none?
+  end
+
+  def test_model_class_should_respond_to_one
+    assert !Topic.one?
+    Topic.delete_all
+    assert !Topic.one?
+    Topic.create!
+    assert Topic.one?
+  end
+
 end


### PR DESCRIPTION
I have seen many people write code like below so far.

```
if Person.count.zero?
  # do something
end

```

if they can code like this,

```
if Person.empty?
  # do something
end

```

the code will look more like RoR. 
They can use `exists?` method of course. But I think there should be `empty?` method as well.
