### PR TITLE
Address ORA-00923 error by quoting a reserved word "SIZE"

### DIFF
--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -16,7 +16,7 @@ module ActiveRecord
 
         query = collection
           .unscope(:select)
-          .select("COUNT(*) AS size", "MAX(#{column}) AS timestamp")
+          .select("COUNT(*) AS #{connection.quote_column_name("size")}", "MAX(#{column}) AS timestamp")
           .unscope(:order)
         result = connection.select_one(query)
 


### PR DESCRIPTION
### Summary

This pull request addresses ORA-00923 error when ActiveRecord unit tests executed for Oracle enhanced adapter.

``` ruby
$ cd activerecord
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/collection_cache_key_test.rb -n test_cache_key_for_empty_relation
... snip ...
# Running:

E

Finished in 0.431709s, 2.3164 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::CollectionCacheKeyTest#test_cache_key_for_empty_relation:
ActiveRecord::StatementInvalid: OCIError: ORA-00923: FROM keyword not found where expected: SELECT COUNT(*) AS size, MAX("DEVELOPERS"."UPDATED_AT") AS timestamp FROM "DEVELOPERS" WHERE "DEVELOPERS"."NAME" = :a1
    stmt.c:243:in oci8lib_230.so
    /home/yahonda/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.1/lib/oci8/cursor.rb:126:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:171:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:39:in `block in exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:527:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:521:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1169:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:22:in `exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:377:in `select'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:41:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:48:in `select_one'
    /home/yahonda/git/rails/activerecord/lib/active_record/collection_cache_key.rb:21:in `collection_cache_key'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:337:in `cache_key'
    test/cases/collection_cache_key_test.rb:51:in `block in <class:CollectionCacheKeyTest>'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$ 
```

``` sql
SELECT COUNT(*) AS size, MAX("DEVELOPERS"."UPDATED_AT") AS timestamp FROM "DEVELOPERS" WHERE "DEVELOPERS"."NAME" = :a1
```

Since "SIZE" is a reserved word of Oracle database. It cannot be used as identifier without quote.

``` sql
SQL> select keyword, reserved from v$reserved_words
  2  where keyword = 'SIZE';

KEYWORD                RESERVED
------------------------------ --------
SIZE                   Y
```
### Other Information

This commit has been tested with all bundled adapters - sqlite3, mysql2 and postgresql adapters. Here are sql statements executed:
- oracle_enhanced

``` sql
SELECT COUNT(*) AS "SIZE", MAX("DEVELOPERS"."UPDATED_AT") AS timestamp FROM "DEVELOPERS"
```
- sqlite3

``` sql
SELECT COUNT(*) AS "size", MAX("developers"."updated_at") AS timestamp FROM "developers"
```
- mysql2

``` sql
- SELECT COUNT(*) AS `size`, MAX(`developers`.`updated_at`) AS timestamp FROM `developers`
```
- postgresql

``` sql
SELECT COUNT(*) AS "size", MAX("developers"."updated_at") AS timestamp FROM "developers"
```
