### PR TITLE
Fix yaml encoder for store accessor

### DIFF
--- a/actionview/test/activerecord/debug_helper_test.rb
+++ b/actionview/test/activerecord/debug_helper_test.rb
@@ -4,7 +4,10 @@ require 'nokogiri'
 class DebugHelperTest < ActionView::TestCase
   def test_debug
     company = Company.new(name: "firebase")
-    assert_match "name: firebase", debug(company)
+    output = debug(company)
+    assert_match "name: name", output
+    assert_match "value_before_type_cast: firebase", output
+    assert_match "active_record_yaml_version: 2", output
   end
 
   def test_debug_with_marshal_error

--- a/activerecord/lib/active_record/attribute_set/yaml_encoder.rb
+++ b/activerecord/lib/active_record/attribute_set/yaml_encoder.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
       def encode(attribute_set, coder)
         coder['concise_attributes'] = attribute_set.each_value.map do |attr|
-          if attr.type.equal?(default_types[attr.name])
+          if attr.type.equal?(default_types[attr.name]) && !attr.changed?
             attr.with_type(nil)
           else
             attr

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -53,7 +53,7 @@ module ActiveRecord
 
       def defined_for?(options_or_to_table = {})
         if options_or_to_table.is_a?(Hash)
-          options_or_to_table.all? {|key, value| options[key].to_s == value.to_s }
+          options_or_to_table.all? {|key, value| send(key).to_s == value.to_s }
         else
           to_table == options_or_to_table.to_s
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -855,6 +855,7 @@ module ActiveRecord
           else
             foreign_key_options = { to_table: reference_name }
           end
+          foreign_key_options[:column] ||= "#{ref_name}_id"
           remove_foreign_key(table_name, **foreign_key_options)
         end
 


### PR DESCRIPTION
Currently CI is broken due to 56a61e0c439d75244992f01468f09f85b5b08b78 and c4cb6862babd2665a65056e205c2a5fd17a5d99d.

This PR includes #25234 and to fix c4cb6862babd2665a65056e205c2a5fd17a5d99d.
