### PR TITLE
Directly reference arel classes for sorting

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1182,10 +1182,14 @@ module ActiveRecord
       order_args.map! do |arg|
         case arg
         when Symbol
-          arel_attribute(arg).asc
+          Arel::Nodes::Ascending.new(arel_attribute(arg))
         when Hash
           arg.map { |field, dir|
-            arel_attribute(field).send(dir.downcase)
+            if dir.downcase.to_s == "desc"
+              Arel::Nodes::Descending.new(arel_attribute(field))
+            else
+              Arel::Nodes::Ascending.new(arel_attribute(field))
+            end
           }
         else
           arg


### PR DESCRIPTION
### Summary

~~Active record allows developers to extend the sql behind column definitions via `arel_attribute()`.~~

The current sorting code assumes that `arel_attribute()` will return an `Arel::Nodes::Attribute` and calls a sorting helper on it (i.e.: `asc`, `desc`). Unfortunately, not all `Arel` nodes define these helpers. Something as simple as a `Arel::Nodes::Grouping` node fails.

The proposed solution is to directly reference the `Arel::Nodes::Ascending` and `Descending` classes.

Thanks for building Rails. very cool stuff
/cc @matthewd 
