### PR TITLE
Build action_cable.js with Blade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ group :cable do
   gem 'redis', require: false
 
   gem 'faye-websocket', require: false
-  gem 'blade', '~> 0.5.1', require: false
+  gem 'blade', '~> 0.5.5', require: false
 end
 
 # Add your own local bundler stuff.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,15 +116,16 @@ GEM
     bcrypt (3.1.11-x86-mingw32)
     beaneater (1.0.0)
     benchmark-ips (2.6.1)
-    blade (0.5.1)
+    blade (0.5.5)
       activesupport (>= 3.0.0)
       blade-qunit_adapter (~> 1.20.0)
-      coffee-script (~> 2.4.0)
-      coffee-script-source (~> 1.10.0)
+      coffee-script
+      coffee-script-source
       curses (~> 1.0.0)
-      eventmachine (~> 1.2.0)
-      faye (~> 1.1.1)
-      sprockets (~> 3.6.0)
+      eventmachine
+      faye
+      sprockets (>= 3.0)
+      sprockets-export (~> 0.9.1)
       thin (~> 1.6.0)
       thor (~> 0.19.1)
       useragent (~> 0.16.7)
@@ -284,6 +285,7 @@ GEM
     sprockets (3.6.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
+    sprockets-export (0.9.1)
     sprockets-rails (3.0.4)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
@@ -331,7 +333,7 @@ DEPENDENCIES
   backburner
   bcrypt (~> 3.1.11)
   benchmark-ips
-  blade (~> 0.5.1)
+  blade (~> 0.5.5)
   byebug
   coffee-rails!
   dalli (>= 2.2.1)

--- a/actioncable/Rakefile
+++ b/actioncable/Rakefile
@@ -8,7 +8,6 @@ dir = File.dirname(__FILE__)
 task :default => :test
 
 task :package => "assets:compile"
-task "package:clean"
 
 Rake::TestTask.new do |t|
   t.libs << "test"

--- a/actioncable/Rakefile
+++ b/actioncable/Rakefile
@@ -1,15 +1,14 @@
 require 'rake/testtask'
 require 'pathname'
-require 'sprockets'
-require 'coffee-script'
 require 'action_cable'
+require 'blade'
 
 dir = File.dirname(__FILE__)
 
 task :default => :test
 
 task :package => "assets:compile"
-task "package:clean" => "assets:clean"
+task "package:clean"
 
 Rake::TestTask.new do |t|
   t.libs << "test"
@@ -27,44 +26,13 @@ namespace :test do
   end
 
   task :javascript do
-    require 'blade'
     Blade.start(interface: :runner)
   end
 end
 
 namespace :assets do
-  root_path = Pathname.new(dir)
-  destination_path = root_path.join("lib/assets/compiled")
-
-  desc "Compile dist/action_cable.js"
+  desc "Compile Action Cable assets"
   task :compile do
-    puts 'Compiling Action Cable assets...'
-
-    precompile_list = %w(action_cable.js)
-
-    environment = Sprockets::Environment.new
-    environment.gzip = false
-    Pathname.glob(root_path.join("app/assets/*/")) do |subdir|
-      environment.append_path subdir
-    end
-
-    compile_path = root_path.join("tmp/sprockets")
-    compile_path.rmtree if compile_path.exist?
-    compile_path.mkpath
-
-    manifest = Sprockets::Manifest.new(environment.index, compile_path)
-    manifest.compile(precompile_list)
-
-    destination_path.rmtree if destination_path.exist?
-    manifest.assets.each do |path, fingerprint_path|
-      destination_path.join(path).dirname.mkpath
-      FileUtils.cp(compile_path.join(fingerprint_path), destination_path.join(path))
-    end
-
-    puts 'Done'
-  end
-
-  task :clean do
-    destination_path.rmtree if destination_path.exist?
+    Blade.build
   end
 end

--- a/actioncable/app/assets/javascripts/action_cable.coffee.erb
+++ b/actioncable/app/assets/javascripts/action_cable.coffee.erb
@@ -1,3 +1,4 @@
+#= export ActionCable
 #= require_self
 #= require ./action_cable/consumer
 
@@ -33,9 +34,3 @@
     if @debugging
       messages.push(Date.now())
       console.log("[ActionCable]", messages...)
-
-# NOTE: We expose ActionCable as a browser global so we can reference it
-# internally without concern for how the module is loaded.
-window?.ActionCable = @ActionCable
-
-module?.exports = @ActionCable

--- a/actioncable/blade.yml
+++ b/actioncable/blade.yml
@@ -5,3 +5,9 @@ load_paths:
 
 logical_paths:
   - test.js
+
+build:
+  logical_paths:
+    - action_cable.js
+  path: lib/assets/compiled
+  clean: true

--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -4,7 +4,6 @@ desc "Default Task"
 task default: [ :test ]
 
 task :package
-task "package:clean"
 
 # Run the unit tests
 Rake::TestTask.new { |t|

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -6,7 +6,6 @@ desc "Default Task"
 task :default => :test
 
 task :package
-task "package:clean"
 
 # Run the unit tests
 Rake::TestTask.new do |t|

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -4,7 +4,6 @@ desc "Default Task"
 task :default => :test
 
 task :package
-task "package:clean"
 
 # Run the unit tests
 

--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -8,7 +8,6 @@ task default: :test
 task test: 'test:default'
 
 task :package
-task "package:clean"
 
 namespace :test do
   desc 'Run all adapter tests'

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -5,7 +5,6 @@ dir = File.dirname(__FILE__)
 task :default => :test
 
 task :package
-task "package:clean"
 
 Rake::TestTask.new do |t|
   t.libs << "test"

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -21,7 +21,6 @@ desc 'Run mysql2, sqlite, and postgresql tests by default'
 task :default => :test
 
 task :package
-task "package:clean"
 
 desc 'Run mysql2, sqlite, and postgresql tests'
 task :test do

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -3,7 +3,6 @@ require 'rake/testtask'
 task :default => :test
 
 task :package
-task "package:clean"
 
 Rake::TestTask.new do |t|
   t.libs << 'test'

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -3,7 +3,6 @@ require 'rake/testtask'
 task :default => :test
 
 task :package
-task "package:clean"
 
 desc "Run all unit tests"
 task :test => 'test:isolated'

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -13,7 +13,6 @@ directory "pkg"
 
     task :clean do
       rm_f gem
-      sh "cd #{framework} && bundle exec rake package:clean" unless framework == "rails"
     end
 
     task :update_versions do


### PR DESCRIPTION
- Compiles `action_cable.js` with Blade, which essentially uses the same Sprockets setup we had in the rake task. No need to duplicate.
- Uses [sprocket-export](https://github.com/javan/sprockets-export)'s `#= export` directive to replace the somewhat incomplete implementation

/cc @maclover7 @jeremy 
