### PR TITLE
Fix typo in ActiveJob #retry_job doc

### DIFF
--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -36,7 +36,7 @@ module ActiveJob
     #
     # ==== Examples
     #
-    #  class SiteScrapperJob < ActiveJob::Base
+    #  class SiteScraperJob < ActiveJob::Base
     #    rescue_from(ErrorLoadingSite) do
     #      retry_job queue: :low_priority
     #    end


### PR DESCRIPTION
### Summary

Fix simple typo in `activejob/lib/active_job/enqueuing.rb`

`SiteScrapperJob` is meant to be `SiteScraperJob`
