### PR TITLE
Actioncable deadlock with multiple channels

### DIFF
--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -20,13 +20,13 @@ module ActionCable
       def initialize
         @mutex = Monitor.new
         @remote_connections = @event_loop = @worker_pool = @channel_classes = @pubsub = nil
-        @channel_classes = self.channel_classes
       end
 
       # Called by Rack to setup the server.
       def call(env)
         setup_heartbeat_timer
         config.connection_class.new(self, env).process
+        @channel_classes = self.channel_classes
       end
 
       # Disconnect all the connections identified by `identifiers` on this server or any others via RemoteConnections.

--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -20,6 +20,7 @@ module ActionCable
       def initialize
         @mutex = Monitor.new
         @remote_connections = @event_loop = @worker_pool = @channel_classes = @pubsub = nil
+        @channel_classes = self.channel_classes
       end
 
       # Called by Rack to setup the server.


### PR DESCRIPTION
I ran into an issue with my ActionCable enabled app where the server was locking up constantly using the current master branch from the rails repository. I was able to recreate the issue in my own fork of the ActionCable examples repo.

I modified the ActionCable example to mount ActionCable at the '/ws' endpoint in the routes.rb file and I also created a second channel which the client subscribes to at the same time as the first: https://github.com/rails/actioncable-examples/compare/master...eacaps:2channel-rails5-master.

To take it one step further, I created a test case in the actioncable examples to demonstrate the issue. The issue wasn't always manifesting itself, so I monkeypatched the ActionCable::Server::Base channel_classes method to put a small delay in: https://github.com/eacaps/actioncable-examples/commit/300de61fae59121ec7fb58b4df6bc00d9b8ef08b.
### Steps to reproduce

```
Open a terminal
$ git clone https://github.com/eacaps/actioncable-examples.git
$ cd actioncable-examples
$ git checkout deadlock-test-case-failure
$ ./bin/setup
$ rake
Run options: --seed 54861

# Running:

=> Booting Puma
=> Rails 5.0.0.beta3 application starting in test on http://0.0.0.0:3000
=> Run `rails server -h` for more startup options
DEPRECATION WARNING: `config.serve_static_files` is deprecated and will be removed in Rails 5.1.
Please use `config.public_file_server.enabled = true` instead.
 (called from block in <top (required)> at /Users/eacaps/workspace/rails5/deadlock/config/environments/test.rb:16)
DEPRECATION WARNING: `config.static_cache_control` is deprecated and will be removed in Rails 5.1.
Please use
`config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }`
instead.
 (called from block in <top (required)> at /Users/eacaps/workspace/rails5/deadlock/config/environments/test.rb:17)
Puma starting in single mode...
* Version 3.4.0 (ruby 2.2.2-p95), codename: Owl Bowl Brawl
* Min threads: 0, max threads: 16
* Environment: development
* Listening on tcp://0.0.0.0:3000
Use Ctrl-C to stop
starting deadlock test
Started GET "/ws" for 127.0.0.1 at 2016-04-26 15:09:57 -0400
Started GET "/ws/" [WebSocket] for 127.0.0.1 at 2016-04-26 15:09:57 -0400
Successfully upgraded to WebSocket (REQUEST_METHOD: GET, HTTP_CONNECTION: Upgrade, HTTP_UPGRADE: websocket)
  User Load (0.2ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
[ActionCable] [The Notorious B.I.G.] Registered connection (Z2lkOi8vYWN0aW9uY2FibGUtZXhhbXBsZXMvVXNlci8x)
70139809484260 - entering channel_classes
70139814496000 - entering channel_classes
70139809484260 - channel_classes at each
Exiting
E

Error:
QuickTest#test_deadlock_situation:
ThreadError: queue empty
    test/deadlock_test.rb:79:in `pop'
    test/deadlock_test.rb:79:in `read_message'
    test/deadlock_test.rb:135:in `test_deadlock_situation'


bin/rails test test/deadlock_test.rb:128



Finished in 13.344337s, 0.0749 runs/s, 0.0749 assertions/s.

1 runs, 1 assertions, 0 failures, 1 errors, 0 skips
```

The test will hang when attempting to load the channel_classes and will eventually error out from failing to read from the websocket.
### Expected behavior

Attempting to subscribe to 2 branches at the same time should not deadlock the server. After digging into the issue it seems like it has something to do with active_support and dependencies.rb which are used by the require statement in the ActionCable::Server::Base channel_classes method. I'm not an expert in rails, but it seemed that both threads were trying to grab the Dependencies.load_interlock and having issues resolving that situation. The simplest solution I could think up was to load the channel classes when the server is initialized. I decided to put it in the ActionCable::Server::Base call method because that seems like the most reasonable place for it. I created a separate branch called `deadlock-test-case` that uses my proposed fixed rails5 branch `actioncable/server-base-channel-classes`.

```
$ git checkout deadlock-test-case
$ bundle install
$ rake
Run options: --seed 58815

# Running:

=> Booting Puma
=> Rails 5.0.0.beta3 application starting in test on http://0.0.0.0:3000
=> Run `rails server -h` for more startup options
DEPRECATION WARNING: `serve_static_files` is deprecated and will be removed in Rails 5.1.
Please use `config.public_file_server.enabled = true` instead.
 (called from block in <top (required)> at /Users/eacaps/workspace/rails5/deadlock/config/environments/test.rb:16)
DEPRECATION WARNING: `static_cache_control` is deprecated and will be removed in Rails 5.1.
Please use
`config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }`
instead.
 (called from block in <top (required)> at /Users/eacaps/workspace/rails5/deadlock/config/environments/test.rb:17)
70180801995260 - entering channel_classes
70180801995260 - channel_classes at each
70180801995260 - channel_classes past each
70180801995260 - channel_classes return each_with_object
Puma starting in single mode...
* Version 3.4.0 (ruby 2.2.2-p95), codename: Owl Bowl Brawl
* Min threads: 0, max threads: 16
* Environment: development
* Listening on tcp://0.0.0.0:3000
Use Ctrl-C to stop
starting deadlock test
Started GET "/ws" for 127.0.0.1 at 2016-04-26 15:21:51 -0400
Started GET "/ws/" [WebSocket] for 127.0.0.1 at 2016-04-26 15:21:51 -0400
Successfully upgraded to WebSocket (REQUEST_METHOD: GET, HTTP_CONNECTION: Upgrade, HTTP_UPGRADE: websocket)
  User Load (0.1ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
[ActionCable] [The Notorious B.I.G.] Registered connection (Z2lkOi8vYWN0aW9uY2FibGUtZXhhbXBsZXMvVXNlci8x)
70180815623020 - entering channel_classes
[ActionCable] [The Notorious B.I.G.] CommentsChannel is transmitting the subscription confirmation
70180848652000 - entering channel_classes
i subscribed
[ActionCable] [The Notorious B.I.G.] OtherChannel transmitting {:data=>"some data"}
[ActionCable] [The Notorious B.I.G.] OtherChannel is transmitting the subscription confirmation
[ActionCable] [The Notorious B.I.G.] Finished "/ws/" [WebSocket] for 127.0.0.1 at 2016-04-26 15:21:52 -0400
Exiting
.

Finished in 5.972153s, 0.1674 runs/s, 1.0047 assertions/s.

1 runs, 6 assertions, 0 failures, 0 errors, 0 skips
```
### System configuration

Using latest rails master branch from:
`gem 'rails', git: 'https://github.com/rails/rails.git', branch: 'master'`

Ruby version info:

```
ruby -v
ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin15]
```
### Additional info

I closed my previous stale issue(https://github.com/rails/rails/issues/24094) since this one has a pull request attached to it.
