### PR TITLE
sanitiser helper may be remove in 5.1, update doc [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -120,7 +120,7 @@ module ActionView
         attr_writer :full_sanitizer, :link_sanitizer, :white_list_sanitizer
 
         # Vendors the full, link and white list sanitizers.
-        # Provided strictly for compatibility and can be removed in Rails 5.
+        # Provided strictly for compatibility and can be removed in Rails 5.1.
         def sanitizer_vendor
           Rails::Html::Sanitizer
         end


### PR DESCRIPTION
using `rails-html-sanitizer` gem still Rails providing `strip_tags`, `strip_links` features. May be it'll not remove in 5; according that updated doc

@kaspth @rafaelfranca 
