### PR TITLE
Make cross-origin Javascript warning logs optional

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -235,7 +235,9 @@ module ActionController #:nodoc:
       # we aren't serving an unauthorized cross-origin response.
       def verify_same_origin_request
         if marked_for_same_origin_verification? && non_xhr_javascript_response?
-          logger.warn CROSS_ORIGIN_JAVASCRIPT_WARNING if logger
+          if logger && log_warning_on_csrf_failure
+            logger.warn CROSS_ORIGIN_JAVASCRIPT_WARNING
+          end
           raise ActionController::InvalidCrossOriginRequest, CROSS_ORIGIN_JAVASCRIPT_WARNING
         end
       end


### PR DESCRIPTION
### Summary

It follows that if you disable log warnings for CSRF errors you don't want to be warned about cross-origin Javascript requests, either. This change adds a check so that warnings are not logged in either case when `log_warning_on_csrf_failure` is `false`.
### Other Information

The motivation for this change is two-fold: it seems to be logical that setting `log_warning_on_csrf_failure` to `false` would disable all warnings (with the raised exception being enough) and at @ICIJ we're seeing our logs flooded with these messages as spammers scan our site. The warnings are non-actionable, so for us it's just noise.
