### PR TITLE
Generate application_record.rb file before model file

### DIFF
--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -21,8 +21,8 @@ module ActiveRecord
       end
 
       def create_model_file
-        template 'model.rb', File.join('app/models', class_path, "#{file_name}.rb")
         generate_application_record
+        template 'model.rb', File.join('app/models', class_path, "#{file_name}.rb")
       end
 
       def create_module_file
@@ -48,7 +48,7 @@ module ActiveRecord
 
         # Used by the migration template to determine the parent name of the model
         def parent_class_name
-          options[:parent] || determine_default_parent_class
+          options[:parent] || "ApplicationRecord"
         end
 
         def application_record_exist?
@@ -62,14 +62,6 @@ module ActiveRecord
             "app/models/#{namespaced_path}/application_record.rb"
           else
             'app/models/application_record.rb'
-          end
-        end
-
-        def determine_default_parent_class
-          if application_record_exist?
-            "ApplicationRecord"
-          else
-            "ActiveRecord::Base"
           end
         end
     end

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -34,7 +34,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
   def test_invokes_default_orm
     run_generator
-    assert_file "app/models/account.rb", /class Account < ActiveRecord::Base/
+    assert_file "app/models/account.rb", /class Account < ApplicationRecord/
   end
 
   def test_model_with_parent_option
@@ -56,7 +56,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
 
   def test_plural_names_are_singularized
     content = run_generator ["accounts".freeze]
-    assert_file "app/models/account.rb", /class Account < ActiveRecord::Base/
+    assert_file "app/models/account.rb", /class Account < ApplicationRecord/
     assert_file "test/models/account_test.rb", /class AccountTest/
     assert_match(/\[WARNING\] The model name 'accounts' was recognized as a plural, using the singular 'account' instead\. Override with --force-plural or setup custom inflection rules for this noun before running the generator\./, content)
   end
@@ -71,7 +71,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_file "app/models/admin.rb", /module Admin/
     assert_file "app/models/admin.rb", /def self\.table_name_prefix/
     assert_file "app/models/admin.rb", /'admin_'/
-    assert_file "app/models/admin/account.rb", /class Admin::Account < ActiveRecord::Base/
+    assert_file "app/models/admin/account.rb", /class Admin::Account < ApplicationRecord/
   end
 
   def test_migration
@@ -386,7 +386,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     run_generator ["account", "supplier:references{required}"]
 
     expected_file = <<-FILE.strip_heredoc
-    class Account < ActiveRecord::Base
+    class Account < ApplicationRecord
       belongs_to :supplier, required: true
     end
     FILE
@@ -397,7 +397,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     run_generator ["account", "supplier:references{required,polymorphic}"]
 
     expected_file = <<-FILE.strip_heredoc
-    class Account < ActiveRecord::Base
+    class Account < ApplicationRecord
       belongs_to :supplier, polymorphic: true, required: true
     end
     FILE
@@ -408,7 +408,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     run_generator ["account", "supplier:references{polymorphic.required}"]
 
     expected_file = <<-FILE.strip_heredoc
-    class Account < ActiveRecord::Base
+    class Account < ApplicationRecord
       belongs_to :supplier, polymorphic: true, required: true
     end
     FILE
@@ -459,7 +459,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   def test_token_option_adds_has_secure_token
     run_generator ["user", "token:token", "auth_token:token"]
     expected_file = <<-FILE.strip_heredoc
-    class User < ActiveRecord::Base
+    class User < ApplicationRecord
       has_secure_token
       has_secure_token :auth_token
     end

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -91,7 +91,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
 
   def test_adds_namespace_to_model
     run_generator
-    assert_file "app/models/test_app/account.rb", /module TestApp/, /  class Account < ActiveRecord::Base/
+    assert_file "app/models/test_app/account.rb", /module TestApp/, /  class Account < ApplicationRecord/
   end
 
   def test_model_with_namespace
@@ -99,7 +99,7 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
     assert_file "app/models/test_app/admin.rb", /module TestApp/, /module Admin/
     assert_file "app/models/test_app/admin.rb", /def self\.table_name_prefix/
     assert_file "app/models/test_app/admin.rb", /'test_app_admin_'/
-    assert_file "app/models/test_app/admin/account.rb", /module TestApp/, /class Admin::Account < ActiveRecord::Base/
+    assert_file "app/models/test_app/admin/account.rb", /module TestApp/, /class Admin::Account < ApplicationRecord/
   end
 
   def test_migration
@@ -201,7 +201,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
     run_generator
 
     # Model
-    assert_file "app/models/test_app/product_line.rb", /module TestApp\n  class ProductLine < ActiveRecord::Base/
+    assert_file "app/models/test_app/product_line.rb", /module TestApp\n  class ProductLine < ApplicationRecord/
     assert_file "test/models/test_app/product_line_test.rb", /module TestApp\n  class ProductLineTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/product_lines.yml"
     assert_migration "db/migrate/create_test_app_product_lines.rb"
@@ -268,7 +268,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ActiveRecord::Base/
+    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ApplicationRecord/
     assert_file "test/models/test_app/admin/role_test.rb", /module TestApp\n  class Admin::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_roles.rb"
@@ -336,7 +336,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin/user/special.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  class Admin::User::Special::Role < ActiveRecord::Base/
+    assert_file "app/models/test_app/admin/user/special/role.rb", /module TestApp\n  class Admin::User::Special::Role < ApplicationRecord/
     assert_file "test/models/test_app/admin/user/special/role_test.rb", /module TestApp\n  class Admin::User::Special::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/user/special/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_user_special_roles.rb"
@@ -402,7 +402,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
 
     # Model
     assert_file "app/models/test_app/admin.rb", /module TestApp\n  module Admin/
-    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ActiveRecord::Base/
+    assert_file "app/models/test_app/admin/role.rb", /module TestApp\n  class Admin::Role < ApplicationRecord/
     assert_file "test/models/test_app/admin/role_test.rb", /module TestApp\n  class Admin::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/test_app/admin/roles.yml"
     assert_migration "db/migrate/create_test_app_admin_roles.rb"

--- a/railties/test/generators/resource_generator_test.rb
+++ b/railties/test/generators/resource_generator_test.rb
@@ -60,14 +60,14 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
 
   def test_plural_names_are_singularized
     content = run_generator ["accounts".freeze]
-    assert_file "app/models/account.rb", /class Account < ActiveRecord::Base/
+    assert_file "app/models/account.rb", /class Account < ApplicationRecord/
     assert_file "test/models/account_test.rb", /class AccountTest/
     assert_match(/\[WARNING\] The model name 'accounts' was recognized as a plural, using the singular 'account' instead\. Override with --force-plural or setup custom inflection rules for this noun before running the generator\./, content)
   end
 
   def test_plural_names_can_be_forced
     content = run_generator ["accounts", "--force-plural"]
-    assert_file "app/models/accounts.rb", /class Accounts < ActiveRecord::Base/
+    assert_file "app/models/accounts.rb", /class Accounts < ApplicationRecord/
     assert_file "test/models/accounts_test.rb", /class AccountsTest/
     assert_no_match(/\[WARNING\]/, content)
   end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -11,7 +11,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     # Model
-    assert_file "app/models/product_line.rb", /class ProductLine < ActiveRecord::Base/
+    assert_file "app/models/product_line.rb", /class ProductLine < ApplicationRecord/
     assert_file "test/models/product_line_test.rb", /class ProductLineTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/product_lines.yml"
     assert_migration "db/migrate/create_product_lines.rb", /belongs_to :product/
@@ -91,7 +91,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     run_generator %w(product_line title:string product:belongs_to user:references --api --no-template-engine --no-helper --no-assets)
 
     # Model
-    assert_file "app/models/product_line.rb", /class ProductLine < ActiveRecord::Base/
+    assert_file "app/models/product_line.rb", /class ProductLine < ApplicationRecord/
     assert_file "test/models/product_line_test.rb", /class ProductLineTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/product_lines.yml"
     assert_migration "db/migrate/create_product_lines.rb", /belongs_to :product/
@@ -205,7 +205,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     # Model
     assert_file "app/models/admin.rb", /module Admin/
-    assert_file "app/models/admin/role.rb", /class Admin::Role < ActiveRecord::Base/
+    assert_file "app/models/admin/role.rb", /class Admin::Role < ApplicationRecord/
     assert_file "test/models/admin/role_test.rb", /class Admin::RoleTest < ActiveSupport::TestCase/
     assert_file "test/fixtures/admin/roles.yml"
     assert_migration "db/migrate/create_admin_roles.rb"


### PR DESCRIPTION
Previously model file was generated first, which resulted in
inheriting from `ActiveRecord::Base`, but since application_record.rb
is generated as well, it should already be used.
