### PR TITLE
Patch 1

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -1115,8 +1115,8 @@ assets.
 ### Serving GZipped version of assets
 
 By default, gzipped version of compiled assets will be generated, along 
-with the non-gzipped version of assets. Gzipped assets help reduce, the transmission of 
-date over the wire. You can configure this by setting the `gzip` flag.
+with the non-gzipped version of assets. Gzipped assets help reduce the transmission of 
+data over the wire. You can configure this by setting the `gzip` flag.
 
 ```ruby
 config.assets.gzip = false # disable gzipped assets generation

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -163,7 +163,7 @@ pipeline is enabled. It is set to true by default.
 
 * `config.assets.js_compressor` defines the JavaScript compressor to use. Possible values are `:closure`, `:uglifier` and `:yui` which require the use of the `closure-compiler`, `uglifier` or `yui-compressor` gems respectively.
 
-* `config.assets.gzip` a flag that enables the creation of gziped version of compiled assets, along with non-gziped assets. Set to `true` by default.  
+* `config.assets.gzip` a flag that enables the creation of gzipped version of compiled assets, along with non-gzipped assets. Set to `true` by default.  
 
 * `config.assets.paths` contains the paths which are used to look for assets. Appending paths to this configuration option will cause those paths to be used in the search for assets.
 


### PR DESCRIPTION
### Summary

Fix some typos from #24786."gzipped" was used in `asset_pipeline.md`, so I figured it made sense to use it in `configuring.md` as well.

cc: @vipulnsward @schneems 
