### PR TITLE
--skip generator options reduce included gems

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -9,7 +9,7 @@ source 'https://rubygems.org'
 <% if gem.options.any? -%>
 , <%= gem.options.map { |k,v|
   "#{k}: #{v.inspect}" }.join(', ') %>
-<% end -%>
+<% end %>
 <% end -%>
 
 # Use ActiveModel has_secure_password

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -458,6 +458,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "test/test_helper.rb" do |helper_content|
       assert_no_match(/fixtures :all/, helper_content)
     end
+    assert_file 'Gemfile' do |content|
+      assert_match(/^# gem\s+["']rails["']/, content)
+      assert_match(/^# gem\s+["']activerecord["']/, content)
+      assert_match(/^gem\s+["']activejob["']/, content)
+      assert_match(/^gem\s+["']activemodel["']/, content)
+      assert_match(/^gem\s+["']railties["']/, content)
+    end
   end
 
   def test_generator_if_skip_action_mailer_is_given
@@ -471,6 +478,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
     assert_file "config/environments/production.rb" do |content|
       assert_no_match(/config\.action_mailer/, content)
+    end
+    assert_file 'Gemfile' do |content|
+      assert_match(/^# gem\s+["']rails["']/, content)
+      assert_match(/^# gem\s+["']actionmailer["']/, content)
+      assert_match(/^gem\s+["']activejob["']/, content)
+      assert_match(/^gem\s+["']activemodel["']/, content)
+      assert_match(/^gem\s+["']railties["']/, content)
     end
   end
 
@@ -511,6 +525,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "app/channels"
     assert_file "Gemfile" do |content|
       assert_no_match(/redis/, content)
+      assert_match(/^# gem\s+["']rails["']/, content)
+      assert_match(/^# gem\s+["']actioncable["']/, content)
+      assert_match(/^gem\s+["']activejob["']/, content)
+      assert_match(/^gem\s+["']activemodel["']/, content)
+      assert_match(/^gem\s+["']railties["']/, content)
     end
   end
 


### PR DESCRIPTION
_(Note: this PR stems from a [Basecamp chat](https://3.basecamp.com/3076981/buckets/24956/chats/12416418@34296341) where @rafaelfranca said "yes, I'd love to --skip-\* change the gemfile instead of not loading the railtie", @SamSaffron expressed some concerns and @matthewd suggested a possible implementation. This PR needs a CHANGELOG and a deprecation policy… but I'd like to know if the team agrees with the concept behind this PR before going any further)_

---

Before this commit, every generated Rails app always included all the component gems of Rails (`activerecord`, `actionmailer`, etc.), whether or not those components were explicitly skipped (e.g.: with `--skip-active-record`).

After this commit, using `--skip-active-record`, `--skip-action-mailer` or `--skip-action-cable` when generating a Rails app/plugin also affects the Gemfile.

Rather than having a single, "include-all" `gem rails` line, the Gemfile will have the specific Rails component listed and commented out if specified.

For instance, `rails new app_name --skip-active-record` will generate a Gemfile that looks like this:

``` ruby
# gem 'rails', '>= 5.1.0.alpha', '< 5.2'
gem 'actioncable', '>= 5.1.0.alpha', '< 5.2'
gem 'actionmailer', '>= 5.1.0.alpha', '< 5.2'
gem 'activejob', '>= 5.1.0.alpha', '< 5.2'
gem 'activemodel', '>= 5.1.0.alpha', '< 5.2'
# gem 'activerecord', '>= 5.1.0.alpha', '< 5.2'
gem 'railties', '>= 5.1.0.alpha', '< 5.2'
```

As a result, the `activerecord` gem and its dependencies won't be bundled.

---

As of 6007e58, the number of gems bundled by `rails new` is 61.
The benefit of this commit is that the number of bundled gems is reduced to:
- 57 when running `--skip-active-record` (`arel` and `sqlite3` are not installed)
- 56 when running `--skip-action-cable` (`nio4r`, `websocket-driver` and `websocket-extensions` are not installed)
- 56 when running `--skip-action-mailer` (`mail`, `mime-types` and `mime-types-data` are not installed)

This PR honors the spirit of Rails as a "modular framework" that allows users to cherry-pick the components that are required for each application. Removing unnecessary gems keeps the size of the application small and reduces the number of possible third-party issues.
