### PR TITLE
Prevent db:schema:load to protected environments

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -256,7 +256,7 @@ db_namespace = namespace :db do
     end
 
     desc 'Loads a schema.rb file into the database'
-    task :load => [:environment, :load_config] do
+    task :load => [:environment, :load_config, :check_protected_environments] do
       ActiveRecord::Tasks::DatabaseTasks.load_schema_current(:ruby, ENV['SCHEMA'])
     end
 


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/22967 to protect against loading a schema on accident in production.

cc @schneems
