### PR TITLE
update record specified in key

### DIFF
--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -19,7 +19,7 @@ module ActiveRecord
       end
 
       def []=(key, value)
-        first_or_initialize(key: key).update_attributes!(value: value)
+        find_or_initialize_by(key: key).update_attributes!(value: value)
       end
 
       def [](key)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -424,6 +424,23 @@ class MigrationTest < ActiveRecord::TestCase
     ENV["RACK_ENV"]  = original_rack_env
   end
 
+  def test_internal_metadata_stores_environment_when_other_data_exists
+    ActiveRecord::InternalMetadata.delete_all
+    ActiveRecord::InternalMetadata[:foo]  = 'bar'
+
+    current_env     = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+    migrations_path = MIGRATIONS_ROOT + "/valid"
+    old_path        = ActiveRecord::Migrator.migrations_paths
+    ActiveRecord::Migrator.migrations_paths = migrations_path
+
+    current_env     = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+    ActiveRecord::Migrator.up(migrations_path)
+    assert_equal current_env, ActiveRecord::InternalMetadata[:environment]
+    assert_equal 'bar', ActiveRecord::InternalMetadata[:foo]
+  ensure
+    ActiveRecord::Migrator.migrations_paths = old_path
+  end
+
   def test_rename_internal_metadata_table
     original_internal_metadata_table_name = ActiveRecord::Base.internal_metadata_table_name
 


### PR DESCRIPTION
### Summary

`#first_or_initialize` does not use attributes to data acquisition.
Therefore, there is a possibility of updating the different record than the one
specified in the key, I think this is not expected behavior.
