### PR TITLE
speed up ActiveModel::Dirty#attribute_changed?

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -174,10 +174,12 @@ module ActiveModel
     end
 
     # Handles <tt>*_changed?</tt> for +method_missing+.
-    def attribute_changed?(attr, options = {}) #:nodoc:
+    def attribute_changed?(attr, options = nil) #:nodoc:
       result = changes_include?(attr)
-      result &&= options[:to] == __send__(attr) if options.key?(:to)
-      result &&= options[:from] == changed_attributes[attr] if options.key?(:from)
+      if options
+        result &&= options[:to] == __send__(attr) if options.key?(:to)
+        result &&= options[:from] == changed_attributes[attr] if options.key?(:from)
+      end
       result
     end
 


### PR DESCRIPTION
### Summary

This change speeds up ActiveModel::Dirty#attribute_changed? by setting the default parameter for options to nil instead of a hash.
### Other Information

[Benchmark](https://gist.github.com/lihanli/b46fb501ea2d13b92b9a47e2b1aaae20) results

```
Warming up --------------------------------------
           unchanged     1.000  i/100ms
Calculating -------------------------------------
           unchanged      0.399  (± 0.0%) i/s -      2.000 

Pausing here -- run Ruby again to measure the next benchmark...
Warming up --------------------------------------
            with nil     1.000  i/100ms
Calculating -------------------------------------
            with nil      0.501  (± 0.0%) i/s -      3.000  in   5.984194s

Comparison:
            with nil:        0.5 i/s
           unchanged:        0.4 i/s - 1.26x slower
```
