### PR TITLE
Access Session::CookieStore with Indifferent Access

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Update `Session::CookieStore` to use `HashWithIndifferentAccess`
+
+        session[:deep][:hash] = "Magic"
+
+        session[:deep][:hash] == "Magic"
+        session[:deep]["hash"] == "Magic"
+
+    *Tom Prats*
+
 ## Rails 5.0.0.rc1 (May 06, 2016) ##
 
 *   Add `ActionController#helpers` to get access to the view context at the controller

--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -93,10 +93,8 @@ module ActionDispatch
       def unpacked_cookie_data(req)
         req.fetch_header("action_dispatch.request.unsigned_session_cookie") do |k|
           v = stale_session_check! do
-            if data = get_cookie(req)
-              data.stringify_keys!
-            end
-            data || {}
+            data = get_cookie(req) || {}
+            data.with_indifferent_access
           end
           req.set_header k, v
         end

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -24,8 +24,21 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
       render plain: Rack::Utils.escape(Verifier.generate(session.to_hash))
     end
 
+    def set_deep_session_value
+      session[:foo] = { bar: "baz" }
+      render plain: Rack::Utils.escape(Verifier.generate(session.to_hash))
+    end
+
     def get_session_value
       render plain: "foo: #{session[:foo].inspect}"
+    end
+
+    def get_deep_session_value_with_symbol
+      render plain: "foo: { bar: #{session[:foo][:bar].inspect} }"
+    end
+
+    def get_deep_session_value_with_string
+      render plain: "foo: { \"bar\" => #{session[:foo]["bar"].inspect} }"
     end
 
     def get_session_id
@@ -92,6 +105,18 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
       get '/get_session_id'
       assert_response :success
       assert_equal "id: #{session_id}", response.body, "should be able to read session id without accessing the session hash"
+    end
+  end
+
+  def test_getting_session_has_indifferent_access
+    with_test_route_set do
+      get '/set_deep_session_value'
+
+      get '/get_deep_session_value_with_symbol'
+      assert_equal 'foo: { bar: "baz" }', response.body
+
+      get '/get_deep_session_value_with_string'
+      assert_equal 'foo: { "bar" => "baz" }', response.body
     end
   end
 


### PR DESCRIPTION
Another shot at allowing the session to be accessed via `HashWithIndifferentAccess`. This time it should only affect the cookie store, and only when unpacking it

Related to https://github.com/rails/rails/pull/20851 and https://github.com/rails/rails/issues/23884
