### PR TITLE
Improve Hash#compact! documentation and tests

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/compact.rb
+++ b/activesupport/lib/active_support/core_ext/hash/compact.rb
@@ -2,18 +2,21 @@ class Hash
   # Returns a hash with non +nil+ values.
   #
   #   hash = { a: true, b: false, c: nil }
-  #   hash.compact       # => { a: true, b: false }
-  #   hash               # => { a: true, b: false, c: nil }
-  #   { c: nil }.compact # => {}
+  #   hash.compact        # => { a: true, b: false }
+  #   hash                # => { a: true, b: false, c: nil }
+  #   { c: nil }.compact  # => {}
+  #   { c: true }.compact # => { c: true }
   def compact
     self.select { |_, value| !value.nil? }
   end
 
   # Replaces current hash with non +nil+ values.
+  # Returns nil if no changes were made, otherwise returns the hash.
   #
   #   hash = { a: true, b: false, c: nil }
-  #   hash.compact! # => { a: true, b: false }
-  #   hash          # => { a: true, b: false }
+  #   hash.compact!        # => { a: true, b: false }
+  #   hash                 # => { a: true, b: false }
+  #   { c: true }.compact! # => nil
   def compact!
     self.reject! { |_, value| value.nil? }
   end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -999,6 +999,10 @@ class HashExtTest < ActiveSupport::TestCase
     h = hash_with_only_nil_values.dup
     assert_equal({}, h.compact)
     assert_equal(hash_with_only_nil_values, h)
+
+    h = @symbols.dup
+    assert_equal(@symbols, h.compact)
+    assert_equal(@symbols, h)
   end
 
   def test_compact!
@@ -1012,6 +1016,10 @@ class HashExtTest < ActiveSupport::TestCase
     h = hash_with_only_nil_values.dup
     assert_equal({}, h.compact!)
     assert_equal({}, h)
+
+    h = @symbols.dup
+    assert_equal(nil, h.compact!)
+    assert_equal(@symbols, h)
   end
 
   def test_new_with_to_hash_conversion


### PR DESCRIPTION
This updates documentation for `Hash#compact` and `Hash#compact!` methods.
Makes it clear what should be returned when no changes were made to the hash.

Like in the following example:

``` ruby
{ a: true, b: false }.compact! # => nil
```

It also improves test coverage for that particular case.
