### PR TITLE
Remove in the doc about MySQL versions below 5 [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -221,9 +221,7 @@ module ActiveRecord
       # * You are creating a nested (savepoint) transaction
       #
       # The mysql2 and postgresql adapters support setting the transaction
-      # isolation level. However, support is disabled for MySQL versions below 5,
-      # because they are affected by a bug[http://bugs.mysql.com/bug.php?id=39170]
-      # which means the isolation level gets persisted outside the transaction.
+      # isolation level.
       def transaction(requires_new: nil, isolation: nil, joinable: true)
         if !requires_new && current_transaction.joinable?
           if isolation


### PR DESCRIPTION
Follow up to #23458.
Active Record supports MySQL >= 5.0 now.
