### PR TITLE
Add require of mattr_accessor since Compatibility relies on it.

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module/attribute_accessors'
+
 module DateAndTime
   module Compatibility
     # If true, +to_time+ preserves the timezone offset of receiver.


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/commit/c9c5788a527b70d7f983e2b4b47e3afd863d9f48 .  This is related to this comment by @kbrock: https://github.com/rails/rails/commit/c9c5788a527b70d7f983e2b4b47e3afd863d9f48#commitcomment-17235829

---

Before

``` text
~/projects/external/rails (master *) $ irb -I'activesupport/lib'
irb(main):001:0> require 'active_support/core_ext/date_and_time/compatibility'
NoMethodError: undefined method `mattr_accessor' for DateAndTime::Compatibility:Module
    from /Users/jfrey/projects/external/rails-dev-box/rails/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb:12:in `<module:Compatibility>'
    from /Users/jfrey/projects/external/rails-dev-box/rails/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb:4:in `<module:DateAndTime>'
    from /Users/jfrey/projects/external/rails-dev-box/rails/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb:3:in `<top (required)>'
    from /Users/jfrey/.rubies/ruby-2.2.4/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/jfrey/.rubies/ruby-2.2.4/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from (irb):1
    from /Users/jfrey/.rubies/ruby-2.2.4/bin/irb:11:in `<main>'
irb(main):002:0> exit

~/projects/external/rails (master *) $ irb -I'activesupport/lib'
irb(main):001:0> require 'active_support'
=> true
irb(main):002:0> require 'active_support/core_ext/date_and_time/compatibility'
=> false
irb(main):003:0> exit
```

After

``` text
~/projects/external/rails (master *) $ irb -I'activesupport/lib'
irb(main):001:0> require 'active_support/core_ext/date_and_time/compatibility'
=> true
irb(main):002:0> exit
```

r? @pixeltrix 
