### PR TITLE
Dont clean connections on Integration tests

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -137,6 +137,7 @@ module ActiveRecord
 
     eager_autoload do
       autoload :AbstractAdapter
+      autoload :ConnectionManagement, "active_record/connection_adapters/abstract/connection_pool"
     end
   end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -951,5 +951,19 @@ module ActiveRecord
         owner_to_pool && owner_to_pool[owner.name]
       end
     end
+
+    class ConnectionManagement
+      attr_accessor :clean_connections
+
+      def initialize
+        @clean_connections = true
+      end
+
+      def run; end
+
+      def complete(*)
+        ActiveRecord::Base.clear_active_connections! if clean_connections
+      end
+    end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -27,6 +27,7 @@ module ActiveRecord
 
     autoload_at 'active_record/connection_adapters/abstract/connection_pool' do
       autoload :ConnectionHandler
+      autoload :ConnectionManagement
     end
 
     autoload_under 'abstract' do

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -42,11 +42,6 @@ module ActiveRecord
 
     def self.install_executor_hooks(executor = ActiveSupport::Executor)
       executor.register_hook(self)
-
-      executor.to_complete do
-        # FIXME: This should be skipped when env['rack.test']
-        ActiveRecord::Base.clear_active_connections!
-      end
     end
   end
 end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -157,9 +157,16 @@ end_warning
       end
     end
 
-    initializer "active_record.set_executor_hooks" do
+    initializer "active_record.set_executor_hooks" do |app|
+      conn_hook = ActiveRecord::ConnectionAdapters::ConnectionManagement.new
+
       ActiveSupport.on_load(:active_record) do
         ActiveRecord::QueryCache.install_executor_hooks
+        app.executor.register_hook(conn_hook)
+      end
+
+      ActiveSupport.on_load(:action_dispatch_integration_test) do
+        conn_hook.clean_connections = false
       end
     end
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -166,7 +166,15 @@ end_warning
       end
 
       ActiveSupport.on_load(:action_dispatch_integration_test) do
-        conn_hook.clean_connections = false
+        mattr_accessor :connection_executor_hook
+        self.connection_executor_hook = conn_hook
+
+        setup do
+          connection_executor_hook.clean_connections = false
+        end
+        teardown do
+          connection_executor_hook.clean_connections = true
+        end
       end
     end
 


### PR DESCRIPTION
### Problem

Connections are going back to the pool with open transactions. This can cause deadlocks.

[related to c7b7c6ad1c773102753f1a11b857d0e37ceb6a21]
### Solution

First, the action of `clear_active_connections!` should not be in the
QueryCache executor. They have different responsibilities.

This brings `ConnectionManagement` class back, now as an executor
instead of Middleware, however it is only responsible for clearing the
connections on complete. [related to #23807]

Also, this adds a flag, so we can turn off the clear_connection action on
Integration tests. 

[fixes #24491]

review @matthewd @jeremy @rafaelfranca @mfazekas

To test the deadlocks, i used a variation of @mfazekas's script, see https://gist.github.com/arthurnn/fbb59a684a75a415a2a8032c0ee99f54
I had to change it, because with this implementation, instead of using `rack.test` env var, the clear connections action is attached to the IntegrationTest class.
