### PR TITLE
[] and read_attribute are not aliases [ci skip]

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -334,8 +334,6 @@ module ActiveRecord
     #
     # Note: +:id+ is always present.
     #
-    # Alias for the #read_attribute method.
-    #
     #   class Person < ActiveRecord::Base
     #     belongs_to :organization
     #   end


### PR DESCRIPTION
The `#[]` method _used to be_ an alias of `#read_attribute`, but since Rails 4 (10f6f90d9d1bbc9598bffea90752fc6bd76904cd), `#[]` will raise an exception for missing attributes. Saying that it is an alias is confusing.
