### PR TITLE
Add empty label to empty options tag

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,2 +1,19 @@
+*   `select_tag`'s `include_blank` option for generation for blank option tag, now adds an empty space label, 
+     when the value as well as content for option tag are empty, so that we confirm with html specification.
+     Ref: https://www.w3.org/TR/html5/forms.html#the-option-element.
+
+    Generation of option before:
+     
+    ```html
+    <option value=""></option>
+    ```
+    
+    Generation of option after: 
+
+    ```html
+    <option value="" label=" "></option>
+    ```
+
+    *Vipul A M *
 
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -134,13 +134,15 @@ module ActionView
 
         if options.include?(:include_blank)
           include_blank = options.delete(:include_blank)
+          options_for_blank_options_tag = { value: '' }
 
           if include_blank == true
             include_blank = ''
+            options_for_blank_options_tag[:label] = ' '
           end
 
           if include_blank
-            option_tags = content_tag("option".freeze, include_blank, value: '').safe_concat(option_tags)
+            option_tags = content_tag("option".freeze, include_blank, options_for_blank_options_tag).safe_concat(option_tags)
           end
         end
 

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -239,8 +239,8 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_select_tag_with_include_blank
-    actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), :include_blank => true
-    expected = %(<select id="places" name="places"><option value=""></option><option>Home</option><option>Work</option><option>Pub</option></select>)
+    actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), include_blank: true
+    expected = %(<select id="places" name="places"><option value="" label=" "></option><option>Home</option><option>Work</option><option>Pub</option></select>)
     assert_dom_equal expected, actual
   end
 
@@ -269,14 +269,14 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_select_tag_with_prompt_and_include_blank
-    actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), :prompt => "string", :include_blank => true
-    expected = %(<select name="places" id="places"><option value="">string</option><option value=""></option><option>Home</option><option>Work</option><option>Pub</option></select>)
+    actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), prompt: "string", include_blank: true
+    expected = %(<select name="places" id="places"><option value="">string</option><option value="" label=" "></option><option>Home</option><option>Work</option><option>Pub</option></select>)
     assert_dom_equal expected, actual
   end
 
   def test_select_tag_with_nil_option_tags_and_include_blank
     actual = select_tag "places", nil, :include_blank => true
-    expected = %(<select id="places" name="places"><option value=""></option></select>)
+    expected = %(<select id="places" name="places"><option value="" label=" "></option></select>)
     assert_dom_equal expected, actual
   end
 


### PR DESCRIPTION
Confirm with the specification when generating emtpy option for select with `include_blank: true` option.
We now generate option with empty label, example: 

`<select id="places" name="places"><option value="" label=" "></option></select>`

 for include_blank: true. Note the space in label, the label can't be `""`, and needs to atleast be a space value. This is only done, if content is missing on the option, and we providing the value from this option.

 Fixes #24816
