### PR TITLE
Add ulimit settings doc for ActionCable [skip ci]

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -455,6 +455,13 @@ with all the popular application servers -- Unicorn, Puma and Passenger.
 Action Cable does not work with WEBrick, because WEBrick does not support the
 Rack socket hijacking API.
 
+When your application have a lot of Action Cable connections, you may need to adjust the Unix `ulimit` settings, for example:
+
+```bash
+$ ulimit -n 65535
+$ ulimit -Hn 65535
+```
+
 ## License
 
 Action Cable is released under the MIT license:

--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -455,7 +455,7 @@ with all the popular application servers -- Unicorn, Puma and Passenger.
 Action Cable does not work with WEBrick, because WEBrick does not support the
 Rack socket hijacking API.
 
-When your application have a lot of Action Cable connections, you may need to adjust the Unix `ulimit` settings, for example:
+When your application has a lot of Action Cable connections, you may need to adjust the Unix `ulimit` settings, for example:
 
 ```bash
 $ ulimit -n 65535


### PR DESCRIPTION
Many Linux Server ulimit default values it too low, for example Ubuntu Server

``` bash
$ ulimit -Sn
1024
$ ulimit -Hn
4096
```

By my test, that default value can connect about 1000  clients, in general web application cases, this is not enough.
So need tell Action Cable users to change it.
