### PR TITLE
return correct type from `EnumType`

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -105,6 +105,8 @@ module ActiveRecord
     end
 
     class EnumType < Type::Value # :nodoc:
+      delegate :type, to: :subtype
+
       def initialize(name, mapping, subtype)
         @name = name
         @mapping = mapping

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -421,4 +421,8 @@ class EnumTest < ActiveRecord::TestCase
     book = Book.new
     assert book.hard?
   end
+
+  test "data type of Enum type" do
+    assert_equal :integer, Book.type_for_attribute('status').type
+  end
 end


### PR DESCRIPTION
### Summary

In Rails 5.0.0.rc2, in the model that using Active Record enums, inspect does not display correctly type.

``` ruby
# migration
class CreateConversations < ActiveRecord::Migration[5.0]
  def change
    create_table :conversations do |t|
      t.integer :status

      t.timestamps
    end
  end
end
```

``` ruby
# model 
class Conversation < ApplicationRecord
  enum status: [ :active, :archived ]
end
```

```
Conversation.inspect # => "Conversation(id: integer, status: , created_at: datetime, updated_at: datetime)"
```

In Rails 4.2 correctly type was displayed.

```
Rails.version # => "4.2.6" 
Conversation.inspect #=> "Conversation(id: integer, status: integer, created_at: datetime, updated_at: datetime)" 
```

This PR fixes to be displayed correctly type the case of Active Record enums.
