### PR TITLE
Fix typo

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -144,8 +144,8 @@ module ActiveRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: :reject_posts
     #
-    #     def reject_posts(attributed)
-    #       attributed['title'].blank?
+    #     def reject_posts(attributes)
+    #       attributes['title'].blank?
     #     end
     #   end
     #


### PR DESCRIPTION
### Summary

Fix typo in nested_attributes.rb changing reject_posts parameter name from 'attributed' to 'attributes'.
