### PR TITLE
Use SHA256 instead of SHA1

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -528,7 +528,7 @@ module ActionDispatch
         end
 
         def digest
-          request.cookies_digest || 'SHA1'
+          request.cookies_digest || 'SHA256'
         end
 
         def key_generator

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -423,7 +423,7 @@ class CookiesTest < ActionController::TestCase
     signed_cookie_salt = @request.env["action_dispatch.signed_cookie_salt"]
     secret = key_generator.generate_key(signed_cookie_salt)
 
-    verifier = ActiveSupport::MessageVerifier.new(secret, serializer: Marshal, digest: 'SHA1')
+    verifier = ActiveSupport::MessageVerifier.new(secret, serializer: Marshal, digest: 'SHA256')
     assert_equal verifier.generate(45), cookies[:user_id]
   end
 

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -7,7 +7,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
   SessionSecret = 'b3c631c314c0bbca50c1b2843150fe33'
   Generator = ActiveSupport::LegacyKeyGenerator.new(SessionSecret)
 
-  Verifier = ActiveSupport::MessageVerifier.new(SessionSecret, :digest => 'SHA1')
+  Verifier = ActiveSupport::MessageVerifier.new(SessionSecret, :digest => 'SHA256')
   SignedBar = Verifier.generate(:foo => "bar", :session_id => SecureRandom.hex(16))
 
   class TestController < ActionController::Base
@@ -133,7 +133,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
   end
 
   # {:foo=>#<SessionAutoloadTest::Foo bar:"baz">, :session_id=>"ce8b0752a6ab7c7af3cdb8a80e6b9e46"}
-  SignedSerializedCookie = "BAh7BzoIZm9vbzodU2Vzc2lvbkF1dG9sb2FkVGVzdDo6Rm9vBjoJQGJhciIIYmF6Og9zZXNzaW9uX2lkIiVjZThiMDc1MmE2YWI3YzdhZjNjZGI4YTgwZTZiOWU0Ng==--2bf3af1ae8bd4e52b9ac2099258ace0c380e601c"
+  SignedSerializedCookie = "BAh7BzoIZm9vbzodU2Vzc2lvbkF1dG9sb2FkVGVzdDo6Rm9vBjoJQGJhckkiCGJhegY6BkVUOg9zZXNzaW9uX2lkSSIlY2U4YjA3NTJhNmFiN2M3YWYzY2RiOGE4MGU2YjllNDYGOwhU--f71955a6b82e4c73073f9b028326bf76e4385f6afbf6c73d3e295b7ca0719067"
 
   def test_deserializes_unloaded_classes_on_get_id
     with_test_route_set do

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -48,7 +48,7 @@ module ActiveSupport
       @secret = secret
       @sign_secret = sign_secret
       @cipher = options[:cipher] || 'aes-256-cbc'
-      @verifier = MessageVerifier.new(@sign_secret || @secret, digest: options[:digest] || 'SHA1', serializer: NullSerializer)
+      @verifier = MessageVerifier.new(@sign_secret || @secret, digest: options[:digest] || 'SHA256', serializer: NullSerializer)
       @serializer = options[:serializer] || Marshal
     end
 

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -36,7 +36,7 @@ module ActiveSupport
     def initialize(secret, options = {})
       raise ArgumentError, 'Secret should not be nil.' unless secret
       @secret = secret
-      @digest = options[:digest] || 'SHA1'
+      @digest = options[:digest] || 'SHA256'
       @serializer = options[:serializer] || Marshal
     end
 

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -64,7 +64,7 @@ class MessageVerifierTest < ActiveSupport::TestCase
     #   AutoloadClass = Struct.new(:foo)
     #   valid_message = @verifier.generate(foo: AutoloadClass.new('foo'))
     #
-    valid_message = "BAh7BjoIZm9vbzonTWVzc2FnZVZlcmlmaWVyVGVzdDo6QXV0b2xvYWRDbGFzcwY6CUBmb29JIghmb28GOgZFVA==--f3ef39a5241c365083770566dc7a9eb5d6ace914"
+    valid_message = "BAh7BjoIZm9vUzonTWVzc2FnZVZlcmlmaWVyVGVzdDo6QXV0b2xvYWRDbGFzcwY7AEkiCGZvbwY6BkVU--cd79e1d143d545c2f4e51f8f681627f4e57d64026d55b0f52cd2d4c1f85303f2"
     exception = assert_raise(ArgumentError, NameError) do
       @verifier.verified(valid_message)
     end


### PR DESCRIPTION
 SHA1 has been deprecated by browser vendors, and mojority users. See https://www.google.com/#q=sha1+deprecation for more.

Upgrade to default to SHA256, instead of the deprecated SHA1 hashing in places that use signing and encryption.
