### PR TITLE
Generalize length validation error

### DIFF
--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -16,14 +16,14 @@ en:
       blank: "can't be blank"
       present: "must be blank"
       too_long:
-        one: "is too long (maximum is 1 character)"
-        other: "is too long (maximum is %{count} characters)"
+        one: "is too long (maximum is 1)"
+        other: "is too long (maximum is %{count})"
       too_short:
-        one: "is too short (minimum is 1 character)"
-        other: "is too short (minimum is %{count} characters)"
+        one: "is too short (minimum is 1)"
+        other: "is too short (minimum is %{count})"
       wrong_length:
-        one: "is the wrong length (should be 1 character)"
-        other: "is the wrong length (should be %{count} characters)"
+        one: "is the wrong length (should be 1)"
+        other: "is the wrong length (should be %{count})"
       not_a_number: "is not a number"
       not_an_integer: "must be an integer"
       greater_than: "must be greater than %{count}"

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -64,7 +64,7 @@ class SecurePasswordTest < ActiveModel::TestCase
     @user.password_confirmation = 'a' * 73
     assert !@user.valid?(:create), 'user should be invalid'
     assert_equal 1, @user.errors.count
-    assert_equal ["is too long (maximum is 72 characters)"], @user.errors[:password]
+    assert_equal ["is too long (maximum is 72)"], @user.errors[:password]
   end
 
   test "create a new user with validation and a blank password confirmation" do
@@ -133,7 +133,7 @@ class SecurePasswordTest < ActiveModel::TestCase
     @existing_user.password_confirmation = 'a' * 73
     assert !@existing_user.valid?(:update), 'user should be invalid'
     assert_equal 1, @existing_user.errors.count
-    assert_equal ["is too long (maximum is 72 characters)"], @existing_user.errors[:password]
+    assert_equal ["is too long (maximum is 72)"], @existing_user.errors[:password]
   end
 
   test "updating an existing user with validation and a blank password confirmation" do

--- a/activemodel/test/cases/validations/i18n_generate_message_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_generate_message_validation_test.rb
@@ -73,11 +73,11 @@ class I18nGenerateMessageValidationTest < ActiveModel::TestCase
 
   # validates_length_of: generate_message(attr, :too_long, message: custom_message, count: option_value.end)
   def test_generate_message_too_long_with_default_message_plural
-    assert_equal "is too long (maximum is 10 characters)", @person.errors.generate_message(:title, :too_long, count: 10)
+    assert_equal "is too long (maximum is 10)", @person.errors.generate_message(:title, :too_long, count: 10)
   end
 
   def test_generate_message_too_long_with_default_message_singular
-    assert_equal "is too long (maximum is 1 character)", @person.errors.generate_message(:title, :too_long, count: 1)
+    assert_equal "is too long (maximum is 1)", @person.errors.generate_message(:title, :too_long, count: 1)
   end
 
   def test_generate_message_too_long_with_custom_message
@@ -86,11 +86,11 @@ class I18nGenerateMessageValidationTest < ActiveModel::TestCase
 
   # validates_length_of: generate_message(attr, :too_short, default: custom_message, count: option_value.begin)
   def test_generate_message_too_short_with_default_message_plural
-    assert_equal "is too short (minimum is 10 characters)", @person.errors.generate_message(:title, :too_short, count: 10)
+    assert_equal "is too short (minimum is 10)", @person.errors.generate_message(:title, :too_short, count: 10)
   end
 
   def test_generate_message_too_short_with_default_message_singular
-    assert_equal "is too short (minimum is 1 character)", @person.errors.generate_message(:title, :too_short, count: 1)
+    assert_equal "is too short (minimum is 1)", @person.errors.generate_message(:title, :too_short, count: 1)
   end
 
   def test_generate_message_too_short_with_custom_message
@@ -99,11 +99,11 @@ class I18nGenerateMessageValidationTest < ActiveModel::TestCase
 
   # validates_length_of: generate_message(attr, :wrong_length, message: custom_message, count: option_value)
   def test_generate_message_wrong_length_with_default_message_plural
-    assert_equal "is the wrong length (should be 10 characters)", @person.errors.generate_message(:title, :wrong_length, count: 10)
+    assert_equal "is the wrong length (should be 10)", @person.errors.generate_message(:title, :wrong_length, count: 10)
   end
 
   def test_generate_message_wrong_length_with_default_message_singular
-    assert_equal "is the wrong length (should be 1 character)", @person.errors.generate_message(:title, :wrong_length, count: 1)
+    assert_equal "is the wrong length (should be 1)", @person.errors.generate_message(:title, :wrong_length, count: 1)
   end
 
   def test_generate_message_wrong_length_with_custom_message

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -35,17 +35,17 @@ class LengthValidationTest < ActiveModel::TestCase
     t.title = "not"
     assert t.invalid?
     assert t.errors[:title].any?
-    assert_equal ["is too short (minimum is 5 characters)"], t.errors[:title]
+    assert_equal ["is too short (minimum is 5)"], t.errors[:title]
 
     t.title = ""
     assert t.invalid?
     assert t.errors[:title].any?
-    assert_equal ["is too short (minimum is 5 characters)"], t.errors[:title]
+    assert_equal ["is too short (minimum is 5)"], t.errors[:title]
 
     t.title = nil
     assert t.invalid?
     assert t.errors[:title].any?
-    assert_equal ["is too short (minimum is 5 characters)"], t.errors["title"]
+    assert_equal ["is too short (minimum is 5)"], t.errors["title"]
   end
 
   def test_validates_length_of_using_maximum_should_allow_nil
@@ -73,7 +73,7 @@ class LengthValidationTest < ActiveModel::TestCase
     t.title = "notvalid"
     assert t.invalid?
     assert t.errors[:title].any?
-    assert_equal ["is too long (maximum is 5 characters)"], t.errors[:title]
+    assert_equal ["is too long (maximum is 5)"], t.errors[:title]
 
     t.title = ""
     assert t.valid?
@@ -94,14 +94,14 @@ class LengthValidationTest < ActiveModel::TestCase
 
     t = Topic.new("title" => "a!", "content" => "I'm ooooooooh so very long")
     assert t.invalid?
-    assert_equal ["is too short (minimum is 3 characters)"], t.errors[:title]
-    assert_equal ["is too long (maximum is 5 characters)"], t.errors[:content]
+    assert_equal ["is too short (minimum is 3)"], t.errors[:title]
+    assert_equal ["is too long (maximum is 5)"], t.errors[:content]
 
     t.title = nil
     t.content = nil
     assert t.invalid?
-    assert_equal ["is too short (minimum is 3 characters)"], t.errors[:title]
-    assert_equal ["is too short (minimum is 3 characters)"], t.errors[:content]
+    assert_equal ["is too short (minimum is 3)"], t.errors[:title]
+    assert_equal ["is too short (minimum is 3)"], t.errors[:content]
 
     t.title = "abe"
     t.content  = "mad"
@@ -116,7 +116,7 @@ class LengthValidationTest < ActiveModel::TestCase
 
     t.title = "Now I'm 10"
     assert t.invalid?
-    assert_equal ["is too long (maximum is 9 characters)"], t.errors[:title]
+    assert_equal ["is too long (maximum is 9)"], t.errors[:title]
 
     t.title = "Four"
     assert t.valid?
@@ -141,7 +141,7 @@ class LengthValidationTest < ActiveModel::TestCase
     t.title = "notvalid"
     assert t.invalid?
     assert t.errors[:title].any?
-    assert_equal ["is the wrong length (should be 5 characters)"], t.errors[:title]
+    assert_equal ["is the wrong length (should be 5)"], t.errors[:title]
 
     t.title = ""
     assert t.invalid?
@@ -266,7 +266,7 @@ class LengthValidationTest < ActiveModel::TestCase
     t.title = "一二三四"
     assert t.invalid?
     assert t.errors[:title].any?
-    assert_equal ["is too short (minimum is 5 characters)"], t.errors["title"]
+    assert_equal ["is too short (minimum is 5)"], t.errors["title"]
   end
 
   def test_validates_length_of_using_maximum_utf8
@@ -278,7 +278,7 @@ class LengthValidationTest < ActiveModel::TestCase
     t.title = "一二34五六"
     assert t.invalid?
     assert t.errors[:title].any?
-    assert_equal ["is too long (maximum is 5 characters)"], t.errors["title"]
+    assert_equal ["is too long (maximum is 5)"], t.errors["title"]
   end
 
   def test_validates_length_of_using_within_utf8
@@ -286,8 +286,8 @@ class LengthValidationTest < ActiveModel::TestCase
 
     t = Topic.new("title" => "一二", "content" => "12三四五六七")
     assert t.invalid?
-    assert_equal ["is too short (minimum is 3 characters)"], t.errors[:title]
-    assert_equal ["is too long (maximum is 5 characters)"], t.errors[:content]
+    assert_equal ["is too short (minimum is 3)"], t.errors[:title]
+    assert_equal ["is too long (maximum is 5)"], t.errors[:content]
     t.title = "一二三"
     t.content  = "12三"
     assert t.valid?
@@ -315,7 +315,7 @@ class LengthValidationTest < ActiveModel::TestCase
     t.title = "一二345六"
     assert t.invalid?
     assert t.errors[:title].any?
-    assert_equal ["is the wrong length (should be 5 characters)"], t.errors["title"]
+    assert_equal ["is the wrong length (should be 5)"], t.errors["title"]
   end
 
   def test_validates_length_of_with_block
@@ -373,7 +373,7 @@ class LengthValidationTest < ActiveModel::TestCase
     p.karma = "Pix"
     assert p.invalid?
 
-    assert_equal ["is too short (minimum is 5 characters)"], p.errors[:karma]
+    assert_equal ["is too short (minimum is 5)"], p.errors[:karma]
 
     p.karma = "The Smiths"
     assert p.valid?

--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -107,7 +107,7 @@ class ValidatesTest < ActiveModel::TestCase
     Person.validates :karma, length: 6..20
     person = Person.new
     assert person.invalid?
-    assert_equal ['is too short (minimum is 6 characters)'], person.errors[:karma]
+    assert_equal ['is too short (minimum is 6)'], person.errors[:karma]
     person.karma = 'something'
     assert person.valid?
   end

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -241,13 +241,13 @@ class ValidationsTest < ActiveModel::TestCase
 
     assert_equal :title, key = t.errors.keys[0]
     assert_equal "can't be blank", t.errors[key][0]
-    assert_equal 'is too short (minimum is 2 characters)', t.errors[key][1]
+    assert_equal 'is too short (minimum is 2)', t.errors[key][1]
     assert_equal :author_name, key = t.errors.keys[1]
     assert_equal "can't be blank", t.errors[key][0]
     assert_equal :author_email_address, key = t.errors.keys[2]
     assert_equal 'will never be valid', t.errors[key][0]
     assert_equal :content, key = t.errors.keys[3]
-    assert_equal 'is too short (minimum is 2 characters)', t.errors[key][0]
+    assert_equal 'is too short (minimum is 2)', t.errors[key][0]
   end
 
   def test_validation_with_if_and_on


### PR DESCRIPTION
### Summary

By default the length validator's error message makes reference to the number of characters in the attribute being validated. For example:

```
x is too long (maximum is 4 characters)
y is too short (minimum is 4 characters)
```

However, the length validator isn't used exclusively for string validation. Since this validator is also used to validate the length/size of collections returning a message referencing the number of characters is _extremely_ confusing. 

This PR simply removes the reference to characters from these messages:

```
x is too long (maximum is 4)
y is too short (minimum is 4)
```
