### PR TITLE
[ci skip]Fix wrong require path raising LoadError

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -619,7 +619,7 @@ basic setup is as follows:
 
 ```ruby
 # cable/config.ru
-require_relative 'config/environment'
+require_relative '../config/environment'
 Rails.application.eager_load!
 
 run ActionCable.server


### PR DESCRIPTION
### Summary

This sample code raised LoadError because of wrong path. So I fixed it.
