### PR TITLE
Pass `pk: false` to `connection.insert` explicitly if do not have a primary key

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -65,7 +65,7 @@ module ActiveRecord
       @klass.connection.insert(
         im,
         'SQL',
-        primary_key,
+        primary_key || false,
         primary_key_value,
         nil,
         binds)

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -174,6 +174,14 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_equal '2', dashboard.id
   end
 
+  def test_create_without_primary_key_no_extra_query
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = 'dashboards'
+    end
+    klass.create! # warmup schema cache
+    assert_queries(3, ignore_none: true) { klass.create! }
+  end
+
   if current_adapter?(:PostgreSQLAdapter)
     def test_serial_with_quoted_sequence_name
       column = MixedCaseMonkey.columns_hash[MixedCaseMonkey.primary_key]


### PR DESCRIPTION
Because causing an extra query by `sql_for_insert` for guessing a
primary key.
https://github.com/rails/rails/blob/v5.0.0/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb#L121-L125
