### PR TITLE
More cleanup of new framework defaults

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -90,7 +90,6 @@ module Rails
 
     def config_when_updating
       cookie_serializer_config_exist = File.exist?('config/initializers/cookies_serializer.rb')
-      new_framework_defaults_config_exist = File.exist?('config/initializers/new_framework_defaults.rb')
       action_cable_config_exist = File.exist?('config/cable.yml')
       rack_cors_config_exist = File.exist?('config/initializers/cors.rb')
 
@@ -100,10 +99,6 @@ module Rails
 
       unless cookie_serializer_config_exist
         gsub_file 'config/initializers/cookies_serializer.rb', /json(?!,)/, 'marshal'
-      end
-
-      unless new_framework_defaults_config_exist
-        remove_file 'config/initializers/new_framework_defaults.rb'
       end
 
       unless action_cable_config_exist

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
@@ -15,14 +15,16 @@ Rails.application.config.action_controller.forgery_protection_origin_check = tru
 <%- unless options[:skip_active_record] -%>
 
 # Require `belongs_to` associations by default.
-Rails.application.config.active_record.belongs_to_required_by_default = true
+Rails.application.config.active_record.belongs_to_required_by_default = <%= options[:update] ? false : true %>
 <%- end -%>
 
 # Do not halt callback chains when a callback returns false.
-ActiveSupport.halt_callback_chains_on_return_false = false
+ActiveSupport.halt_callback_chains_on_return_false = <%= options[:update] ? true : false %>
+<%- unless options[:update] -%>
 
 # Configure SSL options to enable HSTS with subdomains.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }
+<%- end -%>
 
 # Preserve the timezone of the receiver when calling to `to_time`.
 # Ruby 2.4 will change the behavior of `to_time` to preserve the timezone

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
@@ -1,33 +1,36 @@
 # Be sure to restart your server when you modify this file.
-# This file contains all the new default configuration options from
-# Rails 5.0.
+#
+# This file contains migration options to ease your Rails 5.0 upgrade.
+# They will be removed in the next major Rails version.
+#
+# Flip the defaults to the value of past versions then once upgraded
+# begin migrating to the new default one by one.
+#
+# Read the Rails 5.0 release notes for more info on each option.
 <%- unless options[:api] -%>
 
-# Enable per-form CSRF tokens.
+# Enable per-form CSRF tokens. This is new feature of Rails 5.
 Rails.application.config.action_controller.per_form_csrf_tokens = true
 
-# Enable origin-checking CSRF mitigation.
+# Enable origin-checking CSRF mitigation. This is new feature of Rails 5.
 Rails.application.config.action_controller.forgery_protection_origin_check = true
 <%- end -%>
+
+# Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
+ActiveSupport.to_time_preserves_timezone = true
 
 # Following config options are introduced to ensure that apps
 # made on earlier versions of Rails are not affected when upgrading.
 <%- unless options[:skip_active_record] -%>
 
-# Require `belongs_to` associations by default.
+# Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = <%= options[:update] ? false : true %>
 <%- end -%>
 
-# Do not halt callback chains when a callback returns false.
+# Do not halt callback chains when a callback returns false. Previous versions had true.
 ActiveSupport.halt_callback_chains_on_return_false = <%= options[:update] ? true : false %>
 <%- unless options[:update] -%>
 
-# Configure SSL options to enable HSTS with subdomains.
+# Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }
 <%- end -%>
-
-# Preserve the timezone of the receiver when calling to `to_time`.
-# Ruby 2.4 will change the behavior of `to_time` to preserve the timezone
-# when converting to an instance of `Time` instead of the previous behavior
-# of converting to the local system timezone.
-ActiveSupport.to_time_preserves_timezone = true

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
@@ -1,18 +1,6 @@
 # Be sure to restart your server when you modify this file.
 # This file contains all the new default configuration options from
 # Rails 5.0.
-<%- unless options[:skip_active_record] -%>
-
-# Require `belongs_to` associations by default. This is a new Rails 5.0
-# default, so it is introduced as a configuration option to ensure that apps
-# made on earlier versions of Rails are not affected when upgrading.
-Rails.application.config.active_record.belongs_to_required_by_default = true
-<%- end -%>
-
-# Do not halt callback chains when a callback returns false. This is a new
-# Rails 5.0 default, so it is introduced as a configuration option to ensure
-# that apps made with earlier versions of Rails are not affected when upgrading.
-ActiveSupport.halt_callback_chains_on_return_false = false
 <%- unless options[:api] -%>
 
 # Enable per-form CSRF tokens.
@@ -22,16 +10,22 @@ Rails.application.config.action_controller.per_form_csrf_tokens = true
 Rails.application.config.action_controller.forgery_protection_origin_check = true
 <%- end -%>
 
-# Configure SSL options to enable HSTS with subdomains. This is a new
-# Rails 5.0 default, so it is introduced as a configuration option to ensure
-# that apps made on earlier versions of Rails are not affected when upgrading.
+# Following config options are introduced to ensure that apps
+# made on earlier versions of Rails are not affected when upgrading.
+<%- unless options[:skip_active_record] -%>
+
+# Require `belongs_to` associations by default.
+Rails.application.config.active_record.belongs_to_required_by_default = true
+<%- end -%>
+
+# Do not halt callback chains when a callback returns false.
+ActiveSupport.halt_callback_chains_on_return_false = false
+
+# Configure SSL options to enable HSTS with subdomains.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }
 
 # Preserve the timezone of the receiver when calling to `to_time`.
 # Ruby 2.4 will change the behavior of `to_time` to preserve the timezone
 # when converting to an instance of `Time` instead of the previous behavior
 # of converting to the local system timezone.
-#
-# Rails 5.0 introduced this config option so that apps made with earlier
-# versions of Rails are not affected when upgrading.
 ActiveSupport.to_time_preserves_timezone = true

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
@@ -1,33 +1,30 @@
 # Be sure to restart your server when you modify this file.
 #
 # This file contains migration options to ease your Rails 5.0 upgrade.
-# They will be removed in the next major Rails version.
 #
-# Flip the defaults to the value of past versions then once upgraded
-# begin migrating to the new default one by one.
+<%- if options[:update] -%>
+# Once upgraded flip defaults one by one to migrate to the new default.
 #
+<%- end -%>
 # Read the Rails 5.0 release notes for more info on each option.
 <%- unless options[:api] -%>
 
-# Enable per-form CSRF tokens. This is new feature of Rails 5.
-Rails.application.config.action_controller.per_form_csrf_tokens = true
+# Enable per-form CSRF tokens. <%= options[:update] ? 'Next major version defaults to true.' : 'Previous versions had false.' %>
+Rails.application.config.action_controller.per_form_csrf_tokens = <%= options[:update] ? false : true %>
 
-# Enable origin-checking CSRF mitigation. This is new feature of Rails 5.
-Rails.application.config.action_controller.forgery_protection_origin_check = true
+# Enable origin-checking CSRF mitigation. <%= options[:update] ? 'Next major version defaults to true.' : 'Previous versions had false.' %>
+Rails.application.config.action_controller.forgery_protection_origin_check = <%= options[:update] ? false : true %>
 <%- end -%>
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 ActiveSupport.to_time_preserves_timezone = true
-
-# Following config options are introduced to ensure that apps
-# made on earlier versions of Rails are not affected when upgrading.
 <%- unless options[:skip_active_record] -%>
 
-# Require `belongs_to` associations by default. Previous versions had false.
+# Require `belongs_to` associations by default. <%= options[:update] ? 'Next major version defaults to true.' : 'Previous versions had false.' %>
 Rails.application.config.active_record.belongs_to_required_by_default = <%= options[:update] ? false : true %>
 <%- end -%>
 
-# Do not halt callback chains when a callback returns false. Previous versions had true.
+# Do not halt callback chains when a callback returns false. <%= options[:update] ? 'Next major version defaults to false.' : 'Previous versions had true.' %>
 ActiveSupport.halt_callback_chains_on_return_false = <%= options[:update] ? true : false %>
 <%- unless options[:update] -%>
 

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -48,7 +48,7 @@ namespace :app do
           require 'rails/generators'
           require 'rails/generators/rails/app/app_generator'
           gen = Rails::Generators::AppGenerator.new ["rails"],
-                                                    { api: !!Rails.application.config.api_only },
+                                                    { api: !!Rails.application.config.api_only, update: true, force: ENV['FORCE'] },
                                                     destination_root: Rails.root
           File.exist?(Rails.root.join("config", "application.rb")) ?
             gen.send(:app_const) : gen.send(:valid_const?)

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -48,7 +48,7 @@ namespace :app do
           require 'rails/generators'
           require 'rails/generators/rails/app/app_generator'
           gen = Rails::Generators::AppGenerator.new ["rails"],
-                                                    { api: !!Rails.application.config.api_only, update: true, force: ENV['FORCE'] },
+                                                    { api: !!Rails.application.config.api_only, update: true },
                                                     destination_root: Rails.root
           File.exist?(Rails.root.join("config", "application.rb")) ?
             gen.send(:app_const) : gen.send(:valid_const?)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -208,7 +208,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     FileUtils.rm("#{app_root}/config/initializers/new_framework_defaults.rb")
 
     stub_rails_application(app_root) do
-      quietly { `FORCE=true bin/rails app:update` }
+      generator = Rails::Generators::AppGenerator.new ["rails"], { update: true }, destination_root: app_root, shell: @shell
+      generator.send(:app_const)
+      quietly { generator.send(:update_config_files) }
 
       assert_file "#{app_root}/config/initializers/new_framework_defaults.rb" do |content|
         assert_match(/ActiveSupport\.halt_callback_chains_on_return_false = true/, content)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -208,24 +208,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     FileUtils.rm("#{app_root}/config/initializers/new_framework_defaults.rb")
 
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
-      generator.send(:app_const)
-      quietly { generator.send(:update_config_files) }
-      assert_no_file "#{app_root}/config/initializers/new_framework_defaults.rb"
-    end
-  end
+      quietly { `FORCE=true bin/rails app:update` }
 
-  def test_rails_update_does_not_new_framework_defaults_if_already_present
-    app_root = File.join(destination_root, 'myapp')
-    run_generator [app_root]
-
-    FileUtils.touch("#{app_root}/config/initializers/new_framework_defaults.rb")
-
-    stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
-      generator.send(:app_const)
-      quietly { generator.send(:update_config_files) }
-      assert_file "#{app_root}/config/initializers/new_framework_defaults.rb"
+      assert_file "#{app_root}/config/initializers/new_framework_defaults.rb" do |content|
+        assert_match(/ActiveSupport\.halt_callback_chains_on_return_false = true/, content)
+        assert_match(/Rails\.application\.config.active_record\.belongs_to_required_by_default = false/, content)
+        assert_no_match(/Rails\.application\.config\.ssl_options/, content)
+      end
     end
   end
 


### PR DESCRIPTION
- Move real new default options to the top of the file.
- After that club together all the options which were added to keep
  backward compatibility. So all of them will get only one header.
- Based on https://github.com/rails/rails/pull/25231#issuecomment-222945173.

r? @kaspth 
