### PR TITLE
Issue #24796 -- enumerable#sum edge case

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -22,7 +22,11 @@ module Enumerable
       map(&block).sum(identity)
     else
       sum = identity ? inject(identity, :+) : inject(:+)
-      sum || identity || 0
+      if !sum && count == 0
+        identity || 0
+      else
+        sum
+      end
     end
   end
 

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -77,6 +77,12 @@ class EnumerableTests < ActiveSupport::TestCase
 
     sum = GenericEnumerable.new([1, 2]).sum(10) {|v| v * 2 }
     assert_typed_equal(16, sum, Integer)
+
+    sum = GenericEnumerable.new([nil]).sum
+    assert_equal nil, sum
+
+    sum = GenericEnumerable.new([false]).sum
+    assert_equal false, sum
   end
 
   def test_nil_sums


### PR DESCRIPTION
### Summary

Addresses issue #24796, albeit in a performance degrading fashion of roughly 6% for enumerable#sum due to using `count`. Per @jeremy, makes `[nil].sum == nil` and `[false].sum == false`, matching inject(:+) results.

~~~Personally I wouldn't merge this due to the performance implications and since this PR solves a rather specific issue that has been around since 2006, but in the off chance somebody deems this important to fix, this is the only solution I was able to dream up. Perhaps somebody more clever than I can dream up a better solution.~~~

Performance looks acceptable now with my latest change.
### Other Information

Benchmark of enumerable_test#test_sums before this PR:

```
Warming up --------------------------------------
               after     1.054k i/100ms
Calculating -------------------------------------
               after     10.424k (± 3.2%) i/s -     52.700k in   5.060879s
```

and after this PR:

```
Warming up --------------------------------------
               after     1.038k i/100ms
Calculating -------------------------------------
               after     10.524k (± 6.2%) i/s -     52.938k in   5.050561s
```
