### PR TITLE
Setup default session store internally, no longer through an initializer

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -362,7 +362,7 @@ If your user sessions don't store critical data or don't need to be around for l
 
 Read more about session storage in the [Security Guide](security.html).
 
-If you need a different session storage mechanism, you can change it in the `config/initializers/session_store.rb` file:
+If you need a different session storage mechanism, you can change it in an initializer:
 
 ```ruby
 # Use the database for sessions instead of the cookie-based default,
@@ -371,7 +371,7 @@ If you need a different session storage mechanism, you can change it in the `con
 # Rails.application.config.session_store :active_record_store
 ```
 
-Rails sets up a session key (the name of the cookie) when signing the session data. These can also be changed in `config/initializers/session_store.rb`:
+Rails sets up a session key (the name of the cookie) when signing the session data. These can also be changed in an initializer:
 
 ```ruby
 # Be sure to restart your server when you modify this file.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -142,7 +142,7 @@ defaults to `:debug` for all environments. The available log levels are: `:debug
 
 * `config.public_file_server.enabled` configures Rails to serve static files from the public directory. This option defaults to `true`, but in the production environment it is set to `false` because the server software (e.g. NGINX or Apache) used to run the application should serve static files instead. If you are running or testing your app in production mode using WEBrick (it is not recommended to use WEBrick in production) set the option to `true.` Otherwise, you won't be able to use page caching and request for files that exist under the public directory.
 
-* `config.session_store` is usually set up in `config/initializers/session_store.rb` and specifies what class to use to store the session. Possible values are `:cookie_store` which is the default, `:mem_cache_store`, and `:disabled`. The last one tells Rails not to deal with sessions. Custom session stores can also be specified:
+* `config.session_store` specifies what class to use to store the session. Possible values are `:cookie_store` which is the default, `:mem_cache_store`, and `:disabled`. The last one tells Rails not to deal with sessions. Defaults to a cookie store with application name as the session key. Custom session stores can also be specified:
 
     ```ruby
     config.session_store :my_custom_store

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Set session store to cookie store internally and remove the initializer from
+    the generated app.
+
+    *Prathamesh Sonpatki*
+
 *   Set the server host using the `HOST` environment variable.
 
     *mahnunchik*

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -188,6 +188,10 @@ module Rails
         end
       end
 
+      def session_store? #:nodoc:
+        @session_store
+      end
+
       def annotations
         SourceAnnotationExtractor::Annotation
       end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -34,8 +34,6 @@ module Rails
         @public_file_server.index_name   = "index"
         @force_ssl                       = false
         @ssl_options                     = {}
-        @session_store                   = :cookie_store
-        @session_options                 = {}
         @time_zone                       = "UTC"
         @beginning_of_week               = :monday
         @log_level                       = nil

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -165,26 +165,31 @@ module Rails
         self.generators.colorize_logging = val
       end
 
-      def session_store(*args)
-        if args.empty?
-          case @session_store
-          when :disabled
-            nil
-          when :active_record_store
+      def session_store(new_session_store = nil, **options)
+        if new_session_store
+
+          if new_session_store == :active_record_store
             begin
               ActionDispatch::Session::ActiveRecordStore
             rescue NameError
               raise "`ActiveRecord::SessionStore` is extracted out of Rails into a gem. " \
                 "Please add `activerecord-session_store` to your Gemfile to use it."
             end
+          end
+
+          @session_store = new_session_store
+          @session_options = options || {}
+        else
+          case @session_store
+          when :disabled
+            nil
+          when :active_record_store
+            ActionDispatch::Session::ActiveRecordStore
           when Symbol
             ActionDispatch::Session.const_get(@session_store.to_s.camelize)
           else
             @session_store
           end
-        else
-          @session_store = args.shift
-          @session_options = args.shift || {}
         end
       end
 

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -33,6 +33,14 @@ module Rails
         end
       end
 
+      # Setup default session store if not already set in config/application.rb
+      initializer :setup_default_session_store, before: :build_middleware_stack do |app|
+        unless app.config.session_store?
+          app_name = app.class.name ? app.railtie_name.chomp('_application') : ''
+          app.config.session_store :cookie_store, key: "_#{app_name}_session"
+        end
+      end
+
       initializer :build_middleware_stack do
         build_middleware_stack
       end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -337,7 +337,6 @@ module Rails
 
       def delete_non_api_initializers_if_api_option
         if options[:api]
-          remove_file 'config/initializers/session_store.rb'
           remove_file 'config/initializers/cookies_serializer.rb'
         end
       end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/session_store.rb.tt
@@ -1,3 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-Rails.application.config.session_store :cookie_store, key: <%= "'_#{app_name}_session'" %>

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1186,6 +1186,22 @@ module ApplicationTests
       end
     end
 
+    test "default session store initializer does not overwrite the user defined session store even if it is disabled" do
+      make_basic_app do |application|
+        application.config.session_store :disabled
+      end
+
+      assert_equal nil, app.config.session_store
+    end
+
+    test "default session store initializer sets session store to cookie store" do
+      session_options = { key: "_myapp_session", cookie_only: true }
+      make_basic_app
+
+      assert_equal ActionDispatch::Session::CookieStore, app.config.session_store
+      assert_equal session_options, app.config.session_options
+    end
+
     test "config.log_level with custom logger" do
       make_basic_app do |application|
         application.config.logger = Logger.new(STDOUT)

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -108,7 +108,6 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
        app/views/layouts/application.html.erb
        config/initializers/assets.rb
        config/initializers/cookies_serializer.rb
-       config/initializers/session_store.rb
        lib/assets
        vendor/assets
        test/helpers

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -131,7 +131,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
         generator.send(:app_const)
         quietly { generator.send(:update_config_files) }
         assert_file "myapp_moved/config/environment.rb", /Rails\.application\.initialize!/
-        assert_file "myapp_moved/config/initializers/session_store.rb", /_myapp_session/
       end
     end
   end
@@ -144,7 +143,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
       generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
       generator.send(:app_const)
       quietly { generator.send(:update_config_files) }
-      assert_file "myapp/config/initializers/session_store.rb", /_myapp_session/
     end
   end
 
@@ -552,13 +550,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "config/application.rb", /\s+require\s+["']active_job\/railtie["']/
   end
 
-  def test_new_hash_style
-    run_generator
-    assert_file "config/initializers/session_store.rb" do |file|
-      assert_match(/config.session_store :cookie_store, key: '_.+_session'/, file)
-    end
-  end
-
   def test_pretend_option
     output = run_generator [File.join(destination_root, "myapp"), "--pretend"]
     assert_no_match(/run  bundle install/, output)
@@ -571,7 +562,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [path, "-d", 'postgresql']
 
     assert_file "foo bar/config/database.yml", /database: foo_bar_development/
-    assert_file "foo bar/config/initializers/session_store.rb", /key: '_foo_bar/
   end
 
   def test_web_console


### PR DESCRIPTION
- By default the session store will be set to cookie store with application name as session key.
- Based on comment by DHH here - https://github.com/rails/rails/issues/25181#issuecomment-222312764.
