### PR TITLE
add multi_caches helper for preloading multiple fragment caches in a single read_multi request

### DIFF
--- a/actionpack/lib/abstract_controller/caching/fragments.rb
+++ b/actionpack/lib/abstract_controller/caching/fragments.rb
@@ -92,6 +92,17 @@ module AbstractController
         end
       end
 
+      def read_multi_fragments(keys, options = nil)
+        return unless cache_configured?
+
+        keys = keys.map { |key| fragment_cache_key(key) }
+        instrument_fragment_cache :read_multi_fragments, count: keys.size do |payload|
+          results = cache_store.read_multi(keys, options)
+          payload[:cache_hits] = results.size
+          results.map { |result| result.respond_to?(:html_safe) ? result.html_safe : result }
+        end
+      end
+
       # Check if a cached fragment from the location signified by
       # +key+ exists (see +expire_fragment+ for acceptable formats).
       def fragment_exist?(key, options = nil)


### PR DESCRIPTION
### Summary

In a similar vein to cached collection partial rendering, I propose a way to preload multiple cache blocks in a single `read_multi` request. Which will turn codes like:

``` rb
cache(cache_key_a) do # trigger cache read
end

cache(cache_key_b) do # trigger cache read
end

cache(cache_key_c) do # trigger cache read
end
```

to

``` rb
multi_caches([cache_key_a, cache_key_b, cache_key_c]) do # trigger cache read_multi
  cache(cache_key_a) do # no cache read
  end

  cache(cache_key_b) do # no cache read
  end

  cache(cache_key_c) do # no cache read
  end
end
```

Which would be useful to improve performance of dashboard or statistic type pages displaying summaries information from multiple different loosely related resources.

Even though currently we can do something similar by wrapping the smaller caches inside a normal cache block, this will result in an increase in cache memory usage, since the outer cache need to be stored under its own key even though the content is composed of smaller cached contents each also stored under their own keys.
### Other Information

It's still an early implementation, and I haven't test if it's actually working or not, but I would like to get some feedback if the idea is feasible/acceptable, and if it is, I will refine the implementation, add tests and add some comments/documentation.. :grin: 

I'm also a bit unsure regarding the name, perhaps instead of `multi_caches` it should be named `preload_caches`?
