### PR TITLE
Add Action Cable guide to list

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -139,6 +139,10 @@
       name: Using Rails for API-only Applications
       url: api_app.html
       description: This guide explains how to effectively use Rails to develop a JSON API application.
+    -
+      name: Action Cable Overview
+      url: action_cable_overview.html
+      description: This guide explains how Action Cable works, and how to use WebSockets to create real-time features.
 
 -
   name: Extending Rails


### PR DESCRIPTION
This effectively publishes the "Action Cable Overview" guide. If we
don't think this is ready for the prime time, we can mark it as a "work
in progress" guide.

[ci skip]
