### PR TITLE
Fix: freeze when autoloaded_constant changes while iterating.

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -559,7 +559,7 @@ module ActiveSupport #:nodoc:
     # as the environment will be in an inconsistent state, e.g. other constants
     # may have already been unloaded and not accessible.
     def remove_unloadable_constants!
-      autoloaded_constants.each { |const| remove_constant const }
+      autoloaded_constants.clone.each { |const| remove_constant const }
       autoloaded_constants.clear
       Reference.clear!
       explicitly_unloadable_constants.each { |const| remove_constant const }


### PR DESCRIPTION
Rails can sometimes freeze in development mode, e.g. when using the cells gem. In this case, autoloaded_constants is modified while iterating over it, which causes an infinite loop. The problem can be prevented by cloning the array before iterating.
