### PR TITLE
Provides friendlier way to access queue adapters of a job.

### DIFF
--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -49,10 +49,10 @@ module ActiveJob
           end
         end
 
-      def assign_adapter(adapter_name, queue_adapter)
-        self._queue_adapter_name = ActiveSupport::StringInquirer.new(adapter_name)
-        self._queue_adapter = queue_adapter
-      end
+        def assign_adapter(adapter_name, queue_adapter)
+          self._queue_adapter_name = adapter_name
+          self._queue_adapter = queue_adapter
+        end
 
         QUEUE_ADAPTER_METHODS = [:enqueue, :enqueue_at].freeze
 

--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -7,6 +7,7 @@ module ActiveJob
     extend ActiveSupport::Concern
 
     included do
+      class_attribute :_queue_adapter_name, instance_accessor: false, instance_predicate: false
       class_attribute :_queue_adapter, instance_accessor: false, instance_predicate: false
       self.queue_adapter = :async
     end
@@ -19,11 +20,15 @@ module ActiveJob
         _queue_adapter
       end
 
+      def queue_adapter_name
+        _queue_adapter_name
+      end
+
       # Specify the backend queue provider. The default queue adapter
       # is the +:async+ queue. See QueueAdapters for more
       # information.
       def queue_adapter=(name_or_adapter_or_class)
-        self._queue_adapter = interpret_adapter(name_or_adapter_or_class)
+        interpret_adapter(name_or_adapter_or_class)
       end
 
       private
@@ -31,15 +36,23 @@ module ActiveJob
         def interpret_adapter(name_or_adapter_or_class)
           case name_or_adapter_or_class
           when Symbol, String
-            ActiveJob::QueueAdapters.lookup(name_or_adapter_or_class).new
+            assign_adapter(name_or_adapter_or_class.to_s,
+                           ActiveJob::QueueAdapters.lookup(name_or_adapter_or_class).new)
           else
             if queue_adapter?(name_or_adapter_or_class)
-              name_or_adapter_or_class
+              adapter_name = "#{name_or_adapter_or_class.class.name.demodulize.remove('Adapter').underscore}"
+              assign_adapter(adapter_name,
+                             name_or_adapter_or_class)
             else
               raise ArgumentError
             end
           end
         end
+
+      def assign_adapter(adapter_name, queue_adapter)
+        self._queue_adapter_name = ActiveSupport::StringInquirer.new(adapter_name)
+        self._queue_adapter = queue_adapter
+      end
 
         QUEUE_ADAPTER_METHODS = [:enqueue, :enqueue_at].freeze
 

--- a/activejob/test/cases/queue_adapter_test.rb
+++ b/activejob/test/cases/queue_adapter_test.rb
@@ -25,13 +25,18 @@ class QueueAdapterTest < ActiveJob::TestCase
     base_queue_adapter = ActiveJob::Base.queue_adapter
 
     child_job_one = Class.new(ActiveJob::Base)
+    assert_equal child_job_one.queue_adapter_name, ActiveJob::Base.queue_adapter_name
+
     child_job_one.queue_adapter = :stub_one
 
-    assert_not_equal ActiveJob::Base.queue_adapter, child_job_one.queue_adapter
+    assert_equal "stub_one", child_job_one.queue_adapter_name
+    assert child_job_one.queue_adapter_name.stub_one?
     assert_kind_of ActiveJob::QueueAdapters::StubOneAdapter, child_job_one.queue_adapter
 
     child_job_two = Class.new(ActiveJob::Base)
     child_job_two.queue_adapter = :stub_two
+    assert child_job_two.queue_adapter_name.stub_two?
+    assert_equal "stub_two", child_job_two.queue_adapter_name
 
     assert_kind_of ActiveJob::QueueAdapters::StubTwoAdapter, child_job_two.queue_adapter
     assert_kind_of ActiveJob::QueueAdapters::StubOneAdapter, child_job_one.queue_adapter, "child_job_one's queue adapter should remain unchanged"

--- a/activejob/test/cases/queue_adapter_test.rb
+++ b/activejob/test/cases/queue_adapter_test.rb
@@ -29,13 +29,13 @@ class QueueAdapterTest < ActiveJob::TestCase
 
     child_job_one.queue_adapter = :stub_one
 
+    assert_not_equal ActiveJob::Base.queue_adapter, child_job_one.queue_adapter
     assert_equal "stub_one", child_job_one.queue_adapter_name
-    assert child_job_one.queue_adapter_name.stub_one?
     assert_kind_of ActiveJob::QueueAdapters::StubOneAdapter, child_job_one.queue_adapter
 
     child_job_two = Class.new(ActiveJob::Base)
     child_job_two.queue_adapter = :stub_two
-    assert child_job_two.queue_adapter_name.stub_two?
+
     assert_equal "stub_two", child_job_two.queue_adapter_name
 
     assert_kind_of ActiveJob::QueueAdapters::StubTwoAdapter, child_job_two.queue_adapter


### PR DESCRIPTION
Since we now support queue adapters on a per job basis, we could have a friendlier way of knowing the type of adapter used in the job.

Introduced a method `queue_adaper_name` that gives a string inquirer.

```
Class Job1 < ActiveJob::Base
  self.queue_adapter = :resque
end

> Job1.queue_adapter_name
#=> "resque"

> Job1.queue_adapter_name.resque?
#=> true

class Job2 < ActiveJob::Base
  self.queue_adapter = CustomAdapter
end
> Job2.queue_adapter_name
#=> "custom"
```
