### PR TITLE
Teach config.ru about relative_url_root

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config.ru
+++ b/railties/lib/rails/generators/rails/app/templates/config.ru
@@ -2,4 +2,6 @@
 
 require_relative 'config/environment'
 
-run Rails.application
+map Rails.application.config.relative_url_root || '/' do
+  run Rails.application
+end


### PR DESCRIPTION
The routes created by the `config.ru` generated by default do not take the value of `relative_url_root` into account.

With this change, Rails applications can be deployed to a non-root path by setting the environment variable `RAILS_RELATIVE_URL_ROOT` and without other modifications to the source code.

This change would alleviate or solve the problems reported in #24393 and #21193.
