### PR TITLE
Extend `ActionController::TestCase` deprecation warning

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -211,7 +211,7 @@
 
     *Derek Prior*
 
-*   `ActionController::TestCase` will be moved to it's own gem in Rails 5.1
+*   `ActionController::TestCase` will be moved to its own gem in Rails 5.1
 
     With the speed improvements made to `ActionDispatch::IntegrationTest` we no
     longer need to keep two separate code bases for testing controllers. In

--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -270,7 +270,7 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 *   Changed the `protect_from_forgery` prepend default to `false`.
     ([commit](https://github.com/rails/rails/commit/39794037817703575c35a75f1961b01b83791191))
 
-*   `ActionController::TestCase` will be moved to it's own gem in Rails 5.1. Use
+*   `ActionController::TestCase` will be moved to its own gem in Rails 5.1. Use
     `ActionDispatch::IntegrationTest` instead.
     ([commit](https://github.com/rails/rails/commit/4414c5d1795e815b102571425974a8b1d46d932d))
 


### PR DESCRIPTION
### Summary

Rails 5 requires a syntax change in `ActionController::TestCase` for all `get/post/put/...` test calls, and emits a deprecation warning. But the bigger picture is that `ActionController::TestCase` is going to be put in a gem in 5.1 and this should be made obvious so that people can have a sense of the full scope of work to fix their tests.
### Other Information

The information that `ActionController::TestCase` as a whole has been
deprecated is not yet on edgerails docs release notes and can be easy to
miss unless you're reading the release notes on github directly (which
the source says not to do).

See https://github.com/rails/rails/pull/18323 for keyword arg change.
See https://github.com/rails/rails/commit/4414c5d1795e815b102571425974a8b1d46d932d for the `ActionController::TestCase` deprecation.
