### PR TITLE
Fix Migrations and Seed Data Typo in Doc

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -1041,7 +1041,7 @@ To add initial data after a database is created, Rails has a built-in
 'seeds' feature that makes the process quick and easy. This is especially 
 useful when reloading the database frequently in development and test environments. 
 It's easy to get started with this feature: just fill up `db/seeds.rb` with some 
-Ruby code, and run `rails db:seed`:
+Ruby code, and run `rake db:seed`:
 
 ```ruby
 5.times do |i|


### PR DESCRIPTION
### Summary

Fixed a typo as running seed data is done with "rake db:seed" instead of "rails db:seed" which returns an error
