### PR TITLE
Robust-ify unsubscribe

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -95,6 +95,8 @@ class ActionCable.Connection
           @subscriptions.notify(identifier, "connected")
         when message_types.rejection
           @subscriptions.reject(identifier)
+        when message_types.unsubscribe_confirmation
+          @subscriptions.notify(identifier, "unsubscribed")
         else
           @subscriptions.notify(identifier, "received", message)
 

--- a/actioncable/app/assets/javascripts/action_cable/subscription.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/subscription.coffee
@@ -63,6 +63,9 @@ class ActionCable.Subscription
     @consumer.send(command: "message", identifier: @identifier, data: JSON.stringify(data))
 
   unsubscribe: ->
+    @consumer.send(command: "unsubscribe", identifier: @identifier)
+
+  unsubscribed: ->
     @consumer.subscriptions.remove(this)
 
   extend = (object, properties) ->

--- a/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
@@ -27,8 +27,6 @@ class ActionCable.Subscriptions
 
   remove: (subscription) ->
     @forget(subscription)
-    unless @findAll(subscription.identifier).length
-      @sendCommand(subscription, "unsubscribe")
     subscription
 
   reject: (identifier) ->

--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -33,6 +33,7 @@ module ActionCable
       welcome: 'welcome'.freeze,
       ping: 'ping'.freeze,
       confirmation: 'confirm_subscription'.freeze,
+      unsubscribe_confirmation: 'confirm_unsubscribe'.freeze,
       rejection: 'reject_subscription'.freeze
     },
     default_mount_path: '/cable'.freeze,

--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -42,6 +42,8 @@ module ActionCable
 
       def remove_subscription(subscription)
         subscription.unsubscribe_from_channel
+      ensure
+        subscription.send :transmit_unsubscribe_confirmation
         subscriptions.delete(subscription.identifier)
       end
 

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -229,7 +229,11 @@ class ClientTest < ActionCable::TestCase
       subscriptions = app.connections.first.subscriptions.send(:subscriptions)
       assert_not_equal 0, subscriptions.size, 'Missing EchoChannel subscription'
       channel = subscriptions.first[1]
+
+      c.send_message command: 'unsubscribe', identifier: identifier
       channel.expects(:unsubscribed)
+      assert_equal({"identifier"=>"{\"channel\":\"EchoChannel\"}", "type"=>"confirm_unsubscribe"}, c.read_message)
+
       c.close
       sleep 0.1 # Data takes a moment to process
 


### PR DESCRIPTION
- introduce `confirm_unsubscribe` message type
- rename `confirm_subscription` to `confirm_subscribe`
- `ensure` that `confirm_unsubscribe` and `subscription` is `delete`d

Fixes #24874.

r? @jeremy 
