### PR TITLE
Update send_data documentation [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -84,7 +84,7 @@ module ActionController #:nodoc:
       # Options:
       # * <tt>:filename</tt> - suggests a filename for the browser to use.
       # * <tt>:type</tt> - specifies an HTTP content type. Defaults to 'application/octet-stream'. You can specify
-      #   either a string or a symbol for a registered type register with <tt>Mime::Type.register</tt>, for example :json
+      #   either a string or a symbol for a registered type register with <tt>Mime::Type.register</tt>, for example :json.
       #   If omitted, type will be guessed from the file extension specified in <tt>:filename</tt>.
       #   If no content type is registered for the extension, default type 'application/octet-stream' will be used.
       # * <tt>:disposition</tt> - specifies whether the file will be shown inline or downloaded.


### PR DESCRIPTION
### Summary

Adds a period at the end of a sentence in the documentation of `send_data`.
### Other Information

Looks like this before the change:
![screen shot 2016-04-19 at 16 59 50](https://cloud.githubusercontent.com/assets/1301152/14643961/b5ceb32a-0650-11e6-99b9-e42911ce4aef.png)
