### PR TITLE
Replace `loop` to `until`

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -2088,8 +2088,7 @@ to this:
 
         def each
           node = self
-          loop do
-            break if node.equal? NULL
+          until node.equal? NULL
             yield node
             node = node.parent
           end


### PR DESCRIPTION
Propose replace `loop` to `until` for better readability and increase speed execute.
The discussion at the [link](https://groups.google.com/forum/#!topic/rubyonrails-core/IxS0dEwhIdQ)

 /cc @fxn 
