### PR TITLE
use wrapper file to add rake task for engines

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/Rakefile
+++ b/railties/lib/rails/generators/rails/plugin/templates/Rakefile
@@ -25,5 +25,5 @@ load 'rails/tasks/statistics.rake'
 
 <% unless options[:skip_gemspec] -%>
 
-Bundler::GemHelper.install_tasks
+require 'bundler/gem_tasks'
 <% end %>


### PR DESCRIPTION
`bundler` provides wrapper file to add rask tasks.
https://github.com/bundler/bundler/blob/master/lib/bundler/gem_tasks.rb

Instead of directly call method, by which require this file,
it can be used without updating of Rakefile if task has been added.
