### PR TITLE
Fix rails restart issue with Puma

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Make `rails restart` command work with Puma by passing the restart command
+    which Puma can use to restart rails server.
+
+    *Prathamesh Sonpatki*
+
 *   The application generator writes a new file `config/spring.rb`, which tells
     Spring to watch additional common files.
 

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -94,7 +94,8 @@ module Rails
         environment:        (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || "development").dup,
         daemonize:          false,
         caching:            nil,
-        pid:                Options::DEFAULT_PID_PATH
+        pid:                Options::DEFAULT_PID_PATH,
+        restart_cmd:        restart_command
       })
     end
 
@@ -129,6 +130,10 @@ module Rails
         unless ActiveSupport::Logger.logger_outputs_to?(Rails.logger, STDOUT)
           Rails.logger.extend(ActiveSupport::Logger.broadcast(console))
         end
+      end
+
+      def restart_command
+        "bin/rails server #{ARGV.join(' ')}"
       end
   end
 end

--- a/railties/lib/rails/dev_caching.rb
+++ b/railties/lib/rails/dev_caching.rb
@@ -15,6 +15,7 @@ module Rails
         end
 
         FileUtils.touch 'tmp/restart.txt'
+        FileUtils.rm_f('tmp/pids/server.pid')
       end
 
       def enable_by_argument(caching)

--- a/railties/lib/rails/tasks/restart.rake
+++ b/railties/lib/rails/tasks/restart.rake
@@ -2,4 +2,5 @@ desc "Restart app by touching tmp/restart.txt"
 task :restart do
   FileUtils.mkdir_p('tmp')
   FileUtils.touch('tmp/restart.txt')
+  FileUtils.rm_f('tmp/pids/server.pid')
 end

--- a/railties/test/application/rake/dev_test.rb
+++ b/railties/test/application/rake/dev_test.rb
@@ -29,6 +29,15 @@ module ApplicationTests
           assert_match(/Development mode is no longer being cached/, output)
         end
       end
+
+      test 'dev:cache removes server.pid also' do
+        Dir.chdir(app_path) do
+          FileUtils.mkdir_p("tmp/pids")
+          FileUtils.touch("tmp/pids/server.pid")
+          `rake dev:cache`
+          assert_not File.exist?("tmp/pids/server.pid")
+        end
+      end
     end
   end
 end

--- a/railties/test/application/rake/restart_test.rb
+++ b/railties/test/application/rake/restart_test.rb
@@ -34,6 +34,15 @@ module ApplicationTests
           assert File.exist?('tmp/restart.txt')
         end
       end
+
+      test 'rake restart removes server.pid also' do
+        Dir.chdir(app_path) do
+          FileUtils.mkdir_p("tmp/pids")
+          FileUtils.touch("tmp/pids/server.pid")
+          `rake restart`
+          assert_not File.exist?("tmp/pids/server.pid")
+        end
+      end
     end
   end
 end

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -118,4 +118,18 @@ class Rails::ServerTest < ActiveSupport::TestCase
       assert_equal old_default_options, server.default_options
     end
   end
+
+  def test_restart_command_contains_customized_options
+    original_args = ARGV.dup
+    args = ["-p", "4567"]
+    ARGV.replace args
+
+    options = Rails::Server::Options.new.parse! args
+    server = Rails::Server.new options
+    expected = "bin/rails server -p 4567"
+
+    assert_equal expected, server.default_options[:restart_cmd]
+  ensure
+    ARGV.replace original_args
+  end
 end


### PR DESCRIPTION
- We need to pass the restart command to Puma so that it will use it
  while restarting the server.
- Besides that we need to remove the pid file for the previous running
  server because otherwise Rack complains about it's presence.
- This also requires some changes on Puma side which are being tracked
  here - https://github.com/puma/puma/pull/936.
- Fixes #23910.

r? @rafaelfranca cc @evanphx
