### PR TITLE
Generate `cable.js` file if does not exist when generating channel

### DIFF
--- a/actioncable/lib/rails/generators/channel/channel_generator.rb
+++ b/actioncable/lib/rails/generators/channel/channel_generator.rb
@@ -13,6 +13,7 @@ module Rails
         template "channel.rb", File.join('app/channels', class_path, "#{file_name}_channel.rb")
 
         if options[:assets]
+          template "assets/cable.js", "app/assets/javascripts/cable.js"
           template "assets/channel.coffee", File.join('app/assets/javascripts/channels', class_path, "#{file_name}.coffee")
         end
 

--- a/actioncable/lib/rails/generators/channel/templates/assets/cable.js
+++ b/actioncable/lib/rails/generators/channel/templates/assets/cable.js
@@ -1,0 +1,13 @@
+// Action Cable provides the framework to deal with WebSockets in Rails.
+// You can generate new channels where WebSocket features live using the rails generate channel command.
+//
+//= require action_cable
+//= require_self
+//= require_tree ./channels
+
+(function() {
+  this.App || (this.App = {});
+
+  App.cable = ActionCable.createConsumer();
+
+}).call(this);

--- a/railties/test/generators/channel_generator_test.rb
+++ b/railties/test/generators/channel_generator_test.rb
@@ -38,4 +38,12 @@ class ChannelGeneratorTest < Rails::Generators::TestCase
 
     assert_no_file "app/assets/javascripts/channels/chat.coffee"
   end
+
+  def test_cable_js_is_created_if_not_present_already
+    run_generator ['chat']
+    FileUtils.rm("#{destination_root}/app/assets/javascripts/cable.js")
+    run_generator ['camp']
+
+    assert_file "app/assets/javascripts/cable.js"
+  end
 end


### PR DESCRIPTION
- Before this, while generating a channel, we were not creating
  `cable.js` if it does not already exist.
- We have similar code for application mailer here -
  https://github.com/rails/rails/commit/0b3ae023d27197417541932632055cd6be4810c4.
- Based on the comment -
  https://github.com/rails/rails/issues/24418#issuecomment-205421995.

r? @jeremy 
