### PR TITLE
Add deprecation warning for ActionDispatch::Request inheritance change

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -11,6 +11,7 @@ require 'action_dispatch/http/filter_parameters'
 require 'action_dispatch/http/upload'
 require 'action_dispatch/http/url'
 require 'active_support/core_ext/array/conversions'
+require 'active_support/deprecation'
 
 module ActionDispatch
   class Request
@@ -404,6 +405,16 @@ module ActionDispatch
 
     def ssl?
       super || scheme == 'wss'.freeze
+    end
+
+    def method_missing(method, *args)
+      super unless Rack::Request.public_instance_methods.include?(method)
+      ActiveSupport::Deprecation.warn(<<-MESSAGE.strip_heredoc)
+              ActionDispatch::Request will no longer inherit from Rack::Request in Rails 5.1.
+              The method '#{method}' and all other public API exposed by ActionDispatch::Request via its inheritance of Rack::Request will be removed without replacement.
+            MESSAGE
+
+      Rack::Request.new(env).send(method, *args)
     end
 
     private

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1262,3 +1262,41 @@ class RequestFormData < BaseRequestTest
     assert !request.form_data?
   end
 end
+
+class RequestDeprecationTest < BaseRequestTest
+  # This is not at all meant to be a complete suite,
+  # but just two examples of what the deprecation warning would look like
+  test 'request[] is deprecated' do
+    request = stub_request(
+      'REQUEST_METHOD' => 'POST',
+      'CONTENT_TYPE' => 'application/x-www-form-urlencoded; charset=utf-8',
+      'rack.input' => StringIO.new("flamenco=love")
+    )
+
+    warning = <<-MESSAGE.strip_heredoc
+              ActionDispatch::Request will no longer inherit from Rack::Request in Rails 5.1.
+              The method '\\[\\]' and all other public API exposed by ActionDispatch::Request via its inheritance of Rack::Request will be removed without replacement.
+            MESSAGE
+
+    assert_deprecated(/#{warning}/) do
+      request['CONTENT_TYPE']
+    end
+  end
+
+  test 'request[]= is deprecated' do
+    request = stub_request(
+      'REQUEST_METHOD' => 'POST',
+      'CONTENT_TYPE' => 'application/x-www-form-urlencoded; charset=utf-8',
+      'rack.input' => StringIO.new("flamenco=love")
+    )
+
+    warning = <<-MESSAGE.strip_heredoc
+              ActionDispatch::Request will no longer inherit from Rack::Request in Rails 5.1.
+              The method '\\[\\]=' and all other public API exposed by ActionDispatch::Request via its inheritance of Rack::Request will be removed without replacement.
+            MESSAGE
+
+    assert_deprecated(/#{warning}/) do
+      request['CONTENT_TYPE'] = 'application/xml'
+    end
+  end
+end


### PR DESCRIPTION
- AD::Request no longer inherits from Rack::Request
- This behavior was introduced via 529136d670c46bd66b56c519d4f51ed8f86c75b1
- Unfortunately, no deprecation warning was put out for users to be
  notified about this :(
- This also means that the removal is a regression :(
- This commit adds a deprecation warning via a method_missing check, to
  see if the method being called on the current instance of AD::Request
  is a public instance method of Rack::Request, and if so, properly route
  to that method, while at the same time providing a deprecation warning.

cc @tenderlove, ref #24555
