### PR TITLE
fix typo [ci skip]

### DIFF
--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -166,7 +166,7 @@ module TestGenerationPrefix
       assert_equal "/pure-awesomeness/blog/posts/1", last_response.body
     end
 
-    test "[ENGINE] url_helpers from engine have higher priotity than application's url_helpers" do
+    test "[ENGINE] url_helpers from engine have higher priority than application's url_helpers" do
       get "/awesome/blog/conflicting_url"
       assert_equal "engine", last_response.body
     end
@@ -319,14 +319,14 @@ module TestGenerationPrefix
       path = engine_object.polymorphic_url(Post.new, :host => "www.example.com")
       assert_equal "http://www.example.com/awesome/blog/posts/1", path
     end
-    
+
     private
       def verify_redirect(url, status = 301)
         assert_equal status, last_response.status
         assert_equal url, last_response.headers["Location"]
         assert_equal expected_redirect_body(url), last_response.body
       end
-      
+
       def expected_redirect_body(url)
         %(<html><body>You are being <a href="#{url}">redirected</a>.</body></html>)
       end
@@ -450,14 +450,14 @@ module TestGenerationPrefix
       get "/absolute_custom_redirect"
       verify_redirect "http://example.org/foo"
     end
-    
+
     private
       def verify_redirect(url, status = 301)
         assert_equal status, last_response.status
         assert_equal url, last_response.headers["Location"]
         assert_equal expected_redirect_body(url), last_response.body
       end
-      
+
       def expected_redirect_body(url)
         %(<html><body>You are being <a href="#{url}">redirected</a>.</body></html>)
       end


### PR DESCRIPTION
Fix typo in file:
`actionpack/test/dispatch/prefix_generation_test.rb`
