### PR TITLE
Make select_year work with include_position: true option, fix #25267

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -1058,7 +1058,7 @@ module ActionView
           prefix = @options[:prefix] || ActionView::Helpers::DateTimeSelector::DEFAULT_PREFIX
           prefix += "[#{@options[:index]}]" if @options.has_key?(:index)
 
-          field_name = @options[:field_name] || type
+          field_name = @options[:field_name] || type.to_s
           if @options[:include_position]
             field_name += "(#{ActionView::Helpers::DateTimeSelector::POSITION[type]}i)"
           end

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -534,6 +534,13 @@ class DateHelperTest < ActionView::TestCase
 
     assert_dom_equal expected, select_year(nil, start_year: 2003, end_year: 2005, with_css_classes: { year: 'my-year' })
   end
+  
+  def test_select_year_with_position
+    expected = %(<select id="date_year_1i" name="date[year(1i)]">\n)
+    expected << %(<option value="2003">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
+    expected << "</select>\n"
+    assert_dom_equal expected, select_year(Date.current, include_position: true,  start_year: 2003, end_year: 2005)
+  end
 
   def test_select_hour
     expected = %(<select id="date_hour" name="date[hour]">\n)


### PR DESCRIPTION
### Summary

Fixes issue #25267, make select_year work with `include_position`, eg.:
`
<%= select_year Date.current, include_position: true %>
`

Is now raising `undefined method '+' for :year:Symbol`.
