### PR TITLE
Action Mailer: rescue_from

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,2 +1,6 @@
+*   Exception handling: use `rescue_from` to handle exceptions raised by
+    mailer actions, by message delivery, and by deferred delivery jobs.
+
+    *Jeremy Daer*
 
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/actionmailer/CHANGELOG.md) for previous changes.

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -5,6 +5,7 @@ require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/module/anonymous'
 
 require 'action_mailer/log_subscriber'
+require 'action_mailer/rescuable'
 
 module ActionMailer
   # Action Mailer allows you to send email from your application using a mailer model and views.
@@ -420,6 +421,7 @@ module ActionMailer
   # * <tt>deliver_later_queue_name</tt> - The name of the queue used with <tt>deliver_later</tt>.
   class Base < AbstractController::Base
     include DeliveryMethods
+    include Rescuable
     include Previews
 
     abstract!

--- a/actionmailer/lib/action_mailer/delivery_job.rb
+++ b/actionmailer/lib/action_mailer/delivery_job.rb
@@ -3,11 +3,32 @@ require 'active_job'
 module ActionMailer
   # The <tt>ActionMailer::DeliveryJob</tt> class is used when you
   # want to send emails outside of the request-response cycle.
+  #
+  # Exceptions are rescued and handled by the mailer class.
   class DeliveryJob < ActiveJob::Base # :nodoc:
     queue_as { ActionMailer::Base.deliver_later_queue_name }
+
+    rescue_from StandardError, with: :handle_exception_with_mailer_class
 
     def perform(mailer, mail_method, delivery_method, *args) #:nodoc:
       mailer.constantize.public_send(mail_method, *args).send(delivery_method)
     end
+
+    private
+      # "Deserialize" the mailer class name by hand in case another argument
+      # (like a Global ID reference) raised DeserializationError.
+      def mailer_class
+        if mailer = Array(@serialized_arguments).first || Array(arguments).first
+          mailer.constantize
+        end
+      end
+
+      def handle_exception_with_mailer_class(exception)
+        if klass = mailer_class
+          klass.handle_exception exception
+        else
+          raise exception
+        end
+      end
   end
 end

--- a/actionmailer/lib/action_mailer/rescuable.rb
+++ b/actionmailer/lib/action_mailer/rescuable.rb
@@ -1,0 +1,27 @@
+module ActionMailer #:nodoc:
+  # Provides `rescue_from` for mailers. Wraps mailer action processing,
+  # mail job processing, and mail delivery.
+  module Rescuable
+    extend ActiveSupport::Concern
+    include ActiveSupport::Rescuable
+
+    class_methods do
+      def handle_exception(exception) #:nodoc:
+        rescue_with_handler(exception) || raise(exception)
+      end
+    end
+
+    def handle_exceptions #:nodoc:
+      yield
+    rescue => exception
+      rescue_with_handler(exception) || raise
+    end
+
+    private
+      def process(*)
+        handle_exceptions do
+          super
+        end
+      end
+  end
+end

--- a/actionmailer/test/mailers/delayed_mailer.rb
+++ b/actionmailer/test/mailers/delayed_mailer.rb
@@ -1,6 +1,26 @@
+require 'active_job/arguments'
+
+class DelayedMailerError < StandardError; end
+
 class DelayedMailer < ActionMailer::Base
+  cattr_accessor :last_error
+  cattr_accessor :last_rescue_from_instance
+
+  rescue_from DelayedMailerError do |error|
+    @@last_error = error
+    @@last_rescue_from_instance = self
+  end
+
+  rescue_from ActiveJob::DeserializationError do |error|
+    @@last_error = error
+    @@last_rescue_from_instance = self
+  end
 
   def test_message(*)
     mail(from: 'test-sender@test.com', to: 'test-receiver@test.com', subject: 'Test Subject', body: 'Test Body')
+  end
+
+  def test_raise(klass_name)
+    raise klass_name.constantize, 'boom'
   end
 end

--- a/actionpack/lib/action_controller/metal/rescue.rb
+++ b/actionpack/lib/action_controller/metal/rescue.rb
@@ -6,17 +6,6 @@ module ActionController #:nodoc:
     extend ActiveSupport::Concern
     include ActiveSupport::Rescuable
 
-    def rescue_with_handler(exception)
-      if exception.cause
-        handler_index = index_of_handler_for_rescue(exception) || Float::INFINITY
-        cause_handler_index = index_of_handler_for_rescue(exception.cause)
-        if cause_handler_index && cause_handler_index <= handler_index
-          exception = exception.cause
-        end
-      end
-      super(exception)
-    end
-
     # Override this method if you want to customize when detailed
     # exceptions must be shown. This method is only called when
     # consider_all_requests_local is false. By default, it returns
@@ -31,7 +20,7 @@ module ActionController #:nodoc:
         super
       rescue Exception => exception
         request.env['action_dispatch.show_detailed_exceptions'] ||= show_detailed_exceptions?
-        rescue_with_handler(exception) || raise(exception)
+        rescue_with_handler(exception) || raise
       end
   end
 end

--- a/actionpack/test/controller/rescue_test.rb
+++ b/actionpack/test/controller/rescue_test.rb
@@ -131,22 +131,6 @@ class RescueController < ActionController::Base
   def missing_template
   end
 
-  def io_error_in_view
-    begin
-      raise IOError.new('this is io error')
-    rescue
-      raise ActionView::TemplateError.new(nil)
-    end
-  end
-
-  def zero_division_error_in_view
-    begin
-      raise ZeroDivisionError.new('this is zero division error')
-    rescue
-      raise ActionView::TemplateError.new(nil)
-    end
-  end
-
   def exception_with_more_specific_handler_for_wrapper
     raise RecordInvalid
   rescue
@@ -251,17 +235,6 @@ class ControllerInheritanceRescueControllerTest < ActionController::TestCase
 end
 
 class RescueControllerTest < ActionController::TestCase
-
-  def test_io_error_in_view
-    get :io_error_in_view
-    assert_equal 'io error', @response.body
-  end
-
-  def test_zero_division_error_in_view
-    get :zero_division_error_in_view
-    assert_equal 'action_view templater error', @response.body
-  end
-
   def test_rescue_handler
     get :not_authorized
     assert_response :forbidden
@@ -276,7 +249,6 @@ class RescueControllerTest < ActionController::TestCase
       get :record_invalid
     end
   end
-
   def test_rescue_handler_with_argument_as_string
     assert_called_with @controller, :show_errors, [Exception] do
       get :record_invalid_raise_as_string
@@ -314,7 +286,6 @@ class RescueControllerTest < ActionController::TestCase
     get :resource_unavailable
     assert_equal "RescueController::ResourceUnavailable", @response.body
   end
-
   def test_block_rescue_handler_with_argument_as_string
     get :resource_unavailable_raise_as_string
     assert_equal "RescueController::ResourceUnavailableToRescueAsString", @response.body
@@ -322,7 +293,7 @@ class RescueControllerTest < ActionController::TestCase
 
   test 'rescue when wrapper has more specific handler than cause' do
     get :exception_with_more_specific_handler_for_wrapper
-    assert_response :unprocessable_entity
+    assert_response :forbidden
   end
 
   test 'rescue when cause has more specific handler than wrapper' do

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -34,7 +34,7 @@ module ActiveJob
         perform(*arguments)
       end
     rescue => exception
-      rescue_with_handler(exception) || raise(exception)
+      rescue_with_handler(exception) || raise
     end
 
     def perform(*)

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,2 +1,6 @@
+*   Rescuable: If a handler doesn't match the exception, check for handlers
+    matching the exception's cause.
+
+    *Jeremy Daer*
 
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/activesupport/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
Action Mailer: Declarative exception handling with `rescue_from`.

Follows the same pattern as controllers and jobs. Exceptions raised in delivery jobs (enqueued by `#deliver_later`) are also delegated to the mailer's rescue_from handlers, so you can handle the DeserializationError raised by delivery jobs:

``` ruby
class MyMailer < ApplicationMailer
  rescue_from ActiveJob::DeserializationError do
    …
  end
```

ActiveSupport::Rescuable polish:
- Add the `rescue_with_handler` class method so exceptions may be handled at the class level without requiring an instance.
- Rationalize `exception.cause` handling. If no handler matches the exception, fall back to the handler that matches its cause.
- Handle exceptions raised elsewhere. Pass `object: …` to execute the `rescue_from` handler (e.g. a method call or a block to instance_exec) against a different object. Defaults to `self`.
