### PR TITLE
string inquiry should be case insensitive

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `ActiveSupport::StringInquirer` is now case insensitive
+
+    *Ignatius Reza Lesmana*
+
 *   `ActiveSupport::Duration` supports weeks and hours.
 
         [1.hour.inspect, 1.hour.value, 1.hour.parts]

--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -17,7 +17,7 @@ module ActiveSupport
 
       def method_missing(method_name, *arguments)
         if method_name[-1] == '?'
-          self == method_name[0..-2]
+          self.casecmp(method_name[0..-2]) == 0
         else
           super
         end

--- a/activesupport/test/string_inquirer_test.rb
+++ b/activesupport/test/string_inquirer_test.rb
@@ -20,4 +20,11 @@ class StringInquirerTest < ActiveSupport::TestCase
   def test_respond_to
     assert_respond_to @string_inquirer, :development?
   end
+
+  def test_ignore_case
+    @string_inquirer = ActiveSupport::StringInquirer.new('Production')
+
+    assert @string_inquirer.production?
+    assert @string_inquirer.Production?
+  end
 end


### PR DESCRIPTION
### Summary

Existing implementation of string inquiry is case sensitive, hence `'GitHub'.inquiry.github?` will return false while `'GitHub'.inquiry.GitHub?` will return true.. which is surprising, given that method in ruby are (mostly) written in `snake_case`
### Other Information

Based on the benchmark written below, performance doesn't seems to be impacted:

```
Calculating -------------------------------------
             inquiry    79.808k i/100ms
 inquiry ignore_case    77.026k i/100ms
-------------------------------------------------
             inquiry      1.603M (± 3.5%) i/s -      8.061M
 inquiry ignore_case      1.517M (± 4.5%) i/s -      7.626M
```

Benchmark code:

``` rb
require 'benchmark/ips'

class StringInquirer < String
  private

    def respond_to_missing?(method_name, include_private = false)
      method_name[-1] == '?'
    end

    def method_missing(method_name, *arguments)
      if method_name[-1] == '?'
        self == method_name[0..-2]
      else
        super
      end
    end
end

class StringInquirerIgnoreCase < String
  private

    def respond_to_missing?(method_name, include_private = false)
      method_name[-1] == '?'
    end

    def method_missing(method_name, *arguments)
      if method_name[-1] == '?'
        self.casecmp(method_name[0..-2]) == 0
      else
        super
      end
    end
end

string        = StringInquirer.new('production')
string_ignore = StringInquirerIgnoreCase.new('Production')


Benchmark.ips do |x|
  x.report('inquiry')             { string.production? }
  x.report('inquiry ignore_case') { string_ignore.production? }
end
```
