### PR TITLE
Helper path extraction should be case-insensitive (5.0)

### DIFF
--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -99,7 +99,7 @@ module ActionController
       #   # => ["application", "chart", "rubygems"]
       def all_helpers_from_path(path)
         helpers = Array(path).flat_map do |_path|
-          extract = /^#{Regexp.quote(_path.to_s)}\/?(.*)_helper.rb$/
+          extract = /^#{Regexp.quote(_path.to_s)}\/?(.*)_helper.rb$/i
           names = Dir["#{_path}/**/*_helper.rb"].map { |file| file.sub(extract, '\1'.freeze) }
           names.sort!
         end

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -191,6 +191,17 @@ class HelperTest < ActiveSupport::TestCase
     assert master_helper_methods.include?(:baz)
   end
 
+  def test_all_helpers_with_helper_dir_with_mixed_case
+    @controller_class.helpers_path = File.expand_path('../../FiXtUrEs', __FILE__)
+
+    # Reload helpers
+    @controller_class._helpers = Module.new
+    @controller_class.helper :all
+
+    # helpers/abc_helper.rb should be included
+    assert master_helper_methods.include?(:bare_a)
+  end
+
   def test_helper_proxy
     methods = AllHelpersController.helpers.methods
 


### PR DESCRIPTION
Fix for #18660 for rails 5 (based on master branch, assuming that's the right place for rails 5 fixes).

I went ahead and made pr's for previous versions... not sure how you guys handle backporting fixes, if extra pr's is noise they can just be closed. However, backporting this fix is important either way.
- 4.2 https://github.com/rails/rails/pull/24822
- 4.1 https://github.com/rails/rails/pull/24823
- 4.0 https://github.com/rails/rails/pull/24824
