### PR TITLE
Update rails-dom-testing gem to 2.0

### DIFF
--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'activejob', version
 
   s.add_dependency 'mail', ['~> 2.5', '>= 2.5.4']
-  s.add_dependency 'rails-dom-testing', '~> 1.0', '>= 1.0.5'
+  s.add_dependency 'rails-dom-testing', '~> 2.0'
 end

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack',      '~> 2.x'
   s.add_dependency 'rack-test', '~> 0.6.3'
   s.add_dependency 'rails-html-sanitizer', '~> 1.0', '>= 1.0.2'
-  s.add_dependency 'rails-dom-testing', '~> 1.0', '>= 1.0.5'
+  s.add_dependency 'rails-dom-testing', '~> 2.0'
   s.add_dependency 'actionview', version
 
   s.add_development_dependency 'activemodel', version

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'builder',       '~> 3.1'
   s.add_dependency 'erubis',        '~> 2.7.0'
   s.add_dependency 'rails-html-sanitizer', '~> 1.0', '>= 1.0.2'
-  s.add_dependency 'rails-dom-testing', '~> 1.0', '>= 1.0.5'
+  s.add_dependency 'rails-dom-testing', '~> 2.0'
 
   s.add_development_dependency 'actionpack',  version
   s.add_development_dependency 'activemodel', version


### PR DESCRIPTION
### Summary

Update rails-dom-testing gem to [2.0.0](https://rubygems.org/gems/rails-dom-testing/versions/2.0.0) for compatibility with Rails 5.

Resolves #24924.
