### PR TITLE
Rails 5.1 point type should not raise exception if empty string is provided as input

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/rails_5_1_point.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/rails_5_1_point.rb
@@ -14,6 +14,8 @@ module ActiveRecord
           def cast(value)
             case value
             when ::String
+              return if value.blank?
+              
               if value[0] == '(' && value[-1] == ')'
                 value = value[1...-1]
               end

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -104,6 +104,13 @@ class PostgresqlPointTest < ActiveRecord::PostgreSQLTestCase
     assert_equal ActiveRecord::Point.new(1, 2), p.x
   end
 
+  def test_empty_string_assignment
+    assert_nothing_raised { PostgresqlPoint.new(x: "") }
+
+    p = PostgresqlPoint.new(x: "")
+    assert_equal nil, p.x
+  end
+
   def test_array_of_points_round_trip
     expected_value = [
       ActiveRecord::Point.new(1, 2),


### PR DESCRIPTION
If there is a form for point type and user left it blank, then type cast will fail. This change will just set attribute as nil.
