### PR TITLE
Depend on puma ~> 3.4 in App templates, so that we can include the puma restart fix

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -181,7 +181,7 @@ module Rails
       def webserver_gemfile_entry
         return [] if options[:skip_puma]
         comment = 'Use Puma as the app server'
-        GemfileEntry.new('puma', '~> 3.0', comment)
+        GemfileEntry.new('puma', '~> 3.4', comment)
       end
 
       def include_all_railties?

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -410,7 +410,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_generator_defaults_to_puma_version
     run_generator [destination_root]
-    assert_gem "puma", "'~> 3.0'"
+    assert_gem "puma", "'~> 3.4'"
   end
 
   def test_generator_if_skip_puma_is_given


### PR DESCRIPTION
Depend on puma ~> 3.4 in App templates, so that we can include the puma restart fix, that fixes support for dev:cache, rails restart etc commands

r? @rafaelfranca 
