### PR TITLE
Fix default_url_options accessor

### DIFF
--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -87,7 +87,7 @@ module ActionDispatch
       include PolymorphicRoutes
 
       included do
-        unless method_defined?(:default_url_options)
+        unless method_defined?(:default_url_options=)
           # Including in a class uses an inheritable hash. Modules get a plain hash.
           if respond_to?(:class_attribute)
             class_attribute :default_url_options
@@ -104,6 +104,10 @@ module ActionDispatch
       def initialize(*)
         @_routes = nil
         super
+      end
+
+      def default_url_options
+        @default_url_options ||= defined?(super) ? super : {}
       end
 
       # Hook overridden in controller to add request information

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4651,6 +4651,37 @@ class TestDefaultUrlOptions < ActionDispatch::IntegrationTest
   end
 end
 
+class TestUrlHelpersInheritance < ActionDispatch::IntegrationTest
+  class PagesController < ActionController::Base
+    def home
+    end
+  end
+
+  Routes = ActionDispatch::Routing::RouteSet.new
+  Routes.draw do
+    get :home, controller: 'pages'
+  end
+
+  APP = build_app Routes
+
+  def app
+    APP
+  end
+
+  module FooHelper
+    include Routes.url_helpers
+  end
+  class Foo
+    include FooHelper
+  end
+
+  def test_url_helpers_inheritance
+    assert_nothing_raised do
+      Foo.new.home_path
+    end
+  end
+end
+
 class TestErrorsInController < ActionDispatch::IntegrationTest
   class ::PostsController < ActionController::Base
     def foo


### PR DESCRIPTION
### Summary

I found this issue when I tested my helper including routes url_helper such as `xxx_path`.

<img width="1126" alt="screen shot 2016-04-21 at 12 05 51 pm" src="https://cloud.githubusercontent.com/assets/1162120/14721091/6cabaf80-07b9-11e6-86fc-ecb40a15e71c.png">

The `helper` of `rspec-rails` does not have `default_url_options` originally because it's not `ActionController` nor `ActionMailer`. In this case, we can't take `default_url_options` to call `xxx_path` even though `ActionDispatch::Routing::UrlFor` defines the setter on the `included` hook.
