### PR TITLE
Active Job Async doesn't support to Async feature as per definition

### DIFF
--- a/activejob/lib/active_job/queue_adapters.rb
+++ b/activejob/lib/active_job/queue_adapters.rb
@@ -33,7 +33,8 @@ module ActiveJob
   #
   # ==== Async
   #
-  # Yes: The Queue Adapter runs the jobs in a separate or forked process.
+  # Yes: The Queue Adapter has the ability to run the job in a non-blocking manner.
+  # It either runs on a separate or forked process, or on a different thread.
   #
   # No: The job is run in the same process.
   #


### PR DESCRIPTION
If [this definition](https://github.com/rails/rails/blob/master/activejob/lib/active_job/queue_adapters.rb#L36) is to be considered, then Active Job Async shouldn't have 'Yes' in Async column as it uses in process memory thread pool as mentioned [here](http://edgeapi.rubyonrails.org/classes/ActiveJob/QueueAdapters/AsyncAdapter.html).
