### PR TITLE
Fix typos in ActionCable Channel [ci skip]

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -178,7 +178,7 @@ App.cable.subscriptions.create "AppearanceChannel",
 ```
 
 Simply calling `App.cable.subscriptions.create` will setup the subscription, which will call `AppearanceChannel#subscribed`,
-which in turn is linked to original `App.cable` -> `ApplicationCable::Connection` instances.
+which in turn is linked to the original `App.cable` -> `ApplicationCable::Connection` instances.
 
 Next, we link the client-side `appear` method to `AppearanceChannel#appear(data)`. This is possible because the server-side
 channel instance will automatically expose the public methods declared on the class (minus the callbacks), so that these

--- a/actioncable/lib/action_cable/channel/periodic_timers.rb
+++ b/actioncable/lib/action_cable/channel/periodic_timers.rb
@@ -12,8 +12,8 @@ module ActionCable
       end
 
       module ClassMethods
-        # Allows you to call a private method <tt>every</tt> so often seconds. This periodic timer can be useful
-        # for sending a steady flow of updates to a client based off an object that was configured on subscription.
+        # Allows you to call a private method periodically. Specify the period, in seconds, using the <tt>every</tt> keyword argument.
+        # This periodic timer can be useful for sending a steady flow of updates to a client based off an object that was configured on subscription.
         # It's an alternative to using streams if the channel is able to do the work internally.
         def periodically(callback, every:)
           self.periodic_timers += [ [ callback, every: every ] ]

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -2,7 +2,7 @@ module ActionCable
   module Channel
     # Streams allow channels to route broadcastings to the subscriber. A broadcasting is, as discussed elsewhere, a pubsub queue where any data
     # placed into it is automatically sent to the clients that are connected at that time. It's purely an online queue, though. If you're not
-    # streaming a broadcasting at the very moment it sends out an update, you will not get that update, if you connect after it has been sent.
+    # streaming a broadcasting at the very moment it sends out an update, you will not get that update, even if you connect after it has been sent.
     #
     # Most commonly, the streamed broadcast is sent straight to the subscriber on the client-side. The channel just acts as a connector between
     # the two parties (the broadcaster and the channel subscriber). Here's an example of a channel that allows subscribers to get all new

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -40,7 +40,7 @@ module ActionCable
     # Second, we rely on the fact that the WebSocket connection is established with the cookies from the domain being sent along. This makes
     # it easy to use signed cookies that were set when logging in via a web interface to authorize the WebSocket connection.
     #
-    # Finally, we add a tag to the connection-specific logger with name of the current user to easily distinguish their messages in the log.
+    # Finally, we add a tag to the connection-specific logger with the name of the current user to easily distinguish their messages in the log.
     #
     # Pretty simple, eh?
     class Base


### PR DESCRIPTION
### Summary

Documentation fixes for action cable channel.
