### PR TITLE
Fix STI based inference, when passing type as a class

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -205,7 +205,7 @@ module ActiveRecord
         if attrs.is_a?(Hash)
           subclass_name = attrs.with_indifferent_access[inheritance_column]
 
-          if subclass_name.present?
+          if subclass_name.to_s.present?
             find_sti_class(subclass_name)
           end
         end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1349,7 +1349,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_attribute_names
-    assert_equal ["id", "type", "firm_id", "firm_name", "name", "client_of", "rating", "account_id", "description"],
+    assert_equal ["id", "type", "firm_id", "firm_name", "name", "client_of", "rating", "account_id", "description", "features"],
                  Company.attribute_names
   end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -571,7 +571,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_pluck_without_column_names
-    assert_equal [[1, "Firm", 1, nil, "37signals", nil, 1, nil, ""]],
+    assert_equal [[1, "Firm", 1, nil, "37signals", nil, 1, nil, "", nil]],
       Company.order(:id).limit(1).pluck
   end
 

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -315,6 +315,13 @@ class InheritanceTest < ActiveRecord::TestCase
     end
   end
 
+  def test_new_when_passing_class_to_type_when_store_attributes_are_present_on_sti_class
+    without_store_full_sti_class do
+      item = Company.new(type: Firm)
+      assert_instance_of Firm, item
+    end
+  end
+
   def test_new_with_autoload_paths
     path = File.expand_path('../../models/autoloadable', __FILE__)
     ActiveSupport::Dependencies.autoload_paths << path

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -44,6 +44,7 @@ end
 
 class Firm < Company
   to_param :name
+  store :features, accessors: [:exceptional_company]
 
   has_many :clients, -> { order "id" }, :dependent => :destroy, :before_remove => :log_before_remove, :after_remove  => :log_after_remove
   has_many :unsorted_clients, :class_name => "Client"

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -196,6 +196,7 @@ ActiveRecord::Schema.define do
     t.integer :rating, default: 1
     t.integer :account_id
     t.string :description, default: ""
+    t.text :features
     t.index [:firm_id, :type, :rating], name: "company_index"
     t.index [:firm_id, :type], name: "company_partial_index", where: "rating > 10"
     t.index :name, name: 'company_name_index', using: :btree


### PR DESCRIPTION
When trying to check if we have a class name value present or not on sti inference,
first convert to a string, so that we don't accidentally call Relation#empty? which leads to undesired
behaviour for store attributes.

Fixes #24808
