### PR TITLE
Add a note about adding CHANGELOG entries at the top of the file 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,9 @@ If there's anything else that's important and relevant to your pull
 request, mention that information here. This could include
 benchmarks, or other information.
 
+If you are updating any of the CHANGELOG files or are asked to update the
+CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.
+
 Finally, if your pull request affects documentation or any non-code
 changes, guidelines for those changes are [available
 here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)


### PR DESCRIPTION
Opening this up for discussion. We have seen lot of times that CHANGELOG entries are added in middle.
