### PR TITLE
Change `filter_parameters` to use returned `value` when procs are passed

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Change `filter_parameters` to use returned `value` instead of destructing `value`
+    when procs are passed.
+
+    *Yuichiro Kaneko*
+
 *   ETags: Introduce `Response#strong_etag=` and `#weak_etag=` and analogous
     options for `fresh_when` and `stale?`. `Response#etag=` sets a weak ETag.
 

--- a/actionpack/lib/action_dispatch/http/parameter_filter.rb
+++ b/actionpack/lib/action_dispatch/http/parameter_filter.rb
@@ -67,7 +67,7 @@ module ActionDispatch
             elsif blocks.any?
               key = key.dup if key.duplicable?
               value = value.dup if value.duplicable?
-              blocks.each { |b| b.call(key, value) }
+              value = blocks.inject(value) { |v, b| b.call(key, v) }
             end
             parents.pop if deep_regexps
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1061,7 +1061,7 @@ class RequestParameterFilter < BaseRequestTest
 
       filter_words << 'blah'
       filter_words << lambda { |key, value|
-        value.reverse! if key =~ /bargain/
+        key =~ /bargain/ ? value.reverse : value
       }
 
       parameter_filter = ActionDispatch::Http::ParameterFilter.new(filter_words)


### PR DESCRIPTION
Because proc is something like function, it is unnatural to expect procs to
destruct passed `value` to filter parameters.
And ruby has more un-destructive method than destructive method,
so using returned value gives developers more flexibility in filtering
parameters.
