### PR TITLE
Keep previous state around for nested calls to #suppress

### DIFF
--- a/activerecord/lib/active_record/suppressor.rb
+++ b/activerecord/lib/active_record/suppressor.rb
@@ -30,10 +30,11 @@ module ActiveRecord
 
     module ClassMethods
       def suppress(&block)
+        previous_state = SuppressorRegistry.suppressed[name]
         SuppressorRegistry.suppressed[name] = true
         yield
       ensure
-        SuppressorRegistry.suppressed[name] = false
+        SuppressorRegistry.suppressed[name] = previous_state
       end
     end
 

--- a/activerecord/test/cases/suppressor_test.rb
+++ b/activerecord/test/cases/suppressor_test.rb
@@ -60,4 +60,16 @@ class SuppressorTest < ActiveRecord::TestCase
       end
     end
   end
+
+  def test_suppresses_when_nested_multiple_times
+    assert_no_difference -> { Notification.count } do
+      Notification.suppress do
+        Notification.suppress { }
+        Notification.create
+        Notification.create!
+        Notification.new.save
+        Notification.new.save!
+      end
+    end
+  end
 end


### PR DESCRIPTION
If a call to `#suppress` from the same class occurred inside another `#suppress` block, the suppression state would be set to false before the outer block completes.

``` ruby
User.suppress do
  # somewhere deep inside another method…
  User.suppress { ... }
  @user.save! # not suppressed in old implementation
end
```

This change keeps the previous state around in memory and unwinds it as the blocks exit.

Also verified that the test fails without the change in `ActiveRecord::Suppressor`.
