### PR TITLE
Don't list out tasks as separately that are under lib, which cause them to be listed twice under Libraries and tasks.

### DIFF
--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -10,7 +10,6 @@ STATS_DIRECTORIES = [
   %w(Channels           app/channels),
   %w(Javascripts        app/assets/javascripts),
   %w(Libraries          lib/),
-  %w(Tasks              lib/tasks),
   %w(APIs               app/apis),
   %w(Controller\ tests  test/controllers),
   %w(Helper\ tests      test/helpers),


### PR DESCRIPTION
Don't list out tasks as separately that are under lib, which cause them to be listed twice under Libraries and tasks.
We already count and list it under libraries.

Fixes #24811

r? @arthurnn 
