### PR TITLE
Add test to better demonstrate `ActiveModel::Errors#added?` behavior

### DIFF
--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -219,6 +219,12 @@ class ErrorsTest < ActiveModel::TestCase
     assert !person.errors.added?(:name, "cannot be blank")
   end
 
+  test "added? returns false when checking for an error, but not providing message arguments" do
+    person = Person.new
+    person.errors.add(:name, "cannot be blank")
+    assert !person.errors.added?(:name)
+  end
+
   test "size calculates the number of error messages" do
     person = Person.new
     person.errors.add(:name, "cannot be blank")


### PR DESCRIPTION
If passing in the Symbol form identifier for the error, then it will not
be in `messages`, so we need to check `details`. Likewise, the fully
composed error message (ex: "is too long (maximum is 25 characters)") is
not in `details`, but is in `messages. Via this patch, we will now be
checking both data sources.

Fixes #25410
