### PR TITLE
Backport ActiveSupport::LoggerThreadSafeLevel

### DIFF
--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -1,9 +1,11 @@
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/logger_silence'
+require 'active_support/logger_thread_safe_level'
 require 'logger'
 
 module ActiveSupport
   class Logger < ::Logger
+    include ActiveSupport::LoggerThreadSafeLevel
     include LoggerSilence
 
     # Broadcasts logs to multiple loggers.
@@ -37,6 +39,11 @@ module ActiveSupport
         define_method(:level=) do |level|
           logger.level = level
           super(level)
+        end
+
+        define_method(:local_level=) do |level|
+          logger.local_level = level if logger.respond_to?(:local_level=)
+          super(level) if respond_to?(:local_level=)
         end
       end
     end

--- a/activesupport/lib/active_support/logger_silence.rb
+++ b/activesupport/lib/active_support/logger_silence.rb
@@ -3,40 +3,22 @@ require 'thread_safe'
 
 module LoggerSilence
   extend ActiveSupport::Concern
-  
+
   included do
     cattr_accessor :silencer
-    attr_reader :local_levels
     self.silencer = true
-  end
-
-
-  def after_initialize
-    @local_levels = ThreadSafe::Cache.new(:initial_capacity => 2)
-  end
-
-  def local_log_id
-    Thread.current.__id__
-  end
-
-  def level
-    local_levels[local_log_id] || super
   end
 
   # Silences the logger for the duration of the block.
   def silence(temporary_level = Logger::ERROR)
     if silencer
       begin
-        old_local_level            = local_levels[local_log_id]
-        local_levels[local_log_id] = temporary_level
+        old_local_level            = local_level
+        self.local_level           = temporary_level
 
         yield self
       ensure
-        if old_local_level
-          local_levels[local_log_id] = old_local_level
-        else
-          local_levels.delete(local_log_id)
-        end
+        self.local_level = old_local_level
       end
     else
       yield self

--- a/activesupport/lib/active_support/logger_thread_safe_level.rb
+++ b/activesupport/lib/active_support/logger_thread_safe_level.rb
@@ -1,0 +1,31 @@
+require 'active_support/concern'
+
+module ActiveSupport
+  module LoggerThreadSafeLevel
+    extend ActiveSupport::Concern
+
+    def after_initialize
+      @local_levels = Concurrent::Map.new(:initial_capacity => 2)
+    end
+
+    def local_log_id
+      Thread.current.__id__
+    end
+
+    def local_level
+      @local_levels[local_log_id]
+    end
+
+    def local_level=(level)
+      if level
+        @local_levels[local_log_id] = level
+      else
+        @local_levels.delete(local_log_id)
+      end
+    end
+
+    def level
+      local_level || super
+    end
+  end
+end

--- a/activesupport/lib/active_support/logger_thread_safe_level.rb
+++ b/activesupport/lib/active_support/logger_thread_safe_level.rb
@@ -1,4 +1,5 @@
 require 'active_support/concern'
+require 'concurrent'
 
 module ActiveSupport
   module LoggerThreadSafeLevel

--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -133,6 +133,50 @@ class LoggerTest < ActiveSupport::TestCase
     assert @output.string.include?("THIS IS HERE")
   end
 
+  def test_logger_silencing_works_for_broadcast
+    another_output  = StringIO.new
+    another_logger  = Logger.new(another_output)
+
+    @logger.extend Logger.broadcast(another_logger)
+
+    @logger.debug "CORRECT DEBUG"
+    @logger.silence do
+      @logger.debug "FAILURE"
+      @logger.error "CORRECT ERROR"
+    end
+
+    assert @output.string.include?("CORRECT DEBUG")
+    assert @output.string.include?("CORRECT ERROR")
+    assert_not @output.string.include?("FAILURE")
+
+    assert another_output.string.include?("CORRECT DEBUG")
+    assert another_output.string.include?("CORRECT ERROR")
+    assert_not another_output.string.include?("FAILURE")
+  end
+
+  def test_broadcast_silencing_does_not_break_plain_ruby_logger
+    another_output  = StringIO.new
+    another_logger  = ::Logger.new(another_output)
+
+    @logger.extend Logger.broadcast(another_logger)
+
+    @logger.debug "CORRECT DEBUG"
+    @logger.silence do
+      @logger.debug "FAILURE"
+      @logger.error "CORRECT ERROR"
+    end
+
+    assert @output.string.include?("CORRECT DEBUG")
+    assert @output.string.include?("CORRECT ERROR")
+    assert_not @output.string.include?("FAILURE")
+
+    assert another_output.string.include?("CORRECT DEBUG")
+    assert another_output.string.include?("CORRECT ERROR")
+    assert another_output.string.include?("FAILURE")
+    # We can't silence plain ruby Logger cause with thread safety
+    # but at least we don't break it
+  end
+
   def test_logger_level_per_object_thread_safety
     logger1 = Logger.new(StringIO.new)
     logger2 = Logger.new(StringIO.new)


### PR DESCRIPTION
@rafaelfranca @sgrif 

Backports the work by @piotrj in #23616 on to `4-2-stable`.

Needed as a prerequisite to backporting #25341.

The work properly handles concurrency for loggers by changing their level through a `local_level`.
