### PR TITLE
Sendmail default arguments match Mail::SendMail

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Removes `-t` from default Sendmail arguments to match the underlying
+    `Mail::Sendmail` setting.
+
+    *Clayton Liggitt*
+
+
 ## Rails 5.0.0.beta3 (February 24, 2016) ##
 
 *   Add support for fragment caching in Action Mailer views.

--- a/actionmailer/lib/action_mailer/delivery_methods.rb
+++ b/actionmailer/lib/action_mailer/delivery_methods.rb
@@ -36,7 +36,7 @@ module ActionMailer
 
       add_delivery_method :sendmail, Mail::Sendmail,
         location:  '/usr/sbin/sendmail',
-        arguments: '-i -t'
+        arguments: '-i'
 
       add_delivery_method :test, Mail::TestMailer
     end

--- a/actionmailer/test/delivery_methods_test.rb
+++ b/actionmailer/test/delivery_methods_test.rb
@@ -39,7 +39,7 @@ class DefaultsDeliveryMethodsTest < ActiveSupport::TestCase
   test "default sendmail settings" do
     settings = {
       location:  '/usr/sbin/sendmail',
-      arguments: '-i -t'
+      arguments: '-i'
     }
     assert_equal settings, ActionMailer::Base.sendmail_settings
   end


### PR DESCRIPTION
Resolves #1755 

A while back, `Mail::Sendmail` was updated to [remove the `-t` argument](https://github.com/mikel/mail/blob/master/lib/mail/network/delivery_methods/sendmail.rb#L45), and this intends to update Rails accordingly.

References:
- https://github.com/mikel/mail/issues/70
- https://github.com/mikel/mail/pull/477
