### PR TITLE
prevent 'attribute_changed?' from returning nil

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -180,7 +180,7 @@ module ActiveModel
         result &&= options[:to] == __send__(attr) if options.key?(:to)
         result &&= options[:from] == changed_attributes[attr] if options.key?(:from)
       end
-      result
+      !!result
     end
 
     # Handles <tt>*_was</tt> for +method_missing+.

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -37,8 +37,8 @@ class DirtyTest < ActiveRecord::TestCase
   def test_attribute_changes
     # New record - no changes.
     pirate = Pirate.new
-    assert !pirate.catchphrase_changed?
-    assert_nil pirate.catchphrase_change
+    assert_equal false, pirate.catchphrase_changed?
+    assert_equal false, pirate.non_validated_parrot_id_changed?
 
     # Change catchphrase.
     pirate.catchphrase = 'arrr'


### PR DESCRIPTION
a simple attempt fix for https://github.com/rails/rails/issues/24220
