### PR TITLE
Update increment! documentation [ci skip]

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -329,10 +329,10 @@ module ActiveRecord
       self
     end
 
-    # Wrapper around #increment that saves the record. This method differs from
-    # its non-bang version in that it passes through the attribute setter.
-    # Saving is not subjected to validation checks. Returns +true+ if the
-    # record could be saved.
+    # Wrapper around #increment that writes the update to the database.
+    # Only +attribute+ is updated; the record itself is not saved.
+    # This means that any other modified attributes will still be dirty.
+    # Validations and callbacks are skipped. Returns +self+.
     def increment!(attribute, by = 1)
       increment(attribute, by)
       change = public_send(attribute) - (attribute_was(attribute.to_s) || 0)
@@ -348,10 +348,10 @@ module ActiveRecord
       increment(attribute, -by)
     end
 
-    # Wrapper around #decrement that saves the record. This method differs from
-    # its non-bang version in the sense that it passes through the attribute setter.
-    # Saving is not subjected to validation checks. Returns +true+ if the
-    # record could be saved.
+    # Wrapper around #decrement that writes the update to the database.
+    # Only +attribute+ is updated; the record itself is not saved.
+    # This means that any other modified attributes will still be dirty.
+    # Validations and callbacks are skipped. Returns +self+.
     def decrement!(attribute, by = 1)
       increment!(attribute, -by)
     end

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -202,11 +202,9 @@ The following methods trigger callbacks:
 
 * `create`
 * `create!`
-* `decrement!`
 * `destroy`
 * `destroy!`
 * `destroy_all`
-* `increment!`
 * `save`
 * `save!`
 * `save(validate: false)`


### PR DESCRIPTION
The `increment!` and `decrement!` methods were reimplemented in https://github.com/rails/rails/pull/11410 to make them safe to call from multiple connections concurrently. This changed their behaviour in a few ways.

Previously they used `update_attribute`, which calls the attribute setter method, runs callbacks, and touches the record. Now they behave more like `update_column`, writing the update to the database directly and bypassing all of those steps.

The change in behaviour was pointed out on the original pull request: https://github.com/rails/rails/pull/11410#discussion_r42289545
