### PR TITLE
configurable token length

### DIFF
--- a/activerecord/lib/active_record/secure_token.rb
+++ b/activerecord/lib/active_record/secure_token.rb
@@ -9,29 +9,33 @@ module ActiveRecord
       #   class User < ActiveRecord::Base
       #     has_secure_token
       #     has_secure_token :auth_token
+      #     has_secure_token :auth_secret, token_length: 80
       #   end
       #
       #   user = User.new
       #   user.save
       #   user.token # => "pX27zsMN2ViQKta1bGfLmVJE"
       #   user.auth_token # => "77TMHrHJFvFDwodq8w7Ev2m7"
+      #   user.auth_secret # => "7vUrfsD6K9GazaY8J7Acxsw3E6wU93TMe9DHWuNe5yj9yfwneBRuH1pdFmNCCo4k3XxMiw8H9i1ectQd"
       #   user.regenerate_token # => true
       #   user.regenerate_auth_token # => true
+      #   user.regenerate_auth_secret # => true
       #
       # <tt>SecureRandom::base58</tt> is used to generate the 24-character unique token, so collisions are highly unlikely.
       #
       # Note that it's still possible to generate a race condition in the database in the same way that
       # {validates_uniqueness_of}[rdoc-ref:Validations::ClassMethods#validates_uniqueness_of] can.
       # You're encouraged to add a unique index in the database to deal with this even more unlikely scenario.
-      def has_secure_token(attribute = :token)
+      def has_secure_token(attribute = :token, opts={})
         # Load securerandom only when has_secure_token is used.
+        token_length = opts[:token_length] || 24
         require 'active_support/core_ext/securerandom'
-        define_method("regenerate_#{attribute}") { update! attribute => self.class.generate_unique_secure_token }
-        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token) unless self.send("#{attribute}?")}
+        define_method("regenerate_#{attribute}") { update! attribute => self.class.generate_unique_secure_token(token_length) }
+        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token(token_length)) unless self.send("#{attribute}?")}
       end
 
-      def generate_unique_secure_token
-        SecureRandom.base58(24)
+      def generate_unique_secure_token(token_length)
+        SecureRandom.base58(token_length)
       end
     end
   end

--- a/activerecord/test/cases/secure_token_test.rb
+++ b/activerecord/test/cases/secure_token_test.rb
@@ -10,17 +10,21 @@ class SecureTokenTest < ActiveRecord::TestCase
     @user.save
     assert_not_nil @user.token
     assert_not_nil @user.auth_token
+    assert_not_nil @user.auth_secret
   end
 
   def test_regenerating_the_secure_token
     @user.save
     old_token = @user.token
     old_auth_token = @user.auth_token
+    old_auth_secret = @user.auth_secret
     @user.regenerate_token
     @user.regenerate_auth_token
+    @user.regenerate_auth_secret
 
     assert_not_equal @user.token, old_token
     assert_not_equal @user.auth_token, old_auth_token
+    assert_not_equal @user.auth_secret, old_auth_secret
   end
 
   def test_token_value_not_overwritten_when_present
@@ -28,5 +32,18 @@ class SecureTokenTest < ActiveRecord::TestCase
     @user.save
 
     assert_equal @user.token, "custom-secure-token"
+  end
+
+  def test_default_token_size
+    @user.save
+
+    assert_equal @user.token.length, 24
+    assert_equal @user.auth_token.length, 24
+  end
+
+  def test_token_size_should_be_customizable
+    @user.save
+
+    assert_equal @user.auth_secret.length, 80
   end
 end

--- a/activerecord/test/models/user.rb
+++ b/activerecord/test/models/user.rb
@@ -1,6 +1,7 @@
 class User < ActiveRecord::Base
   has_secure_token
   has_secure_token :auth_token
+  has_secure_token :auth_secret, token_length: 80
 end
 
 class UserWithNotification < User

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1014,6 +1014,7 @@ ActiveRecord::Schema.define do
   create_table :users, force: true do |t|
     t.string :token
     t.string :auth_token
+    t.string :auth_secret
   end
 
   create_table :test_with_keyword_column_name, force: true do |t|


### PR DESCRIPTION
User Should be able to configure token length. Suppose we can have multiple tokens (secret_key, secret_token) and we want secret_token to be of default size (24 char) but want to make secret_token of more characters e.g 80 characters.

Here are the Pull Requests already done in `has_secure_token` gem independently:
https://github.com/robertomiranda/has_secure_token/pull/11
https://github.com/robertomiranda/has_secure_token/pull/17

I think this PR can be really helpful.

Thanks
