### PR TITLE
Change api status from private to plugin

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -109,7 +109,7 @@ module AbstractController
     end
 
     # Process the rendered format.
-    # :api: private
+    # :api: plugin
     def _process_format(format)
     end
 


### PR DESCRIPTION
These three methods are used in either ActionController::Base and
ActionMailer::Base, and are actually called from within
AbstractController::Base itself. This signifies that these methods are
apart of the plugin API that AbstractController::Base exposes for its
descendants

[ci skip]
