### PR TITLE
The behavior of `filter_parameters` will be changed with Rails 5.1

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add warning to change the behavior of `filter_parameters` with Rails 5.1.
+
+    To give developers more flexibility in filtering parameters,
+    in Rails 5.1 procs passed to `filter_parameters` should return filtered value
+    instead of mutating the value.
+
+    See #24397
+
+    *Yuichiro Kaneko*
+
 *   Adds support for including ActionController::Cookies in API controllers.
     Previously, including the module would raise when trying to define
     a `cookies` helper method. Skip calling #helper_method if it is not

--- a/actionpack/lib/action_dispatch/http/parameter_filter.rb
+++ b/actionpack/lib/action_dispatch/http/parameter_filter.rb
@@ -49,6 +49,13 @@ module ActionDispatch
           @regexps = regexps
           @deep_regexps = deep_regexps.any? ? deep_regexps : nil
           @blocks  = blocks
+          unless blocks.empty?
+            ActiveSupport::Deprecation.warn(<<-MESSAGE.strip_heredoc)
+              The behavior of `filter_parameters` will be changed with Rails 5.1.
+              Currently procs passed to `filter_parameters` should mutate the value.
+              In Rails 5.1 procs passed to `filter_parameters` should return filtered value.
+            MESSAGE
+          end
         end
 
         def call(original_params, parents = [])

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1068,8 +1068,20 @@ class RequestParameterFilter < BaseRequestTest
       before_filter['barg'] = {:bargain=>'gain', 'blah'=>'bar', 'bar'=>{'bargain'=>{'blah'=>'foo'}}}
       after_filter['barg']  = {:bargain=>'niag', 'blah'=>'[FILTERED]', 'bar'=>{'bargain'=>{'blah'=>'[FILTERED]'}}}
 
-      assert_equal after_filter, parameter_filter.filter(before_filter)
+      ActiveSupport::Deprecation.silence do
+        assert_equal after_filter, parameter_filter.filter(before_filter)
+      end
     end
+  end
+
+  test "passing procs to ParameterFilter warns deprecation" do
+    filter_words = []
+    filter_words << lambda { |key, value|
+      value.reverse! if key =~ /bargain/
+    }
+
+    parameter_filter = ActionDispatch::Http::ParameterFilter.new(filter_words)
+    assert_deprecated { parameter_filter.filter([{'foo'=>'bar'}]) }
   end
 
   test "filtered_parameters returns params filtered" do


### PR DESCRIPTION
See also: https://github.com/rails/rails/pull/24397

Because proc is something like function, it is unnatural to expect procs to
destruct passed `value` to filter parameters.
And ruby has more un-destructive method than destructive method,
so using returned value gives developers more flexibility in filtering
parameters.

Because that change enforces for developers to rewrite procs passed to
`filter_parameters`, in Rails 5.0 we print deprecation warnings and
will change the behavior in Rails 5.1.
