### PR TITLE
Remove intermediary local variables

### DIFF
--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -330,21 +330,18 @@ module ActionView
     end
 
     def render_partial
-      view, locals, block = @view, @locals, @block
-      object, as = @object, @variable
-
-      if !block && (layout = @options[:layout])
+      if !@block && (layout = @options[:layout])
         layout = find_template(layout.to_s, @template_keys)
       end
 
-      object = locals[as] if object.nil? # Respect object when object is false
-      locals[as] = object if @has_object
+      @object = @locals[@variable] if @object.nil? # Respect object when object is false
+      @locals[@variable] = @object if @has_object
 
-      content = @template.render(view, locals) do |*name|
-        view._layout_for(*name, &block)
+      content = @template.render(@view, @locals) do |*name|
+        @view._layout_for(*name, &@block)
       end
 
-      content = layout.render(view, locals){ content } if layout
+      content = layout.render(@view, @locals){ content } if layout
       content
     end
 

--- a/actionview/lib/action_view/renderer/renderer.rb
+++ b/actionview/lib/action_view/renderer/renderer.rb
@@ -15,7 +15,7 @@ module ActionView
       @lookup_context = lookup_context
     end
 
-    # Main render entry point shared by Action View and Action Controller.
+    # Main render entry point
     def render(context, options)
       if options.key?(:partial)
         render_partial(context, options)

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -47,11 +47,11 @@ module ActionView
     # Renders the given template. A string representing the layout can be
     # supplied as well.
     def render_template(template, layout_name = nil, locals = nil) #:nodoc:
-      view, locals = @view, locals || {}
+      locals = locals || {}
 
       render_with_layout(layout_name, locals) do |layout|
         instrument(:template, :identifier => template.identifier, :layout => layout.try(:virtual_path)) do
-          template.render(view, locals) { |*name| view._layout_for(*name) }
+          template.render(@view, locals) { |*name| @view._layout_for(*name) }
         end
       end
     end
@@ -61,9 +61,8 @@ module ActionView
       content = yield(layout)
 
       if layout
-        view = @view
-        view.view_flow.set(:layout, content)
-        layout.render(view, locals){ |*name| view._layout_for(*name) }
+        @view.view_flow.set(:layout, content)
+        layout.render(@view, locals){ |*name| @view._layout_for(*name) }
       else
         content
       end


### PR DESCRIPTION
In many places in the Action View, short-lived intermediary local
variables are created. This has the effect of adding slightly more
complexity to the code (more variables!), and it is easier to just use
the pre-existing variable.
