### PR TITLE
Fail db rake tasks when the configuration misses the database name

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -4,6 +4,7 @@ module ActiveRecord
   module Tasks # :nodoc:
     class DatabaseAlreadyExists < StandardError; end # :nodoc:
     class DatabaseNotSupported < StandardError; end # :nodoc:
+    class DatabaseNotSpecified < StandardError; end # :nodoc:
 
     # ActiveRecord::Tasks::DatabaseTasks is a utility class, which encapsulates
     # logic behind common tasks used to manage database and migrations.
@@ -287,7 +288,11 @@ module ActiveRecord
 
         configurations = ActiveRecord::Base.configurations.values_at(*environments)
         configurations.compact.each do |configuration|
-          yield configuration unless configuration['database'].blank?
+          if configuration['database'].blank?
+            raise DatabaseNotSpecified, 'You tried to run a database rake task, but no database is specified.'
+          else
+            yield configuration
+          end
         end
       end
 


### PR DESCRIPTION
Before this change a rake db task would silently succeed without doing anything e.g.

```
$ RAILS_ENV=development bundle exec rake db:create --trace
** Invoke db:create (first_time)
** Invoke db:load_config (first_time)
** Execute db:load_config
** Execute db:create
```

This can easily happen if the database.yml defines the configuration from environment variables and those variables are not set. It's rather hard to debug and running the task with `--trace` is not helpful either. This change raises an exception pointing to the cause of the problem.
