### PR TITLE
Add `:nodoc:` to `schema_creation` [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -20,7 +20,7 @@ module ActiveRecord
         MySQL::Table.new(table_name, base)
       end
 
-      def schema_creation
+      def schema_creation # :nodoc:
         MySQL::SchemaCreation.new(self)
       end
 


### PR DESCRIPTION
`schema_creation` is not public API.

https://github.com/rails/rails/blob/v5.0.0.beta4/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L121
https://github.com/rails/rails/blob/v5.0.0.beta4/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L78
