### PR TITLE
[ci skip] Add additional documentation to ActiveModel::Errors

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -382,10 +382,21 @@ module ActiveModel
     end
 
     # Returns +true+ if an error on the attribute with the given message is
-    # present, +false+ otherwise. +message+ is treated the same as for +add+.
+    # present, or +false+ otherwise. +message+ is treated the same as for +add+.
     #
     #   person.errors.add :name, :blank
     #   person.errors.added? :name, :blank # => true
+    #   person.errors.added? :name, "can't be blank" # => true
+    #
+    # If the error message requires an option, then it returns +true+ with
+    # the correct option, or +false+ with an incorrect or missing option.
+    #
+    #  person.errors.add :name, :too_long, { count: 25 }
+    #  person.errors.added? :name, :too_long, count: 25 # => true
+    #  person.errors.added? :name, :too_long, count: 24 # => false
+    #  person.errors.added? :name, :too_long # => false
+    #  person.errors.added? :name, "is too long (maximum is 25 characters)" # => true
+    #  person.errors.added? :name, "is too long" # => false
     def added?(attribute, message = :invalid, options = {})
       message = message.call if message.respond_to?(:call)
       message = normalize_message(attribute, message, options)


### PR DESCRIPTION
### Summary

There was confusion on `errors.added?` in issue #25410. This documentation provides more clarification on how `added?` works.
