### PR TITLE
Document and test ActionDispatch server_port

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -354,6 +354,17 @@ module ActionDispatch
         standard_port? ? '' : ":#{port}"
       end
 
+      # Returns the requested port, such as 8080, based on SERVER_PORT
+      #
+      #   class Request < Rack::Request
+      #     include ActionDispatch::Http::URL
+      #   end
+      #
+      #   req = Request.new 'SERVER_PORT' => '80'
+      #   req.server_port # => 80
+      #
+      #   req = Request.new 'SERVER_PORT' => '8080'
+      #   req.server_port # => 8080
       def server_port
         get_header('SERVER_PORT').to_i
       end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -358,6 +358,17 @@ class RequestPort < BaseRequestTest
     request = stub_request 'HTTP_HOST' => 'www.example.org:8080'
     assert_equal ':8080', request.port_string
   end
+
+  test "server port" do
+    request = stub_request 'SERVER_PORT' => '8080'
+    assert_equal 8080, request.server_port
+
+    request = stub_request 'SERVER_PORT' => '80'
+    assert_equal 80, request.server_port
+
+    request = stub_request 'SERVER_PORT' => ''
+    assert_equal 0, request.server_port
+  end
 end
 
 class RequestPath < BaseRequestTest


### PR DESCRIPTION
### Summary

Added inline documentation and tests for `server_port`. Currently `server_port` is not tested for different return values and is not documented.
