### PR TITLE
Fix lack of belongs_to validation when running db:setup and db:reset

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -23,7 +23,7 @@ db_namespace = namespace :db do
   end
 
   desc 'Creates the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:create:all to create all databases in the config). Without RAILS_ENV or when RAILS_ENV is development, it defaults to creating the development and test databases.'
-  task :create => [:load_config] do
+  task :create => [:environment, :load_config] do
     ActiveRecord::Tasks::DatabaseTasks.create_current
   end
 
@@ -34,7 +34,7 @@ db_namespace = namespace :db do
   end
 
   desc 'Drops the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:drop:all to drop all databases in the config). Without RAILS_ENV or when RAILS_ENV is development, it defaults to dropping the development and test databases.'
-  task :drop => [:load_config, :check_protected_environments] do
+  task :drop => [:check_protected_environments] do
     db_namespace["drop:_unsafe"].invoke
   end
 


### PR DESCRIPTION
### Summary

Fixes #23854.

Creating a record that is missing a required-by-default `belongs_to` association with `create!` in seeds.rb doesn't raise an error when running `db:setup` or `db:reset`. This causes invalid records to be persisted to the database.

I tracked this down to `:environment` not being called in the `db:create` task (which setup and reset call) and being called out of order (after `:load_config`) in `db:drop` (technically, `:load_config` is called twice there, due to `:check_protected_environments` calling it also).
### Other Information

This bug _may_ have been introduced when `:check_protected_environments` was added in #22967.
Also, for reference, `belongs_to` was made required by default in #18233.
