### PR TITLE
Disallow calling `#deliver_later` after local message modifications.

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Disallow calling `#deliver_later` after making local modifications to
+    the message which would be lost when the delivery job is enqueued.
+
+    Prevents a common, hard-to-find bug like
+
+        message = Notifier.welcome(user, foo)
+        message.message_id = my_generated_message_id
+        message.deliver_later
+
+    The message_id is silently lost! *Only the mailer arguments are passed
+    to the delivery job.*
+
+    This raises an exception now. Make modifications to the message within
+    the mailer method instead, or use a custom Active Job to manage delivery
+    instead of using #deliver_later.
+
+    *Jeremy Daer*
+
 *   Removes `-t` from default Sendmail arguments to match the underlying
     `Mail::Sendmail` setting.
 

--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -93,4 +93,12 @@ class MessageDeliveryTest < ActiveSupport::TestCase
       @mail.deliver_later(queue: :another_queue)
     end
   end
+
+  test 'deliver_later after accessing the message is disallowed' do
+    @mail.message # Load the message, which calls the mailer method.
+
+    assert_raise RuntimeError do
+      @mail.deliver_later
+    end
+  end
 end


### PR DESCRIPTION
Prevents a common, hard-to-find bug where local message changes aren't enqueued with the delivery job:

``` ruby
message = Notifier.welcome(user, foo)
message.message_id = my_generated_message_id
message.deliver_later
```

The message_id is silently lost here! _Only the mailer arguments are passed to the delivery job._

This raises an exception now.

Make modifications to the message within the mailer method or use a custom Active Job to manage delivery instead of using `#deliver_later`.
