### PR TITLE
[ci skip] Clarify DDL term in ActiveRecord::Transactions

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -189,8 +189,8 @@ module ActiveRecord
     #
     # === Caveats
     #
-    # If you're on MySQL, then do not use DDL operations in nested transactions
-    # blocks that are emulated with savepoints. That is, do not execute statements
+    # If you're on MySQL, then do not use Data Definition Language(DDL) operations in nested
+    # transactions blocks that are emulated with savepoints. That is, do not execute statements
     # like 'CREATE TABLE' inside such blocks. This is because MySQL automatically
     # releases all savepoints upon executing a DDL operation. When +transaction+
     # is finished and tries to release the savepoint it created earlier, a
@@ -480,11 +480,11 @@ module ActiveRecord
 
     # Updates the attributes on this particular Active Record object so that
     # if it's associated with a transaction, then the state of the Active Record
-    # object will be updated to reflect the current state of the transaction
+    # object will be updated to reflect the current state of the transaction.
     #
     # The +@transaction_state+ variable stores the states of the associated
     # transaction. This relies on the fact that a transaction can only be in
-    # one rollback or commit (otherwise a list of states would be required)
+    # one rollback or commit (otherwise a list of states would be required).
     # Each Active Record object inside of a transaction carries that transaction's
     # TransactionState.
     #


### PR DESCRIPTION
### Summary

DDL is used but not defined in the file, so I added it to its first occurrence for those unfamiliar with the acronym. I also added periods where missing.
