### PR TITLE
Fix setting route's to in a scope

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1062,6 +1062,10 @@ module ActionDispatch
           def merge_shallow_scope(parent, child) #:nodoc:
             child ? true : false
           end
+
+          def merge_to_scope(parent, child)
+            child
+          end
       end
 
       # Resource routing allows you to quickly declare all of the common routes
@@ -1582,6 +1586,10 @@ module ActionDispatch
             raise ArgumentError, "Unknown scope #{on.inspect} given to :on"
           end
 
+          if @scope[:to]
+            options[:to] ||= @scope[:to]
+          end
+
           if @scope[:controller] && @scope[:action]
             options[:to] ||= "#{@scope[:controller]}##{@scope[:action]}"
           end
@@ -2021,7 +2029,7 @@ to this:
       class Scope # :nodoc:
         OPTIONS = [:path, :shallow_path, :as, :shallow_prefix, :module,
                    :controller, :action, :path_names, :constraints,
-                   :shallow, :blocks, :defaults, :via, :format, :options]
+                   :shallow, :blocks, :defaults, :via, :format, :options, :to]
 
         RESOURCE_SCOPES = [:resource, :resources]
         RESOURCE_METHOD_SCOPES = [:collection, :member, :new]

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -102,6 +102,18 @@ module ActionDispatch
         assert_equal("PUT", fakeset.routes.first.verb)
       end
 
+      def test_to_scope
+        fakeset = FakeSet.new
+        mapper = Mapper.new fakeset
+        mapper.scope(to: "posts#index") do
+          mapper.get :all
+          mapper.post :most
+        end
+
+        assert_equal "posts#index", fakeset.routes.to_a[0].defaults[:to]
+        assert_equal "posts#index", fakeset.routes.to_a[1].defaults[:to]
+      end
+
       def test_map_slash
         fakeset = FakeSet.new
         mapper = Mapper.new fakeset


### PR DESCRIPTION
### Summary

Fixes #25488
97d7dc4 introduced a regression that resulted in ArgumentError when to
was in options of the scope and not of particular route.
### Other Information

I am not sure if this behavior should be supported cause I'm not sure it's possible to find such usage in documentation. But it was supported before so some people may rely on that.
