### PR TITLE
Do not cache ActiveSupport::TimeZone#utc_offset

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -272,7 +272,6 @@ module ActiveSupport
       @name = name
       @utc_offset = utc_offset
       @tzinfo = tzinfo || TimeZone.find_tzinfo(name)
-      @current_period = nil
     end
 
     # Returns the offset of this time zone from UTC in seconds.
@@ -280,8 +279,7 @@ module ActiveSupport
       if @utc_offset
         @utc_offset
       else
-        @current_period ||= tzinfo.current_period if tzinfo
-        @current_period.utc_offset if @current_period
+        tzinfo.current_period.utc_offset if tzinfo && tzinfo.current_period
       end
     end
 

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -318,6 +318,17 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal(-18_000, zone.utc_offset)
   end
 
+  def test_utc_offset_is_not_cached_when_current_period_gets_stale
+    tz = ActiveSupport::TimeZone.create('Moscow')
+    travel_to(Time.utc(2014, 10, 25, 21)) do # 1 hour before TZ change
+      assert_equal 14400, tz.utc_offset, 'utc_offset should be initialized according to current_period'
+    end
+
+    travel_to(Time.utc(2014, 10, 25, 22)) do # after TZ change
+      assert_equal 10800, tz.utc_offset, 'utc_offset should not be cached when current_period gets stale'
+    end
+  end
+
   def test_seconds_to_utc_offset_with_colon
     assert_equal "-06:00", ActiveSupport::TimeZone.seconds_to_utc_offset(-21_600)
     assert_equal "+00:00", ActiveSupport::TimeZone.seconds_to_utc_offset(0)


### PR DESCRIPTION
### Summary

Fixes #24659.

During time zone transition, when current time zone changes its `utc_offset`, `ActiveSupport::TimeZone` caches this information and it becomes stale.

This can be an issue when `TZInfo::TimeZone#current_period` is refreshed
due to time zone period transition, but it's not reflected in
`ActiveSupport::TimeZone` object.

 For example, on `Sun, 26 Oct 2014 22:00 UTC`, [Moscow changed](http://www.timeanddate.com/time/zone/russia/moscow) its `TZ` from
 `MSK +04:00` to `MSK +03:00` (-1 hour). If `ActiveSupport::TimeZone['Moscow']`
 happens to be initialized just before the time zone transition, it will
 cache its stale `utc_offset` even after the time zone transition.

This PR removes cache and fixes this issue.
### Benchmark

Performance is obviously decreased since we're calculating real stuff now, and not just take cached field, but IMO 50k i/s is good enough:

``` bash
Calculating -------------------------------------
          non cached     4.035k i/100ms
              cached    24.141k i/100ms
-------------------------------------------------
          non cached     50.239k (± 5.0%) i/s -    254.205k
              cached      5.186M (±15.9%) i/s -     24.986M
```
