### PR TITLE
Perfomance fix for ActiveSupport::Inflector.ordinal

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -326,17 +326,23 @@ module ActiveSupport
     #   ordinal(-11)   # => "th"
     #   ordinal(-1021) # => "st"
     def ordinal(number)
-      abs_number = number.to_i.abs
-
-      if (11..13).include?(abs_number % 100)
-        "th"
-      else
-        case abs_number % 10
-          when 1; "st"
-          when 2; "nd"
-          when 3; "rd"
-          else    "th"
-        end
+      case number
+        when 1; "st".freeze
+        when 2; "nd".freeze
+        when 3; "rd".freeze
+        when 4, 5, 6, 7, 8, 9, 10, 11, 12, 13; "th".freeze
+        else
+          num_modulo = number.to_i.abs % 100
+          if 11 <= num_modulo && num_modulo <= 13
+            "th".freeze
+          else
+            case num_modulo % 10
+              when 1; "st".freeze
+              when 2; "nd".freeze
+              when 3; "rd".freeze
+              else    "th".freeze
+            end
+          end
       end
     end
 


### PR DESCRIPTION
``` ruby
require 'benchmark/ips'

def o1(number)
  abs_number = number.to_i.abs

  if (11..13).include?(abs_number % 100)
    "th"
  else
    case abs_number % 10
      when 1; "st"
      when 2; "nd"
      when 3; "rd"
      else    "th"
    end
  end
end

def o3(number)
  case number
  when 1; "st".freeze
  when 2; "nd".freeze
  when 3; "rd".freeze
  when 4, 5, 6, 7, 8, 9, 10, 11, 12, 13; "th".freeze
  else
    num_modulo = number.to_i.abs % 100
    if 11 <= num_modulo && num_modulo <= 13
      'th'.freeze
    else
      case num_modulo % 10
        when 1; "st".freeze
        when 2; "nd".freeze
        when 3; "rd".freeze
        else    "th".freeze
      end
    end
  end
end

Benchmark.ips do |x|
  x.report('orig') { o1(1); o1(2); o1(3); o1(4); o1(11); o1(111); o1(1523) }
  x.report('ord3') { o3(1); o3(2); o3(3); o3(4); o3(11); o3(111); o3(1523) }
  x.compare!
end
```

```
Warming up --------------------------------------
                orig    50.090k i/100ms
                ord3    98.538k i/100ms
Calculating -------------------------------------
                orig    623.562k (± 1.2%) i/s -      3.156M in   5.061423s
                ord3      1.612M (± 1.0%) i/s -      8.080M in   5.013749s

Comparison:
                ord3:  1611765.6 i/s
                orig:   623561.9 i/s - 2.58x slower
```
