### PR TITLE
Move `DateTime#getlocal` to `/core_ext/date_time/calculations.rb`

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -152,6 +152,18 @@ class DateTime
   end
   alias_method :getutc, :utc
 
+  # Returns a <tt>Time.local()</tt> instance of the simultaneous time in your
+  # system's <tt>ENV['TZ']</tt> zone.
+  def localtime(utc_offset = nil)
+    utc = getutc
+
+    Time.utc(
+      utc.year, utc.month, utc.day,
+      utc.hour, utc.min, utc.sec + utc.sec_fraction
+    ).getlocal(utc_offset)
+  end
+  alias_method :getlocal, :localtime
+
   # Returns +true+ if <tt>offset == 0</tt>.
   def utc?
     offset == 0

--- a/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
@@ -2,15 +2,4 @@ require 'active_support/core_ext/date_and_time/compatibility'
 
 class DateTime
   prepend DateAndTime::Compatibility
-
-  # Returns a <tt>Time.local()</tt> instance of the simultaneous time in your
-  # system's <tt>ENV['TZ']</tt> zone.
-  def getlocal(utc_offset = nil)
-    utc = getutc
-
-    Time.utc(
-      utc.year, utc.month, utc.day,
-      utc.hour, utc.min, utc.sec + utc.sec_fraction
-    ).getlocal(utc_offset)
-  end
 end


### PR DESCRIPTION
`DateTime#getlocal` is newly added public API.
It's responsible is same as `DateTime#utc`, so `calculations.rb` is
a best plase to define this method.
For keeping consistency with `DateTime#utc`, defines `#localtime` and
defines `getlocal` as an alias method.

r? @pixeltrix
