### PR TITLE
ADD: new method for logging response status code and response content length

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -15,7 +15,7 @@ module Rails
                     :railties_order, :relative_url_root, :secret_key_base, :secret_token,
                     :serve_static_files, :ssl_options, :static_cache_control, :session_options,
                     :time_zone, :reload_classes_only_on_change,
-                    :beginning_of_week, :filter_redirect, :x
+                    :beginning_of_week, :filter_redirect, :log_start_response_message, :x
 
       attr_reader :encoding
 
@@ -50,6 +50,7 @@ module Rails
         @eager_load                    = nil
         @secret_token                  = nil
         @secret_key_base               = nil
+        @log_start_response_message    = false
         @x                             = Custom.new
 
         @assets = ActiveSupport::OrderedOptions.new

--- a/railties/test/rack_logger_test.rb
+++ b/railties/test/rack_logger_test.rb
@@ -70,6 +70,47 @@ module Rails
           end
         end
       end
+
+      def test_started_response_message_with_flag_disabled
+        logger_filename = "./rack_logger_test.log"
+        File.open(logger_filename, "w")
+
+        _logger = ::Logger.new(File.new(logger_filename, 'w+'))
+        logger = TestLogger.new(_logger, nil, &Proc.new { [200, {}, []] })
+
+        Rails.application.config.log_start_response_message = false
+        logger.call('REQUEST_METHOD' => 'GET').last.close
+        logger.logger.close
+
+        found_resp_line = false
+        File.open(logger_filename, "r+").each do |line|
+          found_resp_line = true if line.include? "Started response HTTP "
+        end
+        assert !found_resp_line
+
+        File.delete(logger_filename)
+      end
+
+      def test_started_response_message_with_flag_enabled
+        logger_filename = "./rack_logger_test.log"
+        File.open(logger_filename, "w")
+
+        _logger = ::Logger.new(File.new(logger_filename, 'w+'))
+        logger = TestLogger.new(_logger, nil, &Proc.new { [200, {}, []] })
+
+        Rails.application.config.log_start_response_message = true
+        logger.call('REQUEST_METHOD' => 'GET').last.close
+        logger.logger.close
+
+        found_resp_line = false
+        File.open(logger_filename, "r+").each do |line|
+          found_resp_line = true if line.include? "Started response HTTP "
+        end
+
+        assert found_resp_line
+
+        File.delete(logger_filename)
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

If log_start_response_message is set to true in application config, Rails logs also: 

```
Started response HTTP 200 (12345 bytes) for [request details]
```
