### PR TITLE
fix named route example [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -118,11 +118,11 @@ module ActionDispatch
   #   controller :blog do
   #     get 'blog/show'     => :list
   #     get 'blog/delete'   => :delete
-  #     get 'blog/edit/:id' => :edit
+  #     get 'blog/edit' => :edit
   #   end
   #
-  #   # provides named routes for show, delete, and edit
-  #   link_to @article.title, show_path(id: @article.id)
+  #   # provides named routes for show, delete and edit
+  #   link_to @article.title, blog_show_path(id: @article.id)
   #
   # == Pretty URLs
   #


### PR DESCRIPTION
On this example it will only create a named route for show and delete. And the named route name was incorrect.
