### PR TITLE
Fix adding implicitly rendered template digests to ETags

### DIFF
--- a/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
+++ b/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
@@ -40,7 +40,9 @@ module ActionController
     end
 
     def pick_template_for_etag(options)
-      options.fetch(:template) { "#{controller_name}/#{action_name}" }
+      unless options[:template] == false
+        options[:template] || "#{controller_name}/#{action_name}"
+      end
     end
 
     def lookup_and_digest_template(template)

--- a/actionpack/test/fixtures/test/with_implicit_template.erb
+++ b/actionpack/test/fixtures/test/with_implicit_template.erb
@@ -1,0 +1,1 @@
+Hello explicitly!


### PR DESCRIPTION
Fixes that modifying an implicitly rendered template for a controller action using `fresh_when` or `stale?`  would not result in a new `ETag` value.

New test failing without this change:

```
$ bundle exec rake test  TEST=test/controller/render_test.rb
Run options: --seed 9680

# Running:

.......S..........................F.........................

Finished in 0.212498s, 282.3556 runs/s, 1416.4839 assertions/s.

  1) Failure:
EtagRenderTest#test_etag_reflects_implicit_template_digest [.../actionpack/test/controller/render_test.rb:558]:
Expected response to be a <200: ok>, but was a <304: Not Modified>.
Expected: 200
  Actual: 304

60 runs, 301 assertions, 1 failures, 0 errors, 1 skips
```

/cc @jeremy 
