### PR TITLE
add missing require

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -9,6 +9,7 @@ require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/object/to_param'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/string/strip'
+require 'active_support/deprecation'
 
 module ActiveSupport
   # See ActiveSupport::Cache::Store for documentation.

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -2,6 +2,8 @@ require 'active_support/core_ext/marshal'
 require 'active_support/core_ext/file/atomic'
 require 'active_support/core_ext/string/conversions'
 require 'uri/common'
+require 'active_support/deprecation'
+require 'active_support/core_ext/string/strip'
 
 module ActiveSupport
   module Cache

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -8,6 +8,8 @@ end
 require 'digest/md5'
 require 'active_support/core_ext/marshal'
 require 'active_support/core_ext/array/extract_options'
+require 'active_support/deprecation'
+require 'active_support/core_ext/string/strip'
 
 module ActiveSupport
   module Cache

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -1,6 +1,8 @@
 require 'active_support/core_ext/object/duplicable'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/per_thread_registry'
+require 'active_support/deprecation'
+require 'active_support/core_ext/string/strip'
 
 module ActiveSupport
   module Cache

--- a/activesupport/lib/active_support/concurrency/latch.rb
+++ b/activesupport/lib/active_support/concurrency/latch.rb
@@ -1,4 +1,5 @@
 require 'concurrent/atomic/count_down_latch'
+require 'active_support/deprecation'
 
 module ActiveSupport
   module Concurrency

--- a/activesupport/lib/active_support/core_ext/module/introspection.rb
+++ b/activesupport/lib/active_support/core_ext/module/introspection.rb
@@ -1,4 +1,6 @@
 require 'active_support/inflector'
+require 'active_support/deprecation'
+require 'active_support/core_ext/string/filters'
 
 class Module
   # Returns the name of the module containing this one.

--- a/activesupport/lib/active_support/core_ext/module/qualified_const.rb
+++ b/activesupport/lib/active_support/core_ext/module/qualified_const.rb
@@ -1,4 +1,6 @@
 require 'active_support/core_ext/string/inflections'
+require 'active_support/deprecation'
+require 'active_support/core_ext/string/filters'
 
 #--
 # Allows code reuse in the methods below without polluting Module.

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -1,5 +1,6 @@
 require 'active_support/inflector/methods'
 require 'active_support/inflector/transliterate'
+require 'active_support/deprecation'
 
 # String inflections define new methods on the String class to transform names for different purposes.
 # For instance, you can figure out the name of a table from the name of a class.

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -1,5 +1,7 @@
 require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/hash/reverse_merge'
+require 'active_support/deprecation'
+require 'active_support/core_ext/string/filters'
 
 module ActiveSupport
   # Implements a hash where keys <tt>:foo</tt> and <tt>"foo"</tt> are considered

--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/string/multibyte'
 require 'active_support/i18n'
+require 'active_support/deprecation'
 
 module ActiveSupport
   module Inflector

--- a/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
@@ -1,3 +1,5 @@
+require 'active_support/deprecation'
+
 module ActiveSupport
   module NumberHelper
     class NumberToHumanSizeConverter < NumberConverter #:nodoc:


### PR DESCRIPTION
### Summary

Added `active_support/deprecation` require to files that are using `ActiveSupport::Deprecation.warn` but does not require `active_support/deprecation`.
