### PR TITLE
Action Cable: Fix CI tests on Sauce Labs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,8 +68,8 @@ group :cable do
   # Lock to 1.1.1 until the fix for https://github.com/faye/faye/issues/394 is released
   gem 'faye', '1.1.1', require: false
 
-  gem 'blade', '~> 0.5.5', require: false
-  gem 'blade-sauce_labs_plugin', '~> 0.5.1', require: false
+  gem 'blade', require: false
+  gem 'blade-sauce_labs_plugin', require: false
 end
 
 # Add your own local bundler stuff.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     bcrypt (3.1.11-x86-mingw32)
     beaneater (1.0.0)
     benchmark-ips (2.6.1)
-    blade (0.5.5)
+    blade (0.5.6)
       activesupport (>= 3.0.0)
       blade-qunit_adapter (~> 1.20.0)
       coffee-script
@@ -126,11 +126,11 @@ GEM
       faye
       sprockets (>= 3.0)
       sprockets-export (~> 0.9.1)
-      thin (~> 1.6.0)
+      thin (>= 1.6.0)
       thor (~> 0.19.1)
       useragent (~> 0.16.7)
     blade-qunit_adapter (1.20.0)
-    blade-sauce_labs_plugin (0.5.1)
+    blade-sauce_labs_plugin (0.5.2)
       childprocess
       faraday
       selenium-webdriver
@@ -166,7 +166,7 @@ GEM
     eventmachine (1.2.0.1)
     eventmachine (1.2.0.1-x64-mingw32)
     eventmachine (1.2.0.1-x86-mingw32)
-    execjs (2.6.0)
+    execjs (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faye (1.1.1)
@@ -310,10 +310,10 @@ GEM
     stackprof (0.2.9)
     sucker_punch (2.0.2)
       concurrent-ruby (~> 1.0.0)
-    thin (1.6.2)
-      daemons (>= 1.0.9)
-      eventmachine (>= 1.0.0)
-      rack (>= 1.0.0)
+    thin (1.7.0)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     thor (0.19.1)
     thread (0.1.7)
     thread_safe (0.3.5)
@@ -348,8 +348,8 @@ DEPENDENCIES
   backburner
   bcrypt (~> 3.1.11)
   benchmark-ips
-  blade (~> 0.5.5)
-  blade-sauce_labs_plugin (~> 0.5.1)
+  blade
+  blade-sauce_labs_plugin
   byebug
   coffee-rails!
   dalli (>= 2.2.1)


### PR DESCRIPTION
AC's JavaScript tests pass locally, but were failing to run on Sauce Labs through its tunnel. I tracked the connection problem down to a subtle change in Event Machine 1.2, noted in https://github.com/javan/blade/commit/cefb4bb8aa29f2423affd865a620a9a064359f71. Example failure: https://saucelabs.com/beta/tests/605a550e968f41b4bf2372d60ec3c482

Looking much better now: https://saucelabs.com/beta/builds/41ccebe564e443f7b073fc6dd1d63b19

/cc @jeremy @maclover7 
