### PR TITLE
Define `arel_visitor` method on all adapters

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -149,7 +149,7 @@ module ActiveRecord
       end
 
       def arel_visitor # :nodoc:
-        (Arel::Visitors::VISITORS[@config[:adapter]] || Arel::Visitors::ToSql).new(self)
+        Arel::Visitors::ToSql.new(self)
       end
 
       def valid_type?(type)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -24,6 +24,10 @@ module ActiveRecord
         MySQL::SchemaCreation.new(self)
       end
 
+      def arel_visitor # :nodoc:
+        Arel::Visitors::MySQL.new(self)
+      end
+
       ##
       # :singleton-method:
       # By default, the Mysql2Adapter will consider all columns of type <tt>tinyint(1)</tt>

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -125,6 +125,10 @@ module ActiveRecord
         PostgreSQL::SchemaCreation.new self
       end
 
+      def arel_visitor # :nodoc:
+        Arel::Visitors::PostgreSQL.new(self)
+      end
+
       # Returns true, since this connection adapter supports prepared statement
       # caching.
       def supports_statement_cache?

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -80,6 +80,10 @@ module ActiveRecord
         SQLite3::SchemaCreation.new self
       end
 
+      def arel_visitor # :nodoc:
+        Arel::Visitors::SQLite.new(self)
+      end
+
       def initialize(connection, logger, connection_options, config)
         super(connection, logger, config)
 


### PR DESCRIPTION
`Arel::Visitors::VISITORS` was removed at https://github.com/rails/arel/pull/412.
