### PR TITLE
Remove `Array#sum` method before override it

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -112,6 +112,8 @@ end
 # just calling the compat method in the first place.
 if Array.instance_methods(false).include?(:sum) && !(%w[a].sum rescue false)
   class Array
+    remove_method :sum
+
     def sum(*args) #:nodoc:
       # Use Enumerable#sum instead.
       super


### PR DESCRIPTION
To suppress warning ('warning: method redefined; discarding old sum')
remove the method before override it.

r? @jeremy 
