### PR TITLE
remove unnessary option setting from test runner

### DIFF
--- a/railties/lib/rails/tasks/routes.rake
+++ b/railties/lib/rails/tasks/routes.rake
@@ -19,6 +19,9 @@ task routes: :environment do
 
   OptionParser.new do |opts|
     opts.banner = "Usage: rails routes [options]"
+
+    Rake.application.standard_rake_options.each { |args| opts.on(*args) }
+
     opts.on("-c CONTROLLER") do |controller|
       routes_filter = { controller: controller }
     end

--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -54,7 +54,7 @@ module Minitest
 
     options[:color] = true
     options[:output_inline] = true
-    options[:patterns] = opts.order!
+    options[:patterns] = defined?(@rake_patterns) ? @rake_patterns : opts.order!
   end
 
   # Running several Rake tasks in a single command would trip up the runner,
@@ -73,10 +73,7 @@ module Minitest
 
     ENV["RAILS_ENV"] = options[:environment] || "test"
 
-    unless run_with_autorun
-      patterns = defined?(@rake_patterns) ? @rake_patterns : options[:patterns]
-      ::Rails::TestRequirer.require_files(patterns)
-    end
+    ::Rails::TestRequirer.require_files(options[:patterns]) unless run_with_autorun
 
     unless options[:full_backtrace] || ENV["BACKTRACE"]
       # Plugin can run without Rails loaded, check before filtering.

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -228,6 +228,17 @@ module ApplicationTests
       MESSAGE
     end
 
+    def test_rake_routes_with_rake_options
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get '/cart', to: 'cart#show'
+        end
+      RUBY
+
+      output = Dir.chdir(app_path){ `bin/rake --rakefile Rakefile routes` }
+      assert_equal "Prefix Verb URI Pattern     Controller#Action\n  cart GET  /cart(.:format) cart#show\n", output
+    end
+
     def test_logger_is_flushed_when_exiting_production_rake_tasks
       add_to_config <<-RUBY
         rake_tasks do

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -502,6 +502,14 @@ module ApplicationTests
       assert_match '1 runs, 1 assertions', output
     end
 
+    def test_pass_rake_options
+      create_test_file :models, 'account'
+      output =  Dir.chdir(app_path) { `bin/rake --rakefile Rakefile --trace=stdout test` }
+
+      assert_match '1 runs, 1 assertions', output
+      assert_match 'Execute test', output
+    end
+
     def test_rails_db_create_all_restores_db_connection
       create_test_file :models, 'account'
       output =  Dir.chdir(app_path) { `bin/rails db:create:all db:migrate && echo ".tables" | rails dbconsole` }


### PR DESCRIPTION
If run the test over the `rake` command, because of the test patterns is passed
via `rake_run` method, do not need to be obtained from the argv.

This probably fixes #24372.
