### PR TITLE
Allow presence_in to take a block

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -13,15 +13,24 @@ class Object
     raise ArgumentError.new("The parameter passed to #in? must respond to #include?")
   end
 
-  # Returns the receiver if it's included in the argument otherwise returns +nil+.
+  # Returns the receiver if it's included in the argument. If the optional code
+  # block is specified, that will be called with +self+ and its result
+  # returned. Otherwise, +nil+ is returned.
   # Argument must be any object which responds to +#include?+. Usage:
   #
   #   params[:bucket_type].presence_in %w( project calendar )
+  #   params[:bucket_type].presence_in %w( project calendar ) { "project" }
   #
   # This will throw an +ArgumentError+ if the argument doesn't respond to +#include?+.
   #
   # @return [Object]
-  def presence_in(another_object)
-    self.in?(another_object) ? self : nil
+  def presence_in(another_object, &block)
+    if self.in?(another_object)
+      self
+    elsif block_given?
+      yield(self)
+    else
+      nil
+    end
   end
 end

--- a/activesupport/test/core_ext/object/inclusion_test.rb
+++ b/activesupport/test/core_ext/object/inclusion_test.rb
@@ -56,4 +56,12 @@ class InTest < ActiveSupport::TestCase
     assert_nil "stuff".presence_in(%w( lots of crap ))
     assert_raise(ArgumentError) { 1.presence_in(1) }
   end
+
+  def test_presence_in_with_block
+    assert_equal "stuff", "stuff".presence_in(%w( lots of stuff )) { 42 }
+    assert_equal 42, "stuff".presence_in(%w( lots of crap )) { 42 }
+    assert_equal "Did not find your stuff",
+      "stuff".presence_in(%w( lots of crap )) { |k| "Did not find your #{k}" }
+    assert_raise(ArgumentError) { 1.presence_in(1) { 42 } }
+  end
 end


### PR DESCRIPTION
When confirming e.g. a parameter's presence in a validated list, you may want to fall back to some default value. Instead of handling a `nil` return, you can now provide a default block – just like you would to, for example, `Hash#fetch`.

Example:

``` rb
# Before
params[:sort].presence_in(valid_sort_list) || valid_sort_list.first

# After
params[:sort].presence_in(valid_sort_list) { valid_sort_list.first }
```

``` rb
# Before
params[:sort].presence_in(valid_sort_list) || raise("Cannot sort by #{params[:sort]}")

# After
params[:sort].presence_in(valid_sort_list) do |key|
  raise "Cannot sort by #{key}"
end
```
