### PR TITLE
Publish Rails 5 release notes

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -198,7 +198,6 @@
       name: Ruby on Rails 5.0 Release Notes
       url: 5_0_release_notes.html
       description: Release notes for Rails 5.0.
-      work_in_progress: true
     -
       name: Ruby on Rails 4.2 Release Notes
       url: 4_2_release_notes.html


### PR DESCRIPTION
After https://github.com/rails/rails/pull/25586 gets in, these are now ready for publishing.
