### PR TITLE
ActionDispatch::DebugLocks

### DIFF
--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -50,6 +50,7 @@ module ActionDispatch
     autoload :Callbacks
     autoload :Cookies
     autoload :DebugExceptions
+    autoload :DebugLocks
     autoload :ExceptionWrapper
     autoload :Executor
     autoload :Flash

--- a/actionpack/lib/action_dispatch/middleware/debug_locks.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_locks.rb
@@ -1,0 +1,122 @@
+module ActionDispatch
+  # This middleware can be used to diagnose deadlocks in the autoload interlock.
+  #
+  # To use it, insert it near the top of the middleware stack, using
+  # <tt>config/application.rb</tt>:
+  #
+  #     config.middleware.insert_before Rack::Sendfile, ActionDispatch::DebugLocks
+  #
+  # After restarting the application and re-triggering the deadlock condition,
+  # <tt>/rails/locks</tt> will show a summary of all threads currently known to
+  # the interlock, which lock level they are holding or awaiting, and their
+  # current backtrace.
+  #
+  # Generally a deadlock will be caused by the interlock conflicting with some
+  # other external lock or blocking I/O call. These cannot be automatically
+  # identified, but should be visible in the displayed backtraces.
+  #
+  # NOTE: The formatting and content of this middleware's output is intended for
+  # human consumption, and should be expected to change between releases.
+  #
+  # This middleware exposes operational details of the server, with no access
+  # control. It should only be enabled when in use, and removed thereafter.
+  class DebugLocks
+    def initialize(app, path = '/rails/locks')
+      @app = app
+      @path = path
+    end
+
+    def call(env)
+      req = ActionDispatch::Request.new env
+
+      if req.get?
+        path = req.path_info.chomp('/'.freeze)
+        if path == @path
+          return render_details(req)
+        end
+      end
+
+      @app.call(env)
+    end
+
+    private
+      def render_details(req)
+        threads = ActiveSupport::Dependencies.interlock.raw_state do |threads|
+          # The Interlock itself comes to a complete halt as long as this block
+          # is executing. That gives us a more consistent picture of everything,
+          # but creates a pretty strong Observer Effect.
+          #
+          # Most directly, that means we need to do as little as possible in
+          # this block. More widely, it means this middleware should remain a
+          # strictly diagnostic tool (to be used when something has gone wrong),
+          # and not for any sort of general monitoring.
+
+          threads.each.with_index do |(thread, info), idx|
+            info[:index] = idx
+            info[:backtrace] = thread.backtrace
+          end
+
+          threads
+        end
+
+        str = threads.map do |thread, info|
+          if info[:exclusive]
+            lock_state = 'Exclusive'
+          elsif info[:sharing] > 0
+            lock_state = 'Sharing'
+            lock_state << " x#{info[:sharing]}" if info[:sharing] > 1
+          else
+            lock_state = 'No lock'
+          end
+
+          if info[:waiting]
+            lock_state << ' (yielded share)'
+          end
+
+          msg = "Thread #{info[:index]} [0x#{thread.__id__.to_s(16)} #{thread.status || 'dead'}]  #{lock_state}\n"
+
+          if info[:sleeper]
+            msg << "  Waiting in #{info[:sleeper]}"
+            msg << " to #{info[:purpose].to_s.inspect}" unless info[:purpose].nil?
+            msg << "\n"
+
+            if info[:compatible]
+              compat = info[:compatible].map { |c| c == false ? "share" : c.to_s.inspect }
+              msg << "  may be pre-empted for: #{compat.join(', ')}\n"
+            end
+
+            blockers = threads.values.select { |binfo| blocked_by?(info, binfo, threads.values) }
+            msg << "  blocked by: #{blockers.map {|i| i[:index] }.join(', ')}\n" if blockers.any?
+          end
+
+          blockees = threads.values.select { |binfo| blocked_by?(binfo, info, threads.values) }
+          msg << "  blocking: #{blockees.map {|i| i[:index] }.join(', ')}\n" if blockees.any?
+
+          msg << "\n#{info[:backtrace].join("\n")}\n" if info[:backtrace]
+        end.join("\n\n---\n\n\n")
+
+        [200, { "Content-Type" => "text/plain", "Content-Length" => str.size }, [str]]
+      end
+
+      def blocked_by?(victim, blocker, all_threads)
+        return false if victim.equal?(blocker)
+
+        case victim[:sleeper]
+        when :start_sharing
+          blocker[:exclusive] ||
+            (!victim[:waiting] && blocker[:compatible] && !blocker[:compatible].include?(false))
+        when :start_exclusive
+          blocker[:sharing] > 0 ||
+            blocker[:exclusive] ||
+            (blocker[:compatible] && !blocker[:compatible].include?(victim[:purpose]))
+        when :yield_shares
+          blocker[:exclusive]
+        when :stop_exclusive
+          blocker[:exclusive] ||
+            victim[:compatible] &&
+            victim[:compatible].include?(blocker[:purpose]) &&
+            all_threads.all? { |other| !other[:compatible] || blocker.equal?(other) || other[:compatible].include?(blocker[:purpose]) }
+        end
+      end
+  end
+end

--- a/activesupport/lib/active_support/dependencies/interlock.rb
+++ b/activesupport/lib/active_support/dependencies/interlock.rb
@@ -46,6 +46,10 @@ module ActiveSupport #:nodoc:
           yield
         end
       end
+
+      def raw_state(&block) # :nodoc:
+        @lock.raw_state(&block)
+      end
     end
   end
 end


### PR DESCRIPTION
While looking at https://github.com/rails/rails/issues/25117, I was again struck by how uninformative "hang on all new requests" is as a diagnostic output.

We'd thrown around the idea of checking thread statuses and guessing when things might be stuck, but I'm still nervous that we'd trip on too many legitimately slow operations.

Instead, I propose this middleware.

If your application appears to be experiencing a deadlock, you can insert this, then go to `/rails/locks`, to see output like:

```
Thread 0 [0x3fda9bc30cfc sleep]  No interlock (yielded share)
  Waiting in start_exclusive to "load"
  may be pre-empted for: "load"
  blocked by: 1

/Users/matthew/.rbenv/versions/2.3.0/lib/ruby/2.3.0/monitor.rb:111:in `sleep'
/Users/matthew/.rbenv/versions/2.3.0/lib/ruby/2.3.0/monitor.rb:111:in `wait'
/Users/matthew/.rbenv/versions/2.3.0/lib/ruby/2.3.0/monitor.rb:111:in `wait'
/Users/matthew/.rbenv/versions/2.3.0/lib/ruby/2.3.0/monitor.rb:123:in `wait_while'
/Users/matthew/src/rails/activesupport/lib/active_support/concurrency/share_lock.rb:220:in `wait_for'
/Users/matthew/src/rails/activesupport/lib/active_support/concurrency/share_lock.rb:82:in `block (2 levels) in start_exclusive'
/Users/matthew/src/rails/activesupport/lib/active_support/concurrency/share_lock.rb:186:in `yield_shares'
/Users/matthew/src/rails/activesupport/lib/active_support/concurrency/share_lock.rb:81:in `block in start_exclusive'
/Users/matthew/.rbenv/versions/2.3.0/lib/ruby/2.3.0/monitor.rb:214:in `mon_synchronize'
/Users/matthew/src/rails/activesupport/lib/active_support/concurrency/share_lock.rb:76:in `start_exclusive'
/Users/matthew/src/rails/activesupport/lib/active_support/concurrency/share_lock.rb:148:in `exclusive'
/Users/matthew/src/rails/activesupport/lib/active_support/dependencies/interlock.rb:11:in `loading'
/Users/matthew/src/rails/activesupport/lib/active_support/dependencies.rb:37:in `load_interlock'
/Users/matthew/src/rails/activesupport/lib/active_support/dependencies.rb:358:in `require_or_load'
/Users/matthew/src/rails/activesupport/lib/active_support/dependencies.rb:511:in `load_missing_constant'
/Users/matthew/src/rails/activesupport/lib/active_support/dependencies.rb:203:in `const_missing'
/Users/matthew/tmp/puma_channel_problem/app/channels/first_channel.rb:3:in `<top (required)>'
/Users/matthew/src/rails/activesupport/lib/active_support/dependencies.rb:293:in `require'
/Users/matthew/src/rails/activesupport/lib/active_support/dependencies.rb:293:in `block in require'
/Users/matthew/src/rails/activesupport/lib/active_support/dependencies.rb:259:in `load_dependency'
/Users/matthew/src/rails/activesupport/lib/active_support/dependencies.rb:293:in `require'
/Users/matthew/src/rails/actioncable/lib/action_cable/server/base.rb:74:in `block (2 levels) in channel_classes'
/Users/matthew/src/rails/actioncable/lib/action_cable/server/base.rb:74:in `each'
/Users/matthew/src/rails/actioncable/lib/action_cable/server/base.rb:74:in `block in channel_classes'
/Users/matthew/.rbenv/versions/2.3.0/lib/ruby/2.3.0/monitor.rb:214:in `mon_synchronize'
/Users/matthew/src/rails/actioncable/lib/action_cable/server/base.rb:72:in `channel_classes'
/Users/matthew/src/rails/actioncable/lib/action_cable/connection/subscriptions.rb:29:in `add'
/Users/matthew/src/rails/actioncable/lib/action_cable/connection/subscriptions.rb:15:in `execute_command'
/Users/matthew/src/rails/actioncable/lib/action_cable/connection/base.rb:88:in `dispatch_websocket_message'
/Users/matthew/src/rails/actioncable/lib/action_cable/server/worker.rb:54:in `block in invoke'
/Users/matthew/src/rails/actioncable/lib/action_cable/server/worker.rb:39:in `block in work'
[snip]


---


Thread 1 [0x3fda9a3cf460 sleep]  Sharing
  blocking: 0

/Users/matthew/.rbenv/versions/2.3.0/lib/ruby/2.3.0/monitor.rb:187:in `lock'
/Users/matthew/.rbenv/versions/2.3.0/lib/ruby/2.3.0/monitor.rb:187:in `mon_enter'
/Users/matthew/.rbenv/versions/2.3.0/lib/ruby/2.3.0/monitor.rb:212:in `mon_synchronize'
/Users/matthew/src/rails/actioncable/lib/action_cable/server/base.rb:72:in `channel_classes'
/Users/matthew/src/rails/actioncable/lib/action_cable/connection/subscriptions.rb:29:in `add'
/Users/matthew/src/rails/actioncable/lib/action_cable/connection/subscriptions.rb:15:in `execute_command'
/Users/matthew/src/rails/actioncable/lib/action_cable/connection/base.rb:88:in `dispatch_websocket_message'
/Users/matthew/src/rails/actioncable/lib/action_cable/server/worker.rb:54:in `block in invoke'
/Users/matthew/src/rails/actioncable/lib/action_cable/server/worker.rb:39:in `block in work'
[snip]
```

Naturally, we're able to provide lots of information about the actual interlock state (some of which is derived from duplicated logic for now, but that could be refactored later), but we can't offer much about whatever "other" lock is involved. However, the above example demonstrates that the backtraces may often be sufficient.
