### PR TITLE
Associations do not call `.to_proc` on Hash

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+* Support Ruby 2.3 by not unexpectedly calling `.to_proc` on Hash objects
+
+    Fixes #25010
+
+    *tlrdstd*
+
 ## Rails 3.2.22 (Jun 16, 2015) ##
 
 * No changes.

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -158,7 +158,7 @@ module ActiveRecord
       end
 
       def interpolate(sql, record = nil)
-        if sql.respond_to?(:to_proc)
+        if sql.respond_to?(:to_proc) && !sql.is_a?(Hash)
           owner.send(:instance_exec, record, &sql)
         else
           sql

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -146,7 +146,7 @@ module ActiveRecord
         private
 
         def interpolate(conditions)
-          if conditions.respond_to?(:to_proc)
+          if conditions.respond_to?(:to_proc) && !conditions.is_a?(Hash)
             instance_eval(&conditions)
           else
             conditions

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -113,7 +113,7 @@ module ActiveRecord
         end
 
         def process_conditions(conditions)
-          if conditions.respond_to?(:to_proc)
+          if conditions.respond_to?(:to_proc) && !conditions.is_a?(Hash)
             conditions = klass.send(:instance_eval, &conditions)
           end
 


### PR DESCRIPTION
### Summary

Don't call `.to_proc` on unsuspecting `Hash` objects that are intended to be ActiveRecord association configuration parameters.

Per #25010, Ruby 2.3 added `to_proc` on Hash objects. The ActiveRecord associations code checks received input to see if it responds to `to_proc`. In Ruby 2.2, `Hash` objects did not. In Ruby 2.3, they do. In these situations, calling `to_proc` leads to variously undefined results.
### Other Information

These are the only suspect calls to `to_proc` in the Rails 3.2 codebase. However, other changes in Ruby 2.3 may or may not require other patches for perfect compatibility.
