### PR TITLE
Introduce the next_*day and prev_*day helpers for DateAndTime related Classes

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Introduce next_*day and prev_*day helpers for Date, DateTime and Time  
+
+    Rails provides the Date#next_week method, but at times this is not the required date.
+    For example, if today is a Monday and there is a need for the next Tuesday, one way is to loop through
+    the next seven days to get the first match for Tuesday, or to blindly use the next_week(:tuesday)
+    method, which would usually not be the required value.
+
+    This implementation adds the Date#(next_sunday..next_saturday) and Date#(prev_sunday..prev_saturday), which would be super helpful for
+    these purposes. It finds the next_*day relative to the current date, being used.
+    Usage example:
+
+    Date.today.next_tuesday # if the next day is a Tueday, it should return tomorrow, else next_week's
+    Date.today.prev_tuesday # if the previous day is a Tueday, it should return yesterday, else prev_week's
+
+    This uses the Calculations API to achieve this efficiently.
+
+    *Oreoluwa Akinniranye*
+
 *   Support parsing JSON time in ISO8601 local time strings in
     `ActiveSupport::JSON.decode` when `parse_json_times` is enabled.
     Strings in the format of `YYYY-MM-DD hh:mm:ss` (without a `Z` at

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,22 +1,21 @@
-*   Introduce next_*day and prev_*day helpers for Date, DateTime and Time  
+*   Extend next_day and prev_day helpers for Date, DateTime and Time  
 
-    Rails provides the Date#next_week method, but at times this is not the required date.
-    For example, if today is a Monday and there is a need for the next Tuesday, one way is to loop through
-    the next seven days to get the first match for Tuesday, or to blindly use the next_week(:tuesday)
-    method, which would usually not be the required value.
-
-    This implementation adds the Date#(next_sunday..next_saturday) and Date#(prev_sunday..prev_saturday), which would be super helpful for
-    these purposes. It finds the next_*day relative to the current date, being used.
+    This implementation extends the Date#next_day and Date#prev_day to accept a day argument which would be super helpful for
+    creating scheduling applications.
     Usage example:
 
     With this implementation, to get the next 4 Thursdays for a list, it can easily be achieved with the snippet below:
 
         4.times{ |i|
-           Date.today.next_thursday + i.week
+           Date.current.next_day(:tuesday) + i.week
         }
 
-        Date.today.next_tuesday # if the next day is a Tueday, it should return tomorrow, else next_week's
-        Date.today.prev_tuesday # if the previous day is a Tueday, it should return yesterday, else prev_week's
+        Date.current.next_day(:tuesday) # if the next day is a Tueday, it should return tomorrow, else next_week's
+        Date.current.prev_day(:tuesday) # if the previous day is a Tueday, it should return yesterday, else prev_week's
+
+    Also added the next_wday and prev_wday to find the next relative date through wday
+
+        Date.current.next_wday(4) # get the next Thursday after today
 
     This uses the Calculations API to achieve this efficiently.
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -9,8 +9,14 @@
     these purposes. It finds the next_*day relative to the current date, being used.
     Usage example:
 
-    Date.today.next_tuesday # if the next day is a Tueday, it should return tomorrow, else next_week's
-    Date.today.prev_tuesday # if the previous day is a Tueday, it should return yesterday, else prev_week's
+    With this implementation, to get the next 4 Thursdays for a list, it can easily be achieved with the snippet below:
+
+        4.times{ |i|
+           Date.today.next_thursday + i.week
+        }
+
+        Date.today.next_tuesday # if the next day is a Tueday, it should return tomorrow, else next_week's
+        Date.today.prev_tuesday # if the previous day is a Tueday, it should return yesterday, else prev_week's
 
     This uses the Calculations API to achieve this efficiently.
 

--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/time/zones'
 require 'active_support/core_ext/date_and_time/calculations'
 
 class Date
-  include DateAndTime::Calculations
+  prepend DateAndTime::Calculations
 
   class << self
     attr_accessor :beginning_of_week_default
@@ -129,7 +129,7 @@ class Date
       options.fetch(:day, day)
     )
   end
-  
+
   # Allow Date to be compared with Time by converting to DateTime and relying on the <=> from there.
   def compare_with_coercion(other)
     if other.is_a?(Time)

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -19,8 +19,21 @@ module DateAndTime
     end
 
     # Returns a new date/time representing the previous day.
-    def prev_day
-      advance(days: -1)
+    # Argument could either be a numeric or a symbol of the day
+    #
+    #   today = Date.current # => Fri, 10 Jul 2015
+    #   today.prev_day(1) # => Thu, 09 Jul 2015
+    #   OR
+    #   today = Date.current # => Fri, 10 Jul 2015
+    #   today.prev_day(:thursday) # => Thu, 09 Jul 2015
+    def prev_day(days_to_advance = 1)
+      if DAYS_INTO_WEEK.keys.include?(days_to_advance)
+        days_to_advance = distance_from_day_name(days_to_advance)
+        days_to_advance -= 7 if days_to_advance >= 0
+      else
+        days_to_advance *= -1
+      end
+      advance(days: days_to_advance)
     end
 
     # Returns a new date/time representing tomorrow.
@@ -29,8 +42,29 @@ module DateAndTime
     end
 
     # Returns a new date/time representing the next day.
-    def next_day
-      advance(days: 1)
+    # Argument could either be a numeric or a symbol of the day
+    #
+    #   today = Date.current # => Fri, 10 Jul 2015
+    #   today.next_day(1) # => Sat, 11 Jul 2015
+    #   OR
+    #   today = Date.current # => Fri, 10 Jul 2015
+    #   today.next_day(:saturday) # => Sat, 11 Jul 2015
+    def next_day(days_to_advance = 1)
+      if DAYS_INTO_WEEK.keys.include?(days_to_advance)
+        days_to_advance = distance_from_day_name(days_to_advance)
+        days_to_advance += 7 if days_to_advance <= 0
+      end
+      advance(days: days_to_advance)
+    end
+
+    def prev_wday(wday_key)
+      day_name = day_from_wday(wday_key)
+      prev_day(day_name.to_sym)
+    end
+
+    def next_wday(wday_key)
+      day_name = day_from_wday(wday_key)
+      next_day(day_name.to_sym)
     end
 
     # Returns true if the date/time is today.
@@ -320,93 +354,16 @@ module DateAndTime
       beginning_of_year..end_of_year
     end
 
-    ##
-    # :method: next_sunday
-    #
-    # Returns the date of the next Sunday after self
-
-    ##
-    # :method: next_monday
-    #
-    # Returns the date of the next Monday after self
-
-    ##
-    # :method: next_tuesday
-    #
-    # Returns the date of the next Tuesday after self
-
-    ##
-    # :method: next_wednesday
-    #
-    # Returns the date of the next Wednesday after self
-
-    ##
-    # :method: next_thursday
-    #
-    # Returns the date of the next Thurday after self
-
-    ##
-    # :method: next_friday
-    #
-    # Returns the date of the next Friday after self
-
-    ##
-    # :method: next_saturday
-    #
-    # Returns the date of the next Saturday after self
-
-    ##
-    # :method: prev_sunday
-    #
-    # Returns the date of the previous Sunday before self
-
-    ##
-    # :method: prev_monday
-    #
-    # Returns the date of the previous Monday before self
-
-    ##
-    # :method: prev_tuesday
-    #
-    # Returns the date of the previous Tuesday before self
-
-    ##
-    # :method: prev_wednesday
-    #
-    # Returns the date of the previous Wednesday before self
-
-    ##
-    # :method: prev_thursday
-    #
-    # Returns the date of the previous Thurday before self
-
-    ##
-    # :method: prev_friday
-    #
-    # Returns the date of the previous Friday before self
-
-    ##
-    # :method: prev_saturday
-    #
-    # Returns the date of the previous Saturday before self
-    DAYS_INTO_WEEK.each do |day_name, index|
-      define_method "next_#{day_name}" do
-        days_advance = 7 - distance_from_next_day_name(day_name)
-        advance(days: days_advance)
-      end
-
-      define_method "prev_#{day_name}" do
-        days_difference = distance_from_next_day_name(day_name)
-        days_advance = days_difference == 0 ? -7 : -days_difference
-        advance(days: days_advance)
-      end
-    end
-
     private
-      def distance_from_next_day_name(day_name)
-        day_number = Date::DAYS_INTO_WEEK[day_name]
-        current_day_number = wday != 0 ? wday - 1 : 6
-        (current_day_number - day_number) % 7
+      def day_from_wday(wday_key)
+        day_name = Date::DAYNAMES[wday_key]
+        day_name.downcase
+      end
+
+      def distance_from_day_name(day_name)
+        index = DAYS_INTO_WEEK[day_name]
+        n = (index + 1) % 7
+        n - wday
       end
 
       def first_hour(date_or_time)

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -320,7 +320,95 @@ module DateAndTime
       beginning_of_year..end_of_year
     end
 
+    ##
+    # :method: next_sunday
+    #
+    # Returns the date of the next Sunday after self
+
+    ##
+    # :method: next_monday
+    #
+    # Returns the date of the next Monday after self
+
+    ##
+    # :method: next_tuesday
+    #
+    # Returns the date of the next Tuesday after self
+
+    ##
+    # :method: next_wednesday
+    #
+    # Returns the date of the next Wednesday after self
+
+    ##
+    # :method: next_thursday
+    #
+    # Returns the date of the next Thurday after self
+
+    ##
+    # :method: next_friday
+    #
+    # Returns the date of the next Friday after self
+
+    ##
+    # :method: next_saturday
+    #
+    # Returns the date of the next Saturday after self
+
+    ##
+    # :method: prev_sunday
+    #
+    # Returns the date of the next Sunday after self
+
+    ##
+    # :method: prev_monday
+    #
+    # Returns the date of the next Monday after self
+
+    ##
+    # :method: prev_tuesday
+    #
+    # Returns the date of the next Tuesday after self
+
+    ##
+    # :method: prev_wednesday
+    #
+    # Returns the date of the next Wednesday after self
+
+    ##
+    # :method: prev_thursday
+    #
+    # Returns the date of the next Thurday after self
+
+    ##
+    # :method: prev_friday
+    #
+    # Returns the date of the next Friday after self
+
+    ##
+    # :method: prev_saturday
+    #
+    # Returns the date of the next Saturday after self
+    DAYS_INTO_WEEK.each do |day_name, index|
+      define_method "next_#{day_name}" do
+        days_advance = 7 - distance_from_next_day_name(day_name)
+        advance(days: days_advance)
+      end
+
+      define_method "prev_#{day_name}" do
+        days_distance = distance_from_next_day_name(day_name)
+        days_advance = days_distance == 0 ? -7 : -days_distance
+        advance(days: days_advance)
+      end
+    end
+
     private
+      def distance_from_next_day_name(day_name)
+        day_number = Date::DAYS_INTO_WEEK[day_name]
+        current_day_number = wday != 0 ? wday - 1 : 6
+        (current_day_number - day_number) % 7
+      end
+
       def first_hour(date_or_time)
         date_or_time.acts_like?(:time) ? date_or_time.beginning_of_day : date_or_time
       end

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -358,37 +358,37 @@ module DateAndTime
     ##
     # :method: prev_sunday
     #
-    # Returns the date of the next Sunday after self
+    # Returns the date of the previous Sunday before self
 
     ##
     # :method: prev_monday
     #
-    # Returns the date of the next Monday after self
+    # Returns the date of the previous Monday before self
 
     ##
     # :method: prev_tuesday
     #
-    # Returns the date of the next Tuesday after self
+    # Returns the date of the previous Tuesday before self
 
     ##
     # :method: prev_wednesday
     #
-    # Returns the date of the next Wednesday after self
+    # Returns the date of the previous Wednesday before self
 
     ##
     # :method: prev_thursday
     #
-    # Returns the date of the next Thurday after self
+    # Returns the date of the previous Thurday before self
 
     ##
     # :method: prev_friday
     #
-    # Returns the date of the next Friday after self
+    # Returns the date of the previous Friday before self
 
     ##
     # :method: prev_saturday
     #
-    # Returns the date of the next Saturday after self
+    # Returns the date of the previous Saturday before self
     DAYS_INTO_WEEK.each do |day_name, index|
       define_method "next_#{day_name}" do
         days_advance = 7 - distance_from_next_day_name(day_name)
@@ -396,8 +396,8 @@ module DateAndTime
       end
 
       define_method "prev_#{day_name}" do
-        days_distance = distance_from_next_day_name(day_name)
-        days_advance = days_distance == 0 ? -7 : -days_distance
+        days_difference = distance_from_next_day_name(day_name)
+        days_advance = days_difference == 0 ? -7 : -days_difference
         advance(days: days_advance)
       end
     end

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/date_and_time/calculations'
 require 'active_support/core_ext/date/calculations'
 
 class Time
-  include DateAndTime::Calculations
+  prepend DateAndTime::Calculations
 
   COMMON_YEAR_DAYS_IN_MONTH = [nil, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -312,93 +312,123 @@ module DateAndTimeBehavior
   end
 
   def test_next_sunday
-    assert_equal date_time_init(2016,5,29,0,0,0), date_time_init(2016,5,28,0,0,0).next_sunday
-    assert_equal date_time_init(2016,4,10,0,0,0), date_time_init(2016,4,6,0,0,0).next_sunday
+    assert_equal date_time_init(2016,5,29,0,0,0), date_time_init(2016,5,28,0,0,0).next_day(:sunday)
+    assert_equal date_time_init(2016,4,10,0,0,0), date_time_init(2016,4,6,0,0,0).next_day(:sunday)
   end
 
   def test_next_monday
-    assert_equal date_time_init(2016,5,30,0,0,0), date_time_init(2016,5,28,0,0,0).next_monday
-    assert_equal date_time_init(2016,4,11,0,0,0), date_time_init(2016,4,6,0,0,0).next_monday
+    assert_equal date_time_init(2016,5,30,0,0,0), date_time_init(2016,5,28,0,0,0).next_day(:monday)
+    assert_equal date_time_init(2016,4,11,0,0,0), date_time_init(2016,4,6,0,0,0).next_day(:monday)
   end
 
   def test_next_tuesday
-    assert_equal date_time_init(2016,5,31,0,0,0), date_time_init(2016,5,28,0,0,0).next_tuesday
-    assert_equal date_time_init(2016,4,12,0,0,0), date_time_init(2016,4,6,0,0,0).next_tuesday
+    assert_equal date_time_init(2016,5,31,0,0,0), date_time_init(2016,5,28,0,0,0).next_day(:tuesday)
+    assert_equal date_time_init(2016,4,12,0,0,0), date_time_init(2016,4,6,0,0,0).next_day(:tuesday)
   end
 
   def test_next_wednesday
-    assert_equal date_time_init(2016,6,1,0,0,0), date_time_init(2016,5,28,0,0,0).next_wednesday
-    assert_equal date_time_init(2016,4,13,0,0,0), date_time_init(2016,4,6,0,0,0).next_wednesday
+    assert_equal date_time_init(2016,6,1,0,0,0), date_time_init(2016,5,28,0,0,0).next_day(:wednesday)
+    assert_equal date_time_init(2016,4,13,0,0,0), date_time_init(2016,4,6,0,0,0).next_day(:wednesday)
   end
 
   def test_next_thursday
-    assert_equal date_time_init(2016,6,2,0,0,0), date_time_init(2016,5,28,0,0,0).next_thursday
-    assert_equal date_time_init(2016,4,7,0,0,0), date_time_init(2016,4,6,0,0,0).next_thursday
+    assert_equal date_time_init(2016,6,2,0,0,0), date_time_init(2016,5,28,0,0,0).next_day(:thursday)
+    assert_equal date_time_init(2016,4,7,0,0,0), date_time_init(2016,4,6,0,0,0).next_day(:thursday)
   end
 
   def test_next_friday
-    assert_equal date_time_init(2016,6,3,0,0,0), date_time_init(2016,5,28,0,0,0).next_friday
-    assert_equal date_time_init(2016,4,8,0,0,0), date_time_init(2016,4,6,0,0,0).next_friday
+    assert_equal date_time_init(2016,6,3,0,0,0), date_time_init(2016,5,28,0,0,0).next_day(:friday)
+    assert_equal date_time_init(2016,4,8,0,0,0), date_time_init(2016,4,6,0,0,0).next_day(:friday)
   end
 
   def test_next_saturday
-    assert_equal date_time_init(2016,6,4,0,0,0), date_time_init(2016,5,28,0,0,0).next_saturday
-    assert_equal date_time_init(2016,4,9,0,0,0), date_time_init(2016,4,6,0,0,0).next_saturday
+    assert_equal date_time_init(2016,6,4,0,0,0), date_time_init(2016,5,28,0,0,0).next_day(:saturday)
+    assert_equal date_time_init(2016,4,9,0,0,0), date_time_init(2016,4,6,0,0,0).next_day(:saturday)
   end
 
   def test_next_sunday_on_saturday
-    assert_equal date_time_init(2016,5,29,0,0,0), date_time_init(2016,5,28,0,0,0).next_sunday
-    assert_equal date_time_init(2016,4,10,0,0,0), date_time_init(2016,4,9,0,0,0).next_sunday
+    assert_equal date_time_init(2016,5,29,0,0,0), date_time_init(2016,5,28,0,0,0).next_day(:sunday)
+    assert_equal date_time_init(2016,4,10,0,0,0), date_time_init(2016,4,9,0,0,0).next_day(:sunday)
   end
 
   def test_next_sunday_on_sunday
-    assert_equal date_time_init(2016,6,5,0,0,0), date_time_init(2016,5,29,0,0,0).next_sunday
-    assert_equal date_time_init(2016,4,17,0,0,0), date_time_init(2016,4,10,0,0,0).next_sunday
+    assert_equal date_time_init(2016,6,5,0,0,0), date_time_init(2016,5,29,0,0,0).next_day(:sunday)
+    assert_equal date_time_init(2016,4,17,0,0,0), date_time_init(2016,4,10,0,0,0).next_day(:sunday)
   end
 
   def test_prev_sunday
-    assert_equal date_time_init(2016,5,22,0,0,0), date_time_init(2016,5,28,0,0,0).prev_sunday
-    assert_equal date_time_init(2016,4,3,0,0,0), date_time_init(2016,4,6,0,0,0).prev_sunday
+    assert_equal date_time_init(2016,5,22,0,0,0), date_time_init(2016,5,28,0,0,0).prev_day(:sunday)
+    assert_equal date_time_init(2016,4,3,0,0,0), date_time_init(2016,4,6,0,0,0).prev_day(:sunday)
   end
 
   def test_prev_monday
-    assert_equal date_time_init(2016,5,23,0,0,0), date_time_init(2016,5,28,0,0,0).prev_monday
-    assert_equal date_time_init(2016,4,4,0,0,0), date_time_init(2016,4,6,0,0,0).prev_monday
+    assert_equal date_time_init(2016,5,23,0,0,0), date_time_init(2016,5,28,0,0,0).prev_day(:monday)
+    assert_equal date_time_init(2016,4,4,0,0,0), date_time_init(2016,4,6,0,0,0).prev_day(:monday)
   end
 
   def test_prev_tuesday
-    assert_equal date_time_init(2016,5,24,0,0,0), date_time_init(2016,5,28,0,0,0).prev_tuesday
-    assert_equal date_time_init(2016,4,5,0,0,0), date_time_init(2016,4,6,0,0,0).prev_tuesday
+    assert_equal date_time_init(2016,5,24,0,0,0), date_time_init(2016,5,28,0,0,0).prev_day(:tuesday)
+    assert_equal date_time_init(2016,4,5,0,0,0), date_time_init(2016,4,6,0,0,0).prev_day(:tuesday)
   end
 
   def test_prev_wednesday
-    assert_equal date_time_init(2016,5,25,0,0,0), date_time_init(2016,5,28,0,0,0).prev_wednesday
-    assert_equal date_time_init(2016,3,30,0,0,0), date_time_init(2016,4,6,0,0,0).prev_wednesday
+    assert_equal date_time_init(2016,5,25,0,0,0), date_time_init(2016,5,28,0,0,0).prev_day(:wednesday)
+    assert_equal date_time_init(2016,3,30,0,0,0), date_time_init(2016,4,6,0,0,0).prev_day(:wednesday)
   end
 
   def test_prev_thursday
-    assert_equal date_time_init(2016,5,26,0,0,0), date_time_init(2016,5,28,0,0,0).prev_thursday
-    assert_equal date_time_init(2016,3,31,0,0,0), date_time_init(2016,4,6,0,0,0).prev_thursday
+    assert_equal date_time_init(2016,5,26,0,0,0), date_time_init(2016,5,28,0,0,0).prev_day(:thursday)
+    assert_equal date_time_init(2016,3,31,0,0,0), date_time_init(2016,4,6,0,0,0).prev_day(:thursday)
   end
 
   def test_prev_friday
-    assert_equal date_time_init(2016,5,27,0,0,0), date_time_init(2016,5,28,0,0,0).prev_friday
-    assert_equal date_time_init(2016,4,1,0,0,0), date_time_init(2016,4,6,0,0,0).prev_friday
+    assert_equal date_time_init(2016,5,27,0,0,0), date_time_init(2016,5,28,0,0,0).prev_day(:friday)
+    assert_equal date_time_init(2016,4,1,0,0,0), date_time_init(2016,4,6,0,0,0).prev_day(:friday)
   end
 
   def test_prev_saturday
-    assert_equal date_time_init(2016,5,21,0,0,0), date_time_init(2016,5,28,0,0,0).prev_saturday
-    assert_equal date_time_init(2016,4,2,0,0,0), date_time_init(2016,4,6,0,0,0).prev_saturday
+    assert_equal date_time_init(2016,5,21,0,0,0), date_time_init(2016,5,28,0,0,0).prev_day(:saturday)
+    assert_equal date_time_init(2016,4,2,0,0,0), date_time_init(2016,4,6,0,0,0).prev_day(:saturday)
   end
 
   def test_prev_saturday_on_sunday
-    assert_equal date_time_init(2016,5,28,0,0,0), date_time_init(2016,5,29,0,0,0).prev_saturday
-    assert_equal date_time_init(2016,4,9,0,0,0), date_time_init(2016,4,10,0,0,0).prev_saturday
+    assert_equal date_time_init(2016,5,28,0,0,0), date_time_init(2016,5,29,0,0,0).prev_day(:saturday)
+    assert_equal date_time_init(2016,4,9,0,0,0), date_time_init(2016,4,10,0,0,0).prev_day(:saturday)
   end
 
   def test_prev_sunday_on_sunday
-    assert_equal date_time_init(2016,5,22,0,0,0), date_time_init(2016,5,29,0,0,0).prev_sunday
-    assert_equal date_time_init(2016,4,3,0,0,0), date_time_init(2016,4,10,0,0,0).prev_sunday
+    assert_equal date_time_init(2016,5,22,0,0,0), date_time_init(2016,5,29,0,0,0).prev_day(:sunday)
+    assert_equal date_time_init(2016,4,3,0,0,0), date_time_init(2016,4,10,0,0,0).prev_day(:sunday)
+  end
+
+  def test_next_sunday_with_wday
+    assert_equal date_time_init(2016,5,29,0,0,0), date_time_init(2016,5,28,0,0,0).next_wday(0)
+    assert_equal date_time_init(2016,4,10,0,0,0), date_time_init(2016,4,6,0,0,0).next_wday(0)
+  end
+
+  def test_next_monday_with_wday
+    assert_equal date_time_init(2016,5,30,0,0,0), date_time_init(2016,5,28,0,0,0).next_wday(1)
+    assert_equal date_time_init(2016,4,11,0,0,0), date_time_init(2016,4,6,0,0,0).next_wday(1)
+  end
+
+  def test_next_tuesday_with_wday
+    assert_equal date_time_init(2016,5,31,0,0,0), date_time_init(2016,5,28,0,0,0).next_wday(2)
+    assert_equal date_time_init(2016,4,12,0,0,0), date_time_init(2016,4,6,0,0,0).next_wday(2)
+  end
+
+  def test_prev_thursday_with_wday
+    assert_equal date_time_init(2016,5,26,0,0,0), date_time_init(2016,5,28,0,0,0).prev_wday(4)
+    assert_equal date_time_init(2016,3,31,0,0,0), date_time_init(2016,4,6,0,0,0).prev_wday(4)
+  end
+
+  def test_prev_friday_with_wday
+    assert_equal date_time_init(2016,5,27,0,0,0), date_time_init(2016,5,28,0,0,0).prev_wday(5)
+    assert_equal date_time_init(2016,4,1,0,0,0), date_time_init(2016,4,6,0,0,0).prev_wday(5)
+  end
+
+  def test_prev_saturday_wday
+    assert_equal date_time_init(2016,5,21,0,0,0), date_time_init(2016,5,28,0,0,0).prev_wday(6)
+    assert_equal date_time_init(2016,4,2,0,0,0), date_time_init(2016,4,6,0,0,0).prev_wday(6)
   end
 
   def with_bw_default(bw = :monday)

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -311,6 +311,96 @@ module DateAndTimeBehavior
     assert date_time_init(2015,1,5,15,15,10).on_weekday?
   end
 
+  def test_next_sunday
+    assert_equal date_time_init(2016,5,29,0,0,0), date_time_init(2016,5,28,0,0,0).next_sunday
+    assert_equal date_time_init(2016,4,10,0,0,0), date_time_init(2016,4,6,0,0,0).next_sunday
+  end
+
+  def test_next_monday
+    assert_equal date_time_init(2016,5,30,0,0,0), date_time_init(2016,5,28,0,0,0).next_monday
+    assert_equal date_time_init(2016,4,11,0,0,0), date_time_init(2016,4,6,0,0,0).next_monday
+  end
+
+  def test_next_tuesday
+    assert_equal date_time_init(2016,5,31,0,0,0), date_time_init(2016,5,28,0,0,0).next_tuesday
+    assert_equal date_time_init(2016,4,12,0,0,0), date_time_init(2016,4,6,0,0,0).next_tuesday
+  end
+
+  def test_next_wednesday
+    assert_equal date_time_init(2016,6,1,0,0,0), date_time_init(2016,5,28,0,0,0).next_wednesday
+    assert_equal date_time_init(2016,4,13,0,0,0), date_time_init(2016,4,6,0,0,0).next_wednesday
+  end
+
+  def test_next_thursday
+    assert_equal date_time_init(2016,6,2,0,0,0), date_time_init(2016,5,28,0,0,0).next_thursday
+    assert_equal date_time_init(2016,4,7,0,0,0), date_time_init(2016,4,6,0,0,0).next_thursday
+  end
+
+  def test_next_friday
+    assert_equal date_time_init(2016,6,3,0,0,0), date_time_init(2016,5,28,0,0,0).next_friday
+    assert_equal date_time_init(2016,4,8,0,0,0), date_time_init(2016,4,6,0,0,0).next_friday
+  end
+
+  def test_next_saturday
+    assert_equal date_time_init(2016,6,4,0,0,0), date_time_init(2016,5,28,0,0,0).next_saturday
+    assert_equal date_time_init(2016,4,9,0,0,0), date_time_init(2016,4,6,0,0,0).next_saturday
+  end
+
+  def test_next_sunday_on_saturday
+    assert_equal date_time_init(2016,5,29,0,0,0), date_time_init(2016,5,28,0,0,0).next_sunday
+    assert_equal date_time_init(2016,4,10,0,0,0), date_time_init(2016,4,9,0,0,0).next_sunday
+  end
+
+  def test_next_sunday_on_sunday
+    assert_equal date_time_init(2016,6,5,0,0,0), date_time_init(2016,5,29,0,0,0).next_sunday
+    assert_equal date_time_init(2016,4,17,0,0,0), date_time_init(2016,4,10,0,0,0).next_sunday
+  end
+
+  def test_prev_sunday
+    assert_equal date_time_init(2016,5,22,0,0,0), date_time_init(2016,5,28,0,0,0).prev_sunday
+    assert_equal date_time_init(2016,4,3,0,0,0), date_time_init(2016,4,6,0,0,0).prev_sunday
+  end
+
+  def test_prev_monday
+    assert_equal date_time_init(2016,5,23,0,0,0), date_time_init(2016,5,28,0,0,0).prev_monday
+    assert_equal date_time_init(2016,4,4,0,0,0), date_time_init(2016,4,6,0,0,0).prev_monday
+  end
+
+  def test_prev_tuesday
+    assert_equal date_time_init(2016,5,24,0,0,0), date_time_init(2016,5,28,0,0,0).prev_tuesday
+    assert_equal date_time_init(2016,4,5,0,0,0), date_time_init(2016,4,6,0,0,0).prev_tuesday
+  end
+
+  def test_prev_wednesday
+    assert_equal date_time_init(2016,5,25,0,0,0), date_time_init(2016,5,28,0,0,0).prev_wednesday
+    assert_equal date_time_init(2016,3,30,0,0,0), date_time_init(2016,4,6,0,0,0).prev_wednesday
+  end
+
+  def test_prev_thursday
+    assert_equal date_time_init(2016,5,26,0,0,0), date_time_init(2016,5,28,0,0,0).prev_thursday
+    assert_equal date_time_init(2016,3,31,0,0,0), date_time_init(2016,4,6,0,0,0).prev_thursday
+  end
+
+  def test_prev_friday
+    assert_equal date_time_init(2016,5,27,0,0,0), date_time_init(2016,5,28,0,0,0).prev_friday
+    assert_equal date_time_init(2016,4,1,0,0,0), date_time_init(2016,4,6,0,0,0).prev_friday
+  end
+
+  def test_prev_saturday
+    assert_equal date_time_init(2016,5,21,0,0,0), date_time_init(2016,5,28,0,0,0).prev_saturday
+    assert_equal date_time_init(2016,4,2,0,0,0), date_time_init(2016,4,6,0,0,0).prev_saturday
+  end
+
+  def test_prev_saturday_on_sunday
+    assert_equal date_time_init(2016,5,28,0,0,0), date_time_init(2016,5,29,0,0,0).prev_saturday
+    assert_equal date_time_init(2016,4,9,0,0,0), date_time_init(2016,4,10,0,0,0).prev_saturday
+  end
+
+  def test_prev_sunday_on_sunday
+    assert_equal date_time_init(2016,5,22,0,0,0), date_time_init(2016,5,29,0,0,0).prev_sunday
+    assert_equal date_time_init(2016,4,3,0,0,0), date_time_init(2016,4,10,0,0,0).prev_sunday
+  end
+
   def with_bw_default(bw = :monday)
     old_bw = Date.beginning_of_week
     Date.beginning_of_week = bw


### PR DESCRIPTION
### Added The prev__day and next__day methods to the DateAndTime related objects

Often when working on time related applications, such as scheduling applications, there is a need for helpers like next_tuesday, next_wednesday, next_sunday. While Rails provides the next_week(:tuesday), it may not often be what's required by the application developer. For instance, if today were a Thursday and the developer wanted to build a scheduling application that allows the user to select from a list Fridays, using Date#next_week(:friday), would result in a week being lost in the list, which may not be the required behaviour. Same applies for the Date#prev_week(:friday).
### Usage Example

With this implementation, to get the next 4 Thursdays for a list, it can easily be achieved with the snippet below:

``` ruby
    4.times{ |i| 
       Date.today.next_thursday + i.week
    }
```
### Methods Introduced

This PR adds the following methods to the DateAndTime related objects: 
`[:next_sunday, :next_monday, :next_tuesday, :next_wednesday, :next_thursday, :next_friday, :next_saturday, :prev_sunday, :prev_monday, :prev_tuesday, :prev_wednesday, :prev_thursday, :prev_friday, :prev_saturday]`
### Related Feature Request

This PR was built on the related Feature Request on https://groups.google.com/forum/?fromgroups#!topic/rubyonrails-core/suUoWFlOsPI

cc @fxn 
