### PR TITLE
Raise `ArgumentError` when an invalid form is passed to `Date#to_time`

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -80,6 +80,7 @@ class Date
   #
   #   date.to_time(:utc)             # => 2007-11-10 00:00:00 UTC
   def to_time(form = :local)
+    raise ArgumentError, "Expected :local or :utc, got #{form.inspect}." unless [:local, :utc].include?(form)
     ::Time.send(form, year, month, day)
   end
 

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -49,6 +49,10 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
         end
       end
     end
+
+    assert_raise(ArgumentError) do
+      Date.new(2005, 2, 21).to_time(:tokyo)
+    end
   end
 
   def test_compare_to_time


### PR DESCRIPTION
Before this commit
`NoMethodError: undefined method`form_name' for Time:Class`is raised
when an invalid argument is passed.
It is better to raise`ArgumentError` and show list of valid arguments
to developers.
