### PR TITLE
Store original exception in action_dispatch.exception, not exception cause

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Store original exception in action_dispatch.exception, not exception cause
+
+    Previously, when an error was raised that had a cause, we would store the cause
+    of the error in `request.env["action_dispatch.exception"]`, rather than the
+    error itself. That causes a loss of important information - it's not possible
+    to get back to the top-level error from the stored exception (since the `cause`
+    relationship on errors in one-way).
+
+    After this change, it is the top-level error, rather than its cause, that will
+    be stored in `request.env["action_dispatch.exception"]`. Any exception handler
+    app can then take responsibilty for inspecting the error's cause, if required.
+
+    Reverses the (undesired) change in behaviour from
+    https://github.com/rails/rails/pull/18774
+
+    *Grey Baker*
+
 *   Check `request.path_parameters` encoding at the point they're set
 
     Check for any non-UTF8 characters in path parameters at the point they're

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -43,7 +43,7 @@ module ActionDispatch
       backtrace_cleaner = request.get_header 'action_dispatch.backtrace_cleaner'
       wrapper = ExceptionWrapper.new(backtrace_cleaner, exception)
       status  = wrapper.status_code
-      request.set_header "action_dispatch.exception", wrapper.exception
+      request.set_header "action_dispatch.exception", exception
       request.set_header "action_dispatch.original_path", request.path_info
       request.path_info = "/#{status}"
       response = @exceptions_app.call(request.env)

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -98,7 +98,7 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
 
   test "calls custom exceptions app" do
     exceptions_app = lambda do |env|
-      assert_kind_of AbstractController::ActionNotFound, env["action_dispatch.exception"]
+      assert_kind_of ActionView::Template::Error, env["action_dispatch.exception"]
       assert_equal "/404", env["PATH_INFO"]
       assert_equal "/not_found_original_exception", env["action_dispatch.original_path"]
       [404, { "Content-Type" => "text/plain" }, ["YOU FAILED"]]


### PR DESCRIPTION
Previously, when an error was raised that had a cause, we would store the cause
of the error in `request.env["action_dispatch.exception"]`, rather than the
error itself. That causes a loss of important information - it's not possible
to get back to the top-level error from the stored exception (since the `cause`
relationship on errors in one-way).

After this change, it is the top-level error, rather than its cause, that will
be stored in `request.env["action_dispatch.exception"]`. Any exception handler
app can then take responsibility for inspecting the error's cause, if required.

Reverses the (undesired?) change in behaviour from
https://github.com/rails/rails/pull/18774

In our app, there are a bunch of places where we want to avoid serving 422s for validation errors, and instead want to blow up. The recent change to store the exception's `cause` means we can no longer do the following:

``` (ruby)
begin
  # code
rescue ActionRecord::ValidationError => e
  raise "Validation error raised when it should not be possible. Someone should look into this! #{e.message}"
end
```
