### PR TITLE
Print the proper ::Float::INFINITY value when used as a default value

### DIFF
--- a/activemodel/lib/active_model/type/float.rb
+++ b/activemodel/lib/active_model/type/float.rb
@@ -7,6 +7,15 @@ module ActiveModel
         :float
       end
 
+      def type_cast_for_schema(value)
+        return "::Float::NAN" if value.try(:nan?)
+        case value
+        when ::Float::INFINITY then "::Float::INFINITY"
+        when -::Float::INFINITY then "-::Float::INFINITY"
+        else super
+        end
+      end
+
       alias serialize cast
 
       private

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -425,6 +425,13 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
       t.datetime :datetime_with_default, default: "2014-06-05 07:17:04"
       t.time     :time_with_default,     default: "07:17:04"
     end
+
+    if current_adapter?(:PostgreSQLAdapter)
+      @connection.create_table :infinity_defaults, force: true do |t|
+        t.float    :float_with_inf_default,    default: Float::INFINITY
+        t.float    :float_with_nan_default,    default: Float::NAN
+      end
+    end
   end
 
   teardown do
@@ -439,5 +446,12 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
     assert_match %r{t\.date\s+"date_with_default",\s+default: '2014-06-05'}, output
     assert_match %r{t\.datetime\s+"datetime_with_default",\s+default: '2014-06-05 07:17:04'}, output
     assert_match %r{t\.time\s+"time_with_default",\s+default: '2000-01-01 07:17:04'}, output
+  end
+
+  def test_schema_dump_with_float_column_infinity_default
+    skip unless current_adapter?(:PostgreSQLAdapter)
+    output = dump_table_schema('infinity_defaults')
+    assert_match %r{t\.float\s+"float_with_inf_default",\s+default: ::Float::INFINITY}, output
+    assert_match %r{t\.float\s+"float_with_nan_default",\s+default: ::Float::NAN}, output
   end
 end

--- a/activerecord/test/cases/type/date_time_test.rb
+++ b/activerecord/test/cases/type/date_time_test.rb
@@ -3,7 +3,7 @@ require "models/task"
 
 module ActiveRecord
   module Type
-    class IntegerTest < ActiveRecord::TestCase
+    class DateTimeTest < ActiveRecord::TestCase
       def test_datetime_seconds_precision_applied_to_timestamp
         skip "This test is invalid if subsecond precision isn't supported" unless subsecond_precision_supported?
         p = Task.create!(starting: ::Time.now)


### PR DESCRIPTION
### Summary

This will properly print `::Float::INFINITY`or `-::Float::INFINITY` in `schema.rb` as the default value of a float / double precision column with value 'Infinity' or '-Infinity' (in the database adapters that support that value). 
### Other Information

Performance-wise, since the `cast_value` in the ActiveModel::Type::Float already refers to potential `Infinity` values, I conclude it's also appropriate to implement the corresponding `::Float::INFINITY` type name print at this abstraction level, since the the schema is not printed very often (and not having this causes problems in all database adapters that support Infinity values).

Addresses https://github.com/rails/rails/issues/22396
