### PR TITLE
Modifies mime-registration test not to interfere with real mime types

### DIFF
--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -155,7 +155,7 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
   test "parses json params after custom json mime type registered" do
     begin
       Mime::Type.unregister :json
-      Mime::Type.register "application/json", :json, %w(application/vnd.api+json)
+      Mime::Type.register "application/json", :json, %w(application/vnd.rails+json)
       assert_parses(
         {"user" => {"username" => "meinac"}, "username" => "meinac"},
         "{\"username\": \"meinac\"}", { 'CONTENT_TYPE' => 'application/json' }
@@ -169,10 +169,10 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
   test "parses json params after custom json mime type registered with synonym" do
     begin
       Mime::Type.unregister :json
-      Mime::Type.register "application/json", :json, %w(application/vnd.api+json)
+      Mime::Type.register "application/json", :json, %w(application/vnd.rails+json)
       assert_parses(
         {"user" => {"username" => "meinac"}, "username" => "meinac"},
-        "{\"username\": \"meinac\"}", { 'CONTENT_TYPE' => 'application/vnd.api+json' }
+        "{\"username\": \"meinac\"}", { 'CONTENT_TYPE' => 'application/vnd.rails+json' }
       )
     ensure
       Mime::Type.unregister :json


### PR DESCRIPTION
The tests introduced in
https://github.com/rails/rails/pull/23816/files#diff-384a5a15d8d53de799fb6541688ea5f9R153
register the JSON API media type `application/vnd.api+json` with `Mime[:json]`. 

The JSON API media type should not be registered with `Mime[:json]`, as discussed in #23712.  
Moreover, since the actual mime type used in the test is incidental, I've changed this to a valid, but fictional `applcation/vnd.rails+json`.

These tests were causing failures in  https://github.com/rails/rails/pull/25050#issuecomment-221092934 where `Mime[:jsonapi]` is being added, so that JSON API request params are parsed with the JSONAPI gem.
