### PR TITLE
Update grammar for `config.enable_dependency_loading` docs

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -94,7 +94,7 @@ application. Accepts a valid week day symbol (e.g. `:monday`).
 
 * `config.eager_load_paths` accepts an array of paths from which Rails will eager load on boot if cache classes is enabled. Defaults to every folder in the `app` directory of the application.
 
-* `config.enable_dependency_loading` when true, enable the autoload loading behavior even if the application is eager loaded and have `cache_classes` as true. Default to false.
+* `config.enable_dependency_loading`: when true, enables autoload loading, even if the application is eager loaded and `config.cache_classes` is set as true. Defaults to false.
 
 * `config.encoding` sets up the application-wide encoding. Defaults to UTF-8.
 


### PR DESCRIPTION
[ci skip]

Backport of #25476 to `5-0-0`.
