### PR TITLE
Replace _meth with _method to remove ambiguity

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -571,15 +571,15 @@ module ActiveSupport
 
       # Install a callback for the given event.
       #
-      #   set_callback :save, :before, :before_meth
-      #   set_callback :save, :after,  :after_meth, if: :condition
+      #   set_callback :save, :before, :before_method
+      #   set_callback :save, :after,  :after_method, if: :condition
       #   set_callback :save, :around, ->(r, block) { stuff; result = block.call; stuff }
       #
       # The second argument indicates whether the callback is to be run +:before+,
       # +:after+, or +:around+ the event. If omitted, +:before+ is assumed. This
       # means the first example above can also be written as:
       #
-      #   set_callback :save, :before_meth
+      #   set_callback :save, :before_method
       #
       # The callback can be specified as a symbol naming an instance method; as a
       # proc, lambda, or block; as a string to be instance evaluated(deprecated); or as an


### PR DESCRIPTION
### Summary

Documentation change to remove ambiguous usage of before_meth and after_meth. In addition, complete words in variable names are generally preferred in Ruby style when possible.

[ci skip]
