### PR TITLE
close hijacked i/o socket after use (fixes #25613)

### DIFF
--- a/actioncable/lib/action_cable/connection/stream.rb
+++ b/actioncable/lib/action_cable/connection/stream.rb
@@ -50,6 +50,7 @@ module ActionCable
         def clean_rack_hijack
           return unless @rack_hijack_io
           @event_loop.detach(@rack_hijack_io, self)
+          @rack_hijack_io.close
           @rack_hijack_io = nil
         end
     end

--- a/actioncable/test/connection/client_socket_test.rb
+++ b/actioncable/test/connection/client_socket_test.rb
@@ -48,6 +48,20 @@ class ActionCable::Connection::ClientSocketTest < ActionCable::TestCase
     end
   end
 
+  test 'closes hijacked i/o socket at shutdown' do
+    skip if ENV['FAYE'].present?
+
+    run_in_eventmachine do
+      connection = open_connection
+
+      client = connection.websocket.send(:websocket)
+      client.instance_variable_get('@stream')
+        .instance_variable_get('@rack_hijack_io')
+        .expects(:close)
+      connection.close
+    end
+  end
+
   private
     def open_connection
       env = Rack::MockRequest.env_for '/test',


### PR DESCRIPTION
### Summary

This PR Fixes #25613. 
### Other Information

This behaviour is required as per the Rack spec located here:

http://www.rubydoc.info/github/rack/rack/file/SPEC

Specifically:

> "After the headers have been sent, and this hijack callback has been called, the application is now responsible for the remaining lifecycle of the IO. The application is also responsible for maintaining HTTP semantics."
