### PR TITLE
Add options hash to has_secure_token method.

### DIFF
--- a/activerecord/lib/active_record/secure_token.rb
+++ b/activerecord/lib/active_record/secure_token.rb
@@ -7,8 +7,9 @@ module ActiveRecord
       #
       #   # Schema: User(token:string, auth_token:string)
       #   class User < ActiveRecord::Base
-      #     has_secure_token
+      #     has_secure_token  # OR has_secure_token uniq: true
       #     has_secure_token :auth_token
+      #     has_secure_token :api_key, uniq: true, length: 32
       #   end
       #
       #   user = User.new
@@ -23,16 +24,44 @@ module ActiveRecord
       # Note that it's still possible to generate a race condition in the database in the same way that
       # {validates_uniqueness_of}[rdoc-ref:Validations::ClassMethods#validates_uniqueness_of] can.
       # You're encouraged to add a unique index in the database to deal with this even more unlikely scenario.
-      def has_secure_token(attribute = :token)
+      def has_secure_token(attribute = :token, options = {})
+        attribute, options = :token, attribute if options.empty? && attribute.is_a?(Hash)
+        options = options.with_indifferent_access
         # Load securerandom only when has_secure_token is used.
         require 'active_support/core_ext/securerandom'
-        define_method("regenerate_#{attribute}") { update! attribute => self.class.generate_unique_secure_token }
-        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token) unless self.send("#{attribute}?")}
+
+        define_method("regenerate_#{attribute}") do
+          token = self.class.generate_unique_secure_token(attribute, options)
+          update_attributes attribute => token
+        end
+
+        before_create do
+          unless self.send("#{attribute}?")
+            self.send("#{attribute}=", self.class.generate_unique_secure_token(attribute, options))
+          end
+        end
       end
 
-      def generate_unique_secure_token
-        SecureRandom.base58(24)
+      def generate_unique_secure_token(attribute, options)
+        if options[:uniq]
+          random_token_for_class(self, attribute, options)
+        else
+          secure_random_token(options)
+        end
       end
+
+      def random_token_for_class(klass, attribute, options)
+        loop do
+          random_token = secure_random_token(options)
+          break random_token unless klass.exists?(attribute => random_token)
+        end
+      end
+
+      def secure_random_token(options)
+        length = options[:length] || 24
+        SecureRandom.base58(length)
+      end
+
     end
   end
 end


### PR DESCRIPTION
### Summary

```
class User
  has_secure_token  # OR has_secure_token uniq: true, length: 12
  has_secure_token :auth_token
  has_secure_token :api_token, uniq: true, length: 32
end
```

**Options**
uniq => Will generate new token if token already exists in database. (default is false). This will even reduce the chances of generating duplicate token.

length => Will generate new token with given length. (default is 24)

In Future we can add more options like uniq: true with scope. Or more advanced options.
**TODO**: Currently class violating SRP.
