### PR TITLE
reference actual class to use middleware

### DIFF
--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -481,7 +481,7 @@ YAML
         end
       RUBY
 
-      add_to_config "config.middleware.use \"Bukkits\""
+      add_to_config "config.middleware.use Bukkits"
       boot_rails
     end
 


### PR DESCRIPTION
Using strings for middleware class names is deprecated in 83b767cef90abfc4c2ee9f4b451b0215501fae9a.
