### PR TITLE
Remove an unused require in ActiveSupport::TestCase

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/object/blank'
-
 module ActiveSupport
   module Testing
     module Assertions


### PR DESCRIPTION
We used to have `assert_blank` and `assert_present`. [ci skip]
