### PR TITLE
Use `take` instead of `first` in `ActiveRecord::Relation#first_or_create`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -13,4 +13,9 @@
 
     *Erol Fornoles*
 
+*   Use `take` instead of `first` in `ActiveRecord::Relation#first_or_create`, 
+    `#first_or_create!` and `#first_or_initialize`.
+     
+    *Guilherme Goettems Schneider*
+
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -161,15 +161,15 @@ module ActiveRecord
     end
 
     def first_or_create(attributes = nil, &block) # :nodoc:
-      first || create(attributes, &block)
+      take || create(attributes, &block)
     end
 
     def first_or_create!(attributes = nil, &block) # :nodoc:
-      first || create!(attributes, &block)
+      take || create!(attributes, &block)
     end
 
     def first_or_initialize(attributes = nil, &block) # :nodoc:
-      first || new(attributes, &block)
+      take || new(attributes, &block)
     end
 
     # Finds the first record with the given attributes, or creates a record

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1370,7 +1370,7 @@ class RelationTest < ActiveRecord::TestCase
 
     same_parrot = Bird.where(:color => 'green').first_or_create([{:name => 'hummingbird'}, {:name => 'macaw'}])
     assert_kind_of Bird, same_parrot
-    assert_equal several_green_birds.first, same_parrot
+    assert_includes several_green_birds, same_parrot
   end
 
   def test_first_or_create_bang_with_valid_options
@@ -1418,7 +1418,7 @@ class RelationTest < ActiveRecord::TestCase
 
     same_parrot = Bird.where(:color => 'green').first_or_create!([{:name => 'hummingbird'}, {:name => 'macaw'}])
     assert_kind_of Bird, same_parrot
-    assert_equal several_green_birds.first, same_parrot
+    assert_includes several_green_birds, same_parrot
   end
 
   def test_first_or_create_with_invalid_array


### PR DESCRIPTION
This change was suggested in discussion of #24847.

`first` adds an order by clause to query that may make it slower.
