### PR TITLE
Require "active_support/core_ext/object/blank" for railties abstract unit

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -18,6 +18,7 @@ RAILS_FRAMEWORK_ROOT = File.expand_path("#{File.dirname(__FILE__)}/../../..")
 
 # These files do not require any others and are needed
 # to run the tests
+require "active_support/core_ext/object/blank"
 require "active_support/testing/isolation"
 require "active_support/core_ext/kernel/reporting"
 require 'tmpdir'


### PR DESCRIPTION
In #25380 I removed an `active_support/core_ext/object/blank` require in the
`activesupport/lib/active_support/testing/assertions.rb`, however it caused a
chain reaction, resulting in failing railties tests. Moving the require to
`railties/test/isolation/abstract_unit.rb` solves the problem and keeps the
require close to where it is used.
