### PR TITLE
Push action_view.collection_caching to be called towards the end

### DIFF
--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -37,10 +37,6 @@ module ActionView
       end
     end
 
-    initializer "action_view.collection_caching", after: "action_controller.set_configs" do |app|
-      PartialRenderer.collection_cache = app.config.action_controller.cache_store
-    end
-
     initializer "action_view.per_request_digest_cache" do |app|
       ActiveSupport.on_load(:action_view) do
         if app.config.consider_all_requests_local
@@ -53,6 +49,10 @@ module ActionView
       ActiveSupport.on_load(:action_controller) do
         ActionView::RoutingUrlFor.include(ActionDispatch::Routing::UrlFor)
       end
+    end
+
+    initializer "action_view.collection_caching", after: "action_controller.set_configs" do |app|
+      PartialRenderer.collection_cache = app.config.action_controller.cache_store
     end
 
     rake_tasks do |app|


### PR DESCRIPTION
Push action_view.collection_caching to be called towards the end, since it depends on being called after action_controller.set_configs.

This causes, other AV initializers after it to be called after all of AC initializers, which get pulled in before since action_controller.set_configs gets called.
Hence, push initializer depending on after hook, to be called after all initializers for this railtie are done.
