### PR TITLE
Clarify fixtures examples [ci skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -495,7 +495,8 @@ users(:david)
 users(:david).id
 
 # one can also access methods available on the User class
-email(david.partner.email, david.location_tonight)
+david = users(:david)
+david.call(david.partner)
 ```
 
 To get multiple fixtures at once, you can pass in a list of fixture names. For example:


### PR DESCRIPTION
Per discussion with @zzak, the existing example doesn't work, returning `undefined local variable or method```david' for #<UserTest:0x007f8799d2b8b0>`. Clarify that david needs to be assigned to a local variable, and get rid of the spurious `email` method that presumably would need to be defined elsewhere in the test class.
