### PR TITLE
Improve documentation and tests for raw_host_with_port and host_with_…

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -217,7 +217,7 @@ module ActionDispatch
         @protocol ||= ssl? ? 'https://' : 'http://'
       end
 
-      # Returns the \host for this request, such as "example.com".
+      # Returns the \host and port for this request, such as "example.com:8080".
       #
       #   class Request < Rack::Request
       #     include ActionDispatch::Http::URL
@@ -225,6 +225,9 @@ module ActionDispatch
       #
       #   req = Request.new 'HTTP_HOST' => 'example.com'
       #   req.raw_host_with_port # => "example.com"
+      #
+      #   req = Request.new 'HTTP_HOST' => 'example.com:80'
+      #   req.raw_host_with_port # => "example.com:80"
       #
       #   req = Request.new 'HTTP_HOST' => 'example.com:8080'
       #   req.raw_host_with_port # => "example.com:8080"
@@ -236,7 +239,7 @@ module ActionDispatch
         end
       end
 
-      # Returns the host for this request, such as example.com.
+      # Returns the host for this request, such as "example.com".
       #
       #   class Request < Rack::Request
       #     include ActionDispatch::Http::URL
@@ -249,11 +252,15 @@ module ActionDispatch
       end
 
       # Returns a \host:\port string for this request, such as "example.com" or
-      # "example.com:8080".
+      # "example.com:8080". Port is only included if it is not a default port
+      # (80 or 443)
       #
       #   class Request < Rack::Request
       #     include ActionDispatch::Http::URL
       #   end
+      #
+      #   req = Request.new 'HTTP_HOST' => 'example.com'
+      #   req.host_with_port # => "example.com"
       #
       #   req = Request.new 'HTTP_HOST' => 'example.com:80'
       #   req.host_with_port # => "example.com"

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -417,6 +417,11 @@ class RequestPath < BaseRequestTest
 end
 
 class RequestHost < BaseRequestTest
+  test "host without specifying port" do
+    request = stub_request 'HTTP_HOST' => 'rubyonrails.org'
+    assert_equal "rubyonrails.org", request.host_with_port
+  end
+
   test "host with default port" do
     request = stub_request 'HTTP_HOST' => 'rubyonrails.org:80'
     assert_equal "rubyonrails.org", request.host_with_port
@@ -425,6 +430,21 @@ class RequestHost < BaseRequestTest
   test "host with non default port" do
     request = stub_request 'HTTP_HOST' => 'rubyonrails.org:81'
     assert_equal "rubyonrails.org:81", request.host_with_port
+  end
+
+  test "raw without specifying port" do
+    request = stub_request 'HTTP_HOST' => 'rubyonrails.org'
+    assert_equal "rubyonrails.org", request.raw_host_with_port
+  end
+
+  test "raw host with default port" do
+    request = stub_request 'HTTP_HOST' => 'rubyonrails.org:80'
+    assert_equal "rubyonrails.org:80", request.raw_host_with_port
+  end
+
+  test "raw host with non default port" do
+    request = stub_request 'HTTP_HOST' => 'rubyonrails.org:81'
+    assert_equal "rubyonrails.org:81", request.raw_host_with_port
   end
 
   test "proxy request" do


### PR DESCRIPTION
### Summary

Improve clarity of raw_host_with_port and host_with_port, with improved documentation and improved test coverage.

Currently it is not clear what the difference between raw_host_with_port and host_with_port is. This change makes it clearer, exactly what the differences are.
