### PR TITLE
Change RangeError to a more specific ActiveModel::RangeError

### DIFF
--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -49,6 +49,7 @@ module ActiveModel
 
   eager_autoload do
     autoload :Errors
+    autoload :RangeError, 'active_model/errors'
     autoload :StrictValidationFailed, 'active_model/errors'
     autoload :UnknownAttributeError, 'active_model/errors'
   end

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -526,6 +526,10 @@ module ActiveModel
   class StrictValidationFailed < StandardError
   end
 
+  # Raised when attribute values are out of range.
+  class RangeError < ::RangeError
+  end
+
   # Raised when unknown attributes are supplied via mass assignment.
   class UnknownAttributeError < NoMethodError
     attr_reader :record, :attribute

--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -46,7 +46,7 @@ module ActiveModel
 
       def ensure_in_range(value)
         unless range.cover?(value)
-          raise RangeError, "#{value} is out of range for #{self.class} with limit #{_limit}"
+          raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit}"
         end
       end
 

--- a/activemodel/test/cases/type/integer_test.rb
+++ b/activemodel/test/cases/type/integer_test.rb
@@ -53,25 +53,25 @@ module ActiveModel
       end
 
       test "values below int min value are out of range" do
-        assert_raises(::RangeError) do
+        assert_raises(ActiveModel::RangeError) do
           Integer.new.serialize(-2147483649)
         end
       end
 
       test "values above int max value are out of range" do
-        assert_raises(::RangeError) do
+        assert_raises(ActiveModel::RangeError) do
           Integer.new.serialize(2147483648)
         end
       end
 
       test "very small numbers are out of range" do
-        assert_raises(::RangeError) do
+        assert_raises(ActiveModel::RangeError) do
           Integer.new.serialize(-9999999999999999999999999999999)
         end
       end
 
       test "very large numbers are out of range" do
-        assert_raises(::RangeError) do
+        assert_raises(ActiveModel::RangeError) do
           Integer.new.serialize(9999999999999999999999999999999)
         end
       end
@@ -96,10 +96,10 @@ module ActiveModel
 
         assert_equal(9223372036854775807, type.serialize(9223372036854775807))
         assert_equal(-9223372036854775808, type.serialize(-9223372036854775808))
-        assert_raises(::RangeError) do
+        assert_raises(ActiveModel::RangeError) do
           type.serialize(-9999999999999999999999999999999)
         end
-        assert_raises(::RangeError) do
+        assert_raises(ActiveModel::RangeError) do
           type.serialize(9999999999999999999999999999999)
         end
       end


### PR DESCRIPTION
#### Summary

When provided with large numbers, ActiveModel fails with a generic
`RangeError`. While it is technically true, the fact that this is a generic,
non specific error make it really hard to implement application wide
`rescue_from` to handle bad requests.

With this PR, ActiveModel would now throw a specific `ActiveModel::RangeError`,
which inherits from `RangeError` to maintain compatibility.
