### PR TITLE
[ci skip] unify whitespace of `gsub`

### DIFF
--- a/actioncable/lib/action_cable/channel/naming.rb
+++ b/actioncable/lib/action_cable/channel/naming.rb
@@ -12,7 +12,7 @@ module ActionCable
         #   Chats::AppearancesChannel.channel_name # => 'chats:appearances'
         #   FooChats::BarAppearancesChannel.channel_name # => 'foo_chats:bar_appearances'
         def channel_name
-          @channel_name ||= name.sub(/Channel$/, '').gsub('::',':').underscore
+          @channel_name ||= name.sub(/Channel$/, '').gsub('::', ':').underscore
         end
       end
 

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -246,7 +246,7 @@ module ActionController
       def decode_credentials(header)
         ActiveSupport::HashWithIndifferentAccess[header.to_s.gsub(/^Digest\s+/, '').split(',').map do |pair|
           key, value = pair.split('=', 2)
-          [key.strip, value.to_s.gsub(/^"|"$/,'').delete('\'')]
+          [key.strip, value.to_s.gsub(/^"|"$/, '').delete('\'')]
         end]
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/hstore.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/hstore.rb
@@ -12,8 +12,8 @@ module ActiveRecord
           def deserialize(value)
             if value.is_a?(::String)
               ::Hash[value.scan(HstorePair).map { |k, v|
-                v = v.upcase == 'NULL' ? nil : v.gsub(/\A"(.*)"\Z/m,'\1').gsub(/\\(.)/, '\1')
-                k = k.gsub(/\A"(.*)"\Z/m,'\1').gsub(/\\(.)/, '\1')
+                v = v.upcase == 'NULL' ? nil : v.gsub(/\A"(.*)"\Z/m, '\1').gsub(/\\(.)/, '\1')
+                k = k.gsub(/\A"(.*)"\Z/m, '\1').gsub(/\\(.)/, '\1')
                 [k, v]
               }]
             else

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -263,7 +263,7 @@ HEADER
       end
 
       def remove_prefix_and_suffix(table)
-        table.gsub(/^(#{@options[:table_name_prefix]})(.+)(#{@options[:table_name_suffix]})$/,  "\\2")
+        table.gsub(/^(#{@options[:table_name_prefix]})(.+)(#{@options[:table_name_suffix]})$/, "\\2")
       end
 
       def ignored?(table_name)

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -22,11 +22,11 @@ class Admin::User < ActiveRecord::Base
   store :json_data_empty, :accessors => [ :is_a_good_guy ], :coder => Coder.new
 
   def phone_number
-    read_store_attribute(:settings, :phone_number).gsub(/(\d{3})(\d{3})(\d{4})/,'(\1) \2-\3')
+    read_store_attribute(:settings, :phone_number).gsub(/(\d{3})(\d{3})(\d{4})/, '(\1) \2-\3')
   end
 
   def phone_number=(value)
-    write_store_attribute(:settings, :phone_number, value && value.gsub(/[^\d]/,''))
+    write_store_attribute(:settings, :phone_number, value && value.gsub(/[^\d]/, ''))
   end
 
   def color

--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -145,7 +145,7 @@ module ActiveSupport
     end
 
     def escape(key)
-      key.gsub(',','\,')
+      key.gsub(',', '\,')
     end
 
     def compile_ext(array)

--- a/activesupport/lib/active_support/testing/declarative.rb
+++ b/activesupport/lib/active_support/testing/declarative.rb
@@ -9,7 +9,7 @@ module ActiveSupport
         #     ...
         #   end
         def test(name, &block)
-          test_name = "test_#{name.gsub(/\s+/,'_')}".to_sym
+          test_name = "test_#{name.gsub(/\s+/, '_')}".to_sym
           defined = method_defined? test_name
           raise "#{test_name} is already defined in #{self}" if defined
           if block_given?

--- a/activesupport/test/xml_mini_test.rb
+++ b/activesupport/test/xml_mini_test.rb
@@ -342,11 +342,11 @@ vehemence of any carnal pleasure.
 EXPECTED
 
       parser = @parsing['base64Binary']
-      assert_equal expected_base64.gsub(/\n/," ").strip, parser.call(base64)
+      assert_equal expected_base64.gsub(/\n/, " ").strip, parser.call(base64)
       parser.call("NON BASE64 INPUT")
 
       parser = @parsing['binary']
-      assert_equal expected_base64.gsub(/\n/," ").strip, parser.call(base64, 'encoding' => 'base64')
+      assert_equal expected_base64.gsub(/\n/, " ").strip, parser.call(base64, 'encoding' => 'base64')
       assert_equal "IGNORED INPUT", parser.call("IGNORED INPUT", {})
     end
   end

--- a/guides/source/4_1_release_notes.md
+++ b/guides/source/4_1_release_notes.md
@@ -702,7 +702,7 @@ for detailed changes.
   `Time.zone.tomorrow`. ([Pull Request](https://github.com/rails/rails/pull/12822))
 
 * Added `String#remove(pattern)` as a short-hand for the common pattern of
-  `String#gsub(pattern,'')`. ([Commit](https://github.com/rails/rails/commit/5da23a3f921f0a4a3139495d2779ab0d3bd4cb5f))
+  `String#gsub(pattern, '')`. ([Commit](https://github.com/rails/rails/commit/5da23a3f921f0a4a3139495d2779ab0d3bd4cb5f))
 
 * Added `Hash#compact` and `Hash#compact!` for removing items with nil value
   from hash. ([Pull Request](https://github.com/rails/rails/pull/13632))

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -270,8 +270,8 @@ task default: :test
         @name ||= begin
           # same as ActiveSupport::Inflector#underscore except not replacing '-'
           underscored = original_name.dup
-          underscored.gsub!(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
-          underscored.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
+          underscored.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+          underscored.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
           underscored.downcase!
 
           underscored


### PR DESCRIPTION
### Summary

It was unified whitespace in the argument of the gsub method.
