### PR TITLE
provide file name for fixture ERB

### DIFF
--- a/activerecord/lib/active_record/fixture_set/file.rb
+++ b/activerecord/lib/active_record/fixture_set/file.rb
@@ -52,9 +52,15 @@ module ActiveRecord
           end
         end
 
+        def prepare_erb(content)
+          erb = ERB.new(content)
+          erb.filename = @file
+          erb
+        end
+
         def render(content)
           context = ActiveRecord::FixtureSet::RenderContext.create_subclass.new
-          ERB.new(content).result(context.get_binding)
+          prepare_erb(content).result(context.get_binding)
         end
 
         # Validate our unmarshalled data.

--- a/activerecord/test/cases/fixture_set/file_test.rb
+++ b/activerecord/test/cases/fixture_set/file_test.rb
@@ -135,6 +135,12 @@ END
         end
       end
 
+      def test_erb_filename
+        filename = 'filename.yaml'
+        erb = File.new(filename).send(:prepare_erb, "<% Rails.env %>\n")
+        assert_equal erb.filename, filename
+      end
+
       private
       def tmp_yaml(name, contents)
         t = Tempfile.new name


### PR DESCRIPTION
### Summary

This pull request fixes #24355 by providing executed file information to the created ERB object.
