### PR TITLE
Backport to 4.2: Broadcast #silence on ActiveSupport::Logger

### DIFF
--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -47,16 +47,16 @@ module ActiveSupport
         end
 
         define_method(:silence) do |level = Logger::ERROR, &block|
-          if logger.respond_to?(:silence)
+          if logger.respond_to?(:silence) && logger.method(:silence).owner != ::Kernel
             logger.silence(level) do
-              if respond_to?(:silence)
+              if respond_to?(:silence) && method(:silence).owner != ::Kernel
                 super(level, &block)
               else
                 block.call(self)
               end
             end
           else
-            if respond_to?(:silence)
+            if respond_to?(:silence) && method(:silence).owner != ::Kernel
               super(level, &block)
             else
               block.call(self)

--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -52,14 +52,14 @@ module ActiveSupport
               if respond_to?(:silence)
                 super(level, &block)
               else
-                block.call(level)
+                block.call(self)
               end
             end
           else
             if respond_to?(:silence)
               super(level, &block)
             else
-              block.call(level)
+              block.call(self)
             end
           end
         end

--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -45,6 +45,24 @@ module ActiveSupport
           logger.local_level = level if logger.respond_to?(:local_level=)
           super(level) if respond_to?(:local_level=)
         end
+
+        define_method(:silence) do |level = Logger::ERROR, &block|
+          if logger.respond_to?(:silence)
+            logger.silence(level) do
+              if respond_to?(:silence)
+                super(level, &block)
+              else
+                block.call(level)
+              end
+            end
+          else
+            if respond_to?(:silence)
+              super(level, &block)
+            else
+              block.call(level)
+            end
+          end
+        end
       end
     end
 

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -3,75 +3,147 @@ require 'abstract_unit'
 module ActiveSupport
   class BroadcastLoggerTest < TestCase
     attr_reader :logger, :log1, :log2
-    def setup
+
+    setup do
       @log1 = FakeLogger.new
       @log2 = FakeLogger.new
       @log1.extend Logger.broadcast @log2
       @logger = @log1
     end
 
-    def test_debug
-      logger.debug "foo"
-      assert_equal 'foo', log1.adds.first[2]
-      assert_equal 'foo', log2.adds.first[2]
+    Logger::Severity.constants.each do |level_name|
+      method = level_name.downcase
+      level = Logger::Severity.const_get(level_name)
+
+      test "##{method} adds the message to all loggers" do
+        logger.send(method, "msg")
+
+        assert_equal [level, "msg", nil], log1.adds.first
+        assert_equal [level, "msg", nil], log2.adds.first
+      end
     end
 
-    def test_close
+    test "#close broadcasts to all loggers" do
       logger.close
+
       assert log1.closed, 'should be closed'
       assert log2.closed, 'should be closed'
     end
 
-    def test_chevrons
+    test "#<< shovels the value into all loggers" do
       logger << "foo"
+
       assert_equal %w{ foo }, log1.chevrons
       assert_equal %w{ foo }, log2.chevrons
     end
 
-    def test_level
-      assert_nil logger.level
-      logger.level = 10
-      assert_equal 10, log1.level
-      assert_equal 10, log2.level
+    test "#level= assigns the level to all loggers" do
+      assert_equal ::Logger::DEBUG, logger.level
+      logger.level = ::Logger::FATAL
+
+      assert_equal ::Logger::FATAL, log1.level
+      assert_equal ::Logger::FATAL, log2.level
     end
 
-    def test_progname
+    test "#progname= assigns to all the loggers" do
       assert_nil logger.progname
-      logger.progname = 10
-      assert_equal 10, log1.progname
-      assert_equal 10, log2.progname
+      logger.progname = ::Logger::FATAL
+
+      assert_equal ::Logger::FATAL, log1.progname
+      assert_equal ::Logger::FATAL, log2.progname
     end
 
-    def test_formatter
+    test "#formatter= assigns to all the loggers" do
       assert_nil logger.formatter
-      logger.formatter = 10
-      assert_equal 10, log1.formatter
-      assert_equal 10, log2.formatter
+      logger.formatter = ::Logger::FATAL
+
+      assert_equal ::Logger::FATAL, log1.formatter
+      assert_equal ::Logger::FATAL, log2.formatter
+    end
+
+    test "#local_level= assigns the local_level to all loggers" do
+      assert_equal ::Logger::DEBUG, logger.local_level
+      logger.local_level = ::Logger::FATAL
+
+      assert_equal ::Logger::FATAL, log1.local_level
+      assert_equal ::Logger::FATAL, log2.local_level
+    end
+
+    test "#silence silences all loggers below the default level of ERROR" do
+      logger.silence do
+        logger.debug "test"
+      end
+
+      assert_equal [], log1.adds
+      assert_equal [], log2.adds
+    end
+
+    test "#silence does not silence at or above ERROR" do
+      logger.silence do
+        logger.error "from error"
+        logger.unknown "from unknown"
+      end
+
+      assert_equal [[::Logger::ERROR, "from error", nil], [::Logger::UNKNOWN, "from unknown", nil]], log1.adds
+      assert_equal [[::Logger::ERROR, "from error", nil], [::Logger::UNKNOWN, "from unknown", nil]], log2.adds
+    end
+
+    test "#silence allows you to override the silence level" do
+      logger.silence(::Logger::FATAL) do
+        logger.error "unseen"
+        logger.fatal "seen"
+      end
+
+      assert_equal [[::Logger::FATAL, "seen", nil]], log1.adds
+      assert_equal [[::Logger::FATAL, "seen", nil]], log2.adds
     end
 
     class FakeLogger
+      include LoggerSilence
+
       attr_reader :adds, :closed, :chevrons
-      attr_accessor :level, :progname, :formatter
+      attr_accessor :level, :progname, :formatter, :local_level
 
       def initialize
-        @adds      = []
-        @closed    = false
-        @chevrons  = []
-        @level     = nil
-        @progname  = nil
-        @formatter = nil
+        @adds        = []
+        @closed      = false
+        @chevrons    = []
+        @level       = ::Logger::DEBUG
+        @local_level = ::Logger::DEBUG
+        @progname    = nil
+        @formatter   = nil
       end
 
-      def debug msg, &block
-        add(:omg, nil, msg, &block)
+      def debug(message, &block)
+        add(::Logger::DEBUG, message, &block)
+      end
+
+      def info(message, &block)
+        add(::Logger::INFO, message, &block)
+      end
+
+      def warn(message, &block)
+        add(::Logger::WARN, message, &block)
+      end
+
+      def error(message, &block)
+        add(::Logger::ERROR, message, &block)
+      end
+
+      def fatal(message, &block)
+        add(::Logger::FATAL, message, &block)
+      end
+
+      def unknown(message, &block)
+        add(::Logger::UNKNOWN, message, &block)
       end
 
       def << x
         @chevrons << x
       end
 
-      def add(*args)
-        @adds << args
+      def add(message_level, message=nil, progname=nil, &block)
+        @adds << [message_level, message, progname] if message_level >= local_level
       end
 
       def close

--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -140,7 +140,8 @@ class LoggerTest < ActiveSupport::TestCase
     @logger.extend Logger.broadcast(another_logger)
 
     @logger.debug "CORRECT DEBUG"
-    @logger.silence do
+    @logger.silence do |logger|
+      assert_kind_of ActiveSupport::Logger, logger
       @logger.debug "FAILURE"
       @logger.error "CORRECT ERROR"
     end
@@ -161,7 +162,8 @@ class LoggerTest < ActiveSupport::TestCase
     @logger.extend Logger.broadcast(another_logger)
 
     @logger.debug "CORRECT DEBUG"
-    @logger.silence do
+    @logger.silence do |logger|
+      assert_kind_of ActiveSupport::Logger, logger
       @logger.debug "FAILURE"
       @logger.error "CORRECT ERROR"
     end


### PR DESCRIPTION
@rafaelfranca @sgrif @tenderlove 

Backport of #25341 to `4-2-stable`. Follow up to #25356. Includes the related bug @rafaelfranca fixed in 5e77a707f287798c5a683508919e01240d202800 backported as well. 
## Problem

As explained in the original issue, the call to `ActiveSupport::Logger#silence` is not correctly delegated to broadcasted loggers. This was fixed by implementing the `#silence` method for logger broadcasting. This, along with rewriting the tests, was done on `master`.

Unfortunately, since on 4.2 in `reporting.rb` there are a number of `Kernel` patches, which includes aliasing the `Kernel#capture` method to `silence`:
https://github.com/rails/rails/blob/806e816bb972296f7419a7fbe67cb8a8c0eab6b5/activesupport/lib/active_support/core_ext/kernel/reporting.rb#L108

This means the `respond_to?` checks break because it duck-types to a logger which supports `silence`, but actually calls out to an unrelated method.
## Solution

It's nasty, but I also validate that the `silence` method is not on `Kernel`. 😞 

I'm open to further suggestions. There's not much prescient for this kind of check. 

Up side is that this is only required in the backport as patch is deprecated and removed on master. If I'm going to refactor/reimplement logger broadcasting I'm not going to do it on the backport branch.
