### PR TITLE
Small typo on a method name:

### DIFF
--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -15,11 +15,11 @@ module ActionMailer
       extend ActiveSupport::Concern
 
       included do
-        teardown :clear_test_deliviers
+        teardown :clear_test_deliveries
       end
 
       private
-      def clear_test_deliviers
+      def clear_test_deliveries
         if ActionMailer::Base.delivery_method == :test
           ActionMailer::Base.deliveries.clear
         end


### PR DESCRIPTION
There was a small typo in a method name:
- clear_test_deliviers -> clear_test_deliveries

I'm not including [ci skip] in the commit message on purpose in case I missed any call to that method
