### PR TITLE
Fix failing railties tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,7 +300,7 @@ GEM
       serverengine (~> 1.5.11)
       thor
       thread (~> 0.1.7)
-    sprockets (3.6.0)
+    sprockets (3.6.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-export (0.9.1)

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1155,10 +1155,10 @@ YAML
       assert_equal "App's bar partial", last_response.body.strip
 
       get("/assets/foo.js")
-      assert_equal "// Bukkit's foo js", last_response.body.strip
+      assert_match "// Bukkit's foo js", last_response.body.strip
 
       get("/assets/bar.js")
-      assert_equal "// App's bar js", last_response.body.strip
+      assert_match "// App's bar js", last_response.body.strip
 
       # ensure that railties are not added twice
       railties = Rails.application.send(:ordered_railties).map(&:class)


### PR DESCRIPTION
- Railties tests related to fetching asset URL started failing after the
  release of sprockets 3.6.1 on Travis.
- This was due to the change in
  https://github.com/rails/sprockets/pull/311/files
  which changed the logic in `concat_javascript_sources` to add `;` at
  the end of file if the source did not end with semicolon.
- Bumped up sprockets minor version and fixed the failing tests.
