### PR TITLE
Gracefully fallback on version migrations for sqlite < 3.7.11

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -298,6 +298,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support multi-value insert
+      def supports_multi_insert?
+        true
+      end
+
       # This is meant to be implemented by the adapters that support extensions
       def disable_extension(name)
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -130,6 +130,10 @@ module ActiveRecord
         true
       end
 
+      def supports_multi_insert?
+        sqlite_version >= '3.7.11'
+      end
+
       def active?
         @active != false
       end


### PR DESCRIPTION
https://github.com/rails/rails/commit/42dd2336b31a8d98776d039a2b9fd7f834156a78 changed INSERT INTO versions to run in 1 single query.

This breaks for sqlite versions < 3.7.11, which is especially the case on Ubuntu 12.04 LTS, that has SQLite version 3.7.9 as default.

So we check for support for multi insert, before performing single query inserts, else fallback to older version of running multiple queries.
