### PR TITLE
Loads proper adapter when database URL has `mysql` protocol

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -39,6 +39,7 @@ module ActiveRecord
           @uri     = uri_parser.parse(url)
           @adapter = @uri.scheme && @uri.scheme.tr('-', '_')
           @adapter = "postgresql" if @adapter == "postgres"
+          @adapter = "mysql2" if @adapter == "mysql"
 
           if @uri.opaque
             @uri.opaque, @query = @uri.opaque.split('?', 2)


### PR DESCRIPTION
### Summary

Previous version of the code tried to load `mysql_adapter.rb` if database URL had `mysql` protocol.
