### PR TITLE
Fix PgArray to always deserialize strings with the scripts encoding

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -18,7 +18,7 @@ module ActiveRecord
 
           def deserialize(value)
             if value.is_a?(::String)
-              type_cast_array(@pg_decoder.decode(value), :deserialize)
+              type_cast_array(@pg_decoder.decode(value.force_encoding(__ENCODING__)), :deserialize)
             else
               super
             end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -300,6 +300,13 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
     assert_equal ["has already been taken"], e2.errors[:tags], "Should have uniqueness message for tags"
   end
 
+  def test_encoding_is_set_to_scripts_encoding_after_save
+    record = PgArray.new(tags: ["München"])
+
+    record.save!
+    assert_equal record.tags.first, "München"
+  end
+
   private
   def assert_cycle field, array
     # test creation


### PR DESCRIPTION
### Summary

Fixes an issue with Arrays in PostgreSQL, where the encoding of the values of the array is changed upon deserialization. The issue is also described in #22730:
### Other Information

This PR is based on #23619 which was closed because the original idea was that this should be fixed upstream in the PG adapter (ged/ruby-pg#11), but @larskanis later commented in https://github.com/rails/rails/pull/23619#issuecomment-189924036 that it's an issue with Rails/activerecord, not the adapter.

I see that setting the encoding to `__ENCODING__` might not be good enough. Ideally, it should be set to the encoding of the connection. Is it safe to access the `ConnectionSpecification` instance via `ActiveRecord::Base.connection_pool.spec.config`? If so, then I would amend this PR to default to the encoding there and fallback to `__ENCODING__` when not available?
