### PR TITLE
Subclasses should inherit associations from parents

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -32,8 +32,13 @@ module ActiveRecord
     end
 
     def self.add_reflection(ar, name, reflection)
+      # Add reflection to the current class, and downstream it to its descendants
       ar.clear_reflections_cache
       ar._reflections = ar._reflections.merge(name.to_s => reflection)
+
+      ar.subclasses.each do |klass|
+        add_reflection(klass, name, reflection)
+      end
     end
 
     def self.add_aggregate_reflection(ar, name, reflection)


### PR DESCRIPTION
- Fixes #20678 (Subclass misses association defined on parent)

---

I can add a test to check on `SpecialUser._reflections['comments']`, but I wasn't sure if that was digging too deep into Active Record internals 😬 
