### PR TITLE
fix fixtures on multiple databases

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -505,47 +505,58 @@ module ActiveRecord
       }
 
       unless files_to_read.empty?
-        connection.disable_referential_integrity do
-          fixtures_map = {}
+        fixtures_map = {}
 
-          fixture_sets = files_to_read.map do |fs_name|
-            klass = class_names[fs_name]
-            conn = klass ? klass.connection : connection
-            fixtures_map[fs_name] = new( # ActiveRecord::FixtureSet.new
+        fixture_sets = files_to_read.map do |fs_name|
+          klass = class_names[fs_name]
+          conn = klass ? klass.connection : connection
+          fixtures_map[fs_name] = new(# ActiveRecord::FixtureSet.new
               conn,
               fs_name,
               klass,
               ::File.join(fixtures_directory, fs_name))
-          end
+        end
 
-          update_all_loaded_fixtures fixtures_map
+        update_all_loaded_fixtures fixtures_map
 
-          connection.transaction(:requires_new => true) do
-            fixture_sets.each do |fs|
-              conn = fs.model_class.respond_to?(:connection) ? fs.model_class.connection : connection
-              table_rows = fs.table_rows
+        all_connections = ActiveRecord::Base.connection_handler.connection_pool_list.map(&:connection)
+        disable_referential_integrity_in_transaction(all_connections) do
+          fixture_sets.each do |fs|
+            conn = fs.model_class.respond_to?(:connection) ? fs.model_class.connection : connection
+            table_rows = fs.table_rows
 
-              table_rows.each_key do |table|
-                conn.delete "DELETE FROM #{conn.quote_table_name(table)}", 'Fixture Delete'
-              end
+            table_rows.each_key do |table|
+              conn.delete "DELETE FROM #{conn.quote_table_name(table)}", 'Fixture Delete'
+            end
 
-              table_rows.each do |fixture_set_name, rows|
-                rows.each do |row|
-                  conn.insert_fixture(row, fixture_set_name)
-                end
-              end
-
-              # Cap primary key sequences to max(pk).
-              if conn.respond_to?(:reset_pk_sequence!)
-                conn.reset_pk_sequence!(fs.table_name)
+            table_rows.each do |fixture_set_name, rows|
+              rows.each do |row|
+                conn.insert_fixture(row, fixture_set_name)
               end
             end
-          end
 
-          cache_fixtures(connection, fixtures_map)
+            # Cap primary key sequences to max(pk).
+            if conn.respond_to?(:reset_pk_sequence!)
+              conn.reset_pk_sequence!(fs.table_name)
+            end
+          end
         end
+        cache_fixtures(connection, fixtures_map)
       end
       cached_fixtures(connection, fixture_set_names)
+    end
+
+    # disables referential integrity on all connections and
+    # starts a transaction on all connection. Finally it executes the
+    # given block.
+    def self.disable_referential_integrity_in_transaction connections, &block
+      return block.call if connections.empty?
+      connection = connections.shift
+      connection.disable_referential_integrity do
+        connection.transaction(:requires_new => true) do
+          disable_referential_integrity_in_transaction connections, &block
+        end
+      end
     end
 
     # Returns a consistent, platform-independent identifier for +label+.


### PR DESCRIPTION
### Summary

When loading fixtures in multiple databases the integrity check is only disabled on one connection (the default). This patch disables the integrity check on all connections and starts a transaction on all connections to load the fixtures into all databases. Finally it restores the integrity check.

As far as I know there is no github issue for this, yet.
I'd like to see this in 4.2 but I can also port this to the 5.0 branch.

Unfortunately I can't provide tests, as I had some issues to have a multi-database test set up running. Can someone more experienced elaborate on this?
