### PR TITLE
Use `QUOTED_TRUE` and `QUOTED_FALSE` instead of magic strings

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -939,8 +939,8 @@ module ActiveRecord
       class MysqlString < Type::String # :nodoc:
         def serialize(value)
           case value
-          when true then "1"
-          when false then "0"
+          when true then QUOTED_TRUE
+          when false then QUOTED_FALSE
           else super
           end
         end
@@ -949,8 +949,8 @@ module ActiveRecord
 
         def cast_value(value)
           case value
-          when true then "1"
-          when false then "0"
+          when true then QUOTED_TRUE
+          when false then QUOTED_FALSE
           else super
           end
         end

--- a/activerecord/test/cases/adapters/mysql2/boolean_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/boolean_test.rb
@@ -43,11 +43,16 @@ class Mysql2BooleanTest < ActiveRecord::Mysql2TestCase
 
     boolean = BooleanType.create!(archived: true, published: true)
     attributes = boolean.reload.attributes_before_type_cast
-
     assert_equal 1, attributes["archived"]
     assert_equal "1", attributes["published"]
 
+    boolean = BooleanType.create!(archived: false, published: false)
+    attributes = boolean.reload.attributes_before_type_cast
+    assert_equal 0, attributes["archived"]
+    assert_equal "0", attributes["published"]
+
     assert_equal 1, @connection.type_cast(true)
+    assert_equal 0, @connection.type_cast(false)
   end
 
   test "test type casting without emulated booleans" do
@@ -55,11 +60,16 @@ class Mysql2BooleanTest < ActiveRecord::Mysql2TestCase
 
     boolean = BooleanType.create!(archived: true, published: true)
     attributes = boolean.reload.attributes_before_type_cast
-
     assert_equal 1, attributes["archived"]
     assert_equal "1", attributes["published"]
 
+    boolean = BooleanType.create!(archived: false, published: false)
+    attributes = boolean.reload.attributes_before_type_cast
+    assert_equal 0, attributes["archived"]
+    assert_equal "0", attributes["published"]
+
     assert_equal 1, @connection.type_cast(true)
+    assert_equal 0, @connection.type_cast(false)
   end
 
   test "with booleans stored as 1 and 0" do


### PR DESCRIPTION
Because we define `QUOTED_TRUE` as `"1"` and `QUOTED_FALSE` as `"0"`.
And add test cases to ensure this commit does not break current
behavior even if the value of `attributes_before_type_cast` is false.
