### PR TITLE
`number_to_phone` extended formatting

### DIFF
--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -35,7 +35,7 @@ module ActionView
       #   end of the generated number.
       # * <tt>:country_code</tt> - Sets the country code for the phone
       #   number.
-      # * <tt>:pattern</tt> - Specifies how the number is divided into three
+      # * <tt>:pattern</tt> - Specifies how the number is divided into
       #   groups with the custom regexp to override the default format.
       # * <tt>:raise</tt> - If true, raises +InvalidNumberError+ when
       #   the argument is invalid.

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -27,7 +27,7 @@ module ActiveSupport
     #   end of the generated number.
     # * <tt>:country_code</tt> - Sets the country code for the phone
     #   number.
-    # * <tt>:pattern</tt> - Specifies how the number is divided into three
+    # * <tt>:pattern</tt> - Specifies how the number is divided into
     #   groups with the custom regexp to override the default format.
     # ==== Examples
     #

--- a/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
@@ -10,26 +10,19 @@ module ActiveSupport
       private
 
         def convert_to_phone_number(number)
-          if opts[:area_code]
-            convert_with_area_code(number)
-          else
-            convert_without_area_code(number)
+          parts = parse(number)
+          if parts
+            number = opts[:area_code] && !parts[0].blank? ? "(#{parts.shift}) " : ""
+            number << parts.join(delimiter)
+            number.slice!(0, 1) if start_with_delimiter?(number)
           end
-        end
-
-        def convert_with_area_code(number)
-          default_pattern = /(\d{1,3})(\d{3})(\d{4}$)/
-          number.gsub!(regexp_pattern(default_pattern),
-                       "(\\1) \\2#{delimiter}\\3")
           number
         end
 
-        def convert_without_area_code(number)
-          default_pattern = /(\d{0,3})(\d{3})(\d{4})$/
-          number.gsub!(regexp_pattern(default_pattern),
-                       "\\1#{delimiter}\\2#{delimiter}\\3")
-          number.slice!(0, 1) if start_with_delimiter?(number)
-          number
+        def parse(number)
+          if match_data = number.match(regexp_pattern)
+            match_data.captures
+          end
         end
 
         def start_with_delimiter?(number)
@@ -48,8 +41,8 @@ module ActiveSupport
           ext.blank? ? "" : " x #{ext}"
         end
 
-        def regexp_pattern(default_pattern)
-          opts.fetch :pattern, default_pattern
+        def regexp_pattern
+          opts.fetch :pattern, /(\d{0,3})(\d{3})(\d{4}$)/
         end
 
     end

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -45,7 +45,7 @@ module ActiveSupport
       def test_number_to_phone
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
           assert_equal("555-1234", number_helper.number_to_phone(5551234))
-          assert_equal("5551234", number_helper.number_to_phone(5551234, {:area_code => true}))
+          assert_equal("555-1234", number_helper.number_to_phone(5551234, {:area_code => true}))
           assert_equal("800-555-1212", number_helper.number_to_phone(8005551212))
           assert_equal("(800) 555-1212", number_helper.number_to_phone(8005551212, {:area_code => true}))
           assert_equal("+1-(800) 555-1212", number_helper.number_to_phone(8005551212, {:area_code => true, :country_code => 1}))
@@ -61,6 +61,9 @@ module ActiveSupport
           assert_equal("+45-22-555-1212", number_helper.number_to_phone(225551212, :country_code => 45))
           assert_equal("(755) 6123-4567", number_helper.number_to_phone(75561234567, pattern: /(\d{3,4})(\d{4})(\d{4})/, area_code: true))
           assert_equal("133-1234-5678", number_helper.number_to_phone(13312345678, pattern: /(\d{3})(\d{4})(\d{4})/))
+          assert_equal("030-123-45-67", number_helper.number_to_phone("0301234567", pattern: /(\d{3})(\d{3})(\d{2})(\d{2})/))
+          assert_equal("+31 030 123 45 67", number_helper.number_to_phone("0301234567", pattern: /(\d{3})(\d{3})(\d{2})(\d{2})/, country_code: 31, delimiter: ' '))
+          assert_equal("+31-(030) 123-45-67", number_helper.number_to_phone("0301234567", pattern: /(\d{3})(\d{3})(\d{2})(\d{2})/, country_code: 31, area_code: true))
         end
       end
 

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -45,8 +45,10 @@ module ActiveSupport
       def test_number_to_phone
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
           assert_equal("555-1234", number_helper.number_to_phone(5551234))
+          assert_equal("5551234", number_helper.number_to_phone(5551234, {:area_code => true}))
           assert_equal("800-555-1212", number_helper.number_to_phone(8005551212))
           assert_equal("(800) 555-1212", number_helper.number_to_phone(8005551212, {:area_code => true}))
+          assert_equal("+1-(800) 555-1212", number_helper.number_to_phone(8005551212, {:area_code => true, :country_code => 1}))
           assert_equal("", number_helper.number_to_phone("", {:area_code => true}))
           assert_equal("800 555 1212", number_helper.number_to_phone(8005551212, {:delimiter => " "}))
           assert_equal("(800) 555-1212 x 123", number_helper.number_to_phone(8005551212, {:area_code => true, :extension => 123}))


### PR DESCRIPTION
For some countries it might be better suited to split phone numbers
into more than 3 groups. E.g. Dutch phone numbers are often formatted
as `030 123 45 67`. This change makes an arbitrary amount of groups
possible by using the number of captures.

I've also added 2 new tests, one that demonstrates that a conversion with `area_code` and `country_code` set results in weird concatenation; `+1-(800) 555-1212`, whereas I think it probably should be `+1 (800) 555-1212`.

Also, there were different regexes for with- and without area code, but the tests did still pass when I used the same regex for both. So it might be that the tests for that behavior are missing. But the differentiation would mean that if a too short phone number, say `1234560`, was given to the function, it would not be altered, whereas I think it should result in `123-4560`. 
