### PR TITLE
Make 'migrate' clear the schema cache afterward

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -137,6 +137,7 @@ module ActiveRecord
         Migrator.migrate(migrations_paths, version) do |migration|
           scope.blank? || scope == migration.scope
         end
+        ActiveRecord::Base.clear_cache!
       ensure
         Migration.verbose = verbose_was
       end

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -274,18 +274,29 @@ module ActiveRecord
   end
 
   class DatabaseTasksMigrateTest < ActiveRecord::TestCase
+    def setup
+      ActiveRecord::Tasks::DatabaseTasks.migrations_paths = 'custom/path'
+    end
+
+    def teardown
+      ActiveRecord::Tasks::DatabaseTasks.migrations_paths = nil
+    end
+
     def test_migrate_receives_correct_env_vars
       verbose, version = ENV['VERBOSE'], ENV['VERSION']
 
-      ActiveRecord::Tasks::DatabaseTasks.migrations_paths = 'custom/path'
       ENV['VERBOSE'] = 'false'
       ENV['VERSION'] = '4'
 
       ActiveRecord::Migrator.expects(:migrate).with('custom/path', 4)
       ActiveRecord::Tasks::DatabaseTasks.migrate
     ensure
-      ActiveRecord::Tasks::DatabaseTasks.migrations_paths = nil
       ENV['VERBOSE'], ENV['VERSION'] = verbose, version
+    end
+
+    def test_migrate_clears_schema_cache_afterward
+      ActiveRecord::Base.expects(:clear_cache!)
+      ActiveRecord::Tasks::DatabaseTasks.migrate
     end
   end
 


### PR DESCRIPTION
back porting: https://github.com/rails/rails/pull/24305 to rails 4.2.x

Changes the migrate task to clear ActiveRecord caches afterward.

Without clearing the caches, removals done in migrations would not be reflected in a separate task in the same process. That is, given a table with a migration to remove a column, the schema cache would still reflect that a table has that in something such as the 'db:seed' task:

rake db:migrate db:seed
(A common thing to do in a script for a project ala bin/setup)

vs

rake db:migrate && rake db:seed
(Two processes)

The first would not reflect that the column was removed. The second would (cache reset)
