### PR TITLE
Minor syntax change

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -328,7 +328,7 @@ this:
     respond_to do |format|
       if @user.save
         format.html { redirect_to @user, notice: 'User was successfully created.' }
-        format.js   {}
+        format.js
         format.json { render json: @user, status: :created, location: @user }
       else
         format.html { render action: "new" }


### PR DESCRIPTION
### Summary

While working on this very example recently, I found that Rails will throw POST errors if you leave an empty block in front the `format.js` when using either `remote: true` or vanilla  JS/JQuery.
