### PR TITLE
Support nested time travel helpers

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   `travel/travel_to` travel time helpers, now support nested calls,  
+     and restore properly to time state for respective blocks.  
+
+        travel_to outer_expected_time do
+          travel_to inner_expected_time do
+            #will work with inner_expected_time as time values
+            end
+          #will work with outer_expected_time as time values
+        end
+
+    *Vipul A M*
+ 
 *   Add `ActiveSupport.to_time_preserves_timezone` config option to control
     how `to_time` handles timezones. In Ruby 2.4+ the behavior will change
     from converting to the local system timezone to preserving the timezone

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -45,6 +45,31 @@ class TimeTravelTest < ActiveSupport::TestCase
     end
   end
 
+  def test_time_helper_travel_to_with_nested_calls
+    Time.stub(:now, Time.now) do
+      outer_expected_time = Time.new(2004, 11, 24, 01, 04, 44)
+      inner_expected_time = Time.new(2004, 10, 24, 01, 04, 44)
+      travel_to outer_expected_time do
+        travel_to inner_expected_time do
+          assert_equal inner_expected_time, Time.now
+        end
+        assert_equal outer_expected_time, Time.now
+      end
+    end
+  end
+
+  def test_time_helper_travel_to_with_nested_calls_and_travel_back
+    current_time = Time.now
+    Time.stub(:now, Time.now) do
+      expected_time = Time.new(2004, 11, 24, 01, 04, 44)
+      travel_to expected_time do
+        assert_equal expected_time, Time.now
+        travel_back
+      end
+      assert_equal current_time.to_i, Time.now.to_i
+    end
+  end
+
   def test_time_helper_travel_to_with_block
     Time.stub(:now, Time.now) do
       expected_time = Time.new(2004, 11, 24, 01, 04, 44)


### PR DESCRIPTION
Currently travel time helpers don't restore to proper previous state if we have called them in a row, or in a nested fashion.

We simply unstub all previous occurrences. Consider following scenario:

``` ruby
 travel_to outer_expected_time do
     travel_to inner_expected_time do
         #perform some operations from some state here
       end
   #perform some operations from some outer state here
 end
```

This will fail for outer scenario in that, we simply just unstub all stubbed objects.
Here onwards we also take into account the object into account to create alias, to be more safe in returning back to previous states.

Fixes #24689
