### PR TITLE
Fix stated default value for escape_html_entities_in_json

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -497,7 +497,7 @@ There are a few configuration options available in Active Support:
 
 * `config.active_support.test_order` sets the order that test cases are executed. Possible values are `:sorted` and `:random`. Currently defaults to `:sorted`. In Rails 5.0, the default will be changed to `:random` instead.
 
-* `config.active_support.escape_html_entities_in_json` enables or disables the escaping of HTML entities in JSON serialization. Defaults to `false`.
+* `config.active_support.escape_html_entities_in_json` enables or disables the escaping of HTML entities in JSON serialization. Defaults to `true`.
 
 * `config.active_support.use_standard_json_time_format` enables or disables serializing dates to ISO 8601 format. Defaults to `true`.
 


### PR DESCRIPTION
With a fresh Rails 4.2.6 app, the effective value of this configuration is true, whereas the documentation says it is false:

``` bash
$ rails -v
Rails 4.2.6

$ rails new foobar
...

$ cd foobar

$ rails console
Loading development environment (Rails 4.2.6)
>> Rails.application.config.active_support.escape_html_entities_in_json
=> nil
>> ActiveSupport.escape_html_entities_in_json
=> true
>> x = { "foo & <>" => "foo & <>" }
=> {"foo & <>"=>"foo & <>"}
>> puts x.to_json
{"foo \u0026 \u003c\u003e":"foo \u0026 \u003c\u003e"}
=> nil
>> ActiveSupport.escape_html_entities_in_json = false
=> false
>> puts x.to_json
{"foo & <>":"foo & <>"}
=> nil
```

The default value for this is defined here:
https://github.com/rails/rails/blob/4-2-stable/activesupport/lib/active_support/json/encoding.rb#L172
