### PR TITLE
Added integer value retrieval for enums

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -10,20 +10,23 @@ module ActiveRecord
   #
   #   # conversation.update! status: 0
   #   conversation.active!
-  #   conversation.active? # => true
-  #   conversation.status  # => "active"
+  #   conversation.active?         # => true
+  #   conversation.status          # => "active"
+  #   conversation.status_integer  # => 0
   #
   #   # conversation.update! status: 1
   #   conversation.archived!
-  #   conversation.archived? # => true
-  #   conversation.status    # => "archived"
+  #   conversation.archived?       # => true
+  #   conversation.status          # => "archived"
+  #   conversation.status_integer  # => 1
   #
   #   # conversation.status = 1
   #   conversation.status = "archived"
   #
   #   conversation.status = nil
-  #   conversation.status.nil? # => true
-  #   conversation.status      # => nil
+  #   conversation.status.nil?     # => true
+  #   conversation.status          # => nil
+  #   conversation.status_integer  # => nil
   #
   # Scopes based on the allowed values of the enum field will be provided
   # as well. With the above example:
@@ -155,6 +158,10 @@ module ActiveRecord
         # def self.statuses() statuses end
         detect_enum_conflict!(name, name.to_s.pluralize, true)
         klass.singleton_class.send(:define_method, name.to_s.pluralize) { enum_values }
+
+        # def status_raw() klass.statuses[self.status] end
+        klass.send(:detect_enum_conflict!, name, "#{name}_integer")
+        define_method("#{name}_integer") { klass.send(name.to_s.pluralize)[self[name]] }
 
         detect_enum_conflict!(name, name)
         detect_enum_conflict!(name, "#{name}=")

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -28,6 +28,14 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal "visible", @book.illustrator_visibility
   end
 
+  test "get integer value" do
+    assert_equal 2, @book.status_integer
+    assert_equal 3, @book.read_status_integer
+    assert_equal 0, @book.language_integer
+    assert_equal 0, @book.author_visibility_integer
+    assert_equal 0, @book.illustrator_visibility_integer
+  end
+
   test "find via scope" do
     assert_equal @book, Book.published.first
     assert_equal @book, Book.read.first


### PR DESCRIPTION
### Summary

Added a getter for integer values of enums.

**Example**

```
class Book < ActiveRecord::Base
  enum status: [:proposed, :written, :published]
end
```

```
book = Book.create(status: :proposed)
book.status
#=> :proposed
book.status_integer
#=> 0
```

Instead of only accessing the integer value using

```
Book.statuses[book.status]
#=> 0
```

or

```
book.read_attribute(:status)
#=> 0
```
