### PR TITLE
convert_to_reader_name method refactoring for ActiveModel::Validations::AcceptanceValidator::AttributeDefinition

### DIFF
--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -64,11 +64,7 @@ module ActiveModel
         private
 
         def convert_to_reader_name(method_name)
-          attr_name = method_name.to_s
-          if attr_name.end_with?("=")
-            attr_name = attr_name[0..-2]
-          end
-          attr_name
+          method_name.to_s.chomp('=')
         end
       end
     end


### PR DESCRIPTION
``` ruby
def convert_to_reader_name(method_name)
  attr_name = method_name.to_s
  if attr_name.end_with?("=")
    attr_name = attr_name[0..-2]
  end
  attr_name
end

def convert_to_reader_name2(method_name)
  method_name.to_s.chomp('=')
end
```

```
Calculating -------------------------------------
convert_to_reader_name         79.413k i/100ms
convert_to_reader_name2       95.023k i/100ms
-------------------------------------------------
convert_to_reader_name     (± 4.9%) i/s -     12.627M
convert_to_reader_name2   (± 4.4%) i/s -     16.629M

Comparison:
convert_to_reader_name2:  3317028.9 i/s
convert_to_reader_name:    2516448.3 i/s - 1.32x slower
```
