### PR TITLE
Active Job: Add note about ability to configure adapters on per job basis in CHANGELOG and release notes

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -80,6 +80,23 @@
 
     *Jeroen van Baarsen*
 
+*   Add ability to configure the queue adapter on a per job basis.
+
+    Now different jobs can have different queue adapters without conflicting with
+    each other.
+
+    Example:
+
+        class EmailJob < ActiveJob::Base
+          self.queue_adapter = :sidekiq
+        end
+
+        class ImageProcessingJob < ActiveJob::Base
+          self.queue_adapter = :delayed_job
+        end
+
+    *tamird*
+
 *   Add an `:only` option to `perform_enqueued_jobs` to filter jobs based on
     type.
 

--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -655,10 +655,14 @@ Please refer to the [Changelog][active-job] for detailed changes.
 
 ### Notable changes
 
-*   `ActiveJob::Base.deserialize` delegates to the job class. this allows jobs
+*   `ActiveJob::Base.deserialize` delegates to the job class. This allows jobs
     to attach arbitrary metadata when they get serialized and read it back when
     they get performed.
     ([Pull Request](https://github.com/rails/rails/pull/18260))
+
+*   Add ability to configure the queue adapter on a per job basis without
+    affecting each other.
+    ([Pull Request](https://github.com/rails/rails/pull/16992))
 
 *   A generated job now inherits from `app/jobs/application_job.rb` by default.
     ([Pull Request](https://github.com/rails/rails/pull/19034))


### PR DESCRIPTION
r? @jeremy 
