### PR TITLE
Add Rails 5.0 release notes to the index page of guides [ci skip]

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -195,6 +195,11 @@
       url: upgrading_ruby_on_rails.html
       description: This guide helps in upgrading applications to latest Ruby on Rails versions.
     -
+      name: Ruby on Rails 5.0 Release Notes
+      url: 5_0_release_notes.html
+      description: Release notes for Rails 5.0.
+      work_in_progress: true
+    -
       name: Ruby on Rails 4.2 Release Notes
       url: 4_2_release_notes.html
       description: Release notes for Rails 4.2.


### PR DESCRIPTION
- It is also marked as WIP as we are still refining it.
