### PR TITLE
Exclude 'tempfile' from UploadedFile's hash representation.

### DIFF
--- a/actionpack/lib/action_dispatch/http/upload.rb
+++ b/actionpack/lib/action_dispatch/http/upload.rb
@@ -73,6 +73,10 @@ module ActionDispatch
       def eof?
         @tempfile.eof?
       end
+
+      def to_hash
+        instance_values.except('tempfile')
+      end
     end
   end
 end

--- a/actionpack/test/dispatch/uploaded_file_test.rb
+++ b/actionpack/test/dispatch/uploaded_file_test.rb
@@ -101,5 +101,20 @@ module ActionDispatch
       assert uf.respond_to?(:headers), 'responds to headers'
       assert uf.respond_to?(:read), 'responds to read'
     end
+
+    def test_to_hash_excludes_tempfile
+      uf = Http::UploadedFile.new(tempfile: Object.new)
+      assert_equal false, uf.to_hash.key?('tempfile')
+    end
+
+    def test_to_json_with_non_ascii_data
+      t = Tempfile.new 'foo'
+      t.binmode
+      t.puts "\x80".force_encoding('ASCII-8BIT')
+      t.rewind
+
+      uf = ActionDispatch::Http::UploadedFile.new(tempfile: t)
+      assert_nothing_raised { uf.to_json }
+    end
   end
 end


### PR DESCRIPTION
### Summary

This fixes `to_json`ifying an `ActionDispatch::Http::UploadedFile` when the uploaded file is binary, by
excluding the uploaded file from the object's `to_hash` representation.

Fixes #25250.
