### PR TITLE
Ensure compatibility between ActionDispatch::Request::Session and Rack

### DIFF
--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -9,7 +9,7 @@ module ActionDispatch
 
       # Singleton object used to determine if an optional param wasn't specified
       Unspecified = Object.new
-      
+
       # Creates a session hash, merging the properties of the previous session if any
       def self.create(store, req, default_options)
         session_was = find req
@@ -196,6 +196,10 @@ module ActionDispatch
       def merge!(other)
         load_for_write!
         @delegate.merge!(other)
+      end
+
+      def each(&block)
+        to_hash.each(&block)
       end
 
       private

--- a/actionpack/test/dispatch/request/session_test.rb
+++ b/actionpack/test/dispatch/request/session_test.rb
@@ -114,5 +114,31 @@ module ActionDispatch
         }.new
       end
     end
+
+    class SessionIntegrationTest < ActionDispatch::IntegrationTest
+      class MySessionApp
+        def call(env)
+          request = Rack::Request.new(env)
+          request.session['hello'] = 'Hello from MySessionApp!'
+          [ 200, {}, ['Hello from MySessionApp!'] ]
+        end
+      end
+
+      Router = ActionDispatch::Routing::RouteSet.new
+      Router.draw do
+        get '/mysessionapp' => MySessionApp.new
+      end
+
+      def app
+        @app ||= RoutedRackApp.new(Router)
+      end
+
+      def test_session_follows_rack_api_contract_1
+        get '/mysessionapp'
+        assert_response :ok
+        assert_equal 'Hello from MySessionApp!', @response.body
+        assert_equal 'Hello from MySessionApp!', session['hello']
+      end
+    end
   end
 end


### PR DESCRIPTION
Adding the `each` method is required for ensuring compability between
Rails, and other Rack frameworks (like Sinatra, etc.), that are mounted
within Rails, and wish to use its session tooling. Prior to this, there
was an inconsistency between ActionDispatch::Request::Session and
Rack::Session::Cookie, due to the absence of the `each` method. This
should hopefully fix that error. :)

For a full integration test with Sinatra and a standalone Rack
application, you can check out the gist for that here: https://gist.github.com/maclover7/08cd95b0bfe259465314311941326470.

Solves #15843.
