### PR TITLE
`take` test should not expect that it returns the first record

### DIFF
--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -345,7 +345,7 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_take
-    assert_equal topics(:first), Topic.take
+    assert_kind_of Topic, Topic.take
   end
 
   def test_take_failing


### PR DESCRIPTION
It is not guaranteed that `take` will return the first record and the test should reflect that.
