### PR TITLE
update regexp which cleaned root path

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -387,10 +387,10 @@ module ActionDispatch
 
       # Invokes Journey::Router::Utils.normalize_path and ensure that
       # (:locale) becomes (/:locale) instead of /(:locale). Except
-      # for root cases, where the latter is the correct one.
+      # for root cases including nesting up to second level.
       def self.normalize_path(path)
         path = Journey::Router::Utils.normalize_path(path)
-        path.gsub!(%r{/(\(+)/?}, '\1/') unless path =~ %r{^/\(+[^)]+\)$}
+        path.gsub!(%r{/(\(+)/?}, '\1/') unless path =~ %r{^/(\(+[^)]+\)){1,2}$}
         path
       end
 

--- a/actionpack/test/journey/router/utils_test.rb
+++ b/actionpack/test/journey/router/utils_test.rb
@@ -42,6 +42,22 @@ module ActionDispatch
         def test_normalize_path_with_nil
           assert_equal "/", Utils.normalize_path(nil)
         end
+
+        def test_normalize_path_root
+          assert_equal "/root", Utils.normalize_path("root")
+        end
+
+        def test_normalize_path_route_one_level_deep
+          assert_equal "/(:foo)", Utils.normalize_path("/(:foo)")
+        end
+
+        def test_normalize_path_route_two_levels_deep_with_second_slash
+          assert_equal "/(/:locale)(/:platform)", Utils.normalize_path("/(/:locale)(/:platform)")
+        end
+
+        def test_normalize_path_route_two_levels_deep
+          assert_equal "/(/:locale)(:platform)", Utils.normalize_path("/(/:locale)(:platform)")
+        end
       end
     end
   end


### PR DESCRIPTION
Closes #12805.
Slash was removed in case of nested scope due to mismatching unless statement. 
