### PR TITLE
Update comment for #retrieve_connection_pool

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -896,15 +896,9 @@ module ActiveRecord
         end
       end
 
-      # Retrieving the connection pool happens a lot so we cache it in @class_to_pool.
+      # Retrieving the connection pool happens a lot, so we cache it in @owner_to_pool.
       # This makes retrieving the connection pool O(1) once the process is warm.
       # When a connection is established or removed, we invalidate the cache.
-      #
-      # Ideally we would use #fetch here, as class_to_pool[klass] may sometimes be nil.
-      # However, benchmarking (https://gist.github.com/jonleighton/3552829) showed that
-      # #fetch is significantly slower than #[]. So in the nil case, no caching will
-      # take place, but that's ok since the nil case is not the common one that we wish
-      # to optimise for.
       def retrieve_connection_pool(spec_name)
         owner_to_pool.fetch(spec_name) do
           # Check if a connection was previously established in an ancestor process,


### PR DESCRIPTION
After PR https://github.com/rails/rails/pull/24844 the documentation for `#retrieve_connection_pool` was out of date. This commit changes:
- the reference from `@class_to_pool` to `@owner_to_pool`.
- with newer Rubies, `#fetch` isn't significantly slower than `#[]`. Since Rails 5 requires Ruby >= 2.2.2, we can just use `#fetch` here.

The old comment linked to https://gist.github.com/jonleighton/3552829 which showed that in some 4 year old ruby, `#fetch` was 30-something percent slower than `#[]`. Benchmarking on different Rubies >= 2.2.2, I get the current difference at around 15%. That’s still quite a lot. Should the code be changed, instead of the documentation?

cc/ @arthurnn
