### PR TITLE
Rails 4.2 don't have any possibility to use several values for where.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   ActiveRecord::Enum#enum: method `enum` added one extra method for each
+    enum declaration. This extra method allows object to get the indexes
+    for several keys (String or Symbol type). This extra method needs for
+    where queries for search by several enum keys.
+
+    Examples:
+        class Book
+          enum status: [:proposed, :written]
+        end
+
+        Book.statuses_by_sym(:proposed, :written) # => [0, 1]
+
+        Book.where(status: Book.statuses_by_sym(:proposed, :written))
+
+    *Yuri Holubchenko*
+
 *   ActiveRecord::Relation#count: raise an ArgumentError when finder options
     are specified or an ActiveRecord::StatementInvalid when an invalid type
     is provided for a column name (e.g. a Hash).

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -287,4 +287,8 @@ class EnumTest < ActiveRecord::TestCase
     book2.status = :uploaded
     assert_equal ['drafted', 'uploaded'], book2.status_change
   end
+
+  test "enum values by symbol" do
+    assert_equal [Book.statuses[:proposed], Book.statuses[:written]], Book.statuses_by_sym(:proposed, :written)
+  end
 end


### PR DESCRIPTION
### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.
### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!

Sometimes when class has many options in one enum we need to doing
where query by several of them. In Rails 5.0 this functionality already
implemented but a lot users has project on Rails 4.2 and they can't
migrate them to Rails 5.0 right now but in any case they need to
search be several enum values. Queries with default enum abilities
became quite big and do the same. Also using int values is not
comfortable because if we have for example ten values, but for search
we need only values with indexes 1, 3, 4 we should always remember
what this values exactly means.

```
class Book
  enum status: [:proposed, :written, :published, :reviewed]
end
```

Previously where query for this code looks like:

```
Book.where(status: [Book.statuses[:proposed], Book.statuses[:published]])
```

Now same query will be looks like:

```
Book.where(status: Book.statuses_by_sym(:proposed, :published))
```

Much shorted and do the same!
