### PR TITLE
Don't autosave readonly records on HMT associations

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -38,10 +38,12 @@ module ActiveRecord
       def insert_record(record, validate = true, raise = false)
         ensure_not_nested
 
-        if raise
-          record.save!(:validate => validate)
-        else
-          return unless record.save(:validate => validate)
+        if !record.readonly?
+          if raise
+            record.save!(:validate => validate)
+          else
+            return unless record.save(:validate => validate)
+          end
         end
 
         save_through_record(record)

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -8,6 +8,9 @@ require 'models/project'
 require 'models/reader'
 require 'models/person'
 require 'models/ship'
+require 'models/club'
+require 'models/member'
+require 'models/membership'
 
 class ReadOnlyTest < ActiveRecord::TestCase
   fixtures :authors, :posts, :comments, :developers, :projects, :developers_projects, :people, :readers
@@ -34,7 +37,6 @@ class ReadOnlyTest < ActiveRecord::TestCase
     e = assert_raise(ActiveRecord::ReadOnlyRecord) { dev.destroy }
     assert_equal "Developer is marked as readonly", e.message
   end
-
 
   def test_find_with_readonly_option
     Developer.all.each { |d| assert !d.readonly? }
@@ -74,6 +76,15 @@ class ReadOnlyTest < ActiveRecord::TestCase
 
   def test_has_many_with_through_is_not_implicitly_marked_readonly_while_finding_last
     assert !posts(:welcome).people.last.readonly?
+  end
+
+  def test_insert_records_via_has_many_through_association_with_readonly
+    club = Club.create!
+    member = Member.create!
+    member.readonly!
+
+    club.members << member
+    assert_equal [member], club.members
   end
 
   def test_readonly_scoping


### PR DESCRIPTION
Check whether the existing record is marked `readonly?` before attempting to save it during `has_many :through` association creation.

Fixes bug introduced in d849f42b4ecf687ed5350f5a2402fb795aa33aac, reported in #24649.

r? @sgrif 
