### PR TITLE
connection adapters column, delegation in Active Record have not use …

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 module ActiveRecord
   # :stopdoc:
   module ConnectionAdapters

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -1,4 +1,3 @@
-require 'set'
 require 'active_support/concern'
 
 module ActiveRecord


### PR DESCRIPTION
…of ‘set’

found these commits https://github.com/rails/rails/commit/9cc8c6f3730df3d94c81a55be9ee1b7b4ffd29f6, https://github.com/rails/rails/commit/9d79334a1dee67e31222c790e231772deafcaeb8 that also should remove it.
