### PR TITLE
Removed a forgotten `with_exclusive_scope` test:

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1032,12 +1032,6 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal t1.title, t2.title
   end
 
-  def test_reload_with_exclusive_scope
-    dev = DeveloperCalledDavid.first
-    dev.update!(name: "NotDavid" )
-    assert_equal dev, dev.reload
-  end
-
   def test_switching_between_table_name
     k = Class.new(Joke)
 


### PR DESCRIPTION
This PR simply removes a test concerning `with_exclusive_scope`.

The method was removed in this commit https://github.com/rails/rails/commit/d242e467819a428ad7e302968e4c9fa1e26d9326
