### PR TITLE
Updating contribution section of guides

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -128,25 +128,20 @@ Contributing to the Rails Documentation
 Ruby on Rails has two main sets of documentation: the guides, which help you
 learn about Ruby on Rails, and the API, which serves as a reference.
 
-You can help improve the Rails guides by making them more coherent, consistent or readable, adding missing information, correcting factual errors, fixing typos, or bringing them up to date with the latest edge Rails.
+You can help improve the documentation by making them more coherent, consistent
+or readable, adding missing information, correcting factual errors, fixing
+typos, or bringing them up to date.
 
-You can either open a pull request to [Rails](http://github.com/rails/rails) or
-ask the [Rails core team](http://rubyonrails.org/core) for commit access on
-docrails if you contribute regularly.
-Please do not open pull requests in docrails, if you'd like to get feedback on your
-change, ask for it in [Rails](http://github.com/rails/rails) instead.
+When working with documentation, please take into account the
+[API Documentation Guidelines](api_documentation_guidelines.html) and the
+[Ruby on Rails Guides Guidelines](ruby_on_rails_guides_guidelines.html).
 
-Docrails is merged with master regularly, so you are effectively editing the Ruby on Rails documentation.
+If you are unsure of the documentation changes,
+[open an issue](https://github.com/rails/rails/issues).
 
-If you are unsure of the documentation changes, you can create an issue in the [Rails](https://github.com/rails/rails/issues) issues tracker on GitHub.
-
-When working with documentation, please take into account the [API Documentation Guidelines](api_documentation_guidelines.html) and the [Ruby on Rails Guides Guidelines](ruby_on_rails_guides_guidelines.html).
-
-NOTE: As explained earlier, ordinary code patches should have proper documentation coverage. Docrails is only used for isolated documentation improvements.
-
-NOTE: To help our CI servers you should add [ci skip] to your documentation commit message to skip build on that commit. Please remember to use it for commits containing only documentation changes.
-
-WARNING: Docrails has a very strict policy: no code can be touched whatsoever, no matter how trivial or small the change. Only RDoc and guides can be edited via docrails. Also, CHANGELOGs should never be edited in docrails.
+NOTE: To help our CI servers you should add [ci skip] to your documentation
+commit message to skip build on that commit. Please remember to use it for
+commits containing only documentation changes.
 
 Translating Rails Guides
 ------------------------


### PR DESCRIPTION
As I was reading the documentation on how to contribute to Rails, I was confused by the section "Contributing to the Rails Documentation". It referred to "docrails" a few times, which I gather was a branch or repo where the documentation used to be maintained. The guides now seem to be in the Rails repo itself, which is great, but the documentation then is out of date.

I chose to mostly slash the obsolete content and simply link out to the “Ruby on Rails Guidelines” and “API Documentation Guidelines” since those sections do a good job of explaining what to do.

The only thing that might be worth adding is something about how to submit changes (i.e. via pull request) but I opted to leave it out since it's well documented below. Thoughts?
