### PR TITLE
[Feature] add 'expires_at' option to ActiveSupport::Cache::Store::Entry

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -608,7 +608,7 @@ module ActiveSupport
       DEFAULT_COMPRESS_LIMIT = 16.kilobytes
 
       # Creates a new cache entry for the specified value. Options supported are
-      # +:compress+, +:compress_threshold+, and +:expires_in+.
+      # +:compress+, +:compress_threshold+, +:expires_in+ and +:expires_at+
       def initialize(value, options = {})
         if should_compress?(value, options)
           @value = compress(value)
@@ -619,6 +619,7 @@ module ActiveSupport
 
         @created_at = Time.now.to_f
         @expires_in = options[:expires_in]
+        self.expires_at = options[:expires_at] if options[:expires_at]
         @expires_in = @expires_in.to_f if @expires_in
       end
 

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -428,6 +428,23 @@ module CacheStoreBehavior
     end
   end
 
+  def test_expires_at
+    time = Time.local(2008, 4, 24)
+
+    Time.stub(:now, time) do
+      @cache.write('foo', 'bar', expires_in: nil, expires_at: time + 60)
+      assert_equal 'bar', @cache.read('foo')
+    end
+
+    Time.stub(:now, time + 30) do
+      assert_equal 'bar', @cache.read('foo')
+    end
+
+    Time.stub(:now, time + 61) do
+      assert_nil @cache.read('foo')
+    end
+  end
+
   def test_race_condition_protection_skipped_if_not_defined
     @cache.write('foo', 'bar')
     time = @cache.send(:read_entry, @cache.send(:normalize_key, 'foo', {}), {}).expires_at


### PR DESCRIPTION
I'm available to rewrite some parts of the docs. But I'm not sure if this implementation is the proper for adding a new option to `ActiveSupport::Cache::Store::Entry`. I'd like to know if this is good and then I can help adding this option to the docs.

Thanks
