### PR TITLE
Cable: Generate .js or .coffee files while generating channel as per the javascript engine of the application

### DIFF
--- a/actioncable/lib/rails/generators/channel/channel_generator.rb
+++ b/actioncable/lib/rails/generators/channel/channel_generator.rb
@@ -16,7 +16,8 @@ module Rails
           if self.behavior == :invoke
             template "assets/cable.js", "app/assets/javascripts/cable.js"
           end
-          template "assets/channel.coffee", File.join('app/assets/javascripts/channels', class_path, "#{file_name}.coffee")
+
+          js_template "assets/channel", File.join('app/assets/javascripts/channels', class_path, "#{file_name}")
         end
 
         generate_application_cable_files

--- a/actioncable/lib/rails/generators/channel/templates/assets/channel.js
+++ b/actioncable/lib/rails/generators/channel/templates/assets/channel.js
@@ -1,0 +1,18 @@
+App.<%= class_name.underscore %> = App.cable.subscriptions.create("<%= class_name %>Channel", {
+  connected: function() {
+    // Called when the subscription is ready for use on the server
+  },
+
+  disconnected: function() {
+    // Called when the subscription has been terminated by the server
+  },
+
+  received: function(data) {
+    // Called when there's incoming data on the websocket for this channel
+  }<%= actions.any? ? ",\n" : '' %>
+<% actions.each do |action| -%>
+  <%=action %>: function() {
+    return this.perform('<%= action %>');
+  }<%= action == actions[-1] ? '' : ",\n" %>
+<% end -%>
+});

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -26,6 +26,10 @@ module Rails
             super
           end
         end
+
+        def js_template(source, destination)
+          template(source + '.js', destination + '.js')
+        end
       end
 
       protected

--- a/railties/test/generators/channel_generator_test.rb
+++ b/railties/test/generators/channel_generator_test.rb
@@ -24,8 +24,24 @@ class ChannelGeneratorTest < Rails::Generators::TestCase
       assert_match(/class ChatChannel < ApplicationCable::Channel/, channel)
     end
 
-    assert_file "app/assets/javascripts/channels/chat.coffee" do |channel|
-      assert_match(/App.cable.subscriptions.create "ChatChannel"/, channel)
+    assert_file "app/assets/javascripts/channels/chat.js" do |channel|
+      assert_match(/App.chat = App.cable.subscriptions.create\("ChatChannel/, channel)
+    end
+  end
+
+  def test_channel_with_multiple_actions_is_created
+    run_generator ['chat', 'speak', 'mute']
+
+    assert_file "app/channels/chat_channel.rb" do |channel|
+      assert_match(/class ChatChannel < ApplicationCable::Channel/, channel)
+      assert_match(/def speak/, channel)
+      assert_match(/def mute/, channel)
+    end
+
+    assert_file "app/assets/javascripts/channels/chat.js" do |channel|
+      assert_match(/App.chat = App.cable.subscriptions.create\("ChatChannel/, channel)
+      assert_match(/,\n\n  speak/, channel)
+      assert_match(/,\n\n  mute: function\(\) \{\n    return this\.perform\('mute'\);\n  \}\n\}\);/, channel)
     end
   end
 
@@ -36,7 +52,7 @@ class ChannelGeneratorTest < Rails::Generators::TestCase
       assert_match(/class ChatChannel < ApplicationCable::Channel/, channel)
     end
 
-    assert_no_file "app/assets/javascripts/channels/chat.coffee"
+    assert_no_file "app/assets/javascripts/channels/chat.js"
   end
 
   def test_cable_js_is_created_if_not_present_already
@@ -52,7 +68,7 @@ class ChannelGeneratorTest < Rails::Generators::TestCase
     run_generator ['chat'], behavior: :revoke
 
     assert_no_file "app/channels/chat_channel.rb"
-    assert_no_file "app/assets/javascripts/channels/chat.coffee"
+    assert_no_file "app/assets/javascripts/channels/chat.js"
 
     assert_file "app/channels/application_cable/channel.rb"
     assert_file "app/channels/application_cable/connection.rb"


### PR DESCRIPTION
### Summary
- Now we will detect what javascript engine user is using and based on
  that we will generate either `.js` or `.coffee` version of the channel
  file.
- This also needs a change in coffee-rails to override the `js_template`
  method. Related PR https://github.com/rails/coffee-rails/pull/72.
- Currently coffee-rails gem sets
  `config.app_generators.javascript_engine` to `:coffee` and using this
  information we override the `js_template` to set the extension as
  `.coffee` in coffee-rails gem.
- Using this approach, we can keep the `channel.js` and `channel.coffee`
  files in the Rails repository itself.
- Additionally the `js_template` method can act as public interface for
  coffee-rails gem to hook into and change the extension to `.coffee`
  without maintaining the actual asset files.

[Prathamesh Sonpatki, Matthew Draper]

This needs more tests coverage but I am opening for discussion.  This is based on discussion with Matthew at RailsConf.

cc @matthewd @rafaelfranca 
