### PR TITLE
Cable: reconcile default worker pool size with low db conn pool size

### DIFF
--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -52,7 +52,17 @@ module ActionCable
         @event_loop || @mutex.synchronize { @event_loop ||= config.event_loop_class.new }
       end
 
-      # The thread worker pool for handling all the connection work on this server. Default size is set by config.worker_pool_size.
+      # The worker pool is where we run connection callbacks and channel actions. We do as little as possible on the server's main thread.
+      # The worker pool is an executor service that's backed by a pool of threads working from a task queue. The thread pool size maxes out
+      # at 4 worker threads by default. Tune the size yourself with config.action_cable.worker_pool_size.
+      #
+      # Using Active Record, Redis, etc within your channel actions means you'll get a separate connection from each thread in the worker pool.
+      # Plan your deployment accordingly: 5 servers each running 5 Puma workers each running an 8-thread worker pool means at least 200 database
+      # connections.
+      #
+      # Also, ensure that your database connection pool size is as least as large as your worker pool size. Otherwise, workers may oversubscribe
+      # the db connection pool and block while they wait for other workers to release their connections. Use a smaller worker pool or a larger
+      # db connection pool instead.
       def worker_pool
         @worker_pool || @mutex.synchronize { @worker_pool ||= ActionCable::Server::Worker.new(max_size: config.worker_pool_size) }
       end

--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -14,7 +14,7 @@ module ActionCable
         @log_tags = []
 
         @connection_class = ActionCable::Connection::Base
-        @worker_pool_size = 100
+        @worker_pool_size = 4
 
         @disable_request_forgery_protection = false
       end


### PR DESCRIPTION
Whack it down from 100 to 4.

Large worker pools means large db connection counts. We aren't set up
for that by default and most apps won't need it out of the box.

We're better off tuning the default worker pool for low traffic, low
resource consumption apps. Those who have higher traffic will scale up
to meet demand.
