### PR TITLE
Allow Oracle bind parameter syntax `:a1` in test_join_conditions_added_to_join_clause

### DIFF
--- a/activerecord/test/cases/associations/left_outer_join_association_test.rb
+++ b/activerecord/test/cases/associations/left_outer_join_association_test.rb
@@ -50,7 +50,7 @@ class LeftOuterJoinAssociationTest < ActiveRecord::TestCase
 
   def test_join_conditions_added_to_join_clause
     queries = capture_sql { Author.left_outer_joins(:essays).to_a }
-    assert queries.any? { |sql| /writer_type.*?=.*?(Author|\?|\$1)/i =~ sql }
+    assert queries.any? { |sql| /writer_type.*?=.*?(Author|\?|\$1|\:a1)/i =~ sql }
     assert queries.none? { |sql| /WHERE/i =~ sql }
   end
 


### PR DESCRIPTION
### Summary

This pull request addresses this failure when tested with Oracle enhanced adapter because of bind value naming difference between RDBMS. i.e. SQLite3 `?`, PostgreSQL `$1` and Oracle `:a1`

``` ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/associations/left_outer_join_association_test.rb -n test_join_conditions_added_to_join_clause

... snip ...

# Running:

F

Finished in 0.463657s, 2.1568 runs/s, 2.1568 assertions/s.

  1) Failure:
LeftOuterJoinAssociationTest#test_join_conditions_added_to_join_clause [test/cases/associations/left_outer_join_association_test.rb:54]:
Failed assertion, no message given.

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```
### Other Information

Here are genated sql statement for each database adapter.
- oracle_enhanced

``` sql
["SELECT \"AUTHORS\".* FROM \"AUTHORS\" LEFT OUTER JOIN \"ESSAYS\" ON \"ESSAYS\".\"WRITER_ID\" = \"AUTHORS\".\"NAME\" AND \"ESSAYS\".\"WRITER_TYPE\" = :a1"]
```
- sqlite3

``` sqk
["SELECT \"authors\".* FROM \"authors\" LEFT OUTER JOIN \"essays\" ON \"essays\".\"writer_id\" = \"authors\".\"name\" AND \"essays\".\"writer_type\" = ?"]
```
- mysql2

``` sql
["SELECT `authors`.* FROM `authors` LEFT OUTER JOIN `essays` ON `essays`.`writer_id` = `authors`.`name` AND `essays`.`writer_type` = 'Author'"]
```
- postgresql

``` sql
["SELECT \"authors\".* FROM \"authors\" LEFT OUTER JOIN \"essays\" ON \"essays\".\"writer_id\" = \"authors\".\"name\" AND \"essays\".\"writer_type\" = $1"]
```

This pull request has been tested with all bundled adapters - sqlite3, mysql2 and postgresql.
