### PR TITLE
merge parent joins for through associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,7 +1,13 @@
 ## Rails 5.0.0.rc1 (May 06, 2016) ##
 
-*   No changes.
+*   Merge parent joins for through associations.
 
+    Merges parent associations joins for through associations into a scope. Previously joins in association scope were
+    taken into account only for root associations with that scope.
+
+    Fixes #22538.
+
+    *Seva Orlov*
 
 ## Rails 5.0.0.beta4 (April 27, 2016) ##
 

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -158,8 +158,9 @@ module ActiveRecord
         scope
       end
 
+      # Merges inner joins from `other` relation to `scope` relation.
       def merge_joins(scope, other)
-        joins_dependency, rest = other.joins_values.partition do |join|
+        association_joins, rest_joins = other.joins_values.partition do |join|
           case join
           when Hash, Symbol, Array
             true
@@ -168,7 +169,7 @@ module ActiveRecord
           end
         end
 
-        join_dependency = ActiveRecord::Associations::JoinDependency.new(other.klass, joins_dependency, rest)
+        join_dependency = ActiveRecord::Associations::JoinDependency.new(other.klass, association_joins, rest_joins)
         scope.joins! join_dependency.join_constraints([], Arel::Nodes::InnerJoin).map(&:joins)
       end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1215,4 +1215,13 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   ensure
     TenantMembership.current_member = nil
   end
+
+  def test_has_many_through_with_joins_in_scope
+    developer = Developer.create! name: 'Jamis'
+    post = Post.first
+    author = Author.create! name: 'John'
+    Comment.create! developer: developer, post: post, body: '', author: author
+
+    assert_includes post.reload.jamises_developer_comments_authors, author
+  end
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -60,6 +60,9 @@ class Post < ActiveRecord::Base
     end
   end
 
+  has_many :jamises_developer_comments, -> { joins(:developer).merge(Developer.jamises) }, class_name: 'Comment'
+  has_many :jamises_developer_comments_authors, through: :jamises_developer_comments, source: :author, source_type: 'Author'
+
   has_many :comments_with_extend, extend: NamedExtension, class_name: "Comment", foreign_key: "post_id" do
     def greeting
       "hello"


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/22538
Merges parent association joins for through associations into a scope. These joins are not taken into account at all right now.

For example  `direct_appointments` join `joins(:role)` will not be merged for `direct_users` association and a call for `direct_users` will fail because `direct` column will not be found in `users` table.

``` ruby
class User < ActiveRecord::Base
end

class Role < ActiveRecord::Base
  scope :direct, ->{ where(direct: true) }
end

class Institution < ActiveRecord::Base
  has_many :direct_appointments, ->{ joins(:role).merge(Role.direct) }, 
class_name: 'Appointment'
  has_many :direct_users, through: :direct_appointments, source: :user
end

class Appointment < ActiveRecord::Base
  belongs_to :role
  belongs_to :institution
  belongs_to :user
end
```

My request adds these joins merging in association scope.
### Other Information

I open request to master, but that issue is also present in Rails 4+, do I need to open requests to branches for 4+ versions?
### Update

Also fixes https://github.com/rails/rails/issues/12933
