### PR TITLE
Fix `find_nth` with `limit_value`

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -147,7 +147,7 @@ module ActiveRecord
     def last(limit = nil)
       return find_last(limit) if loaded? || limit_value
 
-      result = limit(limit || 1)
+      result = limit(limit)
       result.order!(arel_attribute(primary_key)) if order_values.empty? && primary_key
       result = result.reverse_order!
 
@@ -536,8 +536,12 @@ module ActiveRecord
             self
           end
 
-          relation = relation.offset(offset_index + index) unless index.zero?
-          relation.limit(limit).to_a
+          if limit_value.nil? || index < limit_value
+            relation = relation.offset(offset_index + index) unless index.zero?
+            relation.limit(limit).to_a
+          else
+            []
+          end
         end
       end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -497,7 +497,7 @@ class FinderTest < ActiveRecord::TestCase
     assert_nil Topic.offset(5).second_to_last
 
     #test with limit
-    # assert_nil Topic.limit(1).second # TODO: currently failing
+    assert_nil Topic.limit(1).second
     assert_nil Topic.limit(1).second_to_last
   end
 
@@ -526,9 +526,9 @@ class FinderTest < ActiveRecord::TestCase
     assert_nil Topic.offset(5).third_to_last
 
     # test with limit
-    # assert_nil Topic.limit(1).third # TODO: currently failing
+    assert_nil Topic.limit(1).third
     assert_nil Topic.limit(1).third_to_last
-    # assert_nil Topic.limit(2).third # TODO: currently failing
+    assert_nil Topic.limit(2).third
     assert_nil Topic.limit(2).third_to_last
   end
 


### PR DESCRIPTION
If the `index` exceeds a `limit`, simply return an empty result without
querying the database.