### PR TITLE
Little perfomance fix for Array#split.

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/grouping.rb
+++ b/activesupport/lib/active_support/core_ext/array/grouping.rb
@@ -100,17 +100,13 @@ class Array
         results
       end
     else
-      results, arr = [[]], self.dup
-      until arr.empty?
-        if (idx = arr.index(value))
-          results.last.concat(arr.shift(idx))
-          arr.shift
-          results << []
-        else
-          results.last.concat(arr.shift(arr.size))
-        end
+      arr = self.dup
+      result = []
+      while (idx = arr.index(value))
+        result << arr.shift(idx)
+        arr.shift
       end
-      results
+      result << arr
     end
   end
 end

--- a/activesupport/test/core_ext/array/grouping_test.rb
+++ b/activesupport/test/core_ext/array/grouping_test.rb
@@ -123,4 +123,12 @@ class SplitTest < ActiveSupport::TestCase
     assert_equal [[], [2, 3, 4], []], a.split { |i| i == 1 || i == 5 }
     assert_equal [1, 2, 3, 4, 5], a
   end
+
+  def test_split_with_repeated_values
+    a = [1, 2, 3, 5, 5, 3, 4, 6, 2, 1, 3]
+    assert_equal [[1, 2], [5, 5], [4, 6, 2, 1], []], a.split(3)
+    assert_equal [[1, 2, 3], [], [3, 4, 6, 2, 1, 3]], a.split(5)
+    assert_equal [[1, 2], [], [], [], [4, 6, 2, 1], []], a.split { |i| i == 3 || i == 5 }
+    assert_equal [1, 2, 3, 5, 5, 3, 4, 6, 2, 1, 3], a
+  end
 end


### PR DESCRIPTION
``` ruby
class Array
  # current behavior
  def split(value = nil)
    if block_given?
      inject([[]]) do |results, element|
        if yield(element)
          results << []
        else
          results.last << element
        end

        results
      end
    else
      results, arr = [[]], self.dup
      until arr.empty?
        if (idx = arr.index(value))
          results.last.concat(arr.shift(idx))
          arr.shift
          results << []
        else
          results.last.concat(arr.shift(arr.size))
        end
      end
      results
    end
  end

  # proposed behavior
  def split2(value = nil)
    if block_given?
      inject([[]]) do |results, element|
        if yield(element)
          results << []
        else
          results.last << element
        end

        results
      end
    else
      arr = self.dup
      result = []
      while (idx = arr.index(value))
        result << arr.shift(idx)
        arr.shift
      end
      result << arr
    end
  end
end
```

``` ruby
arr = (1..12).to_a

Benchmark.ips do |x|
     x.report('before') { arr.split(3) }
     x.report('after') { arr.split2(3) }
end
```

```
          Calculating -------------------------------------
          before    40.770k i/100ms
           after    58.464k i/100ms
          -------------------------------------------------
          before    629.568k (± 5.0%) i/s -      3.180M
           after      1.159M (± 4.5%) i/s -      5.788M
```
