### PR TITLE
Update example of passing a proc to `:message` option for validating records [ci skip]

### DIFF
--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Update example of passing a proc to `:message` option for validating records.
+
+    This behavior was recently changed in https://github.com/rails/rails/pull/24119 to
+    pass the object being validated as first argument to the `:message` proc
+    instead of key of the field being validated.
+
 ## Rails 5.0.0.beta3 (February 24, 2016) ##
 
 *   No changes.

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -785,7 +785,7 @@ A `String` `:message` value can optionally contain any/all of `%{value}`,
 `%{attribute}`, and `%{model}` which will be dynamically replaced when
 validation fails.
 
-A `Proc` `:message` value is given two arguments: a message key for i18n, and
+A `Proc` `:message` value is given two arguments: the object being validated, and
 a hash with `:model`, `:attribute`, and `:value` key-value pairs.
 
 ```ruby
@@ -801,10 +801,10 @@ class Person < ApplicationRecord
   # Proc
   validates :username,
     uniqueness: {
-      # key = "activerecord.errors.models.person.attributes.username.taken"
+      # object = person object being validated
       # data = { model: "Person", attribute: "Username", value: <username> }
-      message: ->(key, data) do
-        "#{data[:value]} taken! Try again #{Time.zone.tomorrow}"
+      message: ->(object, data) do
+        "Hey #{object.name}!, #{data[:value]} is taken already! Try again #{Time.zone.tomorrow}"
       end
     }
 end


### PR DESCRIPTION
- This change is made as the behavior for `:message` proc was changed in
  https://github.com/rails/rails/pull/24119.
- Also check
  https://github.com/rails/rails/pull/24431#issuecomment-206106790 for
  reference.

r? @rafaelfranca 
