### PR TITLE
Prevent raising RangeError in AR presence validation

### DIFF
--- a/activerecord/test/cases/validations/association_validation_test.rb
+++ b/activerecord/test/cases/validations/association_validation_test.rb
@@ -86,6 +86,19 @@ class AssociationValidationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_validates_presence_of_belongs_to_association__out_of_range_error
+    repair_validations(Interest) do
+      Interest.validates_presence_of(:man)
+      man = Man.create!(:name => 'John')
+      interest = Interest.create!(:man => man, :topic => 'Airplanes')
+
+      interest.man_id = 10_000_000_000
+
+      assert !interest.valid?
+      assert interest.errors[:man_id] == ["is invalid"]
+    end
+  end
+
   def test_validates_presence_of_belongs_to_association__existing_parent
     repair_validations(Interest) do
       Interest.validates_presence_of(:man)


### PR DESCRIPTION
### Summary

After updating ActiveRecord version from 4.1 in my application I noticed a strange behavior. If I call `#valid?` method for an ActiveRecord model, it may raise an unexpected `RangeError` exception. For example:

``` ruby
user = User.create!(account: Account.first!)

user.account_id = 10_000_000_000
user.valid? 
# => RangeError: 10000000000 is out of range for ActiveRecord::Type::Integer with limit 4
```

What happened was that during a `presence` validation for association it called a method `ensure_in_range` several times, which checks whether a value in a DB type range or not.

To fix this issue I would suggest catching the exception and adding `:invalid` attribute error to a record.
### Other Information

Here is a stack trace when I run tests without these changes:

```
RangeError: 10000000000 is out of range for ActiveModel::Type::Integer with limit 4
    rails/activemodel/lib/active_model/type/integer.rb:49:in `ensure_in_range'
    rails/activemodel/lib/active_model/type/integer.rb:27:in `serialize'
    rails/activerecord/lib/active_record/attribute.rb:51:in `value_for_database'
    rails/activerecord/lib/active_record/relation/query_attribute.rb:11:in `value_for_database'
    rails/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:191:in `block in exec_query'
    rails/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:191:in `map'
    rails/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:191:in `exec_query'
    rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:377:in `select_prepared'
    rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:39:in `select_all'
    rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
    rails/activerecord/lib/active_record/querying.rb:39:in `find_by_sql'
    rails/activerecord/lib/active_record/statement_cache.rb:109:in `execute'
    rails/activerecord/lib/active_record/associations/singular_association.rb:59:in `get_records'
    rails/activerecord/lib/active_record/associations/singular_association.rb:63:in `find_target'
    rails/activerecord/lib/active_record/associations/association.rb:138:in `load_target'
    rails/activerecord/lib/active_record/associations/association.rb:53:in `reload'
    rails/activerecord/lib/active_record/associations/singular_association.rb:15:in `reader'
    rails/activerecord/lib/active_record/associations/builder/association.rb:111:in `man'
    rails/activemodel/lib/active_model/errors.rb:483:in `generate_message'
    rails/activemodel/lib/active_model/errors.rb:500:in `normalize_message'
    rails/activemodel/lib/active_model/errors.rb:331:in `add'
    rails/activemodel/lib/active_model/validations/presence.rb:7:in `validate_each'
    rails/activerecord/lib/active_record/validations/presence.rb:15:in `block in validate'
    rails/activerecord/lib/active_record/validations/presence.rb:5:in `each'
    rails/activerecord/lib/active_record/validations/presence.rb:5:in `validate'
    rails/activesupport/lib/active_support/callbacks.rb:405:in `public_send'
    rails/activesupport/lib/active_support/callbacks.rb:405:in `block in make_lambda'
    rails/activesupport/lib/active_support/callbacks.rb:169:in `call'
    rails/activesupport/lib/active_support/callbacks.rb:169:in `block (2 levels) in halting'
    rails/activesupport/lib/active_support/callbacks.rb:547:in `call'
    rails/activesupport/lib/active_support/callbacks.rb:547:in `block (2 levels) in default_terminator'
    rails/activesupport/lib/active_support/callbacks.rb:546:in `catch'
    rails/activesupport/lib/active_support/callbacks.rb:546:in `block in default_terminator'
    rails/activesupport/lib/active_support/callbacks.rb:170:in `call'
    rails/activesupport/lib/active_support/callbacks.rb:170:in `block in halting'
    rails/activesupport/lib/active_support/callbacks.rb:454:in `call'
    rails/activesupport/lib/active_support/callbacks.rb:454:in `block in call'
    rails/activesupport/lib/active_support/callbacks.rb:454:in `each'
    rails/activesupport/lib/active_support/callbacks.rb:454:in `call'
    rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
    rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_validate_callbacks'
    rails/activemodel/lib/active_model/validations.rb:408:in `run_validations!'
    rails/activemodel/lib/active_model/validations/callbacks.rb:113:in `block in run_validations!'
    rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
    rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_validation_callbacks'
    rails/activemodel/lib/active_model/validations/callbacks.rb:113:in `run_validations!'
    rails/activemodel/lib/active_model/validations.rb:338:in `valid?'
    rails/activerecord/lib/active_record/validations.rb:65:in `valid?'
    test/cases/validations/association_validation_test.rb:97:in `block in test_validates_presence_of_belongs_to_association__out_of_range_error'
    rails/activerecord/test/cases/validations_repair_helper.rb:14:in `repair_validations'
    test/cases/validations/association_validation_test.rb:90:in `test_validates_presence_of_belongs_to_association__out_of_range_error'
```

Probably similar issues https://github.com/rails/rails/issues/20140, https://github.com/rails/rails/issues/21309.
