### PR TITLE
Added method none? to ArrayInquirer.

### DIFF
--- a/activesupport/lib/active_support/array_inquirer.rb
+++ b/activesupport/lib/active_support/array_inquirer.rb
@@ -28,6 +28,20 @@ module ActiveSupport
       end
     end
 
+    # Passes each element of +candidates+ collection to ArrayInquirer collection.
+    # The method returns true if none of the elements in +candidates+ are part of ArrayInquirer collection.
+    # If +candidates+ collection is not given, method returns false.
+    #
+    #   variants = ActiveSupport::ArrayInquirer.new([:phone, :tablet])
+    #
+    #   variants.none?                     # => false
+    #   variants.none?(:phone, :tablet)     # => false
+    #   variants.none?('phone', 'desktop')  # => false
+    #   variants.none?(:desktop, :watch)    # => true
+    def none?(*candidates, &block)
+      !any?(*candidates, &block)
+    end
+
     private
       def respond_to_missing?(name, include_private = false)
         name[-1] == '?'

--- a/activesupport/test/array_inquirer_test.rb
+++ b/activesupport/test/array_inquirer_test.rb
@@ -18,14 +18,34 @@ class ArrayInquirerTest < ActiveSupport::TestCase
     assert_not @array_inquirer.any?(:desktop, :watch)
   end
 
+  def test_none
+    assert_not @array_inquirer.none?
+    assert @array_inquirer.none?(:desktop)
+    assert @array_inquirer.none?(:desktop, :watch)
+    assert_not @array_inquirer.none?(:watch, :tablet)
+    assert_not @array_inquirer.none?(:mobile)
+  end
+
   def test_any_string_symbol_mismatch
     assert @array_inquirer.any?('mobile')
     assert @array_inquirer.any?(:api)
   end
 
+  def test_none_string_symbol_mismatch
+    assert_not @array_inquirer.none?('mobile')
+    assert_not @array_inquirer.none?(:api)
+    assert @array_inquirer.none?(:desktop)
+    assert @array_inquirer.none?('laptop')
+  end
+
   def test_any_with_block
     assert @array_inquirer.any? { |v| v == :mobile }
     assert_not @array_inquirer.any? { |v| v == :desktop }
+  end
+
+  def test_none_with_block
+    assert_not @array_inquirer.none? { |v| v == :mobile }
+    assert @array_inquirer.none? { |v| v == :desktop }
   end
 
   def test_respond_to


### PR DESCRIPTION
This is complementary to the `any?` method present in ActiveSupport::ArrayInquirer.

```
variants = ActiveSupport::ArrayInquirer.new([:phone, :tablet])
variants.none?                     # => false
variants.none?(:phone, :tablet)     # => false
variants.none?('phone', 'desktop')  # => false
variants.none?(:desktop, :watch)    # => true

```
