### PR TITLE
Change doc for race_condition_ttl option of ActiveSupport::Cache::Sto…

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -250,14 +250,14 @@ module ActiveSupport
       #   sleep 60
       #
       #   Thread.new do
-      #     val_1 = cache.fetch('foo', race_condition_ttl: 10) do
+      #     val_1 = cache.fetch('foo', race_condition_ttl: 10.seconds) do
       #       sleep 1
       #       'new value 1'
       #     end
       #   end
       #
       #   Thread.new do
-      #     val_2 = cache.fetch('foo', race_condition_ttl: 10) do
+      #     val_2 = cache.fetch('foo', race_condition_ttl: 10.seconds) do
       #       'new value 2'
       #     end
       #   end


### PR DESCRIPTION
The related option of this method, `expires_in` is documented
as expecting an `ActiveSupport::Duration` value. To minimize any sort of
ambiguity between duration options, this change also documents
`race_condition_ttl` accepting `ActiveSupport::Duration`.
