### PR TITLE
extension synonyms yml and yaml

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add extension synonyms `yml` and `yaml` for MIME type `application/x-yaml`.
+    
+   *bogdanvlviv*
+
 *   When a `respond_to` collector with a block doesn't have a response, then
     a `:no_content` response should be rendered.  This brings the default
     rendering behavior introduced by https://github.com/rails/rails/issues/19036

--- a/actionpack/lib/action_dispatch/http/mime_types.rb
+++ b/actionpack/lib/action_dispatch/http/mime_types.rb
@@ -21,7 +21,7 @@ Mime::Type.register "video/mpeg", :mpeg, [], %w(mpg mpeg mpe)
 Mime::Type.register "application/xml", :xml, %w( text/xml application/x-xml )
 Mime::Type.register "application/rss+xml", :rss
 Mime::Type.register "application/atom+xml", :atom
-Mime::Type.register "application/x-yaml", :yaml, %w( text/yaml )
+Mime::Type.register "application/x-yaml", :yaml, %w( text/yaml ), %w(yml yaml)
 
 Mime::Type.register "multipart/form-data", :multipart_form
 Mime::Type.register "application/x-www-form-urlencoded", :url_encoded_form


### PR DESCRIPTION
Add extension synonyms `yml` and `yaml` for MIME type `application/x-yaml`.
