### PR TITLE
Allow `AssetUrlHelper#asset_url` to be used in mailers

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow `AssetUrlHelper#asset_url` to be used in mailers. As of now, mailer
+    templates need to provide a complete path to their assets including the protocol.
+
+    Instead forcing `asset_url` to use the protocol as `:request`,
+    it tries to use the `config.default_asset_host_protocol` and
+    for last it sets as `:relative`.
+
+    *akshetpandey*, *Roque Pinel*
+
 ## Rails 5.0.0.beta4 (April 27, 2016) ##
 
 *   `date_select` helper `:with_css_classes` option now accepts a hash of strings 

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -168,7 +168,12 @@ module ActionView
       #   asset_url "application.js", host: "http://cdn.example.com" # => http://cdn.example.com/assets/application.js
       #
       def asset_url(source, options = {})
-        path_to_asset(source, options.merge(:protocol => :request))
+        protocol = if respond_to?(:request)
+          :request
+        else
+          (defined?(config.default_asset_host_protocol) && config.default_asset_host_protocol) || :relative
+        end
+        path_to_asset(source, options.merge(protocol: protocol))
       end
       alias_method :url_to_asset, :asset_url # aliased to avoid conflicts with an asset_url named route
 

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -783,6 +783,10 @@ class AssetUrlHelperEmptyModuleTest < ActionView::TestCase
     assert_equal "/foo", @module.asset_url("foo")
   end
 
+  def test_asset_url_with_host
+    assert_equal '//example.com/foo', @module.asset_url('foo', host: 'example.com')
+  end
+
   def test_asset_url_with_request
     @module.instance_eval do
       def request
@@ -813,6 +817,17 @@ class AssetUrlHelperEmptyModuleTest < ActionView::TestCase
     end
 
     assert @module.config.asset_host
-    assert_equal "http://custom.example.com/foo", @module.asset_url("foo", :host => "http://custom.example.com")
+    assert_equal "http://custom.example.com/foo", @module.asset_url("foo", host: "http://custom.example.com")
+  end
+
+  def test_asset_url_with_default_asset_protocol
+    @module.instance_eval do
+      def config
+        Struct.new(:default_asset_host_protocol).new('gopher')
+      end
+    end
+
+    assert @module.config.default_asset_host_protocol
+    assert_equal 'gopher://example.com/foo', @module.asset_url('foo', host: 'example.com')
   end
 end


### PR DESCRIPTION
As of now, mailer templates need to provide a complete path to their assets including the protocol.

Instead forcing `asset_url` to use the protocol as `:request`, it tries to use the `config.default_asset_host_protocol` and for last it sets as `:relative`.

Closes #19390
