### PR TITLE
`FlashHash` returns deleted value

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -178,7 +178,6 @@ module ActionDispatch
         key = key.to_s
         @discard.delete key
         @flashes.delete key
-        self
       end
 
       def to_hash

--- a/actionpack/test/controller/flash_hash_test.rb
+++ b/actionpack/test/controller/flash_hash_test.rb
@@ -40,10 +40,11 @@ module ActionDispatch
 
     def test_delete
       @hash['foo'] = 'bar'
-      @hash.delete 'foo'
+      delete = @hash.delete 'foo'
 
       assert !@hash.key?('foo')
       assert_nil @hash['foo']
+      assert_equal 'bar', delete
     end
 
     def test_to_hash


### PR DESCRIPTION
If `FlashHash` is attempting to provide a `Hash`-like interface to
users, then it should also return the deleted value, when the `delete`
method is called.

Fixes #24738.
