### PR TITLE
Fix links to source code [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Everyone interacting in Rails and its sub-projects' codebases, issue trackers, c
 
 ## Code Status
 
-[![Build Status](https://travis-ci.org/rails/rails.svg?branch=master)](https://travis-ci.org/rails/rails)
+[![Build Status](https://travis-ci.org/rails/rails.svg?branch=5-0-stable)](https://travis-ci.org/rails/rails)
 
 ## License
 

--- a/actionmailer/README.rdoc
+++ b/actionmailer/README.rdoc
@@ -150,7 +150,7 @@ The latest version of Action Mailer can be installed with RubyGems:
 
 Source code can be downloaded as part of the Rails project on GitHub
 
-* https://github.com/rails/rails/tree/master/actionmailer
+* https://github.com/rails/rails/tree/5-0-stable/actionmailer
 
 
 == License

--- a/actionpack/README.rdoc
+++ b/actionpack/README.rdoc
@@ -32,7 +32,7 @@ The latest version of Action Pack can be installed with RubyGems:
 
 Source code can be downloaded as part of the Rails project on GitHub
 
-* https://github.com/rails/rails/tree/master/actionpack
+* https://github.com/rails/rails/tree/5-0-stable/actionpack
 
 
 == License

--- a/actionview/README.rdoc
+++ b/actionview/README.rdoc
@@ -13,7 +13,7 @@ The latest version of Action View can be installed with RubyGems:
 
 Source code can be downloaded as part of the Rails project on GitHub
 
-* https://github.com/rails/rails/tree/master/actionview
+* https://github.com/rails/rails/tree/5-0-stable/actionview
 
 
 == License

--- a/activejob/README.md
+++ b/activejob/README.md
@@ -102,7 +102,7 @@ The latest version of Active Job can be installed with RubyGems:
 
 Source code can be downloaded as part of the Rails project on GitHub
 
-* https://github.com/rails/rails/tree/master/activejob
+* https://github.com/rails/rails/tree/5-0-stable/activejob
 
 ## License
 

--- a/activemodel/README.rdoc
+++ b/activemodel/README.rdoc
@@ -239,7 +239,7 @@ The latest version of Active Model can be installed with RubyGems:
 
 Source code can be downloaded as part of the Rails project on GitHub
 
-* https://github.com/rails/rails/tree/master/activemodel
+* https://github.com/rails/rails/tree/5-0-stable/activemodel
 
 
 == License

--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -192,7 +192,7 @@ The latest version of Active Record can be installed with RubyGems:
 
 Source code can be downloaded as part of the Rails project on GitHub:
 
-* https://github.com/rails/rails/tree/master/activerecord
+* https://github.com/rails/rails/tree/5-0-stable/activerecord
 
 
 == License

--- a/activesupport/README.rdoc
+++ b/activesupport/README.rdoc
@@ -14,7 +14,7 @@ The latest version of Active Support can be installed with RubyGems:
 
 Source code can be downloaded as part of the Rails project on GitHub:
 
-* https://github.com/rails/rails/tree/master/activesupport
+* https://github.com/rails/rails/tree/5-0-stable/activesupport
 
 
 == License

--- a/railties/README.rdoc
+++ b/railties/README.rdoc
@@ -17,7 +17,7 @@ The latest version of Railties can be installed with RubyGems:
 
 Source code can be downloaded as part of the Rails project on GitHub
 
-* https://github.com/rails/rails/tree/master/railties
+* https://github.com/rails/rails/tree/5-0-stable/railties
 
 == License
 


### PR DESCRIPTION
As these were pointing to wrong source code. These should point to 5-0-stable.
