### PR TITLE
remove rails 4 specification in bin/rails for plugins

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
@@ -1,4 +1,5 @@
-# This command will automatically be run when you run "rails" with Rails 4 gems installed from the root of your application.
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path('../..', __FILE__)
 ENGINE_PATH = File.expand_path('../../lib/<%= namespaced_name -%>/engine', __FILE__)


### PR DESCRIPTION
### Summary

While setting up a Rails engine with Rails 5.0.0.beta3, I noticed that the `bin/rails` for that plugin specified "Rails 4 gems". Thought it'd be nice to update it to say "Rails 5 gems" and also let the comments meet an 80 character line length :p

> Thanks for contributing to Rails!
- CONTRIBUTING.md

You're welcome :)
