### PR TITLE
Dup given object to xml mini converted, so we can handle frozen objects

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -126,7 +126,7 @@ class Hash
     # Note that passing custom disallowed types will override the default types,
     # which are Symbol and YAML.
     def from_xml(xml, disallowed_types = nil)
-      ActiveSupport::XMLConverter.new(xml, disallowed_types).to_h
+      ActiveSupport::XMLConverter.new(xml.dup, disallowed_types).to_h
     end
 
     # Builds a Hash from XML just like <tt>Hash.from_xml</tt>, but also allows Symbol and YAML.

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1762,4 +1762,10 @@ class HashToXmlTest < ActiveSupport::TestCase
       Hash.from_xml(attack_xml)
     end
   end
+
+  def test_from_xml_doesnt_taint_strings
+    string_object = "<?xml version=\"1.0\"?><a>Cat</a>".freeze
+    assert_equal({"a"=>"Cat"}, Hash.from_xml(string_object))
+    assert_equal "<?xml version=\"1.0\"?><a>Cat</a>", string_object
+  end
 end


### PR DESCRIPTION
Fixes #24647
