### PR TITLE
Change valid_type? from abstract adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -154,7 +154,7 @@ module ActiveRecord
       end
 
       def valid_type?(type)
-        true
+        false
       end
 
       def schema_creation

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -154,6 +154,10 @@ module ActiveRecord
         true
       end
 
+      def valid_type?(type)
+        true
+      end
+
       # Returns 62. SQLite supports index names up to 64
       # characters. The rest is used by rails internally to perform
       # temporary rename operations

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -17,6 +17,17 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     end
   end
 
+  def test_valid_column
+    with_example_table do
+      column = @conn.columns('ex').find { |col| col.name == 'id' }
+      assert @conn.valid_type?(column.type)
+    end
+  end
+
+  def test_invalid_column
+    assert_not @conn.valid_type?(:foobar)
+  end
+
   def test_columns_for_distinct_zero_orders
     assert_equal "posts.id",
       @conn.columns_for_distinct("posts.id", [])


### PR DESCRIPTION
Don't simply assume a type is a valid database type. This is only always true in the case of sqlite.
Others adapters need to perform a check for validity.
Also adds coverage for mysql2 db type validation.
