### PR TITLE
Translate numeric value out of range to the specific exception

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -738,6 +738,7 @@ module ActiveRecord
         ER_DO_NOT_HAVE_DEFAULT  = 1364
         ER_NO_REFERENCED_ROW_2  = 1452
         ER_DATA_TOO_LONG        = 1406
+        ER_OUT_OF_RANGE         = 1264
         ER_LOCK_DEADLOCK        = 1213
         ER_CANNOT_ADD_FOREIGN   = 1215
         ER_CANNOT_CREATE_TABLE  = 1005
@@ -758,6 +759,8 @@ module ActiveRecord
             end
           when ER_DATA_TOO_LONG
             ValueTooLong.new(message)
+          when ER_OUT_OF_RANGE
+            RangeError.new(message)
           when ER_NOT_NULL_VIOLATION, ER_DO_NOT_HAVE_DEFAULT
             NotNullViolation.new(message)
           when ER_LOCK_DEADLOCK

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -408,6 +408,7 @@ module ActiveRecord
 
         # See http://www.postgresql.org/docs/current/static/errcodes-appendix.html
         VALUE_LIMIT_VIOLATION = "22001"
+        NUMERIC_VALUE_OUT_OF_RANGE = "22003"
         NOT_NULL_VIOLATION    = "23502"
         FOREIGN_KEY_VIOLATION = "23503"
         UNIQUE_VIOLATION      = "23505"
@@ -424,6 +425,8 @@ module ActiveRecord
             InvalidForeignKey.new(message)
           when VALUE_LIMIT_VIOLATION
             ValueTooLong.new(message)
+          when NUMERIC_VALUE_OUT_OF_RANGE
+            RangeError.new(message)
           when NOT_NULL_VIOLATION
             NotNullViolation.new(message)
           when SERIALIZATION_FAILURE

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -194,7 +194,7 @@ module ActiveRecord
                                    name, primary_key, id)
         end
         record
-      rescue RangeError
+      rescue ::RangeError
         raise RecordNotFound.new("Couldn't find #{name} with an out of range value for '#{primary_key}'",
                                  name, primary_key)
       end
@@ -223,7 +223,7 @@ module ActiveRecord
           statement.execute(hash.values, self, connection).first
         rescue TypeError
           raise ActiveRecord::StatementInvalid
-        rescue RangeError
+        rescue ::RangeError
           nil
         end
       end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -159,6 +159,10 @@ module ActiveRecord
   class ValueTooLong < StatementInvalid
   end
 
+  # Raised when values that executed are out of range.
+  class RangeError < StatementInvalid
+  end
+
   # Raised when number of bind variables in statement given to +:condition+ key
   # (for example, when using {ActiveRecord::Base.find}[rdoc-ref:FinderMethods#find] method)
   # does not match number of expected values supplied.

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -76,7 +76,7 @@ module ActiveRecord
     #   Post.find_by "published_at < ?", 2.weeks.ago
     def find_by(arg, *args)
       where(arg, *args).take
-    rescue RangeError
+    rescue ::RangeError
       nil
     end
 
@@ -84,7 +84,7 @@ module ActiveRecord
     # an ActiveRecord::RecordNotFound error.
     def find_by!(arg, *args)
       where(arg, *args).take!
-    rescue RangeError
+    rescue ::RangeError
       raise RecordNotFound.new("Couldn't find #{@klass.name} with an out of range value",
                                @klass.name)
     end
@@ -333,7 +333,7 @@ module ActiveRecord
       end
 
       connection.select_value(relation, "#{name} Exists", relation.bound_attributes) ? true : false
-    rescue RangeError
+    rescue ::RangeError
       false
     end
 
@@ -458,7 +458,7 @@ module ActiveRecord
         else
           find_some(ids)
         end
-      rescue RangeError
+      rescue ::RangeError
         raise RecordNotFound, "Couldn't find #{@klass.name} with an out of range ID"
       end
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -226,6 +226,14 @@ module ActiveRecord
 
         assert_not_nil error.cause
       end
+
+      def test_numeric_value_out_of_ranges_are_translated_to_specific_exception
+        error = assert_raises(ActiveRecord::RangeError) do
+          Book.connection.create("INSERT INTO books(author_id) VALUES (2147483648)")
+        end
+
+        assert_not_nil error.cause
+      end
     end
 
     def test_disable_referential_integrity

--- a/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
@@ -34,10 +34,10 @@ class Mysql2UnsignedTypeTest < ActiveRecord::Mysql2TestCase
     assert_raise(ActiveModel::RangeError) do
       UnsignedType.create(unsigned_bigint: -10)
     end
-    assert_raise(ActiveRecord::StatementInvalid) do
+    assert_raise(ActiveRecord::RangeError) do
       UnsignedType.create(unsigned_float: -10.0)
     end
-    assert_raise(ActiveRecord::StatementInvalid) do
+    assert_raise(ActiveRecord::RangeError) do
       UnsignedType.create(unsigned_decimal: -10.0)
     end
   end


### PR DESCRIPTION
Raise `ActiveRecord::RangeError` when values that executed are out of range.
