### PR TITLE
Fix Railties test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,9 @@ addons:
   postgresql: "9.4"
 
 bundler_args: --without test --jobs 3 --retry 3
-#FIXME: Remove bundler uninstall on Travis when https://github.com/bundler/bundler/issues/4493 is fixed.
+
 before_install:
-  - rvm @global do gem uninstall bundler --all --ignore-dependencies --executables
-  - rvm @global do gem install bundler -v '1.11.2'
-  - bundle --version
+  - gem install bundler
   - "rm ${BUNDLE_GEMFILE}.lock"
   - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
   - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
-
+gem 'pry'
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem 'rake', '>= 11.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
     bunny (2.2.2)
       amq-protocol (>= 2.0.1)
     byebug (8.2.1)
+    coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -181,6 +182,10 @@ GEM
     pg (0.18.4)
     pg (0.18.4-x64-mingw32)
     pg (0.18.4-x86-mingw32)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     psych (2.0.17)
     puma (2.16.0)
     que (0.11.2)
@@ -233,6 +238,7 @@ GEM
     sigdump (0.2.3)
     sinatra (1.0)
       rack (>= 1.0)
+    slop (3.6.0)
     sneakers (2.3.5)
       bunny (~> 2.2.0)
       serverengine (~> 1.5.11)
@@ -300,6 +306,7 @@ DEPENDENCIES
   mysql2 (>= 0.4.4)
   nokogiri (>= 1.6.7.1)
   pg (>= 0.18.0)
+  pry
   psych (~> 2.0)
   puma
   qu-rails!
@@ -329,4 +336,4 @@ DEPENDENCIES
   wdm (>= 0.1.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.1

--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -254,6 +254,7 @@ module ActionDispatch
     HTTP_METHODS = [:get, :head, :post, :patch, :put, :delete, :options] #:nodoc:
 
     #:stopdoc:
+    require 'active_support/core_ext/string/filters'
     INSECURE_URL_PARAMETERS_MESSAGE = <<-MSG.squish
       Attempting to generate a URL from non-sanitized request parameters!
 

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -121,6 +121,9 @@ module Rails
         else
           namespace, configuration = args.shift, args.shift
           namespace = namespace.to_sym if namespace.respond_to?(:to_sym)
+          if method == :orm
+            require 'pry'; binding.pry
+          end
           @options[:rails][method] = namespace
         end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -191,8 +191,6 @@ module ApplicationTests
         config.root = '#{new_app}'
       RUBY
 
-      use_frameworks []
-
       app 'development'
 
       assert_equal Pathname.new(new_app), Rails.application.root
@@ -200,8 +198,6 @@ module ApplicationTests
 
     test "the application root is Dir.pwd if there is no config.ru" do
       File.delete("#{app_path}/config.ru")
-
-      use_frameworks []
 
       Dir.chdir("#{app_path}") do
         app 'development'
@@ -253,8 +249,6 @@ module ApplicationTests
         config.eager_load = true
         config.cache_classes = true
       RUBY
-
-      use_frameworks []
 
       assert_nothing_raised do
         app 'development'

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -108,7 +108,7 @@ module ApplicationTests
     end
 
     test "removing Active Record omits its middleware" do
-      use_frameworks []
+      remove_frameworks [:activerecord]
       boot!
       assert !middleware.include?("ActiveRecord::Migration::CheckPending")
     end
@@ -179,7 +179,6 @@ module ApplicationTests
     end
 
     test "use middleware" do
-      use_frameworks []
       add_to_config "config.middleware.use Rack::Config"
       boot!
       assert_equal "Rack::Config", middleware.last

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -300,15 +300,13 @@ module TestHelpers
       app_file("app/controllers/#{name}_controller.rb", contents)
     end
 
-    def use_frameworks(arr)
-      to_remove = [:actionmailer, :activerecord] - arr
-
-      if to_remove.include?(:activerecord)
+    def remove_frameworks(arr)
+      if arr.include?(:activerecord)
         remove_from_config "active_record/railtie"
         remove_from_config 'config.active_record.*'
       end
 
-      $:.reject! {|path| path =~ %r'/(#{to_remove.join('|')})/' }
+      $:.reject! {|path| path =~ %r'/(#{arr.join('|')})/' }
     end
 
     def boot_rails

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -965,7 +965,6 @@ YAML
       RUBY
 
       boot_rails
-
       app_generators = Rails.application.config.generators.options[:rails]
       assert_equal :mongoid  , app_generators[:orm]
       assert_equal :liquid   , app_generators[:template_engine]
@@ -987,7 +986,7 @@ YAML
       RUBY
 
       boot_rails
-
+# require 'pry'; binding.pry
       generators = Bukkits::Engine.config.generators.options[:rails]
       assert_equal :active_record, generators[:orm]
       assert_equal :rspec        , generators[:test_framework]


### PR DESCRIPTION
This test was failing due to Bundler v1.12.0 being released, which
exposed a flaw in how the following test from
`railties/test/application/initializers/frameworks_test.rb` was being
run:

``` ruby
test "database middleware doesn't initialize when activerecord is not in frameworks" do
  use_frameworks []
  require "#{app_path}/config/environment"
  assert_nil defined?(ActiveRecord::Base)
end
```

Despite that the test assumed that Active Record was not loaded, it was.
I am honestly not sure how this test was passing before, but the release
of the previously mentioned version of Bundler broke this test
(rightfully so). Now, frameworks which should not be included (as this
test assumes) will not be loaded into the Rails application, and the
test will pass correctly.

This is a partial revert of #24839.
