### PR TITLE
Use rails 5 in rails engine bin

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -238,6 +238,11 @@ module ActiveModel
         namespace = self.parents.detect do |n|
           n.respond_to?(:use_relative_model_naming?) && n.use_relative_model_naming?
         end
+
+        if respond_to?(:use_relative_model_naming?) && use_relative_model_naming?
+          namespace = name.split('::').first.constantize
+        end
+
         ActiveModel::Name.new(self, namespace)
       end
     end

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -3,6 +3,8 @@ require 'models/contact'
 require 'models/sheep'
 require 'models/track_back'
 require 'models/blog_post'
+require 'models/asset/base'
+require 'models/asset/image'
 
 class NamingTest < ActiveModel::TestCase
   def setup
@@ -191,6 +193,44 @@ class NamingUsingRelativeModelNameTest < ActiveModel::TestCase
 
   def test_i18n_key
     assert_equal :"blog/post", @model_name.i18n_key
+  end
+end
+
+class NamingUsingRelativeModelNameTestViaAbstractClass < ActiveModel::TestCase
+  def setup
+    @model_name = Asset::Image.model_name
+  end
+
+  def test_singular
+    assert_equal 'asset_image', @model_name.singular
+  end
+
+  def test_plural
+    assert_equal 'asset_images', @model_name.plural
+  end
+
+  def test_element
+    assert_equal 'image', @model_name.element
+  end
+
+  def test_collection
+    assert_equal 'asset/images', @model_name.collection
+  end
+
+  def test_human
+    assert_equal 'Image', @model_name.human
+  end
+
+  def test_route_key
+    assert_equal 'images', @model_name.route_key
+  end
+
+  def test_param_key
+    assert_equal 'image', @model_name.param_key
+  end
+
+  def test_i18n_key
+    assert_equal :"asset/image", @model_name.i18n_key
   end
 end
 

--- a/activemodel/test/models/asset/base.rb
+++ b/activemodel/test/models/asset/base.rb
@@ -1,0 +1,7 @@
+module Asset
+  class Base
+    def self.use_relative_model_naming?
+      true
+    end
+  end
+end

--- a/activemodel/test/models/asset/image.rb
+++ b/activemodel/test/models/asset/image.rb
@@ -1,0 +1,5 @@
+module Asset
+  class Image < Asset::Base
+    extend ActiveModel::Naming
+  end
+end

--- a/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
@@ -1,4 +1,5 @@
-# This command will automatically be run when you run "rails" with Rails 4 gems installed from the root of your application.
+# This command will automatically be run when you run "rails" with Rails 5 gems
+# installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path('../..', __FILE__)
 ENGINE_PATH = File.expand_path('../../lib/<%= namespaced_name -%>/engine', __FILE__)


### PR DESCRIPTION
### Summary

While setting up a Rails engine with Rails 5.0.0.beta3, I noticed that the `bin/rails` for that plugin specified "Rails 4 gems". Thought it'd be nice to update it to say "Rails 5 gems" and also let the comments meet an 80 character line length :p

> Thanks for contributing to Rails!
- CONTRIBUTING.md

You're welcome :)
