### PR TITLE
Adds support to wrap aliased attributed in object hash in params wrapper

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -105,7 +105,11 @@ module ActionController
 
           unless super || exclude
             if m.respond_to?(:attribute_names) && m.attribute_names.any?
-              self.include = m.attribute_names
+              if m.respond_to?(:attribute_aliases) && m.attribute_aliases.any?
+                self.include = m.attribute_names + m.attribute_aliases.keys
+              else
+                self.include = m.attribute_names
+              end
             end
           end
         end

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -236,6 +236,10 @@ class NamespacedParamsWrapperTest < ActionController::TestCase
     def self.attribute_names
       ["username"]
     end
+
+    def self.attribute_aliases
+      {"nick" => "username"}
+    end
   end
 
   class SampleTwo
@@ -265,6 +269,19 @@ class NamespacedParamsWrapperTest < ActionController::TestCase
         @request.env['CONTENT_TYPE'] = 'application/json'
         post :parse, params: { 'username' => 'sikachu', 'title' => 'Developer' }
         assert_parameters({ 'username' => 'sikachu', 'title' => 'Developer', 'user' => { 'username' => 'sikachu' }})
+      end
+    ensure
+      Admin.send :remove_const, :User
+    end
+  end
+
+  def test_namespace_lookup_from_model_alias
+    Admin.const_set(:User, Class.new(SampleOne))
+    begin
+      with_default_wrapper_options do
+        @request.env['CONTENT_TYPE'] = 'application/json'
+        post :parse, params: { 'nick' => 'sikachu', 'title' => 'Developer' }
+        assert_parameters({ 'nick' => 'sikachu', 'title' => 'Developer', 'user' => { 'nick' => 'sikachu' }})
       end
     ensure
       Admin.send :remove_const, :User


### PR DESCRIPTION
Opening up for discussion. Will take care of docs/changelog if this looks good.
r? @jeremy . cc @qrush 

Fixes #24213
