### PR TITLE
Return false only when habtm join table has composite primary keys

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -77,7 +77,12 @@ module ActiveRecord::Associations::Builder # :nodoc:
         end
 
         def self.primary_key
-          false
+          pks = connection.primary_keys(self.table_name)
+          if pks.count > 1
+            false
+          else
+            super
+          end
         end
       }
 


### PR DESCRIPTION
### Summary

This pull request addresses #25388
### Steps to reproduce

``` ruby
$ cd activerecord
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/associations/has_and_belongs_to_many_associations_test.rb -n test_has_and_belongs_to_many_in_a_namespaced_model_pointing_to_a_namespaced_model
```
### Current behavior without this pull request

``` ruby
ActiveRecord::StatementInvalid: OCIError: ORA-01400: cannot insert NULL into ("ARUNIT"."ARTICLES_MAGAZINES"."ID"): INSERT INTO "ARTICLES_MAGAZINES" ("ARTICLE_ID", "MAGAZINE_ID") VALUES (:a1, :a2)
```
### Other Information

Oracle enhanced adapter does not support `auto_increment` or `AUTOINCREMENT` features yet, 
then it needs to insert primary key column "ID" explicitly. To get the primary key column, [`attributes_for_create`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/attribute_methods.rb#L444-L448) uses [`pk_attribute?`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/attribute_methods.rb#L454-L456).

In master branch with https://github.com/rails/rails/commit/2df891dc commit, [`self.class.primary_key`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb#L79-L81) always returns false for habtm to avoid `WARNING: Rails does not support composite primary key.` by
https://github.com/rails/rails/pull/23345

In `4-2-stable` branch [`primary_key`](https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/attribute_methods/primary_key.rb#L72-L74) returns the actual primary key column, "id" here. then it can create a sql statement which set "id" column explicitly as follows:
- SQL statement generated with this pull request

``` sql
INSERT INTO "ARTICLES_MAGAZINES" ("ARTICLE_ID", "MAGAZINE_ID", "ID") VALUES (:a1, :a2, :a3)  [["article_id", 10000], ["magazine_id", 10000], ["id", 10000]]
```

This pull request has been tested also for all bundled adapters, sqlite3, postgresql, and mysql2. Once it get merged, I wanted it would be backported into `5-0-stable` branch.
