### PR TITLE
Correctly handle frozen options for ActiveRecord::Serialization#seria…

### DIFF
--- a/activerecord/lib/active_record/serialization.rb
+++ b/activerecord/lib/active_record/serialization.rb
@@ -9,7 +9,7 @@ module ActiveRecord #:nodoc:
     end
 
     def serializable_hash(options = nil)
-      options = options.try(:clone) || {}
+      options = options.try(:dup) || {}
 
       options[:except] = Array(options[:except]).map(&:to_s)
       options[:except] |= Array(self.class.inheritance_column)

--- a/activerecord/test/cases/json_serialization_test.rb
+++ b/activerecord/test/cases/json_serialization_test.rb
@@ -149,10 +149,8 @@ class JsonSerializationTest < ActiveRecord::TestCase
   end
 
   def test_serializable_hash_should_not_modify_options_in_argument
-    options = { only: :name }
-    @contact.serializable_hash(options)
-
-    assert_nil options[:except]
+    options = { only: :name }.freeze
+    assert_nothing_raised { @contact.serializable_hash(options) }
   end
 end
 


### PR DESCRIPTION
### Summary

This pull request fixes a bug that causes `ActiveRecord::Serialization#serializable_hash` to raise a RuntimeError when it receives a frozen hash as its argument. Instead of cloning the argument to prevent mutation of the input parameter, this patch dup's it. This will clear the frozen state and allow for modifications of the local duplicate.
### Other Information

This patch reworks an existing test to verify the new behavior. I figured it was easier to kill two birds with one stone here and the new version of the test should be less brittle.
