### PR TITLE
Define `Pathname#as_json`

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -2,6 +2,7 @@
 require 'json'
 require 'bigdecimal'
 require 'uri/generic'
+require 'pathname'
 require 'active_support/core_ext/big_decimal/conversions' # for #to_s
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/hash/slice'
@@ -194,6 +195,12 @@ class DateTime
 end
 
 class URI::Generic #:nodoc:
+  def as_json(options = nil)
+    to_s
+  end
+end
+
+class Pathname #:nodoc:
   def as_json(options = nil)
     to_s
   end

--- a/activesupport/test/json/encoding_test_cases.rb
+++ b/activesupport/test/json/encoding_test_cases.rb
@@ -78,6 +78,8 @@ module JSONTest
 
     URITests      = [[ URI.parse('http://example.com'), %("http://example.com") ]]
 
+    PathnameTests = [[ Pathname.new('lib/index.rb'), %("lib/index.rb") ]]
+
     DateTests     = [[ Date.new(2005,2,1), %("2005/02/01") ]]
     TimeTests     = [[ Time.utc(2005,2,1,15,15,10), %("2005/02/01 15:15:10 +0000") ]]
     DateTimeTests = [[ DateTime.civil(2005,2,1,15,15,10), %("2005/02/01 15:15:10 +0000") ]]


### PR DESCRIPTION
### Summary

When the Pathname object is converted as JSON,
it should be a string that means itself.

Expected:

```
>> Pathname.new('/path/to/somewhere.txt').as_json
"/path/to/somewhere.txt"
```

Actual:

```
>> Pathname.new('/path/to/somewhere.txt').as_json
{"path"=>"/path/to/somewhere.txt"}
```
