### PR TITLE
Add `:nodoc:` to `insert_versions_sql` [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -989,7 +989,7 @@ module ActiveRecord
         insert_versions_sql(versions)
       end
 
-      def insert_versions_sql(versions)
+      def insert_versions_sql(versions) # :nodoc:
         sm_table = ActiveRecord::Migrator.schema_migrations_table_name
 
         if supports_multi_insert?

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -298,7 +298,7 @@ module ActiveRecord
         false
       end
 
-      # Does this adapter support multi-value insert
+      # Does this adapter support multi-value insert?
       def supports_multi_insert?
         true
       end


### PR DESCRIPTION
Follow up to #24685. `insert_versions_sql` is not public API.
