### PR TITLE
nodoc `ActiveRecord::AttributeSet::YAMLEncoder`

### DIFF
--- a/activerecord/lib/active_record/attribute_set/yaml_encoder.rb
+++ b/activerecord/lib/active_record/attribute_set/yaml_encoder.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   class AttributeSet
     # Attempts to do more intelligent YAML dumping of an
     # ActiveRecord::AttributeSet to reduce the size of the resulting string
-    class YAMLEncoder
+    class YAMLEncoder # :nodoc:
       def initialize(default_types)
         @default_types = default_types
       end


### PR DESCRIPTION
As mentioned in 7b86ea6715ee987e61a7f3bd8e72b1bbfcfbbbe7, this is an
internal class.

[ci skip]

r? @sgrif
