### PR TITLE
[ci skip] Reword doc for around_enqueue callback

### DIFF
--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -126,8 +126,8 @@ module ActiveJob
         set_callback(:enqueue, :after, *filters, &blk)
       end
 
-      # Defines a callback that will get called before and after the
-      # job is enqueued.
+      # Defines a callback that will get called around the enqueueing
+      # of the job.
       #
       #   class VideoProcessJob < ActiveJob::Base
       #     queue_as :default


### PR DESCRIPTION
Taken literally, the documentation suggests that the callback gets
called twice (before and after enqueueing). By wording it similarly to
that of around_perform this confusion is avoided.
