### PR TITLE
Fix forced cache miss for fetch.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Raise an argument error if no block is passed to #fetch with option
+    `force: true` is set.
+
+        cache.fetch('today', force: true) # => ArgumentError: Missing block
+
+    *Santosh Wadghule*
+
 *   `ActiveSupport::Duration` supports weeks and hours.
 
         [1.hour.inspect, 1.hour.value, 1.hour.parts]

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -198,10 +198,16 @@ module ActiveSupport
       #   cache.fetch('city')   # => "Duckburgh"
       #
       # You may also specify additional options via the +options+ argument.
-      # Setting <tt>force: true</tt> will force a cache miss:
+      # Setting <tt>force: true</tt> will force a cache miss and return value of
+      # the block will be written to the cache under the given cache key.
       #
       #   cache.write('today', 'Monday')
-      #   cache.fetch('today', force: true)  # => nil
+      #   cache.fetch('today', force: true) { 'Tuesday' } # => 'Tuesday'
+      #
+      # It will raise an argument error if no block is passed to #fetch with
+      # option <tt>force: true</tt> is set.
+      #
+      #   cache.fetch('today', force: true) # => ArgumentError: Missing block
       #
       # Setting <tt>:compress</tt> will store a large cache entry set by the call
       # in a compressed format.
@@ -292,6 +298,8 @@ module ActiveSupport
           else
             save_block_result_to_cache(name, options) { |_name| yield _name }
           end
+        elsif options && options[:force]
+          raise ArgumentError, 'Missing block'
         else
           read(name, options)
         end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -266,6 +266,20 @@ module CacheStoreBehavior
     end
   end
 
+  def test_fetch_with_forced_cache_miss_with_block
+    @cache.write('foo', 'bar')
+    assert_equal 'foo_bar', @cache.fetch('foo', force: true) { 'foo_bar' }
+  end
+
+  def test_fetch_with_forced_cache_miss_without_block
+    @cache.write('foo', 'bar')
+    assert_raises(ArgumentError, 'Missing block') do
+      @cache.fetch('foo', force: true)
+    end
+
+    assert_equal 'bar', @cache.read('foo')
+  end
+
   def test_should_read_and_write_hash
     assert @cache.write('foo', {:a => "b"})
     assert_equal({:a => "b"}, @cache.read('foo'))


### PR DESCRIPTION
As per given document, if we call fetch method with 'force: true' option without
the block, it should force a cache miss. But it was happening properly,
so added this fix.

https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache.rb#L200-L204

``` ruby
# You may also specify additional options via the +options+ argument.
# Setting <tt>force: true</tt> will force a cache miss:
#
#   cache.write('today', 'Monday')
#   cache.fetch('today', force: true)  # => nil
```

**UPDATE**

Based on the discussion with Jeremy. Now we have only raised argument error if no block is passed to `fetch` method with option `force: true` is set.

r? @jeremy 
