### PR TITLE
Don't deserialize strings that look like GlobalIDs as GlobalIDs

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -86,8 +86,6 @@ module ActiveJob
 
       def deserialize_argument(argument)
         case argument
-        when String
-          GlobalID::Locator.locate(argument) || argument
         when *TYPE_WHITELIST
           argument
         when Array

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -44,6 +44,10 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     assert_arguments_roundtrip([a: 1, "b" => 2])
   end
 
+  test 'should maintain strings that look like Global IDs' do
+    assert_arguments_roundtrip ['gid://notanapp/NotAnObject/1']
+  end
+
   test 'should maintain hash with indifferent access' do
     symbol_key = { a: 1 }
     string_key = { 'a' => 1 }


### PR DESCRIPTION
### Summary

We've had issues where our jobs error on GlobalID deserialization, which enqueues a job to report the error to our exception tracker (Sentry). The problem occurs because the original arguments are included in exception report, which means the GlobalID that causes the issue is included. Sentry's gem knows that `_aj_globalid` needs to be mangled to prevent this from happening and works around this https://github.com/getsentry/raven-ruby/commit/a96d47babcb0df4d2bc7d80b3d40e98fcc7acf17 but because there is still a String that looks like a GlobalID the problem persists.

I believe that we should be able to enqueue jobs with strings that look like GlobalIDs without triggering a deserialization attempt (that's why GLOBALID_KEY was introduced), and I think the code causing the issue is just a remnant.
### Other Information

This issue is present in rails 4.2.6 (and earlier 4.2 releases) and should be backported.
