### PR TITLE
Freeze `EMPTY_ARRAY`

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -756,7 +756,7 @@ module ActionController
         end
       end
 
-      EMPTY_ARRAY = []
+      EMPTY_ARRAY = [].freeze
       def hash_filter(params, filter)
         filter = filter.with_indifferent_access
 


### PR DESCRIPTION
Because `EMPTY_ARRAY` is used to be compared with `filter[key]`, it
is better to freeze `EMPTY_ARRAY` to ensure elements are not added to
`EMPTY_ARRAY`.
