### PR TITLE
Fix default key length on cipher

### DIFF
--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -15,9 +15,8 @@ module ActiveSupport
     end
 
     # Returns a derived key suitable for use.  The default key_size is chosen
-    # to be compatible with the default settings of ActiveSupport::MessageVerifier.
-    # i.e. OpenSSL::Digest::SHA1#block_length
-    def generate_key(salt, key_size=64)
+    # to be compatible with the acceptable key length of aes-256-cbc, the default cipher.
+    def generate_key(salt, key_size=32)
       OpenSSL::PKCS5.pbkdf2_hmac_sha1(@secret, salt, @iterations, key_size)
     end
   end
@@ -32,9 +31,8 @@ module ActiveSupport
     end
 
     # Returns a derived key suitable for use.  The default key_size is chosen
-    # to be compatible with the default settings of ActiveSupport::MessageVerifier.
-    # i.e. OpenSSL::Digest::SHA1#block_length
-    def generate_key(salt, key_size=64)
+    # to be compatible with the acceptable key length of aes-256-cbc, the default cipher.
+    def generate_key(salt, key_size=32)
       @cache_keys["#{salt}#{key_size}"] ||= @key_generator.generate_key(salt, key_size)
     end
   end

--- a/activesupport/test/key_generator_test.rb
+++ b/activesupport/test/key_generator_test.rb
@@ -19,7 +19,7 @@ class KeyGeneratorTest < ActiveSupport::TestCase
   test "Generating a key of the default length" do
     derived_key = @generator.generate_key("some_salt")
     assert_kind_of String, derived_key
-    assert_equal OpenSSL::Digest::SHA1.new.block_length, derived_key.length, "Should have generated a key of the default size"
+    assert_equal OpenSSL::Cipher.new('aes-256-cbc').key_len, derived_key.length, "Should have generated a key of the default size"
   end
 
   test "Generating a key of an alternative length" do

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -15,7 +15,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
   end
 
   def setup
-    @secret    = SecureRandom.hex(64)
+    @secret    = SecureRandom.random_bytes(32)
     @verifier  = ActiveSupport::MessageVerifier.new(@secret, :serializer => ActiveSupport::MessageEncryptor::NullSerializer)
     @encryptor = ActiveSupport::MessageEncryptor.new(@secret)
     @data = { :some => "data", :now => Time.local(2010) }
@@ -51,7 +51,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
   def test_alternative_serialization_method
     prev = ActiveSupport.use_standard_json_time_format
     ActiveSupport.use_standard_json_time_format = true
-    encryptor = ActiveSupport::MessageEncryptor.new(SecureRandom.hex(64), SecureRandom.hex(64), :serializer => JSONSerializer.new)
+    encryptor = ActiveSupport::MessageEncryptor.new(SecureRandom.random_bytes(32), SecureRandom.random_bytes(128), :serializer => JSONSerializer.new)
     message = encryptor.encrypt_and_sign({ :foo => 123, 'bar' => Time.utc(2010) })
     exp = { "foo" => 123, "bar" => "2010-01-01T00:00:00.000Z" }
     assert_equal exp, encryptor.decrypt_and_verify(message)


### PR DESCRIPTION
We default to using aes-256-cbc as our verification/signing cipher. It can accept key lengths of 128, 192 or 256-bit, whereas currently we were providing twice the acceptable value.

ruby < 2.4 allowed accepting these values, as extra key bits were ignored. Since https://github.com/ruby/ruby/commit/ce635262f53b760284d56bb1027baebaaec175d1 this now has a strict checking on key length.

Default to key length 32 bytes, to match the compatible length for  aes-256-cbc

Fixes #25185
