### PR TITLE
Introduce Date#all_day

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -294,6 +294,11 @@ module DateAndTime
     end
     alias :at_end_of_year :end_of_year
 
+    # Returns a Range representing the whole day of the current date/time.
+    def all_day
+      beginning_of_day..end_of_day
+    end
+
     # Returns a Range representing the whole week of the current date/time.
     # Week starts on start_day, default is <tt>Date.week_start</tt> or <tt>config.week_start</tt> when set.
     def all_week(start_day = Date.beginning_of_week)

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -227,11 +227,6 @@ class Time
   end
   alias :at_end_of_minute :end_of_minute
 
-  # Returns a Range representing the whole day of the current time.
-  def all_day
-    beginning_of_day..end_of_day
-  end
-
   def plus_with_duration(other) #:nodoc:
     if ActiveSupport::Duration === other
       other.since(self)

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -284,6 +284,23 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_all_day
+    beginning_of_day = Time.local(2011,6,7,0,0,0)
+    end_of_day = Time.local(2011,6,7,23,59,59,Rational(999999999, 1000))
+    assert_equal beginning_of_day..end_of_day, Date.new(2011,6,7).all_day
+  end
+
+  def test_all_day_when_zone_is_set
+    zone = ActiveSupport::TimeZone["Hawaii"]
+    with_env_tz "UTC" do
+      with_tz_default zone do
+        beginning_of_day = zone.local(2011,6,7,0,0,0)
+        end_of_day = zone.local(2011,6,7,23,59,59,Rational(999999999, 1000))
+        assert_equal beginning_of_day..end_of_day, Date.new(2011,6,7).all_day
+      end
+    end
+  end
+
   def test_all_week
     assert_equal Date.new(2011,6,6)..Date.new(2011,6,12), Date.new(2011,6,7).all_week
     assert_equal Date.new(2011,6,5)..Date.new(2011,6,11), Date.new(2011,6,7).all_week(:sunday)


### PR DESCRIPTION
Useful for queries like:

```
Item.where(created_at: Date.current.all_day)
```

There was already a `Time#all_day` with the same behaviour, so you can already do

```
Item.where(created_at: Date.current.to_time.all_day)
```

but arguably having the method on `Date` as well makes it both read better, and more convenient to write.
