### PR TITLE
schema_load triggers 2nd schema_load (via locking)

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -150,7 +150,7 @@ module ActiveRecord
 
         # The version column used for optimistic locking. Defaults to +lock_version+.
         def locking_column
-          reset_locking_column unless defined?(@locking_column)
+          @locking_column = DEFAULT_LOCKING_COLUMN unless defined?(@locking_column)
           @locking_column
         end
 

--- a/activerecord/test/cases/schema_loading_test.rb
+++ b/activerecord/test/cases/schema_loading_test.rb
@@ -1,0 +1,53 @@
+require 'thread'
+require "cases/helper"
+
+module SchemaLoadCounter
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    attr_accessor :load_schema_calls
+
+    def load_schema!
+      self.load_schema_calls ||= 0
+      self.load_schema_calls +=1
+      super
+    end
+  end
+end
+
+class SchemaLoadingTest < ActiveRecord::TestCase
+  def test_basic_model_is_loaded_once
+    klass = define_model
+    klass.new
+    assert_equal 1, klass.load_schema_calls
+  end
+
+  def test_model_with_custom_lock_is_loaded_once
+    klass = define_model do |c|
+      c.table_name = :lock_without_defaults_cust
+      c.locking_column = :custom_lock_version
+    end
+    klass.new
+    assert_equal 1, klass.load_schema_calls
+  end
+
+  def test_model_with_changed_custom_lock_is_loaded_twice
+    klass = define_model do |c|
+      c.table_name = :lock_without_defaults_cust
+    end
+    klass.new
+    klass.locking_column = :custom_lock_version
+    klass.new
+    assert_equal 2, klass.load_schema_calls
+  end
+
+  private
+
+    def define_model
+      Class.new(ActiveRecord::Base) do
+        include SchemaLoadCounter
+        self.table_name = :lock_without_defaults
+        yield self if block_given?
+      end
+    end
+end


### PR DESCRIPTION
### Summary

Rails is double loading (`schema_load!`) for all of our models.
### Details

Currently, loading the schema (`schema_load`)
accesses the locking column (`locking_column`)
which defaults the value (`reset_locking_column`)
which invalidates the schema (`reload_schema_from_cache`)
which forces another schema load (`schema_load`).

Good news:

The second `schema_load` does accesses `locking_column`,
but `locking_column` is set this time through, so it does not call `reset_locking_column`
and it does not trigger an infinite loop.
### Solution

I feel `reset_locking_column` should still invalidate the schema.
So instead, this sets `@locking_column` directly in the default case only.
Please let me know if you have another solution.

/cc @matthewd 
