### PR TITLE
Allow actioncable connections from all ports in development

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -22,7 +22,7 @@ module ActionCable
 
     initializer "action_cable.set_configs" do |app|
       options = app.config.action_cable
-      options.allowed_request_origins ||= "http://localhost:3000" if ::Rails.env.development?
+      options.allowed_request_origins ||= /https?:\/\/localhost:\d+/ if ::Rails.env.development?
 
       app.paths.add "config/cable", with: "config/cable.yml"
 


### PR DESCRIPTION
### Summary

This PR addresses the issue raised in rails#25406 which is that changing the port number via `rails s -p xxxx`, where `xxxx != 3000`,  causes actioncable to fail with the following errors being logged to the javascript console and server logs:
#### Javascript

`WebSocket connection to 'ws://localhost:xxxx/cable' failed: Error during WebSocket handshake: Unexpected response code: 404`
#### Server Logs

`Request origin not allowed: http://localhost:xxxx Failed to upgrade to WebSocket (REQUEST_METHOD: GET, HTTP_CONNECTION: Upgrade, HTTP_UPGRADE: websocket)`

This issue is resolved by allowing any port to use actioncable in development. I would have preferred to be specific about the port, but at the point `engine.rb` is loaded, `ENV[PORT]` is not set, and allowing all ports removes the need to resort to things like [this](http://stackoverflow.com/questions/4295816/how-to-tell-which-port-rails-is-running-on-in-an-initializer/13839413#13839413).
