### PR TITLE
Display railtie class name in `rails initializers`

### DIFF
--- a/railties/lib/rails/initializable.rb
+++ b/railties/lib/rails/initializable.rb
@@ -9,8 +9,6 @@ module Rails
     class Initializer
       attr_reader :name, :block
 
-      delegate :railtie_name, to: :@context
-
       def initialize(name, context, options, &block)
         options[:group] ||= :default
         @name, @context, @options, @block = name, context, options, block
@@ -35,6 +33,10 @@ module Rails
       def bind(context)
         return self if @context
         Initializer.new(@name, context, @options, &block)
+      end
+
+      def context_class
+        @context.class
       end
     end
 

--- a/railties/lib/rails/initializable.rb
+++ b/railties/lib/rails/initializable.rb
@@ -9,6 +9,8 @@ module Rails
     class Initializer
       attr_reader :name, :block
 
+      delegate :railtie_name, to: :@context
+
       def initialize(name, context, options, &block)
         options[:group] ||= :default
         @name, @context, @options, @block = name, context, options, block

--- a/railties/lib/rails/tasks/initializers.rake
+++ b/railties/lib/rails/tasks/initializers.rake
@@ -1,6 +1,6 @@
 desc "Print out all defined initializers in the order they are invoked by Rails."
 task initializers: :environment do
   Rails.application.initializers.tsort_each do |initializer|
-    puts initializer.name
+    puts "#{initializer.instance_variable_get(:@context).class} #{initializer.name.inspect}"
   end
 end

--- a/railties/lib/rails/tasks/initializers.rake
+++ b/railties/lib/rails/tasks/initializers.rake
@@ -1,6 +1,6 @@
 desc "Print out all defined initializers in the order they are invoked by Rails."
 task initializers: :environment do
   Rails.application.initializers.tsort_each do |initializer|
-    puts "#{initializer.instance_variable_get(:@context).class} #{initializer.name.inspect}"
+    puts "#{initializer.railtie_name}.#{initializer.name}"
   end
 end

--- a/railties/lib/rails/tasks/initializers.rake
+++ b/railties/lib/rails/tasks/initializers.rake
@@ -1,6 +1,6 @@
 desc "Print out all defined initializers in the order they are invoked by Rails."
 task initializers: :environment do
   Rails.application.initializers.tsort_each do |initializer|
-    puts "#{initializer.railtie_name}.#{initializer.name}"
+    puts "#{initializer.context_class}.#{initializer.name}"
   end
 end

--- a/railties/test/initializable_test.rb
+++ b/railties/test/initializable_test.rb
@@ -174,6 +174,11 @@ module InitializableTests
         end
       end
     end
+
+    test "Initializer provides context's class name" do
+      foo = Foo.new
+      assert_equal foo.class, foo.initializers.first.context_class
+    end
   end
 
   class BeforeAfter < ActiveSupport::TestCase


### PR DESCRIPTION
### Summary

I add a class name to recognize same macro name like `load_config_initializers` and `load_environment_config` etc in `rails initializers`.
