### PR TITLE
Clearing ActionMailer deliveries on test setup vs teardown (4.2-stable)

### DIFF
--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -61,12 +61,12 @@ module ActionMailer
           set_delivery_method :test
           @old_perform_deliveries = ActionMailer::Base.perform_deliveries
           ActionMailer::Base.perform_deliveries = true
+          ActionMailer::Base.deliveries.clear
         end
 
         def restore_test_deliveries
           restore_delivery_method
           ActionMailer::Base.perform_deliveries = @old_perform_deliveries
-          ActionMailer::Base.deliveries.clear
         end
 
         def set_delivery_method(method)


### PR DESCRIPTION
### Summary

Resolves #21434

The ActionMailer deliveries collection can be cleared at the beginning of test setup vs at teardown.  With this configuration, each test is starting fresh, as expected (at least I expect).  Rails 5 update coming soon.

cc @mgodwin -- was able to use your test app to reproduce locally and resolve
