### PR TITLE
Remove CLIENT_FOUND_ROWS connection flag (use MySQL default)

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -14,14 +14,6 @@ module ActiveRecord
       config[:username] = 'root' if config[:username].nil?
       config[:flags] ||= 0
 
-      if Mysql2::Client.const_defined? :FOUND_ROWS
-        if config[:flags].kind_of? Array
-          config[:flags].push "FOUND_ROWS".freeze
-        else
-          config[:flags] |= Mysql2::Client::FOUND_ROWS
-        end
-      end
-
       client = Mysql2::Client.new(config)
       ConnectionAdapters::Mysql2Adapter.new(client, logger, nil, config)
     rescue Mysql2::Error => error

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -101,14 +101,14 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   def test_passing_arbitary_flags_to_adapter
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.merge({flags: Mysql2::Client::COMPRESS}))
-      assert_equal (Mysql2::Client::COMPRESS |  Mysql2::Client::FOUND_ROWS), ActiveRecord::Base.connection.raw_connection.query_options[:flags]
+      assert_equal Mysql2::Client::COMPRESS, ActiveRecord::Base.connection.raw_connection.query_options[:flags]
     end
   end
 
   def test_passing_flags_by_array_to_adapter
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.merge({flags: ['COMPRESS'] }))
-      assert_equal ["COMPRESS", "FOUND_ROWS"], ActiveRecord::Base.connection.raw_connection.query_options[:flags]
+      assert_equal ["COMPRESS"], ActiveRecord::Base.connection.raw_connection.query_options[:flags]
     end
   end
 


### PR DESCRIPTION
The MySQL2 adapter sets the `CLIENT_FOUND_ROWS` flag on the connection, which changes the semantics of [`mysql_rows_affected()`](http://dev.mysql.com/doc/refman/en/mysql-affected-rows.html). This PR removes that flag which makes the connection behave in a more "usual" way (at least in MySQL terms, since this flag is not set by default).

Looking through ActiveRecord, I believe in practice this only impacts `UPDATE` statements (Rails does not use the `INSERT ... ON DUPLICATE KEY UPDATE` statements). The relevant excerpt from the MySQL documentation linked above:

> For UPDATE statements, the affected-rows value by default is the number of rows actually changed. If you specify the CLIENT_FOUND_ROWS flag to mysql_real_connect() when connecting to mysqld, the affected-rows value is the number of rows “found”; that is, matched by the WHERE clause.

Below is an illustration of how the change in this PR manifests in the ActiveRecord query APIs.

Assuming this SQL is run before each of the 3 examples below:

``` sql
DROP DATABASE IF EXISTS sum;
CREATE DATABASE sum;
USE sum;
CREATE TABLE foo (bar INT, gyp VARCHAR(255));
INSERT INTO foo (bar, gyp) VALUES (123, 'abc');
INSERT INTO foo (bar, gyp) VALUES (456, 'def');
```

Behavior before this PR:

``` ruby
>> ActiveRecord::Base.logger = Logger.new(STDOUT)
=> #<Logger...>
>> ActiveRecord::Base.establish_connection("mysql2://root@localhost/sum")
=> #<ActiveRecord::ConnectionAdapters::ConnectionPool...>
>> ActiveRecord::Base.connection.update("UPDATE foo SET gyp = 'abc' WHERE bar = 123")
D, [2016-06-11T20:51:33.914605 #37472] DEBUG -- :    (0.7ms)  UPDATE foo SET gyp = 'abc' WHERE bar = 123
=> 1
>> ActiveRecord::Base.connection.update("UPDATE foo SET gyp = 'abc' WHERE bar IN (123, 456)")
D, [2016-06-11T20:51:37.891697 #37472] DEBUG -- :    (2.0ms)  UPDATE foo SET gyp = 'abc' WHERE bar IN (123, 456)
=> 2
```

Behavior after this PR:

``` ruby
>> ActiveRecord::Base.logger = Logger.new(STDOUT)
=> #<Logger...>
>> ActiveRecord::Base.establish_connection("mysql2://root@localhost/sum")
=> #<ActiveRecord::ConnectionAdapters::ConnectionPool...>
>> ActiveRecord::Base.connection.update("UPDATE foo SET gyp = 'abc' WHERE bar = 123")
D, [2016-06-11T21:12:10.153860 #37434] DEBUG -- :    (1.0ms)  UPDATE foo SET gyp = 'abc' WHERE bar = 123
=> 0
>> ActiveRecord::Base.connection.update("UPDATE foo SET gyp = 'abc' WHERE bar IN (123, 456)")
D, [2016-06-11T21:12:14.199660 #37434] DEBUG -- :    (0.7ms)  UPDATE foo SET gyp = 'abc' WHERE bar IN (123, 456)
=> 1
```

For comparison, if you execute these statements via a mysql client, it behaves like the latter:

``` bash
mysql> UPDATE foo SET gyp = 'abc' WHERE bar = 123;
Query OK, 0 rows affected (0.00 sec)
Rows matched: 1  Changed: 0  Warnings: 0

mysql> UPDATE foo SET gyp = 'abc' WHERE bar IN (123, 456);
Query OK, 1 row affected (0.00 sec)
Rows matched: 2  Changed: 1  Warnings: 0
```

All of the above were run with:

``` bash
$ ruby -v
ruby 2.2.4p230 (2015-12-16 revision 53155) [x86_64-darwin14]

$ mysqld --version
mysqld  Ver 5.6.26 for osx10.10 on x86_64 (Homebrew)

$ mysql --version
mysql  Ver 14.14 Distrib 5.6.26, for osx10.10 (x86_64) using  EditLine wrapper
```

I was expecting this change to create some breakage in the test suite, but it passed. I noticed [a reference about this from a while back](https://github.com/brianmario/mysql2/issues/107#issuecomment-665747) implying it would be a difficult change -- do you know if that is that still the case? /cc @tenderlove @brianmario

Clearly this could be a risky change, since it changes behavior that folks may be relying on. On the other hand, it doesn't appear to break anything in the test suite, and I think it is better default since it is makes the MySQL connection behave in the way you'd expect without knowing that the AR MySQL2 adapter sets the CLIENT_NOT_FOUND flag. I'd definitely consider it a breaking change, either way.

Interested to hear thoughts. Am I missing any important behavior that relies on this flag, which is not well covered by the test suite? Any other gotchas?
