### PR TITLE
Cable: Extract stream handler construction for easy override & testing

### DIFF
--- a/actioncable/lib/action_cable/server/worker.rb
+++ b/actioncable/lib/action_cable/server/worker.rb
@@ -12,8 +12,10 @@ module ActionCable
       define_callbacks :work
       include ActiveRecordConnectionManagement
 
+      attr_reader :executor
+
       def initialize(max_size: 5)
-        @pool = Concurrent::ThreadPoolExecutor.new(
+        @executor = Concurrent::ThreadPoolExecutor.new(
           min_threads: 1,
           max_threads: max_size,
           max_queue: 0,
@@ -23,11 +25,11 @@ module ActionCable
       # Stop processing work: any work that has not already started
       # running will be discarded from the queue
       def halt
-        @pool.kill
+        @executor.kill
       end
 
       def stopping?
-        @pool.shuttingdown?
+        @executor.shuttingdown?
       end
 
       def work(connection)
@@ -40,14 +42,14 @@ module ActionCable
         self.connection = nil
       end
 
-      def async_invoke(receiver, method, *args)
-        @pool.post do
-          invoke(receiver, method, *args)
+      def async_invoke(receiver, method, *args, connection: receiver)
+        @executor.post do
+          invoke(receiver, method, *args, connection: connection)
         end
       end
 
-      def invoke(receiver, method, *args)
-        work(receiver) do
+      def invoke(receiver, method, *args, connection:)
+        work(connection) do
           begin
             receiver.send method, *args
           rescue Exception => e

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -142,6 +142,7 @@ module ActionCable::StreamTests
         connection.websocket.expects(:transmit)
         @server.broadcast 'test_room_1', { foo: 'bar' }, coder: DummyEncoder
         wait_for_async
+        wait_for_executor connection.server.worker_pool.executor
       end
     end
 

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -226,7 +226,9 @@ class ClientTest < ActionCable::TestCase
       assert_equal(1, app.connections.count)
       assert(app.remote_connections.where(identifier: identifier))
 
-      channel = app.connections.first.subscriptions.send(:subscriptions).first[1]
+      subscriptions = app.connections.first.subscriptions.send(:subscriptions)
+      assert_not_equal 0, subscriptions.size, 'Missing EchoChannel subscription'
+      channel = subscriptions.first[1]
       channel.expects(:unsubscribed)
       c.close
       sleep 0.1 # Data takes a moment to process

--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -49,10 +49,7 @@ end
 
 module ConcurrentRubyConcurrencyHelpers
   def wait_for_async
-    e = Concurrent.global_io_executor
-    until e.completed_task_count == e.scheduled_task_count
-      sleep 0.1
-    end
+    wait_for_executor Concurrent.global_io_executor
   end
 
   def run_in_eventmachine
@@ -66,5 +63,11 @@ class ActionCable::TestCase < ActiveSupport::TestCase
     include EventMachineConcurrencyHelpers
   else
     include ConcurrentRubyConcurrencyHelpers
+  end
+
+  def wait_for_executor(executor)
+    until executor.completed_task_count == executor.scheduled_task_count
+      sleep 0.1
+    end
   end
 end

--- a/actioncable/test/worker_test.rb
+++ b/actioncable/test/worker_test.rb
@@ -33,12 +33,12 @@ class WorkerTest < ActiveSupport::TestCase
   end
 
   test "invoke" do
-    @worker.invoke @receiver, :run
+    @worker.invoke @receiver, :run, connection: @receiver.connection
     assert_equal :run, @receiver.last_action
   end
 
   test "invoke with arguments" do
-    @worker.invoke @receiver, :process, "Hello"
+    @worker.invoke @receiver, :process, "Hello", connection: @receiver.connection
     assert_equal [ :process, "Hello" ], @receiver.last_action
   end
 end


### PR DESCRIPTION
Stream handler builders (decoder, transmitter, default handler) to simplify override in subclasses and decoration by mixins, e.g. for logging, instrumentation, error handling.

Sparked by code in #24162.
