### PR TITLE
documentation for add_references index option

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -776,7 +776,8 @@ module ActiveRecord
       # [<tt>:type</tt>]
       #   The reference column type. Defaults to +:integer+.
       # [<tt>:index</tt>]
-      #   Add an appropriate index. Defaults to false.
+      #   Add an appropriate index. Defaults to false.  
+      #   See #add_index for usage of this option.
       # [<tt>:foreign_key</tt>]
       #   Add an appropriate foreign key constraint. Defaults to false.
       # [<tt>:polymorphic</tt>]
@@ -795,6 +796,14 @@ module ActiveRecord
       # ====== Create supplier_id, supplier_type columns and appropriate index
       #
       #   add_reference(:products, :supplier, polymorphic: true, index: true)
+      #
+      # ====== Create a supplier_id column with a unique index
+      #
+      #   add_reference(:products, :supplier, index: { unique: true })
+      #
+      # ====== Create a supplier_id column with a named index
+      #
+      #   add_reference(:products, :supplier, index: { name: "my_supplier_index" })
       #
       # ====== Create a supplier_id column and appropriate foreign key
       #

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -246,7 +246,8 @@ class AddUserRefToProducts < ActiveRecord::Migration[5.0]
 end
 ```
 
-This migration will create a `user_id` column and appropriate index.
+This migration will create a `user_id` column and appropriate index.   
+For more `add_reference` options, visit the [API documentation](http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_reference).
 
 There is also a generator which will produce join tables if `JoinTable` is part of the name:
 


### PR DESCRIPTION
The documentation for `add_reference` index option didn't have much info or links pointing people in the right direction to find out more.

This PR adds the following:
- Add link for finding the addional options for index.
- Add example for unique index as this is a common requirement.
- Add link in guide for index options.
## Migration Guide

<img width="820" alt="screen shot 2016-04-16 at 14 41 54" src="https://cloud.githubusercontent.com/assets/354592/14581311/7e66f512-03e1-11e6-9522-15186c12369b.png">
## API Docs

<img width="956" alt="screen shot 2016-04-16 at 20 17 07" src="https://cloud.githubusercontent.com/assets/354592/14583122/41426e1c-0410-11e6-93b8-07921f6f8ca6.png">
