### PR TITLE
Bump bcrypt-ruby version to 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ else
   gem 'arel'
 end
 
-gem 'bcrypt-ruby', '~> 3.0.0'
+gem 'bcrypt-ruby', '~> 3.1.0'
 gem 'jquery-rails'
 
 if ENV['JOURNEY']

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -10,9 +10,9 @@ module ActiveModel
       # a "password_confirmation" attribute) are automatically added.
       # You can add more validations by hand if need be.
       #
-      # You need to add bcrypt-ruby (~> 3.0.0) to Gemfile to use has_secure_password:
+      # You need to add bcrypt-ruby (~> 3.1.0) to Gemfile to use has_secure_password:
       #
-      #   gem 'bcrypt-ruby', '~> 3.0.0'
+      #   gem 'bcrypt-ruby', '~> 3.1.0'
       #
       # Example using Active Record (which automatically includes ActiveModel::SecurePassword):
       #
@@ -34,7 +34,7 @@ module ActiveModel
       def has_secure_password
         # Load bcrypt-ruby only when has_secure_password is used.
         # This is to avoid ActiveModel (and by extension the entire framework) being dependent on a binary library.
-        gem 'bcrypt-ruby', '~> 3.0.0'
+        gem 'bcrypt-ruby', '~> 3.1.0'
         require 'bcrypt'
 
         attr_reader :password

--- a/railties/guides/code/getting_started/Gemfile
+++ b/railties/guides/code/getting_started/Gemfile
@@ -23,7 +23,7 @@ end
 gem 'jquery-rails'
 
 # To use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.0.0'
+# gem 'bcrypt-ruby', '~> 3.1.0'
 
 # To use Jbuilder templates for JSON
 # gem 'jbuilder'

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -11,7 +11,7 @@ source 'https://rubygems.org'
 <%= javascript_gemfile_entry %>
 
 # To use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.0.0'
+# gem 'bcrypt-ruby', '~> 3.1.0'
 
 # To use Jbuilder templates for JSON
 # gem 'jbuilder'


### PR DESCRIPTION
Rails 3.2 running on Ruby >=2.2.0 still has the problem where bcrypt-ruby
throws BCrypt::Errors::InvalidSalt error while trying to serialize
to yaml ActiveRecord models with has_secure_password enabled.

bcrypt-ruby 3.1.9 fixes this problem
