### PR TITLE
Comment out jbuilder for normal apps too

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -308,7 +308,7 @@ module Rails
 
       def jbuilder_gemfile_entry
         comment = 'Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder'
-        GemfileEntry.new 'jbuilder', '~> 2.5', comment, {}, options[:api]
+        GemfileEntry.new 'jbuilder', '~> 2.5', comment, {}, true
       end
 
       def coffee_gemfile_entry

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -563,9 +563,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_inclusion_of_jbuilder
+  def test_inclusion_of_jbuilder_but_commented
     run_generator
-    assert_gem 'jbuilder'
+
+    assert_file 'Gemfile', /# gem 'jbuilder'/
   end
 
   def test_inclusion_of_a_debugger


### PR DESCRIPTION
- It's surprising that we comment out jbuilder in the Gemfile for API
  only apps but not for normal apps.
- So this commit comments out jbuilder for normal apps too.

A related question. Now that we have API only mode, do we need to add an entry for jbuilder for normal apps?  cc @dhh 
