### PR TITLE
Follow up of #23461

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -66,7 +66,7 @@ module ActiveRecord
       def initialize(connection, logger, connection_options, config)
         super(connection, logger, config)
 
-        @statements = StatementPool.new(self.class.type_cast_config_to_integer(config.fetch(:statement_limit) { 1000 }))
+        @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
 
         if version < '5.0.0'
           raise "Your version of MySQL (#{full_version.match(/^\d+\.\d+\.\d+/)[0]}) is too old. Active Record supports MySQL >= 5.0."

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -214,7 +214,7 @@ module ActiveRecord
         connect
         add_pg_encoders
         @statements = StatementPool.new @connection,
-                                        self.class.type_cast_config_to_integer(config.fetch(:statement_limit) { 1000 })
+                                        self.class.type_cast_config_to_integer(config[:statement_limit])
 
         if postgresql_version < 90100
           raise "Your version of PostgreSQL (#{postgresql_version}) is too old. Active Record supports PostgreSQL >= 9.1."

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -88,7 +88,7 @@ module ActiveRecord
         super(connection, logger, config)
 
         @active     = nil
-        @statements = StatementPool.new(self.class.type_cast_config_to_integer(config.fetch(:statement_limit) { 1000 }))
+        @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
       end
 
       def supports_ddl_transactions?

--- a/activerecord/lib/active_record/connection_adapters/statement_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/statement_pool.rb
@@ -3,9 +3,11 @@ module ActiveRecord
     class StatementPool
       include Enumerable
 
-      def initialize(max = 1000)
+      DEFAULT_STATEMENT_LIMIT = 1000
+
+      def initialize(statement_limit = nil)
         @cache = Hash.new { |h,pid| h[pid] = {} }
-        @max = max
+        @statement_limit = statement_limit || DEFAULT_STATEMENT_LIMIT
       end
 
       def each(&block)
@@ -25,7 +27,7 @@ module ActiveRecord
       end
 
       def []=(sql, stmt)
-        while @max <= cache.size
+        while @statement_limit <= cache.size
           dealloc(cache.shift.last)
         end
         cache[sql] = stmt


### PR DESCRIPTION
- Rename max to statement_limit
- Remove magic number 1000 from everywhere
- Defined StatementPool::DEFAULT_STATEMENT_LIMIT and started using it everywhere
