### PR TITLE
Prevent raising RangeError in AR presence validation [4-2-stable]

### DIFF
--- a/activerecord/test/cases/validations/association_validation_test.rb
+++ b/activerecord/test/cases/validations/association_validation_test.rb
@@ -74,6 +74,19 @@ class AssociationValidationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_validates_presence_of_belongs_to_association__out_of_range_error
+    repair_validations(Interest) do
+      Interest.validates_presence_of(:man)
+      man = Man.create!(:name => 'John')
+      interest = Interest.create!(:man => man, :topic => 'Airplanes')
+
+      interest.man_id = 10_000_000_000
+
+      assert !interest.valid?
+      assert interest.errors[:man_id] == ["is invalid"]
+    end
+  end
+
   def test_validates_presence_of_belongs_to_association__existing_parent
     repair_validations(Interest) do
       Interest.validates_presence_of(:man)


### PR DESCRIPTION
### Summary

After updating ActiveRecord version to 4.2 in my application I noticed a strange behavior. If I call `#valid?` method for an ActiveRecord model, it may raise an unexpected `RangeError` exception. For example:

```
RangeError: SOME_INTEGER is out of range for ActiveRecord::Type::Integer with limit 4
```

What happened was that during a `presence` validation for association it called a method `type_cast_for_database` several times, which checks whether a value in a range or not.

To fix this issue I would suggest catching the exception and adding `:invalid` attribute error to a record.
### Other Information

Here is a stack trace when I run tests without these changes:

```
AssociationValidationTest#test_validates_presence_of_belongs_to_association__out_of_range_error:
RangeError: 10000000000 is out of range for ActiveRecord::Type::Integer with limit 4
    rails/activerecord/lib/active_record/type/integer.rb:45:in `ensure_in_range'
    rails/activerecord/lib/active_record/type/integer.rb:23:in `type_cast_for_database'
    rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:28:in `type_cast'
    rails/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:278:in `block in exec_query'
    rails/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:277:in `map'
    rails/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:277:in `exec_query'
    rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:356:in `select'
    rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:32:in `select_all'
    rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
    rails/activerecord/lib/active_record/querying.rb:39:in `find_by_sql'
    rails/activerecord/lib/active_record/statement_cache.rb:107:in `execute'
    rails/activerecord/lib/active_record/associations/singular_association.rb:53:in `get_records'
    rails/activerecord/lib/active_record/associations/singular_association.rb:57:in `find_target'
    rails/activerecord/lib/active_record/associations/association.rb:138:in `load_target'
    rails/activerecord/lib/active_record/associations/association.rb:53:in `reload'
    rails/activerecord/lib/active_record/associations/singular_association.rb:9:in `reader'
    rails/activerecord/lib/active_record/associations/builder/association.rb:115:in `man'
    rails/activemodel/lib/active_model/validator.rb:149:in `block in validate'
    rails/activemodel/lib/active_model/validator.rb:148:in `each'
    rails/activemodel/lib/active_model/validator.rb:148:in `validate'
    rails/activerecord/lib/active_record/validations/presence.rb:5:in `validate'
    rails/activesupport/lib/active_support/callbacks.rb:455:in `public_send'
    rails/activesupport/lib/active_support/callbacks.rb:455:in `block in make_lambda'
    rails/activesupport/lib/active_support/callbacks.rb:192:in `call'
    rails/activesupport/lib/active_support/callbacks.rb:192:in `block in simple'
    rails/activesupport/lib/active_support/callbacks.rb:504:in `call'
    rails/activesupport/lib/active_support/callbacks.rb:504:in `block in call'
    rails/activesupport/lib/active_support/callbacks.rb:504:in `each'
    rails/activesupport/lib/active_support/callbacks.rb:504:in `call'
    rails/activesupport/lib/active_support/callbacks.rb:92:in `__run_callbacks__'
    rails/activesupport/lib/active_support/callbacks.rb:778:in `_run_validate_callbacks'
    rails/activemodel/lib/active_model/validations.rb:399:in `run_validations!'
    rails/activemodel/lib/active_model/validations/callbacks.rb:113:in `block in run_validations!'
    rails/activesupport/lib/active_support/callbacks.rb:88:in `__run_callbacks__'
    rails/activesupport/lib/active_support/callbacks.rb:778:in `_run_validation_callbacks'
    rails/activemodel/lib/active_model/validations/callbacks.rb:113:in `run_validations!'
    rails/activemodel/lib/active_model/validations.rb:338:in `valid?'
    rails/activerecord/lib/active_record/validations.rb:58:in `valid?'
    test/cases/validations/association_validation_test.rb:85:in `block in test_validates_presence_of_belongs_to_association__out_of_range_error'
    rails/activerecord/test/cases/validations_repair_helper.rb:16:in `repair_validations'
    test/cases/validations/association_validation_test.rb:78:in `test_validates_presence_of_belongs_to_association__out_of_range_error'
```

Probably similar issues https://github.com/rails/rails/issues/20140, https://github.com/rails/rails/issues/21309.
