### PR TITLE
Encourage best practice in the HTTP Token authentication example code

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -347,7 +347,12 @@ module ActionController
     #     private
     #       def authenticate
     #         authenticate_or_request_with_http_token do |token, options|
-    #           token == TOKEN
+    #           # Compare the tokens in a time-constant manner, to mitigate
+    #           # timing attacks.
+    #           ActiveSupport::SecurityUtils.secure_compare(
+    #             ::Digest::SHA256.hexdigest(token),
+    #             ::Digest::SHA256.hexdigest(TOKEN)
+    #           )
     #         end
     #       end
     #   end


### PR DESCRIPTION
### Summary

This modifies the HTTP Token authentication example code. It currently uses `==` during an authentication method. This is vulnerable to timing attacks. Using something like `ActiveSupport::SecurityUtils.secure_compare` is more secure. That method was actually introduced to mitigate a CVE in the same file, fixed in October 2015: https://github.com/rails/rails/commit/17e6f1507b7f2c2a883c180f4f9548445d6dfbda

It may seem trivial, but we should always encourage secure best practice, even if it does make the example code a bit more obtuse.
