### PR TITLE
Normalize whitespace for Hash#compact documentation

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/compact.rb
+++ b/activesupport/lib/active_support/core_ext/hash/compact.rb
@@ -1,9 +1,9 @@
 class Hash
   # Returns a hash with non +nil+ values.
   #
-  #   hash = { a: true, b: false, c: nil}
-  #   hash.compact # => { a: true, b: false}
-  #   hash # => { a: true, b: false, c: nil}
+  #   hash = { a: true, b: false, c: nil }
+  #   hash.compact       # => { a: true, b: false }
+  #   hash               # => { a: true, b: false, c: nil }
   #   { c: nil }.compact # => {}
   def compact
     self.select { |_, value| !value.nil? }
@@ -11,9 +11,9 @@ class Hash
 
   # Replaces current hash with non +nil+ values.
   #
-  #   hash = { a: true, b: false, c: nil}
-  #   hash.compact! # => { a: true, b: false}
-  #   hash # => { a: true, b: false}
+  #   hash = { a: true, b: false, c: nil }
+  #   hash.compact! # => { a: true, b: false }
+  #   hash          # => { a: true, b: false }
   def compact!
     self.reject! { |_, value| value.nil? }
   end


### PR DESCRIPTION
This is a similar change that occurred for `Hash#except` in #21087.
