### PR TITLE
Use `inspect` in `type_cast_for_schema` for date/time and decimal values

### DIFF
--- a/activemodel/lib/active_model/type/date.rb
+++ b/activemodel/lib/active_model/type/date.rb
@@ -12,7 +12,7 @@ module ActiveModel
       end
 
       def type_cast_for_schema(value)
-        "'#{value.to_s(:db)}'"
+        value.to_s(:db).inspect
       end
 
       private

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -38,7 +38,7 @@ module ActiveModel
         end
 
         def type_cast_for_schema(value)
-          "'#{value.to_s(:db)}'"
+          value.to_s(:db).inspect
         end
 
         def user_input_in_time_zone(value)

--- a/activerecord/lib/active_record/type/decimal_without_scale.rb
+++ b/activerecord/lib/active_record/type/decimal_without_scale.rb
@@ -4,6 +4,10 @@ module ActiveRecord
       def type
         :decimal
       end
+
+      def type_cast_for_schema(value)
+        value.to_s.inspect
+      end
     end
   end
 end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -420,11 +420,12 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
 
   setup do
     @connection = ActiveRecord::Base.connection
-    @connection.create_table :defaults, force: true do |t|
+    @connection.create_table :dump_defaults, force: true do |t|
       t.string   :string_with_default,   default: "Hello!"
       t.date     :date_with_default,     default: "2014-06-05"
       t.datetime :datetime_with_default, default: "2014-06-05 07:17:04"
       t.time     :time_with_default,     default: "07:17:04"
+      t.decimal  :decimal_with_default,  default: "1234567890.0123456789", precision: 20, scale: 10
     end
 
     if current_adapter?(:PostgreSQLAdapter)
@@ -436,17 +437,17 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
   end
 
   teardown do
-    return unless @connection
-    @connection.drop_table "defaults", if_exists: true
+    @connection.drop_table "dump_defaults", if_exists: true
   end
 
   def test_schema_dump_defaults_with_universally_supported_types
-    output = dump_table_schema("defaults")
+    output = dump_table_schema("dump_defaults")
 
     assert_match %r{t\.string\s+"string_with_default",.*?default: "Hello!"}, output
-    assert_match %r{t\.date\s+"date_with_default",\s+default: '2014-06-05'}, output
-    assert_match %r{t\.datetime\s+"datetime_with_default",\s+default: '2014-06-05 07:17:04'}, output
-    assert_match %r{t\.time\s+"time_with_default",\s+default: '2000-01-01 07:17:04'}, output
+    assert_match %r{t\.date\s+"date_with_default",\s+default: "2014-06-05"}, output
+    assert_match %r{t\.datetime\s+"datetime_with_default",\s+default: "2014-06-05 07:17:04"}, output
+    assert_match %r{t\.time\s+"time_with_default",\s+default: "2000-01-01 07:17:04"}, output
+    assert_match %r{t\.decimal\s+"decimal_with_default",\s+precision: 20,\s+scale: 10,\s+default: "1234567890.0123456789"}, output
   end
 
   def test_schema_dump_with_float_column_infinity_default


### PR DESCRIPTION
Currently dumping defaults on schema is inconsistent.

Before:

``` ruby
  create_table "defaults", force: :cascade do |t|
    t.string   "string_with_default",   default: "Hello!"
    t.date     "date_with_default",     default: '2014-06-05'
    t.datetime "datetime_with_default", default: '2014-06-05 07:17:04'
    t.time     "time_with_default",     default: '2000-01-01 07:17:04'
    t.decimal  "decimal_with_default",  default: 1234567890
  end
```

After:

``` ruby
  create_table "defaults", force: :cascade do |t|
    t.string   "string_with_default",   default: "Hello!"
    t.date     "date_with_default",     default: "2014-06-05"
    t.datetime "datetime_with_default", default: "2014-06-05 07:17:04"
    t.time     "time_with_default",     default: "2000-01-01 07:17:04"
    t.decimal  "decimal_with_default",  default: "1234567890"
  end
```
