### PR TITLE
Remove passing original exception

### DIFF
--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -20,8 +20,8 @@ module ActiveRecord
         file = path.absolute? ? path.to_s : File.join(root, path)
 
         FileUtils.rm(file)
-      rescue Errno::ENOENT => error
-        raise NoDatabaseError.new(error.message, error)
+      rescue Errno::ENOENT
+        raise NoDatabaseError
       end
 
       def purge


### PR DESCRIPTION
Passing original exception was deprecated by rails/rails#18774. 

This produced the warning when we use activerecord with sqlite3 adaper and call "drop" task:

```
DEPRECATION WARNING: Passing #original_exception is deprecated and has no effect. Exceptions will automatically capture the original exception.
```

I think this is just unfinished work of rails/rails#18774.
