### PR TITLE
Add more info to insecure URL generation error

### DIFF
--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -252,5 +252,13 @@ module ActionDispatch
 
     SEPARATORS = %w( / . ? ) #:nodoc:
     HTTP_METHODS = [:get, :head, :post, :patch, :put, :delete, :options] #:nodoc:
+    INSECURE_URL_PARAMETERS_MESSAGE = <<-MSG.squish
+      Generating a URL from non-sanitized request parameters is insecure.
+
+      An attacker may use this to inject malicious data into the URL and may,
+      for instance, change the host to one which they control. For this reason,
+      you should whitelist and sanitize any parameters you intend to pass to URL
+      helpers rather than passing the collection of raw parameters directly.
+    MSG
   end
 end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -289,7 +289,7 @@ module ActionDispatch
                           if last.permitted?
                             args.pop.to_h
                           else
-                            raise ArgumentError, "Generating a URL from non sanitized request parameters is insecure!"
+                            raise ArgumentError, ActionDispatch::Routing::INSECURE_URL_PARAMETERS_MESSAGE
                           end
                         end
               helper.call self, args, options

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -173,7 +173,7 @@ module ActionDispatch
                          route_name)
         when ActionController::Parameters
           unless options.permitted?
-            raise ArgumentError.new("Generating a URL from non sanitized request parameters is insecure!")
+            raise ArgumentError.new(ActionDispatch::Routing::INSECURE_URL_PARAMETERS_MESSAGE)
           end
           route_name = options.delete :use_route
           _routes.url_for(options.to_h.symbolize_keys.

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -176,7 +176,6 @@ class RedirectTest < ActionController::TestCase
     assert_equal "http://www.example.com", redirect_to_url
   end
 
-
   def test_relative_url_redirect_with_status
     get :relative_url_redirect_with_status
     assert_response 302
@@ -313,7 +312,7 @@ class RedirectTest < ActionController::TestCase
     error = assert_raise(ArgumentError) do
       get :redirect_to_params
     end
-    assert_equal "Generating a URL from non sanitized request parameters is insecure!", error.message
+    assert_equal ActionDispatch::Routing::INSECURE_URL_PARAMETERS_MESSAGE, error.message
   end
 
   def test_redirect_to_with_block


### PR DESCRIPTION
### Summary

I always appreciate having a bit more information as to why something is
now an error. We can use this error to tell people why what they were
previously doing is insecure and give them hints on how to fix it.
