### PR TITLE
rm  create_savepoint, release_savepoint methods from AbstractAdapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -291,9 +291,6 @@ module ActiveRecord
         exec_rollback_to_savepoint(name)
       end
 
-      def exec_rollback_to_savepoint(name = nil) #:nodoc:
-      end
-
       def default_sequence_name(table, column)
         nil
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/savepoints.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/savepoints.rb
@@ -1,10 +1,6 @@
 module ActiveRecord
   module ConnectionAdapters
-    module Savepoints #:nodoc:
-      def supports_savepoints?
-        true
-      end
-
+    module Savepoints
       def create_savepoint(name = current_savepoint_name)
         execute("SAVEPOINT #{name}")
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -67,6 +67,7 @@ module ActiveRecord
       include QueryCache
       include ActiveSupport::Callbacks
       include ColumnDumper
+      include Savepoints
 
       SIMPLE_INT = /\A\d+\z/
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -404,12 +404,6 @@ module ActiveRecord
         @connection
       end
 
-      def create_savepoint(name = nil)
-      end
-
-      def release_savepoint(name = nil)
-      end
-
       def case_sensitive_comparison(table, attribute, column, value)
         if value.nil?
           table[attribute].eq(value)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -15,7 +15,6 @@ module ActiveRecord
     class AbstractMysqlAdapter < AbstractAdapter
       include MySQL::Quoting
       include MySQL::ColumnDumper
-      include Savepoints
 
       def update_table_definition(table_name, base) # :nodoc:
         MySQL::Table.new(table_name, base)

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -57,6 +57,10 @@ module ActiveRecord
         true
       end
 
+      def supports_savepoints?
+        true
+      end
+
       # HELPER METHODS ===========================================
 
       def each_hash(result) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -168,6 +168,10 @@ module ActiveRecord
         false
       end
 
+      def supports_savepoints?
+        true
+      end
+
       def index_algorithms
         { concurrently: 'CONCURRENTLY' }
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -117,7 +117,6 @@ module ActiveRecord
       include PostgreSQL::SchemaStatements
       include PostgreSQL::DatabaseStatements
       include PostgreSQL::ColumnDumper
-      include Savepoints
 
       def schema_creation # :nodoc:
         PostgreSQL::SchemaCreation.new self

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -52,7 +52,6 @@ module ActiveRecord
       ADAPTER_NAME = 'SQLite'.freeze
 
       include SQLite3::Quoting
-      include Savepoints
 
       NATIVE_DATABASE_TYPES = {
         primary_key:  'INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL',


### PR DESCRIPTION
They have been moved to Savepoints module

EDIT:Added another change to move savepoints include to abstract adapter, which depends on previous change.
