### PR TITLE
Bring back support for callable cache key when rendering collection

### DIFF
--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -393,9 +393,14 @@ class CollectionCacheController < ActionController::Base
     @customers = [Customer.new('david', 1)]
     render partial: 'customers/commented_customer', collection: @customers, as: :customer, cached: true
   end
+
+  def index_with_callable_cache_key
+    @customers = [Customer.new('david', 1)]
+    render partial: 'customers/customer', collection: @customers, cached: -> customer { 'cached_david' }
+  end
 end
 
-class AutomaticCollectionCacheTest < ActionController::TestCase
+class CollectionCacheTest < ActionController::TestCase
   def setup
     super
     @controller = CollectionCacheController.new
@@ -436,6 +441,11 @@ class AutomaticCollectionCacheTest < ActionController::TestCase
 
     get :index_with_comment
     assert_equal 1, @controller.partial_rendered_times
+  end
+
+  def test_caching_with_callable_cache_key
+    get :index_with_callable_cache_key
+    assert_customer_cached 'cached_david', 'david, 1'
   end
 
   private

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -130,9 +130,10 @@ module ActionView
       #
       # When rendering a collection of objects that each use the same partial, a `cached`
       # option can be passed.
+      #
       # For collections rendered such:
       #
-      #   <%= render partial: 'notifications/notification', collection: @notifications, cached: true %>
+      #   <%= render partial: 'projects/project', collection: @projects, cached: true %>
       #
       # The `cached: true` will make Action View's rendering read several templates
       # from cache at once instead of one call per template.
@@ -142,13 +143,21 @@ module ActionView
       # Works great alongside individual template fragment caching.
       # For instance if the template the collection renders is cached like:
       #
-      #   # notifications/_notification.html.erb
-      #   <% cache notification do %>
+      #   # projects/_project.html.erb
+      #   <% cache project do %>
       #     <%# ... %>
       #   <% end %>
       #
       # Any collection renders will find those cached templates when attempting
       # to read multiple templates at once.
+      #
+      # If your collection cache depends on multiple sources (try to avoid this to keep things simple),
+      # you can name all these dependencies as part of a block that returns an array:
+      #
+      #   <%= render partial: 'projects/project', collection: @projects, cached: -> project { [ project, current_user ] } %>
+      #
+      # This will include both records as part of the cache key and updating either of them will
+      # expire the cache.
       def cache(name = {}, options = {}, &block)
         if controller.respond_to?(:perform_caching) && controller.perform_caching
           name_options = options.slice(:skip_digest, :virtual_path)

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -25,9 +25,15 @@ module ActionView
         end
       end
 
+      def callable_cache_key?
+        @options[:cached].respond_to?(:call)
+      end
+
       def collection_by_cache_keys
+        seed = callable_cache_key? ? @options[:cached] : ->(i) { i }
+
         @collection.each_with_object({}) do |item, hash|
-          hash[expanded_cache_key(item)] = item
+          hash[expanded_cache_key(seed.call(item))] = item
         end
       end
 


### PR DESCRIPTION
Custom callable cache key was originally considered valid and is supported when multi_fetch_fragments [first merged](https://github.com/rails/rails/pull/18948), but eventually it got removed when caching was made [explicit](https://github.com/rails/rails/pull/23695).. I'm not sure if this is an accidental oversight, or is a conscious decision to not support callable cache key -- since there're no explanation for the reasoning behind it in the linked PR..

Another thing that feels a bit weird is the decision to rename the option from `cache` to `cached`.. though, I guess, this was made to force people who migrate from the multi_fetch_fragments to update their codes? This does make the migration path rather painful though..

I still think that there're still valid cases for supporting callable cache key, and the code  for supporting it doesn't seems to be complicated.. wdyt guys?
