### PR TITLE
Experimental Alternative to #25302

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -3,6 +3,34 @@ require 'pathname'
 require 'concurrent/atomic/atomic_boolean'
 
 module ActiveSupport
+  # Allows you to "listen" to changes in a file system.
+  # The evented file updater does not hit disk when checking for updates
+  # instead it uses platform specific file system events to trigger a change
+  # in state.
+  #
+  # The file checker takes an array of files to watch or a hash specifying directories
+  # and file extensions to watch. It also takes a block that is called when
+  # EventedFileUpdateChecker#execute is run or when EventedFileUpdateChecker#execute_if_updated
+  # is run and there have been changes to the file system.
+  #
+  # Note: To start listening to change events you must first call
+  # EventedFileUpdateChecker#updated? inside of each process.
+  #
+  # Example:
+  #
+  #     checker = EventedFileUpdateChecker.new(["/tmp/foo"], -> { puts "changed" })
+  #     checker.updated?
+  #     # => false
+  #     checker.execute_if_updated
+  #     # => nil
+  #
+  #     FileUtils.touch("/tmp/foo")
+  #
+  #     checker.updated?
+  #     # => true
+  #     checker.execute_if_updated
+  #     # => "changed"
+  #
   class EventedFileUpdateChecker #:nodoc: all
     def initialize(files, dirs = {}, &block)
       @ph    = PathHelper.new

--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -44,7 +44,8 @@ module ActiveSupport
       @updated    = Concurrent::AtomicBoolean.new(false)
       @lcsp       = @ph.longest_common_subpath(@dirs.keys)
       @pid_hash   = Concurrent::Hash.new
-      @parent_pid = Process.pid
+      @pid        = Process.pid
+      @boot_mutex = Mutex.new
 
       if (@dtw = directories_to_watch).any?
         # Loading listen triggers warnings. These are originated by a legit
@@ -62,7 +63,13 @@ module ActiveSupport
     end
 
     def updated?
-      boot! unless @pid_hash[Process.pid]
+      @boot_mutex.synchronize do
+        if @pid != Process.pid
+          boot!
+          @pid = Process.pid
+          @updated.make_true
+        end
+      end
       @updated.true?
     end
 
@@ -82,8 +89,6 @@ module ActiveSupport
     private
       def boot!
         Listen.to(*@dtw, &method(:changed)).start
-        @pid_hash[Process.pid] = true
-        @updated.make_true if @parent_pid != Process.pid
       end
 
       def changed(modified, added, removed)

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -11,7 +11,8 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
   end
 
   def new_checker(files = [], dirs = {}, &block)
-    ActiveSupport::EventedFileUpdateChecker.new(files, dirs, &block).tap do
+    ActiveSupport::EventedFileUpdateChecker.new(files, dirs, &block).tap do |c|
+      c.updated?
       wait
     end
   end

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -12,7 +12,6 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
 
   def new_checker(files = [], dirs = {}, &block)
     ActiveSupport::EventedFileUpdateChecker.new(files, dirs, &block).tap do |c|
-      c.updated?
       wait
     end
   end
@@ -34,6 +33,48 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
   def rm_f(files)
     super
     wait
+  end
+
+  test 'notifies forked processes' do
+    FileUtils.touch(tmpfiles)
+
+    checker = new_checker(tmpfiles) { }
+    assert !checker.updated?
+
+    # Pipes used for flow controll across fork.
+    boot_reader,  boot_writer  = IO.pipe
+    touch_reader, touch_writer = IO.pipe
+
+    pid = fork do
+      assert checker.updated?
+
+      # Clear previous check value.
+      checker.execute
+      assert !checker.updated?
+
+      # Fork is booted, ready for file to be touched
+      # notify parent process.
+      boot_writer.write("booted")
+
+      # Wait for parent process to signal that file
+      # has been touched.
+      IO.select([touch_reader])
+
+      assert checker.updated?
+    end
+
+    assert pid
+
+    # Wait for fork to be booted before touching files.
+    IO.select([boot_reader])
+    touch(tmpfiles)
+
+    # Notify fork that files have been touched.
+    touch_writer.write("touched")
+
+    assert checker.updated?
+
+    Process.wait(pid)
   end
 end
 

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -46,10 +46,7 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
     touch_reader, touch_writer = IO.pipe
 
     pid = fork do
-      assert checker.updated?
-
       # Clear previous check value.
-      checker.execute
       assert !checker.updated?
 
       # Fork is booted, ready for file to be touched


### PR DESCRIPTION
With #25302 we have to assume that the files on disk have changed in a fork. This means that the first call to `updated? must always be true. Instead we can use 3 different IO.pipe to synchronize communications between between any number of forked processes.

We use 1 pipe for the primary communication, another pipe is used by children to notify the parent that a new fork has booted. Once a child is detected as being booted a value is written to the primary pipe either 'T' if the files have changed or 'F' if they haven't. Once the value is read the same pipe responds with on the final pipe with an ACK. This lets the parent know that 1 of the processes has received a message and it can begin waiting for the next process to boot.

There exists a scenario where a race condition is possible. Parent PID boots, and there's no changes on disk. Child process boots and asks the parent if there are any changes. The parent PID may send a "F" to the child but between the time that the "F" is sent and it is read the file may change. We can eliminate this race condition if we boot the listener on the child process before we tell the parent that the child has booted. That's exactly what this PR does, is hooks into the `before_listen` and uses that to boot a worker before we even tell the parent process we've booted.

As is this is a WIP and more of a proof of concept. I think it's an interesting solution that may possibly be viable. It seems more technically complete than #25302 however that completeness comes at additional complexity. cc @e2
