### PR TITLE
Add load_config to db:seed rake task

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -191,7 +191,7 @@ db_namespace = namespace :db do
   task :setup => ['db:schema:load_if_ruby', 'db:structure:load_if_sql', :seed]
 
   desc 'Loads the seed data from db/seeds.rb'
-  task :seed do
+  task :seed => [:environment, :load_config] do
     db_namespace['abort_if_pending_migrations'].invoke
     ActiveRecord::Tasks::DatabaseTasks.load_seed
   end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -191,8 +191,7 @@ db_namespace = namespace :db do
   task :setup => ['db:schema:load_if_ruby', 'db:structure:load_if_sql', :seed]
 
   desc 'Loads the seed data from db/seeds.rb'
-  task :seed => [:environment, :load_config] do
-    db_namespace['abort_if_pending_migrations'].invoke
+  task :seed => [:environment, :load_config, :abort_if_pending_migrations] do
     ActiveRecord::Tasks::DatabaseTasks.load_seed
   end
 


### PR DESCRIPTION
Rake task `db:seed` does not use the `environment` and `load_config` info, which is different from other tasks. It breaks when I overwrite `load_config` task, while other tasks that used `load_config` work as expected. 
