### PR TITLE
Fix url in routes DSL error message

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -423,7 +423,7 @@ module ActionDispatch
       def eval_block(block)
         if block.arity == 1
           raise "You are using the old router DSL which has been removed in Rails 3.1. " <<
-            "Please check how to update your routes file at: http://www.engineyard.com/blog/2010/the-lowdown-on-routes-in-rails-3/"
+            "Please check how to update your routes file at: https://blog.engineyard.com/2010/the-lowdown-on-routes-in-rails-3"
         end
         mapper = Mapper.new(self)
         if default_scope


### PR DESCRIPTION
### Summary

this page returns 404 :(

http://www.engineyard.com/blog/2010/the-lowdown-on-routes-in-rails-3/

it's moved to fllowing:

https://blog.engineyard.com/2010/the-lowdown-on-routes-in-rails-3
