### PR TITLE
Memoize the `RouteSet#url_helpers` module

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Memoize the `RouteSet#url_helpers` module
+
+   *jeffrafter*
+
 *   Add extension synonyms `yml` and `yaml` for MIME type `application/x-yaml`.
 
    *bogdanvlviv*

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -440,7 +440,8 @@ module ActionDispatch
       def url_helpers(supports_path = true)
         routes = self
 
-        Module.new do
+        @_url_helpers ||= {}
+        @_url_helpers[supports_path] ||= Module.new do
           extend ActiveSupport::Concern
           include UrlFor
 


### PR DESCRIPTION
### Summary

This fixes a performance regression introduced between 4.1.x and 4.2.x.

Every call to a URL helper would create a new Module. Doing this repeatedly was not fast.

Fixes #23451
