### PR TITLE
Array#split refactoring for case with block

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/grouping.rb
+++ b/activesupport/lib/active_support/core_ext/array/grouping.rb
@@ -89,24 +89,19 @@ class Array
   #   [1, 2, 3, 4, 5].split(3)              # => [[1, 2], [4, 5]]
   #   (1..10).to_a.split { |i| i % 3 == 0 } # => [[1, 2], [4, 5], [7, 8], [10]]
   def split(value = nil)
+    arr = self.dup
+    result = []
     if block_given?
-      inject([[]]) do |results, element|
-        if yield(element)
-          results << []
-        else
-          results.last << element
-        end
-
-        results
+      while (idx = arr.index { |i| yield i })
+        result << arr.shift(idx)
+        arr.shift
       end
     else
-      arr = self.dup
-      result = []
       while (idx = arr.index(value))
         result << arr.shift(idx)
         arr.shift
       end
-      result << arr
     end
+    result << arr
   end
 end


### PR DESCRIPTION
``` ruby
class Array
  # before
  def split(value = nil)
    if block_given?
      inject([[]]) do |results, element|
        if yield(element)
          results << []
        else
          results.last << element
        end

        results
      end
    else
      arr = self.dup
      result = []
      while (idx = arr.index(value))
        result << arr.shift(idx)
        arr.shift
      end
      result << arr
    end
  end

  # after
  def split2(value = nil)
    arr = self.dup
    result = []
    if block_given?
      while (idx = arr.index { |i| yield i })
        result << arr.shift(idx)
        arr.shift
      end
    else
      while (idx = arr.index(value))
        result << arr.shift(idx)
        arr.shift
      end
    end
    result << arr
  end
end 

arr = (1..12).to_a

Benchmark.ips do |x|
  x.report('before') { arr.split { |i| i % 3 == 0 } }
  x.report('after') { arr.split2 { |i| i % 3 == 0 } }
  x.compare!
end
```

```
Calculating -------------------------------------
              before    26.319k i/100ms
               after    29.414k i/100ms
-------------------------------------------------
              before    350.623k (± 1.6%) i/s -      1.763M
               after    416.227k (± 1.4%) i/s -      2.088M

Comparison:
               after:   416226.8 i/s
              before:   350622.8 i/s - 1.19x slower
```
