### PR TITLE
Revert "Rename `active_record_internal_metadatas` to `ar_internal_metadata"

### DIFF
--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -14,10 +14,6 @@ module ActiveRecord
         "#{table_name_prefix}#{ActiveRecord::Base.internal_metadata_table_name}#{table_name_suffix}"
       end
 
-      def original_table_name
-        "#{table_name_prefix}active_record_internal_metadatas#{table_name_suffix}"
-      end
-
       def []=(key, value)
         find_or_initialize_by(key: key).update_attributes!(value: value)
       end
@@ -30,17 +26,8 @@ module ActiveRecord
         ActiveSupport::Deprecation.silence { connection.table_exists?(table_name) }
       end
 
-      def original_table_exists?
-        # This method will be removed in Rails 5.1
-        # Since it is only necessary when `active_record_internal_metadatas` could exist
-        ActiveSupport::Deprecation.silence { connection.table_exists?(original_table_name) }
-      end
-
       # Creates an internal metadata table with columns +key+ and +value+
       def create_table
-        if original_table_exists?
-          connection.rename_table(original_table_name, table_name)
-        end
         unless table_exists?
           key_options = connection.internal_string_options_for_primary_key
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -445,21 +445,6 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Migrator.migrations_paths = old_path
   end
 
-  def test_rename_internal_metadata_table
-    original_internal_metadata_table_name = ActiveRecord::Base.internal_metadata_table_name
-
-    ActiveRecord::Base.internal_metadata_table_name = "active_record_internal_metadatas"
-    Reminder.reset_table_name
-
-    ActiveRecord::Base.internal_metadata_table_name = original_internal_metadata_table_name
-    Reminder.reset_table_name
-
-    assert_equal "ar_internal_metadata", ActiveRecord::InternalMetadata.table_name
-  ensure
-    ActiveRecord::Base.internal_metadata_table_name = original_internal_metadata_table_name
-    Reminder.reset_table_name
-  end
-
   def test_proper_table_name_on_migration
     reminder_class = new_isolated_reminder_class
     migration = ActiveRecord::Migration.new


### PR DESCRIPTION
### Summary

This reverts commit 407e0ab5e5cddf6a8b6b278b12f50772d13b4d86 which is part of #23025.

407e0ab5e5cddf6a8b6b278b12f50772d13b4d86 is necessary only for users who had been using Rails 5.0.0.beta1.  As long as they upgrade to 5.0.0.beta2 or later version of Rails 5.0. `internal_metadata_table_name` should have been `ar_internal_metadata`. 

This method can be removed in Rails 5.1. I think it is good timing to open this pull request since Rails 5.0.0 released.
