### PR TITLE
Refactor connection handler

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -905,17 +905,7 @@ module ActiveRecord
       # take place, but that's ok since the nil case is not the common one that we wish
       # to optimise for.
       def retrieve_connection_pool(spec_id)
-        pool_for(spec_id)
-      end
-
-      private
-
-      def owner_to_pool
-        @owner_to_pool[Process.pid]
-      end
-
-      def pool_for(spec_id)
-        owner_to_pool.fetch(spec_id) {
+        owner_to_pool.fetch(spec_id) do
           if ancestor_pool = pool_from_any_process_for(spec_id)
             # A connection was established in an ancestor process that must have
             # subsequently forked. We can't reuse the connection, but we can copy
@@ -926,7 +916,13 @@ module ActiveRecord
           else
             owner_to_pool[spec_id] = nil
           end
-        }
+        end
+      end
+
+      private
+
+      def owner_to_pool
+        @owner_to_pool[Process.pid]
       end
 
       def pool_from_any_process_for(spec_id)

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -778,8 +778,7 @@ module ActiveRecord
     end
 
     # ConnectionHandler is a collection of ConnectionPool objects. It is used
-    # for keeping separate connection pools for Active Record models that connect
-    # to different databases.
+    # for keeping separate connection pools that connect to different databases.
     #
     # For example, suppose that you have 5 models, with the following hierarchy:
     #
@@ -821,6 +820,10 @@ module ActiveRecord
     # ConnectionHandler accessible via ActiveRecord::Base.connection_handler.
     # All Active Record models use this handler to determine the connection pool that they
     # should use.
+    #
+    # The ConnectionHandler class is not coupled with the Active models, as it has no knowlodge
+    # about the model. The model, needs to pass a specification name to the handler,
+    # in order to lookup the correct connection pool.
     class ConnectionHandler
       def initialize
         # These caches are keyed by klass.name, NOT klass. Keying them by klass

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -164,7 +164,7 @@ module ActiveRecord
         #   spec.config
         #   # => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" }
         #
-        def spec(config, id = "primary")
+        def spec(config, id = nil)
           spec = resolve(config).symbolize_keys
 
           raise(AdapterNotSpecified, "database configuration does not specify adapter") unless spec.key?(:adapter)
@@ -179,6 +179,13 @@ module ActiveRecord
           end
 
           adapter_method = "#{spec[:adapter]}_connection"
+
+          id ||=
+            if config.is_a?(Symbol)
+              config.to_s
+            else
+              "primary"
+            end
           ConnectionSpecification.new(id, spec, adapter_method)
         end
 

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       attr_reader :config, :adapter_method, :id
 
       def initialize(id, config, adapter_method)
-        @config, @adapter_method, @id = config, adapter_method, id
+        @id, @config, @adapter_method = id, config, adapter_method
       end
 
       def initialize_dup(original)

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -3,10 +3,10 @@ require 'uri'
 module ActiveRecord
   module ConnectionAdapters
     class ConnectionSpecification #:nodoc:
-      attr_reader :config, :adapter_method, :id
+      attr_reader :name, :config, :adapter_method
 
-      def initialize(id, config, adapter_method)
-        @id, @config, @adapter_method = id, config, adapter_method
+      def initialize(name, config, adapter_method)
+        @name, @config, @adapter_method = name, config, adapter_method
       end
 
       def initialize_dup(original)
@@ -164,7 +164,7 @@ module ActiveRecord
         #   spec.config
         #   # => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" }
         #
-        def spec(config, id = nil)
+        def spec(config, name = nil)
           spec = resolve(config).symbolize_keys
 
           raise(AdapterNotSpecified, "database configuration does not specify adapter") unless spec.key?(:adapter)
@@ -180,13 +180,13 @@ module ActiveRecord
 
           adapter_method = "#{spec[:adapter]}_connection"
 
-          id ||=
+          name ||=
             if config.is_a?(Symbol)
               config.to_s
             else
               "primary"
             end
-          ConnectionSpecification.new(id, spec, adapter_method)
+          ConnectionSpecification.new(name, spec, adapter_method)
         end
 
         private

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -3,10 +3,10 @@ require 'uri'
 module ActiveRecord
   module ConnectionAdapters
     class ConnectionSpecification #:nodoc:
-      attr_reader :config, :adapter_method
+      attr_reader :config, :adapter_method, :id
 
-      def initialize(config, adapter_method)
-        @config, @adapter_method = config, adapter_method
+      def initialize(id, config, adapter_method)
+        @config, @adapter_method, @id = config, adapter_method, id
       end
 
       def initialize_dup(original)
@@ -164,7 +164,7 @@ module ActiveRecord
         #   spec.config
         #   # => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" }
         #
-        def spec(config)
+        def spec(config, id = "primary")
           spec = resolve(config).symbolize_keys
 
           raise(AdapterNotSpecified, "database configuration does not specify adapter") unless spec.key?(:adapter)
@@ -179,7 +179,7 @@ module ActiveRecord
           end
 
           adapter_method = "#{spec[:adapter]}_connection"
-          ConnectionSpecification.new(spec, adapter_method)
+          ConnectionSpecification.new(id, spec, adapter_method)
         end
 
         private

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -91,9 +91,7 @@ module ActiveRecord
       retrieve_connection
     end
 
-    def specification_id=(value)
-      @specification_id = value
-    end
+    attr_writer :specification_id
 
     # Return the specification id from this class otherwise look it up
     # in the parent.

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -51,7 +51,7 @@ module ActiveRecord
       resolver =   ConnectionAdapters::ConnectionSpecification::Resolver.new configurations
       # TODO: uses name on establish_connection, for backwards compatibility
       spec     =   resolver.spec(spec, self == Base ? "primary" : name)
-      self.specification_name = spec.name
+      self.connection_specification_name = spec.name
 
       unless respond_to?(spec.adapter_method)
         raise AdapterNotFound, "database configuration specifies nonexistent #{spec.config[:adapter]} adapter"
@@ -91,15 +91,15 @@ module ActiveRecord
       retrieve_connection
     end
 
-    attr_writer :specification_name
+    attr_writer :connection_specification_name
 
     # Return the specification id from this class otherwise look it up
     # in the parent.
-    def specification_name
-      unless defined?(@specification_name)
-        @specification_name = self == Base ? "primary" : superclass.specification_name
+    def connection_specification_name
+      unless defined?(@connection_specification_name)
+        @connection_specification_name = self == Base ? "primary" : superclass.connection_specification_name
       end
-      @specification_name
+      @connection_specification_name
     end
 
     def connection_id
@@ -121,19 +121,19 @@ module ActiveRecord
     end
 
     def connection_pool
-      connection_handler.retrieve_connection_pool(specification_name) or raise ConnectionNotEstablished
+      connection_handler.retrieve_connection_pool(connection_specification_name) or raise ConnectionNotEstablished
     end
 
     def retrieve_connection
-      connection_handler.retrieve_connection(specification_name)
+      connection_handler.retrieve_connection(connection_specification_name)
     end
 
     # Returns +true+ if Active Record is connected.
     def connected?
-      connection_handler.connected?(specification_name)
+      connection_handler.connected?(connection_specification_name)
     end
 
-    def remove_connection(name = specification_name)
+    def remove_connection(name = connection_specification_name)
       connection_handler.remove_connection(name)
     end
 

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -96,15 +96,15 @@ module ActiveRecord
 
     def specification_id(fallback = true)
       return @specification_id if defined?(@specification_id)
-      find_legacy_spec_id(self) if fallback
+      find_parent_spec_id(self) if fallback
     end
 
-    def find_legacy_spec_id(klass)
+    def find_parent_spec_id(klass)
       return "primary" if klass == Base
       if id = klass.specification_id(false)
         return id
       end
-      find_legacy_spec_id(klass.superclass)
+      find_parent_spec_id(klass.superclass)
     end
 
     def connection_id

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -51,7 +51,7 @@ module ActiveRecord
       resolver =   ConnectionAdapters::ConnectionSpecification::Resolver.new configurations
       # TODO: uses name on establish_connection, for backwards compatibility
       spec     =   resolver.spec(spec, self == Base ? "primary" : name)
-      self.specification_id = spec.id
+      self.specification_name = spec.name
 
       unless respond_to?(spec.adapter_method)
         raise AdapterNotFound, "database configuration specifies nonexistent #{spec.config[:adapter]} adapter"
@@ -91,15 +91,15 @@ module ActiveRecord
       retrieve_connection
     end
 
-    attr_writer :specification_id
+    attr_writer :specification_name
 
     # Return the specification id from this class otherwise look it up
     # in the parent.
-    def specification_id
-      unless defined?(@specification_id)
-        @specification_id = self == Base ? "primary" : superclass.specification_id
+    def specification_name
+      unless defined?(@specification_name)
+        @specification_name = self == Base ? "primary" : superclass.specification_name
       end
-      @specification_id
+      @specification_name
     end
 
     def connection_id
@@ -121,20 +121,20 @@ module ActiveRecord
     end
 
     def connection_pool
-      connection_handler.retrieve_connection_pool(specification_id) or raise ConnectionNotEstablished
+      connection_handler.retrieve_connection_pool(specification_name) or raise ConnectionNotEstablished
     end
 
     def retrieve_connection
-      connection_handler.retrieve_connection(specification_id)
+      connection_handler.retrieve_connection(specification_name)
     end
 
     # Returns +true+ if Active Record is connected.
     def connected?
-      connection_handler.connected?(specification_id)
+      connection_handler.connected?(specification_name)
     end
 
-    def remove_connection(id = specification_id)
-      connection_handler.remove_connection(id)
+    def remove_connection(name = specification_name)
+      connection_handler.remove_connection(name)
     end
 
     def clear_cache! # :nodoc:

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -257,7 +257,7 @@ module ActiveRecord
       # Returns the Arel engine.
       def arel_engine # :nodoc:
         @arel_engine ||=
-          if Base == self || connection_handler.retrieve_connection_pool(self)
+          if Base == self || connection_handler.retrieve_connection_pool(specification_id)
             self
           else
             superclass.arel_engine

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -257,7 +257,7 @@ module ActiveRecord
       # Returns the Arel engine.
       def arel_engine # :nodoc:
         @arel_engine ||=
-          if Base == self || connection_handler.retrieve_connection_pool(specification_id)
+          if Base == self || connection_handler.retrieve_connection_pool(specification_name)
             self
           else
             superclass.arel_engine

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -257,7 +257,7 @@ module ActiveRecord
       # Returns the Arel engine.
       def arel_engine # :nodoc:
         @arel_engine ||=
-          if Base == self || connection_handler.retrieve_connection_pool(specification_name)
+          if Base == self || connection_handler.retrieve_connection_pool(connection_specification_name)
             self
           else
             superclass.arel_engine

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -117,7 +117,7 @@ module ActiveRecord
       end
 
       def create_all
-        old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.specification_name)
+        old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
         each_local_configuration { |configuration| create configuration }
         if old_pool
           ActiveRecord::Base.connection_handler.establish_connection(old_pool.spec)

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -117,10 +117,10 @@ module ActiveRecord
       end
 
       def create_all
-        old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base)
+        old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.specification_id)
         each_local_configuration { |configuration| create configuration }
         if old_pool
-          ActiveRecord::Base.connection_handler.establish_connection(ActiveRecord::Base, old_pool.spec)
+          ActiveRecord::Base.connection_handler.establish_connection(old_pool.spec)
         end
       end
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -117,7 +117,7 @@ module ActiveRecord
       end
 
       def create_all
-        old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.specification_id)
+        old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.specification_name)
         each_local_configuration { |configuration| create configuration }
         if old_pool
           ActiveRecord::Base.connection_handler.establish_connection(old_pool.spec)

--- a/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
+++ b/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
@@ -37,7 +37,7 @@ module ActiveRecord
       end
 
       def test_close
-        pool = Pool.new(ConnectionSpecification.new({}, nil))
+        pool = Pool.new(ConnectionSpecification.new("primary", {}, nil))
         pool.insert_connection_for_test! @adapter
         @adapter.pool = pool
 

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -6,11 +6,11 @@ module ActiveRecord
       def setup
         @handler = ConnectionHandler.new
         resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new Base.configurations
-        @spec_id = "primary"
-        @pool    = @handler.establish_connection(resolver.spec(:arunit, @spec_id))
+        @spec_name = "primary"
+        @pool    = @handler.establish_connection(resolver.spec(:arunit, @spec_name))
       end
 
-      def test_establish_connection_uses_spec_id
+      def test_establish_connection_uses_spec_name
         config = {"readonly" => {"adapter" => 'sqlite3'}}
         resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new(config)
         spec =   resolver.spec(:readonly)
@@ -22,19 +22,19 @@ module ActiveRecord
       end
 
       def test_retrieve_connection
-        assert @handler.retrieve_connection(@spec_id)
+        assert @handler.retrieve_connection(@spec_name)
       end
 
       def test_active_connections?
         assert !@handler.active_connections?
-        assert @handler.retrieve_connection(@spec_id)
+        assert @handler.retrieve_connection(@spec_name)
         assert @handler.active_connections?
         @handler.clear_active_connections!
         assert !@handler.active_connections?
       end
 
       def test_retrieve_connection_pool
-        assert_not_nil @handler.retrieve_connection_pool(@spec_id)
+        assert_not_nil @handler.retrieve_connection_pool(@spec_name)
       end
 
       def test_retrieve_connection_pool_with_invalid_id
@@ -77,7 +77,7 @@ module ActiveRecord
 
           pid = fork {
             rd.close
-            pool = @handler.retrieve_connection_pool(@spec_id)
+            pool = @handler.retrieve_connection_pool(@spec_name)
             wr.write Marshal.dump pool.schema_cache.size
             wr.close
             exit!

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -4,49 +4,51 @@ module ActiveRecord
   module ConnectionAdapters
     class ConnectionHandlerTest < ActiveRecord::TestCase
       def setup
-        @klass    = Class.new(Base)   { def self.name; 'klass';    end }
-        @subklass = Class.new(@klass) { def self.name; 'subklass'; end }
-
         @handler = ConnectionHandler.new
-        @pool    = @handler.establish_connection(@klass, Base.connection_pool.spec)
+        resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new Base.configurations
+        spec =   resolver.spec(:arunit)
+
+        @spec_id = "primary"
+        @pool    = @handler.establish_connection(spec)
       end
 
       def test_retrieve_connection
-        assert @handler.retrieve_connection(@klass)
+        assert @handler.retrieve_connection(@spec_id)
       end
 
       def test_active_connections?
         assert !@handler.active_connections?
-        assert @handler.retrieve_connection(@klass)
+        assert @handler.retrieve_connection(@spec_id)
         assert @handler.active_connections?
         @handler.clear_active_connections!
         assert !@handler.active_connections?
       end
 
-      def test_retrieve_connection_pool_with_ar_base
-        assert_nil @handler.retrieve_connection_pool(ActiveRecord::Base)
-      end
+#      def test_retrieve_connection_pool_with_ar_base
+#        assert_nil @handler.retrieve_connection_pool(ActiveRecord::Base)
+#      end
 
       def test_retrieve_connection_pool
-        assert_not_nil @handler.retrieve_connection_pool(@klass)
+        assert_not_nil @handler.retrieve_connection_pool(@spec_id)
       end
 
-      def test_retrieve_connection_pool_uses_superclass_when_no_subclass_connection
-        assert_not_nil @handler.retrieve_connection_pool(@subklass)
-      end
+#      def test_retrieve_connection_pool_uses_superclass_when_no_subclass_connection
+#        assert_not_nil @handler.retrieve_connection_pool(@subklass)
+#      end
 
-      def test_retrieve_connection_pool_uses_superclass_pool_after_subclass_establish_and_remove
-        sub_pool = @handler.establish_connection(@subklass, Base.connection_pool.spec)
-        assert_same sub_pool, @handler.retrieve_connection_pool(@subklass)
-
-        @handler.remove_connection @subklass
-        assert_same @pool, @handler.retrieve_connection_pool(@subklass)
-      end
+#      def test_retrieve_connection_pool_uses_superclass_pool_after_subclass_establish_and_remove
+#        sub_pool = @handler.establish_connection(@subklass, Base.connection_pool.spec)
+#        assert_same sub_pool, @handler.retrieve_connection_pool(@subklass)
+#
+#        @handler.remove_connection @subklass
+#        assert_same @pool, @handler.retrieve_connection_pool(@subklass)
+#      end
 
       def test_connection_pools
         assert_equal([@pool], @handler.connection_pools)
       end
 
+      # TODO
       if Process.respond_to?(:fork)
         def test_connection_pool_per_pid
           object_id = ActiveRecord::Base.connection.object_id
@@ -79,7 +81,7 @@ module ActiveRecord
 
           pid = fork {
             rd.close
-            pool = @handler.retrieve_connection_pool(@klass)
+            pool = @handler.retrieve_connection_pool(@spec_id)
             wr.write Marshal.dump pool.schema_cache.size
             wr.close
             exit!

--- a/activerecord/test/cases/connection_adapters/connection_specification_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_specification_test.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     class ConnectionSpecificationTest < ActiveRecord::TestCase
       def test_dup_deep_copy_config
-        spec = ConnectionSpecification.new({ :a => :b }, "bar")
+        spec = ConnectionSpecification.new("primary", { :a => :b }, "bar")
         assert_not_equal(spec.config.object_id, spec.dup.config.object_id)
       end
     end

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -333,14 +333,13 @@ module ActiveRecord
 
       # make sure exceptions are thrown when establish_connection
       # is called with an anonymous class
-#      def test_anonymous_class_exception
-#        anonymous = Class.new(ActiveRecord::Base)
-#        handler = ActiveRecord::Base.connection_handler
-#
-#        assert_raises(RuntimeError) {
-#          handler.establish_connection anonymous, nil
-#        }
-#      end
+      def test_anonymous_class_exception
+        anonymous = Class.new(ActiveRecord::Base)
+
+        assert_raises(RuntimeError) do
+          anonymous.establish_connection
+        end
+      end
 
       def test_pool_sets_connection_schema_cache
         connection = pool.checkout

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -333,14 +333,14 @@ module ActiveRecord
 
       # make sure exceptions are thrown when establish_connection
       # is called with an anonymous class
-      def test_anonymous_class_exception
-        anonymous = Class.new(ActiveRecord::Base)
-        handler = ActiveRecord::Base.connection_handler
-
-        assert_raises(RuntimeError) {
-          handler.establish_connection anonymous, nil
-        }
-      end
+#      def test_anonymous_class_exception
+#        anonymous = Class.new(ActiveRecord::Base)
+#        handler = ActiveRecord::Base.connection_handler
+#
+#        assert_raises(RuntimeError) {
+#          handler.establish_connection anonymous, nil
+#        }
+#      end
 
       def test_pool_sets_connection_schema_cache
         connection = pool.checkout

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -116,14 +116,14 @@ module ActiveRecord
             "encoding" => "utf8" }, spec)
         end
 
-        def test_spec_id_on_key_lookup
+        def test_spec_name_on_key_lookup
           spec = spec(:readonly, 'readonly' => {'adapter' => 'sqlite3'})
-          assert_equal "readonly", spec.id
+          assert_equal "readonly", spec.name
         end
 
-        def test_spec_id_with_inline_config
+        def test_spec_name_with_inline_config
           spec = spec({'adapter' => 'sqlite3'})
-          assert_equal "primary", spec.id, "should default to primary id"
+          assert_equal "primary", spec.name, "should default to primary id"
         end
       end
     end

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -116,6 +116,15 @@ module ActiveRecord
             "encoding" => "utf8" }, spec)
         end
 
+        def test_spec_id_on_key_lookup
+          spec = spec(:readonly, 'readonly' => {'adapter' => 'sqlite3'})
+          assert_equal "readonly", spec.id
+        end
+
+        def test_spec_id_with_inline_config
+          spec = spec({'adapter' => 'sqlite3'})
+          assert_equal "primary", spec.id, "should default to primary id"
+        end
       end
     end
   end

--- a/activerecord/test/cases/multiple_db_test.rb
+++ b/activerecord/test/cases/multiple_db_test.rb
@@ -89,8 +89,8 @@ class MultipleDbTest < ActiveRecord::TestCase
   end
 
   def test_connection
-    assert_equal Entrant.arel_engine.connection, Bird.arel_engine.connection
-    assert_not_equal Entrant.arel_engine.connection, Course.arel_engine.connection
+    assert_equal Entrant.arel_engine.connection.object_id, Bird.arel_engine.connection.object_id
+    assert_not_equal Entrant.arel_engine.connection.object_id, Course.arel_engine.connection.object_id
   end
 
   unless in_memory_db?

--- a/activerecord/test/cases/multiple_db_test.rb
+++ b/activerecord/test/cases/multiple_db_test.rb
@@ -25,10 +25,10 @@ class MultipleDbTest < ActiveRecord::TestCase
   end
 
   def test_swapping_the_connection
-    old_spec_id, Course.specification_id = Course.specification_id, "primary"
+    old_spec_name, Course.specification_name = Course.specification_name, "primary"
     assert_equal(Entrant.connection, Course.connection)
   ensure
-    Course.specification_id = old_spec_id
+    Course.specification_name = old_spec_name
   end
 
   def test_find

--- a/activerecord/test/cases/multiple_db_test.rb
+++ b/activerecord/test/cases/multiple_db_test.rb
@@ -24,6 +24,13 @@ class MultipleDbTest < ActiveRecord::TestCase
     assert_equal(ActiveRecord::Base.connection, Entrant.connection)
   end
 
+  def test_swapping_the_connection
+    old_spec_id, Course.specification_id = Course.specification_id, "primary"
+    assert_equal(Entrant.connection, Course.connection)
+  ensure
+    Course.specification_id = old_spec_id
+  end
+
   def test_find
     c1 = Course.find(1)
     assert_equal "Ruby Development", c1.name

--- a/activerecord/test/cases/multiple_db_test.rb
+++ b/activerecord/test/cases/multiple_db_test.rb
@@ -25,10 +25,10 @@ class MultipleDbTest < ActiveRecord::TestCase
   end
 
   def test_swapping_the_connection
-    old_spec_name, Course.specification_name = Course.specification_name, "primary"
+    old_spec_name, Course.connection_specification_name = Course.connection_specification_name, "primary"
     assert_equal(Entrant.connection, Course.connection)
   ensure
-    Course.specification_name = old_spec_name
+    Course.connection_specification_name = old_spec_name
   end
 
   def test_find


### PR DESCRIPTION
~~~**NOTICE** This is still in early stages, but I want to create a PR, so we can discuss based on some concrete implementation that have been discussed for a while among the Rails team.~~~
### Summary

ConnectionHandler will not have any knowledge of AR models now, it will
only know about the specs.
Like that we can decouple the two, and allow the same model to use more
than one connection.
### Context

Historically, folks used to create abstract AR classes on the fly in
order to have multiple connections for the same model, and override the
connection methods.

With this, now we can override the `specificiation_id` method in the
model, to return a key, that will be used to find the connection_pool
from the handler.

@jeremy thoughts?
### How can users extend this?

database.yml

```
production:
  database: ...
readonly:
  database: ...
```

```
class User < ApplicationRecord
  self.connection_specification_name = "readonly"
end
```

or

```
class User < ApplicationRecord
  def self.connection_specification_name 
     @in_readonly_mode ? "readonly" : "primary"
  end
end
```

In this example `in_readonly_mode` could be an ivar that is set at runtime to change the connection at runtime.

Pretty much the gist of this is, models can now extend that method, and change the connection it will be used. This is possible because now the connection handler doesnt hash the connections by the class name anymore.
### Is this backwards compatible?

Yes, 
- The default `connection_specification_name` behaviour is to fallback to the parent method, if `connection_specification_name` not defined.
- When doing an establish_connection in a AR model: ie: `User.establish_connection()`, that will set the `connection_specification_name` to the model name.
