### PR TITLE
Remove "bundler uninstall" in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,7 @@ addons:
   postgresql: "9.4"
 
 bundler_args: --without test --jobs 3 --retry 3
-#FIXME: Remove bundler uninstall on Travis when https://github.com/bundler/bundler/issues/4493 is fixed.
 before_install:
-  - rvm @global do gem uninstall bundler --all --ignore-dependencies --executables
-  - rvm @global do gem install bundler -v '1.11.2'
   - bundle --version
   - "rm ${BUNDLE_GEMFILE}.lock"
   - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"


### PR DESCRIPTION
Remove "bundle unisntall" which added In [this PR](https://github.com/rails/rails/pull/24839).
In [#4493](https://github.com/bundler/bundler/issues/4493), resolving bundle update discrepancy has been  reported.
