### PR TITLE
make `as` option work with get parameters

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -336,8 +336,10 @@ module ActionDispatch
             end
             path = request_encoder.append_format_to location.path
             path = location.query ? "#{path}?#{location.query}" : path
-          else
-            path = request_encoder.append_format_to path
+          elsif !as.nil?
+            location = URI.parse(path)
+            path = request_encoder.append_format_to location.path
+            path = location.query ? "#{path}?#{location.query}" : path
           end
 
           hostname, port = host.split(':')

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -1210,6 +1210,20 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_get_parameters_with_as_option
+    with_routing do |routes|
+      routes.draw do
+        ActiveSupport::Deprecation.silence do
+          get ':action' => FooController
+        end
+      end
+
+      get '/foos_json?foo=heyo', as: :json
+
+      assert_equal({ 'foo' => 'heyo' }, response.parsed_body)
+    end
+  end
+
   private
     def post_to_foos(as:)
       with_routing do |routes|


### PR DESCRIPTION
Currently, if path is a relative path, add format without the discrimination of the query.
Therefore, if there is a query, format at end of the query would been added,
format was not be specified correctly.

This fix add format to end of path rather than query.
