### PR TITLE
Make OR more permissive, let folks write wrong queries if they want to

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1211,7 +1211,7 @@ module ActiveRecord
 
     def structurally_incompatible_values_for_or(other)
       Relation::SINGLE_VALUE_METHODS.reject { |m| send("#{m}_value") == other.send("#{m}_value") } +
-        (Relation::MULTI_VALUE_METHODS - [:extending]).reject { |m| send("#{m}_values") == other.send("#{m}_values") } +
+        (Relation::MULTI_VALUE_METHODS - [:joins, :eager_load, :references, :extending]).reject { |m| send("#{m}_values") == other.send("#{m}_values") } +
         (Relation::CLAUSE_METHODS - [:having, :where]).reject { |m| send("#{m}_clause") == other.send("#{m}_clause") }
     end
 


### PR DESCRIPTION
### Summary

I was trying to port some old code that used or_chain, and wanted to use ActiveRecord::Relation#or instead. However, I quickly ran aground, because whereas or_chain doesn't try to protect me from stupidity, the new ActiveRecord::Relation#or code does.

The real world use case was I have a UI that lets a user select from a bunch of named scopes, which I then join together like this:

```
query=scopes.map {|scope_name|MyClass.send scope_name}.
           inject {|query,scope_query|query.or(scope_query)}
```

Some of those scopes eager_load associations and have restrictions on them, and currently that's not allowed.

The patch simply removes some of the restrictions on joining and including other tables, and lets me make my own mistakes. I know that it can generate unintentionally valid but wrong sql, but that's so much better than using "#to_sql" and stitching the SQL together manually.

Here's a [gist about spammy cat videos ](https://gist.github.com/robmathews/b00bd2319ab4fd1768ab57224b6ed895) showing before and after the change, with failing/passing tests.
### Other Information

There was a discussion over [here](https://github.com/rails/rails/issues/24055) about it, although that was more of a complaint about the docs.
