### PR TITLE
Enhance behavior of Exception JSON encoding to include instance_value…

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -200,6 +200,10 @@ end
 
 class Exception
   def as_json(options = nil)
-    to_s
+    if instance_values.empty?
+      to_s
+    else
+      super(options)
+    end
   end
 end

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -427,6 +427,17 @@ EXPECTED
     assert_equal '"foo"', ActiveSupport::JSON.encode(exception)
   end
 
+  class DetailedException < Exception
+    def initialize(message)
+      @message = message
+    end
+  end
+
+  def test_exception_with_instance_values_to_json
+    exception = DetailedException.new("foo")
+    assert_equal %({"message":"foo"}), ActiveSupport::JSON.encode(exception)
+  end
+
   protected
 
     def object_keys(json_object)


### PR DESCRIPTION
In [this change](https://github.com/rails/rails/pull/23702/files), the behavior of Exception JSON encoding was changed to always return `#to_s`. Previously, the behavior was to include `#instance_values` in the resulting JSON object, as per the [Object#as_json](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/object/json.rb#L48-L54) method.

Given the following class:

``` ruby
class DetailedException < Exception 
  def initialize(message) 
    @message = message 
  end
 end
```

a. Behavior _before_ the [related change](https://github.com/rails/rails/pull/23702/files):

``` ruby
ex = DetailedException.new("error details")
ex.to_json
=> "{\"message\":\"error details\"}"
```

b. Current behavior, after the related change:

``` ruby
ex = DetailedException.new("error message")
ex.to_json
=> "\"TestJSONEncoding::DetailedException\""
```

This pull request restores the previous behavior (a) if there are `#instance_values` on the Exception object, but keeps the current behavior (b) if there are no `#instance_values`. I think it's important to return a JSON object with instance variable details when encoding Exceptions to JSON, in the context of logging, for example.
