### PR TITLE
Fix MessageEncryptorTest

### DIFF
--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -15,7 +15,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
   end
 
   def setup
-    @secret    = SecureRandom.hex(64)
+    @secret    = SecureRandom.random_bytes(32)
     @verifier  = ActiveSupport::MessageVerifier.new(@secret, :serializer => ActiveSupport::MessageEncryptor::NullSerializer)
     @encryptor = ActiveSupport::MessageEncryptor.new(@secret)
     @data = { :some => "data", :now => Time.local(2010) }
@@ -51,7 +51,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
   def test_alternative_serialization_method
     prev = ActiveSupport.use_standard_json_time_format
     ActiveSupport.use_standard_json_time_format = true
-    encryptor = ActiveSupport::MessageEncryptor.new(SecureRandom.hex(64), SecureRandom.hex(64), :serializer => JSONSerializer.new)
+    encryptor = ActiveSupport::MessageEncryptor.new(SecureRandom.random_bytes(32), SecureRandom.random_bytes(128), :serializer => JSONSerializer.new)
     message = encryptor.encrypt_and_sign({ :foo => 123, 'bar' => Time.utc(2010) })
     exp = { "foo" => 123, "bar" => "2010-01-01T00:00:00.000Z" }
     assert_equal exp, encryptor.decrypt_and_verify(message)


### PR DESCRIPTION
By r55146 commit on Ruby, `OpenSSL::Cipher#key=` raises
`ArgumentError` when too long "key" is passed.
In Rails test cases "aes-256-cbc" is used.
Key length of "aes-256-cbc" is 256 bits (32 bytes).

`SecureRandom.hex(64)` generates 64 words string
which is 128 bytes.

Change to use `SecureRandom.random_bytes(32)` to generate
32 bytes key.

ref: https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=55146&view=revision
