### PR TITLE
Remove dormant check

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -876,9 +876,7 @@ module ActiveRecord
       def retrieve_connection(spec_name) #:nodoc:
         pool = retrieve_connection_pool(spec_name)
         raise ConnectionNotEstablished, "No connection pool with id '#{spec_name}' found." unless pool
-        conn = pool.connection
-        raise ConnectionNotEstablished, "No connection for '#{spec_name}' in connection pool" unless conn
-        conn
+        pool.connection
       end
 
       # Returns true if a connection that's accessible to this class has


### PR DESCRIPTION
This check was introduced in 6edaa267174dfedaf5b152b9eba25b4eb5e34c99 and moved through multiple refactorings. No test are broken after removal and AFAICS there is no way to trigger it.
