### PR TITLE
Change comments to not exceed 80 characters

### DIFF
--- a/actioncable/lib/rails/generators/channel/templates/application_cable/channel.rb
+++ b/actioncable/lib/rails/generators/channel/templates/application_cable/channel.rb
@@ -1,4 +1,5 @@
-# Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto reloading.
+# Be sure to restart your server when you modify this file. Action Cable runs in
+# a loop that does not support auto reloading.
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/actioncable/lib/rails/generators/channel/templates/application_cable/connection.rb
+++ b/actioncable/lib/rails/generators/channel/templates/application_cable/connection.rb
@@ -1,4 +1,5 @@
-# Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto reloading.
+# Be sure to restart your server when you modify this file. Action Cable runs in
+# a loop that does not support auto reloading.
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end


### PR DESCRIPTION
When I create a new Rails 5 project and copy over my .rubocop.yml it complains about these lines being too long. All other files seem to keep to this limit. Other generated files do keep to this, but action cable doesn't.
