### PR TITLE
EventedFileUpdateChecker boots once per process

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -3,6 +3,34 @@ require 'pathname'
 require 'concurrent/atomic/atomic_boolean'
 
 module ActiveSupport
+  # Allows you to "listen" to changes in a file system.
+  # The evented file updater does not hit disk when checking for updates
+  # instead it uses platform specific file system events to trigger a change
+  # in state.
+  #
+  # The file checker takes an array of files to watch or a hash specifying directories
+  # and file extensions to watch. It also takes a block that is called when
+  # EventedFileUpdateChecker#execute is run or when EventedFileUpdateChecker#execute_if_updated
+  # is run and there have been changes to the file system.
+  #
+  # Note: To start listening to change events you must first call
+  # EventedFileUpdateChecker#updated? inside of each process.
+  #
+  # Example:
+  #
+  #     checker = EventedFileUpdateChecker.new(["/tmp/foo"], -> { puts "changed" })
+  #     checker.updated?
+  #     # => false
+  #     checker.execute_if_updated
+  #     # => nil
+  #
+  #     FileUtils.touch("/tmp/foo")
+  #
+  #     checker.updated?
+  #     # => true
+  #     checker.execute_if_updated
+  #     # => "changed"
+  #
   class EventedFileUpdateChecker #:nodoc: all
     def initialize(files, dirs = {}, &block)
       @ph    = PathHelper.new

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -11,7 +11,8 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
   end
 
   def new_checker(files = [], dirs = {}, &block)
-    ActiveSupport::EventedFileUpdateChecker.new(files, dirs, &block).tap do
+    ActiveSupport::EventedFileUpdateChecker.new(files, dirs, &block).tap do |c|
+      c.updated?
       wait
     end
   end

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -12,7 +12,6 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
 
   def new_checker(files = [], dirs = {}, &block)
     ActiveSupport::EventedFileUpdateChecker.new(files, dirs, &block).tap do |c|
-      c.updated?
       wait
     end
   end
@@ -34,6 +33,48 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
   def rm_f(files)
     super
     wait
+  end
+
+  test 'notifies forked processes' do
+    FileUtils.touch(tmpfiles)
+
+    checker = new_checker(tmpfiles) { }
+    assert !checker.updated?
+
+    # Pipes used for flow controll across fork.
+    boot_reader,  boot_writer  = IO.pipe
+    touch_reader, touch_writer = IO.pipe
+
+    pid = fork do
+      assert checker.updated?
+
+      # Clear previous check value.
+      checker.execute
+      assert !checker.updated?
+
+      # Fork is booted, ready for file to be touched
+      # notify parent process.
+      boot_writer.write("booted")
+
+      # Wait for parent process to signal that file
+      # has been touched.
+      IO.select([touch_reader])
+
+      assert checker.updated?
+    end
+
+    assert pid
+
+    # Wait for fork to be booted before touching files.
+    IO.select([boot_reader])
+    touch(tmpfiles)
+
+    # Notify fork that files have been touched.
+    touch_writer.write("touched")
+
+    assert checker.updated?
+
+    Process.wait(pid)
   end
 end
 


### PR DESCRIPTION
We need one file checker booted per process as talked about in #24990. Before we do a check to see if any updates have been registered by the listener we first check to make sure that the current process has booted a listener.

We are intentionally not starting a listener when the checker is created. This way we can avoid #25259 in which puma warns of multiple threads created before fork. As written the listener for each process will be invoked by the `ActionDispatch::Executor` middleware when the `updated?` method is called. This is the first middleware on the stack and will be invoked before application code is read into memory.

The downside of this approach is that the API is a little less obvious. I.e. that you have to call `updated?` to get the listener to start is not intuitive. We could make `boot!` not private if we want to make the API a little nicer. Alternatively we could boot when the checker is initialized however this reintroduces the puma threads warning, and also means that in cases of `rails server` or when using `preload!` that we have extra threads notifying of changes on a process that we don't care about.

[close #24990] [close #25259]
