### PR TITLE
Restrict `delegate_missing_to` to only public methods

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -267,7 +267,7 @@ class Module
       end
 
       def method_missing(method, *args, &block)
-        #{target}.send(method, *args, &block)
+        #{target}.public_send(method, *args, &block)
       end
     RUBY
   end

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -40,6 +40,12 @@ class Someone < Struct.new(:name, :place)
 
   FAILED_DELEGATE_LINE_2 = __LINE__ + 1
   delegate :bar, :to => :place, :allow_nil => true
+
+  private
+
+  def private_name
+    @name
+  end
 end
 
 Invoice   = Struct.new(:client) do
@@ -336,6 +342,14 @@ class ModuleTest < ActiveSupport::TestCase
 
   def test_delegate_to_missing_with_reserved_methods
     assert_equal "David", DecoratedReserved.new(@david).name
+  end
+
+  def test_delegate_to_missing_does_not_call_private
+    err = assert_raises(NoMethodError) do
+      DecoratedReserved.new(@david).private_name
+    end
+
+    assert_match /private method `private_name' called for/, err.message
   end
 
   def test_parent


### PR DESCRIPTION
r? @rafaelfranca
