### PR TITLE
Temporarily fix for issue #25440

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -309,7 +309,7 @@ module ActiveRecord
     # ==== Example:
     #   # Instantiates a single new object
     #   User.new(first_name: 'Jamie')
-    def initialize(attributes = nil)
+    def initialize(attributes = nil, *args)
       @attributes = self.class._default_attributes.deep_dup
       self.class.define_attribute_methods
 


### PR DESCRIPTION
### Summary

It allows extra arguments so that migration doesn't outputs an error.
See the issue for more details: https://github.com/rails/rails/issues/25440.
Fixes #25440.
