### PR TITLE
Fix sqlite3 test failure

### DIFF
--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -80,14 +80,14 @@ class SQLite3QuotingTest < ActiveRecord::SQLite3TestCase
 
   def test_quoting_binary_strings
     value = "hello".encode('ascii-8bit')
-    type = Type::String.new
+    type = ActiveRecord::Type::String.new
 
     assert_equal "'hello'", @conn.quote(type.serialize(value))
   end
 
   def test_quoted_time_returns_date_qualified_time
     value = ::Time.utc(2000, 1, 1, 12, 30, 0, 999999)
-    type = Type::Time.new
+    type = ActiveRecord::Type::Time.new
 
     assert_equal "'2000-01-01 12:30:00.999999'", @conn.quote(type.serialize(value))
   end

--- a/activerecord/test/cases/adapters/sqlite3/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/statement_pool_test.rb
@@ -4,7 +4,7 @@ class SQLite3StatementPoolTest < ActiveRecord::SQLite3TestCase
   if Process.respond_to?(:fork)
     def test_cache_is_per_pid
 
-      cache = StatementPool.new(10)
+      cache = ActiveRecord::ConnectionAdapters::SQLite3Adapter::StatementPool.new(10)
       cache['foo'] = 'bar'
       assert_equal 'bar', cache['foo']
 


### PR DESCRIPTION
Sqlite3 test failure is due to 66ebbc4952f6cfb37d719f63036441ef98149418.
