### PR TITLE
Makes scaffold index page more readable

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb
@@ -1,7 +1,7 @@
 <p id="notice"><%%= notice %></p>
 
 <h1><%= plural_table_name.titleize %></h1>
-
+<h2><%%= link_to '+ Add New <%= singular_table_name.titleize %>', new_<%= singular_table_name %>_path %></h2>
 <table>
   <thead>
     <tr>
@@ -25,7 +25,3 @@
     <%% end %>
   </tbody>
 </table>
-
-<br>
-
-<%%= link_to 'New <%= singular_table_name.titleize %>', new_<%= singular_table_name %>_path %>

--- a/railties/lib/rails/generators/rails/scaffold/templates/scaffold.css
+++ b/railties/lib/rails/generators/rails/scaffold/templates/scaffold.css
@@ -23,20 +23,40 @@ a {
 a:visited {
   color: #666;
 }
-
+table{
+  border: 1px solid #cccccc;
+  border-spacing: 0px;
+}
 a:hover {
   color: #fff;
   background-color: #000;
 }
 
 th {
-  padding-bottom: 5px;
+   border-bottom: 1px solid #cccccc;
+  height: 15px;
 }
 
 td {
   padding-bottom: 7px;
   padding-left: 5px;
   padding-right: 5px;
+  font-family: verdana, arial, helvetica, sans-serif;
+  border-left: none;
+  border-bottom: 1px solid #cccccc;
+  border-right: 1px solid #cccccc;
+  vertical-align: top;
+  font-size: 13px;
+  color: inherit;
+  border-top: solid 1px transparent;
+  white-space: normal;
+}
+
+tr:nth-child(even) {
+  background: #f2f2f2
+}
+tr:nth-child(odd) {
+  background: #FFF
 }
 
 div.field,


### PR DESCRIPTION
### Summary

Wanted to improve scaffolding index pages from a UI/UX standpoint, make them more readable, give an overall "spreadsheet"-type look to it, so I made adjustments accordingly to railties/lib/rails/generators/rails/scaffold/templates/scaffold.css (various CSS changes, including table borders and alternating row colors) and railties/lib/rails/generators/erb/scaffold/templates/index.html.erb (moved "Add new" to the top of the table.
### Other Information

Not much... Obviously this is a huge change visually for those using scaffold (and an improvement IMHO)
