### PR TITLE
guides/source/api_app.md code reference fix

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -228,7 +228,7 @@ building, and make sense in an API-only Rails application.
 You can get a list of all middleware in your application via:
 
 ```bash
-$ rails middleware
+$ rake middleware
 ```
 
 ### Using the Cache Middleware


### PR DESCRIPTION
### Summary

In guide/source/api_app.md file line 231, a code reference is made that lists all middleware in the application. The reference should be 'rake middleware' but it's now 'rails middleware'. This modification fixes it.
