### PR TITLE
Do not attempt to return connection with open transaction to pool

### DIFF
--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -44,8 +44,9 @@ module ActiveRecord
       executor.register_hook(self)
 
       executor.to_complete do
-        # FIXME: This should be skipped when env['rack.test']
-        ActiveRecord::Base.clear_active_connections!
+        unless ActiveRecord::Base.connection.transaction_open?
+          ActiveRecord::Base.clear_active_connections!
+        end
       end
     end
   end


### PR DESCRIPTION
When the query cache completes, if Active Record is still inside of a
transaction, it is because the transaction is meant to be left open
above this unit of work (such as transactional fixtures in tests). There
were several tests around the behavior of "tests" that were invalid, as
tests are not run through the executor. They have been changed to
reflect the new behavior, which is closer to what actually occurs in
Rails tests.

Fixes #23989
Fixes #24491
Close #24500
