### PR TITLE
Use "show_source_idx" to find current source

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
@@ -19,7 +19,7 @@
 
   <script type="text/javascript">
     var traceFrames = document.getElementsByClassName('trace-frames');
-    var selectedFrame, currentSource = document.getElementById('frame-source-0');
+    var selectedFrame, currentSource = document.getElementById('frame-source-<%= @show_source_idx %>');
 
     // Add click listeners for all stack frames
     for (var i = 0; i < traceFrames.length; i++) {


### PR DESCRIPTION
### Summary

This fixes a small bug of the ActionDispatch's template.

In the ActionDispatch's traces, the application trace could be indexed in other than the zeroth order. It can occur a wrong behavior when we change extracted source by clicking a trace link (see below gif). We should use `@show_source_idx` to find current source.
### Other Information
#### The wrong behavior

![wrong-behavior](https://raw.githubusercontent.com/sh19910711/test/sh19910711-patch-1/action-dispatch-current.gif)

Thanks.
