### PR TITLE
render_to_string changes content-type for subsequent render

### DIFF
--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -67,9 +67,7 @@ module ActionController
     end
 
     def _set_rendered_content_type(format)
-      unless response.content_type
         self.content_type = format.to_s
-      end
     end
 
     # Normalize arguments by catching blocks and setting them on :update.

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -9,7 +9,7 @@ module ActionView
 
       prepend_formats(template.formats)
 
-      @lookup_context.rendered_format ||= (template.formats.first || formats.first)
+      @lookup_context.rendered_format = (template.formats.first || formats.first)
 
       render_template(template, options[:layout], options[:locals])
     end

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -625,6 +625,11 @@ class TestController < ApplicationController
     render :action => "calling_partial_with_layout", :layout => "layouts/partial_with_layout"
   end
 
+  def render_changes_rendered_format
+    render_to_string file: 'test', formats: [:xml], layout: false
+    render plain: '<p>hello world</p>'
+  end
+
   before_action only: :render_with_filters do
     request.format = :xml
   end
@@ -1327,5 +1332,12 @@ class RenderTest < ActionController::TestCase
   def test_render_call_to_partial_with_layout_in_main_layout_and_within_content_for_layout
     get :render_call_to_partial_with_layout_in_main_layout_and_within_content_for_layout
     assert_equal "Before (Anthony)\nInside from partial (Anthony)\nAfter\nBefore (David)\nInside from partial (David)\nAfter\nBefore (Ramm)\nInside from partial (Ramm)\nAfter", @response.body
+  end
+
+  def test_render_changes_rendered_format
+    get :render_changes_rendered_format
+    assert_equal 200, @response.status
+    assert_equal '<p>hello world</p>', @response.body
+    assert_equal 'text/plain; charset=utf-8', @response.headers['Content-Type']
   end
 end

--- a/actionview/test/fixtures/actionpack/test.xml.erb
+++ b/actionview/test/fixtures/actionpack/test.xml.erb
@@ -1,0 +1,1 @@
+<foo>Hello World!</foo>


### PR DESCRIPTION
This uncaches `@lookup_context.rendered_format`, since it was causing
bugs like #14173. This patch includes a regression test :)
