### PR TITLE
Remove unneeded comment in Actionview test [ci skip]

### DIFF
--- a/actionview/test/activerecord/polymorphic_routes_test.rb
+++ b/actionview/test/activerecord/polymorphic_routes_test.rb
@@ -86,8 +86,6 @@ class PolymorphicRoutesTest < ActionController::TestCase
 
   def test_string
     with_test_routes do
-      # FIXME: why are these different? Symbol case passes through to
-      # `polymorphic_url`, but the String case doesn't.
       assert_equal "http://example.com/projects", polymorphic_url("projects")
       assert_equal "projects", url_for("projects")
     end


### PR DESCRIPTION
### Summary

Remove unneeded comment in Actionview test, because this test passes even if you use String.

``` rb
 def test_string
  with_test_routes do
    # FIXME: why are these different? Symbol case passes through to
    # `polymorphic_url`, but the String case doesn't.
    assert_equal "http://example.com/projects", polymorphic_url("projects")
    assert_equal "projects", url_for("projects")
  end
end
```
### Other Information

This test passes both Symbol case and String case.

``` rb
def test_string
  with_test_routes do
    assert_equal "http://example.com/projects", polymorphic_url("projects")
    assert_equal "http://example.com/projects", polymorphic_url(:projects)
    assert_equal "projects", url_for("projects")
  end
end
```

Thanks for contributing to Rails!
