### PR TITLE
Check for protected environments before trying to load structure.sql file

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -302,7 +302,7 @@ db_namespace = namespace :db do
     end
 
     desc "Recreates the databases from the structure.sql file"
-    task :load => [:environment, :load_config] do
+    task :load => [:environment, :load_config, :check_protected_environments] do
       ActiveRecord::Tasks::DatabaseTasks.load_schema_current(:sql, ENV['SCHEMA'])
     end
 


### PR DESCRIPTION
- Check for protected environments while running `db:structure:load`
  similar to how `db:schema:load` behaves.
- Followup of https://github.com/rails/rails/pull/24399.

r? @schneems 
