### PR TITLE
Should keep quoting behaivor of a time column value in sqlite3 adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -14,6 +14,10 @@ module ActiveRecord
           @quoted_column_names[name] ||= %Q("#{super.gsub('"', '""')}")
         end
 
+        def quoted_time(value)
+          quoted_date(value)
+        end
+
         private
 
         def _quote(value)

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -8,9 +8,7 @@ module ActiveRecord
     class SQLite3Adapter
       class QuotingTest < ActiveRecord::SQLite3TestCase
         def setup
-          @conn = Base.sqlite3_connection :database => ':memory:',
-            :adapter => 'sqlite3',
-            :timeout => 100
+          @conn = ActiveRecord::Base.connection
         end
 
         def test_type_cast_binary_encoding_without_logger
@@ -88,6 +86,13 @@ module ActiveRecord
           type = Type::String.new
 
           assert_equal "'hello'", @conn.quote(type.serialize(value))
+        end
+
+        def test_quoted_time_returns_date_qualified_time
+          value = ::Time.utc(2000, 1, 1, 12, 30, 0, 999999)
+          type = Type::Time.new
+
+          assert_equal "'2000-01-01 12:30:00.999999'", @conn.quote(type.serialize(value))
         end
       end
     end


### PR DESCRIPTION
Follow up to #24542.

In MySQL and PostgreSQL, a time column value is saved as ignored the
date part of it. But in SQLite3, a time column value is saved as a string.

We should keep previous quoting behavior in sqlite3 adapter.

```
sqlite> CREATE TABLE "foos" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "start" time(0), "finish" time(4));
sqlite> INSERT INTO "foos" ("start", "finish") VALUES ('2000-01-01 12:30:00', '2000-01-01 12:30:00.999900');
sqlite> SELECT "foos".* FROM "foos";
1|2000-01-01 12:30:00|2000-01-01 12:30:00.999900
sqlite> SELECT  "foos".* FROM "foos" WHERE "foos"."start" = '2000-01-01 12:30:00' LIMIT 1;
1|2000-01-01 12:30:00|2000-01-01 12:30:00.999900
sqlite> SELECT  "foos".* FROM "foos" WHERE "foos"."start" = '12:30:00' LIMIT 1;
sqlite>
```

r? @jeremy 
