### PR TITLE
Set counter caches to correct values in fixtures

### DIFF
--- a/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
+++ b/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
@@ -37,7 +37,7 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
 
   def test_eager_association_loading_with_hmt_does_not_table_name_collide_when_joining_associations
     authors = Author.joins(:posts).eager_load(:comments).where(posts: { tags_count: 1 }).to_a
-    assert_equal 1, assert_no_queries { authors.size }
+    assert_equal 3, assert_no_queries { authors.size }
     assert_equal 10, assert_no_queries { authors[0].comments.size }
   end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -831,7 +831,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_find_scoped_grouped_having
-    assert_equal 1, authors(:david).popular_grouped_posts.length
+    assert_equal 2, authors(:david).popular_grouped_posts.length
     assert_equal 0, authors(:mary).popular_grouped_posts.length
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -927,13 +927,13 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 11, posts.count(:all)
     assert_equal 11, posts.count(:id)
 
-    assert_equal 1, posts.where("comments_count > 1").count
-    assert_equal 9, posts.where(comments_count: 0).count
+    assert_equal 3, posts.where("comments_count > 1").count
+    assert_equal 6, posts.where(comments_count: 0).count
   end
 
   def test_count_with_block
     posts = Post.all
-    assert_equal 10, posts.count { |p| p.comments_count.even? }
+    assert_equal 8, posts.count { |p| p.comments_count.even? }
   end
 
   def test_count_on_association_relation
@@ -950,10 +950,10 @@ class RelationTest < ActiveRecord::TestCase
   def test_count_with_distinct
     posts = Post.all
 
-    assert_equal 3, posts.distinct(true).count(:comments_count)
+    assert_equal 4, posts.distinct(true).count(:comments_count)
     assert_equal 11, posts.distinct(false).count(:comments_count)
 
-    assert_equal 3, posts.distinct(true).select(:comments_count).count
+    assert_equal 4, posts.distinct(true).select(:comments_count).count
     assert_equal 11, posts.distinct(false).select(:comments_count).count
   end
 
@@ -992,7 +992,7 @@ class RelationTest < ActiveRecord::TestCase
 
     best_posts = posts.where(comments_count: 0)
     best_posts.load # force load
-    assert_no_queries { assert_equal 9, best_posts.size }
+    assert_no_queries { assert_equal 6, best_posts.size }
   end
 
   def test_size_with_limit
@@ -1003,7 +1003,7 @@ class RelationTest < ActiveRecord::TestCase
 
     best_posts = posts.where(comments_count: 0)
     best_posts.load # force load
-    assert_no_queries { assert_equal 9, best_posts.size }
+    assert_no_queries { assert_equal 6, best_posts.size }
   end
 
   def test_size_with_zero_limit
@@ -1026,7 +1026,7 @@ class RelationTest < ActiveRecord::TestCase
   def test_count_complex_chained_relations
     posts = Post.select("comments_count").where("id is not null").group("author_id").where("comments_count > 0")
 
-    expected = { 1 => 2 }
+    expected = { 1 => 4, 2 => 1 }
     assert_equal expected, posts.count
   end
 
@@ -1781,7 +1781,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   test "arel_attribute respects a custom table" do
-    assert_equal [posts(:welcome)], custom_post_relation.ranked_by_comments.limit_by(1).to_a
+    assert_equal [posts(:sti_comments)], custom_post_relation.ranked_by_comments.limit_by(1).to_a
   end
 
   test "alias_tracker respects a custom table" do

--- a/activerecord/test/fixtures/other_posts.yml
+++ b/activerecord/test/fixtures/other_posts.yml
@@ -5,3 +5,4 @@ second_welcome:
   author_id: 1
   title: Welcome to the another weblog
   body: It's really nice today
+  comments_count: 1

--- a/activerecord/test/fixtures/posts.yml
+++ b/activerecord/test/fixtures/posts.yml
@@ -28,6 +28,7 @@ sti_comments:
   author_id: 1
   title: sti comments
   body: hello
+  comments_count: 5
   type: Post
 
 sti_post_and_comments:
@@ -35,6 +36,7 @@ sti_post_and_comments:
   author_id: 1
   title: sti me
   body: hello
+  comments_count: 2
   type: StiPost
 
 sti_habtm:
@@ -50,6 +52,8 @@ eager_other:
   title: eager loading with OR'd conditions
   body: hello
   type: Post
+  comments_count: 1
+  tags_count: 3
 
 misc_by_bob:
   id: 8
@@ -57,6 +61,7 @@ misc_by_bob:
   title: misc post by bob
   body: hello
   type: Post
+  tags_count: 1
 
 misc_by_mary:
   id: 9
@@ -64,6 +69,7 @@ misc_by_mary:
   title: misc post by mary
   body: hello
   type: Post
+  tags_count: 1
 
 other_by_bob:
   id: 10
@@ -71,6 +77,7 @@ other_by_bob:
   title: other post by bob
   body: hello
   type: Post
+  tags_count: 1
 
 other_by_mary:
   id: 11
@@ -78,3 +85,4 @@ other_by_mary:
   title: other post by mary
   body: hello
   type: Post
+  tags_count: 1


### PR DESCRIPTION
### Summary

I tried to make a patch in AR that suppose to fix an issue, but some of tests started to fail because posts fixtures counter caches are set incorrectly and invalid data is put into database. So this patch just sets right fixture values to the right value for all fixtures.
