### PR TITLE
Fix marshal with autoloading for nested class/module

### DIFF
--- a/activesupport/lib/active_support/core_ext/marshal.rb
+++ b/activesupport/lib/active_support/core_ext/marshal.rb
@@ -3,7 +3,7 @@ module ActiveSupport
     def load(source)
       super(source)
     rescue ArgumentError, NameError => exc
-      if exc.message.match(%r|undefined class/module (.+)|)
+      if exc.message.match(%r|undefined class/module (.+?)(::)?\z|)
         # try loading the class/module
         loaded = $1.constantize
 

--- a/activesupport/test/core_ext/marshal_test.rb
+++ b/activesupport/test/core_ext/marshal_test.rb
@@ -29,7 +29,12 @@ class MarshalTest < ActiveSupport::TestCase
     ActiveSupport::Dependencies.clear
 
     with_autoloading_fixtures do
-      assert_kind_of EM, Marshal.load(dumped)
+      object = nil
+      assert_nothing_raised do
+        object = Marshal.load(dumped)
+      end
+
+      assert_kind_of EM, object
     end
   end
 
@@ -43,7 +48,12 @@ class MarshalTest < ActiveSupport::TestCase
     ActiveSupport::Dependencies.clear
 
     with_autoloading_fixtures do
-      assert_kind_of ClassFolder::ClassFolderSubclass, Marshal.load(dumped)
+      object = nil
+      assert_nothing_raised do
+        object = Marshal.load(dumped)
+      end
+
+      assert_kind_of ClassFolder::ClassFolderSubclass, object
     end
   end
 
@@ -128,7 +138,12 @@ class MarshalTest < ActiveSupport::TestCase
       ActiveSupport::Dependencies.clear
 
       with_autoloading_fixtures do
-        assert_kind_of EM, Marshal.load(f)
+        object = nil
+        assert_nothing_raised do
+          object = Marshal.load(f)
+        end
+
+        assert_kind_of EM, object
       end
     end
   end


### PR DESCRIPTION
#24150 break autoloading for nested class/module.

There is test for nested class but it doesn't work correctly.
Following code will autoload `ClassFolder::ClassFolderSubclass` before `Marshal.load`:

`assert_kind_of ClassFolder::ClassFolderSubclass, Marshal.load(dumped)`
