### PR TITLE
Adding validates_instance_of method to check class of an attribute

### DIFF
--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -15,6 +15,8 @@ en:
       empty: "can't be empty"
       blank: "can't be blank"
       present: "must be blank"
+      instance_is: "not instance of %{is_a}"
+      instance_in: "not instance among %{in}"
       too_long:
         one: "is too long (maximum is 1 character)"
         other: "is too long (maximum is %{count} characters)"

--- a/activemodel/lib/active_model/validations/instance.rb
+++ b/activemodel/lib/active_model/validations/instance.rb
@@ -1,0 +1,59 @@
+module ActiveModel
+  module Validations
+    # == \Active \Model Absence Validator
+    class ObjectValidator < EachValidator #:nodoc:
+
+      def initialize(options)
+        raise ArgumentError, "cannot validate instance without :is_a or :in" unless options.key?(:is_a) || options.key?(:in)
+        raise ArgumentError, "cannot validate instance for value and in range" if options.key?(:is_a) && options.key?(:in)
+        super
+      end
+
+      def validate_each(record, attr_name, value)
+        validate_is_a(record, attr_name, value) if options.key?(:is_a)
+        validate_in(record, attr_name, value) if options.key?(:in)
+      end
+
+      def validate_is_a(record, attr_name, value)
+        record.errors.add(attr_name, :instance_is, options) unless value.is_a? options[:is_a]
+      end
+
+      def validate_in(record, attr_name, value)
+        raise ArgumentError ":in value not an array" unless options[:in].is_a?(Array)
+        unless options[:in].any?{|class_name| value.is_a?(class_name)}
+          record.errors.add(attr_name, :instance_in, options)
+        end
+      end
+    end
+
+    module HelperMethods
+      # Validates that the specified attributes belongs to the mentioned class (as defined by
+      # Object#is_a?). Happens by default on save.
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_instance_of :residence, is_a: Address
+      #   end
+      #
+      # The residence attribute must be in the object and it must belong to class Address.
+      #
+      # Configuration options:
+      # * <tt>:message</tt> - A custom error message (default is: "not instance of").
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_instance_of :friend, in: [Employee, Student]
+      #   end
+      #
+      # The friend attribute must be in the object and it must belong to any of  Employee or Student.
+      #
+      # Configuration options:
+      # * <tt>:message</tt> - A custom error message (default is: "not instance among").
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # See <tt>ActiveModel::Validation#validates</tt> for more information
+      def validates_instance_of(*attr_names)
+        validates_with ObjectValidator, _merge_attributes(attr_names)
+      end
+    end
+  end
+end

--- a/activemodel/test/cases/validations/instance_validation_test.rb
+++ b/activemodel/test/cases/validations/instance_validation_test.rb
@@ -1,7 +1,6 @@
 require 'cases/helper'
 require 'models/topic'
 require 'models/person'
-require 'models/custom_reader'
 
 class InstanceValidationTest < ActiveModel::TestCase
   teardown do

--- a/activemodel/test/cases/validations/instance_validation_test.rb
+++ b/activemodel/test/cases/validations/instance_validation_test.rb
@@ -1,0 +1,34 @@
+require 'cases/helper'
+require 'models/topic'
+require 'models/person'
+require 'models/custom_reader'
+
+class InstanceValidationTest < ActiveModel::TestCase
+  teardown do
+    Topic.clear_validators!
+    Person.clear_validators!
+  end
+
+  def test_validates_instance_of_single_value
+    Topic.validates_instance_of(:title, is_a: String)
+    t = Topic.new
+    t.title = 1000
+    assert t.invalid?
+    assert_equal ["not instance of String"], t.errors[:title]
+  end
+
+  def test_validates_instance_of_in
+    Topic.validates_instance_of(:author_name, in: [String, Person])
+    t = Topic.new
+    t.author_name = 1000
+    assert t.invalid?
+    assert_equal ["not instance among [String, Person]"], t.errors[:author_name]
+
+    t.author_name = "Bingo!"
+    assert t.valid?
+
+    t.author_name = Person.new
+    assert t.valid?
+  end
+
+end


### PR DESCRIPTION
While working on one of the projects I'd come across a code like

```
class Order < ActiveRecord::Base
  has_one :approver
  attr_accessor :approver
  validates_presence_of :approver
end

class Moderator < User
end

class SuperAdmin < Moderator
end
```

Now if the logic is to say that approver can only be a `SuperAdmin`, we'd want to have a way to determine the validity of the record.

Added `validates_instance_of` method to check for such validation.

```
class Order < ActiveRecord::Base
  validates_instance_of :approver, is_a: SuperAdmin #This will validate if class is SuperAdmin
  validates_instance_of ::approver, in: [SuperAdmin, Moderator] will pass if approver is either of SuperAdmin or Moderator
```
