### PR TITLE
rake notes rspec's folder

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -16,6 +16,7 @@ class SourceAnnotationExtractor
   class Annotation < Struct.new(:line, :tag, :text)
     def self.directories
       @@directories ||= %w(app config db lib test) + (ENV['SOURCE_ANNOTATION_DIRECTORIES'] || '').split(',')
+      @@directories << 'spec' if Dir.glob('*').include?('spec') 
     end
 
     def self.extensions


### PR DESCRIPTION
### Summary
- It's new feature wich allows you to recive Notes by runing `rake notes` with rspec folder affected
- Tests have not been conducted
### Other Information

add 'spec' folder to array directories if it exist
