### PR TITLE
Fix method String#upcase_first

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,6 +1,6 @@
 *   Add `String#upcase_first` method.
 
-     *Glauco Custódio*
+    *Glauco Custódio*, *bogdanvlviv*
 
 *   Prevent `Marshal.load` from looping infinitely when trying to autoload a constant
     which resolves to a different name.

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -224,7 +224,9 @@ class String
 
   # Converts just the first character to uppercase.
   #
-  #  'what a Lovely Day'.upcase_first # => "What a Lovely Day"
+  #   'what a Lovely Day'.upcase_first # => "What a Lovely Day"
+  #   'w'.upcase_first                 # => "W"
+  #   ''.upcase_first                  # => ""
   def upcase_first
     ActiveSupport::Inflector.upcase_first(self)
   end

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -142,9 +142,11 @@ module ActiveSupport
 
     # Converts just the first character to uppercase.
     #
-    #  'what a Lovely Day'.upcase_first # => "What a Lovely Day"
+    #   upcase_first('what a Lovely Day') # => "What a Lovely Day"
+    #   upcase_first('w')                 # => "W"
+    #   upcase_first('')                  # => ""
     def upcase_first(string)
-      string[0].upcase.concat(string[1..-1])
+      string.length > 0 ? string[0].upcase.concat(string[1..-1]) : ''
     end
 
     # Capitalizes all the words and replaces some characters in the string to

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -80,6 +80,14 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal "What a Lovely Day", "what a Lovely Day".upcase_first
   end
 
+  def test_upcase_first_with_one_char
+    assert_equal "W", "w".upcase_first
+  end
+
+  def test_upcase_first_with_empty_string
+    assert_equal "", "".upcase_first
+  end
+
   def test_camelize
     CamelToUnderscore.each do |camel, underscore|
       assert_equal(camel, underscore.camelize)


### PR DESCRIPTION
Method `String#upcase_first` called to empty string raises error because of 
`""[0] # => nil` 
`""[0].upcase # => NoMethodError: undefined method 'upcase' for nil:NilClass`
or 
`""[1..-1] #=> nil` 
`i_am_string.concat(nil) # => TypeError: no implicit conversion of nil into String`

We have method `String#upcase`. it work with empty string. I think expected that `String#upcase_string` will be work with empty strings instead of raise error.

If this changes is not correct, at least we must raise another error instead of `NoMethodError: undefined method 'upcase' for nil:NilClass`.
