### PR TITLE
Make pg adapter use bigserial for pk by default

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -18,4 +18,8 @@
 
     *Erol Fornoles*
 
+*   PostgreSQL: Use bigserial as primary key type for new tables
+
+    *Pavel Pravosud*
+
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         private
 
         def default_primary_key?(column)
-          schema_type(column) == :serial
+          schema_type(column) == :bigserial
         end
 
         def schema_type(column)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -70,7 +70,7 @@ module ActiveRecord
       ADAPTER_NAME = 'PostgreSQL'.freeze
 
       NATIVE_DATABASE_TYPES = {
-        primary_key: "serial primary key",
+        primary_key: "bigserial primary key",
         string:      { name: "character varying" },
         text:        { name: "text" },
         integer:     { name: "integer" },

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -103,6 +103,16 @@ module ActiveRecord
       end
 
       class V5_0 < V5_1
+        def create_table(table_name, options = {})
+          # Since version 5.1 Postgres adapter uses bigserial type for primary
+          # keys by default. This compat layer makes old migrations utilize
+          # serial type instead, the way it used to work before 5.1
+          if connection.adapter_name == "PostgreSQL"
+            options[:id] ||= "serial"
+          end
+
+          super table_name, options
+        end
       end
 
       class V4_2 < V5_0

--- a/activerecord/test/cases/adapters/postgresql/legacy_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/legacy_migration_test.rb
@@ -1,0 +1,49 @@
+require "cases/helper"
+
+class PostgreslqLegacyMigrationTest < ActiveRecord::PostgreSQLTestCase
+  class GenerateTableWithoutBigserial < ActiveRecord::Migration::Compatibility::V5_0
+    def change
+      create_table :legacy_integer_pk do |table|
+        table.string :foo
+      end
+
+      create_table :override_pk, id: :bigint do |table|
+        table.string :bar
+      end
+    end
+  end
+
+  def setup
+    super
+
+    @migration_verbose_old = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+
+    migrations = [GenerateTableWithoutBigserial.new(nil, 1)]
+    ActiveRecord::Migrator.new(:up, migrations).migrate
+  end
+
+  def teardown
+    ActiveRecord::Migration.verbose = @migration_verbose_old
+
+    super
+  end
+
+  def test_create_table_uses_serial_as_pkey_by_default
+    assert_equal "integer", sql_type_for(:legacy_integer_pk, :id)
+  end
+
+  def test_create_tables_respects_pk_column_type_override
+    assert_equal "bigint", sql_type_for(:override_pk, :id)
+  end
+
+  private
+
+  def sql_type_for(table_name, column_name)
+    column = ActiveRecord::Base.connection
+      .columns(table_name.to_s)
+      .detect { |c| c.name == column_name.to_s }
+
+    column && column.sql_type
+  end
+end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -327,6 +327,7 @@ if current_adapter?(:PostgreSQLAdapter, :Mysql2Adapter)
       @connection = ActiveRecord::Base.connection
       if current_adapter?(:PostgreSQLAdapter)
         @connection.create_table(:widgets, id: :bigserial, force: true)
+        @connection.create_table(:badges, id: :serial, force: true)
       else
         @connection.create_table(:widgets, id: :bigint, force: true)
       end
@@ -348,10 +349,18 @@ if current_adapter?(:PostgreSQLAdapter, :Mysql2Adapter)
       assert_not_nil widget.id
     end
 
+    if current_adapter?(:PostgreSQLAdapter)
+      test "schema dump primary key with serial" do
+        schema = dump_table_schema "badges"
+        assert_match %r{create_table "badges", id: :serial, force: :cascade}, schema
+      end
+    end
+
     test "schema dump primary key with bigserial" do
       schema = dump_table_schema "widgets"
       if current_adapter?(:PostgreSQLAdapter)
-        assert_match %r{create_table "widgets", id: :bigserial, force: :cascade}, schema
+        # bigserial is the default for PostgreSQL adapter, so it won't show up
+        assert_match %r{create_table "widgets", force: :cascade}, schema
       else
         assert_match %r{create_table "widgets", id: :bigint, force: :cascade}, schema
       end


### PR DESCRIPTION
This PR makes postgres adapter generate tables using bigserial type for primary keys. There are no performance implications by doing this and it should be fully backwards compatible.

Also, see https://twitter.com/pvh/status/730141012048281600

/cc @tenderlove @pvh @schneems @hone 
