### PR TITLE
Cleanup message shown while running destructive action against protected database

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -156,8 +156,8 @@ module ActiveRecord
 
   class ProtectedEnvironmentError < ActiveRecordError #:nodoc:
     def initialize(env = "production")
-      msg = "You are attempting to run a destructive action against your '#{env}' database\n"
-      msg << "If you are sure you want to continue, run the same command with the environment variable\n"
+      msg = "You are attempting to run a destructive action against your '#{env}' database.\n"
+      msg << "If you are sure you want to continue, run the same command with the environment variable:\n"
       msg << "DISABLE_DATABASE_ENVIRONMENT_CHECK=1"
       super(msg)
     end


### PR DESCRIPTION
r? @schneems 
Looks like this now 

```
$ RAILS_ENV=production rake db:structure:load
rake aborted!
ActiveRecord::ProtectedEnvironmentError: You are attempting to run a destructive action against your 'production' database.
If you are sure you want to continue, run the same command with the environment variable:
DISABLE_DATABASE_ENVIRONMENT_CHECK=1
/Users/prathamesh/Projects/sources/rails/activerecord/lib/active_record/tasks/database_tasks.rb:51:in `check_protected_environments!'
/Users/prathamesh/Projects/sources/rails/activerecord/lib/active_record/railties/databases.rake:11:in `block (2 levels) in <top (required)>'
Tasks: TOP => db:structure:load => db:check_protected_environments
(See full trace by running task with --trace)
```
