### PR TITLE
render_to_string Regression Outside of Real Requests in Rails 5.0.0.rc1

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -122,7 +122,7 @@ module AbstractController
     def _normalize_render(*args, &block)
       options = _normalize_args(*args, &block)
       #TODO: remove defined? when we restore AP <=> AV dependency
-      if defined?(request) && request.variant.present?
+      if defined?(request) && !request.nil? && request.variant.present?
         options[:variant] = request.variant
       end
       _normalize_options(options)

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -564,6 +564,13 @@ class MetalRenderTest < ActionController::TestCase
   end
 end
 
+class ActionControllerBaseRenderTest < ActionController::TestCase
+  def test_direct_render_to_string
+    ac = ActionController::Base.new()
+    assert_equal "Hello world!", ac.render_to_string(template: 'test/hello_world')
+  end
+end
+
 class ImplicitRenderTest < ActionController::TestCase
   tests ImplicitRenderTestController
 


### PR DESCRIPTION
### Summary

This pull request addresses a regression in Rails 5 RC1..Beta when using render_to_string outside a real request. It restores the functionality of PR #14129, which fixed #14125 and was introduced in Rails 4.1.

When doing:

`ApplicationController.new.render_to_string( [...] )`

outside of a request (in my case, a PDF render in ActiveJob), the `request` variable is defined but as `nil`. This was fixed in Rails 4.1, but the check was removed by @tenderlove  (e6425f6ecad2a1b771455f73ada9d15f72a687eb) to nuke what appeared like a useless conditional. 

This change restores the nil check, but does so with `!request.nil?` so the purpose is easier understood to prevent future regressions.
