### PR TITLE
Update changelog for backport of ActiveSupport::Logger.broadcast #silence and ActiveSupport::LoggerThreadSafeLevel

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Fixed `ActiveSupport::Logger.broadcast` so that calls to `#silence` now
+    properly delegate to all loggers. Silencing now properly suppresses logging
+    to both the log and the console.
+
+    *Kevin McPhillips*
+
+*   Backported `ActiveSupport::LoggerThreadSafeLevel`. Assigning the
+    `Rails.logger.level` is now thread safe.
+
+    *Kevin McPhillips*
+
 *   Fixed a problem with ActiveSupport::SafeBuffer.titleize calling capitalize
     on nil.
 


### PR DESCRIPTION
@rafaelfranca 

Updates the changelog to reflect 4.2 backports from #25397 and #25356.
