### PR TITLE
Selectively add `li ul, li ol { margin:0 1.5em; }` to subColl as needed

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -16,7 +16,6 @@
 .large {font-size: larger;}
 .hide {display: none;}
 
-li ul, li ol { margin:0 1.5em; }
 ul, ol { margin: 0 1.5em 1.5em 1.5em; }
 
 ul { list-style-type: disc; }
@@ -601,6 +600,8 @@ h6 {
   font-size: 1em;
   font-weight: normal;
 }
+
+#subCol li ul, li ol { margin:0 1.5em; }
 
 div.code_container {
   background: #EEE url(../images/tab_grey.gif) no-repeat left top;


### PR DESCRIPTION
Selectively add `li ul, li ol { margin:0 1.5em; }` to subColl as needed for Chapters column, instead of leaking to other lists.
This fixes list spacing on other pages.

Before:
 https://monosnap.com/file/CNIMXcqv3HuRrObTNYWYFis8I3G8PT
After:
 https://monosnap.com/file/0IyEKEy9hcRCIx82etR8ikinCo3vNb

Chapters column remains as is: http://take.ms/M0BkF

r? @fxn 
