### PR TITLE
Remove unnecessary `message` shadow method

### DIFF
--- a/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
+++ b/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
@@ -24,7 +24,7 @@ module ActionMailer
     end
 
     def transform! #:nodoc:
-      return message if html_part.blank?
+      return @message if html_part.blank?
 
       html_source.gsub!(PATTERN) do |match|
         if part = find_part(match[9..-2])
@@ -34,16 +34,13 @@ module ActionMailer
         end
       end
 
-      message
+      @message
     end
 
     private
-      def message
-        @message
-      end
 
       def html_part
-        @html_part ||= message.html_part
+        @html_part ||= @message.html_part
       end
 
       def html_source
@@ -55,7 +52,7 @@ module ActionMailer
       end
 
       def find_part(cid)
-        message.all_parts.find{ |p| p.attachment? && p.cid == cid }
+        @message.all_parts.find{ |p| p.attachment? && p.cid == cid }
       end
   end
 end


### PR DESCRIPTION
It doesn't make sense to want to overwrite the `message` (you are passing it in via the constructor...?).
