### PR TITLE
Fix association distinct count on column name bug

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -373,10 +373,7 @@ module ActiveRecord
       end
 
       def distinct
-        seen = {}
-        load_target.find_all do |record|
-          seen[record.id] = true unless seen.key?(record.id)
-        end
+        @association_scope.distinct
       end
       alias uniq distinct
 

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -412,9 +412,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   def test_include_has_many_through_polymorphic_has_many
     author            = Author.includes(:taggings).find authors(:david).id
     expected_taggings = taggings(:welcome_general, :thinking_general)
-    assert_no_queries do
-      assert_equal expected_taggings, author.taggings.distinct.sort_by(&:id)
-    end
+    assert_equal expected_taggings, author.taggings.distinct.sort_by(&:id)
   end
 
   def test_eager_load_has_many_through_has_many

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -793,4 +793,11 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 50, result[1].credit_limit
     assert_equal 50, result[2].credit_limit
   end
+
+  def test_distinct_count_on_association_column
+    Contract.destroy_all
+    company = Company.create!(:name => "test", :contracts => [Contract.new(:developer_id => 7), Contract.new(:developer_id => 7), Contract.new(:developer_id => 1)])
+    assert_equal 2, Contract.distinct.count(:developer_id)
+    company.contracts.distinct.count(:developer_id)
+  end
 end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -796,8 +796,8 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_distinct_count_on_association_column
     Contract.destroy_all
-    company = Company.create!(:name => "test", :contracts => [Contract.new(:developer_id => 7), Contract.new(:developer_id => 7), Contract.new(:developer_id => 1)])
+    company = Company.create!(name: "test", contracts: [Contract.new(developer_id: 7), Contract.new(developer_id: 7), Contract.new(developer_id: 1)])
     assert_equal 2, Contract.distinct.count(:developer_id)
-    company.contracts.distinct.count(:developer_id)
+    assert_equal 2, company.contracts.distinct.count(:developer_id)
   end
 end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -775,10 +775,8 @@ class RelationTest < ActiveRecord::TestCase
     author = Author.preload(:taggings).find_by_id(david.id)
     expected_taggings = taggings(:welcome_general, :thinking_general)
 
-    assert_no_queries do
-      assert_equal expected_taggings, author.taggings.distinct.sort_by(&:id)
-      assert_equal expected_taggings, author.taggings.uniq.sort_by(&:id)
-    end
+    assert_equal expected_taggings, author.taggings.distinct.sort_by(&:id)
+    assert_equal expected_taggings, author.taggings.uniq.sort_by(&:id)
 
     authors = Author.all
     assert_equal david, authors.find_by_id_and_name(david.id, david.name)


### PR DESCRIPTION
Fixes a bug in which attempting to count number of distinct entries on a column in an assocation returned 0. The problem can be seen in the test.

`company.contracts.distinct.count(:developer_id)` was returning 0 instead of executing the database query for a distinct count on that property. (Previously this code searched an array of distinct `contracts` for the object `:developer_id` using `Array#count` which seems like the wrong behaviour.)

Any feedback on how to improve this is much appreciated.
