### PR TITLE
[ci skip] Fix ActionCable README

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -385,7 +385,7 @@ Rails.application.config.action_cable.log_tags = [
 
 For a full list of all configuration options, see the `ActionCable::Server::Configuration` class.
 
-Also note that your server must provide at least the same number of database connections as you have workers. The default worker pool is set to 100, so that means you have to make at least that available. You can change that in `config/database.yml` through the `pool` attribute.
+Also note that your server must provide at least the same number of database connections as you have workers. The default worker pool is set to 4, so that means you have to make at least that available. You can change that in `config/database.yml` through the `pool` attribute.
 
 
 ## Running the cable server


### PR DESCRIPTION
### Summary

Fix ActionCable readme.
Default worker pool size was changed from 100 to 4 at #24376 
