### PR TITLE
More Action Pack `abstract_unit` cleanup

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -34,7 +34,6 @@ require 'action_dispatch'
 require 'active_support/dependencies'
 require 'active_model'
 require 'active_record'
-require 'action_controller/caching'
 
 require 'pp' # require 'pp' early to prevent hidden_methods from not picking up the pretty-print methods until too late
 
@@ -57,10 +56,6 @@ ActiveSupport::Deprecation.debug = true
 
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false
-
-# Register danish language for testing
-I18n.backend.store_translations 'da', {}
-I18n.backend.store_translations 'pt-BR', {}
 
 FIXTURE_LOAD_PATH = File.join(File.dirname(__FILE__), 'fixtures')
 
@@ -359,36 +354,14 @@ module RoutingTestHelpers
   end
 end
 
-class MetalRenderingController < ActionController::Metal
-  include AbstractController::Rendering
-  include ActionController::Rendering
-  include ActionController::Renderers
-end
-
 class ResourcesController < ActionController::Base
   def index() head :ok end
   alias_method :show, :index
 end
 
-class ThreadsController  < ResourcesController; end
-class MessagesController < ResourcesController; end
 class CommentsController < ResourcesController; end
-class ReviewsController < ResourcesController; end
-
 class AccountsController <  ResourcesController; end
-class AdminController   <  ResourcesController; end
-class ProductsController < ResourcesController; end
 class ImagesController < ResourcesController; end
-
-module Backoffice
-  class ProductsController < ResourcesController; end
-  class ImagesController < ResourcesController; end
-
-  module Admin
-    class ProductsController < ResourcesController; end
-    class ImagesController < ResourcesController; end
-  end
-end
 
 # Skips the current run on Rubinius using Minitest::Assertions#skip
 def rubinius_skip(message = '')

--- a/actionpack/test/controller/metal/renderers_test.rb
+++ b/actionpack/test/controller/metal/renderers_test.rb
@@ -1,6 +1,12 @@
 require 'abstract_unit'
 require 'active_support/core_ext/hash/conversions'
 
+class MetalRenderingController < ActionController::Metal
+  include AbstractController::Rendering
+  include ActionController::Rendering
+  include ActionController::Renderers
+end
+
 class MetalRenderingJsonController < MetalRenderingController
   class Model
     def to_json(options = {})

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -3,8 +3,22 @@ require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/object/with_options'
 require 'active_support/core_ext/array/extract_options'
 
-class ResourcesTest < ActionController::TestCase
+class AdminController < ResourcesController; end
+class MessagesController < ResourcesController; end
+class ProductsController < ResourcesController; end
+class ThreadsController < ResourcesController; end
 
+module Backoffice
+  class ProductsController < ResourcesController; end
+  class ImagesController < ResourcesController; end
+
+  module Admin
+    class ProductsController < ResourcesController; end
+    class ImagesController < ResourcesController; end
+  end
+end
+
+class ResourcesTest < ActionController::TestCase
   def test_default_restful_routes
     with_restful_routing :messages do
       assert_simply_restful_for :messages

--- a/actionpack/test/dispatch/routing/concerns_test.rb
+++ b/actionpack/test/dispatch/routing/concerns_test.rb
@@ -1,5 +1,7 @@
 require 'abstract_unit'
 
+class ReviewsController < ResourcesController; end
+
 class RoutingConcernsTest < ActionDispatch::IntegrationTest
   class Reviewable
     def self.call(mapper, options = {})


### PR DESCRIPTION
- Remove dead classes / dead code
- Move class definitions to where they are used, don't define in a
  shared space
