### PR TITLE
Adds whitespace for consistency

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -169,7 +169,7 @@ class CreateCustomers < ActiveRecord::Migration
     end
 
     create_table :orders do |t|
-      t.belongs_to :customer, index:true
+      t.belongs_to :customer, index: true
       t.datetime :order_date
       t.timestamps null: false
     end


### PR DESCRIPTION
### Summary

There are 11 references to index: true in this file and 10 of them have
space between "index" and "true".  This just makes the 11th one
consistent.

[skip-ci]
