### PR TITLE
Mention object type explicitly instead of implicit. [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -190,7 +190,7 @@ module ActiveRecord
     # provides methods for manipulating the schema representation.
     #
     # Inside migration files, the +t+ object in {create_table}[rdoc-ref:SchemaStatements#create_table]
-    # is actually of this type:
+    # is actually of <tt>ActiveRecord::ConnectionAdapters::TableDefinition</tt> type:
     #
     #   class SomeMigration < ActiveRecord::Migration[5.0]
     #     def up


### PR DESCRIPTION
Mention object type explicitly instead of implicit.
