### PR TITLE
The `decimal` type without `scale` should behave as an `integer`

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -15,6 +15,7 @@ require "models/boolean"
 require "models/column_name"
 require "models/subscriber"
 require "models/comment"
+require "models/numeric_data"
 require "models/minimalistic"
 require "models/warehouse_thing"
 require "models/parrot"
@@ -906,13 +907,6 @@ class BasicsTest < ActiveRecord::TestCase
         assert_equal "a text field", default.char3
       end
     end
-  end
-
-  class NumericData < ActiveRecord::Base
-    self.table_name = "numeric_data"
-
-    attribute :my_house_population, :integer
-    attribute :atoms_in_universe, :integer
   end
 
   def test_big_decimal_conditions

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -9,6 +9,7 @@ require "models/possession"
 require "models/topic"
 require "models/reply"
 require "models/minivan"
+require "models/numeric_data"
 require "models/speedometer"
 require "models/ship_part"
 require "models/treasure"
@@ -16,14 +17,6 @@ require "models/developer"
 require "models/comment"
 require "models/rating"
 require "models/post"
-
-class NumericData < ActiveRecord::Base
-  self.table_name = "numeric_data"
-
-  attribute :world_population, :integer
-  attribute :my_house_population, :integer
-  attribute :atoms_in_universe, :integer
-end
 
 class CalculationsTest < ActiveRecord::TestCase
   fixtures :companies, :accounts, :topics, :speedometers, :minivans, :books

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -4,10 +4,7 @@ require "models/pirate"   # For timestamps
 require "models/parrot"
 require "models/person"   # For optimistic locking
 require "models/aircraft"
-
-class NumericData < ActiveRecord::Base
-  self.table_name = "numeric_data"
-end
+require "models/numeric_data"
 
 class DirtyTest < ActiveRecord::TestCase
   include InTimeZone

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -14,10 +14,6 @@ require MIGRATIONS_ROOT + "/rename/2_rename_things"
 require MIGRATIONS_ROOT + "/decimal/1_give_me_big_numbers"
 
 class BigNumber < ActiveRecord::Base
-  unless current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter)
-    attribute :value_of_e, :integer
-  end
-  attribute :my_house_population, :integer
 end
 
 class Reminder < ActiveRecord::Base; end

--- a/activerecord/test/models/numeric_data.rb
+++ b/activerecord/test/models/numeric_data.rb
@@ -1,0 +1,3 @@
+class NumericData < ActiveRecord::Base
+  self.table_name = "numeric_data"
+end


### PR DESCRIPTION
No need setting attribute type explicitly.
