### PR TITLE
Hashing in AR wthout array allocation and updating corresponding documentation to reference the class

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -426,11 +426,11 @@ module ActiveRecord
     end
     alias :eql? :==
 
-    # Delegates to id in order to allow two records of the same type and id to work with something like:
-    #   [ Person.find(1), Person.find(2), Person.find(3) ] & [ Person.find(1), Person.find(4) ] # => [ Person.find(1) ]
+    # Delegates to class and id in order to allow two records of the same type and id to work with something like:
+    #   [ Person.find(1), Product.find(2), Person.find(3) ] & [ Person.find(1), Person.find(2), Person.find(4) ] # => [ Person.find(1) ]
     def hash
       if id
-        [self.class, id].hash
+        self.class.hash ^ id.hash
       else
         super
       end


### PR DESCRIPTION
### Summary

I noticed the comment in c8be4574 by @sgrif mentioning array allocation he didn't like. I'd read elsewhere that multiple hashes could just be combined with xor. Also updating documentation to reference that we're also hashing in the class.
### Other Information

Only addressing because of comments in the prior commit. I'm obviously not going to hunt around trying to shave an object allocation from random methods. Probably more useful for the documentation side of the commit more than anything else.

Does this need a change log since previous change didn't have one?
