### PR TITLE
Perfomance fix for ActiveSupport Enumerable#index_by

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -34,7 +34,9 @@ module Enumerable
   #     => { "Chade- Fowlersburg-e" => <Person ...>, "David Heinemeier Hansson" => <Person ...>, ...}
   def index_by
     if block_given?
-      Hash[map { |elem| [yield(elem), elem] }]
+      result = {}
+      each { |elem| result[yield(elem)] = elem }
+      result
     else
       to_enum(:index_by) { size if respond_to?(:size) }
     end


### PR DESCRIPTION
``` ruby
module Enumerable
  # current behaviour
  def index_by
    if block_given?
      Hash[map { |elem| [yield(elem), elem] }]
    else
      to_enum(:index_by) { size if respond_to?(:size) }
    end
  end

  # new behaviour
  def index_by2
    if block_given?
      result = {}
      each {|elem| result[yield(elem)] = elem }
      result
    else
      to_enum(:index_by) { size if respond_to?(:size) }
    end
  end
end

ExpandedPayment = Struct.new(:dollars, :cents)
arr = [
  ExpandedPayment.new(5, 99),
  ExpandedPayment.new(15, 199),
  ExpandedPayment.new(25, 299),
  ExpandedPayment.new(5, 99),
  ExpandedPayment.new(15, 1199),
  ExpandedPayment.new(25, 2299),
  ExpandedPayment.new(55, 5399)
]
Benchmark.ips do |x|
  x.report('before')   { arr.index_by(&:dollars) }
  x.report('after')    { arr.index_by2(&:dollars) }
  x.compare!
end
```

```
Calculating -------------------------------------
              before    34.731k i/100ms
               after    48.206k i/100ms
-------------------------------------------------
              before    508.451k (± 1.2%) i/s -      2.570M
               after    720.068k (± 0.9%) i/s -      3.615M

Comparison:
               after:   720067.6 i/s
              before:   508451.1 i/s - 1.42x slower
```
