### PR TITLE
convert accented characters to ascii before calculating the path size

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -868,7 +868,7 @@ module ActiveRecord
       def fixtures(*fixture_set_names)
         if fixture_set_names.first == :all
           fixture_set_names = Dir["#{fixture_path}/{**,*}/*.{yml}"]
-          fixture_set_names.map! { |f| f[(fixture_path.to_s.size + 1)..-5] }
+          fixture_set_names.map! { |f| f[(ActiveSupport::Inflector.transliterate(fixture_path).size + 1)..-5] }
         else
           fixture_set_names = fixture_set_names.flatten.map { |n| n.to_s }
         end


### PR DESCRIPTION
Summary

Some characters, for i.e: ó, have a larger length than 1 due to it's byte size. When calculated the fixture path, the starting index is determined by the length of a path that may or may not contain a character like "ó". This may lead to incorrect fixture file paths.

To solve this, I used the transliterate method to convert the file_paths characters to ascii prior to calculating the length.

Other Information

Please review issue #25303 for more details.
