### PR TITLE
Remove unnecessary `assert_valid_default`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/column.rb
@@ -6,7 +6,6 @@ module ActiveRecord
 
         def initialize(*)
           super
-          assert_valid_default
           extract_default
         end
 
@@ -36,12 +35,6 @@ module ActiveRecord
         def extract_default
           if blob_or_text_column?
             @default = null || strict ? nil : ''
-          end
-        end
-
-        def assert_valid_default
-          if blob_or_text_column? && default.present?
-            raise ArgumentError, "#{type} columns cannot have a default value: #{default.inspect}"
           end
         end
       end

--- a/activerecord/test/cases/column_definition_test.rb
+++ b/activerecord/test/cases/column_definition_test.rb
@@ -60,15 +60,8 @@ module ActiveRecord
         end
 
         def test_should_not_set_default_for_blob_and_text_data_types
-          assert_raise ArgumentError do
-            MySQL::Column.new("title", "a", SqlTypeMetadata.new(sql_type: "blob"))
-          end
-
           text_type = MySQL::TypeMetadata.new(
             SqlTypeMetadata.new(type: :text))
-          assert_raise ArgumentError do
-            MySQL::Column.new("title", "Hello", text_type)
-          end
 
           text_column = MySQL::Column.new("title", nil, text_type)
           assert_equal nil, text_column.default


### PR DESCRIPTION
This was added at c7c3f73 but it never raised because MySQL cannot
create text/blob columns with a default value.
