### PR TITLE
Prevent `RangeError` for `FinderMethods#exists?`

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -333,6 +333,8 @@ module ActiveRecord
       end
 
       connection.select_value(relation, "#{name} Exists", relation.bound_attributes) ? true : false
+    rescue RangeError
+      false
     end
 
     # This method is called whenever no records are found with either a single
@@ -579,7 +581,7 @@ module ActiveRecord
         # e.g., reverse_order.offset(index-1).first
       end
     end
-    
+
     private
 
     def find_nth_with_limit_and_offset(index, limit, offset:) # :nodoc:

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -32,6 +32,7 @@ module ActiveRecord
 
           record.errors.add(attribute, :taken, error_options)
         end
+      rescue RangeError
       end
 
     protected
@@ -65,8 +66,6 @@ module ActiveRecord
 
         column = klass.columns_hash[attribute_name]
         cast_type = klass.type_for_attribute(attribute_name)
-        value = cast_type.serialize(value)
-        value = klass.connection.type_cast(value)
 
         comparison = if !options[:case_sensitive] && !value.nil?
           # will use SQL LOWER function before comparison, unless it detects a case insensitive collation
@@ -77,11 +76,9 @@ module ActiveRecord
         if value.nil?
           klass.unscoped.where(comparison)
         else
-          bind = Relation::QueryAttribute.new(attribute_name, value, Type::Value.new)
+          bind = Relation::QueryAttribute.new(attribute_name, value, cast_type)
           klass.unscoped.where(comparison, bind)
         end
-      rescue RangeError
-        klass.none
       end
 
       def scope_relation(record, table, relation)

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -32,7 +32,6 @@ module ActiveRecord
 
           record.errors.add(attribute, :taken, error_options)
         end
-      rescue RangeError
       end
 
     protected

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -173,11 +173,9 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
-  def test_exists_fails_when_parameter_has_invalid_type
-    assert_raises(ActiveModel::RangeError) do
-      assert_equal false, Topic.exists?(("9"*53).to_i) # number that's bigger than int
-    end
+  def test_exists_returns_false_when_parameter_has_invalid_type
     assert_equal false, Topic.exists?("foo")
+    assert_equal false, Topic.exists?(("9"*53).to_i) # number that's bigger than int
   end
 
   def test_exists_does_not_select_columns_without_alias


### PR DESCRIPTION
`FinderMethods#exists?` should return a boolean rather than raising an exception.
