### PR TITLE
Fix ActiveRecord::LogSubscriber edge case

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -22,7 +22,11 @@ module ActiveRecord
 
     def render_bind(attribute)
       value = if attribute.type.binary? && attribute.value
-        "<#{attribute.value.bytesize} bytes of binary data>"
+        if attribute.value.is_a?(Hash)
+          "<#{attribute.value_for_database.to_s.bytesize} bytes of binary data>"
+        else
+          "<#{attribute.value.bytesize} bytes of binary data>"
+        end
       else
         attribute.value_for_database
       end

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -215,5 +215,11 @@ class LogSubscriberTest < ActiveRecord::TestCase
       wait
       assert_match(/<16 bytes of binary data>/, @logger.logged(:debug).join)
     end
+
+    def test_binary_data_hash
+      Binary.create(data: { a: 1 })
+      wait
+      assert_match(/<7 bytes of binary data>/, @logger.logged(:debug).join)
+    end
   end
 end


### PR DESCRIPTION
If an attribute was of the binary type, and also was a Hash, it would
previously not be logged, and instead raise an error saying that
`bytesize` was not defined for the `attribute.value` (a `Hash`).

Now, as is done on 4-2-stable, the attribute's database value is
`bytesize`d, and then logged out to the terminal.

Fixes #24955.

Reproduction script:

``` ruby
require 'active_record'
require 'minitest/autorun'
require 'logger'

ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.binary :preferences
  end
end

class Post < ActiveRecord::Base
  serialize :preferences
end

class BugTest < Minitest::Test
  def test_24955
    Post.create!(preferences: {a: 1})

    assert_equal 1, Post.count
  end
end
```
