### PR TITLE
Don't force a connection to be established in the query cache middleware

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -113,7 +113,9 @@ module ActiveRecord
     end
 
     def retrieve_connection
-      connection_handler.retrieve_connection(connection_specification_name)
+      connection = connection_handler.retrieve_connection(connection_specification_name)
+      connection.enable_query_cache! if query_cache_enabled?
+      connection
     end
 
     # Returns +true+ if Active Record is connected.

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -21,19 +21,42 @@ module ActiveRecord
           yield
         end
       end
+
+      # Enable the query cache for any connections made on this thread
+      def enable_query_cache!
+        ActiveRecord::RuntimeRegistry.query_cache_enabled = true
+        if connected?
+          connection.enable_query_cache!
+        end
+      end
+
+      # Whether the query cache is enabled for the current thread
+      def query_cache_enabled?
+        ActiveRecord::RuntimeRegistry.query_cache_enabled
+      end
+
+      # Disables the query cache for the current connection, and stops enabling
+      # the query cache for future connections which are established
+      def disable_query_cache!
+        ActiveRecord::RuntimeRegistry.query_cache_enabled = false
+        if connected?
+          connection.disable_query_cache!
+        end
+      end
     end
 
     def self.run
-      connection    = ActiveRecord::Base.connection
-      enabled       = connection.query_cache_enabled
-      connection.enable_query_cache!
+      enabled_before_run = ActiveRecord::Base.query_cache_enabled?
+      ActiveRecord::Base.enable_query_cache!
 
-      enabled
+      enabled_before_run
     end
 
-    def self.complete(enabled)
-      ActiveRecord::Base.connection.clear_query_cache
-      ActiveRecord::Base.connection.disable_query_cache! unless enabled
+    def self.complete(enabled_before_run)
+      if ActiveRecord::Base.connected?
+        ActiveRecord::Base.connection.clear_query_cache
+      end
+      ActiveRecord::Base.disable_query_cache! unless enabled_before_run
     end
 
     def self.install_executor_hooks(executor = ActiveSupport::Executor)

--- a/activerecord/lib/active_record/runtime_registry.rb
+++ b/activerecord/lib/active_record/runtime_registry.rb
@@ -12,9 +12,9 @@ module ActiveRecord
   class RuntimeRegistry # :nodoc:
     extend ActiveSupport::PerThreadRegistry
 
-    attr_accessor :connection_handler, :sql_runtime
+    attr_accessor :connection_handler, :sql_runtime, :query_cache_enabled
 
-    [:connection_handler, :sql_runtime].each do |val|
+    [:connection_handler, :sql_runtime, :query_cache_enabled].each do |val|
       class_eval %{ def self.#{val}; instance.#{val}; end }, __FILE__, __LINE__
       class_eval %{ def self.#{val}=(x); instance.#{val}=x; end }, __FILE__, __LINE__
     end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -232,6 +232,20 @@ class QueryCacheTest < ActiveRecord::TestCase
     }.call({})
   end
 
+  def test_query_caching_is_local_to_the_current_thread
+    ActiveRecord::Base.clear_all_connections!
+
+    middleware {
+      assert ActiveRecord::Base.query_cache_enabled?
+      assert ActiveRecord::Base.connection.query_cache_enabled
+
+      Thread.new {
+        refute ActiveRecord::Base.query_cache_enabled?
+        refute ActiveRecord::Base.connection.query_cache_enabled
+      }.join
+    }.call({})
+  end
+
   private
     def middleware(&app)
       executor = Class.new(ActiveSupport::Executor)

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -29,14 +29,16 @@ class QueryCacheTest < ActiveRecord::TestCase
   end
 
   def test_exceptional_middleware_leaves_enabled_cache_alone
-    ActiveRecord::Base.connection.enable_query_cache!
+    ActiveRecord::Base.enable_query_cache!
 
     mw = middleware { |env|
       raise "lol borked"
     }
     assert_raises(RuntimeError) { mw.call({}) }
 
-    assert ActiveRecord::Base.connection.query_cache_enabled, 'cache on'
+    assert ActiveRecord::Base.query_cache_enabled?, 'cache on'
+  ensure
+    ActiveRecord::Base.disable_query_cache!
   end
 
   def test_middleware_delegates
@@ -208,6 +210,26 @@ class QueryCacheTest < ActiveRecord::TestCase
     ActiveRecord::Base.connection.uncached do
       assert_equal 0, Post.where(title: 'rollback').to_a.count
     end
+  end
+
+  def test_query_cache_does_not_establish_connection_if_unconnected
+    ActiveRecord::Base.clear_all_connections!
+    refute ActiveRecord::Base.connected? # sanity check
+
+    middleware {
+      refute ActiveRecord::Base.connected?, "QueryCache forced ActiveRecord::Base to establish a connection in setup"
+    }.call({})
+
+    refute ActiveRecord::Base.connected?, "QueryCache forced ActiveRecord::Base to establish a connection in cleanup"
+  end
+
+  def test_query_cache_is_enabled_on_connections_established_after_middleware_runs
+    ActiveRecord::Base.clear_all_connections!
+    refute ActiveRecord::Base.connected? # sanity check
+
+    middleware {
+      assert ActiveRecord::Base.connection.query_cache_enabled, "QueryCache did not get lazily enabled"
+    }.call({})
   end
 
   private


### PR DESCRIPTION
We shouldn't assume the environment in which the executor is being used,
_especially_ now that this is no longer a middleware. Active Record is
meant to establish its connection lazily as needed, but the query cache
middleware currently is forcing it, which can cause things like boot
time to slow down as a database connection is needed to load routes,
etc.

The way query caching is handled is actually pretty leaky. If the result
of `ActiveRecord::Base.connection` is different in the `run` and
`complete` stages, we will have leaked enabling the query cache in the
first connection, and potentially changed the state of the latter.

This is equally leaky, but will enable the query cache on the new
connection when it is established during the course of the block. I
think the long term solution here is to have query caching decoupled
from the connection adapter, and instead handle it at a higher level.
That's a much larger refactoring though, and I need to explore whether
its worthwhile and if there's the expectation of the query cache living
on the connection adapter in the public API.

In the short term, this solves the concrete problem at hand.
## Alternatives

We could simply not enable the query cache if Active Record isn't
already connected. I'm concerened that this would actually cause the
query cache to be actually disabled in some applications though, and
adds a very subtle implicit contract to the executor which I don't want
to have.
