### PR TITLE
Backport #25364 to 4-2-stable

### DIFF
--- a/activerecord/lib/active_record/type/date.rb
+++ b/activerecord/lib/active_record/type/date.rb
@@ -9,6 +9,10 @@ module ActiveRecord
         ::Date
       end
 
+      def type_cast_for_database(value)
+        type_cast(value)
+      end
+
       def type_cast_for_schema(value)
         "'#{value.to_s(:db)}'"
       end

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -71,7 +71,7 @@ module ActiveRecord
           assert_equal '10.1', @conn.type_cast('10.1', c)
 
           c = Column.new(nil, 1, Type::Date.new)
-          assert_equal '10.1', @conn.type_cast('10.1', c)
+          assert_equal '2016-05-11', @conn.type_cast('2016-05-11 19:00:00', c)
         end
 
         def test_type_cast_bigdecimal

--- a/activerecord/test/cases/date_test.rb
+++ b/activerecord/test/cases/date_test.rb
@@ -1,7 +1,19 @@
 require 'cases/helper'
 require 'models/topic'
 
-class InvalidDateTest < ActiveRecord::TestCase
+class DateTest < ActiveRecord::TestCase
+  def test_date_with_time_value
+    time_value = Time.new(2016, 05, 11, 19, 0, 0)
+    topic = Topic.create(last_read: time_value)
+    assert_equal topic, Topic.find_by(last_read: time_value)
+  end
+
+  def test_date_with_string_value
+    string_value = '2016-05-11 19:00:00'
+    topic = Topic.create(last_read: string_value)
+    assert_equal topic, Topic.find_by(last_read: string_value)
+  end
+
   def test_assign_valid_dates
     valid_dates = [[2007, 11, 30], [1993, 2, 28], [2008, 2, 29]]
 


### PR DESCRIPTION
This PR is backport #25364 to 4-2-stable.

Currently `Type::Date#serialize` does not cast a value to a date object.
It should be cast to a date object for finding by date column correctly
working.

Fixes #25354.

r? @rafaelfranca 
