### PR TITLE
Possibly resolve #24028 - Warn about possible deadlock in Dependencies::Interlock 

### DIFF
--- a/activesupport/lib/active_support/dependencies/interlock.rb
+++ b/activesupport/lib/active_support/dependencies/interlock.rb
@@ -5,22 +5,58 @@ module ActiveSupport #:nodoc:
     class Interlock
       def initialize # :nodoc:
         @lock = ActiveSupport::Concurrency::ShareLock.new
+        @waiting = {}
+        @waiting.extend(MonitorMixin)
+        @watcher = nil
+      end
+
+      def start_timeout(timeout = 5)
+        @watcher.kill if @watcher && @watcher.alive?
+        @watcher = Thread.new do
+          sleep(timeout)
+          puts "Dependencies::Interlock has not moved in in #{timeout} seconds. There might be a deadlock."
+        end
+      end
+
+      def start_watch
+        @waiting.synchronize do
+          @waiting[Thread.current] = true
+          start_timeout
+        end
+      end
+
+      def end_watch
+        @waiting.synchronize do
+          @waiting.delete(Thread.current)
+          if @waiting.keys.empty?
+            @watcher.kill
+            @watcher = nil
+          else
+            start_timeout
+          end
+        end
       end
 
       def loading
+        start_watch
         @lock.exclusive(purpose: :load, compatible: [:load], after_compatible: [:load]) do
+          end_watch
           yield
         end
       end
 
       def unloading
+        start_watch
         @lock.exclusive(purpose: :unload, compatible: [:load, :unload], after_compatible: [:load, :unload]) do
+          end_watch
           yield
         end
       end
 
       def start_unloading
+        start_watch
         @lock.start_exclusive(purpose: :unload, compatible: [:load, :unload])
+        end_watch
       end
 
       def done_unloading


### PR DESCRIPTION
### Summary

This is meant as a possible solution to resolve #24028. It adds an extra watcher thread to the Dependencies::Interlock class in order to watch for potential Deadlocks while autoloading. 
### Other Information

This doesn't attempt to resolve the issue of the deadlock, but instead tries to warn the user if any threads spend too long in the loading or unloading phase.
