### PR TITLE
Use 'public_send' over '__send__' for model's attribute methods.

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -179,13 +179,13 @@ module ActiveModel
     # Handles <tt>*_changed?</tt> for +method_missing+.
     def attribute_changed?(attr, from: OPTION_NOT_GIVEN, to: OPTION_NOT_GIVEN) # :nodoc:
       !!changes_include?(attr) &&
-        (to == OPTION_NOT_GIVEN || to == __send__(attr)) &&
+        (to == OPTION_NOT_GIVEN || to == public_send(attr)) &&
         (from == OPTION_NOT_GIVEN || from == changed_attributes[attr])
     end
 
     # Handles <tt>*_was</tt> for +method_missing+.
     def attribute_was(attr) # :nodoc:
-      attribute_changed?(attr) ? changed_attributes[attr] : __send__(attr)
+      attribute_changed?(attr) ? changed_attributes[attr] : public_send(attr)
     end
 
     # Handles <tt>*_previously_changed?</tt> for +method_missing+.
@@ -226,7 +226,7 @@ module ActiveModel
 
       # Handles <tt>*_change</tt> for +method_missing+.
       def attribute_change(attr)
-        [changed_attributes[attr], __send__(attr)] if attribute_changed?(attr)
+        [changed_attributes[attr], public_send(attr)] if attribute_changed?(attr)
       end
 
       # Handles <tt>*_previous_change</tt> for +method_missing+.
@@ -239,7 +239,7 @@ module ActiveModel
         return if attribute_changed?(attr)
 
         begin
-          value = __send__(attr)
+          value = public_send(attr)
           value = value.duplicable? ? value.clone : value
         rescue TypeError, NoMethodError
         end
@@ -250,7 +250,7 @@ module ActiveModel
       # Handles <tt>restore_*!</tt> for +method_missing+.
       def restore_attribute!(attr)
         if attribute_changed?(attr)
-          __send__("#{attr}=", changed_attributes[attr])
+          public_send("#{attr}=", changed_attributes[attr])
           clear_attribute_changes([attr])
         end
       end


### PR DESCRIPTION
Use `public_send` over `__send__` for model's attribute methods as they are
always **public** methods.
