### PR TITLE
Refactoring `ActiveRecord::Migration.[]`

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -524,13 +524,7 @@ module ActiveRecord
     end
 
     def self.[](version)
-      version = version.to_s
-      name = "V#{version.tr('.', '_')}"
-      unless Compatibility.const_defined?(name)
-        versions = Compatibility.constants.grep(/\AV[0-9_]+\z/).map { |s| s.to_s.delete('V').tr('_', '.').inspect }
-        raise ArgumentError, "Unknown migration version #{version.inspect}; expected one of #{versions.sort.join(', ')}"
-      end
-      Compatibility.const_get(name)
+      Compatibility.find_version!(version)
     end
 
     def self.current_version

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -1,6 +1,16 @@
 module ActiveRecord
   class Migration
     module Compatibility # :nodoc: all
+      def self.find_version!(version)
+        version = version.to_s
+        name = "V#{version.tr('.', '_')}"
+        unless const_defined?(name)
+          versions = constants.grep(/\AV[0-9_]+\z/).map { |s| s.to_s.delete('V').tr('_', '.').inspect }
+          raise ArgumentError, "Unknown migration version #{version.inspect}; expected one of #{versions.sort.join(', ')}"
+        end
+        const_get(name)
+      end
+
       V5_0 = Current
 
       module FourTwoShared


### PR DESCRIPTION
Move logic about how Migration Version module is found to
`ActiveRecord::Migration::Compatibility`.
`ActiveRecord::Migration` knows too much abount how Migration
Version modules are managed.
Migration Version modules are placed under `ActiveRecord::Migration::Compatibility`,
so it is better `Compatibility` knows how to find a suitable module.
