### PR TITLE
[ci skip] Fixes incorrect command to list middleware

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -227,7 +227,7 @@ building, and make sense in an API-only Rails application.
 You can get a list of all middleware in your application via:
 
 ```bash
-$ rails middleware
+$ rake middleware
 ```
 
 ### Using the Cache Middleware


### PR DESCRIPTION
### Summary

Minor change to documentation.  While following along, one command was incorrect so I've updated it.
### Other Information

'rails middleware' doesn't work
'rake middleware' is the desired command.
