### PR TITLE
Bash markdown syntax

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -408,7 +408,7 @@ run ActionCable.server
 ```
 
 Then you start the server using a binstub in bin/cable ala:
-```
+```sh
 #!/bin/bash
 bundle exec puma -p 28080 cable/config.ru
 ```


### PR DESCRIPTION
Added 'sh' to bash code for markdown formatting.
