### PR TITLE
Ensure result is cleared at ConnectionAdapters::PostgreSQLAdapter#execute_and_clear

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -591,8 +591,11 @@ module ActiveRecord
           else
             result = exec_cache(sql, name, binds)
           end
-          ret = yield result
-          result.clear
+          begin
+            ret = yield result
+          ensure
+            result.clear
+          end
           ret
         end
 


### PR DESCRIPTION
### Summary

It seems like `result` can be _not_ cleared in case of exception.
This is probably the reason our Postgres connections leak so much: they start with tiny memory footprint, but soon they grow to 5-7 gb per connection.
### Other Information

Not sure why this haven't been done before and if this breaks anything; discuss?
