### PR TITLE
do not add `ActionView::Digestor::PerRequestDigestCacheExpiry` to API only applications

### DIFF
--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -39,7 +39,7 @@ module ActionView
 
     initializer "action_view.per_request_digest_cache" do |app|
       ActiveSupport.on_load(:action_view) do
-        if app.config.consider_all_requests_local
+        if app.config.consider_all_requests_local && !app.config.api_only
           app.middleware.use ActionView::Digestor::PerRequestDigestCacheExpiry
         end
       end

--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -331,6 +331,19 @@ will be:
 { :person => { :firstName => "Yehuda", :lastName => "Katz" } }
 ```
 
+### Using ActionView::Digestor::PerRequestDigestCacheExpiry
+
+If you're using digest caching — e.g. via cache helpers in templates — you
+should add `ActionView::Digestor::PerRequestDigestCacheExpiry` to ensure the
+template digests Rails caches in a request is cleared when it's done.
+The middleware should only be included in development environments. Therefore use:
+
+```ruby
+if app.config.consider_all_requests_local
+ config.middleware.use ActionView::Digestor::PerRequestDigestCacheExpiry
+end
+```
+
 ### Other Middleware
 
 Rails ships with a number of other middleware that you might want to use in an


### PR DESCRIPTION
API only applications is not used templates by default, I think that is unnecessary.
