### PR TITLE
Fix config deprecation warnings, improve deprecation tests

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -57,30 +57,30 @@ module Rails
       end
 
       def static_cache_control=(value)
-        ActiveSupport::Deprecation.warn <<-eow.strip_heredoc
-          `config.static_cache_control` is deprecated and will be removed in Rails 5.1.
-          Please use
-          `config.public_file_server.headers = { 'Cache-Control' => '#{value}' }`
-          instead.
-        eow
+        ActiveSupport::Deprecation.warn <<-MESSAGE.squish
+          `config.static_cache_control` is deprecated and will be removed in
+          Rails 5.1. Please use `config.public_file_server.headers = {
+          'Cache-Control' => '#{value}' }` instead.
+        MESSAGE
 
         @static_cache_control = value
       end
 
       def serve_static_files
-        ActiveSupport::Deprecation.warn <<-eow.strip_heredoc
-          `config.serve_static_files` is deprecated and will be removed in Rails 5.1.
-          Please use `config.public_file_server.enabled` instead.
-        eow
+        ActiveSupport::Deprecation.warn <<-MESSAGE.squish
+          `config.serve_static_files` is deprecated and will be removed in
+          Rails 5.1. Please use `config.public_file_server.enabled` instead.
+        MESSAGE
 
         @public_file_server.enabled
       end
 
       def serve_static_files=(value)
-        ActiveSupport::Deprecation.warn <<-eow.strip_heredoc
-          `config.serve_static_files` is deprecated and will be removed in Rails 5.1.
-          Please use `config.public_file_server.enabled = #{value}` instead.
-        eow
+        ActiveSupport::Deprecation.warn <<-MESSAGE.squish
+          `config.serve_static_files` is deprecated and will be removed in
+          Rails 5.1. Please use `config.public_file_server.enabled = #{value}`
+          instead.
+        MESSAGE
 
         @public_file_server.enabled = value
       end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -370,9 +370,16 @@ module ApplicationTests
       end
     end
 
-    test "config.serve_static_files is deprecated" do
+    def test_config_serve_static_files_is_deprecated
+      message = "`config.serve_static_files` is deprecated and will be " \
+        "removed in Rails 5.1. Please use `config.public_file_server.enabled"
+
       make_basic_app do |application|
-        assert_deprecated do
+        assert_deprecated("#{message}` instead.") do
+          application.config.serve_static_files
+        end
+
+        assert_deprecated("#{message} = true` instead.") do
           application.config.serve_static_files = true
         end
 
@@ -380,13 +387,18 @@ module ApplicationTests
       end
     end
 
-    test "config.static_cache_control is deprecated" do
+    def test_config_static_cache_control_is_deprecated
+      value   = "public, max-age=60"
+      message = "`config.static_cache_control` is deprecated and will be " \
+        "removed in Rails 5.1. Please use `config.public_file_server.headers" \
+        " = { 'Cache-Control' => '#{value}' }` instead."
+
       make_basic_app do |application|
-        assert_deprecated do
-          application.config.static_cache_control = "public, max-age=60"
+        assert_deprecated(message) do
+          application.config.static_cache_control = value
         end
 
-        assert_equal application.config.static_cache_control, "public, max-age=60"
+        assert_equal application.config.static_cache_control, value
       end
     end
 


### PR DESCRIPTION
- Squish arbitrary line breaks from the deprecation warnings
- Enhance the tests to include the warning messages
- Use standard test naming; added benefit of being slightly easier to run individual tests
- Wrap the changed code at 80 characters

This fixes console warnings that looked like this on server start:

```
DEPRECATION WARNING: `config.static_cache_control` is deprecated and will be removed in Rails 5.1.
Please use
`config.public_file_server.headers = { 'Cache-Control' => 'true' }`
instead.
```
