### PR TITLE
[ci skip] Update redirecting links in guides

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -871,7 +871,7 @@ Please refer to the [Changelog][active-support] for detailed changes.
     `module Foo; extend ActiveSupport::Concern; end` boilerplate.
     ([Commit](https://github.com/rails/rails/commit/b16c36e688970df2f96f793a759365b248b582ad))
 
-*   New [guide](constant_autoloading_and_reloading.html) about constant autoloading and reloading.
+*   New [guide](autoloading_and_reloading_constants.html) about constant autoloading and reloading.
 
 Credits
 -------

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -111,7 +111,7 @@
           <%= link_to 'open an issue', 'https://github.com/rails/rails/issues' %>.
         </p>
         <p>And last but not least, any kind of discussion regarding Ruby on Rails
-          documentation is very welcome in the <%= link_to 'rubyonrails-docs mailing list', 'http://groups.google.com/group/rubyonrails-docs' %>.
+          documentation is very welcome in the <%= link_to 'rubyonrails-docs mailing list', 'https://groups.google.com/forum/#!forum/rubyonrails-docs' %>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
### Summary

I found a few links that were receiving 301 status codes, so I updated them to link to the correct url.
