### PR TITLE
Add TIP about app:update task in 'A Guide for Upgrading Ruby on Rails'

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -44,7 +44,7 @@ TIP: Ruby 1.8.7 p248 and p249 have marshaling bugs that crash Rails. Ruby Enterp
 
 ### The Task
 
-Rails provides the `app:update` task. After updating the Rails version
+Rails provides the `app:update` task (`rails:update` on 4.2 and earlier). After updating the Rails version
 in the Gemfile, run this task.
 This will help you with the creation of new files and changes of old files in an
 interactive session.


### PR DESCRIPTION
The task 'rails app:update' only works in Rails 5. I think it worths adding the TIP about executing 'rake rails:update' for earlier versions.
