### PR TITLE
Do not clear active connections when testing

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/executor.rb
+++ b/actionpack/lib/action_dispatch/middleware/executor.rb
@@ -10,9 +10,9 @@ module ActionDispatch
       state = @executor.run!
       begin
         response = @app.call(env)
-        returned = response << ::Rack::BodyProxy.new(response.pop) { state.complete! }
+        returned = response << ::Rack::BodyProxy.new(response.pop) { state.complete!(env: env) }
       ensure
-        state.complete! unless returned
+        state.complete!(env: env) unless returned
       end
     end
   end

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -44,8 +44,8 @@ module ActiveRecord
       executor.register_hook(self)
 
       executor.to_complete do
-        # FIXME: This should be skipped when env['rack.test']
-        ActiveRecord::Base.clear_active_connections!
+        testing = @args[:env]['rack.test']
+        ActiveRecord::Base.clear_active_connections! unless testing
       end
     end
   end

--- a/activesupport/lib/active_support/execution_wrapper.rb
+++ b/activesupport/lib/active_support/execution_wrapper.rb
@@ -103,7 +103,8 @@ module ActiveSupport
     # exactly once on the result of any call to +run!+.
     #
     # Where possible, prefer +wrap+.
-    def complete!
+    def complete!(**args)
+      @args = args
       run_callbacks(:complete)
     ensure
       self.class.active.delete Thread.current


### PR DESCRIPTION
This was a slight regression when the new ActiveSupport::Executor API
was introduced. It isn't great that we now have `@args` as apart of the
`complete!` method, but I don't think there is any other way to pass in
the current Rack `env` or similar arguments.
