### PR TITLE
Broaden compat with other minitest plugins.

### DIFF
--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -430,6 +430,26 @@ module ApplicationTests
       end
     end
 
+    def test_unknown_option_is_invalid
+      create_test_file
+
+      assert_match 'invalid option: --unknown', run_test_command('--unknown')
+    end
+
+    def test_extra_plugin_options_goes_through_unscathed
+      skip 'cannot get this to load the plugin'
+
+      app_file 'lib/minitest/extra_plugin.rb', <<-RUBY
+        class Minitest
+          def self.plugin_extra_options(opts, options)
+            opts.on('--extra') { puts 'extra option found' }
+          end
+        end
+      RUBY
+
+      assert_match '0 runs, 0 assertions', run_test_command('--extra')
+    end
+
     def test_shows_filtered_backtrace_by_default
       create_backtrace_test
 


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/25046

For a test command using options from other plugins,
e.g. 'bin/rails test --other-plugin-option', we'd abort test runs because
`opts.order!` raises on unknown options.

The option isn't invalid, it's just that our plugin doesn't define it. Defer
that raise to when minitest parses options, so every plugin defines options,
and it can truly be considered an invalid option.

By skipping unknown options and parsing the remainder we can collect file
patterns after these unknown options.

cc @senny @arthurnn 
