### PR TITLE
Change some establish_connection logic

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -911,8 +911,7 @@ module ActiveRecord
             # A connection was established in an ancestor process that must have
             # subsequently forked. We can't reuse the connection, but we can copy
             # the specification and establish a new connection with it.
-            spec = ancestor_pool.spec
-            establish_connection(spec.config.merge("name" => spec.name)).tap do |pool|
+            establish_connection(ancestor_pool.spec.to_hash).tap do |pool|
               pool.schema_cache = ancestor_pool.schema_cache if ancestor_pool.schema_cache
             end
           else

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -837,7 +837,15 @@ module ActiveRecord
       end
       alias :connection_pools :connection_pool_list
 
-      def establish_connection(spec)
+      def establish_connection(spec_or_config, name: "primary")
+        if spec_or_config.is_a?(ConnectionSpecification)
+          spec = spec_or_config
+        else
+          resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new(ActiveRecord::Base.configurations)
+          spec = resolver.spec(spec_or_config, name)
+        end
+
+        remove_connection(spec.name)
         owner_to_pool[spec.name] = ConnectionAdapters::ConnectionPool.new(spec)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -180,6 +180,10 @@ module ActiveRecord
 
           adapter_method = "#{spec[:adapter]}_connection"
 
+          unless ActiveRecord::Base.respond_to?(adapter_method)
+            raise AdapterNotFound, "database configuration specifies nonexistent #{spec.config[:adapter]} adapter"
+          end
+
           name ||=
             if config.is_a?(Symbol)
               config.to_s

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -164,7 +164,7 @@ module ActiveRecord
         #   spec.config
         #   # => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" }
         #
-        def spec(config, name = nil)
+        def spec(config)
           spec = resolve(config).symbolize_keys
 
           raise(AdapterNotSpecified, "database configuration does not specify adapter") unless spec.key?(:adapter)
@@ -184,13 +184,7 @@ module ActiveRecord
             raise AdapterNotFound, "database configuration specifies nonexistent #{spec.config[:adapter]} adapter"
           end
 
-          name ||=
-            if config.is_a?(Symbol)
-              config.to_s
-            else
-              "primary"
-            end
-          ConnectionSpecification.new(name, spec, adapter_method)
+          ConnectionSpecification.new(spec.delete(:name) || "primary", spec, adapter_method)
         end
 
         private
@@ -235,7 +229,7 @@ module ActiveRecord
         #
         def resolve_symbol_connection(spec)
           if config = configurations[spec.to_s]
-            resolve_connection(config)
+            resolve_connection(config).merge("name" => spec.to_s)
           else
             raise(AdapterNotSpecified, "'#{spec}' database is not configured. Available: #{configurations.keys.inspect}")
           end

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -13,6 +13,10 @@ module ActiveRecord
         @config = original.config.dup
       end
 
+      def to_hash
+        @config.merge(name: @name)
+      end
+
       # Expands a connection string into a hash.
       class ConnectionUrlResolver # :nodoc:
 

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -44,21 +44,13 @@ module ActiveRecord
     #
     # The exceptions AdapterNotSpecified, AdapterNotFound and +ArgumentError+
     # may be returned on an error.
-    def establish_connection(spec = nil)
+    def establish_connection(config = nil)
       raise "Anonymous class is not allowed." unless name
 
-      spec     ||= DEFAULT_ENV.call.to_sym
-      resolver =   ConnectionAdapters::ConnectionSpecification::Resolver.new configurations
-      # TODO: uses name on establish_connection, for backwards compatibility
-      spec     =   resolver.spec(spec, self == Base ? "primary" : name)
-
-      unless respond_to?(spec.adapter_method)
-        raise AdapterNotFound, "database configuration specifies nonexistent #{spec.config[:adapter]} adapter"
-      end
-
-      remove_connection(spec.name)
-      self.connection_specification_name = spec.name
-      connection_handler.establish_connection spec
+      config ||= DEFAULT_ENV.call.to_sym
+      spec_name = self == Base ? "primary" : name
+      self.connection_specification_name = spec_name
+      connection_handler.establish_connection(config, name: spec_name)
     end
 
     class MergeAndResolveDefaultUrlConfig # :nodoc:

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -50,7 +50,12 @@ module ActiveRecord
       config ||= DEFAULT_ENV.call.to_sym
       spec_name = self == Base ? "primary" : name
       self.connection_specification_name = spec_name
-      connection_handler.establish_connection(config, name: spec_name)
+
+      resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new(Base.configurations)
+      spec = resolver.resolve(config).symbolize_keys
+      spec[:name] = spec_name
+
+      connection_handler.establish_connection(spec)
     end
 
     class MergeAndResolveDefaultUrlConfig # :nodoc:

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -120,7 +120,7 @@ module ActiveRecord
         old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
         each_local_configuration { |configuration| create configuration }
         if old_pool
-          ActiveRecord::Base.connection_handler.establish_connection(old_pool.spec.config.merge("name" => old_pool.spec.name))
+          ActiveRecord::Base.connection_handler.establish_connection(old_pool.spec.to_hash)
         end
       end
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -120,7 +120,7 @@ module ActiveRecord
         old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
         each_local_configuration { |configuration| create configuration }
         if old_pool
-          ActiveRecord::Base.connection_handler.establish_connection(old_pool.spec)
+          ActiveRecord::Base.connection_handler.establish_connection(old_pool.spec.config.merge("name" => old_pool.spec.name))
         end
       end
 

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -5,16 +5,15 @@ module ActiveRecord
     class ConnectionHandlerTest < ActiveRecord::TestCase
       def setup
         @handler = ConnectionHandler.new
-        resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new Base.configurations
         @spec_name = "primary"
-        @pool    = @handler.establish_connection(resolver.spec(:arunit, @spec_name))
+        @pool    = @handler.establish_connection(ActiveRecord::Base.configurations['arunit'])
       end
 
       def test_establish_connection_uses_spec_name
         config = {"readonly" => {"adapter" => 'sqlite3'}}
         resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new(config)
         spec =   resolver.spec(:readonly)
-        @handler.establish_connection(spec)
+        @handler.establish_connection(spec.config.merge("name" => spec.name))
 
         assert_not_nil @handler.retrieve_connection_pool('readonly')
       ensure

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         config = {"readonly" => {"adapter" => 'sqlite3'}}
         resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new(config)
         spec =   resolver.spec(:readonly)
-        @handler.establish_connection(spec.config.merge("name" => spec.name))
+        @handler.establish_connection(spec.to_hash)
 
         assert_not_nil @handler.retrieve_connection_pool('readonly')
       ensure

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -27,7 +27,7 @@ module ActiveRecord
         ENV['DATABASE_URL'] = "postgres://localhost/foo"
         config   = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
         actual   = resolve_spec(:default_env, config)
-        expected = { "adapter"=>"postgresql", "database"=>"foo", "host"=>"localhost" }
+        expected = { "adapter"=>"postgresql", "database"=>"foo", "host"=>"localhost", "name"=>"default_env" }
         assert_equal expected, actual
       end
 
@@ -37,7 +37,7 @@ module ActiveRecord
 
         config   = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
         actual   = resolve_spec(:foo, config)
-        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost" }
+        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost","name"=>"foo" }
         assert_equal expected, actual
       end
 
@@ -47,7 +47,7 @@ module ActiveRecord
 
         config   = { "not_production" => { "adapter" => "not_postgres", "database" => "not_foo" } }
         actual   = resolve_spec(:foo, config)
-        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost" }
+        expected = { "adapter" => "postgresql", "database" => "foo", "host" => "localhost","name"=>"foo" }
         assert_equal expected, actual
       end
 
@@ -55,7 +55,7 @@ module ActiveRecord
         ENV['DATABASE_URL'] = "postgres://localhost/foo"
         config   = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
         actual   = resolve_spec(:production, config)
-        expected = { "adapter"=>"not_postgres", "database"=>"not_foo", "host"=>"localhost" }
+        expected = { "adapter"=>"not_postgres", "database"=>"not_foo", "host"=>"localhost", "name"=>"production" }
         assert_equal expected, actual
       end
 
@@ -93,7 +93,7 @@ module ActiveRecord
         ENV['DATABASE_URL'] = "ibm-db://localhost/foo"
         config   = { "default_env" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
         actual   = resolve_spec(:default_env, config)
-        expected = { "adapter"=>"ibm_db", "database"=>"foo", "host"=>"localhost" }
+        expected = { "adapter"=>"ibm_db", "database"=>"foo", "host"=>"localhost", "name"=>"default_env" }
         assert_equal expected, actual
       end
 

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -28,7 +28,8 @@ module ActiveRecord
           assert_equal({
             "adapter"  =>  "abstract",
             "host"     =>  "foo",
-            "encoding" => "utf8" }, spec)
+            "encoding" => "utf8",
+            "name"     => "production"}, spec)
         end
 
         def test_url_sub_key
@@ -36,7 +37,8 @@ module ActiveRecord
           assert_equal({
             "adapter"  => "abstract",
             "host"     => "foo",
-            "encoding" => "utf8" }, spec)
+            "encoding" => "utf8",
+            "name"     => "production"}, spec)
         end
 
         def test_url_sub_key_merges_correctly
@@ -46,7 +48,8 @@ module ActiveRecord
             "adapter"  => "abstract",
             "host"     => "foo",
             "encoding" => "utf8",
-            "pool"     => "3" }, spec)
+            "pool"     => "3",
+            "name"     => "production"}, spec)
         end
 
         def test_url_host_no_db
@@ -113,7 +116,8 @@ module ActiveRecord
           assert_equal({
             "adapter"  => "sqlite3",
             "database" => "foo",
-            "encoding" => "utf8" }, spec)
+            "encoding" => "utf8",
+            "name"     => "production"}, spec)
         end
 
         def test_spec_name_on_key_lookup


### PR DESCRIPTION
### Summary

Move `establish_connection` to connection handler.
This give us room to deprecate `establish_connection` on the AR::Base to use the one from the connection handler instead.
### Details

As you know, now the connection handler is not coupled with the model anymore, so establish connection should not be a method in the model.

With this API, you would do something like:

```
ActiveRecord::Base.connection_handler.establish_connection({database: 'foo'}, name: "readonly")
class User < ActiveRecord::Base
  self.connection_specification_name = "readonly"
end

ActiveRecord::Base.connection_handler.establish_connection(:some_key_from_databaseyml, name: "readonly")

ActiveRecord::Base.connection_handler.establish_connection("URL://", name: "readonly")
```

This is backwards compatible as far as I can tell, so it is safe to be backported to 5.0.0
### Next steps (all still up to discussion)
- Make AR internals use `ActiveRecord::Base.connection_handler.establish_connection` API
- Deprecate `AR::Base.establish_connection`
- Make ConnectionSpecification only work with a hash or a string.
  - Hash: when passing a full config
  - String: using a database url
  - Symbol: we wont need this anymore, this is used to point to a config from the databases.yml file (see next item)
- Change database.yml file to the following:

```
production:
  primary: 
    database: foo
  secondary:
    database: foo_readonly
  shard:
    database: shard1
```

Like that, the railties AR initializer, can iterate over the ENV key, and create pools for each of the configs using the right name.

cc @jeremy @tenderlove @rafaelfranca @matthewd 
also @jrafanie as we discussed that today.
