### PR TITLE
Do not include default column limit in schema.rb

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -41,14 +41,14 @@ module ActiveRecord
       NATIVE_DATABASE_TYPES = {
         primary_key: "int auto_increment PRIMARY KEY",
         string:      { name: "varchar", limit: 255 },
-        text:        { name: "text" },
+        text:        { name: "text", limit: 65535 },
         integer:     { name: "int", limit: 4 },
         float:       { name: "float" },
         decimal:     { name: "decimal" },
         datetime:    { name: "datetime" },
         time:        { name: "time" },
         date:        { name: "date" },
-        binary:      { name: "blob" },
+        binary:      { name: "blob", limit: 65535 },
         boolean:     { name: "tinyint", limit: 1 },
         json:        { name: "json" },
       }

--- a/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
@@ -49,6 +49,6 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
   test "schema dump includes collation" do
     output = dump_table_schema("charset_collations")
     assert_match %r{t.string\s+"string_ascii_bin",\s+collation: "ascii_bin"$}, output
-    assert_match %r{t.text\s+"text_ucs2_unicode_ci",\s+limit: 65535,\s+collation: "ucs2_unicode_ci"$}, output
+    assert_match %r{t.text\s+"text_ucs2_unicode_ci",\s+collation: "ucs2_unicode_ci"$}, output
   end
 end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -218,12 +218,17 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_match %r{t\.boolean\s+"has_fun",.+default: false}, output
   end
 
-  if current_adapter?(:Mysql2Adapter)
-    def test_schema_dump_should_add_default_value_for_mysql_text_field
-      output = standard_dump
-      assert_match %r{t\.text\s+"body",\s+limit: 65535,\s+null: false$}, output
-    end
+  def test_schema_dump_does_not_include_limit_for_text_field
+    output = standard_dump
+    assert_match %r{t\.text\s+"params"$}, output
+  end
 
+  def test_schema_dump_does_not_include_limit_for_binary_field
+    output = standard_dump
+    assert_match %r{t\.binary\s+"data"$}, output
+  end
+
+  if current_adapter?(:Mysql2Adapter)
     def test_schema_dump_includes_length_for_mysql_binary_fields
       output = standard_dump
       assert_match %r{t\.binary\s+"var_binary",\s+limit: 255$}, output
@@ -233,11 +238,11 @@ class SchemaDumperTest < ActiveRecord::TestCase
     def test_schema_dump_includes_length_for_mysql_blob_and_text_fields
       output = standard_dump
       assert_match %r{t\.blob\s+"tiny_blob",\s+limit: 255$}, output
-      assert_match %r{t\.binary\s+"normal_blob",\s+limit: 65535$}, output
+      assert_match %r{t\.binary\s+"normal_blob"$}, output
       assert_match %r{t\.binary\s+"medium_blob",\s+limit: 16777215$}, output
       assert_match %r{t\.binary\s+"long_blob",\s+limit: 4294967295$}, output
       assert_match %r{t\.text\s+"tiny_text",\s+limit: 255$}, output
-      assert_match %r{t\.text\s+"normal_text",\s+limit: 65535$}, output
+      assert_match %r{t\.text\s+"normal_text"$}, output
       assert_match %r{t\.text\s+"medium_text",\s+limit: 16777215$}, output
       assert_match %r{t\.text\s+"long_text",\s+limit: 4294967295$}, output
     end


### PR DESCRIPTION
Follow up of #20815.

``` ruby
class CreatePeople < ActiveRecord::Migration[5.0]
  def change
    create_table :people do |t|
      t.integer :int
      t.bigint :bint
      t.text :txt
      t.binary :bin
    end
  end
end
```

Result.

In postgresql and sqlite3 adapters:

``` ruby
ActiveRecord::Schema.define(version: 20160531141018) do

  create_table "people", force: :cascade do |t|
    t.integer "int"
    t.bigint  "bint"
    t.text    "txt"
    t.binary  "bin"
  end

end
```

In mysql2 adapter:

``` ruby
ActiveRecord::Schema.define(version: 20160531141018) do

  create_table "people", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
    t.integer "int"
    t.bigint  "bint"
    t.text    "txt",  limit: 65535
    t.binary  "bin",  limit: 65535
  end

end
```

After this patch:

``` ruby
ActiveRecord::Schema.define(version: 20160531141018) do

  create_table "people", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
    t.integer "int"
    t.bigint  "bint"
    t.text    "txt"
    t.binary  "bin"
  end

end
```
