### PR TITLE
Fix Typo in `SuckerPunchAdapter`

### DIFF
--- a/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
@@ -5,7 +5,7 @@ module ActiveJob
     # == Sucker Punch adapter for Active Job
     #
     # Sucker Punch is a single-process Ruby asynchronous processing library.
-    # This reduces the cost of of hosting on a service like Heroku along
+    # This reduces the cost of hosting on a service like Heroku along
     # with the memory footprint of having to maintain additional jobs if
     # hosting on a dedicated server. All queues can run within a
     # single application (eg. Rails, Sinatra, etc.) process.


### PR DESCRIPTION
### Summary

Fixes a double-word typo, `of of` -> `of`.
