### PR TITLE
Stop logging all noisy stack trace when actual trace is empty and simply point where to configure trace

### DIFF
--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -2,7 +2,7 @@ require 'active_support/backtrace_cleaner'
 
 module Rails
   class BacktraceCleaner < ActiveSupport::BacktraceCleaner
-    APP_DIRS_PATTERN = /^\/?(app|config|lib|test)/
+    APP_DIRS_PATTERN = /^\/?(app|config|lib|test|\(\w*\))/
     RENDER_TEMPLATE_PATTERN = /:in `_render_template_\w*'/
     EMPTY_STRING = ''.freeze
     SLASH        = '/'.freeze

--- a/railties/lib/rails/commands/console.rb
+++ b/railties/lib/rails/commands/console.rb
@@ -7,6 +7,14 @@ module Rails
   class Console
     include ConsoleHelper
 
+    module BacktraceCleaner
+      def filter_backtrace(bt)
+        if result = super
+          Rails.backtrace_cleaner.filter([result]).first
+        end
+      end
+    end
+
     class << self
       def parse_arguments(arguments)
         options = {}
@@ -34,6 +42,10 @@ module Rails
       app.load_console
 
       @console = app.config.console || IRB
+
+      if @console == IRB
+        IRB::WorkSpace.prepend(BacktraceCleaner)
+      end
     end
 
     def sandbox?

--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -1,24 +1,32 @@
 require 'abstract_unit'
 require 'rails/backtrace_cleaner'
 
-class BacktraceCleanerVendorGemTest < ActiveSupport::TestCase
+class BacktraceCleanerTest < ActiveSupport::TestCase
   def setup
     @cleaner = Rails::BacktraceCleaner.new
   end
 
   test "should format installed gems correctly" do
-    @backtrace = [ "#{Gem.path[0]}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
-    @result = @cleaner.clean(@backtrace, :all)
-    assert_equal "nosuchgem (1.2.3) lib/foo.rb", @result[0]
+    backtrace = [ "#{Gem.path[0]}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
+    result = @cleaner.clean(backtrace, :all)
+    assert_equal "nosuchgem (1.2.3) lib/foo.rb", result[0]
   end
 
   test "should format installed gems not in Gem.default_dir correctly" do
-    @target_dir = Gem.path.detect { |p| p != Gem.default_dir }
+    target_dir = Gem.path.detect { |p| p != Gem.default_dir }
     # skip this test if default_dir is the only directory on Gem.path
     if @target_dir
-      @backtrace = [ "#{@target_dir}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
-      @result = @cleaner.clean(@backtrace, :all)
-      assert_equal "nosuchgem (1.2.3) lib/foo.rb", @result[0]
+      backtrace = [ "#{target_dir}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
+      result = @cleaner.clean(backtrace, :all)
+      assert_equal "nosuchgem (1.2.3) lib/foo.rb", result[0]
     end
+  end
+
+  test "should consider traces from irb lines as User code" do
+    backtrace = [ "from (irb):1",
+                  "from /Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'",
+                  "from bin/rails:4:in `<main>'" ]
+    result = @cleaner.clean(backtrace, :all)
+    assert_equal "from (irb):1", result[0]
   end
 end


### PR DESCRIPTION
r? @dhh 

First pass at: Stop logging all noisy stack trace when actual trace is empty and simply point where to configure trace.

Fixes #25219
See also #24434
