### PR TITLE
ConncectionPool: Prevent reuse of a connection with open transactions

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/executor.rb
+++ b/actionpack/lib/action_dispatch/middleware/executor.rb
@@ -7,6 +7,7 @@ module ActionDispatch
     end
 
     def call(env)
+      @executor.instance_variable_set('@rack_test', env['rack.test'])
       state = @executor.run!
       begin
         response = @app.call(env)

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -507,6 +507,7 @@ module ActiveRecord
       # +conn+: an AbstractAdapter object, which was obtained by earlier by
       # calling #checkout on this pool.
       def checkin(conn)
+        conn.assert_connection_reuseable
         synchronize do
           remove_connection_from_thread_cache conn
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -369,6 +369,13 @@ module ActiveRecord
         reconnect! unless active?
       end
 
+      # raises if there are opened transactions on the connection preventing reuse of connection.
+      def assert_connection_reuseable
+        if transaction_open?
+          raise ActiveRecordError, "Attempt to reuse a connection with open transaction"
+        end
+      end
+
       # Provides access to the underlying database driver for this adapter. For
       # example, this method returns a Mysql2::Client object in case of Mysql2Adapter,
       # and a PGconn object in case of PostgreSQLAdapter.

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -44,8 +44,8 @@ module ActiveRecord
       executor.register_hook(self)
 
       executor.to_complete do
-        # FIXME: This should be skipped when env['rack.test']
-        ActiveRecord::Base.clear_active_connections!
+        is_test = self.class.instance_variable_get("@rack_test")
+        ActiveRecord::Base.clear_active_connections! unless is_test
       end
     end
   end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -110,6 +110,7 @@ module ActiveRecord
       end
 
       def test_not_specifying_database_name_for_cross_database_selects
+        teardown_fixtures
         begin
           assert_nothing_raised do
             ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations['arunit'].except(:database))

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -11,7 +11,12 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
     end
   end
 
-  teardown do
+  def teardown
+    ActiveRecord::Base.connection.singleton_class.class_eval do
+      remove_method :execute
+      alias_method :execute, :execute_without_stub
+      remove_method :execute_without_stub
+    end
     reset_connection
   end
 

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -99,6 +99,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_passing_arbitary_flags_to_adapter
+    teardown_fixtures
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.merge({flags: Mysql2::Client::COMPRESS}))
       assert_equal (Mysql2::Client::COMPRESS |  Mysql2::Client::FOUND_ROWS), ActiveRecord::Base.connection.raw_connection.query_options[:flags]
@@ -106,6 +107,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_passing_flags_by_array_to_adapter
+    teardown_fixtures
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.merge({flags: ['COMPRESS'] }))
       assert_equal ["COMPRESS", "FOUND_ROWS"], ActiveRecord::Base.connection.raw_connection.query_options[:flags]
@@ -113,6 +115,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_mysql_set_session_variable
+    teardown_fixtures
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.deep_merge({:variables => {:default_week_format => 3}}))
       session_mode = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.DEFAULT_WEEK_FORMAT"
@@ -121,6 +124,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_mysql_set_session_variable_to_default
+    teardown_fixtures
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.deep_merge({:variables => {:default_week_format => :default}}))
       global_mode = ActiveRecord::Base.connection.exec_query "SELECT @@GLOBAL.DEFAULT_WEEK_FORMAT"

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -12,6 +12,7 @@ module ActiveRecord
 
     def setup
       super
+      teardown_fixtures
       @subscriber = SQLSubscriber.new
       @subscription = ActiveSupport::Notifications.subscribe('sql.active_record', @subscriber)
       @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1310,6 +1310,7 @@ class BasicsTest < ActiveRecord::TestCase
 
   if Process.respond_to?(:fork) && !in_memory_db?
     def test_marshal_between_processes
+      teardown_fixtures
       # Define a new model to ensure there are no caches
       if self.class.const_defined?("Post", false)
         flunk "there should be no post constant"

--- a/activerecord/test/cases/connection_management_test.rb
+++ b/activerecord/test/cases/connection_management_test.rb
@@ -17,6 +17,7 @@ module ActiveRecord
       end
 
       def setup
+        teardown_fixtures
         @env = {}
         @app = App.new
         @management = middleware(@app)

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -215,6 +215,7 @@ class QueryCacheTest < ActiveRecord::TestCase
   private
     def middleware(&app)
       executor = Class.new(ActiveSupport::Executor)
+      executor.instance_variable_set('@rack_test', true)
       ActiveRecord::QueryCache.install_executor_hooks executor
       lambda { |env| executor.wrap { app.call(env) } }
     end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -8,6 +8,10 @@ require 'rack'
 class QueryCacheTest < ActiveRecord::TestCase
   fixtures :tasks, :topics, :categories, :posts, :categories_posts
 
+  setup do
+    teardown_fixtures
+  end
+
   teardown do
     Task.connection.clear_query_cache
     ActiveRecord::Base.connection.disable_query_cache!

--- a/activerecord/test/support/connection_helper.rb
+++ b/activerecord/test/support/connection_helper.rb
@@ -1,5 +1,6 @@
 module ConnectionHelper
   def run_without_connection
+    teardown_fixtures
     original_connection = ActiveRecord::Base.remove_connection
     yield original_connection
   ensure
@@ -8,6 +9,7 @@ module ConnectionHelper
 
   # Used to drop all cache query plans in tests.
   def reset_connection
+    teardown_fixtures
     original_connection = ActiveRecord::Base.remove_connection
     ActiveRecord::Base.establish_connection(original_connection)
   end


### PR DESCRIPTION
Checking in a connection with an open transaction can lead to flaky issues as thread started the transaction might or might not get back the same connection.

See #24491
