### PR TITLE
Fix typo in exception class name

### DIFF
--- a/actionview/lib/action_view/helpers/tags/datetime_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_field.rb
@@ -14,7 +14,7 @@ module ActionView
         private
 
           def format_date(value)
-            raise NoImplementedError
+            raise NotImplementedError
           end
 
           def datetime_value(value)


### PR DESCRIPTION
Typo introduced in https://github.com/rails/rails/commit/aa6dde37cd46fc56b6bd3197564a8428399aec33
