### PR TITLE
Remove superfluous `RuntimeError` when raising

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -699,8 +699,8 @@ module ActionMailer
 
       private
         def _raise_error
-          raise RuntimeError, "Can't add attachments after `mail` was called.\n" \
-                              "Make sure to use `attachments[]=` before calling `mail`."
+          raise "Can't add attachments after `mail` was called.\n" \
+                "Make sure to use `attachments[]=` before calling `mail`."
         end
     end
 

--- a/activerecord/lib/active_record/attribute_set/builder.rb
+++ b/activerecord/lib/active_record/attribute_set/builder.rb
@@ -42,7 +42,7 @@ module ActiveRecord
 
     def []=(key, value)
       if frozen?
-        raise RuntimeError, "Can't modify frozen hash"
+        raise "Can't modify frozen hash"
       end
       delegate_hash[key] = value
     end

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -962,7 +962,7 @@ module ActiveRecord
 
     def setup_fixtures(config = ActiveRecord::Base)
       if pre_loaded_fixtures && !use_transactional_tests
-        raise RuntimeError, 'pre_loaded_fixtures requires use_transactional_tests'
+        raise 'pre_loaded_fixtures requires use_transactional_tests'
       end
 
       @fixture_cache = {}
@@ -1018,10 +1018,10 @@ module ActiveRecord
 
       def instantiate_fixtures
         if pre_loaded_fixtures
-          raise RuntimeError, 'Load fixtures before instantiating them.' if ActiveRecord::FixtureSet.all_loaded_fixtures.empty?
+          raise 'Load fixtures before instantiating them.' if ActiveRecord::FixtureSet.all_loaded_fixtures.empty?
           ActiveRecord::FixtureSet.instantiate_all_loaded_fixtures(self, load_instances?)
         else
-          raise RuntimeError, 'Load fixtures before instantiating them.' if @loaded_fixtures.nil?
+          raise 'Load fixtures before instantiating them.' if @loaded_fixtures.nil?
           @loaded_fixtures.each_value do |fixture_set|
             ActiveRecord::FixtureSet.instantiate_fixtures(self, fixture_set, load_instances?)
           end


### PR DESCRIPTION
By default, `raise` will raise a `RuntimeError`.

```
irb(main):004:0> raise RuntimeError, 'error!'
RuntimeError: error!
    from (irb):4
    from /Users/jon/.rbenv/versions/2.3.0/bin/irb:11:in `<main>'
irb(main):005:0> raise 'error!'
RuntimeError: error!
    from (irb):5
    from /Users/jon/.rbenv/versions/2.3.0/bin/irb:11:in `<main>'
```

cc @vipulnsward, as promised :)
