### PR TITLE
Extract variant setter to process method

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -109,6 +109,9 @@ module AbstractController
     def _process_format(format)
     end
 
+    def _process_variant(options)
+    end
+
     def _set_html_content_type # :nodoc:
     end
 
@@ -119,10 +122,7 @@ module AbstractController
     # :api: private
     def _normalize_render(*args, &block)
       options = _normalize_args(*args, &block)
-      #TODO: remove defined? when we restore AP <=> AV dependency
-      if defined?(request) && !request.nil? && request.variant.present?
-        options[:variant] = request.variant
-      end
+      _process_variant(options)
       _normalize_options(options)
       options
     end

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -54,6 +54,12 @@ module ActionController
 
     private
 
+      def _process_variant(options)
+        if defined?(request) && !request.nil? && request.variant.present?
+          options[:variant] = request.variant
+        end
+      end
+
       def _render_in_priorities(options)
         RENDER_FORMATS_IN_PRIORITY.each do |format|
           return options[format] if options.key?(format)


### PR DESCRIPTION
Provide an API interface similar to how format is handled in
Controllers. In situations where variants are not needed (ex: in
Action Mailer) the method will simply trigger a no-op, and will not
affect end users.
