### PR TITLE
Should work foreign key in test schema without `if supports_foreign_keys?` statement

### DIFF
--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -343,7 +343,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
         t.column :name, :string
         t.column :owner_id, :bigint
         t.index [:name]
-        t.foreign_key :dog_owners, column: "owner_id" if supports_foreign_keys?
+        t.foreign_key :dog_owners, column: "owner_id"
       end
     end
     def down

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1005,16 +1005,14 @@ ActiveRecord::Schema.define do
   create_table :records, force: true do |t|
   end
 
-  if supports_foreign_keys?
-    # fk_test_has_fk should be before fk_test_has_pk
+  disable_referential_integrity do
+    create_table :fk_test_has_pk, primary_key: "pk_id", force: :cascade do |t|
+    end
+
     create_table :fk_test_has_fk, force: true do |t|
-      t.bigint :fk_id, null: false
+      t.references :fk, null: false
+      t.foreign_key :fk_test_has_pk, column: "fk_id", name: "fk_name", primary_key: "pk_id"
     end
-
-    create_table :fk_test_has_pk, force: true, primary_key: "pk_id" do |t|
-    end
-
-    add_foreign_key :fk_test_has_fk, :fk_test_has_pk, column: "fk_id", name: "fk_name", primary_key: "pk_id"
   end
 
   create_table :overloaded_types, force: true do |t|


### PR DESCRIPTION
If an adapter does not support foreign key feature, should be noop.

https://github.com/rails/rails/blob/v5.0.0.rc1/activerecord/test/cases/migration/foreign_key_test.rb#L288-L294
https://github.com/rails/rails/blob/v5.0.0.rc1/activerecord/test/cases/migration/references_foreign_key_test.rb#L208-L214
