### PR TITLE
Don't create new arrays when trying to compute non_empty_predicates for ast generation

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -158,8 +158,9 @@ module ActiveRecord
         end
       end
 
+      ARRAY_WITH_EMPTY_STRING = ['']
       def non_empty_predicates
-        predicates - ['']
+        predicates - ARRAY_WITH_EMPTY_STRING
       end
 
       def wrap_sql_literal(node)


### PR DESCRIPTION
Don't create new arrays when trying to compute non_empty_predicates for where clause predicate. 
Get a 3-4% improvement in AST generation.

Perf compare: https://gist.github.com/vipulnsward/7e4e9ecb157e574002313249a7969c82

r? @sgrif 

Found while checking up https://github.com/rails/rails/issues/24588
