### PR TITLE
Remove magic comment in generated `schema.rb`

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -50,10 +50,6 @@ module ActiveRecord
       def header(stream)
         define_params = @version ? "version: #{@version}" : ""
 
-        if stream.respond_to?(:external_encoding) && stream.external_encoding
-          stream.puts "# encoding: #{stream.external_encoding.name}"
-        end
-
         stream.puts <<HEADER
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -47,10 +47,6 @@ class SchemaDumperTest < ActiveRecord::TestCase
     end
   end
 
-  def test_magic_comment
-    assert_match "# encoding: #{Encoding.default_external.name}", standard_dump
-  end
-
   def test_schema_dump
     output = standard_dump
     assert_match %r{create_table "accounts"}, output


### PR DESCRIPTION
Rails 5.0 has been dropped Ruby 1.9 support.
I think no need magic comment anymore.
