### PR TITLE
Allowing the usage of symbols in attributes method for serialization.

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/hash/slice'
+require 'active_support/core_ext/hash/indifferent_access'
 
 module ActiveModel
   # == Active \Model \Serialization
@@ -26,7 +27,7 @@ module ActiveModel
   #   person.serializable_hash   # => {"name"=>"Bob"}
   #
   # An +attributes+ hash must be defined and should contain any attributes you
-  # need to be serialized. Attributes must be strings, not symbols.
+  # need to be serialized.
   # When called, serializable hash will use instance methods that match the name
   # of the attributes hash's keys. In order to override this behavior, take a look
   # at the private method +read_attribute_for_serialization+.
@@ -126,12 +127,12 @@ module ActiveModel
 
       attribute_names = attributes.keys
       if only = options[:only]
-        attribute_names &= Array(only).map(&:to_s)
+        attribute_names &= Array(only)
       elsif except = options[:except]
-        attribute_names -= Array(except).map(&:to_s)
+        attribute_names -= Array(except)
       end
 
-      hash = {}
+      hash = HashWithIndifferentAccess.new
       attribute_names.each { |n| hash[n] = read_attribute_for_serialization(n) }
 
       Array(options[:methods]).each { |m| hash[m.to_s] = send(m) }

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -29,6 +29,14 @@ class SerializationTest < ActiveModel::TestCase
     end
   end
 
+  class SuperUser < User
+
+    def attributes
+      instance_values.except("address", "friends").symbolize_keys
+    end
+
+  end
+
   class Address
     include ActiveModel::Serialization
 
@@ -48,6 +56,7 @@ class SerializationTest < ActiveModel::TestCase
     @user.address.zip = 11111
     @user.friends = [User.new('Joe', 'joe@example.com', 'male'),
                      User.new('Sue', 'sue@example.com', 'female')]
+    @super_user = SuperUser.new('John', 'john@example.com', 'male')
   end
 
   def test_method_serializable_hash_should_work
@@ -63,6 +72,21 @@ class SerializationTest < ActiveModel::TestCase
   def test_method_serializable_hash_should_work_with_except_option
     expected = {"gender"=>"male", "email"=>"david@example.com"}
     assert_equal expected, @user.serializable_hash(except: ['name'])
+  end
+
+  def test_method_serializable_hash_should_work_with_symbolizes_attributes
+    expected = {"name"=>"John", "gender"=>"male", "email"=>"john@example.com"}
+    assert_equal expected, @super_user.serializable_hash
+  end
+
+  def test_method_serializable_hash_should_work_with_only_option_with_symbolized_attributes
+    expected = {"name"=>"John"}
+    assert_equal expected, @super_user.serializable_hash(only: [:name])
+  end
+
+  def test_method_serializable_hash_should_work_with_except_option_with_symbolized_attributes
+    expected = {"gender"=>"male", "email"=>"john@example.com"}
+    assert_equal expected, @super_user.serializable_hash(except: [:name])
   end
 
   def test_method_serializable_hash_should_work_with_methods_option

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -57,12 +57,12 @@ class SerializationTest < ActiveModel::TestCase
 
   def test_method_serializable_hash_should_work_with_only_option
     expected = {"name"=>"David"}
-    assert_equal expected, @user.serializable_hash(only: [:name])
+    assert_equal expected, @user.serializable_hash(only: ['name'])
   end
 
   def test_method_serializable_hash_should_work_with_except_option
     expected = {"gender"=>"male", "email"=>"david@example.com"}
-    assert_equal expected, @user.serializable_hash(except: [:name])
+    assert_equal expected, @user.serializable_hash(except: ['name'])
   end
 
   def test_method_serializable_hash_should_work_with_methods_option
@@ -77,7 +77,7 @@ class SerializationTest < ActiveModel::TestCase
 
   def test_method_serializable_hash_should_work_with_except_and_methods
     expected = {"gender"=>"male", "foo"=>"i_am_foo", "bar"=>"i_am_bar"}
-    assert_equal expected, @user.serializable_hash(except: [:name, :email], methods: [:foo, :bar])
+    assert_equal expected, @user.serializable_hash(except: ['name', 'email'], methods: [:foo, :bar])
   end
 
   def test_should_raise_NoMethodError_for_non_existing_method
@@ -90,7 +90,7 @@ class SerializationTest < ActiveModel::TestCase
     end
 
     expected = { "name" => "Jon" }
-    assert_equal expected, @user.serializable_hash(only: :name)
+    assert_equal expected, @user.serializable_hash(only: 'name')
   end
 
   def test_include_option_with_singular_association
@@ -155,14 +155,14 @@ class SerializationTest < ActiveModel::TestCase
 
   def test_only_include
     expected = {"name"=>"David", "friends" => [{"name" => "Joe"}, {"name" => "Sue"}]}
-    assert_equal expected, @user.serializable_hash(only: :name, include: { friends: { only: :name } })
+    assert_equal expected, @user.serializable_hash(only: 'name', include: { friends: { only: 'name' } })
   end
 
   def test_except_include
     expected = {"name"=>"David", "email"=>"david@example.com",
                 "friends"=> [{"name" => 'Joe', "email" => 'joe@example.com'},
                              {"name" => "Sue", "email" => 'sue@example.com'}]}
-    assert_equal expected, @user.serializable_hash(except: :gender, include: { friends: { except: :gender } })
+    assert_equal expected, @user.serializable_hash(except: 'gender', include: { friends: { except: 'gender' } })
   end
 
   def test_multiple_includes_with_options

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -74,7 +74,7 @@ class JsonSerializationTest < ActiveModel::TestCase
   end
 
   test "should allow attribute filtering with only" do
-    json = @contact.to_json(only: [:name, :age])
+    json = @contact.to_json(only: ['name', 'age'])
 
     assert_match %r{"name":"Konata Izumi"}, json
     assert_match %r{"age":16}, json
@@ -84,7 +84,7 @@ class JsonSerializationTest < ActiveModel::TestCase
   end
 
   test "should allow attribute filtering with except" do
-    json = @contact.to_json(except: [:name, :age])
+    json = @contact.to_json(except: ['name', 'age'])
 
     assert_no_match %r{"name":"Konata Izumi"}, json
     assert_no_match %r{"age":16}, json
@@ -99,10 +99,10 @@ class JsonSerializationTest < ActiveModel::TestCase
     def @contact.favorite_quote; "Constraints are liberating"; end
 
     # Single method.
-    assert_match %r{"label":"Has cheezburger"}, @contact.to_json(only: :name, methods: :label)
+    assert_match %r{"label":"Has cheezburger"}, @contact.to_json(only: 'name', methods: :label)
 
     # Both methods.
-    methods_json = @contact.to_json(only: :name, methods: [:label, :favorite_quote])
+    methods_json = @contact.to_json(only: 'name', methods: [:label, :favorite_quote])
     assert_match %r{"label":"Has cheezburger"}, methods_json
     assert_match %r{"favorite_quote":"Constraints are liberating"}, methods_json
   end
@@ -120,11 +120,11 @@ class JsonSerializationTest < ActiveModel::TestCase
   end
 
   test "serializable_hash should not modify options passed in argument" do
-    options = { except: :name }
+    options = { except: 'name' }
     @contact.serializable_hash(options)
 
     assert_nil options[:only]
-    assert_equal :name, options[:except]
+    assert_equal 'name', options[:except]
   end
 
   test "as_json should return a hash if include_root_in_json is true" do
@@ -187,7 +187,7 @@ class JsonSerializationTest < ActiveModel::TestCase
   end
 
   test "custom as_json options should be extensible" do
-    def @contact.as_json(options = {}); super(options.merge(only: [:name])); end
+    def @contact.as_json(options = {}); super(options.merge(only: ['name'])); end
     json = @contact.to_json
 
     assert_match %r{"name":"Konata Izumi"}, json

--- a/activerecord/test/cases/json_serialization_test.rb
+++ b/activerecord/test/cases/json_serialization_test.rb
@@ -68,7 +68,7 @@ class JsonSerializationTest < ActiveRecord::TestCase
   end
 
   def test_should_allow_attribute_filtering_with_only
-    json = @contact.to_json(:only => [:name, :age])
+    json = @contact.to_json(:only => ['name', 'age'])
 
     assert_match %r{"name":"Konata Izumi"}, json
     assert_match %r{"age":16}, json
@@ -78,7 +78,7 @@ class JsonSerializationTest < ActiveRecord::TestCase
   end
 
   def test_should_allow_attribute_filtering_with_except
-    json = @contact.to_json(:except => [:name, :age])
+    json = @contact.to_json(:except => ['name', 'age'])
 
     assert_no_match %r{"name":"Konata Izumi"}, json
     assert_no_match %r{"age":16}, json
@@ -183,7 +183,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
   end
 
   def test_includes_uses_association_name_and_applies_attribute_filters
-    json = @david.to_json(:include => { :posts => { :only => :title } })
+    json = @david.to_json(:include => { :posts => { :only => 'title' } })
 
     assert_match %r{"name":"David"}, json
     assert_match %r{"posts":\[}, json
@@ -196,7 +196,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
   end
 
   def test_includes_fetches_second_level_associations
-    json = @david.to_json(:include => { :posts => { :include => { :comments => { :only => :body } } } })
+    json = @david.to_json(:include => { :posts => { :include => { :comments => { :only => 'body' } } } })
 
     assert_match %r{"name":"David"}, json
     assert_match %r{"posts":\[}, json
@@ -214,7 +214,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
           :include => {
             :taggings => {
               :include => {
-                :tag => { :only => :name }
+                :tag => { :only => 'name' }
               }
             }
           }
@@ -249,7 +249,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
   def test_should_allow_only_option_for_list_of_authors
     set_include_root_in_json(false) do
       authors = [@david, @mary]
-      assert_equal %([{"name":"David"},{"name":"Mary"}]), ActiveSupport::JSON.encode(authors, only: :name)
+      assert_equal %([{"name":"David"},{"name":"Mary"}]), ActiveSupport::JSON.encode(authors, only: 'name')
     end
   end
 
@@ -267,9 +267,9 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
   def test_should_allow_includes_for_list_of_authors
     authors = [@david, @mary]
     json = ActiveSupport::JSON.encode(authors,
-      :only => :name,
+      :only => 'name',
       :include => {
-        :posts => { :only => :id }
+        :posts => { :only => 'id' }
       }
     )
 
@@ -285,7 +285,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
         1 => @david,
         2 => @mary
       }
-      assert_equal %({"1":{"author":{"name":"David"}}}), ActiveSupport::JSON.encode(authors_hash, only: [1, :name])
+      assert_equal %({"1":{"author":{"name":"David"}}}), ActiveSupport::JSON.encode(authors_hash, only: [1, 'name'])
     end
   end
 
@@ -293,7 +293,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
     set_include_root_in_json(true) do
       authors_relation = Author.where(id: [@david.id, @mary.id])
 
-      json = ActiveSupport::JSON.encode authors_relation, only: :name
+      json = ActiveSupport::JSON.encode authors_relation, only: 'name'
       assert_equal '[{"author":{"name":"David"}},{"author":{"name":"Mary"}}]', json
     end
   end

--- a/activerecord/test/cases/serialization_test.rb
+++ b/activerecord/test/cases/serialization_test.rb
@@ -38,7 +38,7 @@ class SerializationTest < ActiveRecord::TestCase
 
   def test_serialize_should_allow_attribute_only_filtering
     FORMATS.each do |format|
-      @serialized = Contact.new(@contact_attributes).send("to_#{format}", :only => [ :age, :name ])
+      @serialized = Contact.new(@contact_attributes).send("to_#{format}", :only => [ 'age', 'name' ])
       contact = Contact.new.send("from_#{format}", @serialized)
       assert_equal @contact_attributes[:name], contact.name, "For #{format}"
       assert_nil contact.avatar, "For #{format}"

--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -294,7 +294,7 @@ objects.
 
 `ActiveModel::Serialization` provides basic serialization for your object.
 You need to declare an attributes hash which contains the attributes you want to
-serialize. Attributes must be strings, not symbols.
+serialize.
 
 ```ruby
 class Person


### PR DESCRIPTION
This is an effort to allow usage of symbols in `attributes` method used for serialization.
This is to avoid following `Attributes must be strings, not symbols.`

We are currently using string in `attributes` method whereas we use symbol when calling `serialize_hash` while providing options for `except` and `only`.

This PR aims to have consistency between the two. So if string is used in `attributes` method, the value for `except` and `only` keys in the input for `serialize_hash` should be string. Same applies with that for symbol.
