### PR TITLE
Edit Module#mattr_accessor documentation

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
@@ -147,7 +147,7 @@ class Module
   #   end
   #
   #   class Person
-  #     include HairColors
+  #     extend HairColors
   #   end
   #
   #   HairColors.hair_colors = [:brown, :black, :blonde, :red]
@@ -172,7 +172,7 @@ class Module
   #   end
   #
   #   class Person
-  #     include HairColors
+  #     extend HairColors
   #   end
   #
   #   Person.new.hair_colors = [:brown]  # => NoMethodError
@@ -185,7 +185,7 @@ class Module
   #   end
   #
   #   class Person
-  #     include HairColors
+  #     extend HairColors
   #   end
   #
   #   Person.new.hair_colors = [:brown]  # => NoMethodError
@@ -200,7 +200,7 @@ class Module
   #   end
   #
   #   class Person
-  #     include HairColors
+  #     extend HairColors
   #   end
   #
   #   Person.class_variable_get("@@hair_colors") # => [:brown, :black, :blonde, :red]


### PR DESCRIPTION
Fixes `Module#mattr_accessor` documentation, so now instances from docs works:

```
module HairColors
  mattr_accessor :hair_colors
end

class Person
  extend HairColors
end

Person.hair_colors = [:brown, :black, :blonde, :red]
Person.hair_colors
=> [:brown, :black, :blonde, :red]

```
#25312
