### PR TITLE
fix scaffold.css

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold/templates/scaffold.css
+++ b/railties/lib/rails/generators/rails/scaffold/templates/scaffold.css
@@ -1,9 +1,6 @@
 body {
   background-color: #fff;
   color: #333;
-}
-
-body, p, ol, ul, td {
   font-family: verdana, arial, helvetica, sans-serif;
   font-size: 13px;
   line-height: 18px;


### PR DESCRIPTION
Do we need to repeat the styling?

The current scaffold generator generate:

``` css
body {                                               
  background-color: #fff;                            
  color: #333;                                       
  font-family: verdana, arial, helvetica, sans-serif;
  font-size: 13px;                                   
  line-height: 18px;                                 
  margin: 33px;                                      
}                                                    

p, ol, ul, td {                                      
  font-family: verdana, arial, helvetica, sans-serif;
  font-size: 13px;                                   
  line-height: 18px;                                 
  margin: 33px;                                      
}
```

Now:

``` css
body {                                               
  background-color: #fff;                            
  color: #333;                                       
  font-family: verdana, arial, helvetica, sans-serif;
  font-size: 13px;                                   
  line-height: 18px;                                 
  margin: 33px;                                      
}                                                    

```
