### PR TITLE
show correct command name in help of rails runner

### DIFF
--- a/railties/lib/rails/commands/runner.rb
+++ b/railties/lib/rails/commands/runner.rb
@@ -2,6 +2,7 @@ require 'optparse'
 
 options = { environment: (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || "development").dup }
 code_or_file = nil
+command = 'bin/rails runner'
 
 if ARGV.first.nil?
   ARGV.push "-h"
@@ -34,7 +35,7 @@ ARGV.clone.options do |opts|
     opts.separator ""
     opts.separator "You can also use runner as a shebang line for your executables:"
     opts.separator "    -------------------------------------------------------------"
-    opts.separator "    #!/usr/bin/env #{File.expand_path($0)} runner"
+    opts.separator "    #!/usr/bin/env #{File.expand_path(command)}"
     opts.separator ""
     opts.separator "    Product.all.each { |p| p.price *= 2 ; p.save! }"
     opts.separator "    -------------------------------------------------------------"
@@ -52,7 +53,7 @@ Rails.application.require_environment!
 Rails.application.load_runner
 
 if code_or_file.nil?
-  $stderr.puts "Run '#{$0} -h' for help."
+  $stderr.puts "Run '#{command} -h' for help."
   exit 1
 elsif File.exist?(code_or_file)
   $0 = code_or_file
@@ -62,7 +63,7 @@ else
     eval(code_or_file, binding, __FILE__, __LINE__)
   rescue SyntaxError, NameError
     $stderr.puts "Please specify a valid ruby command or the path of a script to run."
-    $stderr.puts "Run '#{$0} -h' for help."
+    $stderr.puts "Run '#{command} -h' for help."
     exit 1
   end
 end


### PR DESCRIPTION
### Summary

If you using spring, help of rails runner will show an incorrect command name.  

```
$ ./bin/rails r a
Running via Spring preloader in process 12334
Please specify a valid ruby command or the path of a script to run.
Run 'rails_runner -h' for help. 
```

`spring` is rewrite `$0` in the interior command name. 
Therefore, for `$0` correct command name does not appear, fixed so that it does not use `$0`.
