### PR TITLE
Remove last uses of `@env[]` and `@env[]=`

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -164,7 +164,7 @@ module ActionDispatch
       end
 
       def format_from_path_extension
-        path = @env['action_dispatch.original_path'] || @env['PATH_INFO']
+        path = get_header('action_dispatch.original_path') || get_header('PATH_INFO')
         if match = path && path.match(/\.(\w+)\z/)
           Mime[match.captures.first]
         end

--- a/actionpack/lib/action_dispatch/testing/test_request.rb
+++ b/actionpack/lib/action_dispatch/testing/test_request.rb
@@ -22,23 +22,23 @@ module ActionDispatch
     private_class_method :default_env
 
     def request_method=(method)
-      @env['REQUEST_METHOD'] = method.to_s.upcase
+      set_header('REQUEST_METHOD', method.to_s.upcase)
     end
 
     def host=(host)
-      @env['HTTP_HOST'] = host
+      set_header('HTTP_HOST', host)
     end
 
     def port=(number)
-      @env['SERVER_PORT'] = number.to_i
+      set_header('SERVER_PORT', number.to_i)
     end
 
     def request_uri=(uri)
-      @env['REQUEST_URI'] = uri
+      set_header('REQUEST_URI', uri)
     end
 
     def path=(path)
-      @env['PATH_INFO'] = path
+      set_header('PATH_INFO', path)
     end
 
     def action=(action_name)
@@ -46,24 +46,24 @@ module ActionDispatch
     end
 
     def if_modified_since=(last_modified)
-      @env['HTTP_IF_MODIFIED_SINCE'] = last_modified
+      set_header('HTTP_IF_MODIFIED_SINCE', last_modified)
     end
 
     def if_none_match=(etag)
-      @env['HTTP_IF_NONE_MATCH'] = etag
+      set_header('HTTP_IF_NONE_MATCH', etag)
     end
 
     def remote_addr=(addr)
-      @env['REMOTE_ADDR'] = addr
+      set_header('REMOTE_ADDR', addr)
     end
 
     def user_agent=(user_agent)
-      @env['HTTP_USER_AGENT'] = user_agent
+      set_header('HTTP_USER_AGENT', user_agent)
     end
 
     def accept=(mime_types)
-      @env.delete('action_dispatch.request.accepts')
-      @env['HTTP_ACCEPT'] = Array(mime_types).collect(&:to_s).join(",")
+      delete_header('action_dispatch.request.accepts')
+      set_header('HTTP_ACCEPT', Array(mime_types).collect(&:to_s).join(","))
     end
   end
 end

--- a/actionpack/test/dispatch/test_request_test.rb
+++ b/actionpack/test/dispatch/test_request_test.rb
@@ -88,6 +88,33 @@ class TestRequestTest < ActiveSupport::TestCase
     assert_equal 'GoogleBot', req.user_agent
   end
 
+  test "setter methods" do
+    req = ActionDispatch::TestRequest.create({})
+    get = 'GET'
+
+    [
+      'request_method=', 'host=', 'request_uri=', 'path=', 'if_modified_since=', 'if_none_match=',
+      'remote_addr=', 'user_agent=', 'accept='
+    ].each do |method|
+      req.send(method, get)
+    end
+
+    req.port = 8080
+    req.accept = 'hello goodbye'
+
+    assert_equal(get, req.get_header('REQUEST_METHOD'))
+    assert_equal(get, req.get_header('HTTP_HOST'))
+    assert_equal(8080, req.get_header('SERVER_PORT'))
+    assert_equal(get, req.get_header('REQUEST_URI'))
+    assert_equal(get, req.get_header('PATH_INFO'))
+    assert_equal(get, req.get_header('HTTP_IF_MODIFIED_SINCE'))
+    assert_equal(get, req.get_header('HTTP_IF_NONE_MATCH'))
+    assert_equal(get, req.get_header('REMOTE_ADDR'))
+    assert_equal(get, req.get_header('HTTP_USER_AGENT'))
+    assert_nil(req.get_header('action_dispatch.request.accepts'))
+    assert_equal('hello goodbye', req.get_header('HTTP_ACCEPT'))
+  end
+
   private
     def assert_cookies(expected, cookie_jar)
       assert_equal(expected, cookie_jar.instance_variable_get("@cookies"))


### PR DESCRIPTION
Last August (2015), @tenderlove worked to remove all `@env[]` and `@env[]=`, in
favor of using `set_header`, `get_header`, etc. (Here's an [example
commit](https://github.com/rails/rails/commit/f16a33b68efc3dc57cfafa27651b9a765e363fbf)).

This PR should remove the last uses of these methods, and fully convert
them to the newly standardized API.
