### PR TITLE
BoomerAPI is not used anywhere, so removed it!

### DIFF
--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -75,13 +75,6 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  class BoomerAPI < Boomer
-    def call(env)
-      env['action_dispatch.show_detailed_exceptions'] = @detailed
-      raise "puke!"
-    end
-  end
-
   RoutesApp = Struct.new(:routes).new(SharedTestRoutes)
   ProductionApp  = ActionDispatch::DebugExceptions.new(Boomer.new(false), RoutesApp)
   DevelopmentApp = ActionDispatch::DebugExceptions.new(Boomer.new(true), RoutesApp)


### PR DESCRIPTION
- It was originally added in 83b4e9073f0852afc065 and partially
  removed in 05d89410bf97d0778e7.

cc @spastorino @jmbejar 
