### PR TITLE
Use of `whether or not` instead of `regardless if ... or not`

### DIFF
--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -40,8 +40,8 @@ module ActiveModel
       self
     end
 
-    # Returns an Array of all key attributes if any is set, regardless if
-    # the object is persisted or not. Returns +nil+ if there are no key attributes.
+    # Returns an Array of all key attributes if any of the attributes is set, whether or not
+    # the object is persisted. Returns +nil+ if there are no key attributes.
     #
     #   class Person
     #     include ActiveModel::Conversion


### PR DESCRIPTION
This is extension of https://github.com/rails/rails/pull/24639

`regardless` is usually followed by `of` and not by `if ... or not`.

r? @vipulnsward 
