### PR TITLE
Support precision compensated sum for Float value

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -21,8 +21,21 @@ module Enumerable
     if block_given?
       map(&block).sum(identity)
     else
-      sum = identity ? inject(identity, :+) : inject(:+)
-      sum || identity || 0
+      sum = identity
+      c = 0.0
+      each do |e|
+        if sum.nil?
+          sum = e
+        elsif sum.kind_of?(Float) || e.kind_of?(Float)
+          y = e - c
+          t = sum + y
+          c = (t - sum) - y
+          sum = t
+        else
+          sum += e
+        end
+      end
+      sum || 0
     end
   end
 

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -79,6 +79,34 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_typed_equal(16, sum, Integer)
   end
 
+  def test_precision_compensated_sums
+    large_number = 100_000_000
+    small_number = 1e-9
+    until (large_number + small_number) == large_number
+      small_number /= 10
+    end
+
+    ary = [large_number, *[small_number]*10]
+    assert_typed_equal large_number+(small_number*10), ary.sum, Float
+    enum = GenericEnumerable.new(ary)
+    assert_typed_equal large_number+(small_number*10), enum.sum, Float
+
+    ary = [large_number, *[small_number]*10]
+    assert_equal large_number+(small_number*10), ary.sum, Float
+    enum = GenericEnumerable.new(ary)
+    assert_equal large_number+(small_number*10), enum.sum, Float
+
+    ary = [large_number/1r, *[small_number]*10]
+    assert_equal large_number+(small_number*10), ary.sum, Float
+    enum = GenericEnumerable.new(ary)
+    assert_equal large_number+(small_number*10), enum.sum, Float
+
+    ary = [small_number, large_number/1r, *[small_number]*10]
+    assert_equal large_number+(small_number*11), ary.sum, Float
+    enum = GenericEnumerable.new(ary)
+    assert_equal large_number+(small_number*11), enum.sum, Float
+  end
+
   def test_nil_sums
     expected_raise = TypeError
 


### PR DESCRIPTION
In addition to #24795, I also want to fix sum to support precision compensation for Float values.
Because the current implementation, simple inject(:+) call, is inconsistent with the core implementation of Array#sum:

```
$ ruby -ve 'p [100000000, *[1e-9]*10].sum'
ruby 2.4.0dev (2016-04-30 trunk 54853) [x86_64-darwin15]
100000000.00000001
$ ruby -v -I lib -r active_support/core_ext/enumerable -e 'p [100000000, *[1e-9]*10].sum'
ruby 2.4.0dev (2016-04-30 trunk 54853) [x86_64-darwin15]
100000000.0
```
