### PR TITLE
Don't perform unnecessary check with false, just use true/false values

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -86,7 +86,7 @@ module ActiveRecord
       def initialize(connection, logger, connection_options, config)
         super(connection, logger, config)
 
-        @active     = nil
+        @active     = true
         @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
       end
 
@@ -134,7 +134,7 @@ module ActiveRecord
       end
 
       def active?
-        @active != false
+        @active
       end
 
       # Disconnects from the database if already connected. Otherwise, this


### PR DESCRIPTION
Don't perform unnecessary check with false, just use true/false values for @active on SQLite adapter.
