### PR TITLE
ActiveRecord remove_index fix for 5.0.0

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1140,6 +1140,8 @@ module ActiveRecord
         end
 
         def index_name_for_remove(table_name, options = {})
+          return options[:name] if can_remove_index_by_name?(options)
+
           # if the adapter doesn't support the indexes call the best we can do
           # is return the default index name for the options provided
           return index_name(table_name, options) unless respond_to?(:indexes)
@@ -1147,7 +1149,7 @@ module ActiveRecord
           checks = []
 
           if options.is_a?(Hash)
-            checks << lambda { |i| i.name == options[:name].to_s } if options.has_key?(:name)
+            checks << lambda { |i| i.name == options[:name].to_s } if options.key?(:name)
             column_names = Array(options[:column]).map(&:to_s)
           else
             column_names = Array(options).map(&:to_s)
@@ -1222,6 +1224,10 @@ module ActiveRecord
         else
           default_or_changes
         end
+      end
+
+      def can_remove_index_by_name?(options)
+        options.is_a?(Hash) && options.key?(:name) && options.except(:name, :algorithm).empty?
       end
     end
   end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -86,6 +86,17 @@ module ActiveRecord
       @connection.remove_index(:accounts, :name => idx_name) rescue nil
     end
 
+    def test_remove_index_when_name_and_wrong_column_name_specified
+      index_name = "accounts_idx"
+
+      @connection.add_index :accounts, :firm_id, :name => index_name
+      assert_raises ArgumentError do
+        @connection.remove_index :accounts, :name => index_name, :column => :wrong_column_name
+      end
+    ensure
+      @connection.remove_index(:accounts, :name => index_name)
+    end
+
     def test_current_database
       if @connection.respond_to?(:current_database)
         assert_equal ARTest.connection_config['arunit']['database'], @connection.current_database

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -69,6 +69,11 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send :remove_method, :index_name_for_remove
   end
 
+  def test_remove_index_when_name_is_specified
+    expected = %(DROP INDEX CONCURRENTLY "index_people_on_last_name")
+    assert_equal expected, remove_index(:people, name: "index_people_on_last_name", algorithm: :concurrently)
+  end
+
   private
     def method_missing(method_symbol, *arguments)
       ActiveRecord::Base.connection.send(method_symbol, *arguments)


### PR DESCRIPTION
### Summary

There is no need to fetch all table indexes in remove_index if name is specified. If name is wrong, then StatementInvalid will be raised.
fixes https://github.com/rails/rails/issues/24359
### Other Information

If column parameter is specified, then indexes are fetched and checked against that column. So `remove_index :a_table, name: :expr_index, column: :column_name` won't remove an index anyway if that index is expression index in postgresql.
