### PR TITLE
Reduce Action Cable testing complexity

### DIFF
--- a/actioncable/test/channel/base_test.rb
+++ b/actioncable/test/channel/base_test.rb
@@ -1,8 +1,15 @@
 require 'test_helper'
-require 'stubs/test_connection'
-require 'stubs/room'
 
 class ActionCable::Channel::BaseTest < ActiveSupport::TestCase
+  class Connection < TestConnection
+    attr_reader :current_user
+
+    def initialize(*)
+      super
+      @identifiers = [:current_user]
+    end
+  end
+
   class ActionCable::Channel::Base
     def kick
       @last_action = [ :kick ]
@@ -73,7 +80,10 @@ class ActionCable::Channel::BaseTest < ActiveSupport::TestCase
 
   setup do
     @user = User.new "lifo"
-    @connection = TestConnection.new(@user)
+
+    @connection = Connection.new
+    @connection.instance_variable_set(:@current_user, @user)
+
     @channel = ChatChannel.new @connection, "{id: 1}", { id: 1 }
   end
 

--- a/actioncable/test/channel/broadcasting_test.rb
+++ b/actioncable/test/channel/broadcasting_test.rb
@@ -3,27 +3,24 @@ require 'stubs/test_connection'
 require 'stubs/room'
 
 class ActionCable::Channel::BroadcastingTest < ActiveSupport::TestCase
-  class ChatChannel < ActionCable::Channel::Base
-  end
-
   setup do
     @connection = TestConnection.new
   end
 
   test "broadcasts_to" do
-    ActionCable.stubs(:server).returns mock().tap { |m| m.expects(:broadcast).with('action_cable:channel:broadcasting_test:chat:Room#1-Campfire', "Hello World") }
-    ChatChannel.broadcast_to(Room.new(1), "Hello World")
+    ActionCable.stubs(:server).returns mock().tap { |m| m.expects(:broadcast).with('test:Room#1-Campfire', "Hello World") }
+    TestChannel.broadcast_to(Room.new(1), "Hello World")
   end
 
   test "broadcasting_for with an object" do
-    assert_equal "Room#1-Campfire", ChatChannel.broadcasting_for(Room.new(1))
+    assert_equal "Room#1-Campfire", TestChannel.broadcasting_for(Room.new(1))
   end
 
   test "broadcasting_for with an array" do
-    assert_equal "Room#1-Campfire:Room#2-Campfire", ChatChannel.broadcasting_for([ Room.new(1), Room.new(2) ])
+    assert_equal "Room#1-Campfire:Room#2-Campfire", TestChannel.broadcasting_for([ Room.new(1), Room.new(2) ])
   end
 
   test "broadcasting_for with a string" do
-    assert_equal "hello", ChatChannel.broadcasting_for("hello")
+    assert_equal "hello", TestChannel.broadcasting_for("hello")
   end
 end

--- a/actioncable/test/channel/naming_test.rb
+++ b/actioncable/test/channel/naming_test.rb
@@ -4,7 +4,11 @@ class ActionCable::Channel::NamingTest < ActiveSupport::TestCase
   class ChatChannel < ActionCable::Channel::Base
   end
 
-  test "channel_name" do
+  test "normal channel_name" do
+    assert_equal "test", TestChannel.channel_name
+  end
+
+  test "nested channel_name" do
     assert_equal "action_cable:channel:naming_test:chat", ChatChannel.channel_name
   end
 end

--- a/actioncable/test/channel/periodic_timers_test.rb
+++ b/actioncable/test/channel/periodic_timers_test.rb
@@ -1,10 +1,8 @@
 require 'test_helper'
-require 'stubs/test_connection'
-require 'stubs/room'
 require 'active_support/time'
 
 class ActionCable::Channel::PeriodicTimersTest < ActiveSupport::TestCase
-  class ChatChannel < ActionCable::Channel::Base
+  class ChatChannel < TestChannel
     # Method name arg
     periodically :send_updates, every: 1
 

--- a/actioncable/test/channel/rejection_test.rb
+++ b/actioncable/test/channel/rejection_test.rb
@@ -1,9 +1,7 @@
 require 'test_helper'
-require 'stubs/test_connection'
-require 'stubs/room'
 
 class ActionCable::Channel::RejectionTest < ActiveSupport::TestCase
-  class SecretChannel < ActionCable::Channel::Base
+  class SecretChannel < TestChannel
     def subscribed
       reject if params[:id] > 0
     end
@@ -11,7 +9,8 @@ class ActionCable::Channel::RejectionTest < ActiveSupport::TestCase
 
   setup do
     @user = User.new "lifo"
-    @connection = TestConnection.new(@user)
+    @connection = TestConnection.new
+    @connection.instance_variable_set(:@current_user, @user)
   end
 
   test "subscription rejection" do
@@ -21,5 +20,4 @@ class ActionCable::Channel::RejectionTest < ActiveSupport::TestCase
     expected = { "identifier" => "{id: 1}", "type" => "reject_subscription" }
     assert_equal expected, @connection.last_transmission
   end
-
 end

--- a/actioncable/test/connection/authorization_test.rb
+++ b/actioncable/test/connection/authorization_test.rb
@@ -1,16 +1,9 @@
 require 'test_helper'
-require 'stubs/test_server'
 
 class ActionCable::Connection::AuthorizationTest < ActionCable::TestCase
-  class Connection < ActionCable::Connection::Base
-    attr_reader :websocket
-
+  class Connection < TestConnection
     def connect
       reject_unauthorized_connection
-    end
-
-    def send_async(method, *args)
-      send method, *args
     end
   end
 
@@ -19,10 +12,7 @@ class ActionCable::Connection::AuthorizationTest < ActionCable::TestCase
       server = TestServer.new
       server.config.allowed_request_origins = %w( http://rubyonrails.com )
 
-      env = Rack::MockRequest.env_for "/test", 'HTTP_CONNECTION' => 'upgrade', 'HTTP_UPGRADE' => 'websocket',
-        'HTTP_HOST' => 'localhost', 'HTTP_ORIGIN' => 'http://rubyonrails.com'
-
-      connection = Connection.new(server, env)
+      connection = Connection.new(server, default_env)
       connection.websocket.expects(:close)
 
       connection.process

--- a/actioncable/test/connection/client_socket_test.rb
+++ b/actioncable/test/connection/client_socket_test.rb
@@ -1,32 +1,6 @@
 require 'test_helper'
-require 'stubs/test_server'
 
 class ActionCable::Connection::ClientSocketTest < ActionCable::TestCase
-  class Connection < ActionCable::Connection::Base
-    attr_reader :connected, :websocket, :errors
-
-    def initialize(*)
-      super
-      @errors = []
-    end
-
-    def connect
-      @connected = true
-    end
-
-    def disconnect
-      @connected = false
-    end
-
-    def send_async(method, *args)
-      send method, *args
-    end
-
-    def on_error(message)
-      @errors << message
-    end
-  end
-
   setup do
     @server = TestServer.new
     @server.config.allowed_request_origins = %w( http://rubyonrails.com )
@@ -50,12 +24,7 @@ class ActionCable::Connection::ClientSocketTest < ActionCable::TestCase
 
   private
     def open_connection
-      env = Rack::MockRequest.env_for '/test',
-        'HTTP_CONNECTION' => 'upgrade', 'HTTP_UPGRADE' => 'websocket',
-        'HTTP_HOST' => 'localhost', 'HTTP_ORIGIN' => 'http://rubyonrails.com'
-      env['rack.hijack'] = -> { env['rack.hijack_io'] = StringIO.new }
-
-      Connection.new(@server, env).tap do |connection|
+      TestConnection.new(@server, rack_hijack_env).tap do |connection|
         connection.process
         connection.send :handle_open
         assert connection.connected

--- a/actioncable/test/connection/cross_site_forgery_test.rb
+++ b/actioncable/test/connection/cross_site_forgery_test.rb
@@ -1,14 +1,7 @@
 require 'test_helper'
-require 'stubs/test_server'
 
 class ActionCable::Connection::CrossSiteForgeryTest < ActionCable::TestCase
   HOST = 'rubyonrails.com'
-
-  class Connection < ActionCable::Connection::Base
-    def send_async(method, *args)
-      send method, *args
-    end
-  end
 
   setup do
     @server = TestServer.new
@@ -68,14 +61,10 @@ class ActionCable::Connection::CrossSiteForgeryTest < ActionCable::TestCase
       response = nil
 
       run_in_eventmachine do
-        response = Connection.new(@server, env_for_origin(origin)).process
+        env = default_env({ 'SERVER_NAME' => HOST, 'HTTP_HOST' => HOST, 'HTTP_ORIGIN' => origin })
+        response = TestConnection.new(@server, env).process
       end
 
       response
-    end
-
-    def env_for_origin(origin)
-      Rack::MockRequest.env_for "/test", 'HTTP_CONNECTION' => 'upgrade', 'HTTP_UPGRADE' => 'websocket', 'SERVER_NAME' => HOST,
-        'HTTP_HOST' => HOST, 'HTTP_ORIGIN' => origin
     end
 end

--- a/actioncable/test/connection/identifier_test.rb
+++ b/actioncable/test/connection/identifier_test.rb
@@ -1,12 +1,8 @@
 require 'test_helper'
-require 'stubs/test_server'
-require 'stubs/user'
 
 class ActionCable::Connection::IdentifierTest < ActionCable::TestCase
-  class Connection < ActionCable::Connection::Base
+  class Connection < TestConnection
     identified_by :current_user
-    attr_reader :websocket
-
     public :process_internal_message
 
     def connect
@@ -62,8 +58,7 @@ class ActionCable::Connection::IdentifierTest < ActionCable::TestCase
     end
 
     def open_connection(server:)
-      env = Rack::MockRequest.env_for "/test", 'HTTP_HOST' => 'localhost', 'HTTP_CONNECTION' => 'upgrade', 'HTTP_UPGRADE' => 'websocket'
-      @connection = Connection.new(server, env)
+      @connection = Connection.new(server, default_env)
 
       @connection.process
       @connection.send :handle_open

--- a/actioncable/test/connection/multiple_identifiers_test.rb
+++ b/actioncable/test/connection/multiple_identifiers_test.rb
@@ -1,9 +1,7 @@
 require 'test_helper'
-require 'stubs/test_server'
-require 'stubs/user'
 
 class ActionCable::Connection::MultipleIdentifiersTest < ActionCable::TestCase
-  class Connection < ActionCable::Connection::Base
+  class Connection < TestConnection
     identified_by :current_user, :current_room
 
     def connect
@@ -28,8 +26,7 @@ class ActionCable::Connection::MultipleIdentifiersTest < ActionCable::TestCase
     end
 
     def open_connection(server:)
-      env = Rack::MockRequest.env_for "/test", 'HTTP_HOST' => 'localhost', 'HTTP_CONNECTION' => 'upgrade', 'HTTP_UPGRADE' => 'websocket'
-      @connection = Connection.new(server, env)
+      @connection = Connection.new(server, default_env)
 
       @connection.process
       @connection.send :handle_open

--- a/actioncable/test/connection/stream_test.rb
+++ b/actioncable/test/connection/stream_test.rb
@@ -1,32 +1,6 @@
 require 'test_helper'
-require 'stubs/test_server'
 
 class ActionCable::Connection::StreamTest < ActionCable::TestCase
-  class Connection < ActionCable::Connection::Base
-    attr_reader :connected, :websocket, :errors
-
-    def initialize(*)
-      super
-      @errors = []
-    end
-
-    def connect
-      @connected = true
-    end
-
-    def disconnect
-      @connected = false
-    end
-
-    def send_async(method, *args)
-      send method, *args
-    end
-
-    def on_error(message)
-      @errors << message
-    end
-  end
-
   setup do
     @server = TestServer.new
     @server.config.allowed_request_origins = %w( http://rubyonrails.com )
@@ -52,12 +26,7 @@ class ActionCable::Connection::StreamTest < ActionCable::TestCase
 
   private
     def open_connection
-      env = Rack::MockRequest.env_for '/test',
-        'HTTP_CONNECTION' => 'upgrade', 'HTTP_UPGRADE' => 'websocket',
-        'HTTP_HOST' => 'localhost', 'HTTP_ORIGIN' => 'http://rubyonrails.com'
-      env['rack.hijack'] = -> { env['rack.hijack_io'] = StringIO.new }
-
-      Connection.new(@server, env).tap do |connection|
+      TestConnection.new(@server, rack_hijack_env).tap do |connection|
         connection.process
         connection.send :handle_open
         assert connection.connected

--- a/actioncable/test/connection/string_identifier_test.rb
+++ b/actioncable/test/connection/string_identifier_test.rb
@@ -1,16 +1,11 @@
 require 'test_helper'
-require 'stubs/test_server'
 
 class ActionCable::Connection::StringIdentifierTest < ActionCable::TestCase
-  class Connection < ActionCable::Connection::Base
+  class Connection < TestConnection
     identified_by :current_token
 
     def connect
       self.current_token = "random-string"
-    end
-
-    def send_async(method, *args)
-      send method, *args
     end
   end
 
@@ -30,8 +25,7 @@ class ActionCable::Connection::StringIdentifierTest < ActionCable::TestCase
     end
 
     def open_connection
-      env = Rack::MockRequest.env_for "/test", 'HTTP_HOST' => 'localhost', 'HTTP_CONNECTION' => 'upgrade', 'HTTP_UPGRADE' => 'websocket'
-      @connection = Connection.new(@server, env)
+      @connection = Connection.new(@server, default_env)
 
       @connection.process
       @connection.send :on_open

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -1,14 +1,6 @@
 require 'test_helper'
 
 class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
-  class Connection < ActionCable::Connection::Base
-    attr_reader :websocket
-
-    def send_async(method, *args)
-      send method, *args
-    end
-  end
-
   class ChatChannel < ActionCable::Channel::Base
     attr_reader :room, :lines
 
@@ -107,9 +99,7 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
     end
 
     def setup_connection
-      env = Rack::MockRequest.env_for "/test", 'HTTP_HOST' => 'localhost', 'HTTP_CONNECTION' => 'upgrade', 'HTTP_UPGRADE' => 'websocket'
-      @connection = Connection.new(@server, env)
-
+      @connection = TestConnection.new(@server, default_env)
       @subscriptions = ActionCable::Connection::Subscriptions.new(@connection)
     end
 end

--- a/actioncable/test/stubs/test_channel.rb
+++ b/actioncable/test/stubs/test_channel.rb
@@ -1,0 +1,2 @@
+class TestChannel < ActionCable::Channel::Base
+end

--- a/actioncable/test/support/env_helpers.rb
+++ b/actioncable/test/support/env_helpers.rb
@@ -1,0 +1,13 @@
+module EnvHelpers
+  def default_env(options = {})
+    Rack::MockRequest.env_for(
+    "/test", { 'HTTP_CONNECTION' => 'upgrade', 'HTTP_UPGRADE' => 'websocket', 'HTTP_HOST' => 'localhost',
+      'HTTP_ORIGIN' => 'http://rubyonrails.com' }.merge!(options)
+    )
+  end
+
+  def rack_hijack_env(options = {})
+    env = default_env
+    env.merge!({ 'rack.hijack' => -> { env['rack.hijack_io'] = StringIO.new } })
+  end
+end

--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -12,6 +12,7 @@ end
 
 # Require all the stubs and models
 Dir[File.dirname(__FILE__) + '/stubs/*.rb'].each {|file| require file }
+Dir[File.dirname(__FILE__) + '/support/*.rb'].each {|file| require file }
 
 if ENV['FAYE'].present?
   require 'faye/websocket'
@@ -64,6 +65,8 @@ class ActionCable::TestCase < ActiveSupport::TestCase
   else
     include ConcurrentRubyConcurrencyHelpers
   end
+
+  include EnvHelpers
 
   def wait_for_executor(executor)
     until executor.completed_task_count == executor.scheduled_task_count


### PR DESCRIPTION
- Remove most individual Connection / Channel classes.
- Recycle stubs across the test suite.
- Simplify `TestConnection` stub.
- Do not inherit from `ActionCable` `Base` classes from within test suite -- only inherit in stubs.
