### PR TITLE
Restore Hash#transform_keys behavior to always return a Hash instance

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -11,7 +11,7 @@ class Hash
   #  hash.transform_keys.with_index { |k, i| [k, i].join } # => {"name0"=>"Rob", "age1"=>"28"}
   def transform_keys
     return enum_for(:transform_keys) { size } unless block_given?
-    result = self.class.new
+    result = {}
     each_key do |key|
       result[yield(key)] = self[key]
     end

--- a/activesupport/test/core_ext/hash/transform_keys_test.rb
+++ b/activesupport/test/core_ext/hash/transform_keys_test.rb
@@ -43,4 +43,20 @@ class TransformKeysTest < ActiveSupport::TestCase
     original.transform_keys!.with_index { |k, i| [k, i].join.to_sym }
     assert_equal({ a0: 'a', b1: 'b' }, original)
   end
+
+  test "transform_keys returns a Hash instance when self is inherited from Hash" do
+    class HashDescendant < ::Hash
+      def initialize(elements = nil)
+        super(elements)
+        (elements || {}).each_pair{ |key, value| self[key] = value }
+      end
+    end
+
+    original = HashDescendant.new({ a: 'a', b: 'b' })
+    mapped = original.transform_keys { |k| "#{k}!".to_sym }
+
+    assert_equal({ a: 'a', b: 'b' }, original)
+    assert_equal({ a!: 'a', b!: 'b' }, mapped)
+    assert_equal(::Hash, mapped.class)
+  end
 end


### PR DESCRIPTION
### Summary

A failure in mongoid's test suite alerted me to a behavior difference between activesupport 4.1 and 4.2:
- activesupport 4.1: `Hash#symbolize_keys` returns a `Hash`.
- activesupport 4.2: `Hash#symbolize_keys` returns an instance of `self.class`.

[Here](https://github.com/rails/rails/commit/f1bad130d0c9bd77c94e43b696adca56c46a66aa) is the related commit.
This behavior change is significant when `self` inherits from `Hash`. For example, a `BSON::Document` (defined in the bson gem, on which mongoid depends) inherits from `Hash`:

``` ruby

> ActiveSupport.version
=> Gem::Version.new("4.1.15")
> doc = BSON::Document.new("a" => 1)
=> {"a"=>1}
> doc.symbolize_keys
=> {:a=>1}
> doc.symbolize_keys.class
=> Hash
```

``` ruby
> ActiveSupport.version
=> Gem::Version.new("4.2.0")
> doc = BSON::Document.new("a" => 1)
=> {"a"=>1}
> doc.symbolize_keys
=> {"a"=>1}
> doc.symbolize_keys.class
=> BSON::Document
```
