### PR TITLE
Fix TimeZone::MAPPING for 'Kyiv'

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -94,7 +94,7 @@ module ActiveSupport
       "Bucharest"                    => "Europe/Bucharest",
       "Cairo"                        => "Africa/Cairo",
       "Helsinki"                     => "Europe/Helsinki",
-      "Kyiv"                         => "Europe/Kiev",
+      "Kyiv"                         => "Europe/Kyiv",
       "Riga"                         => "Europe/Riga",
       "Sofia"                        => "Europe/Sofia",
       "Tallinn"                      => "Europe/Tallinn",


### PR DESCRIPTION
ICANN renamed `Europe/Kiev` to `Europe/Kyiv` in
2022b release, https://mm.icann.org/pipermail/tz-announce/2022-August/000071.html.

`tzinfo/tzinfo-data` gem updated to tzdata version 2022b, https://github.com/tzinfo/tzinfo-data/commit/5a58dcb82e99bf860e2bb95a402707e7e4bbbb1d.

Related to https://en.wikipedia.org/wiki/KyivNotKiev

The original request to ICANN: https://mm.icann.org/pipermail/tz/2016-April/023512.html
