### PR TITLE
Add ActiveSupport::Notifications hook to ActionCable::Server.broadcast

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,2 +1,5 @@
+*  Add ActiveSupport::Notifications hook to Broadcaster#broadcast
+
+   *Matthew Wear*
 
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/actioncable/CHANGELOG.md) for previous changes.

--- a/actioncable/lib/action_cable/server/broadcasting.rb
+++ b/actioncable/lib/action_cable/server/broadcasting.rb
@@ -39,8 +39,12 @@ module ActionCable
 
           def broadcast(message)
             server.logger.info "[ActionCable] Broadcasting to #{broadcasting}: #{message.inspect}"
-            encoded = coder ? coder.encode(message) : message
-            server.pubsub.broadcast broadcasting, encoded
+
+            payload = { broadcasting: broadcasting, message: message, coder: coder }
+            ActiveSupport::Notifications.instrument("broadcast.action_cable", payload) do
+              encoded = coder ? coder.encode(message) : message
+              server.pubsub.broadcast broadcasting, encoded
+            end
           end
         end
     end

--- a/actioncable/test/server/broadcasting_test.rb
+++ b/actioncable/test/server/broadcasting_test.rb
@@ -1,15 +1,60 @@
 require "test_helper"
+require "stubs/test_server"
 
 class BroadcastingTest < ActiveSupport::TestCase
-  class TestServer
-    include ActionCable::Server::Broadcasting
-  end
-
   test "fetching a broadcaster converts the broadcasting queue to a string" do
     broadcasting = :test_queue
     server = TestServer.new
     broadcaster = server.broadcaster_for(broadcasting)
 
     assert_equal "test_queue", broadcaster.broadcasting
+  end
+
+  test "broadcast generates notification" do
+    begin
+      server = TestServer.new
+
+      events = []
+      ActiveSupport::Notifications.subscribe "broadcast.action_cable" do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      broadcasting = "test_queue"
+      message = { body: "test message" }
+      server.broadcast(broadcasting, message)
+
+      assert_equal 1, events.length
+      assert_equal "broadcast.action_cable", events[0].name
+      assert_equal broadcasting, events[0].payload[:broadcasting]
+      assert_equal message, events[0].payload[:message]
+      assert_equal ActiveSupport::JSON, events[0].payload[:coder]
+    ensure
+      ActiveSupport::Notifications.unsubscribe "broadcast.action_cable"
+    end
+  end
+
+  test "broadcaster from broadcaster_for generates notification" do
+    begin
+      server = TestServer.new
+
+      events = []
+      ActiveSupport::Notifications.subscribe "broadcast.action_cable" do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      broadcasting = "test_queue"
+      message = { body: "test message" }
+
+      broadcaster = server.broadcaster_for(broadcasting)
+      broadcaster.broadcast(message)
+
+      assert_equal 1, events.length
+      assert_equal "broadcast.action_cable", events[0].name
+      assert_equal broadcasting, events[0].payload[:broadcasting]
+      assert_equal message, events[0].payload[:message]
+      assert_equal ActiveSupport::JSON, events[0].payload[:coder]
+    ensure
+      ActiveSupport::Notifications.unsubscribe "broadcast.action_cable"
+    end
   end
 end


### PR DESCRIPTION
### Summary

ActionCable already has `ActiveSupport::Notifications` hooks around a number of operations in `Channel::Base`. It would be nice to gain visibility into messages sent via `ActionCable.server.broadcast`. This PR adds a notification hook to the broadcast method that will allow users to monitor and profile the performance messages being sent over the PubSub adapter.
