### PR TITLE
QuietAssets is in Rails now

### DIFF
--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -43,6 +43,7 @@ module Rails
           middleware.use ::ActionDispatch::RequestId
 
           # Must come after Rack::MethodOverride to properly log overridden methods
+          middleware.use ::Rails::Rack::QuietAssets if config.respond_to?(:quiet_assets) && config.quiet_assets
           middleware.use ::Rails::Rack::Logger, config.log_tags
           middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
           middleware.use ::ActionDispatch::DebugExceptions, app, config.debug_exception_response_format

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -1,5 +1,6 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  config.quiet_assets = true
 
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development

--- a/railties/lib/rails/rack.rb
+++ b/railties/lib/rails/rack.rb
@@ -1,5 +1,6 @@
 module Rails
   module Rack
-    autoload :Logger, "rails/rack/logger"
+    autoload :Logger,      "rails/rack/logger"
+    autoload :QuietAssets, "rails/rack/quiet_assets"
   end
 end

--- a/railties/lib/rails/rack/quiet_assets.rb
+++ b/railties/lib/rails/rack/quiet_assets.rb
@@ -1,0 +1,18 @@
+module Rails
+  module Rack
+    class QuietAssets
+      def initialize(app)
+        @app = app
+        @assets_regex = %r(\A/{0,2}#{Rails.application.config.assets.prefix})
+      end
+
+      def call(env)
+        if env['PATH_INFO'] =~ @assets_regex
+          Rails.logger.silence { @app.call(env) }
+        else
+          @app.call(env)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I assume everyone's aware of annoying assets logs and suppressed them with https://github.com/evrone/quiet_assets gem. It was convenient for a long while but it also suffered from thread safety issues because the trick was to manipulate logger level. Since @dhh said it'd be great to have it in Rails https://github.com/evrone/quiet_assets/issues/47#issuecomment-184186025 it's time to do so. Guys please leave me feedback about everything (like if you're not agree to put this middleware to Rails::Rack or name of the config option or whatever) and I'll fix it.
