### PR TITLE
Add option to skip target removal on has_one associations

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_one.rb
+++ b/activerecord/lib/active_record/associations/builder/has_one.rb
@@ -5,7 +5,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_options(options)
-      valid = super + [:as]
+      valid = super + [:as, :multiple]
       valid += [:through, :source, :source_type] if options[:through]
       valid
     end

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -39,7 +39,9 @@ module ActiveRecord
           save &&= owner.persisted?
 
           transaction_if(save) do
-            remove_target!(options[:dependent]) if target && !target.destroyed? && assigning_another_record
+            if target && !target.destroyed? && assigning_another_record && !options[:multiple]
+              remove_target!(options[:dependent])
+            end
 
             if record
               set_owner_attributes(record)

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -134,6 +134,20 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_equal [companies(:first_firm).id], Account.destroyed_account_ids[companies(:first_firm).id]
   end
 
+  def test_association_change_does_not_affect_old_records
+    firm = companies(:first_firm)
+    old_account = companies(:first_firm).account_with_multiple_support
+    new_account = Account.new(:credit_limit => 5)
+
+    firm.account_with_multiple_support = new_account
+
+    # association has option :multiple => true, so don't update old account
+    assert_equal firm.id, old_account.reload.firm_id
+
+    # new account still gets associated correctly
+    assert_equal firm.account_with_multiple_support, new_account.reload
+  end
+
   def test_natural_assignment_to_already_associated_record
     company = companies(:first_firm)
     account = accounts(:signals37)

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -76,6 +76,7 @@ class Firm < Company
   has_one :account_using_foreign_and_primary_keys, :foreign_key => "firm_name", :primary_key => "name", :class_name => "Account"
   has_one :account_with_inexistent_foreign_key, class_name: 'Account', foreign_key: "inexistent"
   has_one :deletable_account, :foreign_key => "firm_id", :class_name => "Account", :dependent => :delete
+  has_one :account_with_multiple_support, :foreign_key => "firm_id", :class_name => "Account", :multiple => true
 
   has_one :account_limit_500_with_hash_conditions, -> { where :credit_limit => 500 }, :foreign_key => "firm_id", :class_name => "Account"
 

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1208,6 +1208,7 @@ The `has_one` association supports these options:
 * `:dependent`
 * `:foreign_key`
 * `:inverse_of`
+* `:multiple`
 * `:primary_key`
 * `:source`
 * `:source_type`
@@ -1273,6 +1274,11 @@ class Account < ApplicationRecord
   belongs_to :supplier, inverse_of: :account
 end
 ```
+
+##### `:multiple`
+By default, a `has_one` association assumes you want there to be at most one record in the association table tied to your model. When you save a new association, any existing entries will be removed, based on your setting in `:dependent` and defaulting to nullification.
+
+To disable this, you can set `:multiple` to `true`.
 
 ##### `:primary_key`
 


### PR DESCRIPTION
`has_one` associations automatically remove all of a model's previously associated records on that table. By default, this is done by updating all matching records to nullify their foreign keys.

As far as I can tell, this feature is not documented anywhere, and cannot be disabled.

Adding the option to set `:multiple => true` lets users opt out of this behavior.

One use case is having both `has_one` and `has_many` associations between two models.

Another is having the association's table store historical records, but only exposing the current one to the model (based on whatever scope is passed in).
