### PR TITLE
Add backticks to `ActiveRecord::Base.where`

### DIFF
--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -50,7 +50,7 @@ ToDo...
 
 Defines an attribute with a type on a model. It will override the type of existing attributes if needed. 
 This allows control over how values are converted to and from SQL when assigned to a model.
-It also changes the behavior of values passed to ActiveRecord::Base.where, which lets use our domain objects across much of Active Record, 
+It also changes the behavior of values passed to `ActiveRecord::Base.where`, which lets use our domain objects across much of Active Record,
 without having to rely on implementation details or monkey patching.
 
 Some things that you can achieve with this:


### PR DESCRIPTION
[ci skip]

I'm going to open backport PRs to move this to `5-0-0` and `5-0-stable` as well.

---

EDIT: The 5.0 release notes are a bit out of date on `5-0-stable`, I'm assuming that needs a PR to be updated, and then this change can be backported. 😬 
