### PR TITLE
ActionCable, sometimes add_channel is not called.

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/subscriber_map.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/subscriber_map.rb
@@ -32,7 +32,11 @@ module ActionCable
       end
 
       def broadcast(channel, message)
-        list = @sync.synchronize { @subscribers[channel].dup }
+        list = @sync.synchronize do
+          return if !@subscribers.key?(channel)
+          @subscribers[channel].dup
+        end
+
         list.each do |subscriber|
           invoke_callback(subscriber, message)
         end

--- a/actioncable/test/subscription_adapter/subscriber_map_test.rb
+++ b/actioncable/test/subscription_adapter/subscriber_map_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class SubscriberMapTest < ActionCable::TestCase
+  test "broadcast should not change subscribers" do
+    setup_subscription_map
+    origin = @subscription_map.instance_variable_get(:@subscribers).dup
+
+    @subscription_map.broadcast('not_exist_channel', '')
+
+    assert_equal origin, @subscription_map.instance_variable_get(:@subscribers)
+  end
+
+  private
+    def setup_subscription_map
+      @subscription_map = ActionCable::SubscriptionAdapter::SubscriberMap.new
+    end
+end


### PR DESCRIPTION
### Summary

One channel could not `broadcast` all messages. That was happened when one connected, after no one has a connection after someone disconnected.

In a case,

```
class OneChannel < ApplicationCable::Channel
  def subscribed
    stream_from 'one_stream'
  end

  def unsubscribed
     ActionCable.server.broadcast('one_stream', {type: 'leave'})
  end
end
```

Sometimes (about once every 7 times), `SubscriberMap#broadcast` is called after all channels are removed from `@subscribers` of `SubscriberMap`.

Then 

```
@subscribers # => {one_stream: []}
```

Then next consumer comes, `SubscriberMap#add_channel` is not called, because `new_channel = !@subscribers.key?(channel)` is `false`.

`SubscriberMap` do not add channel for `one_stream`, until `SubscriberMap#add_subscriber` is called again after all channels are removed again. 
