### PR TITLE
update `assert_no_performed_jobs` doc to use `assert_no_performed_jobs` method [ci skip]

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -193,26 +193,13 @@ module ActiveJob
     #   end
     #
     # The block form supports filtering. If the :only option is specified,
-    # then only the listed job(s) will be performed.
+    # then only the listed job(s) will not be performed.
     #
-    #     def test_hello_job
-    #       assert_performed_jobs 1, only: HelloJob do
-    #         HelloJob.perform_later('jeremy')
-    #         LoggingJob.perform_later
-    #       end
+    #   def test_no_logging
+    #     assert_no_performed_jobs only: LoggingJob do
+    #       HelloJob.perform_later('jeremy')
     #     end
-    #
-    # An array may also be specified, to support testing multiple jobs.
-    #
-    #     def test_hello_and_logging_jobs
-    #       assert_nothing_raised do
-    #         assert_performed_jobs 2, only: [HelloJob, LoggingJob] do
-    #           HelloJob.perform_later('jeremy')
-    #           LoggingJob.perform_later('stewie')
-    #           RescueJob.perform_later('david')
-    #         end
-    #       end
-    #     end
+    #   end
     #
     # Note: This assertion is simply a shortcut for:
     #


### PR DESCRIPTION
There is a example to use the `assert_performed_jobs` in `assert_no_performed_jobs`'s doc, but I think this is a mistake.
