### PR TITLE
Properly calculate cache key for queries with offset

### DIFF
--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -18,6 +18,8 @@ module ActiveRecord
           .unscope(:select)
           .select("COUNT(*) AS #{connection.quote_column_name("size")}", "MAX(#{column}) AS timestamp")
           .unscope(:order)
+          .unscope(:limit)
+          .unscope(:offset)
         result = connection.select_one(query)
 
         if result.blank?

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -75,9 +75,9 @@ module ActiveRecord
       assert_match(/\Acomments\/query-(\h+)-0\Z/, empty_loaded_collection.cache_key)
     end
 
-    test "cache_key for queries with offset which return 0 rows" do
+    test "cache_key for queries with offset" do
       developers = Developer.offset(20)
-      assert_match(/\Adevelopers\/query-(\h+)-0\Z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/, developers.cache_key)
     end
 
     test "cache_key with a relation having selected columns" do


### PR DESCRIPTION
### Summary

Fixes #25454

So far the queries with offset would always result in cache key without
timestamp (because the offset was applied to aggregation which basically
does not work with aggregations - it always returns empty).

This commit fixes that, so the queries with offset have timestamp if
timestamp column is available.
