### PR TITLE
do not create unnecessary directory

### DIFF
--- a/railties/lib/rails/tasks/tmp.rake
+++ b/railties/lib/rails/tasks/tmp.rake
@@ -5,9 +5,7 @@ namespace :tmp do
   tmp_dirs = [ 'tmp/cache',
                'tmp/sockets',
                'tmp/pids',
-               'tmp/cache/assets/development',
-               'tmp/cache/assets/test',
-               'tmp/cache/assets/production' ]
+               'tmp/cache/assets' ]
 
   tmp_dirs.each { |d| directory d }
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -344,8 +344,7 @@ module ApplicationTests
 
       clean_assets!
 
-      files = Dir["#{app_path}/public/assets/**/*", "#{app_path}/tmp/cache/assets/development/*",
-                  "#{app_path}/tmp/cache/assets/test/*", "#{app_path}/tmp/cache/assets/production/*"]
+      files = Dir["#{app_path}/public/assets/**/*"]
       assert_equal 0, files.length, "Expected no assets, but found #{files.join(', ')}"
     end
 


### PR DESCRIPTION
This was added in a4c358f, but `config.assets` has been removed in 5172d93.
Also, do not use env path to `Sprockets::Cache::FileStore` even `sprockets-rails`.
ref: https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/railtie.rb#L129
