### PR TITLE
Allow to mark strings as unsafe with #html_unsafe

### DIFF
--- a/actionview/lib/action_view/buffers.rb
+++ b/actionview/lib/action_view/buffers.rb
@@ -46,5 +46,9 @@ module ActionView
     def html_safe
       self
     end
+
+    def html_unsafe
+      self
+    end
   end
 end

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -257,4 +257,7 @@ class String
   def html_safe
     ActiveSupport::SafeBuffer.new(self)
   end
+
+  # Marks a string as unsafe. It is the opposite of calling #html_safe.
+  alias html_unsafe to_str
 end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -674,6 +674,20 @@ class OutputSafetyTest < ActiveSupport::TestCase
     assert_equal @string, @string.html_safe
   end
 
+  test "A string can be marked unsafe" do
+    string = @string.html_unsafe
+    assert !string.html_safe?
+  end
+
+  test "Marking a string unsafe returns exactly the string" do
+    assert @string.equal? @string.html_unsafe
+  end
+
+  test "Marking a safe string unsafe returns the string" do
+    string = @string.html_safe
+    assert_equal @string, string.html_unsafe
+  end
+
   test "A fixnum is safe by default" do
     assert 5.html_safe?
   end


### PR DESCRIPTION
This can be useful when a string should be escaped even if coming from 
a place that already makes it as safe.

For example if some HTML produced by `render partial:` is used in a 
`data-attribute`.

**Note:** I'm not completely sure if `StreamingBuffer#html_unsafe` is necessary, will remove the method or update specs as needed.
