### PR TITLE
Introduce new ActiveRecord transaction error classes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -742,7 +742,7 @@ module ActiveRecord
         when ER_DATA_TOO_LONG
           ValueTooLong.new(message)
         when ER_LOCK_DEADLOCK
-          TransactionSerializationError.new(message)
+          DeadlockDetected.new(message)
         else
           super
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -407,6 +407,7 @@ module ActiveRecord
         FOREIGN_KEY_VIOLATION = "23503"
         UNIQUE_VIOLATION      = "23505"
         SERIALIZATION_FAILURE = "40001"
+        DEADLOCK_DETECTED     = "40P01"
 
         def translate_exception(exception, message)
           return exception unless exception.respond_to?(:result)
@@ -419,7 +420,9 @@ module ActiveRecord
           when VALUE_LIMIT_VIOLATION
             ValueTooLong.new(message)
           when SERIALIZATION_FAILURE
-            TransactionSerializationError.new(message)
+            SerializationFailure.new(message)
+          when DEADLOCK_DETECTED
+            DeadlockDetected.new(message)
           else
             super
           end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -285,14 +285,24 @@ module ActiveRecord
   class TransactionIsolationError < ActiveRecordError
   end
 
-  # TransactionSerializationError will be raised when a transaction is rolled
+  # TransactionRollbackError will be raised when a transaction is rolled
   # back by the database due to a serialization failure or a deadlock.
   #
   # See the following:
   #
   # * http://www.postgresql.org/docs/current/static/transaction-iso.html
   # * https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html#error_er_lock_deadlock
-  class TransactionSerializationError < ActiveRecordError
+  class TransactionRollbackError < ActiveRecordError
+  end
+
+  # SerializationFailure will be raised when a transaction is rolled
+  # back by the database due to a serialization failure.
+  class SerializationFailure < TransactionRollbackError
+  end
+
+  # DeadlockDetected will be raised when a transaction is rolled
+  # back by the database when a deadlock is encountered.
+  class DeadlockDetected < TransactionRollbackError
   end
 
   # IrreversibleOrderError is raised when a relation's order is too complex for


### PR DESCRIPTION
### Summary

This is a WIP follow-up to #25093.

I went ahead with @jeremy's recommendation of introducing `ActiveRecord::TransactionRollbackError`, with subclasses to distinguish between a serialization failure or deadlock.

Checked around, and it looks like MySQL is just returning an `Error: 1213 SQLSTATE: 40001`, whereas PostgreSQL tries to distinguish between serialization failures and deadlocks. Given the following test scenarios:

``` ruby
thread = Thread.new do
  Sample.transaction isolation: :serializable do
    Sample.delete_all

    10.times do |i|
      sleep 0.1

      Sample.create value: i
    end
  end
end

sleep 0.1

Sample.transaction isolation: :serializable do
  Sample.delete_all

  10.times do |i|
    sleep 0.1

    Sample.create value: i
  end
end

thread.join
```

``` ruby
s1 = Sample.create value: 1
s2 = Sample.create value: 2

thread = Thread.new do
  Sample.transaction do
    s1.lock!
    sleep 1
    s2.update_attributes value: 1
  end
end

sleep 0.5

Sample.transaction do
  s2.lock!
  sleep 1
  s1.update_attributes value: 2
end

thread.join
```

PostgreSQL returns `40001` for the first scenario and `40P01` for the second. MySQL returns `40001` for both.

Also checked MS SQL Server and Oracle and - like MySQL - they only have error mappings for `40001`, which they use for serialization failures.
### Other Information:

PostgreSQL: http://www.postgresql.org/docs/devel/static/errcodes-appendix.html
MySQL 5.7: https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html
MS SQL Server: https://msdn.microsoft.com/en-us/library/ms714687.aspx
Oracle Database 12c: https://docs.oracle.com/database/121/ZZMOD/appd.htm#ZZMOD338
