### PR TITLE
Support skip nil for cache fetch

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -179,5 +179,12 @@
 
     *Eileen M. Uchitelle*, *Aaron Patterson*
 
+*   Support not to cache `nil` for `ActiveSupport::Cache#fetch`
+
+        cache.fetch('bar', skip_nil: true) { nil }
+        cache.exist?('bar') # => false
+
+    *Martin Hong*
+
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -229,6 +229,14 @@ module ActiveSupport
       # ask whether you should force a cache write. Otherwise, it's clearer to
       # just call <tt>Cache#write</tt>.
       #
+      # Setting <tt>skip_nil: true</tt> will not cache nil result:
+      #
+      #   cache.fetch('foo') { nil }
+      #   cache.fetch('bar', skip_nil: true) { nil }
+      #   cache.exist?('foo') # => true
+      #   cache.exist?('bar') # => false
+      #
+      #
       # Setting <tt>compress: false</tt> disables compression of the cache entry.
       #
       # Setting <tt>:expires_in</tt> will set an expiration time on the cache.

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -695,7 +695,7 @@ module ActiveSupport
             yield(name)
           end
 
-          write(name, result, options)
+          write(name, result, options) unless result.nil? && options[:skip_nil]
           result
         end
     end

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -52,6 +52,12 @@ module CacheStoreBehavior
     end
   end
 
+  def test_fetch_cache_miss_with_skip_nil
+    assert_not_called(@cache, :write) do
+      assert_nil @cache.fetch("foo", skip_nil: true) { nil }
+    end
+  end
+
   def test_fetch_with_forced_cache_miss_with_block
     @cache.write("foo", "bar")
     assert_equal "foo_bar", @cache.fetch("foo", force: true) { "foo_bar" }

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -55,6 +55,7 @@ module CacheStoreBehavior
   def test_fetch_cache_miss_with_skip_nil
     assert_not_called(@cache, :write) do
       assert_nil @cache.fetch("foo", skip_nil: true) { nil }
+      assert_equal false, @cache.exist?("foo")
     end
   end
 


### PR DESCRIPTION
### Summary

Provide a `skip_nil` setting for cache store. According to our cases, we need to cache some results retrieved from external services with 1 day expiration time, but if they are down with some accidental reasons, nil result will be cached whole day, instead, we hope not to cache that result, so we can always retry retrieving and it can cache expected result again once the services come back normal.

I have added one more spec for this setting and it ensures not to break existed behaviours, I also updated the documentation for #fetch method.
