### PR TITLE
Load :author_addresses fixture to keep data integrity

### DIFF
--- a/activerecord/test/cases/associations/left_outer_join_association_test.rb
+++ b/activerecord/test/cases/associations/left_outer_join_association_test.rb
@@ -7,7 +7,7 @@ require 'models/categorization'
 require 'models/person'
 
 class LeftOuterJoinAssociationTest < ActiveRecord::TestCase
-  fixtures :authors, :essays, :posts, :comments, :categorizations, :people
+  fixtures :authors, :essays, :posts, :comments, :categorizations, :people, :author_addresses
 
   def test_construct_finder_sql_applies_aliases_tables_on_association_conditions
     result = Author.left_outer_joins(:thinking_posts, :welcome_posts).to_a

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -23,7 +23,7 @@ require "models/edge"
 
 class RelationTest < ActiveRecord::TestCase
   fixtures :authors, :topics, :entrants, :developers, :companies, :developers_projects, :accounts, :categories, :categorizations, :posts, :comments,
-    :tags, :taggings, :cars, :minivans
+    :tags, :taggings, :cars, :minivans, :author_addresses
 
   class TopicWithCallbacks < ActiveRecord::Base
     self.table_name = :topics


### PR DESCRIPTION
### Summary

This pull request addresses following error when tested with Oracle enhanced adapter.

It is probably caused by implementation differences between each RDBMS and/or bundled adapters
to re-enable foreign key constraint to check existing data integrity or not. Oracle enhanced adapter does, mysql2 and postgresql adapter looks not.

I think it is fair to add :author_addresses fixture in this testcase since this data should exist because :authors will need the "parent" table data.

This pull request has tested with all bundled adapters (sqlite, mysql2 and postgresql).

```
$ cd activerecord
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/relations_test.rb -n test_scoped_build
... snip ...
# Running:

E

Finished in 1.461881s, 0.6840 runs/s, 0.0000 assertions/s.

  1) Error:
RelationTest#test_scoped_build:
ActiveRecord::StatementInvalid: OCIError: ORA-02298: cannot validate (ARUNIT.FK_RAILS_94423A17A3) - parent keys not found: ALTER TABLE AUTHORS ENABLE CONSTRAINT FK_RAILS_94423A17A3
    stmt.c:243:in oci8lib_230.so
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.2/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.2/lib/oci8/oci8.rb:276:in `exec_internal'
    /home/yahonda/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ruby-oci8-2.2.2/lib/oci8/oci8.rb:267:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:450:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:92:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:566:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:560:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1244:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:447:in `block in disable_referential_integrity'
    /home/yahonda/git/rails/activerecord/lib/active_record/result.rb:52:in `block in each'
    /home/yahonda/git/rails/activerecord/lib/active_record/result.rb:52:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/result.rb:52:in `each'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:446:in `disable_referential_integrity'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:523:in `create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:1015:in `load_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:977:in `setup_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:852:in `before_setup'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```
### Other Information

`:authors` has a foreign key to `:author_addresses`. 

https://github.com/rails/rails/blob/master/activerecord/test/schema/schema.rb#L55-L71

``` ruby
  create_table :authors, force: true do |t|
    t.string :name, null: false
    t.integer :author_address_id
    t.integer :author_address_extra_id
    t.string :organization_id
    t.string :owned_essay_id
  end

  create_table :author_addresses, force: true do |t|
  end

  add_foreign_key :authors, :author_addresses
```
#### During fixture load, all constraints are disabled and re-enabled by executing `disable_referential_integrity`
- postgresql

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb

``` sql
"ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL"
"ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL"
```
- mysql2

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb

``` sql
"SET FOREIGN_KEY_CHECKS = 0"
"SET FOREIGN_KEY_CHECKS = #{old}" (default is 1)
```
- Oracle enhanced
  https://github.com/rsim/oracle-enhanced/blob/master/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb

``` sql
"ALTER TABLE #{constraint["table_name"]} DISABLE CONSTRAINT #{constraint["constraint_name"]}"
"ALTER TABLE #{constraint["table_name"]} ENABLE CONSTRAINT #{constraint["constraint_name"]}"
```
#### Here are actual sql statement executed to load authors
- Oracle enhanced

``` sql
DROP TABLE "AUTHORS"
DROP SEQUENCE "AUTHORS_SEQ"
CREATE TABLE "AUTHORS" ("ID" NUMBER(38) NOT NULL PRIMARY KEY, "NAME" VARCHAR2(255) NOT NULL, "AUTHOR_ADDRESS_ID" NUMBER(38), "AUTHOR_ADDRESS_EXTRA_ID" NUMBER(38), "ORGANIZATION_ID" VARCHAR2(255), "OWNED_ESSAY_ID" VARCHAR2(255))
CREATE SEQUENCE "AUTHORS_SEQ" START WITH 10000
DROP TABLE "AUTHOR_ADDRESSES"
DROP SEQUENCE "AUTHOR_ADDRESSES_SEQ"
CREATE TABLE "AUTHOR_ADDRESSES" ("ID" NUMBER(38) NOT NULL PRIMARY KEY)
CREATE SEQUENCE "AUTHOR_ADDRESSES_SEQ" START WITH 10000
ALTER TABLE "AUTHORS" ADD CONSTRAINT "FK_RAILS_94423A17A3" FOREIGN KEY ("AUTHOR_ADDRESS_ID") REFERENCES "AUTHOR_ADDRESSES" ("ID")
ALTER TABLE AUTHORS DISABLE CONSTRAINT FK_RAILS_94423A17A3
DELETE FROM "AUTHORS"
INSERT INTO "AUTHORS" ("ID", "NAME", "AUTHOR_ADDRESS_ID", "AUTHOR_ADDRESS_EXTRA_ID", "ORGANIZATION_ID", "OWNED_ESSAY_ID") VALUES (1, 'David', 1, 2, 'No Such Agency', 'A Modest Proposal')
INSERT INTO "AUTHORS" ("ID", "NAME", "AUTHOR_ADDRESS_ID") VALUES (2, 'Mary', 3)
INSERT INTO "AUTHORS" ("ID", "NAME", "AUTHOR_ADDRESS_ID") VALUES (3, 'Bob', 4)
DROP SEQUENCE "AUTHORS_SEQ"
CREATE SEQUENCE "AUTHORS_SEQ" START WITH 4
ALTER TABLE AUTHORS ENABLE CONSTRAINT FK_RAILS_94423A17A3
```

According to Oracle manual [Checks for Modified and Existing Data](https://docs.oracle.com/database/121/CNCPT/datainte.htm#CNCPT33339)

``` sql
ALTER TABLE AUTHORS ENABLE CONSTRAINT <constraint_name>
```

is equal to this. By default enable constraint in Oracle checks both existing and future data.

``` sql
ALTER TABLE AUTHORS ENABLE VALIDATE CONSTRAINT <constraint_name>
```

> Modified Data ENABLE
> Existing Data  VALIDATE
> 
> Existing and future data must obey the constraint. An attempt to apply a new constraint to a populated table results in an error if existing rows violate the constraint.
- postgresql

``` sql
DROP TABLE "authors"
CREATE TABLE "authors" ("id" serial primary key, "name" character varying NOT NULL, "author_address_id" integer, "author_address_extra_id" integer, "organization_id" character varying, "owned_essay_id" character varying)
CREATE TABLE "author_addresses" ("id" serial primary key)
ALTER TABLE "authors" ADD CONSTRAINT "fk_rails_94423a17a3" FOREIGN KEY ("author_address_id") REFERENCES "author_addresses" ("id")
ALTER TABLE "authors" DISABLE TRIGGER ALL
DELETE FROM "authors"
INSERT INTO "authors" ("id", "name", "author_address_id", "author_address_extra_id", "organization_id", "owned_essay_id") VALUES (1, 'David', 1, 2, 'No Such Agency', 'A Modest');
INSERT INTO "authors" ("id", "name", "author_address_id") VALUES (2, 'Mary', 3)
INSERT INTO "authors" ("id", "name", "author_address_id") VALUES (3, 'Bob', 4)
ALTER TABLE "authors" ENABLE TRIGGER ALL;
```

I have not found PostgreSQL documentation how `enable trigger all` works for existing data yet.
- mysql2

``` sql
DROP TABLE `authors`
CREATE TABLE `authors` (`id` int AUTO_INCREMENT PRIMARY KEY, `name` varchar(255) NOT NULL, `author_address_id` int, `author_address_extra_id` int, `organization_id` varchar(255), `owned_essay_id` varchar(255)) ENGINE=InnoDB
DROP TABLE `author_addresses`
CREATE TABLE `author_addresses` (`id` int AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB
ALTER TABLE `authors` ADD CONSTRAINT `fk_rails_94423a17a3` FOREIGN KEY (`author_address_id`) REFERENCES `author_addresses` (`id`) 
SET FOREIGN_KEY_CHECKS = 0
DELETE FROM `authors`
INSERT INTO `authors` (`id`, `name`, `author_address_id`, `author_address_extra_id`, `organization_id`, `owned_essay_id`) VALUES (1, 'David', 1, 2, 'No Such Agency', 'A Modest Proposal')
INSERT INTO `authors` (`id`, `name`, `author_address_id`) VALUES (2, 'Mary', 3)
INSERT INTO `authors` (`id`, `name`, `author_address_id`) VALUES (3, 'Bob', 4)
SET FOREIGN_KEY_CHECKS = 1
```

[foreign_key_checks](http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_foreign_key_checks)

> Note
> Setting foreign_key_checks to 1 does not trigger a scan of the existing table data. Therefore, rows added to the table while foreign_key_checks = 0 will not be verified for consistency.
