### PR TITLE
Fix `remove_reference` to be able to handle `to_table` option

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -53,7 +53,7 @@ module ActiveRecord
 
       def defined_for?(options_or_to_table = {})
         if options_or_to_table.is_a?(Hash)
-          options_or_to_table.all? {|key, value| options[key].to_s == value.to_s }
+          options_or_to_table.all? {|key, value| send(key).to_s == value.to_s }
         else
           to_table == options_or_to_table.to_s
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -855,6 +855,7 @@ module ActiveRecord
           else
             foreign_key_options = { to_table: reference_name }
           end
+          foreign_key_options[:column] ||= "#{ref_name}_id"
           remove_foreign_key(table_name, **foreign_key_options)
         end
 


### PR DESCRIPTION
Currently CI is broken due to 56a61e0c439d75244992f01468f09f85b5b08b78 and c4cb6862babd2665a65056e205c2a5fd17a5d99d.

This PR is to fix 56a61e0c439d75244992f01468f09f85b5b08b78.

`ForeignKeyDefinition` does not include `to_table` option in `options`.
