### PR TITLE
Added Array#clear! and Array#clear?

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/clear.rb
+++ b/activesupport/lib/active_support/core_ext/array/clear.rb
@@ -1,0 +1,14 @@
+class Array
+  # A friendly method name to add to `clear` and `clear!`
+  alias_method :clear?,  :empty?
+
+  # Clears the array and returns cleared elements
+  #
+  #   %w( a b c d ).clear!   # => ["a", "b", "c", "d"]
+  #   %w().clear!            # => []
+  def clear!
+    array = dup
+    clear
+    array
+  end
+end

--- a/activesupport/test/core_ext/array/clear_test.rb
+++ b/activesupport/test/core_ext/array/clear_test.rb
@@ -1,0 +1,15 @@
+require 'abstract_unit'
+require 'active_support/core_ext/array/clear'
+
+class ClearTest < ActiveSupport::TestCase
+  def test_clear!
+    array = %w( a b c d )
+    assert_equal %w( a b c d ), array.clear!
+    assert_equal [], array
+  end
+
+  def test_clear?
+    assert_equal false, %w( a b c d ).clear?
+    assert_equal true, %w().clear?
+  end
+end


### PR DESCRIPTION
- Added `Array#clear!`
  - Useful for multiple applications when you want to use array elements and clear them.
  - Dries code like this to one line (batch operations), example:

```
# if we have a loop that appends elements to array
# we want to write those elements in batches whenever a certain batch size is reached
# and then clear the array to make space for new elements
# old approach

   Model.collection.insert_many(array)
   array.clear

# using clear!

   Model.collection.insert_many(array.clear!)
```
- Added `Array#clear?`
  - Plays well with `clear` and `clear!`
