### PR TITLE
Discart the schema and host information when building the per-form token

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -405,7 +405,8 @@ module ActionController #:nodoc:
       end
 
       def normalize_action_path(action_path)
-        action_path.split('?').first.to_s.chomp('/')
+        uri = URI.parse(action_path)
+        uri.path.chomp('/')
       end
   end
 end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -781,6 +781,19 @@ class PerFormTokensControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  def test_ignores_origin_during_generation
+    get :index, params: {form_path: 'https://example.com/per_form_tokens/post_one/'}
+
+    form_token = assert_presence_and_fetch_form_csrf_token
+
+    # This is required because PATH_INFO isn't reset between requests.
+    @request.env['PATH_INFO'] = '/per_form_tokens/post_one'
+    assert_nothing_raised do
+      post :post_one, params: {custom_authenticity_token: form_token}
+    end
+    assert_response :success
+  end
+
   def test_ignores_trailing_slash_during_validation
     get :index
 


### PR DESCRIPTION
When the token is generated by the form we were using the schema and host information while only using the path to compare if the action was the same. This was causing the token to be invalid.

To fix this we use the same information to generate the token and check it.

Fix #24257

Review @jeremy @mastahyeti.
