### PR TITLE
use OpenSSL::Cipher instead of deprecated OpenSSL::Cipher::Cipher

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -97,7 +97,7 @@ module ActiveSupport
     end
 
     def new_cipher
-      OpenSSL::Cipher::Cipher.new(@cipher)
+      OpenSSL::Cipher.new(@cipher)
     end
 
     def verifier


### PR DESCRIPTION
use `OpenSSL::Cipher` instead of deprecated `OpenSSL::Cipher::Cipher` for cipher creation.

Based on https://github.com/rails/rails/pull/25192#discussion_r65018222 and http://ruby-doc.org/stdlib-1.9.3/libdoc/openssl/rdoc/OpenSSL/Cipher/Cipher.html
