### PR TITLE
Added notice when a database is successfully created or dropped.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -4,6 +4,28 @@
 
     *Sean Griffin*
 
+*   Added notice when a database is successfully created or dropped.
+
+    Example:
+
+      ```
+      $ bin/rails db:create
+      Created database 'blog_development'
+      Created database 'blog_test'
+      ```
+
+      ```
+      $ bin/rails db:drop
+      Dropped database 'blog_development'
+      Dropped database 'blog_test'
+      ```
+    Changed older notices
+    `blog_development  already exists` to `Database 'blog_development' already exists`
+    and
+    `Couldn't drop blog_development` to `Couldn't drop database 'blog_development'`.
+
+    *bogdanvlviv*
+
 *   MariaDB 5.3+ supports microsecond datetime precision.
 
     *Jeremy Daer*

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -107,8 +107,9 @@ module ActiveRecord
       def create(*arguments)
         configuration = arguments.first
         class_for_adapter(configuration['adapter']).new(*arguments).create
+        $stdout.puts "Created database '#{configuration['database']}'"
       rescue DatabaseAlreadyExists
-        $stderr.puts "#{configuration['database']} already exists"
+        $stderr.puts "Database '#{configuration['database']}' already exists"
       rescue Exception => error
         $stderr.puts error
         $stderr.puts "Couldn't create database for #{configuration.inspect}"
@@ -133,11 +134,12 @@ module ActiveRecord
       def drop(*arguments)
         configuration = arguments.first
         class_for_adapter(configuration['adapter']).new(*arguments).drop
+        $stdout.puts "Dropped database '#{configuration['database']}'"
       rescue ActiveRecord::NoDatabaseError
         $stderr.puts "Database '#{configuration['database']}' does not exist"
       rescue Exception => error
         $stderr.puts error
-        $stderr.puts "Couldn't drop #{configuration['database']}"
+        $stderr.puts "Couldn't drop database '#{configuration['database']}'"
         raise
       end
 

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -8,6 +8,13 @@ module ActiveRecord
       ActiveRecord::Tasks::MySQLDatabaseTasks.stubs(:new).returns @mysql_tasks
       ActiveRecord::Tasks::PostgreSQLDatabaseTasks.stubs(:new).returns @postgresql_tasks
       ActiveRecord::Tasks::SQLiteDatabaseTasks.stubs(:new).returns @sqlite_tasks
+
+      $stdout, @original_stdout = StringIO.new, $stdout
+      $stderr, @original_stderr = StringIO.new, $stderr
+    end
+
+    def teardown
+      $stdout, $stderr = @original_stdout, @original_stderr
     end
   end
 

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -12,6 +12,13 @@ module ActiveRecord
 
       ActiveRecord::Base.stubs(:connection).returns(@connection)
       ActiveRecord::Base.stubs(:establish_connection).returns(true)
+
+      $stdout, @original_stdout = StringIO.new, $stdout
+      $stderr, @original_stderr = StringIO.new, $stderr
+    end
+
+    def teardown
+      $stdout, $stderr = @original_stdout, @original_stderr
     end
 
     def test_establishes_connection_without_database
@@ -48,14 +55,20 @@ module ActiveRecord
       ActiveRecord::Tasks::DatabaseTasks.create @configuration
     end
 
-    def test_create_when_database_exists_outputs_info_to_stderr
-      $stderr.expects(:puts).with("my-app-db already exists").once
+    def test_when_database_created_successfully_outputs_info_to_stdout
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
 
+      assert_equal $stdout.string, "Created database 'my-app-db'\n"
+    end
+
+    def test_create_when_database_exists_outputs_info_to_stderr
       ActiveRecord::Base.connection.stubs(:create_database).raises(
-        ActiveRecord::StatementInvalid.new("Can't create database 'dev'; database exists:")
+        ActiveRecord::Tasks::DatabaseAlreadyExists
       )
 
       ActiveRecord::Tasks::DatabaseTasks.create @configuration
+
+      assert_equal $stderr.string, "Database 'my-app-db' already exists\n"
     end
   end
 
@@ -77,6 +90,13 @@ module ActiveRecord
       ActiveRecord::Base.stubs(:establish_connection).
         raises(@error).
         then.returns(true)
+
+      $stdout, @original_stdout = StringIO.new, $stdout
+      $stderr, @original_stderr = StringIO.new, $stderr
+    end
+
+    def teardown
+      $stdout, $stderr = @original_stdout, @original_stderr
     end
 
     def test_root_password_is_requested
@@ -160,6 +180,13 @@ module ActiveRecord
 
       ActiveRecord::Base.stubs(:connection).returns(@connection)
       ActiveRecord::Base.stubs(:establish_connection).returns(true)
+
+      $stdout, @original_stdout = StringIO.new, $stdout
+      $stderr, @original_stderr = StringIO.new, $stderr
+    end
+
+    def teardown
+      $stdout, $stderr = @original_stdout, @original_stderr
     end
 
     def test_establishes_connection_to_mysql_database
@@ -172,6 +199,12 @@ module ActiveRecord
       @connection.expects(:drop_database).with('my-app-db')
 
       ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+    end
+
+    def test_when_database_dropped_successfully_outputs_info_to_stdout
+      ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+
+      assert_equal $stdout.string, "Dropped database 'my-app-db'\n"
     end
   end
 
@@ -307,6 +340,5 @@ module ActiveRecord
       ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
     end
   end
-
 end
 end

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -12,6 +12,13 @@ module ActiveRecord
 
       ActiveRecord::Base.stubs(:connection).returns(@connection)
       ActiveRecord::Base.stubs(:establish_connection).returns(true)
+
+      $stdout, @original_stdout = StringIO.new, $stdout
+      $stderr, @original_stderr = StringIO.new, $stderr
+    end
+
+    def teardown
+      $stdout, $stderr = @original_stdout, @original_stderr
     end
 
     def test_establishes_connection_to_postgresql_database
@@ -63,14 +70,20 @@ module ActiveRecord
       assert_raises(Exception) { ActiveRecord::Tasks::DatabaseTasks.create @configuration }
     end
 
-    def test_create_when_database_exists_outputs_info_to_stderr
-      $stderr.expects(:puts).with("my-app-db already exists").once
+    def test_when_database_created_successfully_outputs_info_to_stdout
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration
 
+      assert_equal $stdout.string, "Created database 'my-app-db'\n"
+    end
+
+    def test_create_when_database_exists_outputs_info_to_stderr
       ActiveRecord::Base.connection.stubs(:create_database).raises(
-        ActiveRecord::StatementInvalid.new('database "my-app-db" already exists')
+        ActiveRecord::Tasks::DatabaseAlreadyExists
       )
 
       ActiveRecord::Tasks::DatabaseTasks.create @configuration
+
+      assert_equal $stderr.string, "Database 'my-app-db' already exists\n"
     end
   end
 
@@ -84,6 +97,13 @@ module ActiveRecord
 
       ActiveRecord::Base.stubs(:connection).returns(@connection)
       ActiveRecord::Base.stubs(:establish_connection).returns(true)
+
+      $stdout, @original_stdout = StringIO.new, $stdout
+      $stderr, @original_stderr = StringIO.new, $stderr
+    end
+
+    def teardown
+      $stdout, $stderr = @original_stdout, @original_stderr
     end
 
     def test_establishes_connection_to_postgresql_database
@@ -100,6 +120,12 @@ module ActiveRecord
       @connection.expects(:drop_database).with('my-app-db')
 
       ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+    end
+
+    def test_when_database_dropped_successfully_outputs_info_to_stdout
+      ActiveRecord::Tasks::DatabaseTasks.drop @configuration
+
+      assert_equal $stdout.string, "Dropped database 'my-app-db'\n"
     end
   end
 
@@ -273,6 +299,5 @@ module ActiveRecord
       ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
     end
   end
-
 end
 end

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -15,6 +15,13 @@ module ActiveRecord
       File.stubs(:exist?).returns(false)
       ActiveRecord::Base.stubs(:connection).returns(@connection)
       ActiveRecord::Base.stubs(:establish_connection).returns(true)
+
+      $stdout, @original_stdout = StringIO.new, $stdout
+      $stderr, @original_stderr = StringIO.new, $stderr
+    end
+
+    def teardown
+      $stdout, $stderr = @original_stdout, @original_stderr
     end
 
     def test_db_checks_database_exists
@@ -23,12 +30,18 @@ module ActiveRecord
       ActiveRecord::Tasks::DatabaseTasks.create @configuration, '/rails/root'
     end
 
+    def test_when_db_created_successfully_outputs_info_to_stdout
+      ActiveRecord::Tasks::DatabaseTasks.create @configuration, '/rails/root'
+
+      assert_equal $stdout.string, "Created database '#{@database}'\n"
+    end
+
     def test_db_create_when_file_exists
       File.stubs(:exist?).returns(true)
 
-      $stderr.expects(:puts).with("#{@database} already exists")
-
       ActiveRecord::Tasks::DatabaseTasks.create @configuration, '/rails/root'
+
+      assert_equal $stderr.string, "Database '#{@database}' already exists\n"
     end
 
     def test_db_create_with_file_does_nothing
@@ -69,6 +82,13 @@ module ActiveRecord
       Pathname.stubs(:new).returns(@path)
       File.stubs(:join).returns('/former/relative/path')
       FileUtils.stubs(:rm).returns(true)
+
+      $stdout, @original_stdout = StringIO.new, $stdout
+      $stderr, @original_stderr = StringIO.new, $stderr
+    end
+
+    def teardown
+      $stdout, $stderr = @original_stdout, @original_stderr
     end
 
     def test_creates_path_from_database
@@ -102,6 +122,12 @@ module ActiveRecord
       FileUtils.expects(:rm).with('/former/relative/path')
 
       ActiveRecord::Tasks::DatabaseTasks.drop @configuration, '/rails/root'
+    end
+
+    def test_when_db_dropped_successfully_outputs_info_to_stdout
+      ActiveRecord::Tasks::DatabaseTasks.drop @configuration, '/rails/root'
+
+      assert_equal $stdout.string, "Dropped database '#{@database}'\n"
     end
   end
 

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -43,6 +43,8 @@ module ApplicationTests
 The Gemfile's dependencies are satisfied
 
 == Preparing database ==
+Created database 'db/development.sqlite3'
+Created database 'db/test.sqlite3'
 
 == Removing old logs and tempfiles ==
 

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -29,11 +29,11 @@ module ApplicationTests
       def db_create_and_drop(expected_database)
         Dir.chdir(app_path) do
           output = `bin/rails db:create`
-          assert_empty output
+          assert_match /Created database/, output
           assert File.exist?(expected_database)
           assert_equal expected_database, ActiveRecord::Base.connection_config[:database]
           output = `bin/rails db:drop`
-          assert_empty output
+          assert_match /Dropped database/, output
           assert !File.exist?(expected_database)
         end
       end


### PR DESCRIPTION
Added notice when a database is successfully created or dropped.

Example:

```
  $ bin/rails db:create
  Created database 'blog_development'
  Created database 'blog_test'
```

```
  $ bin/rails db:drop
  Dropped database 'blog_development'
  Dropped database 'blog_test'
```

Changed older notices
`blog_development  already exists` to `Database 'blog_development' already exists` and
`Couldn't drop blog_development` to `Couldn't drop database 'blog_development'`.
