### PR TITLE
Rename controller _filters to _callbacks in docs

### DIFF
--- a/actionpack/README.rdoc
+++ b/actionpack/README.rdoc
@@ -14,7 +14,7 @@ It consists of several modules:
   handling HTTP caching logic, cookies and sessions.
 
 * Action Controller, which provides a base controller class that can be
-  subclassed to implement filters and actions to handle requests. The result
+  subclassed to implement callbacks and actions to handle requests. The result
   of an action is typically content generated from views.
 
 With the Ruby on Rails framework, users only directly interface with the

--- a/actionpack/README.rdoc
+++ b/actionpack/README.rdoc
@@ -14,7 +14,7 @@ It consists of several modules:
   handling HTTP caching logic, cookies and sessions.
 
 * Action Controller, which provides a base controller class that can be
-  subclassed to implement action callbacks and actions to handle requests. The result
+  subclassed to implement actions to handle requests. The result
   of an action is typically content generated from views.
 
 With the Ruby on Rails framework, users only directly interface with the

--- a/actionpack/README.rdoc
+++ b/actionpack/README.rdoc
@@ -14,7 +14,7 @@ It consists of several modules:
   handling HTTP caching logic, cookies and sessions.
 
 * Action Controller, which provides a base controller class that can be
-  subclassed to implement callbacks and actions to handle requests. The result
+  subclassed to implement action callbacks and actions to handle requests. The result
   of an action is typically content generated from views.
 
 With the Ruby on Rails framework, users only directly interface with the

--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -32,6 +32,7 @@ module ActionController
       end
     end
 
+    # <tt>payload[:filter]</tt> refers to action callbacks, previously being call 'filters'.
     def halted_callback(event)
       info { "Filter chain halted as #{event.payload[:filter].inspect} rendered or redirected" }
     end

--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -32,8 +32,8 @@ module ActionController
       end
     end
 
-    # <tt>payload[:filter]</tt> refers to action callbacks, previously being call 'filters'.
     def halted_callback(event)
+      # NOTE: payload[:filter] refers to action callbacks, previously being call 'filters'.
       info { "Filter chain halted as #{event.payload[:filter].inspect} rendered or redirected" }
     end
 

--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -71,6 +71,7 @@ module ActionController
   private
 
     # A hook invoked every time a before callback is halted.
+    # <tt>payload[:filter]</tt> refers to action callbacks, previously being call 'filters'.
     def halted_callback_hook(filter)
       ActiveSupport::Notifications.instrument("halted_callback.action_controller", filter: filter)
     end

--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -71,8 +71,10 @@ module ActionController
   private
 
     # A hook invoked every time a before callback is halted.
-    # <tt>payload[:filter]</tt> refers to action callbacks, previously being call 'filters'.
+    # <tt>payload[:filter]</tt> contains the callback name:
+    # the symbol or proc originally passed to +before_action+.
     def halted_callback_hook(filter)
+      # NOTE: The payload is named :filter for historical reasons; before_action used to be before_filter.
       ActiveSupport::Notifications.instrument("halted_callback.action_controller", filter: filter)
     end
 

--- a/actionpack/test/controller/action_callbacks_test.rb
+++ b/actionpack/test/controller/action_callbacks_test.rb
@@ -10,7 +10,9 @@ class ActionController::Base
 
     def before_actions
       action_callbacks = _process_action_callbacks.select { |c| c.kind == :before }
-      action_callbacks.map!(&:raw_action_callback)
+      # NOTE: Even though we no longer refer to controller callbacks
+      # as 'filters', they are still called filters in ActiveSupport::Callbacks
+      action_callbacks.map!(&:raw_filter)
     end
   end
 end

--- a/actionpack/test/controller/action_callbacks_test.rb
+++ b/actionpack/test/controller/action_callbacks_test.rb
@@ -10,8 +10,6 @@ class ActionController::Base
 
     def before_actions
       action_callbacks = _process_action_callbacks.select { |c| c.kind == :before }
-      # NOTE: Even though we no longer refer to controller callbacks
-      # as 'filters', they are still called filters in ActiveSupport::Callbacks
       action_callbacks.map!(&:raw_filter)
     end
   end

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -15,6 +15,7 @@ class ActionController::Base
   end
 end
 
+# <tt>filters</tt> refers to action callbacks, previously being call 'filters'.
 class FilterTest < ActionController::TestCase
   class TestController < ActionController::Base
     before_action :ensure_login

--- a/guides/source/5_1_release_notes.md
+++ b/guides/source/5_1_release_notes.md
@@ -359,7 +359,7 @@ Please refer to the [Changelog][action-mailer] for detailed changes.
 *   Allowed passing lambdas as values to the `default` method.
     ([Commit](https://github.com/rails/rails/commit/1cec84ad2ddd843484ed40b1eb7492063ce71baf))
 
-*   Added support for parameterized invocation of mailers to share before filters and defaults
+*   Added support for parameterized invocation of mailers to share before callbacks and defaults
     between different mailer actions.
     ([Commit](https://github.com/rails/rails/commit/1cec84ad2ddd843484ed40b1eb7492063ce71baf))
 

--- a/guides/source/5_1_release_notes.md
+++ b/guides/source/5_1_release_notes.md
@@ -359,7 +359,7 @@ Please refer to the [Changelog][action-mailer] for detailed changes.
 *   Allowed passing lambdas as values to the `default` method.
     ([Commit](https://github.com/rails/rails/commit/1cec84ad2ddd843484ed40b1eb7492063ce71baf))
 
-*   Added support for parameterized invocation of mailers to share before action callbacks and defaults
+*   Added support for parameterized invocation of mailers to share action callbacks and defaults
     between different mailer actions.
     ([Commit](https://github.com/rails/rails/commit/1cec84ad2ddd843484ed40b1eb7492063ce71baf))
 

--- a/guides/source/5_1_release_notes.md
+++ b/guides/source/5_1_release_notes.md
@@ -359,7 +359,7 @@ Please refer to the [Changelog][action-mailer] for detailed changes.
 *   Allowed passing lambdas as values to the `default` method.
     ([Commit](https://github.com/rails/rails/commit/1cec84ad2ddd843484ed40b1eb7492063ce71baf))
 
-*   Added support for parameterized invocation of mailers to share before callbacks and defaults
+*   Added support for parameterized invocation of mailers to share before action callbacks and defaults
     between different mailer actions.
     ([Commit](https://github.com/rails/rails/commit/1cec84ad2ddd843484ed40b1eb7492063ce71baf))
 

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -679,7 +679,7 @@ end
 
 You may notice in the above code that we're using `render xml: @users`, not `render xml: @users.to_xml`. If the object is not a String, then Rails will automatically invoke `to_xml` for us.
 
-Action Callbacks
+Action callbacks
 -------
 
 Action callbacks are methods that are run "before", "after" or "around" a controller action.
@@ -715,7 +715,7 @@ end
 
 Now, the `LoginsController`'s `new` and `create` actions will work as before without requiring the user to be logged in. The `:only` option is used to skip this action callback only for these actions, and there is also an `:except` option which works the other way. These options can be used when adding action callbacks too, so you can add a action callback which only runs for selected actions in the first place.
 
-### After Action Callbacks and Around Action Callbacks
+### After action callbacks and Around action callbacks
 
 In addition to "before" action callbacks, you can also run action callbacks after an action has been executed, or both before and after.
 
@@ -747,7 +747,7 @@ Note that an "around" action callback also wraps rendering. In particular, if in
 
 You can choose not to yield and build the response yourself, in which case the action will not be run.
 
-### Other Ways to Use Action Callbacks
+### Other Ways to Use action callbacks
 
 While the most common way to use action callbacks is by creating private methods and using *_action to add them, there are two other ways to do the same thing.
 

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -10,7 +10,7 @@ After reading this guide, you will know:
 * How to follow the flow of a request through a controller.
 * How to restrict parameters passed to your controller.
 * How and why to store data in the session or cookies.
-* How to work with filters to execute code during request processing.
+* How to work with callbacks to execute code during request processing.
 * How to use Action Controller's built-in HTTP authentication.
 * How to stream data directly to the user's browser.
 * How to filter sensitive parameters so they do not appear in the application's log.
@@ -63,7 +63,7 @@ The [Layouts & Rendering Guide](layouts_and_rendering.html) explains this in mor
 
 `ApplicationController` inherits from `ActionController::Base`, which defines a number of helpful methods. This guide will cover some of these, but if you're curious to see what's in there, you can see all of them in the [API documentation](http://api.rubyonrails.org/classes/ActionController.html) or in the source itself.
 
-Only public methods are callable as actions. It is a best practice to lower the visibility of methods (with `private` or `protected`) which are not intended to be actions, like auxiliary methods or filters.
+Only public methods are callable as actions. It is a best practice to lower the visibility of methods (with `private` or `protected`) which are not intended to be actions, like auxiliary methods or callbacks.
 
 Parameters
 ----------
@@ -679,14 +679,14 @@ end
 
 You may notice in the above code that we're using `render xml: @users`, not `render xml: @users.to_xml`. If the object is not a String, then Rails will automatically invoke `to_xml` for us.
 
-Filters
+Callbacks
 -------
 
-Filters are methods that are run "before", "after" or "around" a controller action.
+Callbacks are methods that are run "before", "after" or "around" a controller action.
 
-Filters are inherited, so if you set a filter on `ApplicationController`, it will be run on every controller in your application.
+Callbacks are inherited, so if you set a callback on `ApplicationController`, it will be run on every controller in your application.
 
-"before" filters may halt the request cycle. A common "before" filter is one which requires that a user is logged in for an action to be run. You can define the filter method this way:
+"before" callbacks may halt the request cycle. A common "before" callback is one which requires that a user is logged in for an action to be run. You can define the callback method this way:
 
 ```ruby
 class ApplicationController < ActionController::Base
@@ -703,9 +703,9 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-The method simply stores an error message in the flash and redirects to the login form if the user is not logged in. If a "before" filter renders or redirects, the action will not run. If there are additional filters scheduled to run after that filter, they are also cancelled.
+The method simply stores an error message in the flash and redirects to the login form if the user is not logged in. If a "before" callback renders or redirects, the action will not run. If there are additional callbacks scheduled to run after that callback, they are also cancelled.
 
-In this example the filter is added to `ApplicationController` and thus all controllers in the application inherit it. This will make everything in the application require the user to be logged in in order to use it. For obvious reasons (the user wouldn't be able to log in in the first place!), not all controllers or actions should require this. You can prevent this filter from running before particular actions with `skip_before_action`:
+In this example the callback is added to `ApplicationController` and thus all controllers in the application inherit it. This will make everything in the application require the user to be logged in in order to use it. For obvious reasons (the user wouldn't be able to log in in the first place!), not all controllers or actions should require this. You can prevent this callback from running before particular actions with `skip_before_action`:
 
 ```ruby
 class LoginsController < ApplicationController
@@ -713,15 +713,15 @@ class LoginsController < ApplicationController
 end
 ```
 
-Now, the `LoginsController`'s `new` and `create` actions will work as before without requiring the user to be logged in. The `:only` option is used to skip this filter only for these actions, and there is also an `:except` option which works the other way. These options can be used when adding filters too, so you can add a filter which only runs for selected actions in the first place.
+Now, the `LoginsController`'s `new` and `create` actions will work as before without requiring the user to be logged in. The `:only` option is used to skip this callback only for these actions, and there is also an `:except` option which works the other way. These options can be used when adding callbacks too, so you can add a callback which only runs for selected actions in the first place.
 
-### After Filters and Around Filters
+### After Callbacks and Around Callbacks
 
-In addition to "before" filters, you can also run filters after an action has been executed, or both before and after.
+In addition to "before" callbacks, you can also run callbacks after an action has been executed, or both before and after.
 
-"after" filters are similar to "before" filters, but because the action has already been run they have access to the response data that's about to be sent to the client. Obviously, "after" filters cannot stop the action from running. Please note that "after" filters are executed only after a successful action, but not when an exception is raised in the request cycle.
+"after" callbacks are similar to "before" callbacks, but because the action has already been run they have access to the response data that's about to be sent to the client. Obviously, "after" callbacks cannot stop the action from running. Please note that "after" callbacks are executed only after a successful action, but not when an exception is raised in the request cycle.
 
-"around" filters are responsible for running their associated actions by yielding, similar to how Rack middlewares work.
+"around" callbacks are responsible for running their associated actions by yielding, similar to how Rack middlewares work.
 
 For example, in a website where changes have an approval workflow an administrator could be able to preview them easily, just apply them within a transaction:
 
@@ -743,15 +743,15 @@ class ChangesController < ApplicationController
 end
 ```
 
-Note that an "around" filter also wraps rendering. In particular, if in the example above, the view itself reads from the database (e.g. via a scope), it will do so within the transaction and thus present the data to preview.
+Note that an "around" callback also wraps rendering. In particular, if in the example above, the view itself reads from the database (e.g. via a scope), it will do so within the transaction and thus present the data to preview.
 
 You can choose not to yield and build the response yourself, in which case the action will not be run.
 
-### Other Ways to Use Filters
+### Other Ways to Use Callbacks
 
-While the most common way to use filters is by creating private methods and using *_action to add them, there are two other ways to do the same thing.
+While the most common way to use callbacks is by creating private methods and using *_action to add them, there are two other ways to do the same thing.
 
-The first is to use a block directly with the *\_action methods. The block receives the controller as an argument. The `require_login` filter from above could be rewritten to use a block:
+The first is to use a block directly with the *\_action methods. The block receives the controller as an argument. The `require_login` callback from above could be rewritten to use a block:
 
 ```ruby
 class ApplicationController < ActionController::Base
@@ -764,16 +764,16 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-Note that the filter in this case uses `send` because the `logged_in?` method is private and the filter does not run in the scope of the controller. This is not the recommended way to implement this particular filter, but in more simple cases it might be useful.
+Note that the callback in this case uses `send` because the `logged_in?` method is private and the callback does not run in the scope of the controller. This is not the recommended way to implement this particular callback, but in more simple cases it might be useful.
 
-The second way is to use a class (actually, any object that responds to the right methods will do) to handle the filtering. This is useful in cases that are more complex and cannot be implemented in a readable and reusable way using the two other methods. As an example, you could rewrite the login filter again to use a class:
+The second way is to use a class (actually, any object that responds to the right methods will do) to handle the action callback. This is useful in cases that are more complex and cannot be implemented in a readable and reusable way using the two other methods. As an example, you could rewrite the login callback again to use a class:
 
 ```ruby
 class ApplicationController < ActionController::Base
-  before_action LoginFilter
+  before_action LoginCallback
 end
 
-class LoginFilter
+class LoginCallback
   def self.before(controller)
     unless controller.send(:logged_in?)
       controller.flash[:error] = "You must be logged in to access this section"
@@ -783,7 +783,7 @@ class LoginFilter
 end
 ```
 
-Again, this is not an ideal example for this filter, because it's not run in the scope of the controller but gets the controller passed as an argument. The filter class must implement a method with the same name as the filter, so for the `before_action` filter the class must implement a `before` method, and so on. The `around` method must `yield` to execute the action.
+Again, this is not an ideal example for this callback, because it's not run in the scope of the controller but gets the controller passed as an argument. The callback class must implement a method with the same name as the callback, so for the `before_action` callback the class must implement a `before` method, and so on. The `around` method must `yield` to execute the action.
 
 Request Forgery Protection
 --------------------------
@@ -849,7 +849,7 @@ Rails collects all of the parameters sent along with the request in the `params`
 
 ### The `response` Object
 
-The response object is not usually used directly, but is built up during the execution of the action and rendering of the data that is being sent back to the user, but sometimes - like in an after filter - it can be useful to access the response directly. Some of these accessor methods also have setters, allowing you to change their values. To get a full list of the available methods, refer to the [Rails API documentation](http://api.rubyonrails.org/classes/ActionDispatch/Response.html) and [Rack Documentation](http://www.rubydoc.info/github/rack/rack/Rack/Response).
+The response object is not usually used directly, but is built up during the execution of the action and rendering of the data that is being sent back to the user, but sometimes - like in an after callback - it can be useful to access the response directly. Some of these accessor methods also have setters, allowing you to change their values. To get a full list of the available methods, refer to the [Rails API documentation](http://api.rubyonrails.org/classes/ActionDispatch/Response.html) and [Rack Documentation](http://www.rubydoc.info/github/rack/rack/Rack/Response).
 
 | Property of `response` | Purpose                                                                                             |
 | ---------------------- | --------------------------------------------------------------------------------------------------- |
@@ -888,7 +888,7 @@ class AdminsController < ApplicationController
 end
 ```
 
-With this in place, you can create namespaced controllers that inherit from `AdminsController`. The filter will thus be run for all actions in those controllers, protecting them with HTTP basic authentication.
+With this in place, you can create namespaced controllers that inherit from `AdminsController`. The callback will thus be run for all actions in those controllers, protecting them with HTTP basic authentication.
 
 ### HTTP Digest Authentication
 
@@ -1202,7 +1202,7 @@ class DinnerController
 end
 ```
 
-Just like the filter, you could also pass `:only` and `:except` to enforce the secure connection only to specific actions:
+Just like the action callbacks, you could also pass `:only` and `:except` to enforce the secure connection only to specific actions:
 
 ```ruby
 class DinnerController

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -63,7 +63,7 @@ The [Layouts & Rendering Guide](layouts_and_rendering.html) explains this in mor
 
 `ApplicationController` inherits from `ActionController::Base`, which defines a number of helpful methods. This guide will cover some of these, but if you're curious to see what's in there, you can see all of them in the [API documentation](http://api.rubyonrails.org/classes/ActionController.html) or in the source itself.
 
-Only public methods are callable as actions. It is a best practice to lower the visibility of methods (with `private` or `protected`) which are not intended to be actions, like auxiliary methods or action callbacks.
+Only public methods are callable as actions. It is a best practice to lower the visibility of methods (with `private` or `protected`) which are not intended to be actions, like auxiliary methods or callback handlers.
 
 Parameters
 ----------
@@ -679,14 +679,14 @@ end
 
 You may notice in the above code that we're using `render xml: @users`, not `render xml: @users.to_xml`. If the object is not a String, then Rails will automatically invoke `to_xml` for us.
 
-Action callbacks
--------
+Action Callbacks
+----------------
 
 Action callbacks are methods that are run "before", "after" or "around" a controller action.
 
 Action callbacks are inherited, so if you set an action callback on `ApplicationController`, it will be run on every controller in your application.
 
-"before" action callbacks may halt the request cycle. A common "before" action callback is one which requires that a user is logged in for an action to be run. You can define the action callback method this way:
+"before_action" callbacks may halt the request cycle. A common "before_action" is one which requires that a user is logged in for an action to be run. You can define the callback method this way:
 
 ```ruby
 class ApplicationController < ActionController::Base
@@ -703,9 +703,9 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-The method simply stores an error message in the flash and redirects to the login form if the user is not logged in. If a "before" action callback renders or redirects, the action will not run. If there are additional action callbacks scheduled to run after that action callback, they are also cancelled.
+The method simply stores an error message in the flash and redirects to the login form if the user is not logged in. If a "before_action"  renders or redirects, the action will not run. If there are additional callbacks scheduled to run after that one, they are also cancelled.
 
-In this example the action callback is added to `ApplicationController` and thus all controllers in the application inherit it. This will make everything in the application require the user to be logged in in order to use it. For obvious reasons (the user wouldn't be able to log in in the first place!), not all controllers or actions should require this. You can prevent this action callback from running before particular actions with `skip_before_action`:
+In this example the callback is added to `ApplicationController` and thus all controllers in the application inherit it. This will make everything in the application require the user to be logged in in order to use it. For obvious reasons (the user wouldn't be able to log in in the first place!), not all controllers or actions should require this. You can prevent this callback from running before particular actions with `skip_before_action`:
 
 ```ruby
 class LoginsController < ApplicationController
@@ -713,15 +713,15 @@ class LoginsController < ApplicationController
 end
 ```
 
-Now, the `LoginsController`'s `new` and `create` actions will work as before without requiring the user to be logged in. The `:only` option is used to skip this action callback only for these actions, and there is also an `:except` option which works the other way. These options can be used when adding action callbacks too, so you can add a action callback which only runs for selected actions in the first place.
+Now, the `LoginsController`'s `new` and `create` actions will work as before without requiring the user to be logged in. The `:only` option is used to skip this callback only for these actions, and there is also an `:except` option which works the other way. These options can be used when adding callbacks too, so you can add a callback which only runs for selected actions in the first place.
 
-### After action callbacks and Around action callbacks
+### after_action Callbacks And around_action Callbacks
 
-In addition to "before" action callbacks, you can also run action callbacks after an action has been executed, or both before and after.
+In addition to "before_action" callbacks, you can also run action callbacks after an action has been executed, or both before and after.
 
-"after" action callbacks are similar to "before" action callbacks, but because the action has already been run they have access to the response data that's about to be sent to the client. Obviously, "after" action callbacks cannot stop the action from running. Please note that "after" action callbacks are executed only after a successful action, but not when an exception is raised in the request cycle.
+"after_action" callbacks are similar to "before_action" callbacks, but because the action has already been run they have access to the response data that's about to be sent to the client. Obviously, "after_action" callbacks cannot stop the action from running. Please note that "after_action" callbacks are executed only after a successful action, but not when an exception is raised in the request cycle.
 
-"around" action callbacks are responsible for running their associated actions by yielding, similar to how Rack middlewares work.
+"around_action" callbacks are responsible for running their associated actions by yielding, similar to how Rack middlewares work.
 
 For example, in a website where changes have an approval workflow an administrator could be able to preview them easily, just apply them within a transaction:
 
@@ -743,7 +743,7 @@ class ChangesController < ApplicationController
 end
 ```
 
-Note that an "around" action callback also wraps rendering. In particular, if in the example above, the view itself reads from the database (e.g. via a scope), it will do so within the transaction and thus present the data to preview.
+Note that an "around_action" callback also wraps rendering. In particular, if in the example above, the view itself reads from the database (e.g. via a scope), it will do so within the transaction and thus present the data to preview.
 
 You can choose not to yield and build the response yourself, in which case the action will not be run.
 

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -10,7 +10,7 @@ After reading this guide, you will know:
 * How to follow the flow of a request through a controller.
 * How to restrict parameters passed to your controller.
 * How and why to store data in the session or cookies.
-* How to work with callbacks to execute code during request processing.
+* How to work with action callbacks to execute code during request processing.
 * How to use Action Controller's built-in HTTP authentication.
 * How to stream data directly to the user's browser.
 * How to filter sensitive parameters so they do not appear in the application's log.
@@ -63,7 +63,7 @@ The [Layouts & Rendering Guide](layouts_and_rendering.html) explains this in mor
 
 `ApplicationController` inherits from `ActionController::Base`, which defines a number of helpful methods. This guide will cover some of these, but if you're curious to see what's in there, you can see all of them in the [API documentation](http://api.rubyonrails.org/classes/ActionController.html) or in the source itself.
 
-Only public methods are callable as actions. It is a best practice to lower the visibility of methods (with `private` or `protected`) which are not intended to be actions, like auxiliary methods or callbacks.
+Only public methods are callable as actions. It is a best practice to lower the visibility of methods (with `private` or `protected`) which are not intended to be actions, like auxiliary methods or action callbacks.
 
 Parameters
 ----------
@@ -679,14 +679,14 @@ end
 
 You may notice in the above code that we're using `render xml: @users`, not `render xml: @users.to_xml`. If the object is not a String, then Rails will automatically invoke `to_xml` for us.
 
-Callbacks
+Action Callbacks
 -------
 
-Callbacks are methods that are run "before", "after" or "around" a controller action.
+Action callbacks are methods that are run "before", "after" or "around" a controller action.
 
-Callbacks are inherited, so if you set a callback on `ApplicationController`, it will be run on every controller in your application.
+Action callbacks are inherited, so if you set an action callback on `ApplicationController`, it will be run on every controller in your application.
 
-"before" callbacks may halt the request cycle. A common "before" callback is one which requires that a user is logged in for an action to be run. You can define the callback method this way:
+"before" action callbacks may halt the request cycle. A common "before" action callback is one which requires that a user is logged in for an action to be run. You can define the action callback method this way:
 
 ```ruby
 class ApplicationController < ActionController::Base
@@ -703,9 +703,9 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-The method simply stores an error message in the flash and redirects to the login form if the user is not logged in. If a "before" callback renders or redirects, the action will not run. If there are additional callbacks scheduled to run after that callback, they are also cancelled.
+The method simply stores an error message in the flash and redirects to the login form if the user is not logged in. If a "before" action callback renders or redirects, the action will not run. If there are additional action callbacks scheduled to run after that action callback, they are also cancelled.
 
-In this example the callback is added to `ApplicationController` and thus all controllers in the application inherit it. This will make everything in the application require the user to be logged in in order to use it. For obvious reasons (the user wouldn't be able to log in in the first place!), not all controllers or actions should require this. You can prevent this callback from running before particular actions with `skip_before_action`:
+In this example the action callback is added to `ApplicationController` and thus all controllers in the application inherit it. This will make everything in the application require the user to be logged in in order to use it. For obvious reasons (the user wouldn't be able to log in in the first place!), not all controllers or actions should require this. You can prevent this action callback from running before particular actions with `skip_before_action`:
 
 ```ruby
 class LoginsController < ApplicationController
@@ -713,15 +713,15 @@ class LoginsController < ApplicationController
 end
 ```
 
-Now, the `LoginsController`'s `new` and `create` actions will work as before without requiring the user to be logged in. The `:only` option is used to skip this callback only for these actions, and there is also an `:except` option which works the other way. These options can be used when adding callbacks too, so you can add a callback which only runs for selected actions in the first place.
+Now, the `LoginsController`'s `new` and `create` actions will work as before without requiring the user to be logged in. The `:only` option is used to skip this action callback only for these actions, and there is also an `:except` option which works the other way. These options can be used when adding action callbacks too, so you can add a action callback which only runs for selected actions in the first place.
 
-### After Callbacks and Around Callbacks
+### After Action Callbacks and Around Action Callbacks
 
-In addition to "before" callbacks, you can also run callbacks after an action has been executed, or both before and after.
+In addition to "before" action callbacks, you can also run action callbacks after an action has been executed, or both before and after.
 
-"after" callbacks are similar to "before" callbacks, but because the action has already been run they have access to the response data that's about to be sent to the client. Obviously, "after" callbacks cannot stop the action from running. Please note that "after" callbacks are executed only after a successful action, but not when an exception is raised in the request cycle.
+"after" action callbacks are similar to "before" action callbacks, but because the action has already been run they have access to the response data that's about to be sent to the client. Obviously, "after" action callbacks cannot stop the action from running. Please note that "after" action callbacks are executed only after a successful action, but not when an exception is raised in the request cycle.
 
-"around" callbacks are responsible for running their associated actions by yielding, similar to how Rack middlewares work.
+"around" action callbacks are responsible for running their associated actions by yielding, similar to how Rack middlewares work.
 
 For example, in a website where changes have an approval workflow an administrator could be able to preview them easily, just apply them within a transaction:
 
@@ -743,15 +743,15 @@ class ChangesController < ApplicationController
 end
 ```
 
-Note that an "around" callback also wraps rendering. In particular, if in the example above, the view itself reads from the database (e.g. via a scope), it will do so within the transaction and thus present the data to preview.
+Note that an "around" action callback also wraps rendering. In particular, if in the example above, the view itself reads from the database (e.g. via a scope), it will do so within the transaction and thus present the data to preview.
 
 You can choose not to yield and build the response yourself, in which case the action will not be run.
 
-### Other Ways to Use Callbacks
+### Other Ways to Use Action Callbacks
 
-While the most common way to use callbacks is by creating private methods and using *_action to add them, there are two other ways to do the same thing.
+While the most common way to use action callbacks is by creating private methods and using *_action to add them, there are two other ways to do the same thing.
 
-The first is to use a block directly with the *\_action methods. The block receives the controller as an argument. The `require_login` callback from above could be rewritten to use a block:
+The first is to use a block directly with the *\_action methods. The block receives the controller as an argument. The `require_login` action callback from above could be rewritten to use a block:
 
 ```ruby
 class ApplicationController < ActionController::Base
@@ -764,16 +764,16 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-Note that the callback in this case uses `send` because the `logged_in?` method is private and the callback does not run in the scope of the controller. This is not the recommended way to implement this particular callback, but in more simple cases it might be useful.
+Note that the action callback in this case uses `send` because the `logged_in?` method is private and the action callback does not run in the scope of the controller. This is not the recommended way to implement this particular action callback, but in more simple cases it might be useful.
 
-The second way is to use a class (actually, any object that responds to the right methods will do) to handle the action callback. This is useful in cases that are more complex and cannot be implemented in a readable and reusable way using the two other methods. As an example, you could rewrite the login callback again to use a class:
+The second way is to use a class (actually, any object that responds to the right methods will do) to handle the action callback. This is useful in cases that are more complex and cannot be implemented in a readable and reusable way using the two other methods. As an example, you could rewrite the login action callback again to use a class:
 
 ```ruby
 class ApplicationController < ActionController::Base
-  before_action LoginCallback
+  before_action LoginActionCallback
 end
 
-class LoginCallback
+class LoginActionCallback
   def self.before(controller)
     unless controller.send(:logged_in?)
       controller.flash[:error] = "You must be logged in to access this section"
@@ -783,7 +783,7 @@ class LoginCallback
 end
 ```
 
-Again, this is not an ideal example for this callback, because it's not run in the scope of the controller but gets the controller passed as an argument. The callback class must implement a method with the same name as the callback, so for the `before_action` callback the class must implement a `before` method, and so on. The `around` method must `yield` to execute the action.
+Again, this is not an ideal example for this action callback, because it's not run in the scope of the controller but gets the controller passed as an argument. The action callback class must implement a method with the same name as the action callback, so for the `before_action` callback the class must implement a `before` method, and so on. The `around` method must `yield` to execute the action.
 
 Request Forgery Protection
 --------------------------
@@ -849,7 +849,7 @@ Rails collects all of the parameters sent along with the request in the `params`
 
 ### The `response` Object
 
-The response object is not usually used directly, but is built up during the execution of the action and rendering of the data that is being sent back to the user, but sometimes - like in an after callback - it can be useful to access the response directly. Some of these accessor methods also have setters, allowing you to change their values. To get a full list of the available methods, refer to the [Rails API documentation](http://api.rubyonrails.org/classes/ActionDispatch/Response.html) and [Rack Documentation](http://www.rubydoc.info/github/rack/rack/Rack/Response).
+The response object is not usually used directly, but is built up during the execution of the action and rendering of the data that is being sent back to the user, but sometimes - like in an after action callback - it can be useful to access the response directly. Some of these accessor methods also have setters, allowing you to change their values. To get a full list of the available methods, refer to the [Rails API documentation](http://api.rubyonrails.org/classes/ActionDispatch/Response.html) and [Rack Documentation](http://www.rubydoc.info/github/rack/rack/Rack/Response).
 
 | Property of `response` | Purpose                                                                                             |
 | ---------------------- | --------------------------------------------------------------------------------------------------- |
@@ -888,7 +888,7 @@ class AdminsController < ApplicationController
 end
 ```
 
-With this in place, you can create namespaced controllers that inherit from `AdminsController`. The callback will thus be run for all actions in those controllers, protecting them with HTTP basic authentication.
+With this in place, you can create namespaced controllers that inherit from `AdminsController`. The action callback will thus be run for all actions in those controllers, protecting them with HTTP basic authentication.
 
 ### HTTP Digest Authentication
 


### PR DESCRIPTION
Just docs update to remove references to controller `filters`.  I replaced `filter` with `callback`, where it seemed appropriate.  Perhaps `action callback` or `action lifecycle hooks` would be more appropriate?
