### PR TITLE
Change the Hash.to_xml with a lamda example

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -31,7 +31,7 @@ class Hash
   #   with +key+ as <tt>:root</tt>, and +key+ singularized as second argument. The
   #   callable can add nodes by using <tt>options[:builder]</tt>.
   #
-  #     'foo'.to_xml(lambda { |options, key| options[:builder].b(key) })
+  #     {foo: lambda { |options, key| options[:builder].b(key) }}.to_xml
   #     # => "<b>foo</b>"
   #
   # * If +value+ responds to +to_xml+ the method is invoked with +key+ as <tt>:root</tt>.


### PR DESCRIPTION
### Summary

Update the hash.to_xml example (with a lambda) to be more clear

The existing example isn't clear on how it works. The documentation is talking about how Hash.to_xml is used but the example makes it look like it's something to do with string.to_xml. And it raises the question why the lambda is used.

I updated the example to be more in line with what is being exampled.
### Other Information

Update 'foo'.to_xml(lambda { |options, key| options[:builder].b(key) })
to  {foo: lambda { |options, key| options[:builder].b(key) }}.to_xml
