### PR TITLE
Fix database runtimes on production log

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -31,9 +31,8 @@ module ActiveRecord
     end
 
     def sql(event)
-      return unless logger.debug?
-
       self.class.runtime += event.duration
+      return unless logger.debug?
 
       payload = event.payload
 


### PR DESCRIPTION
### Summary

Rails default production configuration establishes `info` as log level. Due to the changes included on https://github.com/rails/rails/commit/191facc857bb4fb52078fb544c6bc1613a81cc80, database runtimes are not being collected if the log level is different than `debug`. This produces that production log reports `db=0.0ms` as database runtime.
### Other Information

Sorry, I tried to include a test to cover this case, but I was not sure about how to do it or where to put it (probably here https://github.com/rails/rails/blob/master/actionpack/test/controller/log_subscriber_test.rb)

/cc @eileencodes 
