### PR TITLE
Pass over all Rails 5 warnings

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -213,7 +213,7 @@ module ActionController #:nodoc:
 
         if !verified_request?
           if logger && log_warning_on_csrf_failure
-            logger.warn "Can't verify CSRF token authenticity"
+            logger.warn "Can't verify CSRF token authenticity."
           end
           handle_unverified_request
         end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1598,7 +1598,7 @@ module ActionDispatch
             route_options = options.dup
             if _path && option_path
               ActiveSupport::Deprecation.warn <<-eowarn
-Specifying strings for both :path and the route path is deprecated.  Change things like this:
+Specifying strings for both :path and the route path is deprecated. Change things like this:
 
   match #{_path.inspect}, :path => #{option_path.inspect}
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -517,14 +517,14 @@ module ActionDispatch
         if route.segment_keys.include?(:controller)
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
             Using a dynamic :controller segment in a route is deprecated and
-            will be removed in Rails 5.1
+            will be removed in Rails 5.1.
           MSG
         end
 
         if route.segment_keys.include?(:action)
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
             Using a dynamic :action segment in a route is deprecated and
-            will be removed in Rails 5.1
+            will be removed in Rails 5.1.
           MSG
         end
 

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -95,7 +95,7 @@ module ActionDispatch
 
         ActiveSupport::Deprecation.warn(<<-MSG.strip_heredoc)
           xhr and xml_http_request methods are deprecated in favor of
-          `get "/posts", xhr: true` and `post "/posts/1", xhr: true`
+          `get "/posts", xhr: true` and `post "/posts/1", xhr: true`.
         MSG
 
         process(request_method, path, params: params, headers: headers, xhr: true)

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -205,7 +205,7 @@ module ActionController
       def overfill_buffer_and_die
         logger = ActionController::Base.logger || Logger.new($stdout)
         response.stream.on_error do
-          logger.warn 'Error while streaming'
+          logger.warn 'Error while streaming.'
           error_latch.count_down
         end
 

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -346,7 +346,7 @@ module ActiveModel
     #   # => {:name=>["can't be empty"]}
     def add_on_empty(attributes, options = {})
       ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)
-        ActiveModel::Errors#add_on_empty is deprecated and will be removed in Rails 5.1
+        ActiveModel::Errors#add_on_empty is deprecated and will be removed in Rails 5.1.
 
         To achieve the same use:
 
@@ -368,7 +368,7 @@ module ActiveModel
     #   # => {:name=>["can't be blank"]}
     def add_on_blank(attributes, options = {})
       ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)
-        ActiveModel::Errors#add_on_blank is deprecated and will be removed in Rails 5.1
+        ActiveModel::Errors#add_on_blank is deprecated and will be removed in Rails 5.1.
 
         To achieve the same use:
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -325,7 +325,7 @@ module ActiveRecord
 
               select_value("SELECT setval('#{quoted_sequence}', #{value})", 'SCHEMA')
             else
-              @logger.warn "#{table} has primary key #{pk} with no default sequence" if @logger
+              @logger.warn "#{table} has primary key #{pk} with no default sequence." if @logger
             end
           end
         end
@@ -340,7 +340,7 @@ module ActiveRecord
           end
 
           if @logger && pk && !sequence
-            @logger.warn "#{table} has primary key #{pk} with no default sequence"
+            @logger.warn "#{table} has primary key #{pk} with no default sequence."
           end
 
           if pk && sequence

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -159,7 +159,7 @@ module ActiveRecord
           id = id.id
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
             You are passing an instance of ActiveRecord::Base to `find`.
-            Please pass the id of the object by calling `.id`
+            Please pass the id of the object by calling `.id`.
           MSG
         end
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -874,7 +874,7 @@ module ActiveRecord
           example_options = options.dup
           example_options[:source] = source_reflection_names.first
           ActiveSupport::Deprecation.warn \
-            "Ambiguous source reflection for through association.  Please " \
+            "Ambiguous source reflection for through association. Please " \
             "specify a :source directive on your declaration like:\n" \
             "\n" \
             "  class #{active_record.name} < ActiveRecord::Base\n" \

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -428,7 +428,7 @@ module ActiveRecord
           id = id.id
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
             You are passing an instance of ActiveRecord::Base to `update`.
-            Please pass the id of the object by calling `.id`
+            Please pass the id of the object by calling `.id`.
           MSG
         end
         object = find(id)
@@ -457,7 +457,7 @@ module ActiveRecord
       if conditions
         ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)
           Passing conditions to destroy_all is deprecated and will be removed in Rails 5.1.
-          To achieve the same use where(conditions).destroy_all
+          To achieve the same use where(conditions).destroy_all.
         MESSAGE
         where(conditions).destroy_all
       else
@@ -527,7 +527,7 @@ module ActiveRecord
       if conditions
         ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)
           Passing conditions to delete_all is deprecated and will be removed in Rails 5.1.
-          To achieve the same use where(conditions).delete_all
+          To achieve the same use where(conditions).delete_all.
         MESSAGE
         where(conditions).delete_all
       else

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -2,7 +2,7 @@ require "active_record/relation/batches/batch_enumerator"
 
 module ActiveRecord
   module Batches
-    ORDER_OR_LIMIT_IGNORED_MESSAGE = "Scoped order and limit are ignored, it's forced to be batch order and batch size"
+    ORDER_OR_LIMIT_IGNORED_MESSAGE = "Scoped order and limit are ignored, it's forced to be batch order and batch size."
 
     # Looping through a collection of records from the database
     # (using the Scoping::Named::ClassMethods.all method, for example)

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -312,7 +312,7 @@ module ActiveRecord
         conditions = conditions.id
         ActiveSupport::Deprecation.warn(<<-MSG.squish)
           You are passing an instance of ActiveRecord::Base to `exists?`.
-          Please pass the id of the object by calling `.id`
+          Please pass the id of the object by calling `.id`.
         MSG
       end
 
@@ -467,7 +467,7 @@ module ActiveRecord
         id = id.id
         ActiveSupport::Deprecation.warn(<<-MSG.squish)
           You are passing an instance of ActiveRecord::Base to `find`.
-          Please pass the id of the object by calling `.id`
+          Please pass the id of the object by calling `.id`.
         MSG
       end
 

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -126,7 +126,7 @@ module ActiveSupport
           def set_cache_value(value, name, amount, options) # :nodoc:
             ActiveSupport::Deprecation.warn(<<-MESSAGE.strip_heredoc)
               `set_cache_value` is deprecated and will be removed from Rails 5.1.
-              Please use `write_cache_value`
+              Please use `write_cache_value` instead.
             MESSAGE
             write_cache_value name, value, options
           end

--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -65,7 +65,6 @@ module ActiveSupport
 
         def deprecation_message(callstack, message = nil)
           message ||= "You are using deprecated behavior which will be removed from the next major or minor release."
-          message += '.' unless message =~ /\.$/
           "DEPRECATION WARNING: #{message} #{deprecation_caller_message(callstack)}"
         end
 


### PR DESCRIPTION
Pass over all Rails 5 warnings, to make sure:
- we are ending sentences properly
- fixing of space issues
- fixed continuity issues in some sentences.

This is continuation of https://github.com/rails/rails/pull/24485  and takes care of warnings at all places.
