### PR TITLE
Extract `type_casted_binds` method

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -156,6 +156,10 @@ module ActiveRecord
 
       private
 
+      def type_casted_binds(binds)
+        binds.map { |attr| type_cast(attr.value_for_database) }
+      end
+
       def types_which_need_no_typecasting
         [nil, Numeric, String]
       end

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -77,7 +77,7 @@ module ActiveRecord
             @connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
           end
 
-          type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
+          type_casted_binds = type_casted_binds(binds)
 
           log(sql, name, binds, type_casted_binds) do
             if cache_stmt

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -597,13 +597,13 @@ module ActiveRecord
         end
 
         def exec_no_cache(sql, name, binds)
-          type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
+          type_casted_binds = type_casted_binds(binds)
           log(sql, name, binds, type_casted_binds) { @connection.async_exec(sql, type_casted_binds) }
         end
 
         def exec_cache(sql, name, binds)
           stmt_key = prepare_statement(sql)
-          type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
+          type_casted_binds = type_casted_binds(binds)
 
           log(sql, name, binds, type_casted_binds, stmt_key) do
             @connection.exec_prepared(stmt_key, type_casted_binds)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -188,7 +188,7 @@ module ActiveRecord
       end
 
       def exec_query(sql, name = nil, binds = [], prepare: false)
-        type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
+        type_casted_binds = type_casted_binds(binds)
 
         log(sql, name, binds, type_casted_binds) do
           # Don't cache statements if they are not prepared
@@ -203,7 +203,6 @@ module ActiveRecord
             ensure
               stmt.close
             end
-            stmt = records
           else
             cache = @statements[sql] ||= {
               :stmt => @connection.prepare(sql)
@@ -212,9 +211,10 @@ module ActiveRecord
             cols = cache[:cols] ||= stmt.columns
             stmt.reset!
             stmt.bind_params(type_casted_binds)
+            records = stmt.to_a
           end
 
-          ActiveRecord::Result.new(cols, stmt.to_a)
+          ActiveRecord::Result.new(cols, records)
         end
       end
 


### PR DESCRIPTION
Because `quote` and `type_cast` against `binds` requires
`prepare_binds_for_database`.
