### PR TITLE
Add line ending detection core ext to File class

### DIFF
--- a/activesupport/lib/active_support/core_ext/file/detect_line_ending_type.rb
+++ b/activesupport/lib/active_support/core_ext/file/detect_line_ending_type.rb
@@ -1,0 +1,42 @@
+require 'fileutils'
+
+class File
+  # This method allows you to determine the line endings used by a file,
+  # by reading characters from the file until a known sequence of line ending 
+  # characters are encountered, without reading the entire file into memory.
+  # If no determination can be made, the default line ending character for 
+  # the local OS is returned.
+  #
+  # There are 3 types of line endings: Windows (\r\n), Unix (\n), and Mac OS 9(\r)
+  # By keeping an array of the 3 most recent characters, we can determine which
+  # line endings are being used.
+  #
+  # Windows = [ any char except "\\", "\r", "\n" ]
+  # Unix = [ any char, any char except "\\", "\n" ]
+  # Mac OS 9 = [ any char except "\\", "\r", any char except "\n" ]
+  #
+  # Example:
+  #
+  #    line_ending_char = File.detect_line_ending_type(file_path)
+  #    IO.foreach(file_path, line_ending_char, universal_newline: true) do |file_line|
+  #        puts file_line
+  #    end
+  #
+  def self.detect_line_ending_type(path)
+    File.open(path, "r") do |target_file| 
+      recent_chars = [nil, nil, nil]
+      target_file.each_char do |char|
+        recent_chars.shift
+        recent_chars << char
+        if recent_chars.first != "\\" && recent_chars.second == "\r" && recent_chars.third == "\n"
+          return "\r\n"
+        elsif recent_chars.second != "\\" && recent_chars.third == "\n"
+          return "\n"
+        elsif recent_chars.first != "\\" && recent_chars.second == "\r"
+          return "\r"
+        end
+      end
+    end
+    return $/ # return default ruby line ending if none found in file
+  end
+end


### PR DESCRIPTION
Add a new core extension to File in ActiveSupport, to allow detection of a file's line ending type. This will provide developers with a convenience method to help parse a file predictably regardless of line ending type, especially when dealing with formats like CSV, which has 3 formats (one for each line ending type) on all major OS platforms that can change per app. For example, Excel may output Windows-format CSV files, whereas LibreOffice may output a Unix format CSV file, or Apple's Numbers app may output Mac OS 9 CSV files. Without the ability to enforce standards on their end users of how and where CSV files should be made to import data, a method like this can be extremely useful in saving a lot of headaches and debugging time.
