### PR TITLE
Fixed ActionCable::Connection::ClientSocketTest test

### DIFF
--- a/actioncable/test/connection/client_socket_test.rb
+++ b/actioncable/test/connection/client_socket_test.rb
@@ -1,10 +1,9 @@
 require 'test_helper'
 require 'stubs/test_server'
 
-class ActionCable::Connection::StreamTest < ActionCable::TestCase
+class ActionCable::Connection::ClientSocketTest < ActionCable::TestCase
   class Connection < ActionCable::Connection::Base
-    attr_reader :websocket, :subscriptions, :message_buffer, :connected
-    attr_reader :errors
+    attr_reader :connected, :websocket, :errors
 
     def initialize(*)
       super

--- a/actioncable/test/connection/stream_test.rb
+++ b/actioncable/test/connection/stream_test.rb
@@ -3,8 +3,7 @@ require 'stubs/test_server'
 
 class ActionCable::Connection::StreamTest < ActionCable::TestCase
   class Connection < ActionCable::Connection::Base
-    attr_reader :websocket, :subscriptions, :message_buffer, :connected
-    attr_reader :errors
+    attr_reader :connected, :websocket, :errors
 
     def initialize(*)
       super


### PR DESCRIPTION
- Fixed ActionCable::Connection::ClientSocketTest that was overriding ActionCable::Connection::StreamTest test name
- Only add attr_readers for required attributes
