### PR TITLE
Lesser '.' objects for number helpers

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
@@ -12,7 +12,7 @@ module ActiveSupport
       private
 
         def parts
-          left, right = number.to_s.split('.')
+          left, right = number.to_s.split('.'.freeze)
           left.gsub!(delimiter_pattern) do |digit_to_delimit|
             "#{digit_to_delimit}#{options[:delimiter]}"
           end

--- a/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
@@ -30,7 +30,7 @@ module ActiveSupport
           formatted_string =
             if BigDecimal === rounded_number && rounded_number.finite?
               s = rounded_number.to_s('F') + '0'*precision
-              a, b = s.split('.', 2)
+              a, b = s.split('.'.freeze, 2)
               a + '.' + b[0, precision]
             else
               "%00.#{precision}f" % rounded_number

--- a/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
@@ -29,9 +29,11 @@ module ActiveSupport
 
           formatted_string =
             if BigDecimal === rounded_number && rounded_number.finite?
-              s = rounded_number.to_s('F') + '0'*precision
+              s = rounded_number.to_s('F')
+              s << '0'.freeze * precision
               a, b = s.split('.'.freeze, 2)
-              a + '.' + b[0, precision]
+              a << '.'.freeze
+              a << b[0, precision]
             else
               "%00.#{precision}f" % rounded_number
             end


### PR DESCRIPTION
### Summary

[ActiveSupport::NumberHelper](http://api.rubyonrails.org/classes/ActiveSupport/NumberHelper.html) `number_to_delimited` and `number_to_rounded` methods were creating duplicate dot (`'.'`) strings in my project. When used with a iterating loop lot of string allocation happens. Debugging done via [derailed_benchmarks](https://github.com/schneems/derailed_benchmarks)

Here is a simplified example:

<h4>number_to_delimited</h4>


``` ruby
class FooController < ApplicationController
  def index
    #Notice here we are iterating 1000 times
    render json: 1000.times.collect { ActiveSupport::NumberHelper.number_to_delimited(1111) }
  end
end
```

Notice 1000 dot initializations in below report

``` ruby
Allocated String Report
-----------------------------------
    # Snipped ...

      1002  "."
      1000  /Users/agupta/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.6/lib/active_support/number_helper/number_to_delimited_converter.rb:15
         2  /Users/agupta/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.6/lib/active_support/subscriber.rb:99
```

<h4>number_to_rounded</h4>


Since _number_to_rounded_ internally calls `NumberToDelimitedConverter` converter the effect is more. 

``` ruby
class FooController < ApplicationController
  def index
   # iterating 1000 times
    render json: 1000.times.collect { ActiveSupport::NumberHelper.number_to_rounded(111.1) }
  end
end
```

Notice 1000 - 1000 dot initializations in below report for _number_to_delimited_converter_ & _number_to_rounded_converter_

``` ruby
Allocated String Report
-----------------------------------
      3002  "."
      1000  /Users/agupta/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.6/lib/active_support/number_helper/number_to_delimited_converter.rb:15
      1000  /Users/agupta/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.6/lib/active_support/number_helper/number_to_rounded_converter.rb:33

#Snipped...
```

After freezing the duplicate string were not formed.  cc @schneems 
