### PR TITLE
Demonstration of logger missing Rack::Cache 304s

### DIFF
--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -62,6 +62,11 @@ module Another
       render :inline => "<%= cache_unless(true, 'foo') { 'bar' } %>"
     end
 
+    def with_fresh_when
+      fresh_when(etag: :test)
+      render text: 'Testing'
+    end
+
     def with_exception
       raise Exception
     end
@@ -346,6 +351,21 @@ class ACLogSubscriberTest < ActionController::TestCase
     assert_equal 2, logs.size
     assert_match(/Completed 404/, logs.last)
   end
+
+  def test_multiple_process_with_parameters
+    get :with_fresh_when, {}
+    first_etag = response.headers['ETag']
+    get :with_fresh_when, {}, { 'If-None-Match' => first_etag }
+    second_etag = response.headers['ETag']
+
+    wait
+
+    assert_equal 4, logs.size
+    assert_equal first_etag, second_etag
+    assert_match(/Completed 200/, logs[1])
+    assert_match(/Completed 304/, logs[3])
+  end
+
 
   def logs
     @logs ||= @logger.logged(:info)


### PR DESCRIPTION
One thing wrong with this. Rack::Cache is never actually
activated here so we're not really executing the full test.
But, I _think_ this demonstrates that the logger does not respect
Rack::Cache. I know that this doesn't happen in our app.

Unfortunately, I'm not sure what the fix is here. If people have ideas,
I am happy to finish this pull request with the solution, but I'm
worried that there may be an architectural problem with how Rack::Cache
modifies the response too "deep" in the rack middleware stack for the
log subscriber to be aware of it.
