### PR TITLE
Fixed issue when template was containing a ruby comment at EOF:

### DIFF
--- a/actionview/lib/action_view/template/handlers/erb/erubis.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubis.rb
@@ -65,6 +65,7 @@ module ActionView
 
           def add_postamble(src)
             flush_newline_if_pending(src)
+            src << "\n"
             src << "@output_buffer.to_s"
           end
 

--- a/actionview/test/fixtures/test/last_line_ruby_comment.erb
+++ b/actionview/test/fixtures/test/last_line_ruby_comment.erb
@@ -1,0 +1,5 @@
+<p> Should be displayed </p>
+<% ['John', 'Jane', 'James'].each do |name| %>
+  <li> <%= name %> </li>
+<% end %>
+<% # This is a ruby comment %>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -34,6 +34,10 @@ module RenderTestCases
     assert_equal "Hello world!", @view.render(file: "test/hello_world")
   end
 
+  def test_render_file_containing_ruby_comment
+    assert_match "<p> Should be displayed </p>", @view.render(:file => "test/last_line_ruby_comment")
+  end
+
   # Test if :formats, :locale etc. options are passed correctly to the resolvers.
   def test_render_file_with_format
     assert_match "<h1>No Comment</h1>", @view.render(file: "comments/empty", formats: [:html])

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -35,7 +35,12 @@ module RenderTestCases
   end
 
   def test_render_file_containing_ruby_comment
-    assert_match "<p> Should be displayed </p>", @view.render(:file => "test/last_line_ruby_comment")
+    old_erb_implementation = ActionView::Template::Handlers::ERB.erb_implementation
+    ActionView::Template::Handlers::ERB.erb_implementation = ActionView::Template::Handlers::ERB::Erubis
+
+    assert_match "<p> Should be displayed </p>", @view.render(file: "test/last_line_ruby_comment")
+  ensure
+    ActionView::Template::Handlers::ERB.erb_implementation = old_erb_implementation
   end
 
   # Test if :formats, :locale etc. options are passed correctly to the resolvers.


### PR DESCRIPTION
This fixes https://github.com/rails/rails/issues/25557

Fixed issue when template was containing a ruby comment at EOF:
- If a template was containing a ruby comment `<% # Comment %>` at the very end of a file, the template was not getting displayed
- When evaluating the generated code from `Eruby#src`, the last statement was looking something like `#Comment; @output_buffer.to_s`. Ruby evaluates this line as a full comment, thus the output_buffer was not returned
- Solution was to flush a new line if a comment was detected without terminating by a `\n`
