### PR TITLE
Allow reverse_order or any arel node

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1120,6 +1120,8 @@ module ActiveRecord
           o.desc
         when Arel::Nodes::Ordering
           o.reverse
+        when Arel::Nodes::Node
+          Arel::Nodes::Descending.new(o)
         when String
           if does_not_support_reverse?(o)
             raise IrreversibleOrderError, "Order #{o.inspect} can not be reversed automatically"

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -229,6 +229,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal topics(:second).title, topics.first.title
   end
 
+  def test_reverse_order_with_arel
+    topics = Topic.order(Topic.arel_table[:title].lower).reverse_order
+    assert_equal topics(:third).title, topics.first.title
+  end
+
   def test_reverse_order_with_function_other_predicates
     topics = Topic.order("author_name, length(title), id").reverse_order
     assert_equal topics(:second).title, topics.first.title


### PR DESCRIPTION
### Summary

In ActiveRecord you can use `reverse_order` on a scope. This adds the support to be able to reverse order an arel expression.

Thanks all
