### PR TITLE
Deprecate the behavior of AR::Dirty inside of after_(create|update|save) callbacks

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -166,7 +166,7 @@ module ActiveRecord
       def initialize_attributes(record, except_from_scope_attributes = nil) #:nodoc:
         except_from_scope_attributes ||= {}
         skip_assign = [reflection.foreign_key, reflection.type].compact
-        assigned_keys = record.changed
+        assigned_keys = record.changed_attribute_names_to_save
         assigned_keys += except_from_scope_attributes.keys.map(&:to_s)
         attributes = create_scope.except(*(assigned_keys - skip_assign))
         record.assign_attributes(attributes)

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -375,7 +375,7 @@ module ActiveRecord
           persisted.map! do |record|
             if mem_record = memory.delete(record)
 
-              ((record.attribute_names & mem_record.attribute_names) - mem_record.changes.keys).each do |name|
+              ((record.attribute_names & mem_record.attribute_names) - mem_record.changed_attribute_names_to_save).each do |name|
                 mem_record[name] = record[name]
               end
 

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -35,7 +35,7 @@ module ActiveRecord
         return target unless target || record
 
         assigning_another_record = target != record
-        if assigning_another_record || record.changed?
+        if assigning_another_record || record.has_changes_to_save?
           save &&= owner.persisted?
 
           transaction_if(save) do

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -45,6 +45,11 @@ module ActiveRecord
         attribute_was(self.class.primary_key)
       end
 
+      def id_in_database
+        sync_with_transaction_state
+        attribute_in_database(self.class.primary_key)
+      end
+
       protected
 
         def attribute_method?(attr_name)
@@ -60,7 +65,7 @@ module ActiveRecord
             end
           end
 
-          ID_ATTRIBUTE_METHODS = %w(id id= id? id_before_type_cast id_was).to_set
+          ID_ATTRIBUTE_METHODS = %w(id id= id? id_before_type_cast id_was id_in_database).to_set
 
           def dangerous_attribute_method?(method_name)
             super && !ID_ATTRIBUTE_METHODS.include?(method_name)

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -267,7 +267,7 @@ module ActiveRecord
     # Returns whether or not this record has been changed in any way (including whether
     # any of its nested autosave associations are likewise changed)
     def changed_for_autosave?
-      new_record? || changed? || marked_for_destruction? || nested_records_changed_for_autosave?
+      new_record? || has_changes_to_save? || marked_for_destruction? || nested_records_changed_for_autosave?
     end
 
     private
@@ -451,7 +451,7 @@ module ActiveRecord
       def record_changed?(reflection, record, key)
         record.new_record? ||
           (record.has_attribute?(reflection.foreign_key) && record[reflection.foreign_key] != key) ||
-          record.attribute_changed?(reflection.foreign_key)
+          record.will_save_change_to_attribute?(reflection.foreign_key)
       end
 
       # Saves the associated record if it's new or <tt>:autosave</tt> is enabled.

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -14,6 +14,7 @@ require "active_support/core_ext/module/introspection"
 require "active_support/core_ext/object/duplicable"
 require "active_support/core_ext/class/subclasses"
 require "active_record/attribute_decorators"
+require "active_record/define_callbacks"
 require "active_record/errors"
 require "active_record/log_subscriber"
 require "active_record/explain_subscriber"
@@ -303,6 +304,7 @@ module ActiveRecord #:nodoc:
     include AttributeDecorators
     include Locking::Optimistic
     include Locking::Pessimistic
+    include DefineCallbacks
     include AttributeMethods
     include Callbacks
     include Timestamp

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -265,17 +265,6 @@ module ActiveRecord
       :before_destroy, :around_destroy, :after_destroy, :after_commit, :after_rollback
     ]
 
-    module ClassMethods # :nodoc:
-      include ActiveModel::Callbacks
-    end
-
-    included do
-      include ActiveModel::Validations::Callbacks
-
-      define_model_callbacks :initialize, :find, :touch, only: :after
-      define_model_callbacks :save, :create, :update, :destroy
-    end
-
     def destroy #:nodoc:
       @_destroy_callback_already_called ||= false
       return if @_destroy_callback_already_called

--- a/activerecord/lib/active_record/define_callbacks.rb
+++ b/activerecord/lib/active_record/define_callbacks.rb
@@ -1,0 +1,20 @@
+module ActiveRecord
+  # This module exists because `ActiveRecord::AttributeMethods::Dirty` needs to
+  # define callbacks, but continue to have its version of `save` be the super
+  # method of `ActiveRecord::Callbacks`. This will be removed when the removal
+  # of deprecated code removes this need.
+  module DefineCallbacks
+    extend ActiveSupport::Concern
+
+    module ClassMethods # :nodoc:
+      include ActiveModel::Callbacks
+    end
+
+    included do
+      include ActiveModel::Validations::Callbacks
+
+      define_model_callbacks :initialize, :find, :touch, :only => :after
+      define_model_callbacks :save, :create, :update, :destroy
+    end
+  end
+end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -253,7 +253,11 @@ module ActiveRecord
       verify_readonly_attribute(name)
       public_send("#{name}=", value)
 
-      changed? ? save(validate: false) : true
+      if has_changes_to_save?
+        save(validate: false)
+      else
+        true
+      end
     end
 
     # Updates the attributes of the model from the passed-in hash and saves the
@@ -336,7 +340,7 @@ module ActiveRecord
     # record could be saved.
     def increment!(attribute, by = 1)
       increment(attribute, by)
-      change = public_send(attribute) - (attribute_was(attribute.to_s) || 0)
+      change = public_send(attribute) - (attribute_in_database(attribute.to_s) || 0)
       self.class.update_counters(id, attribute => change)
       clear_attribute_change(attribute) # eww
       self
@@ -548,7 +552,7 @@ module ActiveRecord
       if attributes_values.empty?
         0
       else
-        self.class.unscoped._update_record attributes_values, id, id_was
+        self.class.unscoped._update_record attributes_values, id, id_in_database
       end
     end
 

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -74,7 +74,7 @@ module ActiveRecord
 
         timestamp_attributes_for_update_in_model.each do |column|
           column = column.to_s
-          next if attribute_changed?(column)
+          next if will_save_change_to_attribute?(column)
           write_attribute(column, current_time)
         end
       end
@@ -82,7 +82,7 @@ module ActiveRecord
     end
 
     def should_record_timestamps?
-      record_timestamps && (!partial_writes? || changed?)
+      record_timestamps && (!partial_writes? || has_changes_to_save?)
     end
 
     def timestamp_attributes_for_create_in_model

--- a/activerecord/lib/active_record/touch_later.rb
+++ b/activerecord/lib/active_record/touch_later.rb
@@ -25,7 +25,7 @@ module ActiveRecord
       # touch the parents as we are not calling the after_save callbacks
       self.class.reflect_on_all_associations(:belongs_to).each do |r|
         if touch = r.options[:touch]
-          ActiveRecord::Associations::Builder::BelongsTo.touch_record(self, r.foreign_key, r.name, touch, :touch_later)
+          ActiveRecord::Associations::Builder::BelongsTo.touch_record(self, changes_to_save, r.foreign_key, r.name, touch, :touch_later)
         end
       end
     end

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -17,7 +17,7 @@ module ActiveRecord
         relation = build_relation(finder_class, attribute, value)
         if record.persisted?
           if finder_class.primary_key
-            relation = relation.where.not(finder_class.primary_key => record.id_was || record.id)
+            relation = relation.where.not(finder_class.primary_key => record.id_in_database || record.id)
           else
             raise UnknownPrimaryKey.new(finder_class, "Can not validate uniqueness for persisted record without primary key.")
           end

--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -14,6 +14,7 @@ module ActiveRecord
           def self.decorate_matching_attribute_types(*); end
           def self.initialize_generated_modules; end
 
+          include ActiveRecord::DefineCallbacks
           include ActiveRecord::AttributeMethods
 
           def self.attribute_names

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -726,6 +726,89 @@ class DirtyTest < ActiveRecord::TestCase
     assert person.changed?
   end
 
+  test "saved_change_to_attribute? returns whether a change occurred in the last save" do
+    person = Person.create!(first_name: "Sean")
+
+    assert person.saved_change_to_first_name?
+    refute person.saved_change_to_gender?
+    assert person.saved_change_to_first_name?(from: nil, to: "Sean")
+    assert person.saved_change_to_first_name?(from: nil)
+    assert person.saved_change_to_first_name?(to: "Sean")
+    refute person.saved_change_to_first_name?(from: "Jim", to: "Sean")
+    refute person.saved_change_to_first_name?(from: "Jim")
+    refute person.saved_change_to_first_name?(to: "Jim")
+  end
+
+  test "saved_change_to_attribute returns the change that occurred in the last save" do
+    person = Person.create!(first_name: "Sean", gender: "M")
+
+    assert_equal [nil, "Sean"], person.saved_change_to_first_name
+    assert_equal [nil, "M"], person.saved_change_to_gender
+
+    person.update(first_name: "Jim")
+
+    assert_equal ["Sean", "Jim"], person.saved_change_to_first_name
+    assert_nil person.saved_change_to_gender
+  end
+
+  test "attribute_before_last_save returns the original value before saving" do
+    person = Person.create!(first_name: "Sean", gender: "M")
+
+    assert_nil person.first_name_before_last_save
+    assert_nil person.gender_before_last_save
+
+    person.first_name = "Jim"
+
+    assert_nil person.first_name_before_last_save
+    assert_nil person.gender_before_last_save
+
+    person.save
+
+    assert_equal "Sean", person.first_name_before_last_save
+    assert_equal "M", person.gender_before_last_save
+  end
+
+  test "saved_changes? returns whether the last call to save changed anything" do
+    person = Person.create!(first_name: "Sean")
+
+    assert person.saved_changes?
+
+    person.save
+
+    refute person.saved_changes?
+  end
+
+  test "saved_changes returns a hash of all the changes that occurred" do
+    person = Person.create!(first_name: "Sean", gender: "M")
+
+    assert_equal [nil, "Sean"], person.saved_changes[:first_name]
+    assert_equal [nil, "M"], person.saved_changes[:gender]
+    assert_equal %w(id first_name gender created_at updated_at).sort, person.saved_changes.keys.sort
+
+    travel(1.second) do
+      person.update(first_name: "Jim")
+    end
+
+    assert_equal ["Sean", "Jim"], person.saved_changes[:first_name]
+    assert_equal %w(first_name lock_version updated_at).sort, person.saved_changes.keys.sort
+  end
+
+  test "changed? in after callbacks returns true but is deprecated" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "people"
+
+      after_save do
+        ActiveSupport::Deprecation.silence do
+          raise "changed? should be true" unless changed?
+        end
+        raise "has_changes_to_save? should be false" if has_changes_to_save?
+      end
+    end
+
+    person = klass.create!(first_name: "Sean")
+    refute person.changed?
+  end
+
   private
     def with_partial_writes(klass, on = true)
       old = klass.partial_writes?

--- a/activerecord/test/models/eye.rb
+++ b/activerecord/test/models/eye.rb
@@ -22,12 +22,12 @@ class Eye < ActiveRecord::Base
   alias trace_after_create2 trace_after_create
 
   def trace_after_update
-    (@after_update_callbacks_stack ||= []) << iris.changed?
+    (@after_update_callbacks_stack ||= []) << iris.has_changes_to_save?
   end
   alias trace_after_update2 trace_after_update
 
   def trace_after_save
-    (@after_save_callbacks_stack ||= []) << iris.changed?
+    (@after_save_callbacks_stack ||= []) << iris.has_changes_to_save?
   end
   alias trace_after_save2 trace_after_save
 end


### PR DESCRIPTION
We pretty frequently get bug reports that "dirty is broken inside of after callbacks". Intuitively they are correct. You'd expect `Model.after_save { puts changed? }; model.save` to do the same thing as `model.save; puts model.changed?`, but it does not.

However, changing this goes much farther than just making the behavior more intuitive. There are a _ton_ of places inside of AR that can be drastically simplified with this change. Specifically, autosave associations, timestamps, touch, counter cache, and just about anything else in AR that works with callbacks have code to try to avoid "double save" bugs which we will be able to flat out remove with this change.

We introduce two new sets of methods, both with names that are meant to be more explicit than dirty. The first set maintains the old behavior, and their names are meant to center that they are about changes that occurred during the save that just happened. They are equivalent to `previous_changes` when called outside of after callbacks, or once the deprecation cycle moves.

The second set is the new behavior. Their names imply that they are talking about changes from the database representation. The fact that this is what we really care about became clear when looking at `BelongsTo.touch_record` when tests were failing. I'm unsure that this set of methods should be in the public API. Outside of after callbacks, they are equivalent to the existing methods on dirty.

I am not married to any of the method names. Please bikeshed the shit out of them, I am open to alternatives.

Dirty itself is not deprecated, nor are the methods inside of it. They will only emit the warning when called inside of after callbacks. The scope of this breakage is pretty large, but the migration path is simple. Given how much this can improve our codebase, and considering that it makes our API more intuitive, I think it's worth doing.
## Unresolved questions

Do we want the "new behavior" methods to be in the public API at all? They are straight aliases to the existing methods in dirty after 5.2/6.0. However, since we get these bug reports, someone probably does want the new behavior today.
## Still left todo

I need to improve the commit messages, and move the deprecation warning up to the caller of `mutation_tracker` to include the exact method to call instead. The current implementation is also emitting deprecation warnings in places where the calls are valid. This will be fixed by moving the warning to the right place.
