### PR TITLE
do not pass conditions to `#destroy_all` [ci skip]

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -54,8 +54,8 @@ module ActiveRecord
   #
   #   class Firm < ActiveRecord::Base
   #     # Destroys the associated clients and people when the firm is destroyed
-  #     before_destroy { |record| Person.destroy_all "firm_id = #{record.id}"   }
-  #     before_destroy { |record| Client.destroy_all "client_of = #{record.id}" }
+  #     before_destroy { |record| Person.where("firm_id = #{record.id}").destroy_all   }
+  #     before_destroy { |record| Client.where("client_of = #{record.id}").destroy_all }
   #   end
   #
   # == Inheritable callback queues

--- a/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
@@ -42,7 +42,7 @@ module ActiveRecord
       # Delegates #delete_all, #update_all, #destroy_all methods to each batch.
       #
       #   People.in_batches.delete_all
-      #   People.in_batches.destroy_all('age < 10')
+      #   People.where('age < 10').in_batches.destroy_all
       #   People.in_batches.update_all('age = age + 1')
       [:delete_all, :update_all, :destroy_all].each do |method|
         define_method(method) do |*args, &block|


### PR DESCRIPTION
Passing conditions to `#destroy_all` was deprecated in c82c5f8.
