### PR TITLE
 :nodoc: version method.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -77,7 +77,7 @@ module ActiveRecord
         }
       end
 
-      def version
+      def version #:nodoc:
         @version ||= Version.new(full_version.match(/^\d+\.\d+\.\d+/)[0])
       end
 


### PR DESCRIPTION
Follow up from https://github.com/rails/rails/pull/21932
 Reason:
- Its not publicly used method.
- Exposing it makes an assumption that other adapters support it based on its usage - ActiveRecord::Base.connection.version

r? @sgrif
