### PR TITLE
`{ internal: true }` from being stored in the router

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -106,7 +106,7 @@ module ActionDispatch
           @ast                = ast
           @anchor             = anchor
           @via                = via
-          @internal           = options[:internal]
+          @internal           = options.delete(:internal)
 
           path_params = ast.find_all(&:symbol?).map(&:to_sym)
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4795,3 +4795,33 @@ class TestPathParameters < ActionDispatch::IntegrationTest
     assert_equal "/ar | /ar/about", @response.body
   end
 end
+
+class TestInternalRoutingParams < ActionDispatch::IntegrationTest
+  Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
+    app.draw do
+      get '/test_internal/:internal' => 'internal#internal'
+    end
+  end
+
+  class ::InternalController < ActionController::Base
+    def internal
+      head :ok
+    end
+  end
+
+  APP = build_app Routes
+
+  def app
+    APP
+  end
+
+  def test_paths_with_partial_dynamic_segments_are_recognised
+    get '/test_internal/123'
+    assert_equal 200, response.status
+
+    assert_equal(
+      { controller: 'internal', action: 'internal', internal: '123' },
+      request.path_parameters
+    )
+  end
+end

--- a/railties/test/rails_info_controller_test.rb
+++ b/railties/test/rails_info_controller_test.rb
@@ -78,4 +78,10 @@ class InfoControllerTest < ActionController::TestCase
     get :routes, params: { path: 'rails/info/routes.html' }
     assert fuzzy_count.call == 0, 'should match optional parts of route literally'
   end
+
+  test "internal routes do not have a default params[:internal] value" do
+    get :properties
+    assert_response :success
+    assert_nil @controller.params[:internal]
+  end
 end


### PR DESCRIPTION
Forgotten followup to #23669 :grimacing:

If you went to an internal route (e.g. `/rails/info/routes`), you would
previously see the following in your logger:

``` bash
Processing by Rails::InfoController#routes as HTML
  Parameters: {"internal"=>true}
  Rendering /Users/jon/code/rails/rails/railties/lib/rails/templates/rails/info/routes.html.erb within layouts/application
  Rendered collection of /Users/jon/code/rails/rails/actionpack/lib/action_dispatch/middleware/templates/routes/_route.html.erb [2 times] (10.5ms)
  Rendered /Users/jon/code/rails/rails/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb (2.5ms)
  Rendered /Users/jon/code/rails/rails/railties/lib/rails/templates/rails/info/routes.html.erb within layouts/application (23.5ms)
Completed 200 OK in 50ms (Views: 35.1ms | ActiveRecord: 0.0ms)
```

Now, with this change, you would see:

``` bash
Processing by Rails::InfoController#routes as HTML
  Rendering /Users/jon/code/rails/rails/railties/lib/rails/templates/rails/info/routes.html.erb within layouts/application
  Rendered collection of /Users/jon/code/rails/rails/actionpack/lib/action_dispatch/middleware/templates/routes/_route.html.erb [2 times] (1.6ms)
  Rendered /Users/jon/code/rails/rails/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb (10.2ms)
  Rendered /Users/jon/code/rails/rails/railties/lib/rails/templates/rails/info/routes.html.erb within layouts/application (17.4ms)
Completed 200 OK in 44ms (Views: 28.0ms | ActiveRecord: 0.0ms)
```
