### PR TITLE
Refactoring for using chomp

### DIFF
--- a/activejob/test/support/integration/test_case_helpers.rb
+++ b/activejob/test/support/integration/test_case_helpers.rb
@@ -28,7 +28,9 @@ module TestCaseHelpers
     end
 
     def adapter_is?(*adapter_class_symbols)
-      adapter_class_symbols.map(&:to_s).include?(ActiveJob::Base.queue_adapter.class.name.split("::").last.gsub(/Adapter$/, '').underscore)
+      adapter_class_symbols
+        .map(&:to_s)
+        .include?(ActiveJob::Base.queue_adapter.class.name.split("::").last.chomp('Adapter').underscore)
     end
 
     def wait_for_jobs_to_finish_for(seconds=60)

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -100,7 +100,7 @@ module ActiveModel
     #   PresenceValidator.kind   # => :presence
     #   UniquenessValidator.kind # => :uniqueness
     def self.kind
-      @kind ||= name.split('::').last.underscore.sub(/_validator$/, '').to_sym unless anonymous?
+      @kind ||= name.split('::').last.underscore.chomp('_validator').to_sym unless anonymous?
     end
 
     # Accepts options that will be made available through the +options+ reader.


### PR DESCRIPTION
1) gsub => chomp

``` ruby
str = 'some_test'
Benchmark.ips do |x|
  x.report("chomp") { str.chomp('_test') }
  x.report("gsub") { str.gsub(/_test$/, '') }
  x.compare!
end
```

```
Calculating -------------------------------------
               chomp   106.067k i/100ms
                gsub    37.549k i/100ms
-------------------------------------------------
               chomp      4.779M (± 1.7%) i/s -     23.971M
                gsub    641.222k (± 1.7%) i/s -      3.229M

Comparison:
               chomp:  4779133.3 i/s
                gsub:   641221.8 i/s - 7.45x slower

```

2) sub => chomp

``` ruby
str = 'some_test'
Benchmark.ips do |x|
  x.report("chomp") { str.chomp('_test') }
  x.report("sub") { str.sub(/_test$/, '') }
  x.compare!
end
```

```
Calculating -------------------------------------
               chomp   142.856k i/100ms
                 sub    63.737k i/100ms
-------------------------------------------------
               chomp      5.273M (± 1.6%) i/s -     26.428M
                 sub      1.680M (± 1.3%) i/s -      8.413M

Comparison:
               chomp:  5273308.8 i/s
                 sub:  1680494.3 i/s - 3.14x slower
```
