### PR TITLE
Change to use a more realistic example [ci skip]

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -53,9 +53,9 @@ module ActiveRecord
   #   end
   #
   #   class Firm < ActiveRecord::Base
-  #     # Destroys the associated clients and people when the firm is destroyed
-  #     before_destroy { |record| Person.where(firm_id: record.id).destroy_all   }
-  #     before_destroy { |record| Client.where(client_of: record.id).destroy_all }
+  #     # Disables access to the system, for associated clients and people when the firm is destroyed
+  #     before_destroy { |record| Person.where(firm_id: record.id).update_all(access: 'disabled')   }
+  #     before_destroy { |record| Client.where(client_of: record.id).update_all(access: 'disabled') }
   #   end
   #
   # == Inheritable callback queues


### PR DESCRIPTION
Change to use a more realistic example and not giving the impression that destroy_all is preferred way to destroy related records.
This example just wants to demonstrate callback behaviour.

cc @kaspth 
