### PR TITLE
Improve fixture load order

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -650,6 +650,8 @@ module ActiveRecord
       # track any join tables we need to insert later
       rows = Hash.new { |h, table| h[table] = [] }
 
+      # Insert the table_name hash key before any join table keys
+      rows[table_name] = []
       rows[table_name] = fixtures.map do |label, fixture|
         row = fixture.to_hash
 


### PR DESCRIPTION
Currently, HABTM and has_many :through join table fixtures are loaded before the fixtures for the parent table. This is because in the `table_rows` method, the `add_join_records` method is called inside the `map` block that adds the parent table fixtures to the `rows` hash. By initializing the parent table's key to an empty array, we can ensure that the parent table will be loaded first. The set of fixtures loaded will never be affected by this change, only the order in which they are loaded.

The reason this change is desirable for my project is that I am storing the foreign keys for a HABTM relation in an array on one of the models, and using an updatable view in place of an actual join table. This is to allow a unique constraint on that array, which is necessary because of an (admittedly peculiar) business logic constraint. The updatable view strategy works in general, but currently fails for fixtures (since the array doesn't yet exist to be updated).

Another case where users may benefit from this change would be cases where referential integrity cannot be disabled. This isn't enough to fix that issue in general, but may fix some instances of it.

My use case is admittedly really niche, but I'm hoping that this patch is acceptable anyway because it has such a small area of effect.
