### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,7 +306,7 @@ DEPENDENCIES
   racc (>= 1.4.6)
   rack-cache (~> 1.2)
   rails!
-  rake (>= 10.3)
+  rake (>= 11.1)
   redcarpet (~> 3.2.3)
   redis
   resque (< 1.26)


### PR DESCRIPTION
'rake' gem is bundled to '>= 11.1' by 30279704646fff33e64c71ee3c4de34bf75232c4
(#23499), but it seems the commit did not fully include Gemfile.lock's.
