### PR TITLE
Take `typeof null` into consideration

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/subscriptions.coffee
@@ -12,7 +12,7 @@ class ActionCable.Subscriptions
 
   create: (channelName, mixin) ->
     channel = channelName
-    params = if typeof channel is "object" then channel else {channel}
+    params = if channel and typeof channel is "object" then channel else {channel}
     subscription = new ActionCable.Subscription @consumer, params, mixin
     @add(subscription)
 


### PR DESCRIPTION
### Summary

The `typeof` operator of JavaScript/CoffeeScript is a bit weird, especially that `typeof null == 'object'`.
I add a guard code, because it seems to be unexpected that if `channel` is `null` then `params` is also `null`. 
