### PR TITLE
`PolymorphicReflection` is not using the methods from `ThroughReflection`

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -135,8 +135,8 @@ module ActiveRecord
     #         BelongsToReflection
     #         HasAndBelongsToManyReflection
     #     ThroughReflection
-    #       PolymorphicReflection
-    #         RuntimeReflection
+    #     PolymorphicReflection
+    #       RuntimeReflection
     class AbstractReflection # :nodoc:
       def through_reflection?
         false
@@ -981,7 +981,7 @@ module ActiveRecord
 
     end
 
-    class PolymorphicReflection < ThroughReflection # :nodoc:
+    class PolymorphicReflection < AbstractReflection # :nodoc:
       def initialize(reflection, previous_reflection)
         @reflection = reflection
         @previous_reflection = previous_reflection


### PR DESCRIPTION
`ThroughReflection` initializes `@delegate_reflection` and delegate all
public methods to `delegate_reflection`. But `PolymorphicReflection`
does not initialize `@delegate_reflection`.
It is enough to inherit `AbstractReflection` (using `alias_candidate`
only).
