### PR TITLE
Add :ssl smtp setting to ActionMailer::Base rdoc

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -392,7 +392,7 @@ module ActionMailer
   #     of an OpenSSL verify constant (<tt>'none'</tt>, <tt>'peer'</tt>, <tt>'client_once'</tt>,
   #     <tt>'fail_if_no_peer_cert'</tt>) or directly the constant (<tt>OpenSSL::SSL::VERIFY_NONE</tt>,
   #     <tt>OpenSSL::SSL::VERIFY_PEER</tt>, ...).
-  #     <tt>:ssl</tt> - Forces ActionMailer to use SSL in the SMTP connection. Defaults to <tt>false</tt>.
+  #     <tt>:ssl/:tls</tt> Enables Action Mailer to use SMTP/TLS (SMTPS: SMTP over direct TLS connection).
   #
   # * <tt>sendmail_settings</tt> - Allows you to override options for the <tt>:sendmail</tt> delivery method.
   #   * <tt>:location</tt> - The location of the sendmail executable. Defaults to <tt>/usr/sbin/sendmail</tt>.

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -392,6 +392,7 @@ module ActionMailer
   #     of an OpenSSL verify constant (<tt>'none'</tt>, <tt>'peer'</tt>, <tt>'client_once'</tt>,
   #     <tt>'fail_if_no_peer_cert'</tt>) or directly the constant (<tt>OpenSSL::SSL::VERIFY_NONE</tt>,
   #     <tt>OpenSSL::SSL::VERIFY_PEER</tt>, ...).
+  #     <tt>:ssl</tt> - Forces ActionMailer to use SSL in the SMTP connection. Defaults to <tt>false</tt>.
   #
   # * <tt>sendmail_settings</tt> - Allows you to override options for the <tt>:sendmail</tt> delivery method.
   #   * <tt>:location</tt> - The location of the sendmail executable. Defaults to <tt>/usr/sbin/sendmail</tt>.


### PR DESCRIPTION
### Summary

Added `:ssl` documentation in `smtp_settings` of `ActionMailer::Base`. It works but it doesn't appeared before in the rdoc.

I'm creating this PR because I needed the use of `:ssl` and I had to dig into the web just to find that it exists. If not set, mailing with NameCheap's privateemail doesn't work even with `enable_starttls_auto` set to `true` 

I think it would be useful if people could read about it in the documentation.
