### PR TITLE
fixed a bug in ActionDispatch::RouteSet#recognize_path

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -849,6 +849,8 @@ module ActionDispatch
             else
               raise ActionController::RoutingError, "A route matches #{path.inspect}, but references missing controller: #{params[:controller].camelize}Controller"
             end
+          else
+            req.path_parameters = old_params
           end
         end
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1526,6 +1526,18 @@ class RouteSetTest < ActiveSupport::TestCase
     assert_equal(name_param, 'mypage')
   end
 
+  def test_if_routes_in_scope_with_optional_path_processed_after_root
+    set.draw do
+      scope path: '(:name)', constraints: lambda { |request| request.params[:name].blank? || (request.params[:name] == 'foo') } do
+        root 'pages#index'
+        get 'bar' => 'pages#bar'
+      end
+    end
+
+    assert_equal({:controller => 'pages', :action => 'bar'},
+      set.recognize_path('/bar'))
+  end
+
   def test_route_requirement_recognize_with_ignore_case
     set.draw do
       get 'page/:name' => 'pages#show',


### PR DESCRIPTION
### Summary

Routes, defined after root route in scopes with optional path and constraints may not
be checked, because route-specific params was not properly cleared from
request. See test
test/controller/routing_test.rb#test_all_routes_with_same_constraint_processed
for reproduction
### Other Information

Was broken since 9b654d47134ef06022861200c2f6e48f8459afb0
