### PR TITLE
Replace Kernel#caller by the faster Kernel#caller_locations

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -164,8 +164,8 @@ class Module
         ''
       end
 
-    file, line = caller(1, 1).first.split(':'.freeze, 2)
-    line = line.to_i
+    location = caller_locations(1, 1).first
+    file, line = location.path, location.lineno
 
     to = to.to_s
     to = "self.#{to}" if DELEGATION_RESERVED_METHOD_NAMES.include?(to)


### PR DESCRIPTION
While profiling our application boot time I noticed `Module#delegate` was a noticeable part of it:

<img width="493" alt="capture d ecran 2016-06-10 a 11 37 58" src="https://cloud.githubusercontent.com/assets/19192189/15969847/cdf93da8-2eff-11e6-900d-7f73ee307540.png">

Since `caller` as the reputation of being relatively inefficient I looked for alternatives and found `caller_locations` introduced in MRI 2.0. I wrote a small benchmark against `5.0.0rc1`: https://gist.github.com/casperisfine/a40137b7b3ce0413d23f16cd7d1d8a05

The improvement is only 10ish % which I admit is not ground breaking, it's better against `4.2` though, because before the `caller` call wasn't bounded: https://github.com/rails/rails/blob/0d5d8594b1a7d7caab0cbc9fe3340bb5bfbe79bd/activesupport/lib/active_support/core_ext/module/delegation.rb#L170-L171

But since it makes the code more readable, it believe it's worth it.

@rafaelfranca @sgrif thoughts? 
