### PR TITLE
ActionController::Parameters: Fix #dig doc code

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -441,12 +441,12 @@ module ActionController
       # Extracts the nested parameter from the given +keys+ by calling +dig+
       # at each step. Returns +nil+ if any intermediate step is +nil+.
       #
-      # params = ActionController::Parameters.new(foo: { bar: { baz: 1 } })
-      # params.dig(:foo, :bar, :baz) # => 1
-      # params.dig(:foo, :zot, :xyz) # => nil
+      #   params = ActionController::Parameters.new(foo: { bar: { baz: 1 } })
+      #   params.dig(:foo, :bar, :baz) # => 1
+      #   params.dig(:foo, :zot, :xyz) # => nil
       #
-      # params2 = ActionController::Parameters.new(foo: [10, 11, 12])
-      # params2.dig(:foo, 1) # => 11
+      #   params2 = ActionController::Parameters.new(foo: [10, 11, 12])
+      #   params2.dig(:foo, 1) # => 11
       def dig(*keys)
         convert_value_to_parameters(@parameters.dig(*keys))
       end


### PR DESCRIPTION
This example code wasn't getting wrapped in a `<code>` tag due to incorrect indentation.
