### PR TITLE
Try to coerce PostgreSQL array single elements types

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -12,8 +12,11 @@ module ActiveRecord
             @subtype = subtype
             @delimiter = delimiter
 
-            @pg_encoder = PG::TextEncoder::Array.new name: "#{type}[]", delimiter: delimiter
-            @pg_decoder = PG::TextDecoder::Array.new name: "#{type}[]", delimiter: delimiter
+            encoder = PG::TextEncoder::const_get(type.to_s.capitalize).new rescue nil
+            @pg_encoder = PG::TextEncoder::Array.new name: "#{type}[]", delimiter: delimiter, elements_type: encoder
+
+            decoder = PG::TextDecoder::const_get(type.to_s.capitalize).new rescue nil
+            @pg_decoder = PG::TextDecoder::Array.new name: "#{type}[]", delimiter: delimiter, elements_type: decoder
           end
 
           def deserialize(value)


### PR DESCRIPTION
Currently, the deserialization representation of a single element in an
array is always a string. I have hit this problem, while having a single
element deserialize method that expected an Integer, yet it got a
string.

Now, I'm not sure whether the `Type#deserialize(value)` do expects the
value to be coerced by the DB to a suitable type (or it should always
expect a string), but if the type is used standalone and not wrapped in
an array, I do get the coerced value.

This change is an effort in trying to hint the builtin
PG::Text{En,De}coders what the single elements type of the PostgreSQL
array is. If the type has no coder associated with it, we use the
stringified representation as before.
