### PR TITLE
Run integration tests through the app's executor

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -755,6 +755,12 @@ module ActionDispatch
         @@app = nil
       end
 
+      def run(*)
+        app.executor.wrap do
+          super
+        end
+      end
+
       module ClassMethods
         def app
           defined?(@@app) ? @@app : ActionDispatch.test_app

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -44,7 +44,6 @@ module ActiveRecord
       executor.register_hook(self)
 
       executor.to_complete do
-        # FIXME: This should be skipped when env['rack.test']
         ActiveRecord::Base.clear_active_connections!
       end
     end


### PR DESCRIPTION
This ensures that the "unit of computation" is an entire test, instead
of the request. This allows us to skip, for example, connection pooling.
This ensures that the same connection is used for the entire test.

We should arguably do this for all tests, but this level is the only
place that we have an obvious lifecycle to hook into.

I think there's still an underlying problem to address, which is that in
general we shouldn't release a connection with an open transaction that
hasn't been poisoned back into the pool. However, that's a slightly
larger change that can be addressed later.

Fixes #24004 (though this may require an upstream change for RSpec)
Fixes #23989
Fixes #24491
Close #24500
Close #24599
