### PR TITLE
Show open in editor link on debug exception page

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -17,10 +17,11 @@ module ActionDispatch
       interceptors << interceptor
     end
 
-    def initialize(app, routes_app = nil, response_format = :default, interceptors = self.class.interceptors)
+    def initialize(app, routes_app = nil, response_format = :default, editor_url = nil, interceptors = self.class.interceptors)
       @app             = app
       @routes_app      = routes_app
       @response_format = response_format
+      @editor_url      = editor_url
       @interceptors    = interceptors
     end
 
@@ -54,7 +55,7 @@ module ActionDispatch
 
       def render_exception(request, exception)
         backtrace_cleaner = request.get_header("action_dispatch.backtrace_cleaner")
-        wrapper = ExceptionWrapper.new(backtrace_cleaner, exception)
+        wrapper = ExceptionWrapper.new(backtrace_cleaner, exception, @editor_url)
         log_error(request, wrapper)
 
         if request.get_header("action_dispatch.show_detailed_exceptions")

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -42,11 +42,12 @@ module ActionDispatch
 
     attr_reader :backtrace_cleaner, :exception, :wrapped_causes, :line_number, :file
 
-    def initialize(backtrace_cleaner, exception)
+    def initialize(backtrace_cleaner, exception, editor_url = nil)
       @backtrace_cleaner = backtrace_cleaner
       @exception = exception
       @exception_class_name = @exception.class.name
       @wrapped_causes = wrapped_causes_for(exception, backtrace_cleaner)
+      @editor_url = editor_url
 
       expand_backtrace if exception.is_a?(SyntaxError) || exception.cause.is_a?(SyntaxError)
     end
@@ -120,10 +121,15 @@ module ActionDispatch
     def source_extracts
       backtrace.map do |trace|
         file, line_number = extract_file_and_line_number(trace)
+        editor_url = @editor_url && @editor_url % {
+          file: URI.encode_www_form_component(file),
+          line: line_number
+        }
 
         {
           code: source_fragment(file, line_number),
-          line_number: line_number
+          line_number: line_number,
+          editor_url: editor_url
         }
       end
     end

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
@@ -4,6 +4,9 @@
   <% if source_extract[:code] %>
     <div class="source <%= "hidden" if show_source_idx != index %>" id="frame-source-<%= error_index %>-<%= index %>">
       <div class="info">
+        <% if source_extract[:editor_url] %>
+          <a class="editor_url" href="<%= source_extract[:editor_url] %>">Open in editor</a>
+        <% end %>
         Extracted source (around line <strong>#<%= source_extract[:line_number] %></strong>):
       </div>
       <div class="data">

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -100,6 +100,10 @@
       padding: 0.5em;
     }
 
+    .info .editor_url {
+      float: right;
+    }
+
     .source .data .line_numbers {
       background-color: #ECECEC;
       color: #AAA;

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -705,4 +705,21 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_select "#container p", /Showing #{__FILE__} where line #\d+ raised/
     assert_select "#container code", /undefined local variable or method `string”'/
   end
+
+  test "debug exceptions app shows open in editor link if such option passed" do
+    @app = ActionDispatch::DebugExceptions.new(Boomer.new(true), RoutesApp, :default, "editor_url_file=%{file},editor_url_line=%{line}")
+    Rails.stub :root, Pathname.new(".") do
+      cleaner = ActiveSupport::BacktraceCleaner.new.tap do |bc|
+        bc.add_silencer { |line| line =~ /method_that_raises/ }
+        bc.add_silencer { |line| line !~ %r{test/dispatch/debug_exceptions_test.rb} }
+      end
+
+      get "/framework_raises", headers: { "action_dispatch.backtrace_cleaner" => cleaner }
+
+      assert_select "div.source:not(.hidden)" do
+        assert_select ".info .editor_url", /Open in editor/
+        assert_match(/editor_url_file=\S+,editor_url_line=\d+/, assert_select(".info .editor_url").first["href"])
+      end
+    end
+  end
 end

--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -29,7 +29,7 @@ module ActionDispatch
       wrapper = ExceptionWrapper.new(nil, exception)
 
       assert_called_with(wrapper, :source_fragment, ["lib/file.rb", 42], returns: "foo") do
-        assert_equal [ code: "foo", line_number: 42 ], wrapper.source_extracts
+        assert_equal [ code: "foo", line_number: 42, editor_url: nil ], wrapper.source_extracts
       end
     end
 
@@ -39,7 +39,7 @@ module ActionDispatch
       wrapper = ExceptionWrapper.new(nil, exc)
 
       assert_called_with(wrapper, :source_fragment, ["c:/path/to/rails/app/controller.rb", 27], returns: "nothing") do
-        assert_equal [ code: "nothing", line_number: 27 ], wrapper.source_extracts
+        assert_equal [ code: "nothing", line_number: 27, editor_url: nil ], wrapper.source_extracts
       end
     end
 
@@ -49,7 +49,16 @@ module ActionDispatch
       wrapper = ExceptionWrapper.new(nil, exc)
 
       assert_called_with(wrapper, :source_fragment, ["invalid", 0], returns: "nothing") do
-        assert_equal [ code: "nothing", line_number: 0 ], wrapper.source_extracts
+        assert_equal [ code: "nothing", line_number: 0, editor_url: nil ], wrapper.source_extracts
+      end
+    end
+
+    test "#source_extracts add editor_url if such option passed" do
+      exception = TestError.new("lib/file.rb:42:in `index'")
+      wrapper = ExceptionWrapper.new(nil, exception, "editor_url_file=%{file},editor_url_line=%{line}")
+
+      assert_called_with(wrapper, :source_fragment, ["lib/file.rb", 42], returns: "foo") do
+        assert_equal [ code: "foo", line_number: 42, editor_url: "editor_url_file=lib%2Ffile.rb,editor_url_line=42" ], wrapper.source_extracts
       end
     end
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -22,7 +22,7 @@ module Rails
                     :require_master_key, :credentials, :disable_sandbox, :add_autoload_paths_to_load_path,
                     :rake_eager_load
 
-      attr_reader :encoding, :api_only, :loaded_config_version, :autoloader
+      attr_reader :encoding, :api_only, :loaded_config_version, :autoloader, :debug_exception_editor_url
 
       def initialize(*)
         super
@@ -72,6 +72,7 @@ module Rails
         @add_autoload_paths_to_load_path         = true
         @feature_policy                          = nil
         @rake_eager_load                         = false
+        @debug_exception_editor_url              = nil
       end
 
       # Loads default configurations. See {the result of the method for each version}[https://guides.rubyonrails.org/configuring.html#results-of-config-load-defaults].
@@ -357,6 +358,14 @@ module Rails
         f.binmode
         f.sync = autoflush_log # if true make sure every write flushes
         f
+      end
+
+      def debug_exception_editor_url=(url)
+        @debug_exception_editor_url =
+          case url
+          when Symbol then "#{url}://open?url=file://%{file}&line=%{line}"
+          when String then url
+          end
       end
 
       class Custom #:nodoc:

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -48,7 +48,7 @@ module Rails
 
           middleware.use ::Rails::Rack::Logger, config.log_tags
           middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
-          middleware.use ::ActionDispatch::DebugExceptions, app, config.debug_exception_response_format
+          middleware.use ::ActionDispatch::DebugExceptions, app, config.debug_exception_response_format, config.debug_exception_editor_url
           middleware.use ::ActionDispatch::ActionableExceptions
 
           unless config.cache_classes

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2503,6 +2503,26 @@ module ApplicationTests
       assert_equal true, Rails.application.config.rake_eager_load
     end
 
+    test "debug_exception_editor_url can be specified" do
+      add_to_config <<-RUBY
+        config.debug_exception_editor_url = '_some_editor_url_'
+      RUBY
+
+      app "development"
+
+      assert_equal "_some_editor_url_", Rails.configuration.debug_exception_editor_url
+    end
+
+    test "debug_exception_editor_url can be specified via shortcut" do
+      add_to_config <<-RUBY
+        config.debug_exception_editor_url = :txmt
+      RUBY
+
+      app "development"
+
+      assert_equal "txmt://open?url=file://%{file}&line=%{line}", Rails.configuration.debug_exception_editor_url
+    end
+
     private
       def force_lazy_load_hooks
         yield # Tasty clarifying sugar, homie! We only need to reference a constant to load it.


### PR DESCRIPTION
Currently, the debug exception page allows us to see only the line where an exception was raised, but sometimes, for better debugging, we need to open a file in the editor. 
This PR adds this possibility.
So after we specify editor URL format, the debug exception page will generate link to open editor

``` ruby
Rails.application.configure do |config|
  config.debug_exception_editor_url = 'my_editor://open?url=file://%{file}&line=%{line}'
  # config.debug_exception_editor_url = :textmate
  # config.debug_exception_editor_url = :emacs
  # config.debug_exception_editor_url = :sublime
end
```

![open_in_editor](https://cloud.githubusercontent.com/assets/471335/14376381/c44bc9d4-fd71-11e5-9233-76f937d7f365.png)
