### PR TITLE
Use public_send over send, when comparing object compatibility for `or`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1210,9 +1210,9 @@ module ActiveRecord
     end
 
     def structurally_incompatible_values_for_or(other)
-      Relation::SINGLE_VALUE_METHODS.reject { |m| send("#{m}_value") == other.send("#{m}_value") } +
-        (Relation::MULTI_VALUE_METHODS - [:extending]).reject { |m| send("#{m}_values") == other.send("#{m}_values") } +
-        (Relation::CLAUSE_METHODS - [:having, :where]).reject { |m| send("#{m}_clause") == other.send("#{m}_clause") }
+      Relation::SINGLE_VALUE_METHODS.reject { |m| public_send("#{m}_value") == other.public_send("#{m}_value") } +
+        (Relation::MULTI_VALUE_METHODS - [:extending]).reject { |m| public_send("#{m}_values") == other.public_send("#{m}_values") } +
+        (Relation::CLAUSE_METHODS - [:having, :where]).reject { |m| public_send("#{m}_clause") == other.public_send("#{m}_clause") }
     end
 
     def new_where_clause


### PR DESCRIPTION
r? @matthewd 
