### PR TITLE
[ci skip] Fix link rubyonrails.org/core => http://rubyonrails.org/community

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -131,7 +131,7 @@ learn about Ruby on Rails, and the API, which serves as a reference.
 You can help improve the Rails guides by making them more coherent, consistent or readable, adding missing information, correcting factual errors, fixing typos, or bringing them up to date with the latest edge Rails.
 
 You can either open a pull request to [Rails](https://github.com/rails/rails) or
-ask the [Rails core team](http://rubyonrails.org/core) for commit access on
+ask the [Rails core team](http://rubyonrails.org/community/#core) for commit access on
 docrails if you contribute regularly.
 Please do not open pull requests in docrails, if you'd like to get feedback on your
 change, ask for it in [Rails](https://github.com/rails/rails) instead.


### PR DESCRIPTION
Fix link rubyonrails.org/core => http://rubyonrails.org/community/#core
