### PR TITLE
speed up ActionDispatch::Journey::Route#matches?

### DIFF
--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -139,8 +139,8 @@ module ActionDispatch
 
       def matches?(request)
         match_verb(request) &&
-        constraints.all? { |method, value|
-          case value
+        !constraints.any? { |method, value|
+          !case value
           when Regexp, String
             value === request.send(method).to_s
           when Array


### PR DESCRIPTION
`any?` is 10-40% faster than `all?` on MRI 2.2 or later. Why? Because MRI has a specific version of `any?` for `Array` and `Hash`. It's faster than `Enumerable#all?`.

`all?` can transform to `any?` by De Morgan's laws. `[].all? { cond }` equals `![].any? { !cond }`. Block calls is the same number of times. Maybe this change is no risk (and no effect on other ruby version).

`Route#matches?` is called each requests. This change makes slightly up.

```
require 'benchmark/ips'

Benchmark.ips do |r|
  r.report "all?" do
    {}.all? { |k,v| v }
  end

  r.report "any?" do
    !{}.any? { |k,v| !v }
  end

  r.compare!
end

Warming up --------------------------------------
                all?    49.058k i/100ms
                any?    52.220k i/100ms
Calculating -------------------------------------
                all?      4.666M (± 5.5%) i/s -     23.204M in   4.988696s
                any?      8.915M (±12.4%) i/s -     43.656M in   4.976557s

Comparison:
                any?:  8914636.5 i/s
                all?:  4665985.0 i/s - 1.91x slower
```

```
require 'benchmark/ips'

Benchmark.ips do |r|
  route = ActionDispatch::Journey::Route.new("name", Object.new, ActionDispatch::Journey::Path::Pattern.from_string('/'), {}, [], {}, [ActionDispatch::Journey::Route.verb_matcher("GET")], nil)
  req = ActionDispatch::TestRequest.create

  r.report "original" do
    route.matches? req
  end

  r.report "optimized" do
    route.optimized_matches? req
  end

  r.compare!
end

Warming up --------------------------------------
            original    41.169k i/100ms
           optimized    44.378k i/100ms
Calculating -------------------------------------
            original      2.268M (± 4.3%) i/s -     11.321M in   5.000226s
           optimized      2.903M (± 2.2%) i/s -     14.512M in   5.001081s

Comparison:
           optimized:  2903088.2 i/s
            original:  2268230.8 i/s - 1.28x slower
```
