### PR TITLE
improved usage of uncountable for inflector specs

### DIFF
--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -59,7 +59,7 @@ class InflectorTest < ActiveSupport::TestCase
     ActiveSupport::Inflector.inflections.uncountables.pop
   end
 
-  ActiveSupport::Inflector.inflections.uncountable.each do |word|
+  ActiveSupport::Inflector.inflections.uncountables.each do |word|
     define_method "test_uncountability_of_#{word}" do
       assert_equal word, ActiveSupport::Inflector.singularize(word)
       assert_equal word, ActiveSupport::Inflector.pluralize(word)
@@ -71,7 +71,7 @@ class InflectorTest < ActiveSupport::TestCase
     uncountable_word = "ors"
     countable_word = "sponsor"
 
-    ActiveSupport::Inflector.inflections.uncountable << uncountable_word
+    ActiveSupport::Inflector.inflections.uncountable(uncountable_word)
 
     assert_equal uncountable_word, ActiveSupport::Inflector.singularize(uncountable_word)
     assert_equal uncountable_word, ActiveSupport::Inflector.pluralize(uncountable_word)


### PR DESCRIPTION
### Summary

This improves the usage of `#uncountable` in the Inflector specs. The two changed operations currently work because `#uncountable` returns the underlying set of uncountables. According to the docs, it seems that access should call `#uncountables` and modification should call `#uncountable` with parameters.

The first change is iterating over the uncountables, which should be accessed using the getter method. The second change is to be consistent with the DSL for adding inflections, instead of mutating the underlying object.
### Other Information

This probably seems cosmetic, but it matters when developing compatible/drop in extensions for AS::Inflector. I'm working on an improvement that matches the docs and API of Inflector, and using the existing specs is incredibly useful to ensure compatibility and prevent breakage.

Thanks!
