### PR TITLE
Fix rails/info routes for apps with globbing route

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Ensure `/rails/info` routes match in development for apps with a catch-all globbing route.
+
+    *Nicholas Firth-McCoy*
+
 ## Rails 5.0.0.rc2 (June 22, 2016) ##
 
 *   No changes.

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -21,10 +21,13 @@ module Rails
 
       initializer :add_builtin_route do |app|
         if Rails.env.development?
-          app.routes.append do
+          app.routes.prepend do
             get '/rails/info/properties' => "rails/info#properties", internal: true
             get '/rails/info/routes'     => "rails/info#routes", internal: true
             get '/rails/info'            => "rails/info#index", internal: true
+          end
+
+          app.routes.append do
             get '/'                      => "rails/welcome#index", internal: true
           end
         end

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -39,6 +39,25 @@ module ApplicationTests
       assert_equal 200, last_response.status
     end
 
+    test "/rails/info routes are accessible with globbing route present" do
+      app("development")
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get '*foo', to: 'foo#index'
+        end
+      RUBY
+
+      get "/rails/info"
+      assert_equal 302, last_response.status
+
+      get "rails/info/routes"
+      assert_equal 200, last_response.status
+
+      get "rails/info/properties"
+      assert_equal 200, last_response.status
+    end
+
     test "root takes precedence over internal welcome controller" do
       app("development")
 


### PR DESCRIPTION
Backport of #25430 to 5-0-stable.

I'm not 100% sure what is getting merged into 5-0-stable at this stage so if this isn't appropriate feel free to close. Am keen to get this fix into 5.0.0 instead of having to wait for 5.1 if possible!

/cc @schneems 
