### PR TITLE
[ci skip] correction in command for generating api documentation

### DIFF
--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -20,7 +20,7 @@ The [Rails API documentation](http://api.rubyonrails.org) is generated with
 in the rails root directory, run `bundle install` and execute:
 
 ```bash
-  ./bin/rails rdoc
+  bundle exec rake rdoc
 ```
 
 Resulting HTML files can be found in the ./doc/rdoc directory.


### PR DESCRIPTION
reverts change in previous commit
https://github.com/rails/rails/commit/ea4f0e2

docs should prefer to use `rails` over `rake` in the context of an
application, but not in the context of the Rails source
