### PR TITLE
keyword arguments for attribute_changed? and drop options assignment for attribute_previously_changed?

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -174,11 +174,11 @@ module ActiveModel
     end
 
     # Handles <tt>*_changed?</tt> for +method_missing+.
-    def attribute_changed?(attr, options = nil) #:nodoc:
+    def attribute_changed?(attr, from: nil, to: nil) #:nodoc:
       result = changes_include?(attr)
-      if options
-        result &&= options[:to] == __send__(attr) if options.key?(:to)
-        result &&= options[:from] == changed_attributes[attr] if options.key?(:from)
+      if from || to
+        result &&= to == __send__(attr) if to
+        result &&= from == changed_attributes[attr] if from
       end
       result
     end
@@ -189,7 +189,7 @@ module ActiveModel
     end
 
     # Handles <tt>*_previously_changed?</tt> for +method_missing+.
-    def attribute_previously_changed?(attr, options = {}) #:nodoc:
+    def attribute_previously_changed?(attr) #:nodoc:
       previous_changes_include?(attr)
     end
 


### PR DESCRIPTION
Followup of https://github.com/rails/rails/pull/24511
- Start making use of keyword arguments for attribute_changed? to reduce hash checks and unnecessary hash passing
- Stop using argument options on attribute_previously_changed?, since its unused
- Slight perf improvements, on attribute_changed:

```
Calculating -------------------------------------
  attribute_changed?    74.559k i/100ms
attribute_changed_new?
                        78.653k i/100ms
-------------------------------------------------
  attribute_changed?      1.710M (± 6.2%) i/s -      8.574M
attribute_changed_new?
                          1.824M (± 5.6%) i/s -      9.124M

```

r? @jeremy cc @rafaelfranca @bogdan 
