### PR TITLE
Travis: cache unicode data downloads and beanstalkd build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,33 @@
 language: ruby
 sudo: false
-script: 'ci/travis.rb'
+
+cache:
+  bundler: true
+  directories:
+    - /tmp/cache/unicode_conformance
+    - /tmp/beanstalkd-1.10
+
+services:
+  - memcached
+  - redis
+  - rabbitmq
+
+addons:
+  postgresql: "9.4"
+
+bundler_args: --without test --jobs 3 --retry 3
+
 before_install:
   - gem install bundler
   - "rm ${BUNDLE_GEMFILE}.lock"
-  - curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp
-  - cd /tmp/beanstalkd-1.10/
-  - make
-  - ./beanstalkd &
-  - cd $TRAVIS_BUILD_DIR
+  - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
+  - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"
+
 before_script:
   - bundle update
-cache: bundler
+
+script: 'ci/travis.rb'
+
 env:
   matrix:
     - "GEM=railties"
@@ -24,10 +40,12 @@ env:
     - "GEM=ar:postgresql"
     - "GEM=aj:integration"
     - "GEM=guides"
+
 rvm:
   - 2.2.4
   - 2.3.0
   - ruby-head
+
 matrix:
   include:
     # Latest compiled version in http://rubies.travis-ci.org
@@ -44,6 +62,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
   fast_finish: true
+
 notifications:
   email: false
   irc:
@@ -56,10 +75,3 @@ notifications:
     on_failure: always
     rooms:
       - secure: "YA1alef1ESHWGFNVwvmVGCkMe4cUy4j+UcNvMUESraceiAfVyRMAovlQBGs6\n9kBRm7DHYBUXYC2ABQoJbQRLDr/1B5JPf/M8+Qd7BKu8tcDC03U01SMHFLpO\naOs/HLXcDxtnnpL07tGVsm0zhMc5N8tq4/L3SHxK7Vi+TacwQzI="
-bundler_args: --without test --jobs 3 --retry 3
-services:
-  - memcached
-  - redis
-  - rabbitmq
-addons:
-  postgresql: "9.4"

--- a/activesupport/test/multibyte_conformance_test.rb
+++ b/activesupport/test/multibyte_conformance_test.rb
@@ -28,7 +28,7 @@ class MultibyteConformanceTest < ActiveSupport::TestCase
 
   UNIDATA_URL = "http://www.unicode.org/Public/#{ActiveSupport::Multibyte::Unicode::UNICODE_VERSION}/ucd"
   UNIDATA_FILE = '/NormalizationTest.txt'
-  CACHE_DIR = File.join(Dir.tmpdir, 'cache')
+  CACHE_DIR = "#{Dir.tmpdir}/cache/unicode_conformance"
   FileUtils.mkdir_p(CACHE_DIR)
   RUN_P = begin
             Downloader.download(UNIDATA_URL + UNIDATA_FILE, CACHE_DIR + UNIDATA_FILE)

--- a/activesupport/test/multibyte_grapheme_break_conformance_test.rb
+++ b/activesupport/test/multibyte_grapheme_break_conformance_test.rb
@@ -27,7 +27,7 @@ class MultibyteGraphemeBreakConformanceTest < ActiveSupport::TestCase
 
   TEST_DATA_URL = "http://www.unicode.org/Public/#{ActiveSupport::Multibyte::Unicode::UNICODE_VERSION}/ucd/auxiliary"
   TEST_DATA_FILE = '/GraphemeBreakTest.txt'
-  CACHE_DIR = File.join(Dir.tmpdir, 'cache')
+  CACHE_DIR = "#{Dir.tmpdir}/cache/unicode_conformance"
 
   def setup
     FileUtils.mkdir_p(CACHE_DIR)

--- a/activesupport/test/multibyte_normalization_conformance_test.rb
+++ b/activesupport/test/multibyte_normalization_conformance_test.rb
@@ -30,7 +30,7 @@ class MultibyteNormalizationConformanceTest < ActiveSupport::TestCase
 
   UNIDATA_URL = "http://www.unicode.org/Public/#{ActiveSupport::Multibyte::Unicode::UNICODE_VERSION}/ucd"
   UNIDATA_FILE = '/NormalizationTest.txt'
-  CACHE_DIR = File.join(Dir.tmpdir, 'cache')
+  CACHE_DIR = "#{Dir.tmpdir}/cache/unicode_conformance"
 
   def setup
     FileUtils.mkdir_p(CACHE_DIR)


### PR DESCRIPTION
Cache slow, hang-happy downloads across builds:
- Unicode NormalizationTest.txt and GraphemeBreakTest.txt
- beanstalkd package
