### PR TITLE
Upgrades foreign key name inference to use #table_name as opposed to association name

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -607,7 +607,7 @@ module ActiveRecord
           elsif options[:as]
             "#{options[:as]}_id"
           else
-            active_record.name.foreign_key
+            active_record.table_name.split(".").last.singularize.foreign_key
           end
         end
 


### PR DESCRIPTION
According to [ActiveRecord::Reflection::AssociationReflection#derive_foreign_key](https://github.com/rails/rails/blob/52ce6ece8c8f74064bb64e0a0b1ddd83092718e1/activerecord/lib/active_record/reflection.rb#L610) and the current documentation, foreign key names are inferred via the class name of the model, when an explicit foreign key name is not provided.

The drawback of this approach is that custom table names are not taken into consideration when inferring the foreign key's name. 

I suggest instead using the following algorithm:

``` ruby
def derive_foreign_key
  if belongs_to?
    "#{name}_id"
  elsif options[:as]
    "#{options[:as]}_id"
  else
    active_record.table_name.split(".").last.singularize.foreign_key
  end
end
```

This has the following benefits:
- Custom table names are supported
- Fully-qualified table names are supported (allowing tables from other schemas not in the search path)
- Backwards compatible with existing implementation
