### PR TITLE
Quoting booleans should return a frozen string

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -112,19 +112,19 @@ module ActiveRecord
       end
 
       def quoted_true
-        "'t'"
+        "'t'".freeze
       end
 
       def unquoted_true
-        't'
+        't'.freeze
       end
 
       def quoted_false
-        "'f'"
+        "'f'".freeze
       end
 
       def unquoted_false
-        'f'
+        'f'.freeze
       end
 
       # Quote date/time values for use in SQL input. Includes microseconds

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module ConnectionAdapters
     module MySQL
       module Quoting # :nodoc:
-        QUOTED_TRUE, QUOTED_FALSE = '1', '0'
+        QUOTED_TRUE, QUOTED_FALSE = '1'.freeze, '0'.freeze
 
         def quote_column_name(name)
           @quoted_column_names[name] ||= "`#{super.gsub('`', '``')}`"

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -149,5 +149,21 @@ module ActiveRecord
         assert_equal "1800", @quoter.quote(30.minutes)
       end
     end
+
+    class QuoteBooleanTest < ActiveRecord::TestCase
+      def setup
+        @connection = ActiveRecord::Base.connection
+      end
+
+      def test_quote_returns_frozen_string
+        assert_predicate @connection.quote(true), :frozen?
+        assert_predicate @connection.quote(false), :frozen?
+      end
+
+      def test_type_cast_returns_frozen_value
+        assert_predicate @connection.type_cast(true), :frozen?
+        assert_predicate @connection.type_cast(false), :frozen?
+      end
+    end
   end
 end


### PR DESCRIPTION
Quoting and type casting should return new quoted boolean instance.

```
Loading development environment (Rails 5.1.0.alpha)
irb(main):001:0> ActiveRecord::Base.connection.quote(true) << ' foo'
=> "1 foo"
irb(main):002:0> ActiveRecord::Base.connection.quote(true) << ' foo'
=> "1 foo foo"
irb(main):003:0> type = ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::MysqlString.new
=> #<ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::MysqlString:0x007fd40c15e018 @precision=nil, @scale=nil, @limit=nil>
irb(main):004:0> type.serialize(true) << ' bar'
=> "1 foo foo bar"
irb(main):005:0> type.cast(true) << ' bar'
=> "1 foo foo bar bar"
```
