### PR TITLE
Schneems/backport evented file boot at check time

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -3,6 +3,34 @@ require 'pathname'
 require 'concurrent/atomic/atomic_boolean'
 
 module ActiveSupport
+  # Allows you to "listen" to changes in a file system.
+  # The evented file updater does not hit disk when checking for updates
+  # instead it uses platform specific file system events to trigger a change
+  # in state.
+  #
+  # The file checker takes an array of files to watch or a hash specifying directories
+  # and file extensions to watch. It also takes a block that is called when
+  # EventedFileUpdateChecker#execute is run or when EventedFileUpdateChecker#execute_if_updated
+  # is run and there have been changes to the file system.
+  #
+  # Note: To start listening to change events you must first call
+  # EventedFileUpdateChecker#updated? inside of each process.
+  #
+  # Example:
+  #
+  #     checker = EventedFileUpdateChecker.new(["/tmp/foo"], -> { puts "changed" })
+  #     checker.updated?
+  #     # => false
+  #     checker.execute_if_updated
+  #     # => nil
+  #
+  #     FileUtils.touch("/tmp/foo")
+  #
+  #     checker.updated?
+  #     # => true
+  #     checker.execute_if_updated
+  #     # => "changed"
+  #
   class EventedFileUpdateChecker #:nodoc: all
     def initialize(files, dirs = {}, &block)
       @ph    = PathHelper.new

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -11,7 +11,8 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
   end
 
   def new_checker(files = [], dirs = {}, &block)
-    ActiveSupport::EventedFileUpdateChecker.new(files, dirs, &block).tap do
+    ActiveSupport::EventedFileUpdateChecker.new(files, dirs, &block).tap do |c|
+      c.updated?
       wait
     end
   end

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -12,7 +12,6 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
 
   def new_checker(files = [], dirs = {}, &block)
     ActiveSupport::EventedFileUpdateChecker.new(files, dirs, &block).tap do |c|
-      c.updated?
       wait
     end
   end
@@ -34,6 +33,48 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
   def rm_f(files)
     super
     wait
+  end
+
+  test 'notifies forked processes' do
+    FileUtils.touch(tmpfiles)
+
+    checker = new_checker(tmpfiles) { }
+    assert !checker.updated?
+
+    # Pipes used for flow controll across fork.
+    boot_reader,  boot_writer  = IO.pipe
+    touch_reader, touch_writer = IO.pipe
+
+    pid = fork do
+      assert checker.updated?
+
+      # Clear previous check value.
+      checker.execute
+      assert !checker.updated?
+
+      # Fork is booted, ready for file to be touched
+      # notify parent process.
+      boot_writer.write("booted")
+
+      # Wait for parent process to signal that file
+      # has been touched.
+      IO.select([touch_reader])
+
+      assert checker.updated?
+    end
+
+    assert pid
+
+    # Wait for fork to be booted before touching files.
+    IO.select([boot_reader])
+    touch(tmpfiles)
+
+    # Notify fork that files have been touched.
+    touch_writer.write("touched")
+
+    assert checker.updated?
+
+    Process.wait(pid)
   end
 end
 


### PR DESCRIPTION
Backport of https://github.com/rails/rails/pull/25302

Even though https://github.com/rails/rails/pull/25302 had a 5-0 milestone, it was never backported to the branch :(

Having master not be the current pre-release target is error prone.
