### PR TITLE
Sanitization of AJ args for logger

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Sanitize args for logging.
+
+    *Max Melentiev*
+
 *   Enable class reloading prior to job dispatch, and ensure Active Record
     connections are returned to the pool when jobs are run in separate threads.
 
@@ -22,7 +26,6 @@
 ## Rails 5.0.0.beta2 (February 01, 2016) ##
 
 *   No changes.
-
 
 ## Rails 5.0.0.beta1 (December 18, 2015) ##
 

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/numeric/time'
 require 'jobs/hello_job'
 require 'jobs/logging_job'
 require 'jobs/nested_job'
+require 'jobs/sanitized_param_job'
 require 'models/person'
 
 class LoggingTest < ActiveSupport::TestCase
@@ -72,6 +73,12 @@ class LoggingTest < ActiveSupport::TestCase
     assert_match(%r{Enqueued.*gid://aj/Person/123}, @logger.messages)
     assert_match(%r{Dummy, here is it: #<Person:.*>}, @logger.messages)
     assert_match(%r{Performing.*gid://aj/Person/123}, @logger.messages)
+  end
+
+  def test_sanitized_parameter_logging
+    SanitizedParamJob.perform_later 'public', 'secret'
+    assert_match(/with arguments: "public", "\[FILTERED\]"/, @logger.messages)
+    refute_match(/secret/, @logger.messages)
   end
 
   def test_globalid_nested_parameter_logging

--- a/activejob/test/jobs/sanitized_param_job.rb
+++ b/activejob/test/jobs/sanitized_param_job.rb
@@ -1,0 +1,11 @@
+class SanitizedParamJob < ActiveJob::Base
+  def perform(one, two)
+    logger.info 'Dummy'
+  end
+
+  def arguments_to_log
+    result = super.dup
+    result[1] = ActiveJob::Logging::SANITIZED_ARG
+    result
+  end
+end


### PR DESCRIPTION
This PR gives ability to sanitize ActiveJob args for logger, to not log any sensitive data. Ex. reset password tokens ([devise's readme](https://github.com/plataformatec/devise/#password-reset-tokens-and-rails-logs)). For now the only way to not leak this data is to use `warn` level for the job logger.
