### PR TITLE
Use SQLite3 3.7.15 which supports multiple values insert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,3 +58,8 @@ services:
   - rabbitmq
 addons:
   postgresql: "9.4"
+  apt:
+    sources:
+      - travis-ci/sqlite3
+    packages:
+      - sqlite3


### PR DESCRIPTION
### Summary

This pull request updates SQLite3 database version to 3.7.15 when tested at Travis CI.
Since SQLite3 3.7.11 supports to insert multiple values in one statement.

Ref #24288 and https://github.com/travis-ci/apt-package-whitelist/issues/368
