### PR TITLE
Fix Typo and Grammar [ci skip]

### DIFF
--- a/RELEASING_RAILS.md
+++ b/RELEASING_RAILS.md
@@ -20,7 +20,7 @@ http://travis-ci.org/rails/rails
 ### Is Sam Ruby happy?  If not, make him happy.
 
 Sam Ruby keeps a [test suite](https://github.com/rubys/awdwr) that makes
-sure the code samples in his book 
+sure the code samples in his book
 ([Agile Web Development with Rails](https://pragprog.com/titles/rails5/agile-web-development-with-rails-5th-edition))
 all work.  These are valuable system tests
 for Rails.  You can check the status of these tests here:
@@ -47,7 +47,7 @@ Ruby implementors have high stakes in making sure Rails works.  Be kind and
 give them a heads up that Rails will be released soonish.
 
 This is only required for major and minor releases, bugfix releases aren't a
-big enough deal, and are supposed to be backwards compatible.
+big enough deal, and are supposed to be backward compatible.
 
 Send an email just giving a heads up about the upcoming release to these
 lists:
@@ -150,7 +150,7 @@ break existing applications.
 
 ### Post the announcement to the Rails blog.
 
-If you used Markdown format for your email, you can just paste it in to the
+If you used Markdown format for your email, you can just paste it into the
 blog.
 
 * http://weblog.rubyonrails.org

--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -430,7 +430,7 @@ For every instance of your server you create and for every worker your server sp
 
 ### Notes
 
-Beware that currently the cable server will _not_ auto-reload any changes in the framework. As we've discussed, long-running cable connections mean long-running objects. We don't yet have a way of reloading the classes of those objects in a safe manner. So when you change your channels, or the model your channels use, you must restart the cable server.
+Beware that currently, the cable server will _not_ auto-reload any changes in the framework. As we've discussed, long-running cable connections mean long-running objects. We don't yet have a way of reloading the classes of those objects in a safe manner. So when you change your channels, or the model your channels use, you must restart the cable server.
 
 We'll get all this abstracted properly when the framework is integrated into Rails.
 

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -138,7 +138,7 @@ module ActionCable
         end
 
         # May be overridden to change the default stream handling behavior
-        # which decodes JSON and transmits to client.
+        # which decodes JSON and transmits to the client.
         #
         # TODO: Tests demonstrating this.
         #

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -488,7 +488,7 @@ module ActionMailer
       end
       private :observer_class_for
 
-      # Returns the name of current mailer. This method is also being used as a path for a view lookup.
+      # Returns the name of the current mailer. This method is also being used as a path for a view lookup.
       # If this is an anonymous mailer, this method will return +anonymous+ instead.
       def mailer_name
         @mailer_name ||= anonymous? ? "anonymous" : name.underscore


### PR DESCRIPTION
Fix typo in files:
`RELEASING_RAILS.md`
`actioncable/README.md`
`actioncable/lib/action_cable/channel/streams.rb`
`actioncable/lib/action_cable/channel/streams.rb`
`actionmailer/lib/action_mailer/base.rb`
