### PR TITLE
Ensure action_controller.cache_store is set up before configuring the collection_cache

### DIFF
--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -37,7 +37,7 @@ module ActionView
       end
     end
 
-    initializer "action_view.collection_caching" do |app|
+    initializer "action_view.collection_caching", after: "action_controller.set_configs" do |app|
       ActiveSupport.on_load(:action_controller) do
         PartialRenderer.collection_cache = app.config.action_controller.cache_store
       end


### PR DESCRIPTION
If `action_controller` is required before the initializers have been run, the `ActionView::PartialRenderer.collection_cache` is set to null.

This ensures that `action_view.collection_caching` initializer is run after the `action_controller.set_configs` so that the `action_controller.cache_store` is always configured.
