### PR TITLE
Disable QueryCache & Pending Migration Checks on ActiveRecord connection failure

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -542,7 +542,7 @@ module ActiveRecord
       end
 
       def call(env)
-        if connection.supports_migrations?
+        if ActiveRecord::Base.connected? && connection.supports_migrations?
           mtime = ActiveRecord::Migrator.last_migration.mtime.to_i
           if @last_check < mtime
             ActiveRecord::Migration.check_pending!(connection)

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -24,27 +24,31 @@ module ActiveRecord
     end
 
     def self.run
-      connection    = ActiveRecord::Base.connection
-      enabled       = connection.query_cache_enabled
-      connection_id = ActiveRecord::Base.connection_id
-      connection.enable_query_cache!
+      if ActiveRecord::Base.connected?
+        connection    = ActiveRecord::Base.connection
+        enabled       = connection.query_cache_enabled
+        connection_id = ActiveRecord::Base.connection_id
+        connection.enable_query_cache!
 
-      [enabled, connection_id]
+        [enabled, connection_id]
+      end
     end
 
     def self.complete(state)
-      enabled, connection_id = state
+      if ActiveRecord::Base.connected?
+        enabled, connection_id = state
 
-      ActiveRecord::Base.connection_id = connection_id
-      ActiveRecord::Base.connection.clear_query_cache
-      ActiveRecord::Base.connection.disable_query_cache! unless enabled
+        ActiveRecord::Base.connection_id = connection_id
+        ActiveRecord::Base.connection.clear_query_cache
+        ActiveRecord::Base.connection.disable_query_cache! unless enabled
+      end
     end
 
     def self.install_executor_hooks(executor = ActiveSupport::Executor)
       executor.register_hook(self)
 
       executor.to_complete do
-        unless ActiveRecord::Base.connection.transaction_open?
+        unless ActiveRecord::Base.connected? && ActiveRecord::Base.connection.transaction_open?
           ActiveRecord::Base.clear_active_connections!
         end
       end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -131,6 +131,7 @@ module ApplicationTests
       app 'development'
 
       ActiveRecord::Migrator.migrations_paths = ["#{app_path}/db/migrate"]
+      ActiveRecord::Base.connection
 
       begin
         get "/foo"


### PR DESCRIPTION
### Summary

Fixes #22154

Currently during request processing, there are naked calls to `ActiveRecord::Base.connection` which will result in an exception being raised if connection to the database is unavailable.  Because of the location of these exceptions it is difficult to handle these exceptions without monkeypatching ActiveRecord.  This PR wraps these calls in a conditional check to `ActiveRecord::Base.connected?` prior to proceeding.  This pattern is already in use for `QueryCache::ClassMethods#cache` and `QueryCache::ClassMethods#uncached`
### Other Information

The test suite passes with these changes although some tests are being skipped when I run in the rails-dev vagrant box (not sure if this is expected).

I am unsure where/how exactly to add tests for this change with respect to how these modules are currently tested, so seeking suggestions on that.

People may be relying on this behavior even though some find it unexpected.  Should this be put behind a configuration flag? Perhaps `config.active_record.allow_nil_connection` or similar?
### Todo
- [ ] Add tests
- [ ] put this behind a config flag?
- [ ] handle `connection.active?` situation mentioned by @williscool in #22154 

Thanks!
