### PR TITLE
Remove reference to non existing link in the welcome page [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -223,8 +223,7 @@ the server.
 
 The "Welcome aboard" page is the _smoke test_ for a new Rails application: it
 makes sure that you have your software configured correctly enough to serve a
-page. You can also click on the _About your application's environment_ link to
-see a summary of your application's environment.
+page.
 
 ### Say "Hello", Rails
 


### PR DESCRIPTION
fix #24469 

The "Welcome aboard" page has no "About your application's environment" link. But docs states so.

```
modified:   guides/source/getting_started.md
```
