### PR TITLE
Dont cache the conn_spec_name when empty

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -96,7 +96,7 @@ module ActiveRecord
     # Return the specification name from the current class or its parent.
     def connection_specification_name
       if !defined?(@connection_specification_name) || @connection_specification_name.nil?
-        @connection_specification_name = self == Base ? "primary" : superclass.connection_specification_name
+        return self == Base ? "primary" : superclass.connection_specification_name
       end
       @connection_specification_name
     end

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -91,7 +91,7 @@ module ActiveRecord
         end
 
         def test_a_class_using_custom_pool_and_switching_back_to_primary
-          klass2     = Class.new(Base)   { def self.name; 'klass2'; end }
+          klass2 = Class.new(Base) { def self.name; 'klass2'; end }
 
           assert_equal klass2.connection.object_id, ActiveRecord::Base.connection.object_id
 
@@ -102,6 +102,15 @@ module ActiveRecord
           klass2.remove_connection
 
           assert_equal klass2.connection.object_id, ActiveRecord::Base.connection.object_id
+        end
+
+        def test_connection_specification_name_should_fallback_to_parent
+          klassA = Class.new(Base)
+          klassB = Class.new(klassA)
+
+          assert_equal klassB.connection_specification_name, klassA.connection_specification_name
+          klassA.connection_specification_name = "readonly"
+          assert_equal "readonly", klassB.connection_specification_name
         end
       end
     end


### PR DESCRIPTION
### Summary

We cannot cache the connection_specification_name when it doesn't
exist. Thats because the parent value could change, and we should keep
falling back to the parent. If we cache that in a children as an ivar,
we would not fallback anymore in the next call, so the children would
not get the new parent spec_name.

review @matthewd as we discussed that.

There is also another way we could cache this, using a hash on AR::Base and cleaning the hash when removing/establish connection. something like https://github.com/rails/rails/commit/e96558f8138d01ea64096f152f32c480af0861e6 , However I dont think thats worth the optimization, as the number of parents that this would fallback is not going to be a big number, so a N call is a ok trade off in that case.
