### PR TITLE
Fix `calculate` with a string value in `from` and eager loading

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -398,15 +398,7 @@ module ActiveRecord
     end
 
     def construct_relation_for_association_calculations
-      from = arel.froms.first
-      if Arel::Table === from
-        apply_join_dependency(self, construct_join_dependency(joins_values))
-      else
-        # FIXME: as far as I can tell, `from` will always be an Arel::Table.
-        # There are no tests that test this branch, but presumably it's
-        # possible for `from` to be a list?
-        apply_join_dependency(self, construct_join_dependency(from))
-      end
+      apply_join_dependency(self, construct_join_dependency(joins_values))
     end
 
     def apply_join_dependency(relation, join_dependency)

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -90,6 +90,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_no_queries { authors.map(&:post) }
   end
 
+  def test_calculate_with_string_in_from_and_eager_loading
+    assert_equal 10, Post.from("authors, posts").eager_load(:comments).where("posts.author_id = authors.id").count
+  end
+
   def test_with_two_tables_in_from_without_getting_double_quoted
     posts = Post.select("posts.*").from("authors, posts").eager_load(:comments).where("posts.author_id = authors.id").order("posts.id").to_a
     assert_equal 2, posts.first.comments.size


### PR DESCRIPTION
`construct_relation_for_association_calculations` pass a string value to
`construct_join_dependency` when setting a string value in `from`.
It should not pass a string value, but always `joins_values`.

Related #14834, #19452.

Fixes #24193.
