### PR TITLE
Fix typo in code snippet under Section 5.8

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -914,7 +914,7 @@ And then finally, add the view for this action, located at
     <th>Text</th>
   </tr>
 
-  <% @articles.each do |article| %>
+  <% @article.each do |article| %>
     <tr>
       <td><%= article.title %></td>
       <td><%= article.text %></td>


### PR DESCRIPTION
### Summary

A typo in the getting started guide documentation. Code snippet under Section 5.8 (Listing All Articles) has the snippet: <% @articles.each do |article| %> , which will return error "undefined method `each' for nil:NilClass".
Must be changed to: <% @article.each do |article| %>
### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
