### PR TITLE
Add tests for keyword arg to: for Module#delegate

### DIFF
--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -193,6 +193,21 @@ class ModuleTest < ActiveSupport::TestCase
     end
   end
 
+  def test_delegation_target_when_prefix_is_true
+    assert_nothing_raised do
+      Name.send :delegate, :go, to: :you, prefix: true
+    end
+    assert_nothing_raised do
+      Name.send :delegate, :go, to: :_you, prefix: true
+    end
+    assert_raise(ArgumentError) do
+      Name.send :delegate, :go, to: :You, prefix: true
+    end
+    assert_raise(ArgumentError) do
+      Name.send :delegate, :go, to: :@you, prefix: true
+    end
+  end
+
   def test_delegation_prefix
     invoice = Invoice.new(@david)
     assert_equal invoice.client_name, "David"


### PR DESCRIPTION
### Summary

When keyword  parameter `prefix: true` is given to `Module#delegate`

``` ruby
you_go   # Good method name (Nothing raised)
_you_go  # Good method name (Nothing raised)
You_go   # Bad method name (ArgumentError raised)
@you_go  # Bad method name (ArgumentError raised)
```
