### PR TITLE
use schema file digest to check of migrations change

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Automatically maintain test database schema even if migration is rolled-back,
+    modified and reapplied.
+
+    *Yuji Yaginuma*
+
 *   Delegate `empty?`, `none?` and `one?`. Now they can be invoked as model class methods.
 
     Example:

--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -19,7 +19,7 @@ module ActiveRecord
       end
 
       def []=(key, value)
-        first_or_initialize(key: key).update_attributes!(value: value)
+        where(key: key).first_or_initialize.update_attributes!(value: value)
       end
 
       def [](key)

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -252,6 +252,7 @@ db_namespace = namespace :db do
       File.open(filename, "w:utf-8") do |file|
         ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, file)
       end
+      ActiveRecord::Migrator.record_schema_file_signature(ActiveRecord::Tasks::DatabaseTasks.schema_file)
       db_namespace['schema:dump'].reenable
     end
 
@@ -298,6 +299,7 @@ db_namespace = namespace :db do
           f.print "\n"
         end
       end
+      ActiveRecord::Migrator.record_schema_file_signature(ActiveRecord::Tasks::DatabaseTasks.schema_file)
       db_namespace['structure:dump'].reenable
     end
 
@@ -328,6 +330,8 @@ db_namespace = namespace :db do
         when :sql
           db_namespace["test:load_structure"].invoke
       end
+      ActiveRecord::InternalMetadata.create_table
+      ActiveRecord::Migrator.record_schema_file_signature(ActiveRecord::Tasks::DatabaseTasks.schema_file)
     end
 
     # desc "Recreate the test database from an existent schema.rb file"

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -223,6 +223,18 @@ module ApplicationTests
           assert_match(/up\s+\d{14}\s+\** NO FILE \**/, output)
         end
       end
+
+      test 'does not record schema file signature when schema file not exist' do
+        add_to_config('config.active_record.dump_schema_after_migration = false')
+        require "#{app_path}/config/environment"
+        Dir.chdir(app_path) do
+          `bin/rails generate model user username:string password:string;
+           bin/rails db:migrate`
+
+          assert_not File.exist?("db/schema.rb")
+          assert_not ActiveRecord::InternalMetadata[:schema_file_signature]
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The current automatic schema maintenance can't detect when a migration is
rolled-back, modified and reapplied.
This is an attempt to detect the change even in such a case.
