### PR TITLE
PostgreSQL: Fix db:structure:load silent failure on SQL error

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,2 +1,16 @@
 
+*   PostgreSQL: Fix db:structure:load silent failure on SQL error
+
+    The command line flag "-v ON_ERROR_STOP=1" should be used
+    when invoking psql to make sure errors are not suppressed.
+
+    Example:
+
+        psql -v ON_ERROR_STOP=1 -q -f awesome-file.sql my-app-db
+
+    Fixes #23818.
+
+    *Ralin Chimev*
+
+
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -2,6 +2,7 @@ module ActiveRecord
   module Tasks # :nodoc:
     class PostgreSQLDatabaseTasks # :nodoc:
       DEFAULT_ENCODING = ENV['CHARSET'] || 'utf8'
+      ON_ERROR_STOP_1 = 'ON_ERROR_STOP=1'.freeze
 
       delegate :connection, :establish_connection, :clear_active_connections!,
         to: ActiveRecord::Base
@@ -67,7 +68,7 @@ module ActiveRecord
 
       def structure_load(filename)
         set_psql_env
-        args = [ '-q', '-f', filename, configuration['database'] ]
+        args = [ '-v', ON_ERROR_STOP_1, '-q', '-f', filename, configuration['database'] ]
         run_cmd('psql', args, 'loading' )
       end
 

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -288,14 +288,14 @@ module ActiveRecord
 
     def test_structure_load
       filename = "awesome-file.sql"
-      Kernel.expects(:system).with('psql', '-q', '-f', filename, @configuration['database']).returns(true)
+      Kernel.expects(:system).with('psql', '-v', 'ON_ERROR_STOP=1', '-q', '-f', filename, @configuration['database']).returns(true)
 
       ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
     end
 
     def test_structure_load_accepts_path_with_spaces
       filename = "awesome file.sql"
-      Kernel.expects(:system).with('psql', '-q', '-f', filename, @configuration['database']).returns(true)
+      Kernel.expects(:system).with('psql', '-v', 'ON_ERROR_STOP=1', '-q', '-f', filename, @configuration['database']).returns(true)
 
       ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
     end


### PR DESCRIPTION
PostgreSQL: Fix db:structure:load silent failure on SQL error

The command line flag "-v ON_ERROR_STOP=1" should be used when invoking psql to make sure errors are not suppressed.

Example: `psql -v ON_ERROR_STOP=1 -q -f awesome-file.sql my-app-db`

Fixes #23818.
