### PR TITLE
Extract notes from files in binary

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -110,7 +110,7 @@ class SourceAnnotationExtractor
   # Otherwise it returns an empty hash.
   def extract_annotations_from(file, pattern)
     lineno = 0
-    result = File.readlines(file).inject([]) do |list, line|
+    result = File.readlines(file, encoding: Encoding::BINARY).inject([]) do |list, line|
       lineno += 1
       next list unless line =~ pattern
       list << Annotation.new(lineno, $1, $2)


### PR DESCRIPTION
### Summary

 Prevents:

```
    ArgumentError: invalid byte sequence in UTF-8
    railties/lib/rails/source_annotation_extractor.rb:115:in `=~'
    railties/lib/rails/source_annotation_extractor.rb:115:in `block in extract_annotations_from'
```
### Other Information

And there's no reason we need to interpret the files as UTF-8  when scanning for annotations.

I can add a test if you'd like, but I'm not sure if it's worth the effort, since it would basically be testing that `File.readlines(file)` will raise an error when `File.readlines(file, encoding: Encoding::BINARY)` will not, which is well covered by the Ruby test suite.

Applies to Rails 4.2 as well.
