### PR TITLE
Replace `Rails.version.to_f` with Active Record

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -528,7 +528,7 @@ module ActiveRecord
     end
 
     def self.current_version
-      Rails.version.to_f
+      ActiveRecord::VERSION::STRING.to_f
     end
 
     MigrationFilenameRegexp = /\A([0-9]+)_([_a-z0-9]*)\.?([_a-z0-9]*)?\.rb\z/ # :nodoc:

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -69,6 +69,10 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Migration.verbose = @verbose_was
   end
 
+  def test_migration_version_matches_component_version
+    assert_equal ActiveRecord::VERSION::STRING.to_f, ActiveRecord::Migration.current_version
+  end
+
   def test_migrator_versions
     migrations_path = MIGRATIONS_ROOT + "/valid"
     old_path = ActiveRecord::Migrator.migrations_paths


### PR DESCRIPTION
Rails should not be explicity mentioned within Active Record, since
railties and the Rails ecosystem is not required for use.
