### PR TITLE
Update delegate to use newer Ruby syntax

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -149,13 +149,10 @@ class Module
   #
   # The target method must be public, otherwise it will raise +NoMethodError+.
   #
-  def delegate(*methods)
-    options = methods.pop
-    unless options.is_a?(Hash) && to = options[:to]
+  def delegate(*methods, to: nil, prefix: nil, allow_nil: nil)
+    unless to
       raise ArgumentError, 'Delegation needs a target. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter).'
     end
-
-    prefix, allow_nil = options.values_at(:prefix, :allow_nil)
 
     if prefix == true && to =~ /^[^a-z_]/
       raise ArgumentError, 'Can only automatically set the delegation prefix when delegating to a method.'


### PR DESCRIPTION
This commit updates `delegate` to use the keyword argument syntax added in Ruby 2. I left the `ArgumentError` when `to` is missing, because it better explains how to correctly use `delegate`.  We could instead rely on the default `ArgumentError` that would be raised if `to` were a required keyword argument.
