### PR TITLE
Add config.action_dispatch.x_accel_mappings to configure path rewriting for Nginx's X-Accel-Redirect header

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,2 +1,12 @@
+*   Add `config.action_dispatch.x_accel_mappings` to configure path rewriting for Nginx's `X-Accel-Redirect` header
+
+    A developer can configure `#send_file` to use Nginx's `X-Accel-Redirect` header,
+    but still not able to configure its pairing header `X-Accel-Mapping` from Rails.
+
+    `Rack::Sendfile#initialize` supports custom mappings since ver 1.5.0 (Jan 2013).
+    A new `config.action_dispatch.x_accel_mappings` option can be used to pass
+    such custom mappings to `Rack::Sendfile` middleware.
+
+    *Alexey Chernenkov*
 
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -16,6 +16,9 @@ module ActionController #:nodoc:
       # via the Rack::Sendfile middleware. The header to use is set via
       # +config.action_dispatch.x_sendfile_header+.
       # Your server can also configure this for you by setting the X-Sendfile-Type header.
+      # X-Accel-Mapping header is used with Nginx for path rewriting,
+      # you can also configure path rewriting via
+      # +config.action_dispatch.x_accel_mappings+.
       #
       # Be careful to sanitize the path parameter if it is coming from a web
       # page. <tt>send_file(params[:path])</tt> allows a malicious user to

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -4,6 +4,7 @@ module ActionDispatch
   class Railtie < Rails::Railtie # :nodoc:
     config.action_dispatch = ActiveSupport::OrderedOptions.new
     config.action_dispatch.x_sendfile_header = nil
+    config.action_dispatch.x_accel_mappings = []
     config.action_dispatch.ip_spoofing_check = true
     config.action_dispatch.show_exceptions = true
     config.action_dispatch.tld_length = 1

--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -275,12 +275,13 @@ Think of it as page caching using HTTP semantics.
 
 ### Using Rack::Sendfile
 
-When you use the `send_file` method inside a Rails controller, it sets the
-`X-Sendfile` header. `Rack::Sendfile` is responsible for actually sending the
-file.
+When you use the `send_file` method inside a Rails controller, `Rack::Sendfile`
+middleware is responsible for sending the file to your front-end web-server.
 
 If your front-end server supports accelerated file sending, `Rack::Sendfile`
-will offload the actual file sending work to the front-end server.
+will offload the actual file sending work to the front-end server. For example,
+it may send only the `X-Sendfile` header to Apache web-server instead of sending
+a whole file.
 
 You can configure the name of the header that your front-end server uses for
 this purpose using `config.action_dispatch.x_sendfile_header` in the appropriate
@@ -299,6 +300,9 @@ config.action_dispatch.x_sendfile_header = "X-Sendfile"
 
 # Nginx
 config.action_dispatch.x_sendfile_header = "X-Accel-Redirect"
+
+# Also, set `X-Accel-Mapping` header in Nginx conf or configure path rewriting from Rails:
+config.action_dispatch.x_accel_mappings = [["/internal/path/", "/external/path/"]]
 ```
 
 Make sure to configure your server to support these options following the

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -1167,6 +1167,8 @@ Apache and NGINX support this option, which can be enabled in
 ```ruby
 # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
 # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+# Also, set `X-Accel-Mapping` header in Nginx conf or configure path rewriting from Rails:
+# config.action_dispatch.x_accel_mappings = [["/internal/path/", "/external/path/"]] # for NGINX
 ```
 
 WARNING: If you are upgrading an existing application and intend to use this

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -222,7 +222,7 @@ Every Rails application comes with a standard set of middleware which it uses in
 * `ActionDispatch::ShowExceptions` rescues any exception returned by the application and renders nice exception pages if the request is local or if `config.consider_all_requests_local` is set to `true`. If `config.action_dispatch.show_exceptions` is set to `false`, exceptions will be raised regardless.
 * `ActionDispatch::RequestId` makes a unique X-Request-Id header available to the response and enables the `ActionDispatch::Request#uuid` method.
 * `ActionDispatch::RemoteIp` checks for IP spoofing attacks and gets valid `client_ip` from request headers. Configurable with the `config.action_dispatch.ip_spoofing_check`, and `config.action_dispatch.trusted_proxies` options.
-* `Rack::Sendfile` intercepts responses whose body is being served from a file and replaces it with a server specific X-Sendfile header. Configurable with `config.action_dispatch.x_sendfile_header`.
+* `Rack::Sendfile` intercepts responses whose body is being served from a file and replaces it with a server specific X-Sendfile header. Configurable with `config.action_dispatch.x_sendfile_header` and `config.action_dispatch.x_accel_mappings`.
 * `ActionDispatch::Callbacks` runs the prepare callbacks before serving the request.
 * `ActionDispatch::Cookies` sets cookies for the request.
 * `ActionDispatch::Session::CookieStore` is responsible for storing the session in cookies. An alternate middleware can be used for this by changing the `config.action_controller.session_store` to an alternate value. Additionally, options passed to this can be configured by using `config.action_controller.session_options`.

--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -208,7 +208,7 @@ Much of Action Controller's functionality is implemented as Middlewares. The fol
 
 **`Rack::Sendfile`**
 
-* Sets server specific X-Sendfile header. Configure this via `config.action_dispatch.x_sendfile_header` option.
+* Sets server specific X-Sendfile header. Configure this via `config.action_dispatch.x_sendfile_header` and `config.action_dispatch.x_accel_mappings` options.
 
 **`ActionDispatch::Static`**
 

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -15,7 +15,7 @@ module Rails
             middleware.use ::ActionDispatch::SSL, config.ssl_options
           end
 
-          middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header
+          middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header, config.action_dispatch.x_accel_mappings
 
           if config.public_file_server.enabled
             headers = config.public_file_server.headers || {}

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -36,6 +36,9 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
+  # Also, set `X-Accel-Mapping` header in Nginx conf or configure path rewriting here.
+  # config.action_dispatch.x_accel_mappings = [["/internal/path/", "/external/path/"]] # for NGINX
+
   <%- unless options[:skip_action_cable] -%>
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil

--- a/railties/test/application/middleware/sendfile_test.rb
+++ b/railties/test/application/middleware/sendfile_test.rb
@@ -58,6 +58,22 @@ module ApplicationTests
       assert_equal File.expand_path(__FILE__), last_response.headers["X-Lighttpd-Send-File"]
     end
 
+    test "config.action_dispatch.x_accel_mappings can be set along with X-Accel-Redirect header" do
+      make_basic_app do |app|
+        app.config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'
+        app.config.action_dispatch.x_accel_mappings = [
+          [File.join(rails_root, "public/"), "/some_external_path/"]
+        ]
+        app.config.public_file_server.enabled = true
+        app.paths["public"] = File.join(rails_root, "public")
+      end
+
+      app_file "public/foo.txt", "foo"
+
+      get "/foo.txt"
+      assert_equal "/some_external_path/foo.txt", last_response.headers["X-Accel-Redirect"]
+    end
+
     test "files handled by ActionDispatch::Static are handled by Rack::Sendfile" do
       make_basic_app do |app|
         app.config.action_dispatch.x_sendfile_header = 'X-Sendfile'


### PR DESCRIPTION
A developer can configure `#send_file` to use Nginx's `X-Accel-Redirect` header (via `config.action_dispatch.x_sendfile_header` option), but still not able to configure its pairing header `X-Accel-Mapping` from Rails.

`Rack::Sendfile#initialize` supports custom mappings [since ver 1.5.0](https://github.com/rack/rack/pull/451) (Jan 2013). A new `config.action_dispatch.x_accel_mappings` option can be used to pass such custom mappings to `Rack::Sendfile` middleware.
