### PR TITLE
`params.permitted?` is false by default

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -106,6 +106,8 @@ module ActionController
   #   params["key"] # => "value"
   class Parameters
     cattr_accessor :permit_all_parameters, instance_accessor: false
+    self.permit_all_parameters = false
+
     cattr_accessor :action_on_unpermitted_parameters, instance_accessor: false
 
     delegate :keys, :key?, :has_key?, :values, :has_value?, :value?, :empty?, :include?,

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -369,4 +369,10 @@ class ParametersPermitTest < ActiveSupport::TestCase
     refute params.permit(foo: [:bar]).has_key?(:foo)
     refute params.permit(foo: :bar).has_key?(:foo)
   end
+
+  test '#permitted? is false by default' do
+    params = ActionController::Parameters.new
+
+    assert_equal false, params.permitted?
+  end
 end


### PR DESCRIPTION
In the docs: "+permit_all_parameters+ - If it's +true+, all the parameters will
be permitted by default. The default is +false+."
