### PR TITLE
WIP: Use the main rails server process to fork all other dedicated processes for CoW benefit

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -467,7 +467,13 @@ module Rails
       self
     end
 
-    # Eager load the application by loading all ruby
+    # Invokes all registered forker hooks.
+    # Check <tt>Rails::Railtie.forkers</tt> for more info.
+    def load_forkers(app=self)
+      run_forkers_blocks(app)
+      self
+    end
+
     # files inside eager_load paths.
     def eager_load!
       config.eager_load_paths.each do |load_path|

--- a/railties/lib/rails/forking.rb
+++ b/railties/lib/rails/forking.rb
@@ -1,1 +1,0 @@
-Rails.application.load_forkers

--- a/railties/lib/rails/forking.rb
+++ b/railties/lib/rails/forking.rb
@@ -1,0 +1,1 @@
+Rails.application.load_forkers

--- a/railties/lib/rails/generators/rails/app/templates/config.ru
+++ b/railties/lib/rails/generators/rails/app/templates/config.ru
@@ -1,5 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'
+require 'rails/forking'
 
 run Rails.application

--- a/railties/lib/rails/generators/rails/app/templates/config.ru
+++ b/railties/lib/rails/generators/rails/app/templates/config.ru
@@ -1,6 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'
-require 'rails/forking'
+Rails.application.load_forkers
 
 run Rails.application

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -156,14 +156,25 @@ module Rails
         @generators
       end
 
-      def forkers(label=nil)
+      def forkers(namespace=nil)
         @forkers ||= {}
+        label = forker = nil
+
+        # preload forker object
+        unless namespace.nil?
+          label = namespace.name.underscore
+          forker = @forkers[label] ||= Forker.new(namespace)
+        end
+
+        # return it (or them) immediately if no block is passed
         unless block_given?
           return @forkers if label.nil?
-          return @forkers[label]
+          return forker
+        else
+          raise "must pass a label" unless forker
+          yield forker
         end
-        forker = @forkers[label] ||= Forker.new
-        yield forker
+    
         @forkers
       end
 

--- a/railties/lib/rails/railtie/forker.rb
+++ b/railties/lib/rails/railtie/forker.rb
@@ -1,0 +1,49 @@
+module Rails
+  class Forker
+    autoload :Runner, 'rails/railtie/forker/runner'
+
+
+    def runner=(runner)
+      @runner=runner 
+    end
+
+    def options
+      @options ||= {}
+    end
+
+    def options=(o)
+      options.merge!(o)
+    end
+
+    def before_fork(&blk)
+      @before_forks ||= []
+      @before_forks << blk if blk
+      @before_forks
+    end
+
+    def after_fork(&blk)
+      @after_forks ||= []
+      @after_forks << blk if blk
+      @after_forks
+    end
+
+
+    def fork!(label, app)
+      before_fork.each { |b| b.call(app) }
+      Process.fork do
+        $0 = "rails: #{label}"
+        after_fork.each { |a| a.call(app) }
+        begin
+          run!
+        rescue
+          exit
+        end
+      end
+
+    end
+
+    def run!
+      @runner::Runner.new(options).run!
+    end 
+  end
+end

--- a/railties/lib/rails/railtie/forker.rb
+++ b/railties/lib/rails/railtie/forker.rb
@@ -2,8 +2,12 @@ module Rails
   class Forker
     autoload :Runner, 'rails/railtie/forker/runner'
 
-    def runner=(runner)
-      @runner=runner 
+    attr_writer :runner
+
+    def initialize(namespace)
+      # inferring namespace
+      puts "namespace: #{namespace}"
+      @runner = namespace.const_get(:Runner) if namespace.const_defined?(:Runner)
     end
 
     def options
@@ -42,7 +46,7 @@ module Rails
     end
 
     def run!
-      @runner::Runner.new(options).run!
+      @runner.new(options).run!
     end 
   end
 end

--- a/railties/lib/rails/railtie/forker.rb
+++ b/railties/lib/rails/railtie/forker.rb
@@ -2,7 +2,6 @@ module Rails
   class Forker
     autoload :Runner, 'rails/railtie/forker/runner'
 
-
     def runner=(runner)
       @runner=runner 
     end

--- a/railties/lib/rails/railtie/forker/runner.rb
+++ b/railties/lib/rails/railtie/forker/runner.rb
@@ -1,0 +1,14 @@
+# This class is supposed to be abstract, and all
+# runners should make their runner inherit from here
+class Rails::Forker::Runner
+
+  attr_reader :options  
+
+  def initialize(opts={})
+    @options = opts
+  end
+
+  def run!
+    raise NotImplementedError, "your runner must implement #run!"
+  end
+end


### PR DESCRIPTION
### Summary

This came from [here](https://github.com/rails/rails/issues/24736). Most applications comprise of single-purpose processes which do-one-thing-well. This has been the main selling point of foreman/Procfile. I think that most rails apps suffer from a RAM boot-time penalty, which is multiplied by the number of processes started from the Procfile, and in cloud deployments like heroku, RAM is a big cost factor. 

My proposal is: make rails main process act as the parent to all process types. Rails is clearly the designated web-process, and most application servers either make it act as standalone process (puma, thin, webrick) or as a master process which forks workers (unicorn, puma cluster, passenger). I'd say, use it also to "fork" the parent background job process (resque, sidekiq, delayed job), the scheduler process (resque-scheduler, rufus, clockwork), basically everything ruby. 

To test my already functioning proof of concept, fork this branch, create a new dev app, add the following: 

``` ruby
# config/application.rb

# don't forget to add "resque" to the Gemfile
# this will be the gem maintainers task to provide proper runners in the future
module Resque
  # The worker doesn't receive any options, all is coming from env vars
  class Runner < Rails::Forker::Runner
    def run!
      worker = Resque::Worker.new('*')
      worker.log "Starting worker #{self}"
      worker.work(5) # interval, will block
    end
  end
end

...
module ForkerApp
  class Application < Rails::Application
    ...
    forkers(Resque)

end
```

I've tested this in an initial app with `rails server` command building with puma, with `puma`executable, both in standalone as in cluster mode (works only with `--preload`, as the fork hooks are set in config.ru), and these were the results with smem after boot:

```
# cluster mode
  PID User     Command                         Swap      USS      PSS      RSS
19401 vagrant  resque-1.26.0: Waiting for         0     5.4M    36.2M    68.8M
19340 vagrant  puma 3.4.0 (tcp://0.0.0.0:3        0     8.2M    40.0M    75.2M    
```
### Other Information

Obviously you can see by the diff that there were no unit tests written (yet), I've concentrated on the minimal stuff to make a PoC work-and-running, and discuss the viability of such a feature for rails. Hopefully afterwards one could discuss some open issues for me:
- railtie API
- Abstract Runner, and gems-should-implement-runner vs. active-job-like-adapters
- Things rails must do by default before and after fork (open threads, reopen file-descriptors)
- "labelize/colorize" logs a-la foreman (maybe foreman-rails extension?)
- how to best configure the options/number of processes
- windows/non-fork environment support

@jeremy for the interest expressed in the issue, @schneems for the interest expressed in lowering the mem footprint of the stack. 
