### PR TITLE
Add some assertions for BigDecimal#to_s

### DIFF
--- a/activesupport/lib/active_support/core_ext/big_decimal/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/big_decimal/conversions.rb
@@ -3,10 +3,8 @@ require 'bigdecimal/util'
 
 module ActiveSupport
   module BigDecimalWithDefaultFormat #:nodoc:
-    DEFAULT_STRING_FORMAT = 'F'
-
-    def to_s(format = nil)
-      super(format || DEFAULT_STRING_FORMAT)
+    def to_s(format = 'F')
+      super(format)
     end
   end
 end

--- a/activesupport/test/core_ext/bigdecimal_test.rb
+++ b/activesupport/test/core_ext/bigdecimal_test.rb
@@ -5,5 +5,7 @@ class BigDecimalTest < ActiveSupport::TestCase
   def test_to_s
     bd = BigDecimal.new '0.01'
     assert_equal '0.01', bd.to_s
+    assert_equal '+0.01', bd.to_s('+F')
+    assert_equal '+0.0 1', bd.to_s('+1F')
   end
 end


### PR DESCRIPTION
### Summary

Add some assertions which are missing when BigDeciml#to_s is passed a parameter such as '+F' or '+nF' .
