### PR TITLE
Specify that we prefer that [ci skip] is added in issue name as well

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -144,7 +144,7 @@ When working with documentation, please take into account the [API Documentation
 
 NOTE: As explained earlier, ordinary code patches should have proper documentation coverage. Docrails is only used for isolated documentation improvements.
 
-NOTE: To help our CI servers you should add [ci skip] to your documentation commit message to skip build on that commit. Please remember to use it for commits containing only documentation changes.
+NOTE: To help our CI servers you should add [ci skip] to your documentation commit message, and the GitHub Pull Request title, to skip build on that commit. Please remember to use it for commits containing only documentation changes.
 
 WARNING: Docrails has a very strict policy: no code can be touched whatsoever, no matter how trivial or small the change. Only RDoc and guides can be edited via docrails. Also, CHANGELOGs should never be edited in docrails.
 


### PR DESCRIPTION
Specify that we prefer that [ci skip] is added in issue name as well. This is to avoid running tests on merge commit, which consists of issue name. If it does not have [ci skip] we still end up running tests on travis for a doc change. Example: https://travis-ci.org/rails/rails/builds/128647792 
