### PR TITLE
Clearing ActionMailer deliveries on test setup (5.0.0.x)

### DIFF
--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -15,10 +15,11 @@ module ActionMailer
       extend ActiveSupport::Concern
 
       included do
-        teardown :clear_test_deliveries
+        setup :clear_test_deliveries
       end
 
       private
+
       def clear_test_deliveries
         if ActionMailer::Base.delivery_method == :test
           ActionMailer::Base.deliveries.clear


### PR DESCRIPTION
### Summary

Resolves #21434.  The ActionMailer deliveries collection can be cleared at the beginning of test setup vs at teardown.
