### PR TITLE
`channel_class_names` ignores channel namespaces

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -35,6 +35,7 @@ module ActionCable
           self.connection_class = ApplicationCable::Connection
         end
 
+        self.base_channel_path = Rails.root.join('app/channels')
         self.channel_paths = Rails.application.paths['app/channels'].existent
 
         options.each { |k,v| send("#{k}=", v) }

--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -8,7 +8,7 @@ module ActionCable
       attr_accessor :disable_request_forgery_protection, :allowed_request_origins
       attr_accessor :cable, :url, :mount_path
 
-      attr_accessor :channel_paths # :nodoc:
+      attr_accessor :channel_paths, :base_channel_path # :nodoc:
 
       def initialize
         @log_tags = []
@@ -21,7 +21,15 @@ module ActionCable
 
       def channel_class_names
         @channel_class_names ||= channel_paths.collect do |channel_path|
-          Pathname.new(channel_path).basename.to_s.split('.').first.camelize
+          # First, remove the base_channel_path, and reveal the relative
+          # location of the `channel_path`
+          path = Pathname.new(channel_path).relative_path_from(base_channel_path).to_s
+
+          # Next, remove the file extension
+          path = path.split('.').first
+
+          # Finally, camelize and turn the file name into a usable constant
+          path.camelize
         end
       end
 

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -18,6 +18,7 @@ class ClientTest < ActionCable::TestCase
 
     server.config.cable = { adapter: 'async' }.with_indifferent_access
     server.config.use_faye = ENV['FAYE'].present?
+    server.config.base_channel_path = Pathname.new(Dir.pwd + '/test/client')
 
     # and now the "real" setup for our test:
     server.config.disable_request_forgery_protection = true

--- a/actioncable/test/server/configuration_test.rb
+++ b/actioncable/test/server/configuration_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class BroadcastingTest < ActiveSupport::TestCase
+  class TestServer
+    include ActionCable::Server::Broadcasting
+  end
+
+  test "properly formats channel_class_names" do
+    config = ActionCable::Server::Configuration.new
+    config.channel_paths = [
+      "myrootpath/app/channels/room_channel.rb",
+      "myrootpath/app/channels/test/room_channel.rb"
+    ]
+
+    config.base_channel_path = Pathname.new('myrootpath/app/channels')
+
+    assert_equal ["RoomChannel", "Test::RoomChannel"], config.channel_class_names
+  end
+end


### PR DESCRIPTION
Fixes #25224.

Say you have `app/channels/test/room_channel.rb` and
`app/channels/room_channel.rb` defined.

Before:

``` ruby
irb(main):001:0> ActionCable.server.config.channel_class_names
=> ["RoomChannel", "RoomChannel"]
```

After:

``` ruby
irb(main):001:0> ActionCable.server.config.channel_class_names
=> ["RoomChannel", "Test::RoomChannel"]
```
