### PR TITLE
[wip] adding rel=noopener for link_to when target=blank_

### DIFF
--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -284,6 +284,37 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_dom_equal %{<a href="/">Hello</a>}, link
   end
 
+  def test_link_with_html_options
+    link = link_to("Hello", url_hash, { class: ["foo", "bar"] })
+    assert_dom_equal %{<a class="foo bar" href="/">Hello</a>}, link
+  end
+
+  def test_link_with_target_blank
+    link = link_to("Hello", url_hash, { target: "_blank" })
+    assert_dom_equal %{<a target="_blank" rel="noopener" href="/">Hello</a>}, link
+  end
+
+  def test_link_with_target_but_no_blank
+    link = link_to("Hello", url_hash, { target: "_self" })
+    assert_dom_equal %{<a target="_self" href="/">Hello</a>}, link
+  end
+
+  def test_link_with_target_blank_with_rel
+    link = link_to("Hello", url_hash, { target: "_blank", rel: "noreferrer" })
+    assert_dom_equal %{<a target="_blank" rel="noreferrer noopener" href="/">Hello</a>}, link
+  end
+
+  def test_link_with_target_blank_with_rel_noopener
+    link = link_to("Hello", url_hash, { target: "_blank", rel: "noopener" })
+    assert_dom_equal %{<a target="_blank" rel="noopener" href="/">Hello</a>}, link
+  end
+
+  def test_link_with_target_blank_but_opener_true
+    option = url_hash.merge({ opener: true })
+    link = link_to("Hello", option, { target: "_blank" })
+    assert_dom_equal %{<a target="_blank" href="/">Hello</a>}, link
+  end
+
   def test_link_tag_with_custom_onclick
     link = link_to("Hello", "http://www.example.com", onclick: "alert('yay!')")
     expected = %{<a href="http://www.example.com" onclick="alert(&#39;yay!&#39;)">Hello</a>}


### PR DESCRIPTION
I'm already discussed on ML here
https://groups.google.com/d/topic/rubyonrails-core/BPGwQXKWsws/discussion
copy are on Summary
### Summary

link with target=blank_ will cause some kind of phishing attack known as _tabnabbing_.
detail of this attacks are described below.
- http://www.azarask.in/blog/post/a-new-type-of-phishing-attack/
- https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/

this is caused by `window.opener` of JavaScript API, and it will prevent by `rel=noopener` new API.

so I propose adding this attribute to `link_to` when it given `target: "_blank"`.

```
link_to "External link", "http://www.rubyonrails.org/", target: "_blank"
```

```
<!-- before -->
<a href="http://www.rubyonrails.org/" target="_blank">External link</a>
<!-- after -->
<a href="http://www.rubyonrails.org/" target="_blank" rel="noopener">External link</a>
```

here is `noopener` spec.

https://html.spec.whatwg.org/multipage/semantics.html#link-type-noopener

currently implemented by chrome/opera.

http://caniuse.com/#search=noopener

`noreferrer` is considered altenative of `noopener` for older browser.
but this cause not to send referrer to server, so it'll cause breakin change for some apps.
`noopener` is no side effect for apps, without using `window.opener` ofcourse.
### API Change

basically `rel=noopener` will add when html option has `target=_blank` by default

``` ruby
link_to("Hello", url_hash, { target: "_blank" })
# <a target="_blank" rel="noopener" href="/">Hello</a>
```

you can opt out to adding `rel=noopener` with `opener: true` option.

``` ruby
option = url_hash.merge({ opener: true })
link_to("Hello", option, { target: "_blank" })
# <a target="_blank" href="/">Hello</a>
```

thanks
Jxck
