### PR TITLE
Do not depend on Rails git repository layout in ActiveSupport tests.

### DIFF
--- a/activesupport/test/testing/file_fixtures_test.rb
+++ b/activesupport/test/testing/file_fixtures_test.rb
@@ -6,7 +6,7 @@ class FileFixturesTest < ActiveSupport::TestCase
   test "#file_fixture returns Pathname to file fixture" do
     path = file_fixture("sample.txt")
     assert_kind_of Pathname, path
-    assert_match %r{activesupport/test/file_fixtures/sample.txt$}, path.to_s
+    assert_match %r{.*/test/file_fixtures/sample.txt$}, path.to_s
   end
 
   test "raises an exception when the fixture file does not exist" do
@@ -23,6 +23,6 @@ class FileFixturesPathnameDirectoryTest < ActiveSupport::TestCase
   test "#file_fixture_path returns Pathname to file fixture" do
     path = file_fixture("sample.txt")
     assert_kind_of Pathname, path
-    assert_match %r{activesupport/test/file_fixtures/sample.txt$}, path.to_s
+    assert_match %r{.*/test/file_fixtures/sample.txt$}, path.to_s
   end
 end


### PR DESCRIPTION
### Summary

We run the tests in our Fedora builds in different directories than those that come with Rails git layout. Can we make these tests more benevolent and allow other directories to be used as well? This is similar to #19625
