### PR TITLE
sanitized_value should not remove cjk character

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -904,9 +904,8 @@ module ActionView
           output.safe_concat("</form>")
         end
 
-        # see http://www.w3.org/TR/html4/types.html#type-name
         def sanitize_to_id(name)
-          name.to_s.delete(']').tr('^-a-zA-Z0-9:.', "_")
+          name.to_s.delete(']').gsub(/[^-:.\p{Word}]/, "_")
         end
     end
   end

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -114,7 +114,7 @@ module ActionView
         end
 
         def sanitized_value(value)
-          value.to_s.gsub(/\s/, "_").gsub(/[^-\w]/, "").downcase
+          value.to_s.gsub(/\s/, "_").gsub(/[^-\p{Word}]/, "").downcase
         end
 
         def select_content_tag(option_tags, options, html_options)

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -317,6 +317,19 @@ class FormCollectionsHelperTest < ActionView::TestCase
     assert_select 'label[for=bar]'
   end
 
+  test 'collection check boxes propagates input id to the label for attribute with cjk characters' do
+    collection = ['中国', '日本', '한국']
+    with_collection_check_boxes :user, :visited, collection, :to_s, :to_s
+
+    assert_select 'input[type=checkbox][value="中国"]#user_visited_中国'
+    assert_select 'input[type=checkbox][value="日本"]#user_visited_日本'
+    assert_select 'input[type=checkbox][value="한국"]#user_visited_한국'
+
+    assert_select 'label[for=user_visited_中国]'
+    assert_select 'label[for=user_visited_日本]'
+    assert_select 'label[for=user_visited_한국]'
+  end
+
   test 'collection check boxes sets the label class defined inside the block' do
     collection = [[1, 'Category 1', {class: 'foo'}], [2, 'Category 2', {class: 'bar'}]]
     with_collection_check_boxes :user, :active, collection, :second, :first do |b|

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -213,6 +213,10 @@ class FormTagHelperTest < ActionView::TestCase
     actual = radio_button_tag('ctrlname', 'apache2.2')
     expected = %(<input id="ctrlname_apache2.2" name="ctrlname" type="radio" value="apache2.2" />)
     assert_dom_equal expected, actual
+
+    actual = radio_button_tag('country', '中国')
+    expected = %(<input id="country_中国" name="country" type="radio" value="中国" />)
+    assert_dom_equal expected, actual
   end
 
   def test_select_tag


### PR DESCRIPTION
according to http://www.w3.org/TR/html-markup/syntax.html#syntax-text

> Text in element contents (including in comments) and attribute values must consist of Unicode characters, with the following restrictions:
> - must not contain U+0000 characters
> - must not contain permanently undefined Unicode characters
> - must not contain control characters other than space characters
