### PR TITLE
Properly verify that cache accepts and uses `expires` value. 

### DIFF
--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -219,12 +219,15 @@ CACHED
   end
 
   def test_fragment_caching_with_options
+    time = Time.now
     get :fragment_cached_with_options
     assert_response :success
     expected_body = "<body>\n<p>ERB</p>\n</body>\n"
 
     assert_equal expected_body, @response.body
-    assert_equal "<p>ERB</p>", @store.read("views/with_options")
+    Time.stub(:now, time + 11) do
+      assert_nil @store.read("views/with_options")
+    end
   end
 
   def test_render_inline_before_fragment_caching

--- a/actionpack/test/fixtures/functional_caching/fragment_cached_with_options.html.erb
+++ b/actionpack/test/fixtures/functional_caching/fragment_cached_with_options.html.erb
@@ -1,3 +1,3 @@
 <body>
-<%= cache 'with_options', skip_digest: true, expires_in: 1.minute do %><p>ERB</p><% end %>
+<%= cache 'with_options', skip_digest: true, expires_in: 10 do %><p>ERB</p><% end %>
 </body>


### PR DESCRIPTION
Properly verify that cache accepts and uses `expires` value. 
