### PR TITLE
Cloning depth set to 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,3 +79,6 @@ notifications:
     on_failure: always
     rooms:
       - secure: "YA1alef1ESHWGFNVwvmVGCkMe4cUy4j+UcNvMUESraceiAfVyRMAovlQBGs6\n9kBRm7DHYBUXYC2ABQoJbQRLDr/1B5JPf/M8+Qd7BKu8tcDC03U01SMHFLpO\naOs/HLXcDxtnnpL07tGVsm0zhMc5N8tq4/L3SHxK7Vi+TacwQzI="
+
+git:
+  depth: 1


### PR DESCRIPTION
### Summary

Set git clone depth in .travis.yml to 1 in order to speed up the build.

Right now is roughly ~7s, so let's see how long does it take with this setting. It's not going to be that much compared with the total (~25') but every second counts! 😄
