### PR TITLE
`partial` option on the digest method is no more needed [ci skip]:

### DIFF
--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -12,7 +12,6 @@ module ActionView
       # * <tt>name</tt>   - Template name
       # * <tt>finder</tt>  - An instance of <tt>ActionView::LookupContext</tt>
       # * <tt>dependencies</tt>  - An array of dependent views
-      # * <tt>partial</tt>  - Specifies whether the template is a partial
       def digest(name:, finder:, dependencies: [])
         dependencies ||= []
         cache_key = [ name, finder.rendered_format, dependencies ].flatten.compact.join('.')


### PR DESCRIPTION
We don't need to pass the `partial` option to the digest method:
- `partial` option is not used anymore, this was removed in https://github.com/rails/rails/pull/23724
