### PR TITLE
Improve error message when record touch fails.

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -479,7 +479,12 @@ module ActiveRecord
     #   ball.touch(:updated_at)   # => raises ActiveRecordError
     #
     def touch(*names, time: nil)
-      raise ActiveRecordError, "cannot touch on a new record object" unless persisted?
+      unless persisted?
+        raise ActiveRecordError, <<-end_error.strip_heredoc
+          cannot touch on a new or destroyed record object. Consider using
+          persisted?, new_record?, or destroyed? before touching
+        end_error
+      end
 
       time ||= current_time_from_proper_timezone
       attributes = timestamp_attributes_for_update_in_model

--- a/activerecord/lib/active_record/touch_later.rb
+++ b/activerecord/lib/active_record/touch_later.rb
@@ -8,7 +8,12 @@ module ActiveRecord
     end
 
     def touch_later(*names) # :nodoc:
-      raise ActiveRecordError, "cannot touch on a new record object" unless persisted?
+      unless persisted?
+        raise ActiveRecordError, <<-end_error.strip_heredoc
+          cannot touch on a new or destroyed record object. Consider using
+          persisted?, new_record?, or destroyed? before touching
+        end_error
+      end
 
       @_defer_touch_attrs ||= timestamp_attributes_for_update_in_model
       @_defer_touch_attrs |= names


### PR DESCRIPTION
The current error message only indicates that a touch can fail because the record is new. In practice, we saw cases where touches were failing because the record had been destroyed. `persisted?` checks `new_record?` _and_ `destroyed?`. It was confusing to get a message about a new record when in reality we were destroying records.

I also included a helpful tip for users to consider using `persisted?`, `new_record?`, or `destroyed?` before touching.
