### PR TITLE
Fix release year of v4.2.5.1 [ci skip]

### DIFF
--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -8,7 +8,7 @@
 *   No changes.
 
 
-## Rails 4.2.5.1 (January 25, 2015) ##
+## Rails 4.2.5.1 (January 25, 2016) ##
 
 *   No changes.
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -8,7 +8,7 @@
 *   No changes.
 
 
-## Rails 4.2.5.1 (January 25, 2015) ##
+## Rails 4.2.5.1 (January 25, 2016) ##
 
 *   No changes.
 


### PR DESCRIPTION
I fixed release year of v4.2.5.1 from 2015 to 2016.
