### PR TITLE
`number_to_phone` formats number with regexp

### DIFF
--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -23,7 +23,7 @@ module ActionView
         end
       end
 
-      # Formats a +number+ into a US phone number (e.g., (555)
+      # Formats a +number+ into a phone number (US by default e.g., (555)
       # 123-9876). You can customize the format in the +options+ hash.
       #
       # ==== Options
@@ -35,6 +35,8 @@ module ActionView
       #   end of the generated number.
       # * <tt>:country_code</tt> - Sets the country code for the phone
       #   number.
+      # * <tt>:pattern</tt> - Specifies how the number is divided into three
+      #   groups with the custom regexp to override the default format.
       # * <tt>:raise</tt> - If true, raises +InvalidNumberError+ when
       #   the argument is invalid.
       #
@@ -52,6 +54,11 @@ module ActionView
       #
       #   number_to_phone(1235551234, country_code: 1, extension: 1343, delimiter: ".")
       #   # => +1.123.555.1234 x 1343
+      #
+      #   number_to_phone(75561234567, pattern: /(\d{1,4})(\d{4})(\d{4})$/, area_code: true)
+      #   # => "(755) 6123-4567"
+      #   number_to_phone(13312345678, pattern: /(\d{3})(\d{4})(\d{4})$/))
+      #   # => "133-1234-5678"
       def number_to_phone(number, options = {})
         return unless number
         options = options.symbolize_keys

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Make `number_to_phone` format number with regexp pattern.
+
+        number_to_phone(18812345678, pattern: /(\d{3})(\d{4})(\d{4})/)
+        # => 188-1234-5678
+
+    *Pan Gaoyong*
+
 *   Add `String#upcase_first` method.
 
     *Glauco Custódio*, *bogdanvlviv*

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -15,7 +15,7 @@ module ActiveSupport
 
     extend self
 
-    # Formats a +number+ into a US phone number (e.g., (555)
+    # Formats a +number+ into a phone number (US by default e.g., (555)
     # 123-9876). You can customize the format in the +options+ hash.
     #
     # ==== Options
@@ -27,6 +27,8 @@ module ActiveSupport
     #   end of the generated number.
     # * <tt>:country_code</tt> - Sets the country code for the phone
     #   number.
+    # * <tt>:pattern</tt> - Specifies how the number is divided into three
+    #   groups with the custom regexp to override the default format.
     # ==== Examples
     #
     #   number_to_phone(5551234)                                     # => "555-1234"
@@ -40,6 +42,11 @@ module ActiveSupport
     #
     #   number_to_phone(1235551234, country_code: 1, extension: 1343, delimiter: '.')
     #   # => "+1.123.555.1234 x 1343"
+    #
+    #   number_to_phone(75561234567, pattern: /(\d{1,4})(\d{4})(\d{4})$/, area_code: true)
+    #   # => "(755) 6123-4567"
+    #   number_to_phone(13312345678, pattern: /(\d{3})(\d{4})(\d{4})$/))
+    #   # => "133-1234-5678"
     def number_to_phone(number, options = {})
       NumberToPhoneConverter.convert(number, options)
     end

--- a/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
@@ -18,12 +18,16 @@ module ActiveSupport
         end
 
         def convert_with_area_code(number)
-          number.gsub!(/(\d{1,3})(\d{3})(\d{4}$)/,"(\\1) \\2#{delimiter}\\3")
+          default_pattern = /(\d{1,3})(\d{3})(\d{4}$)/
+          number.gsub!(regexp_pattern(default_pattern),
+                       "(\\1) \\2#{delimiter}\\3")
           number
         end
 
         def convert_without_area_code(number)
-          number.gsub!(/(\d{0,3})(\d{3})(\d{4})$/,"\\1#{delimiter}\\2#{delimiter}\\3")
+          default_pattern = /(\d{0,3})(\d{3})(\d{4})$/
+          number.gsub!(regexp_pattern(default_pattern),
+                       "\\1#{delimiter}\\2#{delimiter}\\3")
           number.slice!(0, 1) if start_with_delimiter?(number)
           number
         end
@@ -43,6 +47,11 @@ module ActiveSupport
         def phone_ext(ext)
           ext.blank? ? "" : " x #{ext}"
         end
+
+        def regexp_pattern(default_pattern)
+          opts.fetch :pattern, default_pattern
+        end
+
     end
   end
 end

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -57,6 +57,8 @@ module ActiveSupport
           assert_equal("+18005551212", number_helper.number_to_phone(8005551212, :country_code => 1, :delimiter => ''))
           assert_equal("22-555-1212", number_helper.number_to_phone(225551212))
           assert_equal("+45-22-555-1212", number_helper.number_to_phone(225551212, :country_code => 45))
+          assert_equal("(755) 6123-4567", number_helper.number_to_phone(75561234567, pattern: /(\d{3,4})(\d{4})(\d{4})/, area_code: true))
+          assert_equal("133-1234-5678", number_helper.number_to_phone(13312345678, pattern: /(\d{3})(\d{4})(\d{4})/))
         end
       end
 


### PR DESCRIPTION
### Summary

By default, the helper method `number_to_phone` formats US number. This commit extends its functionality to format number for other countries with a custom regular expression. For example,
formatting a non-us mobile number,

```
number_to_phone(18812345678, pattern: /(\d{3})(\d{4})(\d{4})/)
# => 188-1234-5678
```

The output phone number is divided into three groups, so the regexp
should also match three groups of numbers.
