### PR TITLE
Remove unnecessary `assert_date_from_db`

### DIFF
--- a/activerecord/test/cases/multiparameter_attributes_test.rb
+++ b/activerecord/test/cases/multiparameter_attributes_test.rb
@@ -11,7 +11,7 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
     topic.attributes = attributes
     # note that extra #to_date call allows test to pass for Oracle, which
     # treats dates/times the same
-    assert_date_from_db Date.new(2004, 6, 24), topic.last_read.to_date
+    assert_equal Date.new(2004, 6, 24), topic.last_read.to_date
   end
 
   def test_multiparameter_attributes_on_date_with_empty_year

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -12,10 +12,6 @@ module ActiveRecord
       SQLCounter.clear_log
     end
 
-    def assert_date_from_db(expected, actual, message = nil)
-      assert_equal expected.to_s, actual.to_s, message
-    end
-
     def capture_sql
       SQLCounter.clear_log
       yield


### PR DESCRIPTION
`assert_date_from_db` was added at 6a2104d for SQL Server.
But latest sqlserver adapter work to pass expected behavior since
8e4624b.
