### PR TITLE
Change default cable.yml production URL to use ENV

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -313,7 +313,7 @@ This file must specify an adapter and a URL for each Rails environment. It may u
 ```yaml
 production: &production
   adapter: redis
-  url: redis://10.10.3.153:6381
+  url: <%= ENV["REDIS_URL"] %>
 development: &development
   adapter: redis
   url: redis://localhost:6379

--- a/railties/lib/rails/generators/rails/app/templates/config/cable.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/cable.yml
@@ -6,4 +6,4 @@ test:
 
 production:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: <%= ENV["REDIS_URL"] %>


### PR DESCRIPTION
### Desired implementation

``` yaml
production:
  adapter: redis
  url: <%= ENV["REDIS_URL"] %>
```
### Current implementation

``` yaml
production:
  adapter: redis
  url: redis://localhost:6379/1
```
#### Why

1) In real life, most instances won't be using a locally hosted version of redis
2) Always better to hide info about production
3) Will more easily integrate with third party software, such as Heroku
