### PR TITLE
Introduce AR::TransactionSerializationError for transaction serialization failures or deadlocks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -3,4 +3,9 @@
 
     *Johannes Opper*
 
+*   Introduce ActiveRecord::TransactionSerializationError for catching
+    transaction serialization failures or deadlocks.
+
+    *Erol Fornoles*
+
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -727,14 +727,22 @@ module ActiveRecord
         column_names.map {|name| quote_column_name(name) + option_strings[name]}
       end
 
+      # See https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html
+      ER_DUP_ENTRY            = 1062
+      ER_NO_REFERENCED_ROW_2  = 1452
+      ER_DATA_TOO_LONG        = 1406
+      ER_LOCK_DEADLOCK        = 1213
+
       def translate_exception(exception, message)
         case error_number(exception)
-        when 1062
+        when ER_DUP_ENTRY
           RecordNotUnique.new(message)
-        when 1452
+        when ER_NO_REFERENCED_ROW_2
           InvalidForeignKey.new(message)
-        when 1406
+        when ER_DATA_TOO_LONG
           ValueTooLong.new(message)
+        when ER_LOCK_DEADLOCK
+          TransactionSerializationError.new(message)
         else
           super
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -406,6 +406,7 @@ module ActiveRecord
         VALUE_LIMIT_VIOLATION = "22001"
         FOREIGN_KEY_VIOLATION = "23503"
         UNIQUE_VIOLATION      = "23505"
+        SERIALIZATION_FAILURE = "40001"
 
         def translate_exception(exception, message)
           return exception unless exception.respond_to?(:result)
@@ -417,6 +418,8 @@ module ActiveRecord
             InvalidForeignKey.new(message)
           when VALUE_LIMIT_VIOLATION
             ValueTooLong.new(message)
+          when SERIALIZATION_FAILURE
+            TransactionSerializationError.new(message)
           else
             super
           end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -285,6 +285,16 @@ module ActiveRecord
   class TransactionIsolationError < ActiveRecordError
   end
 
+  # TransactionSerializationError will be raised when a transaction is rolled
+  # back by the database due to a serialization failure or a deadlock.
+  #
+  # See the following:
+  #
+  # * http://www.postgresql.org/docs/current/static/transaction-iso.html
+  # * https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html#error_er_lock_deadlock
+  class TransactionSerializationError < ActiveRecordError
+  end
+
   # IrreversibleOrderError is raised when a relation's order is too complex for
   # +reverse_order+ to automatically reverse.
   class IrreversibleOrderError < ActiveRecordError

--- a/activerecord/test/cases/adapters/mysql2/transaction_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/transaction_test.rb
@@ -1,0 +1,62 @@
+require "cases/helper"
+require 'support/connection_helper'
+
+module ActiveRecord
+  class Mysql2TransactionTest < ActiveRecord::Mysql2TestCase
+    self.use_transactional_tests = false
+
+    class Sample < ActiveRecord::Base
+      self.table_name = 'samples'
+    end
+
+    setup do
+      @connection = ActiveRecord::Base.connection
+      @connection.clear_cache!
+
+      @connection.transaction do
+        @connection.drop_table 'samples', if_exists: true
+        @connection.create_table('samples') do |t|
+          t.integer 'value'
+        end
+      end
+
+      Sample.reset_column_information
+    end
+
+    teardown do
+      @connection.drop_table 'samples', if_exists: true
+    end
+
+    test "raises error when a serialization failure occurs" do
+      assert_raises(ActiveRecord::TransactionSerializationError) do
+        thread = Thread.new do
+          Sample.transaction isolation: :serializable do
+            Sample.delete_all
+
+            10.times do |i|
+              sleep 0.1
+
+              Sample.create value: i
+            end
+          end
+        end
+
+        sleep 0.1
+
+        Sample.transaction isolation: :serializable do
+          Sample.delete_all
+
+          10.times do |i|
+            sleep 0.1
+
+            Sample.create value: i
+          end
+
+          sleep 1
+        end
+
+        thread.join
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/transaction_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/transaction_test.rb
@@ -1,0 +1,72 @@
+require "cases/helper"
+require 'support/connection_helper'
+
+module ActiveRecord
+  class PostgresqlTransactionTest < ActiveRecord::PostgreSQLTestCase
+    self.use_transactional_tests = false
+
+    class Sample < ActiveRecord::Base
+      self.table_name = 'samples'
+    end
+
+    setup do
+      @connection = ActiveRecord::Base.connection
+
+      @connection.transaction do
+        @connection.drop_table 'samples', if_exists: true
+        @connection.create_table('samples') do |t|
+          t.integer 'value'
+        end
+      end
+
+      Sample.reset_column_information
+    end
+
+    teardown do
+      @connection.drop_table 'samples', if_exists: true
+    end
+
+    test "raises error when a serialization failure occurs" do
+      with_warning_suppression do
+        assert_raises(ActiveRecord::TransactionSerializationError) do
+          thread = Thread.new do
+            Sample.transaction isolation: :serializable do
+              Sample.delete_all
+
+              10.times do |i|
+                sleep 0.1
+
+                Sample.create value: i
+              end
+            end
+          end
+
+          sleep 0.1
+
+          Sample.transaction isolation: :serializable do
+            Sample.delete_all
+
+            10.times do |i|
+              sleep 0.1
+
+              Sample.create value: i
+            end
+
+            sleep 1
+          end
+
+          thread.join
+        end
+      end
+    end
+
+    protected
+
+    def with_warning_suppression
+      log_level = @connection.client_min_messages
+      @connection.client_min_messages = 'error'
+      yield
+      @connection.client_min_messages = log_level
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Since transaction isolation levels are already available on ActiveRecord, I was wondering if it would be useful to introduce an exception that can be rescued to handle transaction serialization errors or deadlocks independent of the database used. Currently, an `ActiveRecord::InvalidStatement` is raised and one has to check its `original_exception` and, depending on the database, see if it was caused by a deadlock. For example:

``` ruby
begin
  Sample.transaction isolation: :serializable do
    # Do something that triggers a serialization failure or deadlock, concurrent with another serializable transaction
  end
rescue ActiveRecord::StatementInvalid => e
  # Do this for PostgreSQL:
  retry if e.original_exception.is_a? PG::TRSerializationFailure
  # Do this for MySQL:
  retry if e.original_exception.respond_to?(:error_number) && e.original_exception.error_number == 1213
end
```

It might be useful to be able to do this instead:

``` ruby
begin
  Sample.transaction isolation: :serializable do
    # Do something that triggers a serialization failure or deadlock, concurrent with another serializable transaction
  end
rescue ActiveRecord::TransactionSerializationError
  retry
end
```
### Other Information

See relevant references:
- http://www.postgresql.org/docs/current/static/transaction-iso.html
- https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html#error_er_lock_deadlock
