### PR TITLE
Consider only uniq elements in the array while building predicates in where condition.

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -13,6 +13,7 @@ module ActiveRecord
 
         ranges, values = values.partition { |v| v.is_a?(Range) }
 
+        values.uniq!
         values_predicate =
           case values.length
           when 0 then NullPredicate

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -318,5 +318,13 @@ module ActiveRecord
     def test_where_with_unsupported_arguments
       assert_raises(ArgumentError) { Author.where(42) }
     end
+
+    test "where condition with array with repititive values" do
+      assert_equal Post.where(id: [1,2,3,4]).to_sql, Post.where(id: [1,2,3,4,1,2,4,1,2]).to_sql
+    end
+
+    test "where clause checks equality instead of IN query when array elements are same" do
+      assert_equal Post.where(id: 1).to_sql, Post.where(id: [1,1,1,1,1]).to_sql
+    end
   end
 end


### PR DESCRIPTION
Currently passing repetitive values in an array within where clause builds query with all the elements.

```
User.where(id: [1,2,3,4,1,2,3,2,3,5,3,2,4,2,1,4,1,5,3,5,2,3,1]).to_sql
"SELECT \"users\".* FROM \"users\" WHERE \"users\".\"id\" IN (1,2,3,4,1,2,3,2,3,5,3,2,4,2,1,4,1,5,3,5,2,3,1)" 

User.where(id: [1, 1, 1, 1]).to_sql
"SELECT \"users\".* FROM \"users\" WHERE \"users\".\"id\" IN (1, 1, 1, 1)" 
```

This PR makes change to consider only the unique elements in the array passed.
So we'll now have

```
User.where(id: [1,2,3,4,1,2,3,2,3,5,3,2,4,2,1,4,1,5,3,5,2,3,1]).to_sql
"SELECT \"users\".* FROM \"users\" WHERE \"users\".\"id\" IN (1, 2, 3, 4, 5)" 

User.where(id: [1, 1, 1, 1]).to_sql
"SELECT \"users\".* FROM \"users\" WHERE \"users\".\"id\" = 1" 
```

Advantages
- Shorter query string which could help in certain query analytics.
- Optimized query by reducing number of elements to check in IN clause.
- Chances of avoiding IN query and use equality check if our input fortunately is array of one element repeated.
