### PR TITLE
remove blank line generated in application_mailer.rb

### DIFF
--- a/actionmailer/lib/rails/generators/mailer/templates/application_mailer.rb
+++ b/actionmailer/lib/rails/generators/mailer/templates/application_mailer.rb
@@ -1,4 +1,4 @@
-<% module_namespacing do %>
+<% module_namespacing do -%>
 class ApplicationMailer < ActionMailer::Base
   default from: 'from@example.com'
   layout 'mailer'


### PR DESCRIPTION
### Summary

Remove blank line generated in application_mailer.rb.
#### before

``` ruby
module Blorgh

  class ApplicationMailer < ActionMailer::Base
    default from: 'from@example.com'
    layout 'mailer'
  end
end 
```
#### after

``` ruby
module Blorgh
  class ApplicationMailer < ActionMailer::Base
    default from: 'from@example.com'
    layout 'mailer'
  end
end
```
