### PR TITLE
Fix counter_cache double increment bug

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -61,6 +61,7 @@ module ActiveRecord
 
         def update_counters_on_replace(record)
           if require_counter_update? && different_target?(record)
+            owner.instance_variable_set :@_after_replace_counter_called, true
             record.increment!(reflection.counter_cache_column)
             decrement_counters
           end

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -33,6 +33,8 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
           if (@_after_create_counter_called ||= false)
             @_after_create_counter_called = false
+          elsif (@_after_replace_counter_called ||= false)
+            @_after_replace_counter_called = false
           elsif attribute_changed?(foreign_key) && !new_record?
             if reflection.polymorphic?
               model     = attribute(reflection.foreign_type).try(:constantize)

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -700,6 +700,17 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal 17, reply.replies.size
   end
 
+  def test_replace_counter_cache
+    topic = Topic.create(title: "Zoom-zoom-zoom")
+    reply = Reply.create(title: "re: zoom", content: "speedy quick!")
+
+    reply.topic = topic
+    reply.save
+    topic.reload
+
+    assert_equal 1, topic.replies_count
+  end
+
   def test_association_assignment_sticks
     post = Post.first
 


### PR DESCRIPTION
### Summary

Fixes counter cache bug, reported in https://github.com/rails/rails/issues/24183. Counter cache is incrementing twice when replacing the association.
### Other Information
- bug can be reproduced with this gist: https://gist.github.com/mikes01/934e7248525e87d1a08c
- @vipulnsward helped me with the fix, here is the gist: https://gist.github.com/vipulnsward/1031bde143ea061be1aa8aa8599f0147
