### PR TITLE
Fix wrong task name in 'A Guide for Upgrading Ruby on Rails' [ci skip]

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -44,13 +44,13 @@ TIP: Ruby 1.8.7 p248 and p249 have marshaling bugs that crash Rails. Ruby Enterp
 
 ### The Task
 
-Rails provides the `app:update` task. After updating the Rails version
+Rails provides the `rails:update` task. After updating the Rails version
 in the Gemfile, run this task.
 This will help you with the creation of new files and changes of old files in an
 interactive session.
 
 ```bash
-$ rails app:update
+$ rake rails:update
    identical  config/boot.rb
        exist  config
     conflict  config/routes.rb


### PR DESCRIPTION
The guide mentions the 'app:update' task, but the correct name is 'rails:update'. The task 'app:update' does not exist.

```
$ rails -v
Rails 5.0.0.beta3
$ rake -T update                                                                           
rake rails:update  # Update configs and some other initially generated files (or use just update:configs or update:bin)
```

The guide also suggest to execute 'rails task', but this only works in Rails 5. As this is a guide about upgrading Rails, the user will be probably in a prior version. So I think it is better to suggest 'rake task'.
