### PR TITLE
Remove #select_one from Mysql2Adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -13,19 +13,6 @@ module ActiveRecord
           result
         end
 
-        # Returns a record hash with the column names as keys and column values
-        # as values.
-        def select_one(arel, name = nil, binds = [])
-          arel, binds = binds_from_relation(arel, binds)
-          @connection.query_options.merge!(as: :hash)
-          select_result(to_sql(arel, binds), name, binds) do |result|
-            @connection.next_result while @connection.more_results?
-            result.first
-          end
-        ensure
-          @connection.query_options.merge!(as: :array)
-        end
-
         # Returns an array of arrays containing the field values.
         # Order is the same as that returned by +columns+.
         def select_rows(sql, name = nil, binds = [])

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -75,6 +75,11 @@ module ActiveRecord
       hash_rows[idx]
     end
 
+    def first
+      return nil if @rows.empty?
+      Hash[@columns.zip(@rows.first)]
+    end
+
     def last
       hash_rows.last
     end

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -81,7 +81,8 @@ module ActiveRecord
     end
 
     def last
-      hash_rows.last
+      return nil if @rows.empty?
+      Hash[@columns.zip(@rows.last)]
     end
 
     def cast_values(type_overrides = {}) # :nodoc:

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -22,6 +22,11 @@ module ActiveRecord
       ], result.to_hash
     end
 
+    test "first returns first row as a hash" do
+      assert_equal(
+        {'col_1' => 'row 1 col 1', 'col_2' => 'row 1 col 2'}, result.first)
+    end
+
     test "each with block returns row hashes" do
       result.each do |row|
         assert_equal ['col_1', 'col_2'], row.keys

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -27,6 +27,11 @@ module ActiveRecord
         {'col_1' => 'row 1 col 1', 'col_2' => 'row 1 col 2'}, result.first)
     end
 
+    test "last returns last row as a hash" do
+      assert_equal(
+        {'col_1' => 'row 3 col 1', 'col_2' => 'row 3 col 2'}, result.last)
+    end
+
     test "each with block returns row hashes" do
       result.each do |row|
         assert_equal ['col_1', 'col_2'], row.keys


### PR DESCRIPTION
This is a follow-up to #25487, where I tried to change Mysql2Adapter’s `#select_one` to work around [a subtle bug](https://github.com/rails/rails/pull/25487#discussion_r68246109) which I unfortunately cannot reliably reproduce. Reproducible or not, I think Mysql2Adapter’s existing `#select_one` implementation is pretty confusing (why does the connection need to know—before executing the query—how the result should be mapped?) and in this PR I will attempt to remove it completely.

Mysql2Adapter’s override of `#select_one` was introduced in #22803, to “Avoid instanciate `ActiveRecord::Result` and calling `ActiveRecord::Result#hash_rows` for the performance”.

The performance problem of calling `hash_rows` when you really only need the first element can perhaps be solved by adding a `ActiveRecord::Result#first` method, optimized for that use case.

`ActiveRecord::Result#last` was introduced back in 40ce68204808f9905413fe15843a7cc0f1c56988, but I’m not sure who uses it. I changed it works identical to the new `#first` method.

Considerations:
- Rails moved away from `Hash[a.zip(b)]` back in ba0568e46d890d57cfef2ea86745bdeb879fefa7 – do we need that optimization here, when it’s not inside a loop?
- `#hash_rows` freezes the column keys (introduced in 3aef5ce9b35a4659379201eb6bb1dba355a83ba4, 2068d300917ed95a82e7377ee77b397fc4084a61, da400fbb0ba6a130237d17cdd58c860be02294ad) for performance reasons. Again, `#first` and `#last` aren’t looping, so do we need to optimize for performance here?
- I considered checking for `defined?(@hash_rows) ? @hash_rows.first : …` but thought it a premature optimization. What do you think?

I’ve run `rake test_mysql2` with [test/config.yml’s `prepared_statements` set to both `true` and `false`](https://github.com/rails/rails/pull/25487#discussion_r68242837), and everything looks fine.

cc/ @kamipo 
