### PR TITLE
Fix jobs overriding AJ::Base#logger

### DIFF
--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -41,7 +41,7 @@ module ActiveJob
       def tag_logger(*tags)
         if logger.respond_to?(:tagged)
           tags.unshift "ActiveJob" unless logger_tagged_by_active_job?
-          ActiveJob::Base.logger.tagged(*tags){ yield }
+          logger.tagged(*tags){ yield }
         else
           yield
         end

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -3,6 +3,7 @@ require "active_support/log_subscriber/test_helper"
 require 'active_support/core_ext/numeric/time'
 require 'jobs/hello_job'
 require 'jobs/logging_job'
+require 'jobs/overridden_logging_job'
 require 'jobs/nested_job'
 require 'models/person'
 
@@ -40,7 +41,6 @@ class LoggingTest < ActiveSupport::TestCase
   def set_logger(logger)
     ActiveJob::Base.logger = logger
   end
-
 
   def test_uses_active_job_as_tag
     HelloJob.perform_later "Cristian"
@@ -118,5 +118,10 @@ class LoggingTest < ActiveSupport::TestCase
     assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
   rescue NotImplementedError
     skip
+  end
+
+  def test_for_tagged_logger_support_is_consistent
+    set_logger ::Logger.new(nil)
+    OverriddenLoggingJob.perform_later "Dummy"
   end
 end

--- a/activejob/test/jobs/overridden_logging_job.rb
+++ b/activejob/test/jobs/overridden_logging_job.rb
@@ -1,0 +1,9 @@
+class OverriddenLoggingJob < ActiveJob::Base
+  def perform(dummy)
+    logger.info "Dummy, here is it: #{dummy}"
+  end
+
+  def logger
+    @logger ||= ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(nil))
+  end
+end


### PR DESCRIPTION
I was tracking down this bug on our test suite:

``` ruby
    NoMethodError: undefined method `tagged' for #<Logger:0x007fba48a52ad0>
    (activejob-4.2.6) lib/active_job/logging.rb:43 in `tag_logger`
    (activejob-4.2.6) lib/active_job/logging.rb:13 in `in `block (2 levels) in <module`
    (activesupport-4.2.6) lib/active_support/callbacks.rb:441 in `instance_exec`
    (activesupport-4.2.6) lib/active_support/callbacks.rb:441 in `block in make_lambda`
    (activesupport-4.2.6) lib/active_support/callbacks.rb:342 in `call`
    (activesupport-4.2.6) lib/active_support/callbacks.rb:342 in `block in simple`
    (activesupport-4.2.6) lib/active_support/callbacks.rb:497 in `call`
    (activesupport-4.2.6) lib/active_support/callbacks.rb:497 in `block in around`
    (activesupport-4.2.6) lib/active_support/callbacks.rb:505 in `call`
    (activesupport-4.2.6) lib/active_support/callbacks.rb:505 in `call`
    (activesupport-4.2.6) lib/active_support/callbacks.rb:92 in `__run_callbacks__`
    (activesupport-4.2.6) lib/active_support/callbacks.rb:778 in `_run_enqueue_callbacks`
    (activesupport-4.2.6) lib/active_support/callbacks.rb:81 in `run_callbacks`
    (activejob-4.2.6) lib/active_job/enqueuing.rb:67 in `enqueue`
```

Turns out, we migrated a lot of old code to ActiveJob, and some of those old job had a `logger` method.
In some specific cases, `#logger` would be taggable, but `ActiveJob::Base.logger` wouldn't.

@rafaelfranca 
