### PR TITLE
Add config.assets.quiet = true as default for generator

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
@@ -9,3 +9,6 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
+
+# Suppress logger output for asset requests.
+Rails.application.config.assets.quiet = true


### PR DESCRIPTION
@rafaelfranca @sgrif @wvanbergen 
Paired with @jonathankwok 

Sets the `config.assets.quiet` to `true` by default, and explicitly in the generator.

From https://github.com/rails/sprockets-rails/pull/355, but also related to https://github.com/rails/rails/pull/25341 to work properly.

This depends on `sprockets-rails` being released and bumped to the newest version. I'm not sure how we manage that dependency. Worst case it's a property set on the `Sprockets::Railtie::OrderedOptions` instance `config` that does nothing. But it's pretty unclear to define a noop property.
