### PR TITLE
Fix failures due to transactions

### DIFF
--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -316,6 +316,8 @@ module ActiveRecord
   end
 
   class DatabaseTasksMigrateTest < ActiveRecord::TestCase
+    self.use_transactional_tests = false
+
     def setup
       ActiveRecord::Tasks::DatabaseTasks.migrations_paths = 'custom/path'
     end


### PR DESCRIPTION
We are erroring due to nested transaction failures from mysql on test_migrate_clears_schema_cache_afterward test on schema creation.

Disable transactions for this test.

Fixes #24391

r? @arthurnn 
