### PR TITLE
Use new hash syntax

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -8,8 +8,8 @@
     <%%= stylesheet_link_tag    'application', media: 'all' %>
     <%- else -%>
       <%- if gemfile_entries.any? { |m| m.name == 'turbolinks' } -%>
-    <%%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => 'reload' %>
-    <%%= javascript_include_tag 'application', 'data-turbolinks-track' => 'reload' %>
+    <%%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
       <%- else -%>
     <%%= stylesheet_link_tag    'application', media: 'all' %>
     <%%= javascript_include_tag 'application' %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -65,8 +65,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_assets
     run_generator
 
-    assert_file("app/views/layouts/application.html.erb", /stylesheet_link_tag\s+'application', media: 'all', 'data-turbolinks-track' => 'reload'/)
-    assert_file("app/views/layouts/application.html.erb", /javascript_include_tag\s+'application', 'data-turbolinks-track' => 'reload'/)
+    assert_file("app/views/layouts/application.html.erb", /stylesheet_link_tag\s+'application', media: 'all', 'data-turbolinks-track': 'reload'/)
+    assert_file("app/views/layouts/application.html.erb", /javascript_include_tag\s+'application', 'data-turbolinks-track': 'reload'/)
     assert_file("app/assets/stylesheets/application.css")
     assert_file("app/assets/javascripts/application.js")
   end


### PR DESCRIPTION
### Summary

Rails 5 now only supports ruby >= 2.2.2, so we can use the newer syntax
safely for these tags, too (I guess?)
