### PR TITLE
Do not mutate query_options

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -17,13 +17,10 @@ module ActiveRecord
         # as values.
         def select_one(arel, name = nil, binds = [])
           arel, binds = binds_from_relation(arel, binds)
-          @connection.query_options.merge!(as: :hash)
           select_result(to_sql(arel, binds), name, binds) do |result|
             @connection.next_result while @connection.more_results?
-            result.first
+            result.each(as: :hash).first
           end
-        ensure
-          @connection.query_options.merge!(as: :array)
         end
 
         # Returns an array of arrays containing the field values.


### PR DESCRIPTION
One of the changes to `#select_one` in #23461 (“Add prepared statements support for `Mysql2Adapter`”) was unnecessarily complex. Mutating `@connection.query_options` both before and after the call to `execute` can be avoided altogether by using `each(as: :hash)`.

cc/ @kamipo 
