### PR TITLE
Extract notes as binary

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -116,7 +116,7 @@ class SourceAnnotationExtractor
   # Otherwise it returns an empty hash.
   def extract_annotations_from(file, pattern)
     lineno = 0
-    result = File.readlines(file).inject([]) do |list, line|
+    result = File.readlines(file, encoding: Encoding::BINARY).inject([]) do |list, line|
       lineno += 1
       next list unless line =~ pattern
       list << Annotation.new(lineno, $1, $2)


### PR DESCRIPTION
### Summary

 Prevents:

```
    ArgumentError: invalid byte sequence in UTF-8
    railties/lib/rails/source_annotation_extractor.rb:115:in `=~'
    railties/lib/rails/source_annotation_extractor.rb:115:in `block in extract_annotations_from'
```

Example

```
Debug info:
line: .bar { a: �; }
(UTF-8) against (?-mix:\/\/\s*(OPTIMIZE|FIXME|TODO|HACK|TECHDEBT|README|@todo|@note):?\s*(.*)$)US-ASCII

{"Encoding.default_external"=>#<Encoding:UTF-8>}
{"Encoding.find('locale')"=>#<Encoding:UTF-8>}
{"Encoding.default_internal"=>#<Encoding:UTF-8>}
{"Encoding.default_external"=>#<Encoding:UTF-8>}
{"__ENCODING__"=>#<Encoding:UTF-8>}
{"Encoding.find('filesystem')"=>#<Encoding:UTF-8>}
{"ENV['LC_ALL']"=>nil}
{"ENV['LC_TYPE']"=>nil}
{"ENV['LANG']"=>"en_US.UTF-8"}

vendor/bundle/ruby/2.2.0/gems/sass-3.4.21/test/sass/results/import_charset_1_8.css: ISO-8859 text

invalid byte sequence in UTF-8
rake aborted!
ArgumentError: invalid byte sequence in UTF-8
/home/ubuntu/rails_server/lib/tasks/notes.rake:10:in `=~'
/home/ubuntu/rails_server/lib/tasks/notes.rake:10:in `block in extract_annotations_from'
```
### Other Information

And there's no reason we need to interpret the files as UTF-8  when scanning for annotations.

~~I can add a test if you'd like, but I'm not sure if it's worth the effort, since it would basically be testing that `File.readlines(file)` will raise an error when `File.readlines(file, encoding: Encoding::BINARY)` will not, which is well covered by the Ruby test suite.~~
- [ ] Add test demonstrating....

Applies to Rails 4.2 as well.

PR originally sent in https://github.com/rails/rails/pull/25000
