### PR TITLE
Suppress warnings

### DIFF
--- a/actionmailer/test/i18n_with_controller_test.rb
+++ b/actionmailer/test/i18n_with_controller_test.rb
@@ -25,7 +25,9 @@ end
 class ActionMailerI18nWithControllerTest < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new
   Routes.draw do
-    get ':controller(/:action(/:id))'
+    ActiveSupport::Deprecation.silence do
+      get ':controller(/:action(/:id))'
+    end
   end
 
   class RoutedRackApp

--- a/actionmailer/test/url_test.rb
+++ b/actionmailer/test/url_test.rb
@@ -79,9 +79,11 @@ class ActionMailerUrlTest < ActionMailer::TestCase
     UrlTestMailer.delivery_method = :test
 
     AppRoutes.draw do
-      get ':controller(/:action(/:id))'
-      get '/welcome'  => 'foo#bar', as: 'welcome'
-      get '/dummy_model' => 'foo#baz', as: 'dummy_model'
+      ActiveSupport::Deprecation.silence do
+        get ':controller(/:action(/:id))'
+        get '/welcome'  => 'foo#bar', as: 'welcome'
+        get '/dummy_model' => 'foo#baz', as: 'dummy_model'
+      end
     end
 
     # string
@@ -108,8 +110,10 @@ class ActionMailerUrlTest < ActionMailer::TestCase
     UrlTestMailer.delivery_method = :test
 
     AppRoutes.draw do
-      get ':controller(/:action(/:id))'
-      get '/welcome' => "foo#bar", as: "welcome"
+      ActiveSupport::Deprecation.silence do
+        get ':controller(/:action(/:id))'
+        get '/welcome' => "foo#bar", as: "welcome"
+      end
     end
 
     expected = new_mail


### PR DESCRIPTION
"Using a dynamic :controller (or :action) segment in a route is deprecated"
by 6520ea5f7e2215a763ca74bf6cfa87be2347d5df (#23980).
