### PR TITLE
Change SQLite3 boolean serialisation to use 0/1 rather than 't'/'f'.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -2,6 +2,24 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLite3
       module Quoting # :nodoc:
+        QUOTED_TRUE, QUOTED_FALSE = '1', '0'
+
+        def quoted_true
+          QUOTED_TRUE
+        end
+
+        def unquoted_true
+          1
+        end
+
+        def quoted_false
+          QUOTED_FALSE
+        end
+
+        def unquoted_false
+          0
+        end
+        
         def quote_string(s)
           @connection.class.quote(s)
         end

--- a/activerecord/test/cases/adapters/mysql2/quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/quoting_test.rb
@@ -1,0 +1,16 @@
+
+require "cases/helper"
+
+class Mysql2QuotingTest < ActiveRecord::Mysql2TestCase
+  def setup
+    @conn = ActiveRecord::Base.connection
+  end
+  
+  def test_type_cast_true
+    assert_equal 1, @conn.type_cast(true)
+  end
+
+  def test_type_cast_false
+    assert_equal 0, @conn.type_cast(false)
+  end
+end

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -44,11 +44,11 @@ module ActiveRecord
         end
 
         def test_type_cast_true
-          assert_equal 't', @conn.type_cast(true)
+          assert_equal 1, @conn.type_cast(true)
         end
 
         def test_type_cast_false
-          assert_equal 'f', @conn.type_cast(false)
+          assert_equal 0, @conn.type_cast(false)
         end
 
         def test_type_cast_bigdecimal


### PR DESCRIPTION
### Summary

This changes the behaviour of the SQLite3 adapter to use 1 and 0 for true and false values respectively, according to the documentation here: http://www.sqlite.org/datatype3.html#boolean

This change is backwards incompatible hence it might be good to make it optional or provide a migration tool. Releasing it as part of Rails 5.0 may be good timing as you can reasonably be expected to release backwards incompatible changes on a major release.

To justify this backwards incompatible change:
- It's specified by SQLite3 documentation to use 0 and 1, not 't' and 'f'.
- 't' and 'f' are both considered true values when using boolean logic e.g. NOT which gives some strange behaviour (example here: https://github.com/rails/rails/issues/17062).
