### PR TITLE
[WIP] Check if given param is a hash, instead of having #stringify_keys

### DIFF
--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -24,10 +24,10 @@ module ActiveModel
     #   cat.name # => 'Gorby'
     #   cat.status => 'sleeping'
     def assign_attributes(new_attributes)
-      if !new_attributes.respond_to?(:stringify_keys)
+      unless new_attributes.is_a?(Hash)
         raise ArgumentError, "When assigning attributes, you must pass a hash as an argument."
       end
-      return if new_attributes.nil? || new_attributes.empty?
+      return if new_attributes.empty?
 
       attributes = new_attributes.stringify_keys
       _assign_attributes(sanitize_for_mass_assignment(attributes))

--- a/activemodel/test/cases/attribute_assignment_test.rb
+++ b/activemodel/test/cases/attribute_assignment_test.rb
@@ -24,6 +24,10 @@ class AttributeAssignmentTest < ActiveModel::TestCase
   class ErrorFromAttributeWriter < StandardError
   end
 
+  class ClassWithMethodStringifyKeys
+    def stringify_keys; nil; end
+  end
+
   class ProtectedParams
     attr_accessor :permitted
     alias :permitted? :permitted
@@ -91,37 +95,40 @@ class AttributeAssignmentTest < ActiveModel::TestCase
   end
 
   test "an ArgumentError is raised if a non-hash-like object is passed" do
-    assert_raises(ArgumentError) do
-      Model.new(1)
+    [nil, 1, 'str', [], -> {}].each do |obj|
+      assert_raises(ArgumentError) { Model.new(obj) }
     end
   end
 
   test "forbidden attributes cannot be used for mass assignment" do
-    params = ProtectedParams.new(name: "Guille", description: "m")
-
-    assert_raises(ActiveModel::ForbiddenAttributesError) do
-      Model.new(params)
-    end
+    params = { name: "Guille", description: "m" }
+    Hash.class_eval { def permitted?; false; end }
+    assert_raises(ActiveModel::ForbiddenAttributesError) { Model.new(params) }
+    Hash.class_eval { undef permitted? }
   end
 
   test "permitted attributes can be used for mass assignment" do
-    params = ProtectedParams.new(name: "Guille", description: "desc")
-    params.permit!
+    params = { name: "Guille", description: "desc" }
+    Hash.class_eval { def permitted?; true; end }
     model = Model.new(params)
-
     assert_equal "Guille", model.name
     assert_equal "desc", model.description
+    Hash.class_eval { undef permitted? }
+  end
+
+  test 'an ArgumentError is raised even given param has #stringify_keys' do
+    obj = ClassWithMethodStringifyKeys.new
+    assert_raises(ArgumentError) { Model.new(obj) }
   end
 
   test "regular hash should still be used for mass assignment" do
     model = Model.new(name: "Guille", description: "m")
-
     assert_equal "Guille", model.name
     assert_equal "m", model.description
   end
 
   test "assigning no attributes should not raise, even if the hash is un-permitted" do
     model = Model.new
-    assert_nil model.assign_attributes(ProtectedParams.new({}))
+    assert_nil model.assign_attributes({})
   end
 end


### PR DESCRIPTION
``` ruby
ActiveModel::AttributeAssignment#assign_attributes(new_attributes)
```
- `new_attributes` has to be a Hash even if `new_attributes` has a method `#stringify_keys`.
