### PR TITLE
Bring Boolean Attributes list for AV Tags helper upto speed with current spec

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -264,8 +264,8 @@ module ActionView
       #   # => <video src="/videos/trailer"></video>
       #   video_tag("trailer.ogg")
       #   # => <video src="/videos/trailer.ogg"></video>
-      #   video_tag("trailer.ogg", controls: true, autobuffer: true)
-      #   # => <video autobuffer="autobuffer" controls="controls" src="/videos/trailer.ogg" ></video>
+      #   video_tag("trailer.ogg", controls: true, preload: 'none')
+      #   # => <video preload="none" controls="controls" src="/videos/trailer.ogg" ></video>
       #   video_tag("trailer.m4v", size: "16x10", poster: "screenshot.png")
       #   # => <video src="/videos/trailer.m4v" width="16" height="10" poster="/assets/screenshot.png"></video>
       #   video_tag("/trailers/hd.avi", size: "16x16")

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -11,12 +11,15 @@ module ActionView
       include CaptureHelper
       include OutputSafetyHelper
 
-      BOOLEAN_ATTRIBUTES = %w(disabled readonly multiple checked autobuffer
-                           autoplay controls loop selected hidden scoped async
-                           defer reversed ismap seamless muted required
-                           autofocus novalidate formnovalidate open pubdate
-                           itemscope allowfullscreen default inert sortable
-                           truespeed typemustmatch).to_set
+      BOOLEAN_ATTRIBUTES = %w(allowfullscreen async autofocus autoplay checked
+                              compact controls declare default defaultchecked
+                              defaultmuted defaultselected defer disabled
+                              enabled formnovalidate hidden indeterminate inert
+                              ismap itemscope loop multiple muted nohref
+                              noresize noshade novalidate nowrap open
+                              pauseonexit readonly required reversed scoped
+                              seamless selected sortable truespeed typemustmatch
+                              visible).to_set
 
       BOOLEAN_ATTRIBUTES.merge(BOOLEAN_ATTRIBUTES.map(&:to_sym))
 

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -238,7 +238,7 @@ class AssetTagHelperTest < ActionView::TestCase
   VideoLinkToTag = {
     %(video_tag("xml.ogg")) => %(<video src="/videos/xml.ogg"></video>),
     %(video_tag("rss.m4v", :autoplay => true, :controls => true)) => %(<video autoplay="autoplay" controls="controls" src="/videos/rss.m4v"></video>),
-    %(video_tag("rss.m4v", :autobuffer => true)) => %(<video autobuffer="autobuffer" src="/videos/rss.m4v"></video>),
+    %(video_tag("rss.m4v", :preload => 'none')) => %(<video preload="none" src="/videos/rss.m4v"></video>),
     %(video_tag("gold.m4v", :size => "160x120")) => %(<video height="120" src="/videos/gold.m4v" width="160"></video>),
     %(video_tag("gold.m4v", "size" => "320x240")) => %(<video height="240" src="/videos/gold.m4v" width="320"></video>),
     %(video_tag("trailer.ogg", :poster => "screenshot.png")) => %(<video poster="/images/screenshot.png" src="/videos/trailer.ogg"></video>),
@@ -288,7 +288,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(audio_tag("//media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="//media.rubyonrails.org/audio/rails_blog_2.mov"></audio>),
     %(audio_tag("audio.mp3", "audio.ogg")) => %(<audio><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>),
     %(audio_tag(["audio.mp3", "audio.ogg"])) => %(<audio><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>),
-    %(audio_tag(["audio.mp3", "audio.ogg"], :autobuffer => true, :controls => true)) => %(<audio autobuffer="autobuffer" controls="controls"><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>)
+    %(audio_tag(["audio.mp3", "audio.ogg"], :preload => 'none', :controls => true)) => %(<audio preload="none" controls="controls"><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>)
   }
 
   FontPathToTag = {

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -3609,10 +3609,6 @@ class DateHelperTest < ActionView::TestCase
     assert_equal expected, time_tag(time)
   end
 
-  def test_time_tag_pubdate_option
-    assert_match(/<time.*pubdate="pubdate">.*<\/time>/, time_tag(Time.now, :pubdate => true))
-  end
-
   def test_time_tag_with_given_text
     assert_match(/<time.*>Right now<\/time>/, time_tag(Time.now, 'Right now'))
   end


### PR DESCRIPTION
Bring Boolean Attributes list for AV Tags helper upto speed with current spec.
This is based on https://github.com/kangax/html-minifier/blob/6b2d4536d82819143b468b41a89c700b6c61631f/src/htmlminifier.js#L197 and spec from https://www.w3.org/TR/html51/single-page.html.

Couple of other changes to tests due to support update:
- autobuffer has been dropped in favour of preload attribute, ref: https://msdn.microsoft.com/en-us/library/ff974743(v=vs.85).aspx
- pubdate attribute has been dropped from spec, ref:  https://www.w3.org/html/wg/tracker/issues/185
