### PR TITLE
refer to rails command instead of rake in doc of `SourceAnnotationExtractor`

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -1,9 +1,9 @@
 # Implements the logic behind the rake tasks for annotations like
 #
-#   rake notes
-#   rake notes:optimize
+#   rails notes
+#   rails notes:optimize
 #
-# and friends. See <tt>rake -T notes</tt> and <tt>railties/lib/rails/tasks/annotations.rake</tt>.
+# and friends. See <tt>rails -T notes</tt> and <tt>railties/lib/rails/tasks/annotations.rake</tt>.
 #
 # Annotation objects are triplets <tt>:line</tt>, <tt>:tag</tt>, <tt>:text</tt> that
 # represent the line where the annotation lives, its tag, and its text. Note


### PR DESCRIPTION
[ci skip]
