### PR TITLE
No need to have conditional based on api options in assets

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/assets/config/manifest.js.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/config/manifest.js.tt
@@ -1,6 +1,4 @@
-<% unless options.api? -%>
 //= link_tree ../images
-<% end -%>
 <% unless options.skip_javascript -%>
 //= link_directory ../javascripts .js
 <% end -%>


### PR DESCRIPTION
- As assets are removed for API only apps anyways, so we don't need any
  conditional upfront.
- assets are removed for API apps here - https://github.com/rails/rails/blob/94ef224aa61ace3fa643eab161ff9056b7d90a62/railties/lib/rails/generators/rails/app/app_generator.rb#L266-L273.
