### PR TITLE
Provide a default Content Security Policy (CSP) that is lenient yet secure

### DIFF
--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -21,7 +21,9 @@ module ActionDispatch
     config.action_dispatch.default_headers = {
       'X-Frame-Options' => 'SAMEORIGIN',
       'X-XSS-Protection' => '1; mode=block',
-      'X-Content-Type-Options' => 'nosniff'
+      'X-Content-Type-Options' => 'nosniff',
+      'Content-Security-Policy' =>
+        "default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src 'self' https:; style-src 'self' https: 'unsafe-inline'"
     }
 
     config.eager_load_namespaces << ActionDispatch


### PR DESCRIPTION
### Summary

This is not a new idea, ["Add Content Security Policy(CSP)"](https://github.com/rails/rails/pull/15777) has been proposed but seems to be stuck in analysis paralysis. Perfect being the enemy good, here's an alternate proposal solving a slightly different problem. Rather than a general solution, this PR proposes a generic CSP that may work for most applications.

Building on the concept of `default_headers`, it would be great if CSP was applied by default. This is mostly geared towards new applications. Unfortunately, making this "report only" will generate a warning in the console since the policy, understandably, lacks a report-uri value. Adding a default report-uri realistically would require adding a CSP reporting endpoint to rails by default. Perhaps it could use the [middleware @xuchu provided](https://github.com/rails/rails/pull/15777/files#diff-3415f63beb241431931eca170e854079).

**Because of these factors, applying the potentially breaking header probably better suited as part of a generator script for new applications but I don't know the cleanest way of accomplishing this.**

In past lives (e.g. Twitter scala applications), applying CSP by default had amazing returns. CSP adoption and awareness went from "wat"/"meh" to "this is useful". The suggested policy should work for most applications and the browser console literally tells you what modifications need to be made. Brand new applications do not produce any violations. Adding code that violates this policy could be caught early on and people can choose to work within the suggested boundaries or they can decide to modify the policy. Naturally, there will be those who disable the policy entirely. That is entirely up to them but at least some thought will be put into it.

This is a bit contentious, of course.
### Other Information

Needs tests, but I wanted to wait for a better integration point before I write tests I know I'm going to throw away.

[An Introduction to Content Security Policy](http://www.html5rocks.com/en/tutorials/security/content-security-policy/)
[GitHub's CSP Journey](http://githubengineering.com/githubs-csp-journey/)

> Thanks for contributing to Rails!

No, no, no. Thank _you_ Rails!
