### PR TITLE
Supporting destroy method on ActiveRecord::Relation object.

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -484,9 +484,15 @@ module ActiveRecord
     #   # Destroy multiple objects
     #   todos = [1,2,3]
     #   Todo.destroy(todos)
-    def destroy(id)
+    #
+    #   Destroys multiple records from the result of a relation
+    #   people = Person.where(group: 'expert')
+    #   people.destroy
+    def destroy(id = :all)
       if id.is_a?(Array)
         id.map { |one_id| destroy(one_id) }
+      elsif id == :all
+        records.each { |record| record.destroy }
       else
         find(id).destroy
       end


### PR DESCRIPTION
We already have `update` method in place for an ActiveRecord::Relation#object.
It only makes sense to have a `destroy` method in place as well.

It does run callbacks on each record that is being destroyed unlike the `delete_all` method.
