### PR TITLE
document simple example of ActionController::MimeResponds#respond_to [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -64,6 +64,13 @@ module ActionController #:nodoc:
     #     @people = Person.all
     #   end
     #
+    # That action implicitly responds to all formats, but formats can also be whitelisted:
+    #
+    #   def index
+    #     @people = Person.all
+    #     respond_to :html, :js
+    #   end
+    #
     # Here's the same action, with web-service support baked in:
     #
     #   def index
@@ -71,11 +78,12 @@ module ActionController #:nodoc:
     #
     #     respond_to do |format|
     #       format.html
+    #       format.js
     #       format.xml { render xml: @people }
     #     end
     #   end
     #
-    # What that says is, "if the client wants HTML in response to this action, just respond as we
+    # What that says is, "if the client wants HTML or JS in response to this action, just respond as we
     # would have before, but if the client wants XML, return them the list of people in XML format."
     # (Rails determines the desired response format from the HTTP Accept header submitted by the client.)
     #


### PR DESCRIPTION
### Summary

I cherry-picked the addition that was merged in #23154, which improves documentation for the `respond_to` method that is used in controller actions.
### Other Information

I've omitted the second commit from the #23154, which removes references to a `respond_to` method that was eliminated in v4.2.0 per #22144.

If this documentation change is welcome, then I will open a PR for the 4-1-stable and 4-2-stable branches as well.
