### PR TITLE
Add default exceptions affected by suppress

### DIFF
--- a/activesupport/lib/active_support/core_ext/kernel/reporting.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/reporting.rb
@@ -1,9 +1,6 @@
 module Kernel
   module_function
 
-  DEFAULT_SUPPRESS_EXCEPTIONS = [StandardError].freeze
-  private_constant :DEFAULT_SUPPRESS_EXCEPTIONS
-
   # Sets $VERBOSE to nil for the duration of the block and back to its original
   # value afterwards.
   #
@@ -40,7 +37,7 @@ module Kernel
   #
   #   puts 'This code gets executed and nothing related to ZeroDivisionError was seen'
   def suppress(*exception_classes)
-    exception_classes = DEFAULT_SUPPRESS_EXCEPTIONS if exception_classes.empty?
+    exception_classes = StandardError if exception_classes.empty?
     yield
   rescue *exception_classes
   end

--- a/activesupport/lib/active_support/core_ext/kernel/reporting.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/reporting.rb
@@ -1,6 +1,9 @@
 module Kernel
   module_function
 
+  DEFAULT_SUPPRESS_EXCEPTIONS = [StandardError].freeze
+  private_constant :DEFAULT_SUPPRESS_EXCEPTIONS
+
   # Sets $VERBOSE to nil for the duration of the block and back to its original
   # value afterwards.
   #
@@ -37,6 +40,7 @@ module Kernel
   #
   #   puts 'This code gets executed and nothing related to ZeroDivisionError was seen'
   def suppress(*exception_classes)
+    exception_classes = DEFAULT_SUPPRESS_EXCEPTIONS if exception_classes.empty?
     yield
   rescue *exception_classes
   end

--- a/activesupport/test/core_ext/kernel_test.rb
+++ b/activesupport/test/core_ext/kernel_test.rb
@@ -42,6 +42,15 @@ class KernelSuppressTest < ActiveSupport::TestCase
     end
   end
 
+  def test_suppress_with_defaults
+    suppress { raise RuntimeError }
+    suppress { raise ArgumentError }
+
+    assert_raise(LoadError) do
+      suppress { raise LoadError }
+    end
+  end
+
   def test_suppression
     suppress(ArgumentError) { raise ArgumentError }
     suppress(LoadError) { raise LoadError }


### PR DESCRIPTION
Allow use `suppress` without list of exceptions.
So that instead of `suppress(StandardError) { ... }` one will be able to simply call `suppress { ... }`
This makes `suppress` more inline with ruby's `rescue`.

```
suppress { do_something_that_might_fail }

# instead of

begin
  do_something_that_might_fail
rescue
end

# or

do_something_that_might_fail rescue nil
```
