### PR TITLE
Use RAILS_MAX_THREADS as pool size on all adapters

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/frontbase.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/frontbase.yml
@@ -8,6 +8,7 @@
 #
 default: &default
   adapter: frontbase
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: localhost
   username: <%= app_name %>
   password: ''

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
@@ -34,6 +34,7 @@
 #
 default: &default
   adapter: ibm_db
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: db2inst1
   password:
   #schema: db2inst1

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
@@ -38,6 +38,7 @@
 
 default: &default
   adapter: jdbc
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= app_name %>
   password:
   driver:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
@@ -11,6 +11,7 @@
 #
 default: &default
   adapter: mysql
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
   host: localhost

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
@@ -6,6 +6,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml
@@ -6,6 +6,7 @@
 #
 default: &default
   adapter: sqlite3
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
@@ -12,7 +12,7 @@
 default: &default
   adapter: mysql2
   encoding: utf8
-  pool: 5
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
 <% if mysql_socket -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
@@ -18,6 +18,7 @@
 #
 default: &default
   adapter: oracle
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= app_name %>
   password:
 

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: 5
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
 development:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
@@ -25,6 +25,7 @@
 default: &default
   adapter: sqlserver
   encoding: utf8
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   reconnect: false
   username: <%= app_name %>
   password:


### PR DESCRIPTION
When `RAILS_MAX_THREADS` is set, the postgresql adapter uses it as the connection pool size, so that there are always enough connections available to serve Action Cable requests: https://github.com/rails/rails/pull/23528

The same logic applies when using the mysql2 or sqlite3 adapters.

/cc @schneems 
