### PR TITLE
Honor shallow: false on nested resources

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1362,6 +1362,8 @@ module ActionDispatch
         #   as a comment on a blog post like <tt>/posts/a-long-permalink/comments/1234</tt>
         #   to be shortened to just <tt>/comments/1234</tt>.
         #
+        #   Set shallow: false on a child resource to ignore a parent's shallow parameter.
+        #
         # [:shallow_path]
         #   Prefixes nested shallow routes with the specified path.
         #
@@ -1724,7 +1726,8 @@ to this:
               return true
             end
 
-            if options.delete(:shallow)
+            if options[:shallow]
+              options.delete(:shallow)
               shallow do
                 send(method, resources.pop, options, &block)
               end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -2128,6 +2128,37 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal 'cards#destroy', @response.body
   end
 
+  def test_shallow_false_inside_nested_shallow_resource
+    draw do
+      resources :blogs, shallow: true do
+        resources :posts do
+          resources :comments, shallow: false
+          resources :tags
+        end
+      end
+    end
+
+    get '/posts/1/comments'
+    assert_equal 'comments#index', @response.body
+    assert_equal '/posts/1/comments', post_comments_path('1')
+
+    get '/posts/1/comments/new'
+    assert_equal 'comments#new', @response.body
+    assert_equal '/posts/1/comments/new', new_post_comment_path('1')
+
+    get '/posts/1/comments/2'
+    assert_equal 'comments#show', @response.body
+    assert_equal '/posts/1/comments/2', post_comment_path('1', '2')
+
+    get '/posts/1/comments/2/edit'
+    assert_equal 'comments#edit', @response.body
+    assert_equal '/posts/1/comments/2/edit', edit_post_comment_path('1', '2')
+
+    get '/tags/3'
+    assert_equal 'tags#show', @response.body
+    assert_equal '/tags/3', tag_path('3')
+  end
+
   def test_shallow_deeply_nested_resources
     draw do
       resources :blogs do


### PR DESCRIPTION
### Summary

Previously there was no way to place a non-shallow resource inside a parent
with `shallow: true` set. Now you can set `shallow: false` on a nested child
resource to generate normal (non-shallow) routes for it.

For example:

``` ruby
resources :blogs, shallow: true do
  resources :posts do
    resources :comments, shallow: false
  end
end
```

Generates:

> /posts/1/comments
> /posts/1/comments/2

Instead of:

> /posts/1/comments
> /comments/2

See #23890 for original request and more clarification.

P.S. This is my first attempt at contributing to Rails, so criticism is welcome!
