### PR TITLE
Move already extracted helper modules/classes over to their own support files

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -1,5 +1,6 @@
 require "cases/helper"
 require 'support/connection_helper'
+require 'support/sql_subscriber'
 
 class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   include ConnectionHelper

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -1,4 +1,5 @@
 require "cases/helper"
+require 'support/in_time_zone'
 require 'support/schema_dumping_helper'
 
 class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -1,5 +1,6 @@
 require "cases/helper"
 require 'support/connection_helper'
+require 'support/sql_subscriber'
 
 module ActiveRecord
   class PostgresqlConnectionTest < ActiveRecord::PostgreSQLTestCase

--- a/activerecord/test/cases/adapters/postgresql/infinity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/infinity_test.rb
@@ -1,4 +1,5 @@
 require "cases/helper"
+require 'support/in_time_zone'
 
 class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
   include InTimeZone

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -1,5 +1,6 @@
 require "cases/helper"
 require 'support/connection_helper'
+require 'support/in_time_zone'
 
 if ActiveRecord::Base.connection.respond_to?(:supports_ranges?) && ActiveRecord::Base.connection.supports_ranges?
   class PostgresqlRange < ActiveRecord::Base

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -2,6 +2,7 @@ require "cases/helper"
 require 'models/owner'
 require 'tempfile'
 require 'support/ddl_helper'
+require 'support/sql_subscriber'
 
 module ActiveRecord
   module ConnectionAdapters

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1,4 +1,5 @@
 require "cases/helper"
+require 'support/in_time_zone'
 require 'models/minimalistic'
 require 'models/developer'
 require 'models/auto_id'

--- a/activerecord/test/cases/date_time_test.rb
+++ b/activerecord/test/cases/date_time_test.rb
@@ -1,4 +1,5 @@
 require "cases/helper"
+require 'support/in_time_zone'
 require 'models/topic'
 require 'models/task'
 

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -1,4 +1,5 @@
 require 'cases/helper'
+require 'support/in_time_zone'
 require 'models/topic'    # For booleans
 require 'models/pirate'   # For timestamps
 require 'models/parrot'

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -168,37 +168,4 @@ end
 
 load_schema
 
-class SQLSubscriber
-  attr_reader :logged
-  attr_reader :payloads
-
-  def initialize
-    @logged = []
-    @payloads = []
-  end
-
-  def start(name, id, payload)
-    @payloads << payload
-    @logged << [payload[:sql].squish, payload[:name], payload[:binds]]
-  end
-
-  def finish(name, id, payload); end
-end
-
-module InTimeZone
-  private
-
-  def in_time_zone(zone)
-    old_zone  = Time.zone
-    old_tz    = ActiveRecord::Base.time_zone_aware_attributes
-
-    Time.zone = zone ? ActiveSupport::TimeZone[zone] : nil
-    ActiveRecord::Base.time_zone_aware_attributes = !zone.nil?
-    yield
-  ensure
-    Time.zone = old_zone
-    ActiveRecord::Base.time_zone_aware_attributes = old_tz
-  end
-end
-
 require 'mocha/setup' # FIXME: stop using mocha

--- a/activerecord/test/support/in_time_zone.rb
+++ b/activerecord/test/support/in_time_zone.rb
@@ -1,0 +1,15 @@
+module InTimeZone
+  private
+
+  def in_time_zone(zone)
+    old_zone = Time.zone
+    old_tz = ActiveRecord::Base.time_zone_aware_attributes
+
+    Time.zone = zone ? ActiveSupport::TimeZone[zone] : nil
+    ActiveRecord::Base.time_zone_aware_attributes = !zone.nil?
+    yield
+  ensure
+    Time.zone = old_zone
+    ActiveRecord::Base.time_zone_aware_attributes = old_tz
+  end
+end

--- a/activerecord/test/support/sql_subscriber.rb
+++ b/activerecord/test/support/sql_subscriber.rb
@@ -1,0 +1,18 @@
+class SQLSubscriber
+  attr_reader :logged
+  attr_reader :payloads
+
+  def initialize
+    @logged = []
+    @payloads = []
+  end
+
+  def start(name, id, payload)
+    @payloads << payload
+    @logged << [payload[:sql].squish, payload[:name], payload[:binds]]
+  end
+
+  def finish(name, id, payload)
+    ;
+  end
+end


### PR DESCRIPTION
Move already extracted helper modules/classes over to their own support files files, instead of polluting helper namespace
