### PR TITLE
[WIP] Add parsing for jsonapi.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ PATH
     activesupport (5.1.0.alpha)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
+      jsonapi (~> 0.1.1.beta2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     rails (5.1.0.alpha)
@@ -184,6 +185,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    jsonapi (0.1.1.beta2)
+      json (~> 1.8)
     kindlerb (0.1.1)
       mustache
       nokogiri

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails-html-sanitizer', '~> 1.0', '>= 1.0.2'
   s.add_dependency 'rails-dom-testing', '~> 2.0'
   s.add_dependency 'actionview', version
-  s.add_dependency 'jsonapi'
 
   s.add_development_dependency 'activemodel', version
 end

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails-html-sanitizer', '~> 1.0', '>= 1.0.2'
   s.add_dependency 'rails-dom-testing', '~> 2.0'
   s.add_dependency 'actionview', version
+  s.add_dependency 'jsonapi'
 
   s.add_development_dependency 'activemodel', version
 end

--- a/actionpack/lib/action_dispatch/http/mime_types.rb
+++ b/actionpack/lib/action_dispatch/http/mime_types.rb
@@ -29,6 +29,7 @@ Mime::Type.register "application/x-www-form-urlencoded", :url_encoded_form
 # http://www.ietf.org/rfc/rfc4627.txt
 # http://www.json.org/JSONRequest.html
 Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest )
+Mime::Type.register "application/vnd.api+json", :jsonapi
 
 Mime::Type.register "application/pdf", :pdf, [], %w(pdf)
 Mime::Type.register "application/zip", :zip, [], %w(zip)

--- a/actionpack/lib/action_dispatch/http/mime_types.rb
+++ b/actionpack/lib/action_dispatch/http/mime_types.rb
@@ -29,6 +29,9 @@ Mime::Type.register "application/x-www-form-urlencoded", :url_encoded_form
 # http://www.ietf.org/rfc/rfc4627.txt
 # http://www.json.org/JSONRequest.html
 Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest )
+
+# https://www.ietf.org/assignments/media-types/application/vnd.api+json
+# http://jsonapi.org/format
 Mime::Type.register "application/vnd.api+json", :jsonapi
 
 Mime::Type.register "application/pdf", :pdf, [], %w(pdf)

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -1,5 +1,3 @@
-require 'jsonapi'
-
 module ActionDispatch
   module Http
     module Parameters
@@ -13,23 +11,7 @@ module ActionDispatch
           data.is_a?(Hash) ? data : {:_json => data}
         },
         Mime[:jsonapi].symbol => -> (raw_post) {
-          data = JSONAPI.parse(raw_post).data
-          hash = {}
-          hash[:id] = data.id unless data.id.nil?
-          hash[:_type] = data.type unless data.type.nil?
-          hash.merge!(data.attributes.to_hash)
-          data.relationships.each do |name, rel|
-            if rel.data.respond_to?(:each)
-              hash["#{name.singularize}_ids".to_sym] = rel.data.map(&:id)
-              hash["#{name.singularize}_types".to_sym] = rel.data.map { |val| val.type.singularize.capitalize }
-            elsif !rel.data.nil?
-              hash["#{name}_id".to_sym] = rel.data.id
-              hash["#{name}_type".to_sym] = rel.data.type.singularize.capitalize
-            else
-              hash["#{name}_id".to_sym] = nil
-            end
-          end
-          hash
+          ActiveSupport::JSONAPI.decode(raw_post)
         }
       }
 

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -1,3 +1,5 @@
+require 'jsonapi'
+
 module ActionDispatch
   module Http
     module Parameters
@@ -9,6 +11,25 @@ module ActionDispatch
         Mime[:json].symbol => -> (raw_post) {
           data = ActiveSupport::JSON.decode(raw_post)
           data.is_a?(Hash) ? data : {:_json => data}
+        },
+        Mime[:jsonapi].symbol => -> (raw_post) {
+          data = JSONAPI.parse(raw_post).data
+          hash = {}
+          hash[:id] = data.id unless data.id.nil?
+          hash[:_type] = data.type unless data.type.nil?
+          hash.merge!(data.attributes.to_hash)
+          data.relationships.each do |name, rel|
+            if rel.data.respond_to?(:each)
+              hash["#{name.singularize}_ids".to_sym] = rel.data.map(&:id)
+              hash["#{name.singularize}_types".to_sym] = rel.data.map { |val| val.type.singularize.capitalize }
+            elsif !rel.data.nil?
+              hash["#{name}_id".to_sym] = rel.data.id
+              hash["#{name}_type".to_sym] = rel.data.type.singularize.capitalize
+            else
+              hash["#{name}_id".to_sym] = nil
+            end
+          end
+          hash
         }
       }
 

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -49,7 +49,7 @@ class MimeTypeTest < ActiveSupport::TestCase
 
   test "parse application with trailing star" do
     accept = "application/*"
-    expect = [Mime[:html], Mime[:js], Mime[:xml], Mime[:rss], Mime[:atom], Mime[:yaml], Mime[:url_encoded_form], Mime[:json], Mime[:pdf], Mime[:zip], Mime[:gzip]]
+    expect = [Mime[:html], Mime[:js], Mime[:xml], Mime[:rss], Mime[:atom], Mime[:yaml], Mime[:url_encoded_form], Mime[:json], Mime[:jsonapi], Mime[:pdf], Mime[:zip], Mime[:gzip]]
     parsed = Mime::Type.parse(accept)
     assert_equal expect, parsed
   end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -37,13 +37,6 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
-  test "does not parse unregistered media types such as application/vnd.api+json" do
-    assert_parses(
-      {},
-      "{\"person\": {\"name\": \"David\"}}", { 'CONTENT_TYPE' => 'application/vnd.api+json' }
-    )
-  end
-
   test "nils are stripped from collections" do
     assert_parses(
       {"person" => []},

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -148,7 +148,7 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
   test "parses json params after custom json mime type registered" do
     begin
       Mime::Type.unregister :json
-      Mime::Type.register "application/json", :json, %w(application/vnd.api+json)
+      Mime::Type.register "application/json", :json, %w(application/custom+json)
       assert_parses(
         {"user" => {"username" => "meinac"}, "username" => "meinac"},
         "{\"username\": \"meinac\"}", { 'CONTENT_TYPE' => 'application/json' }
@@ -162,10 +162,10 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
   test "parses json params after custom json mime type registered with synonym" do
     begin
       Mime::Type.unregister :json
-      Mime::Type.register "application/json", :json, %w(application/vnd.api+json)
+      Mime::Type.register "application/json", :json, %w(application/custom+json)
       assert_parses(
         {"user" => {"username" => "meinac"}, "username" => "meinac"},
-        "{\"username\": \"meinac\"}", { 'CONTENT_TYPE' => 'application/vnd.api+json' }
+        "{\"username\": \"meinac\"}", { 'CONTENT_TYPE' => 'application/custom+json' }
       )
     ensure
       Mime::Type.unregister :json

--- a/actionpack/test/dispatch/request/jsonapi_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/jsonapi_params_parsing_test.rb
@@ -1,0 +1,53 @@
+require 'abstract_unit'
+
+class JsonapiParamsParsingTest < ActionDispatch::IntegrationTest
+  class TestController < ActionController::Base
+    class << self
+      attr_accessor :last_request_parameters
+    end
+
+    def parse
+      self.class.last_request_parameters = request.request_parameters
+      head :ok
+    end
+  end
+
+  def teardown
+    TestController.last_request_parameters = nil
+  end
+
+  test "parses json params for application json" do
+    payload = "{ \"data\": { \"type\": \"posts\", \"attributes\": { \"title\":"\
+              "\"Hello\", \"date\": \"today\"} , \"relationships\": { "\
+              "\"author\": { \"data\": { \"id\": \"2\", \"type\": \"users\" }"\
+              " }, \"comments\": { \"data\": [ { \"type\": \"comments\","\
+              "\"id\": \"3\" }, { \"type\": \"comments\", \"id\": \"4\" } ]"\
+              " }, \"journal\": { \"data\": null } } } }"
+    expected = { "_type" => "posts", "title" => "Hello", "date" => "today",
+                 "author_id" => "2", "author_type" => "User",
+                 "comment_ids" => ["3", "4"], "comment_types" => ["Comment", "Comment"],
+                 "journal_id" => nil }
+    assert_parses(expected, payload, { 'CONTENT_TYPE' => 'application/vnd.api+json' })
+  end
+
+  private
+
+  def assert_parses(expected, actual, headers = {})
+    with_test_routing do
+      post "/parse", params: actual, headers: headers
+      assert_response :ok
+      assert_equal(expected, TestController.last_request_parameters)
+    end
+  end
+
+  def with_test_routing
+    with_routing do |set|
+      set.draw do
+        ActiveSupport::Deprecation.silence do
+          post ':action', :to => ::JsonapiParamsParsingTest::TestController
+        end
+      end
+      yield
+    end
+  end
+end

--- a/actionpack/test/dispatch/request/jsonapi_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/jsonapi_params_parsing_test.rb
@@ -31,23 +31,22 @@ class JsonapiParamsParsingTest < ActionDispatch::IntegrationTest
   end
 
   private
-
-  def assert_parses(expected, actual, headers = {})
-    with_test_routing do
-      post "/parse", params: actual, headers: headers
-      assert_response :ok
-      assert_equal(expected, TestController.last_request_parameters)
-    end
-  end
-
-  def with_test_routing
-    with_routing do |set|
-      set.draw do
-        ActiveSupport::Deprecation.silence do
-          post ':action', :to => ::JsonapiParamsParsingTest::TestController
-        end
+    def assert_parses(expected, actual, headers = {})
+      with_test_routing do
+        post "/parse", params: actual, headers: headers
+        assert_response :ok
+        assert_equal(expected, TestController.last_request_parameters)
       end
-      yield
     end
-  end
+
+    def with_test_routing
+      with_routing do |set|
+        set.draw do
+          ActiveSupport::Deprecation.silence do
+            post ':action', :to => ::JsonapiParamsParsingTest::TestController
+          end
+        end
+        yield
+      end
+    end
 end

--- a/actionpack/test/dispatch/request/jsonapi_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/jsonapi_params_parsing_test.rb
@@ -16,7 +16,7 @@ class JsonapiParamsParsingTest < ActionDispatch::IntegrationTest
     TestController.last_request_parameters = nil
   end
 
-  test "parses json params for application json" do
+  test "parses jsonapi params for application/vnd.api+json" do
     payload = "{ \"data\": { \"type\": \"posts\", \"attributes\": { \"title\":"\
               "\"Hello\", \"date\": \"today\"} , \"relationships\": { "\
               "\"author\": { \"data\": { \"id\": \"2\", \"type\": \"users\" }"\

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'tzinfo',     '~> 1.1'
   s.add_dependency 'minitest',   '~> 5.1'
   s.add_dependency 'concurrent-ruby', '~> 1.0', '>= 1.0.2'
+  s.add_dependency 'jsonapi'
 end

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'tzinfo',     '~> 1.1'
   s.add_dependency 'minitest',   '~> 5.1'
   s.add_dependency 'concurrent-ruby', '~> 1.0', '>= 1.0.2'
-  s.add_dependency 'jsonapi'
+  s.add_dependency 'jsonapi',    '~> 0.1.1.beta2'
 end

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -53,6 +53,7 @@ module ActiveSupport
     autoload :Gzip
     autoload :Inflector
     autoload :JSON
+    autoload :JSONAPI
     autoload :KeyGenerator
     autoload :MessageEncryptor
     autoload :MessageVerifier

--- a/activesupport/lib/active_support/jsonapi.rb
+++ b/activesupport/lib/active_support/jsonapi.rb
@@ -1,0 +1,1 @@
+require 'active_support/jsonapi/decoding'

--- a/activesupport/lib/active_support/jsonapi/decoding.rb
+++ b/activesupport/lib/active_support/jsonapi/decoding.rb
@@ -1,0 +1,45 @@
+require 'jsonapi'
+
+module ActiveSupport
+  module JSONAPI
+    class << self
+      # Parses a JSON API string into a hash.
+      # See http://jsonapi.org for more info.
+      def decode(json)
+        json = ActiveSupport::JSON.parse(json)
+        data = ::JSONAPI.parse(json).data
+        return {} if data.nil?
+        hash = {}
+        hash[:id] = data.id unless data.id.nil?
+        hash[:_type] = data.type
+        hash.merge!(data.attributes.to_hash)
+        data.relationships.each do |name, rel|
+          if rel.data.respond_to?(:each)
+            hash["#{name.singularize}_ids".to_sym] = rel.data.map(&:id)
+            hash["#{name.singularize}_types".to_sym] = rel.data.map { |val| val.type.singularize.capitalize }
+          elsif !rel.data.nil?
+            hash["#{name}_id".to_sym] = rel.data.id
+            hash["#{name}_type".to_sym] = rel.data.type.singularize.capitalize
+          else
+            hash["#{name}_id".to_sym] = nil
+          end
+        end
+        hash
+      end
+
+      # Returns the class of the error that will be raised when there is an
+      # error in decoding the JSON API payload. Using this method means you
+      # won't directly depend on the ActiveSupport's JSON API implementation, in
+      # case it changes in the future.
+      #
+      #   begin
+      #     obj = ActiveSupport::JSONAPI.decode(some_string)
+      #   rescue ActiveSupport::JSONAPI.parse_error
+      #     Rails.logger.warn("Attempted to decode invalid JSON API payload: #{some_string}")
+      #   end
+      def parse_error
+        ::JSONAPI::InvalidDocument
+      end
+    end
+  end
+end

--- a/activesupport/lib/active_support/jsonapi/decoding.rb
+++ b/activesupport/lib/active_support/jsonapi/decoding.rb
@@ -6,7 +6,7 @@ module ActiveSupport
       # Parses a JSON API string into a hash.
       # See http://jsonapi.org for more info.
       def decode(json)
-        json = ActiveSupport::JSON.parse(json)
+        json = ActiveSupport::JSON.decode(json)
         data = ::JSONAPI.parse(json).data
         return {} if data.nil?
         hash = {}

--- a/activesupport/lib/active_support/jsonapi/decoding.rb
+++ b/activesupport/lib/active_support/jsonapi/decoding.rb
@@ -10,18 +10,18 @@ module ActiveSupport
         data = ::JSONAPI.parse(json).data
         return {} if data.nil?
         hash = {}
-        hash[:id] = data.id unless data.id.nil?
-        hash[:_type] = data.type
+        hash["id"] = data.id unless data.id.nil?
+        hash["_type"] = data.type
         hash.merge!(data.attributes.to_hash)
         data.relationships.each do |name, rel|
           if rel.data.respond_to?(:each)
-            hash["#{name.singularize}_ids".to_sym] = rel.data.map(&:id)
-            hash["#{name.singularize}_types".to_sym] = rel.data.map { |val| val.type.singularize.capitalize }
+            hash["#{name.singularize}_ids"] = rel.data.map(&:id)
+            hash["#{name.singularize}_types"] = rel.data.map { |val| val.type.singularize.capitalize }
           elsif !rel.data.nil?
-            hash["#{name}_id".to_sym] = rel.data.id
-            hash["#{name}_type".to_sym] = rel.data.type.singularize.capitalize
+            hash["#{name}_id"] = rel.data.id
+            hash["#{name}_type"] = rel.data.type.singularize.capitalize
           else
-            hash["#{name}_id".to_sym] = nil
+            hash["#{name}_id"] = nil
           end
         end
         hash

--- a/activesupport/test/jsonapi/decoding_test.rb
+++ b/activesupport/test/jsonapi/decoding_test.rb
@@ -1,0 +1,30 @@
+require 'abstract_unit'
+require 'active_support/jsonapi'
+
+class TestJSONAPIDecoding < ActiveSupport::TestCase
+  TESTS = {
+    %({"data": {"id": "1", "type": "posts"}}) => { "_type" => "posts", "id" => "1" },
+    %({"data": {"id": "1", "type": "posts", "attributes": {"title": "hello", "date": "today"}}}) => { "_type" => "posts", "id" => "1", "title" => "hello", "date" => "today" },
+    %({"data": {"id": "1", "type": "posts", "relationships": {"author": {"data": {"type": "users", "id": "2"}}, "journal": {"data": null}, "comments": {"data": [{"type":"comments", "id":"3"},{"type":"comments","id":"4"}]}}}}) => { "_type" => "posts", "id" => "1", "author_id" => "2", "author_type" => "User", "journal_id" => nil, "comment_ids" => ["3", "4"], "comment_types" => ["Comment", "Comment"]  }
+  }
+
+  TESTS.each_with_index do |(json, expected), index|
+    test "json decodes #{index}" do
+      silence_warnings do
+        assert_equal expected, ActiveSupport::JSONAPI.decode(json), "JSONAPI decoding \
+          failed for #{json}"
+      end
+    end
+  end
+
+  def test_failed_json_decoding
+#    assert_raise(ActiveSupport::JSON.parse_error) { ActiveSupport::JSON.decode(%(undefined)) }
+#    assert_raise(ActiveSupport::JSON.parse_error) { ActiveSupport::JSON.decode(%({a: 1})) }
+#    assert_raise(ActiveSupport::JSON.parse_error) { ActiveSupport::JSON.decode(%({: 1})) }
+#    assert_raise(ActiveSupport::JSON.parse_error) { ActiveSupport::JSON.decode(%()) }
+  end
+
+  def test_cannot_pass_unsupported_options
+    assert_raise(ArgumentError) { ActiveSupport::JSONAPI.decode("", create_additions: true) }
+  end
+end


### PR DESCRIPTION
### Summary
- Add the `:jsonapi` MIME type (`application/vnd.api+json`).
- Add a default parser for the `:jsonapi` MIME type using the [`jsonapi`](http://github.com/beauby/jsonapi) gem.

The following [JSON API](http://jsonapi.org) payload:

``` json
{ 
  "data": { 
    "type": "posts", 
    "attributes" : {
      "title": "Hello",
      "date": "today"
    }, 
    "relationships": { 
      "author": { "data": { "id": "2", "type": "users" } }, 
      "comments": { 
        "data": [
          { "type": "comments", "id": "3" }, 
          { "type": "comments", "id": "4" }
        ]
      }, 
      "journal": { "data": null }
    }
  }
}
```

will be parsed into:

``` ruby
{ 
  "_type" => "posts", 
  "title" => "Hello", 
  "date" => "today",
  "author_id" => "2",
  "author_type" => "User",
  "comment_ids" => ["3", "4"],
  "comment_types" => ["Comment", "Comment"],
  "journal_id" => nil 
}
```
### Other Information

Related to #23712.
Based on @bf4's [blog post](http://www.benjaminfleischer.com/journey-of-a-media-type-in-rails-part-1).
