### PR TITLE
replace ActiveRecord::Base to ApplicationRecord in sample code

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -29,7 +29,7 @@ module ActiveRecord
     # You can override +to_param+ in your model to make +user_path+ construct
     # a path using the user's name instead of the user's id:
     #
-    #   class User < ActiveRecord::Base
+    #   class User < ApplicationRecord
     #     def to_param  # overridden
     #       name
     #     end
@@ -73,7 +73,7 @@ module ActiveRecord
       # using +method_name+, which can be any attribute or method that
       # responds to +to_s+.
       #
-      #   class User < ActiveRecord::Base
+      #   class User < ApplicationRecord
       #     to_param :name
       #   end
       #


### PR DESCRIPTION
### Summary

I replaced `ActiveRecord::Base` to `ApplicationRecord` in some sample codes.
I think It is better because ApplicationRecord is a new superclass for all app models from rails5.

http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html
