### PR TITLE
Add tests for Hash#_deep_transform_keys_in_object(!)

### DIFF
--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1768,4 +1768,16 @@ class HashToXmlTest < ActiveSupport::TestCase
       Hash.from_xml(attack_xml)
     end
   end
+
+  def test__deep_transform_keys_in_object_returns_unchanged_first_arg_unless_array_or_hash
+    ['string', -> {}, 123, Object.new].each do |object|
+      assert_same object, {}.send(:_deep_transform_keys_in_object, object)
+    end
+  end
+
+  def test__deep_transform_keys_in_object_returns_changed_first_arg_if_array_or_hash
+    [{}, []].each do |object|
+      assert_not_same object, {}.send(:_deep_transform_keys_in_object, object)
+    end
+  end
 end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1769,15 +1769,17 @@ class HashToXmlTest < ActiveSupport::TestCase
     end
   end
 
-  def test__deep_transform_keys_in_object_returns_unchanged_first_arg_unless_array_or_hash
+  def test__deep_transform_keys_in_object_returns_unchanged_object_unless_first_arg_is_array_or_hash
+    h = {}
     ['string', -> {}, 123, Object.new].each do |object|
-      assert_same object, {}.send(:_deep_transform_keys_in_object, object)
+      assert_same object, h.send(:_deep_transform_keys_in_object, object)
     end
   end
 
-  def test__deep_transform_keys_in_object_returns_changed_first_arg_if_array_or_hash
+  def test__deep_transform_keys_in_object_returns_changed_object_if_first_arg_is_array_or_hash
+    h = {}
     [{}, []].each do |object|
-      assert_not_same object, {}.send(:_deep_transform_keys_in_object, object)
+      assert_not_same object, h.send(:_deep_transform_keys_in_object, object)
     end
   end
 end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1769,17 +1769,21 @@ class HashToXmlTest < ActiveSupport::TestCase
     end
   end
 
-  def test__deep_transform_keys_in_object_returns_unchanged_object_unless_first_arg_is_array_or_hash
-    h = {}
+  test '_deep_transform_keys_in_object returns the same object unless first arg is array or hash' do
     ['string', -> {}, 123, Object.new].each do |object|
-      assert_same object, h.send(:_deep_transform_keys_in_object, object)
+      assert_same object, {}.send(:_deep_transform_keys_in_object, object)
     end
   end
 
-  def test__deep_transform_keys_in_object_returns_changed_object_if_first_arg_is_array_or_hash
-    h = {}
+  test '_deep_transform_keys_in_object returns different object if first arg is array or hash' do
     [{}, []].each do |object|
-      assert_not_same object, h.send(:_deep_transform_keys_in_object, object)
+      assert_not_same object, {}.send(:_deep_transform_keys_in_object, object)
+    end
+  end
+
+  test '_deep_transform_keys_in_object! always returns the same object' do
+    [{}, [], 'string', -> {}, 123, Object.new].each do |object|
+      assert_same object, {}.send(:_deep_transform_keys_in_object!, object)
     end
   end
 end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -74,6 +74,12 @@ class HashExtTest < ActiveSupport::TestCase
     assert_respond_to h, :except!
   end
 
+  def test_private_methods
+    h = {}
+    assert_equal true, h.private_methods.include?(:_deep_transform_keys_in_object)
+    assert_equal true, h.private_methods.include?(:_deep_transform_keys_in_object!)
+  end
+
   def test_transform_keys
     assert_equal @upcase_strings, @strings.transform_keys{ |key| key.to_s.upcase }
     assert_equal @upcase_strings, @symbols.transform_keys{ |key| key.to_s.upcase }


### PR DESCRIPTION
### Summary

Tests for private methods `Hash#_deep_transform_keys_in_object` and  `Hash#_deep_transform_keys_in_object!` are missing.
#### Add tests for
- existence of the methods
- return value of the methods
