### PR TITLE
Fix getting binds from relation with default_scope and join

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -384,7 +384,7 @@ module ActiveRecord
 
         def binds_from_relation(relation, binds)
           if relation.is_a?(Relation) && binds.empty?
-            relation, binds = relation.arel, relation.bind_values
+            relation, binds = relation.arel, relation.bind_values + relation.arel.bind_values
           end
           [relation, binds]
         end

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -225,13 +225,13 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_joins_with_default_scopes
-    company = CompanyWithZeroId.create!(id: 0)
-    DeveloperWithZeroId.create!(id: 0, firm: company)
+    company = CompanyWithIdMillion.create!(id: 1_000_000)
+    DeveloperWithIdMillion.create!(id: 1_000_000, firm: company)
 
-    scope = DeveloperWithZeroId.joins(:firm)
+    scope = DeveloperWithIdMillion.joins(:firm)
     assert scope.exists?
 
-    result = DeveloperWithZeroId.connection.select_all(scope)
+    result = DeveloperWithIdMillion.connection.select_all(scope)
     assert result.present?
   end
 

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -4,6 +4,7 @@ require 'models/comment'
 require 'models/developer'
 require 'models/computer'
 require 'models/vehicle'
+require 'models/company'
 
 class DefaultScopingTest < ActiveRecord::TestCase
   fixtures :developers, :posts, :comments
@@ -221,6 +222,17 @@ class DefaultScopingTest < ActiveRecord::TestCase
     expected = Developer.all.collect { |dev| dev.name }
     received = Developer.joins('JOIN developers_projects ON id = developer_id').select(:id).unscope(:joins, :select).collect { |dev| dev.name }
     assert_equal expected, received
+  end
+
+  def test_joins_with_default_scopes
+    company = CompanyWithZeroId.create!(id: 0)
+    DeveloperWithZeroId.create!(id: 0, firm: company)
+
+    scope = DeveloperWithZeroId.joins(:firm)
+    assert scope.exists?
+
+    result = DeveloperWithZeroId.connection.select_all(scope)
+    assert result.present?
   end
 
   def test_unscope_includes

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -100,9 +100,9 @@ class Firm < Company
     end
 end
 
-class CompanyWithZeroId < ActiveRecord::Base
+class CompanyWithIdMillion < ActiveRecord::Base
   self.table_name = 'companies'
-  default_scope { where(id: 0) }
+  default_scope { where(id: 1_000_000) }
 end
 
 class DependentFirm < Company

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -100,6 +100,11 @@ class Firm < Company
     end
 end
 
+class CompanyWithZeroId < ActiveRecord::Base
+  self.table_name = 'companies'
+  default_scope { where(id: 0) }
+end
+
 class DependentFirm < Company
   has_one :account, :foreign_key => "firm_id", :dependent => :nullify
   has_many :companies, :foreign_key => 'client_of', :dependent => :nullify

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -125,10 +125,10 @@ class DeveloperCalledDavid < ActiveRecord::Base
   default_scope { where("name = 'David'") }
 end
 
-class DeveloperWithZeroId < ActiveRecord::Base
+class DeveloperWithIdMillion < ActiveRecord::Base
   self.table_name = 'developers'
-  default_scope { where(id: 0) }
-  belongs_to :firm, class_name: 'CompanyWithZeroId'
+  default_scope { where(id: 1_000_000) }
+  belongs_to :firm, class_name: 'CompanyWithIdMillion'
 end
 
 class LazyLambdaDeveloperCalledDavid < ActiveRecord::Base

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -125,6 +125,12 @@ class DeveloperCalledDavid < ActiveRecord::Base
   default_scope { where("name = 'David'") }
 end
 
+class DeveloperWithZeroId < ActiveRecord::Base
+  self.table_name = 'developers'
+  default_scope { where(id: 0) }
+  belongs_to :firm, class_name: 'CompanyWithZeroId'
+end
+
 class LazyLambdaDeveloperCalledDavid < ActiveRecord::Base
   self.table_name = 'developers'
   default_scope lambda { where(:name => 'David') }


### PR DESCRIPTION
### Summary

Hi, when I use `select_all` for a model with `default_scope` and join another model with another `default_scope` `ActiveRecord` misses a bind for this join.

For example:

``` ruby

class CompanyWithZeroId < ActiveRecord::Base
  self.table_name = 'companies'
  default_scope { where(id: 0) }
end

class DeveloperWithZeroId < ActiveRecord::Base
  self.table_name = 'developers'
  default_scope { where(id: 0) }

  belongs_to :company, class_name: 'CompanyWithZeroId'
end

DeveloperWithZeroId.connection.select_all(DeveloperWithZeroId.joins(:company))
# => SELECT "developers".* FROM "developers" INNER JOIN "companies" ON "companies"."id" = "developers"."firm_id" AND "companies"."id" = ? WHERE "developers"."id" = ?  [["id", 0]]
```

As you can see it has only one bind `'id = 0'` instead of two. 

I can't reproduce it in the `master` branch, only in the `4-2-stable`. 
Probably because it was already fixed [here](https://github.com/rails/rails/commit/16ce2eecd3eb23034555bb37b29c12985243d908) by @sgrif.
