### PR TITLE
Revert "add doc for `:type` option of `#create_join_table` [ci skip]"

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -317,8 +317,6 @@ module ActiveRecord
       # [<tt>:force</tt>]
       #   Set to true to drop the table before creating it.
       #   Defaults to false.
-      # [<tt>:type</tt>]
-      #   The column type of primary key. Defaults to +:integer+.
       #
       # Note that #create_join_table does not create any indices by default; you can use
       # its block form to do so yourself:


### PR DESCRIPTION
Reverts rails/rails#24667
