### PR TITLE
Raise `ArgumentError` when an invalid form is passed to `String#to_time`

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -17,6 +17,8 @@ class String
   #   "2012-12-13T06:12".to_time(:utc)   # => 2012-12-13 06:12:00 UTC
   #   "12/13/2012".to_time               # => ArgumentError: argument out of range
   def to_time(form = :local)
+    raise ArgumentError, "Expected :local or :utc, got #{form.inspect}." unless [:local, :utc].include?(form)
+
     parts = Date._parse(self, false)
     used_keys = %i(year mon mday hour min sec sec_fraction offset)
     return if (parts.keys & used_keys).empty?

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -459,6 +459,10 @@ class StringConversionsTest < ActiveSupport::TestCase
       assert_nil "010".to_time
       assert_nil "".to_time
     end
+
+    assert_raise(ArgumentError) do
+      "2011-02-27 22:50 -0100".to_time(:tokyo)
+    end
   end
 
   def test_string_to_time_utc_offset


### PR DESCRIPTION
`String#to_time` accepted any an argument as `form` and
behaved like as if `:local` was passed. This change notifies
developers they passed an invalid argument.
