### PR TITLE
Add `take_or_create`, `take_or_create!` and `take_or_initialize` methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `take_or_create`, `take_or_create!` and `take_or_initialize` methods 
+    as alternatives for `find_or_{create,create!,initialize}` but without 
+    doing an order by to find the record.
+    
+    *Guilherme Goettems Schneider*
+
 ## Rails 5.0.0.beta4 (April 27, 2016) ##
 
 *   PostgreSQL: Support Expression Indexes and Operator Classes.

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -2,7 +2,8 @@ module ActiveRecord
   module Querying
     delegate :find, :take, :take!, :first, :first!, :last, :last!, :exists?, :any?, :many?, :none?, :one?, to: :all
     delegate :second, :second!, :third, :third!, :fourth, :fourth!, :fifth, :fifth!, :forty_two, :forty_two!, :third_to_last, :third_to_last!, :second_to_last, :second_to_last!, to: :all
-    delegate :first_or_create, :first_or_create!, :first_or_initialize, to: :all
+    delegate :first_or_create, :first_or_create!, :first_or_initialize,
+             :take_or_create, :take_or_create!, :take_or_initialize, to: :all
     delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, to: :all
     delegate :find_by, :find_by!, to: :all
     delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, to: :all

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -172,6 +172,23 @@ module ActiveRecord
       first || new(attributes, &block)
     end
 
+    # Finds a record for current scope, or creates a record with the given
+    # attributes if one is not found. See #create.
+    def take_or_create(attributes = nil, &block)
+      take || create(attributes, &block)
+    end
+
+    # Like #take_or_create but calls #create! so an exception is raised if the
+    # created record is invalid.
+    def take_or_create!(attributes = nil, &block)
+      take || create!(attributes, &block)
+    end
+
+    # Like #take_or_create but calls #new instead of #create.
+    def take_or_initialize(attributes = nil, &block)
+      take || new(attributes, &block)
+    end
+
     # Finds the first record with the given attributes, or creates a record
     # with the attributes if one is not found:
     #

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2130,6 +2130,20 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal [client], firm.reload.clients_of_firm
   end
 
+  test "take_or_initialize adds the record to the association" do
+    firm = Firm.create! name: 'omg'
+    client = firm.clients_of_firm.take_or_initialize
+    assert_equal [client], firm.clients_of_firm
+  end
+
+  test "take_or_create adds the record to the association" do
+    firm = Firm.create! name: 'omg'
+    firm.clients_of_firm.load_target
+    client = firm.clients_of_firm.take_or_create name: 'lol'
+    assert_equal [client], firm.clients_of_firm
+    assert_equal [client], firm.reload.clients_of_firm
+  end
+
   test "delete_all, when not loaded, doesn't load the records" do
     post = posts(:welcome)
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1449,6 +1449,128 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 'parrot', parrot.name
   end
 
+  def test_take_or_create
+    parrot = Bird.where(color: 'green').take_or_create(name: 'parrot')
+    assert_kind_of Bird, parrot
+    assert parrot.persisted?
+    assert_equal 'parrot', parrot.name
+    assert_equal 'green', parrot.color
+
+    same_parrot = Bird.where(color: 'green').take_or_create(name: 'parakeet')
+    assert_kind_of Bird, same_parrot
+    assert same_parrot.persisted?
+    assert_equal parrot, same_parrot
+  end
+
+  def test_take_or_create_with_no_parameters
+    parrot = Bird.where(color: 'green').take_or_create
+    assert_kind_of Bird, parrot
+    assert !parrot.persisted?
+    assert_equal 'green', parrot.color
+  end
+
+  def test_take_or_create_with_block
+    parrot = Bird.where(color: 'green').take_or_create { |bird| bird.name = 'parrot' }
+    assert_kind_of Bird, parrot
+    assert parrot.persisted?
+    assert_equal 'green', parrot.color
+    assert_equal 'parrot', parrot.name
+
+    same_parrot = Bird.where(color: 'green').take_or_create { |bird| bird.name = 'parakeet' }
+    assert_equal parrot, same_parrot
+  end
+
+  def test_take_or_create_with_array
+    several_green_birds = Bird.where(color: 'green').take_or_create([{name: 'parrot'}, {name: 'parakeet'}])
+    assert_kind_of Array, several_green_birds
+    several_green_birds.each { |bird| assert bird.persisted? }
+
+    same_parrot = Bird.where(color: 'green').take_or_create([{name: 'hummingbird'}, {name: 'macaw'}])
+    assert_kind_of Bird, same_parrot
+    assert_includes several_green_birds, same_parrot
+  end
+
+  def test_take_or_create_bang_with_valid_options
+    parrot = Bird.where(color: 'green').take_or_create!(name: 'parrot')
+    assert_kind_of Bird, parrot
+    assert parrot.persisted?
+    assert_equal 'parrot', parrot.name
+    assert_equal 'green', parrot.color
+
+    same_parrot = Bird.where(color: 'green').take_or_create!(name: 'parakeet')
+    assert_kind_of Bird, same_parrot
+    assert same_parrot.persisted?
+    assert_equal parrot, same_parrot
+  end
+
+  def test_take_or_create_bang_with_invalid_options
+    assert_raises(ActiveRecord::RecordInvalid) { Bird.where(color: 'green').take_or_create!(pirate_id: 1) }
+  end
+
+  def test_take_or_create_bang_with_no_parameters
+    assert_raises(ActiveRecord::RecordInvalid) { Bird.where(color: 'green').take_or_create! }
+  end
+
+  def test_take_or_create_bang_with_valid_block
+    parrot = Bird.where(color: 'green').take_or_create! { |bird| bird.name = 'parrot' }
+    assert_kind_of Bird, parrot
+    assert parrot.persisted?
+    assert_equal 'green', parrot.color
+    assert_equal 'parrot', parrot.name
+
+    same_parrot = Bird.where(color: 'green').take_or_create! { |bird| bird.name = 'parakeet' }
+    assert_equal parrot, same_parrot
+  end
+
+  def test_take_or_create_bang_with_invalid_block
+    assert_raise(ActiveRecord::RecordInvalid) do
+      Bird.where(color: 'green').take_or_create! { |bird| bird.pirate_id = 1 }
+    end
+  end
+
+  def test_take_or_create_with_valid_array
+    several_green_birds = Bird.where(color: 'green').take_or_create!([{name: 'parrot'}, {name: 'parakeet'}])
+    assert_kind_of Array, several_green_birds
+    several_green_birds.each { |bird| assert bird.persisted? }
+
+    same_parrot = Bird.where(color: 'green').take_or_create!([{name: 'hummingbird'}, {name: 'macaw'}])
+    assert_kind_of Bird, same_parrot
+    assert_includes several_green_birds, same_parrot
+  end
+
+  def test_take_or_create_with_invalid_array
+    assert_raises(ActiveRecord::RecordInvalid) { Bird.where(color: 'green').take_or_create!([ {name: 'parrot'}, {pirate_id: 1} ]) }
+  end
+
+  def test_take_or_initialize
+    parrot = Bird.where(color: 'green').take_or_initialize(name: 'parrot')
+    assert_kind_of Bird, parrot
+    assert !parrot.persisted?
+    assert parrot.valid?
+    assert parrot.new_record?
+    assert_equal 'parrot', parrot.name
+    assert_equal 'green', parrot.color
+  end
+
+  def test_take_or_initialize_with_no_parameters
+    parrot = Bird.where(color: 'green').take_or_initialize
+    assert_kind_of Bird, parrot
+    assert !parrot.persisted?
+    assert !parrot.valid?
+    assert parrot.new_record?
+    assert_equal 'green', parrot.color
+  end
+
+  def test_take_or_initialize_with_block
+    parrot = Bird.where(color: 'green').take_or_initialize { |bird| bird.name = 'parrot' }
+    assert_kind_of Bird, parrot
+    assert !parrot.persisted?
+    assert parrot.valid?
+    assert parrot.new_record?
+    assert_equal 'green', parrot.color
+    assert_equal 'parrot', parrot.name
+  end
+
   def test_find_or_create_by
     assert_nil Bird.find_by(name: 'bob')
 


### PR DESCRIPTION
They are alternatives for `find_or_{create,create!,initialize}` but without
adding an order clause to find the record.

When methods `first_or_{create,create!,initialize}` where introduced (https://github.com/rails/rails/commit/84dad446c6a23a15f67b9d558e8039891a008bff), the `first` method didn't add an order clause (introduced in https://github.com/rails/rails/commit/07e5301e697d6a02ed3c079aba07c261d53c1846) which may have performance issues.

Since `take` was introduced (restoring old behaviour of `first` that didn't add the order clause), it becomes the standard way of finding a record in database.

See also http://aserafin.pl/2016/02/19/side-effects-of-using-first-or-create-at-scale/ for a motivation for this change.

I think we may even deprecate `first_or_{create,create!,initialize}` in favor of `take_or_{create,create!,initialize}`, since `take` is more idiomatic nowadays and it would be rare that user really wants the first record in this case. It is always possible to add order to the scope before calling take_or methods if needed.
