### PR TITLE
[ci skip] Remove duplicate alias documentation in ActiveModel::Validations

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -304,8 +304,6 @@ module ActiveModel
     # Runs all the specified validations and returns +true+ if no errors were
     # added otherwise +false+.
     #
-    # Aliased as validate.
-    #
     #   class Person
     #     include ActiveModel::Validations
     #


### PR DESCRIPTION
### Summary

RDoc already adds a linked line where the alias is declared:

> _Also aliased as: validate_

This removes the redundant line.

![duplication](https://cloud.githubusercontent.com/assets/5634381/16119796/a9555840-33a2-11e6-9f6a-1c7551ed7ea7.PNG)
