### PR TITLE
Could not add an existing readonly record to HMT collection

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -38,10 +38,12 @@ module ActiveRecord
       def insert_record(record, validate = true, raise = false)
         ensure_not_nested
 
-        if raise
-          record.save!(:validate => validate)
-        else
-          return unless record.save(:validate => validate)
+        if record.new_record?
+          if raise
+            record.save!(:validate => validate)
+          else
+            return unless record.save(:validate => validate)
+          end
         end
 
         save_through_record(record)

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -395,6 +395,7 @@ module ActiveRecord
 
               if autosave != false && (@new_record_before_save || record.new_record?)
                 if autosave
+                  record.save(:validate => false) if record.persisted? && record.changed?
                   saved = association.insert_record(record, false)
                 else
                   association.insert_record(record) unless reflection.nested?

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -8,6 +8,9 @@ require 'models/project'
 require 'models/reader'
 require 'models/person'
 require 'models/ship'
+require 'models/club'
+require 'models/member'
+require 'models/membership'
 
 class ReadOnlyTest < ActiveRecord::TestCase
   fixtures :authors, :posts, :comments, :developers, :projects, :developers_projects, :people, :readers
@@ -74,6 +77,15 @@ class ReadOnlyTest < ActiveRecord::TestCase
 
   def test_has_many_with_through_is_not_implicitly_marked_readonly_while_finding_last
     assert !posts(:welcome).people.last.readonly?
+  end
+
+  def test_insert_records_via_has_many_through_association_with_readonly
+    club = Club.create!
+    member = Member.create!
+    member.readonly!
+
+    club.members << member
+    assert_equal [member], club.members
   end
 
   def test_readonly_scoping


### PR DESCRIPTION
`HasManyThroughAssociation#insert_record` should only always save _new_ records, not existing records with may or may not have any changes. That's the responsibility of `AutosaveAssociation`.

Fixes bug introduced in d849f42b4ecf687ed5350f5a2402fb795aa33aac, reported in #24649, first suggested solution was PR #24651 (now closed).
