### PR TITLE
Add `quoted_time` for truncating the date part of a time column value

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -146,6 +146,10 @@ module ActiveRecord
         end
       end
 
+      def quoted_time(value) # :nodoc:
+        quoted_date(value).sub(/\A2000-01-01 /, '')
+      end
+
       def prepare_binds_for_database(binds) # :nodoc:
         binds.map(&:value_for_database)
       end
@@ -166,6 +170,7 @@ module ActiveRecord
         # BigDecimals need to be put in a non-normalized form and quoted.
         when BigDecimal then value.to_s('F')
         when Numeric, ActiveSupport::Duration then value.to_s
+        when Type::Time::Value then "'#{quoted_time(value)}'"
         when Date, Time then "'#{quoted_date(value)}'"
         when Symbol     then "'#{quote_string(value.to_s)}'"
         when Class      then "'#{value}'"
@@ -181,6 +186,7 @@ module ActiveRecord
         when false      then unquoted_false
         # BigDecimals need to be put in a non-normalized form and quoted.
         when BigDecimal then value.to_s('F')
+        when Type::Time::Value then quoted_time(value)
         when Date, Time then quoted_date(value)
         when *types_which_need_no_typecasting
           value

--- a/activerecord/lib/active_record/type/time.rb
+++ b/activerecord/lib/active_record/type/time.rb
@@ -2,6 +2,18 @@ module ActiveRecord
   module Type
     class Time < ActiveModel::Type::Time
       include Internal::Timezone
+
+      class Value < DelegateClass(::Time) # :nodoc:
+      end
+
+      def serialize(value)
+        case value = super
+        when ::Time
+          Value.new(value)
+        else
+          value
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/time_precision_test.rb
+++ b/activerecord/test/cases/time_precision_test.rb
@@ -44,7 +44,6 @@ class TimePrecisionTest < ActiveRecord::TestCase
   end
 
   def test_formatting_time_according_to_precision
-    skip("TIME column on MariaDB doesn't ignore the date part of the string when it coerces to time") if current_adapter?(:Mysql2Adapter) && ActiveRecord::Base.connection.mariadb?
     @connection.create_table(:foos, force: true) do |t|
       t.time :start,  precision: 0
       t.time :finish, precision: 4


### PR DESCRIPTION
Context #24522.

TIME column on MariaDB doesn't ignore the date part of the string when
it coerces to time.

```
root@localhost [test] > CREATE TABLE `foos` (`id` int AUTO_INCREMENT PRIMARY KEY, `start` time(0), `finish` time(4)) ENGINE=InnoDB;
Query OK, 0 rows affected (0.02 sec)

root@localhost [test] > INSERT INTO `foos` (`start`, `finish`) VALUES ('2000-01-01 12:30:00', '2000-01-01 12:30:00.999900');
Query OK, 1 row affected, 2 warnings (0.00 sec)

Note (Code 1265): Data truncated for column 'start' at row 1
Note (Code 1265): Data truncated for column 'finish' at row 1
root@localhost [test] > SELECT `foos`.* FROM `foos`;
+----+----------+---------------+
| id | start    | finish        |
+----+----------+---------------+
|  1 | 12:30:00 | 12:30:00.9999 |
+----+----------+---------------+
1 row in set (0.00 sec)

root@localhost [test] > SELECT  `foos`.* FROM `foos` WHERE `foos`.`start` = '2000-01-01 12:30:00' LIMIT 1;
Empty set (0.00 sec)

root@localhost [test] > SELECT  `foos`.* FROM `foos` WHERE `foos`.`start` = '12:30:00' LIMIT 1;
+----+----------+---------------+
| id | start    | finish        |
+----+----------+---------------+
|  1 | 12:30:00 | 12:30:00.9999 |
+----+----------+---------------+
1 row in set (0.00 sec)
```

r? @vipulnsward 
