### PR TITLE
Add explicit caller location to deprecation message

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/aliasing.rb
+++ b/activesupport/lib/active_support/core_ext/module/aliasing.rb
@@ -24,7 +24,7 @@ class Module
   #
   # so you can safely chain foo, foo?, foo! and/or foo= with the same feature.
   def alias_method_chain(target, feature)
-    ActiveSupport::Deprecation.warn("alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super.")
+    ActiveSupport::Deprecation.warn("alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super.", caller_locations(1))
 
     # Strip out punctuation on predicates, bang or writer methods since
     # e.g. target?_without_feature is not a valid method name.


### PR DESCRIPTION
### Summary

Fixes #24858. This resolves issues where the caller location for `alias_method_chain` calls were incorrect.

This will resolve issues where the core_ext for aliasing showed up as caller location instead of the actual caller location.
