### PR TITLE
Provide the ability to override the queue adapter used by jobs under test

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -9,7 +9,7 @@ module ActiveJob
       to: :queue_adapter
 
     def before_setup # :nodoc:
-      test_adapter = ActiveJob::QueueAdapters::TestAdapter.new
+      test_adapter = queue_adapter_for_test
 
       @old_queue_adapters = (ActiveJob::Base.subclasses << ActiveJob::Base).select do |klass|
         # only override explicitly set adapters, a quirk of `class_attribute`
@@ -30,6 +30,19 @@ module ActiveJob
       @old_queue_adapters.each do |(klass, adapter)|
         klass.queue_adapter = adapter
       end
+    end
+
+    # Specifies the queue adapter to use with all active job test helpers.
+    #
+    # Returns an instance of the queue adapter and defaults to
+    # <tt>ActiveJob::QueueAdapters::TestAdapter</tt>.
+    #
+    # Note: The adapter provided by this method must provide some additional
+    # methods from those expected of a standard <tt>ActiveJob::QueueAdapter</tt>
+    # in order to be used with the active job test helpers. Refer to
+    # <tt>ActiveJob::QueueAdapters::TestAdapter</tt>.
+    def queue_adapter_for_test
+      ActiveJob::QueueAdapters::TestAdapter.new
     end
 
     # Asserts that the number of enqueued jobs matches the given number.

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -509,3 +509,15 @@ class PerformedJobsTest < ActiveJob::TestCase
     assert_equal 2, ActiveJob::Base.queue_adapter.performed_jobs.count
   end
 end
+
+class OverrideQueueAdapterTest < ActiveJob::TestCase
+  class CustomQueueAdapter < ActiveJob::QueueAdapters::TestAdapter; end
+
+  def queue_adapter_for_test
+    CustomQueueAdapter.new
+  end
+
+  def test_assert_job_has_custom_queue_adapter_set
+    assert_instance_of CustomQueueAdapter, HelloJob.queue_adapter
+  end
+end


### PR DESCRIPTION
Our Rails application uses a custom background job implementation from before ActiveJob. We're trying to migrate our code to use ActiveJob and part of that is to update our test suite to use the ActiveJob test helpers. In order to do that, we wrote a test queue adapter which wraps our background job queue adapter and conforms to the `ActiveJob::QueueAdapter::TestAdapter` interface in order to make the active job assertions work. Currently, `ActiveJob::TestHelper` provides no way to override the queue adapter used in tests, so we're stuck maintaining a patch that provides this behaviour.

This PR adds a method called `queue_adapter_for_test` to `ActiveJob::TestHelper`. The new method is expected to provide an instance of the queue adapter to be used for jobs under test. It maintains the current behaviour by defaulting to an instance of `ActiveJob::QueueAdapter::TestAdapter`. 

Tests that include `ActiveJob::TestHelper` or extend from `ActiveJob::TestCase` can now provide a custom queue adapter by overriding `queue_adapter_for_test` in their test class.

@rafaelfranca @byroot 
