### PR TITLE
Fix request encoding in tests when string literals are frozen

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -423,7 +423,7 @@ module ActionDispatch
           end
 
           def append_format_to(path)
-            path << @path_format unless @url_encoded_form
+            path += @path_format unless @url_encoded_form
             path
           end
 


### PR DESCRIPTION
When running tests with `--enable-frozen-string-literal` or `# frozen_string_literal: true`, it's currently attempted to mutate the path string in order to append the format, causing a `RuntimeError`.

``` ruby
get '/posts', as: :json
```

```
RuntimeError:
 can't modify frozen String
```

This commit fixes the problem by replacing the mutation with a concatenation, returning a new string.

Unfortunately I couldn't unit test the fix as it would require to use some string literal directive in the test suite, but I think these kind of fixes will be covered in the future once frozen literals are enabled by default project-wide.

cc @rafaelfranca @kaspth
