### PR TITLE
Do not inspect array of over 10 elements

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Inspecting an object with an associated array of over 10 elements no longer
+    truncates the array, preventing `inspect` from looping infinitely in some
+    cases.
+
+    *Kevin McPhillips*
+
 *   Removed the unused methods `ActiveRecord::Base.connection_id` and
     `ActiveRecord::Base.connection_id=`
 

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -279,9 +279,8 @@ module ActiveRecord
     # Returns an <tt>#inspect</tt>-like string for the value of the
     # attribute +attr_name+. String attributes are truncated up to 50
     # characters, Date and Time attributes are returned in the
-    # <tt>:db</tt> format, Array attributes are truncated up to 10 values.
-    # Other attributes return the value of <tt>#inspect</tt> without
-    # modification.
+    # <tt>:db</tt> format. Other attributes return the value of
+    # <tt>#inspect</tt> without modification.
     #
     #   person = Person.create!(name: 'David Heinemeier Hansson ' * 3)
     #
@@ -292,7 +291,7 @@ module ActiveRecord
     #   # => "\"2012-10-22 00:15:07\""
     #
     #   person.attribute_for_inspect(:tag_ids)
-    #   # => "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...]"
+    #   # => "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]"
     def attribute_for_inspect(attr_name)
       value = read_attribute(attr_name)
 
@@ -300,9 +299,6 @@ module ActiveRecord
         "#{value[0, 50]}...".inspect
       elsif value.is_a?(Date) || value.is_a?(Time)
         %("#{value.to_s(:db)}")
-      elsif value.is_a?(Array) && value.size > 10
-        inspected = value.first(10).inspect
-        %(#{inspected[0...-1]}, ...])
       else
         value.inspect
       end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -189,8 +189,13 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_attribute_for_inspect_for_array_field
+    record = PgArray.new { |a| a.ratings = (1..10).to_a }
+    assert_equal("[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]", record.attribute_for_inspect(:ratings))
+  end
+
+  def test_attribute_for_inspect_for_array_field_for_large_array
     record = PgArray.new { |a| a.ratings = (1..11).to_a }
-    assert_equal("[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...]", record.attribute_for_inspect(:ratings))
+    assert_equal("[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]", record.attribute_for_inspect(:ratings))
   end
 
   def test_escaping

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -27,12 +27,31 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     ActiveRecord::Base.send(:attribute_method_matchers).concat(@old_matchers)
   end
 
-  def test_attribute_for_inspect
+  def test_attribute_for_inspect_string
     t = topics(:first)
     t.title = "The First Topic Now Has A Title With\nNewlines And More Than 50 Characters"
 
-    assert_equal %("#{t.written_on.to_s(:db)}"), t.attribute_for_inspect(:written_on)
     assert_equal '"The First Topic Now Has A Title With\nNewlines And ..."', t.attribute_for_inspect(:title)
+  end
+
+  def test_attribute_for_inspect_date
+    t = topics(:first)
+
+    assert_equal %("#{t.written_on.to_s(:db)}"), t.attribute_for_inspect(:written_on)
+  end
+
+  def test_attribute_for_inspect_array
+    t = topics(:first)
+    t.content = [Object.new]
+
+    assert_match %r(\[#<Object:0x[0-9a-f]+>\]), t.attribute_for_inspect(:content)
+  end
+
+  def test_attribute_for_inspect_long_array
+    t = topics(:first)
+    t.content = (1..11).to_a
+
+    assert_equal "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]", t.attribute_for_inspect(:content)
   end
 
   def test_attribute_present


### PR DESCRIPTION
@rafaelfranca @sgrif 
cc @xuorig @etiennebarrie 
## Problem

Calling `inspect` on an active record model that has an attribute containing an array of over 10 elements bypasses the MRI recursion cache and in some cases can loop infinitely.
## Reproduction
- Given a parent object `X` which is an active record model.
- Given that `X` has an attribute or a serialized attribute containing an array called `ys`.
- Given that array `ys` contains instances of class `Y`.
- Given that `Y` contains a reference to `X` called `x`.
- Given that the array `ys` is over 10 elements long.
- Then calling `inspect` on an instance of `X` loops infinitely.

``` ruby
class X < ActiveRecord::Base
  serialize :ys, Array
end

class Y
  attr_accessor :x
end

parent = X.create
11.times do
  child = Y.new
  child.x = parent
  parent.ys << child
end

parent.save
parent.inspect # failure
```
## Description

The core of the issue is that MRI provides a recursion cache on `object_id`. So if you call `inspect` on an array it will check to see if this object has already been inspected, and if so return the cached version. See:
https://github.com/ruby/ruby/blob/f1707e44fb21e8e64c7f470bb0984d6b6b6b7829/object.c#L566
https://github.com/ruby/ruby/blob/4060211c96f5d54b551fed536779a79821d1628e/thread.c#L4594

The bug occurs in rails when we build the `inspect` on an active record object with properties, and those properties reference back to the parent. It works as expected with 10 items or fewer in the array because we call `inspect` on the array directly. It is implemented as essentially:

``` ruby
      elsif value.is_a?(Array) && value.size > 10
        value.first(10).inspect # this is a new array
      else
        value.inspect # this is the same array
      end
```

With 11 items or over, we call `.first(10)` to shorten the array. But this creates a _new_ array with a different `object_id`. This bypasses the caching and loops infinitely.
## Solution

This is a naive solution. Want to get confirmation through discussion.

If the array is too long, simply output its size rather than truncating and inspecting the result.

Tests not yet written. Will probably break a ton of them.
