### PR TITLE
Remove redundant id_value argument from sql_for_insert

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -120,7 +120,7 @@ module ActiveRecord
       # If the next id was calculated in advance (as in Oracle), it should be
       # passed in as +id_value+.
       def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [])
-        sql, binds, pk, sequence_name = sql_for_insert(to_sql(arel, binds), pk, id_value, sequence_name, binds)
+        sql, binds, pk, sequence_name = sql_for_insert(to_sql(arel, binds), pk, sequence_name, binds)
         value = exec_insert(sql, name, binds, pk, sequence_name)
         id_value || last_inserted_id(value)
       end
@@ -377,7 +377,7 @@ module ActiveRecord
           exec_query(sql, name, binds, prepare: true)
         end
 
-        def sql_for_insert(sql, pk, id_value, sequence_name, binds)
+        def sql_for_insert(sql, pk, sequence_name, binds)
           [sql, binds, pk, sequence_name]
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -117,7 +117,7 @@ module ActiveRecord
         end
         alias :exec_update :exec_delete
 
-        def sql_for_insert(sql, pk, id_value, sequence_name, binds) # :nodoc:
+        def sql_for_insert(sql, pk, sequence_name, binds) # :nodoc:
           if pk.nil?
             # Extract the table from the insert sql. Yuck.
             table_ref = extract_table_ref_from_insert_sql(sql)

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -90,7 +90,7 @@ module ActiveRecord
 
       def test_sql_for_insert_with_returning_disabled
         connection = connection_without_insert_returning
-        sql, binds = connection.sql_for_insert('sql', nil, nil, nil, 'binds')
+        sql, binds = connection.sql_for_insert('sql', nil, nil, 'binds')
         assert_equal ['sql', 'binds'], [sql, binds]
       end
 


### PR DESCRIPTION
The argument id_value isn't used for anything. Removing passing of the value to make the code clearer while following along.
