### PR TITLE
Define ActiveRecord::Attribute::Null#type_cast

### DIFF
--- a/activerecord/lib/active_record/attribute.rb
+++ b/activerecord/lib/active_record/attribute.rb
@@ -170,7 +170,7 @@ module ActiveRecord
         super(name, nil, Type::Value.new)
       end
 
-      def value
+      def type_cast(*)
         nil
       end
 

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -63,6 +63,15 @@ module ActiveRecord
       end
     end
 
+    test "model with nonexistent attribute with default value can be saved" do
+      klass = Class.new(OverloadedType) do
+        attribute :non_existent_string_with_default, :string, default: 'nonexistent'
+      end
+
+      model = klass.new
+      assert model.save
+    end
+
     test "changing defaults" do
       data = OverloadedType.new
       unoverloaded_data = UnoverloadedType.new


### PR DESCRIPTION
Using `ActiveRecord::Base.attribute` to declare an attribute with a default value on a model where the attribute is not backed by the database would raise a `NotImplementedError` when `model.save` is called.

The error originates from [activerecord/lib/active_record/attribute.rb#L84](https://github.com/rails/rails/blob/59d252196b36f6afaafd231756d69ea21537cf5d/activerecord/lib/active_record/attribute.rb#L84).
This is called from [activerecord/lib/active_record/attribute.rb#L46](https://github.com/rails/rails/blob/59d252196b36f6afaafd231756d69ea21537cf5d/activerecord/lib/active_record/attribute.rb#L46) on an `ActiveRecord::Attribute::Null` object.

This commit corrects the behavior by implementing `ActiveRecord::Attribute::Null#type_cast`.

With `ActiveRecord::Attribute::Null#type_cast` defined, [`ActiveRecord::Attribute::Null#value`](https://github.com/rails/rails/blob/59d252196b36f6afaafd231756d69ea21537cf5d/activerecord/lib/active_record/attribute.rb#L173..L175) can be replaced with its [super method](https://github.com/rails/rails/blob/59d252196b36f6afaafd231756d69ea21537cf5d/activerecord/lib/active_record/attribute.rb#L36..L40).

fixes #24979
