### PR TITLE
Add a query_cache enabled/disable config

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -112,6 +112,13 @@ module ActiveRecord
       mattr_accessor :warn_on_records_fetched_greater_than, instance_writer: false
       self.warn_on_records_fetched_greater_than = nil
 
+      ##
+      # :singleton-method:
+      # Enable or disable query cache
+      # Default value is +true+, use +false+ to disable query cache.
+      mattr_accessor :query_cache, instance_accessor: false
+      self.query_cache = true
+
       mattr_accessor :maintain_test_schema, instance_accessor: false
 
       mattr_accessor :belongs_to_required_by_default, instance_accessor: false

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -41,7 +41,7 @@ module ActiveRecord
     end
 
     def self.install_executor_hooks(executor = ActiveSupport::Executor)
-      executor.register_hook(self)
+      executor.register_hook(self) if ActiveRecord::Base.query_cache
 
       executor.to_complete do
         # FIXME: This should be skipped when env['rack.test']

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -71,6 +71,17 @@ class QueryCacheTest < ActiveRecord::TestCase
     mw.call({})
   end
 
+  def test_cache_is_ignored_if_query_cache_disabled
+    old_value, ActiveRecord::Base.query_cache = ActiveRecord::Base.query_cache, false
+    mw = middleware { |env|
+      assert_queries(2) { 2.times { Task.find(1) } }
+      [200, {}, nil]
+    }
+    mw.call({})
+  ensure
+    ActiveRecord::Base.query_cache = old_value
+  end
+
   def test_cache_enabled_during_call
     assert !ActiveRecord::Base.connection.query_cache_enabled, 'cache off'
 


### PR DESCRIPTION
As query cache is not a middleware anymore, we need to add some
way to disable it.
This adds a `config.active_record.query_cache` config

Fixes this comment https://github.com/rails/rails/pull/23807#issuecomment-208007306

review @rafaelfranca @matthewd 
