### PR TITLE
Get rid of unnecessary alias for changed_attributes

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -202,9 +202,8 @@ module ActiveModel
 
       # Returns +true+ if attr_name is changed, +false+ otherwise.
       def changes_include?(attr_name)
-        attributes_changed_by_setter.include?(attr_name)
+        changed_attributes.include?(attr_name)
       end
-      alias attribute_changed_by_setter? changes_include?
 
       # Returns +true+ if attr_name were changed before the model was saved,
       # +false+ otherwise.
@@ -255,18 +254,14 @@ module ActiveModel
         end
       end
 
-      # This is necessary because `changed_attributes` might be overridden in
-      # other implementations (e.g. in `ActiveRecord`)
-      alias_method :attributes_changed_by_setter, :changed_attributes # :nodoc:
-
       # Force an attribute to have a particular "before" value
       def set_attribute_was(attr, old_value)
-        attributes_changed_by_setter[attr] = old_value
+        changed_attributes[attr] = old_value
       end
 
       # Remove changes information for the provided attributes.
       def clear_attribute_changes(attributes) # :doc:
-        attributes_changed_by_setter.except!(*attributes)
+        changed_attributes.except!(*attributes)
       end
   end
 end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -213,7 +213,7 @@ module ActiveRecord
       became = klass.new
       became.instance_variable_set("@attributes", @attributes)
       became.instance_variable_set("@mutation_tracker", @mutation_tracker) if defined?(@mutation_tracker)
-      became.instance_variable_set("@changed_attributes", attributes_changed_by_setter)
+      became.instance_variable_set("@changed_attributes", changed_attributes)
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)
       became.errors.copy!(errors)


### PR DESCRIPTION
The provided alias `attributes_changed_by_setter` for `changed_attributes` is never used. Accordingly to the comment it's supposed to be used in ActiveRecord, but currently never anywhere. It's hard to read and understand which method should be used `attributes_changed_by_setter` or `changed_attributes`. In order to prevent a bigger mess in the future I propose to get rid of this alias.
