### PR TITLE
[ci skip] Fix ActionCable Guides

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -583,7 +583,7 @@ For a full list of all configuration options, see the
 `ActionCable::Server::Configuration` class.
 
 Also note that your server must provide at least the same number of database
-connections as you have workers. The default worker pool size is set to 100, so
+connections as you have workers. The default worker pool size is set to 4, so
 that means you have to make at least that available. You can change that in
 `config/database.yml` through the `pool` attribute.
 


### PR DESCRIPTION
### Summary

Default worker pool size was changed from 100 to 4 at #24376
#24810 is related PR.
