### PR TITLE
Use a single loop in ActiveSupport:FileUpdateChecker#max_mtime 

### DIFF
--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -118,7 +118,12 @@ module ActiveSupport
       paths.each do |path|
         time = File.mtime(path)
 
-        if time < time_now && time > max_time
+        # This avoids ActiveSupport::CoreExt::Time#time_with_coercion
+        # which is super slow when comparing two Time objects
+        #
+        # Equivalent Ruby:
+        # time < time_now && time > max_time
+        if time.compare_without_coercion(time_now) < 0 && time.compare_without_coercion(max_time) > 0
           max_time = time
         end
       end

--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -112,7 +112,18 @@ module ActiveSupport
     # reloading is not triggered.
     def max_mtime(paths)
       time_now = Time.now
-      paths.map {|path| File.mtime(path)}.reject {|mtime| time_now < mtime}.max
+      time_at_zero = Time.at(0)
+      max_time = time_at_zero
+
+      paths.each do |path|
+        time = File.mtime(path)
+
+        if time < time_now && time > max_time
+          max_time = time
+        end
+      end
+
+      max_time.object_id == time_at_zero.object_id ? nil : max_time
     end
 
     def compile_glob(hash)


### PR DESCRIPTION
### Summary

Optimizes ActiveSupport::FileUpdateChecker#max_mtime with a single loop memoization rather than using multiple loops. This method is used fairly extensively in Sprockets for regenerating asset bundles, so this should give a pretty big boost (it accounts for about 25% of CPU time on our requests).

This gives about a 25% speed improvement over the old implementation.
### Other Information

Benchmarks:

``` ruby
require 'benchmark/ips'

MTIME = Time.now

class File
  def initialize
    sleep(rand(0.5))

    @mtime = Time.now
  end

  def mtime
    MTIME
  end
end

ARR = [File.new, File.new, File.new, File.new, File.new]

def double_loop
  time_now = Time.now
  ARR.map { |f| f.mtime }.reject { |time| time > time_now }.max
end

def single_memoized
  time_now = Time.now
  max_time = Time.at(0)

  ARR.each do |f|
    time = f.mtime

    if time < time_now && time > max_time
      max_time = time
    end
  end

  max_time.object_id == time_at_zero.object_id ? nil : max_time
end

Benchmark.ips do |x|
  x.report("double_loop") { double_loop }
  x.report("single_memoized") { single_memoized }

  x.compare!
end
```

``` bash
$ ruby map_reject_vs_memoized.rb 
Calculating -------------------------------------
         double_loop    27.036k i/100ms
     single_memoized    33.987k i/100ms
-------------------------------------------------
         double_loop    325.405k (±14.8%) i/s -      1.595M
     single_memoized    412.660k (±12.2%) i/s -      2.039M

Comparison:
     single_memoized:   412660.0 i/s
         double_loop:   325404.8 i/s - 1.27x slower
```

@rafaelfranca 
