### PR TITLE
add bignum column into numeric_test

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -914,7 +914,8 @@ class BasicsTest < ActiveRecord::TestCase
       :bank_balance => 1586.43,
       :big_bank_balance => BigDecimal("1000234000567.95"),
       :world_population => 6000000000,
-      :my_house_population => 3
+      :my_house_population => 3,
+      :avogadro_constant => 602214085700000000000000
     )
     assert m.save
     assert_equal 0, NumericData.where("bank_balance > ?", 2000.0).count
@@ -925,16 +926,14 @@ class BasicsTest < ActiveRecord::TestCase
       :bank_balance => 1586.43,
       :big_bank_balance => BigDecimal("1000234000567.95"),
       :world_population => 6000000000,
-      :my_house_population => 3
+      :my_house_population => 3,
+      :avogadro_constant => 602214085700000000000000
     )
     assert m.save
 
     m1 = NumericData.find(m.id)
     assert_not_nil m1
 
-    # As with migration_test.rb, we should make world_population >= 2**62
-    # to cover 64-bit platforms and test it is a Bignum, but the main thing
-    # is that it's an Integer.
     assert_kind_of Integer, m1.world_population
     assert_equal 6000000000, m1.world_population
 
@@ -946,6 +945,11 @@ class BasicsTest < ActiveRecord::TestCase
 
     assert_kind_of BigDecimal, m1.big_bank_balance
     assert_equal BigDecimal("1000234000567.95"), m1.big_bank_balance
+
+    assert_equal m1.avogadro_constant.is_a?(Bignum), true
+    unless current_adapter?(:SQLite3Adapter)
+      assert_equal 602214085700000000000000, m1.avogadro_constant
+    end
   end
 
   def test_numeric_fields_with_scale
@@ -953,16 +957,14 @@ class BasicsTest < ActiveRecord::TestCase
       :bank_balance => 1586.43122334,
       :big_bank_balance => BigDecimal("234000567.952344"),
       :world_population => 6000000000,
-      :my_house_population => 3
+      :my_house_population => 3,
+      :avogadro_constant => 602214085700000000000000
     )
     assert m.save
 
     m1 = NumericData.find(m.id)
     assert_not_nil m1
 
-    # As with migration_test.rb, we should make world_population >= 2**62
-    # to cover 64-bit platforms and test it is a Bignum, but the main thing
-    # is that it's an Integer.
     assert_kind_of Integer, m1.world_population
     assert_equal 6000000000, m1.world_population
 
@@ -974,6 +976,11 @@ class BasicsTest < ActiveRecord::TestCase
 
     assert_kind_of BigDecimal, m1.big_bank_balance
     assert_equal BigDecimal("234000567.95"), m1.big_bank_balance
+
+    assert_equal m1.avogadro_constant.is_a?(Bignum), true
+    unless current_adapter?(:SQLite3Adapter)
+      assert_equal 602214085700000000000000, m1.avogadro_constant
+    end
   end
 
   def test_auto_id

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -164,7 +164,8 @@ class MigrationTest < ActiveRecord::TestCase
       :big_bank_balance => BigDecimal("1000234000567.95"),
       :world_population => 6000000000,
       :my_house_population => 3,
-      :value_of_e => BigDecimal("2.7182818284590452353602875")
+      :value_of_e => BigDecimal("2.7182818284590452353602875"),
+      :avogadro_constant => 602214085700000000000000
     )
 
     b = BigNumber.first
@@ -176,8 +177,6 @@ class MigrationTest < ActiveRecord::TestCase
     assert_not_nil b.my_house_population
     assert_not_nil b.value_of_e
 
-    # TODO: set world_population >= 2**62 to cover 64-bit platforms and test
-    # is_a?(Bignum)
     assert_kind_of Integer, b.world_population
     assert_equal 6000000000, b.world_population
     assert_kind_of Integer, b.my_house_population
@@ -186,6 +185,10 @@ class MigrationTest < ActiveRecord::TestCase
     assert_equal BigDecimal("1586.43"), b.bank_balance
     assert_kind_of BigDecimal, b.big_bank_balance
     assert_equal BigDecimal("1000234000567.95"), b.big_bank_balance
+    unless current_adapter?(:SQLite3Adapter)
+      assert_equal 602214085700000000000000, b.avogadro_constant
+    end
+    assert_equal b.avogadro_constant.is_a?(Bignum), true
 
     # This one is fun. The 'value_of_e' field is defined as 'DECIMAL' with
     # precision/scale explicitly left out.  By the SQL standard, numbers

--- a/activerecord/test/migrations/decimal/1_give_me_big_numbers.rb
+++ b/activerecord/test/migrations/decimal/1_give_me_big_numbers.rb
@@ -6,6 +6,7 @@ class GiveMeBigNumbers < ActiveRecord::Migration::Current
       table.column :world_population, :decimal, :precision => 10
       table.column :my_house_population, :decimal, :precision => 2
       table.column :value_of_e, :decimal
+      table.column :avogadro_constant, :decimal, :precision => 24
     end
   end
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -519,6 +519,7 @@ ActiveRecord::Schema.define do
     else
       t.decimal :atoms_in_universe, precision: 55, scale: 0
     end
+    t.decimal :avogadro_constant, precision: 24, scale: 0
   end
 
   create_table :orders, force: true do |t|


### PR DESCRIPTION
### Summary

Add a Bignum test to 'base_test.rb' and 'migration_test.rb'.
### Other Information

I found this TODO in test and edited. But my concern is this feature in ruby 2.4. (Bignum become alias of Integer, so is_a?(Bignum) will not fail but becomes meaningless.)
https://bugs.ruby-lang.org/issues/12005

So, I need to add some condition logic about ruby version?
Or these changes are not so important? If so, I think following comment should be updated.

```
# TODO: set world_population >= 2**62 to cover 64-bit platforms and test        
# is_a?(Bignum)
```
