### PR TITLE
Translate NOT NULL violation to the specific exception

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -734,6 +734,8 @@ module ActiveRecord
 
         # See https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html
         ER_DUP_ENTRY            = 1062
+        ER_NOT_NULL_VIOLATION   = 1048
+        ER_DO_NOT_HAVE_DEFAULT  = 1364
         ER_NO_REFERENCED_ROW_2  = 1452
         ER_DATA_TOO_LONG        = 1406
         ER_LOCK_DEADLOCK        = 1213
@@ -756,6 +758,8 @@ module ActiveRecord
             end
           when ER_DATA_TOO_LONG
             ValueTooLong.new(message)
+          when ER_NOT_NULL_VIOLATION, ER_DO_NOT_HAVE_DEFAULT
+            NotNullViolation.new(message)
           when ER_LOCK_DEADLOCK
             Deadlocked.new(message)
           else

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -408,6 +408,7 @@ module ActiveRecord
 
         # See http://www.postgresql.org/docs/current/static/errcodes-appendix.html
         VALUE_LIMIT_VIOLATION = "22001"
+        NOT_NULL_VIOLATION    = "23502"
         FOREIGN_KEY_VIOLATION = "23503"
         UNIQUE_VIOLATION      = "23505"
         SERIALIZATION_FAILURE = "40001"
@@ -423,6 +424,8 @@ module ActiveRecord
             InvalidForeignKey.new(message)
           when VALUE_LIMIT_VIOLATION
             ValueTooLong.new(message)
+          when NOT_NULL_VIOLATION
+            NotNullViolation.new(message)
           when SERIALIZATION_FAILURE
             SerializationFailure.new(message)
           when DEADLOCK_DETECTED

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -530,6 +530,8 @@ module ActiveRecord
           #   column *column_name* is not unique
           when /column(s)? .* (is|are) not unique/, /UNIQUE constraint failed: .*/
             RecordNotUnique.new(message)
+          when /.* may not be NULL/, /NOT NULL constraint failed: .*/
+            NotNullViolation.new(message)
           else
             super
           end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -151,6 +151,10 @@ module ActiveRecord
       end
   end
 
+  # Raised when a record cannot be inserted or updated because it would violate a not null constraint.
+  class NotNullViolation < StatementInvalid
+  end
+
   # Raised when a record cannot be inserted or updated because a value too long for a column type.
   class ValueTooLong < StatementInvalid
   end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -182,6 +182,14 @@ module ActiveRecord
       assert_not_nil error.cause
     end
 
+    def test_not_null_violations_are_translated_to_specific_exception
+      error = assert_raises(ActiveRecord::NotNullViolation) do
+        Post.create
+      end
+
+      assert_not_nil error.cause
+    end
+
     unless current_adapter?(:SQLite3Adapter)
       def test_foreign_key_violations_are_translated_to_specific_exception
         error = assert_raises(ActiveRecord::InvalidForeignKey) do

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -169,7 +169,7 @@ if current_adapter?(:Mysql2Adapter)
           assert_nil record.non_null_text
           assert_nil record.non_null_blob
 
-          assert_raises(ActiveRecord::StatementInvalid) { klass.create }
+          assert_raises(ActiveRecord::NotNullViolation) { klass.create }
         end
       end
     end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -43,7 +43,7 @@ module ActiveRecord
           t.column :foo, :string, null: false
         end
 
-        assert_raises(ActiveRecord::StatementInvalid) do
+        assert_raises(ActiveRecord::NotNullViolation) do
           connection.execute "insert into testings (foo) values (NULL)"
         end
       end
@@ -233,7 +233,7 @@ module ActiveRecord
           end
           connection.add_column :testings, :bar, :string, null: false
 
-          assert_raise(ActiveRecord::StatementInvalid) do
+          assert_raise(ActiveRecord::NotNullViolation) do
             connection.execute "insert into testings (foo, bar) values ('hello', NULL)"
           end
         end
@@ -244,12 +244,16 @@ module ActiveRecord
           t.column :foo, :string
         end
 
-        con = connection
-        connection.execute "insert into testings (#{con.quote_column_name('id')}, #{con.quote_column_name('foo')}) values (1, 'hello')"
-        assert_nothing_raised { connection.add_column :testings, :bar, :string, null: false, default: "default" }
+        quoted_id  = connection.quote_column_name("id")
+        quoted_foo = connection.quote_column_name("foo")
+        quoted_bar = connection.quote_column_name("bar")
+        connection.execute("insert into testings (#{quoted_id}, #{quoted_foo}) values (1, 'hello')")
+        assert_nothing_raised do
+          connection.add_column :testings, :bar, :string, null: false, default: "default"
+        end
 
-        assert_raises(ActiveRecord::StatementInvalid) do
-          connection.execute "insert into testings (#{con.quote_column_name('id')}, #{con.quote_column_name('foo')}, #{con.quote_column_name('bar')}) values (2, 'hello', NULL)"
+        assert_raises(ActiveRecord::NotNullViolation) do
+          connection.execute("insert into testings (#{quoted_id}, #{quoted_foo}, #{quoted_bar}) values (2, 'hello', NULL)")
         end
       end
 


### PR DESCRIPTION
Raise `ActiveRecord::NotNullViolation` when a record cannot be inserted
or updated because it would violate a not null constraint.
