### PR TITLE
Remove unused boot_rails method and it's usage

### DIFF
--- a/railties/test/application/asset_debugging_test.rb
+++ b/railties/test/application/asset_debugging_test.rb
@@ -28,8 +28,6 @@ module ApplicationTests
       RUBY
 
       ENV["RAILS_ENV"] = "production"
-
-      boot_rails
     end
 
     def teardown

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -9,7 +9,6 @@ module ApplicationTests
 
     def setup
       build_app(initializers: true)
-      boot_rails
     end
 
     def teardown

--- a/railties/test/application/configuration/custom_test.rb
+++ b/railties/test/application/configuration/custom_test.rb
@@ -5,7 +5,6 @@ module ApplicationTests
     class CustomTest < ActiveSupport::TestCase
       def setup
         build_app
-        boot_rails
         FileUtils.rm_rf("#{app_path}/config/environments")
       end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -51,7 +51,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
       supress_default_config
     end
 
@@ -570,7 +569,7 @@ module ApplicationTests
       app_file 'config/secrets.yml', <<-YAML
         shared:
           api_key: 3b7cd727
-        
+
         development:
           api_key: abc12345
       YAML

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -5,7 +5,6 @@ class ConsoleTest < ActiveSupport::TestCase
 
   def setup
     build_app
-    boot_rails
   end
 
   def teardown

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -6,7 +6,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
     end
 
     def teardown

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -6,7 +6,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
       FileUtils.rm_rf "#{app_path}/config/environments"
     end
 

--- a/railties/test/application/initializers/hooks_test.rb
+++ b/railties/test/application/initializers/hooks_test.rb
@@ -6,7 +6,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
       FileUtils.rm_rf "#{app_path}/config/environments"
     end
 

--- a/railties/test/application/initializers/i18n_test.rb
+++ b/railties/test/application/initializers/i18n_test.rb
@@ -6,7 +6,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
       FileUtils.rm_rf "#{app_path}/config/environments"
       require "rails/all"
     end

--- a/railties/test/application/initializers/load_path_test.rb
+++ b/railties/test/application/initializers/load_path_test.rb
@@ -6,7 +6,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
       FileUtils.rm_rf "#{app_path}/config/environments"
     end
 

--- a/railties/test/application/initializers/notifications_test.rb
+++ b/railties/test/application/initializers/notifications_test.rb
@@ -6,7 +6,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
     end
 
     def teardown

--- a/railties/test/application/integration_test_case_test.rb
+++ b/railties/test/application/integration_test_case_test.rb
@@ -6,7 +6,6 @@ module ApplicationTests
 
     setup do
       build_app
-      boot_rails
     end
 
     teardown do

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -5,7 +5,6 @@ class LoadingTest < ActiveSupport::TestCase
 
   def setup
     build_app
-    boot_rails
   end
 
   def teardown

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -9,7 +9,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
     end
 
     def teardown

--- a/railties/test/application/middleware/cache_test.rb
+++ b/railties/test/application/middleware/cache_test.rb
@@ -6,7 +6,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
       require 'rack/test'
       extend Rack::Test::Methods
     end

--- a/railties/test/application/middleware/cookies_test.rb
+++ b/railties/test/application/middleware/cookies_test.rb
@@ -10,7 +10,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
       FileUtils.rm_rf("#{app_path}/config/environments")
     end
 

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -8,7 +8,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
     end
 
     def teardown

--- a/railties/test/application/middleware/sendfile_test.rb
+++ b/railties/test/application/middleware/sendfile_test.rb
@@ -6,7 +6,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
       FileUtils.rm_rf "#{app_path}/config/environments"
     end
 

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -8,7 +8,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
       FileUtils.rm_rf "#{app_path}/config/environments"
     end
 

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -6,7 +6,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
       FileUtils.rm_rf "#{app_path}/config/environments"
     end
 

--- a/railties/test/application/multiple_applications_test.rb
+++ b/railties/test/application/multiple_applications_test.rb
@@ -6,7 +6,6 @@ module ApplicationTests
 
     def setup
       build_app(initializers: true)
-      boot_rails
       require "#{rails_root}/config/environment"
       Rails.application.config.some_setting = 'something_or_other'
     end

--- a/railties/test/application/paths_test.rb
+++ b/railties/test/application/paths_test.rb
@@ -6,7 +6,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
       FileUtils.rm_rf("#{app_path}/config/environments")
       app_file "config/environments/development.rb", ""
       add_to_config <<-RUBY

--- a/railties/test/application/rackup_test.rb
+++ b/railties/test/application/rackup_test.rb
@@ -12,7 +12,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
     end
 
     def teardown

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -8,7 +8,6 @@ module ApplicationTests
 
       def setup
         build_app
-        boot_rails
         FileUtils.rm_rf("#{app_path}/config/environments")
       end
 

--- a/railties/test/application/rake/framework_test.rb
+++ b/railties/test/application/rake/framework_test.rb
@@ -8,7 +8,6 @@ module ApplicationTests
 
       def setup
         build_app
-        boot_rails
         FileUtils.rm_rf("#{app_path}/config/environments")
       end
 

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -5,7 +5,6 @@ module ApplicationTests
     class RakeMigrationsTest < ActiveSupport::TestCase
       def setup
         build_app
-        boot_rails
         FileUtils.rm_rf("#{app_path}/config/environments")
       end
 

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -149,7 +149,6 @@ module ApplicationTests
       end
 
       def boot_rails
-        super
         require "#{app_path}/config/environment"
       end
     end

--- a/railties/test/application/rake/restart_test.rb
+++ b/railties/test/application/rake/restart_test.rb
@@ -7,7 +7,6 @@ module ApplicationTests
 
       def setup
         build_app
-        boot_rails
       end
 
       def teardown

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -7,7 +7,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
     end
 
     def teardown

--- a/railties/test/application/rendering_test.rb
+++ b/railties/test/application/rendering_test.rb
@@ -8,7 +8,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
     end
 
     def teardown

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -8,7 +8,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
     end
 
     def teardown

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -8,7 +8,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
 
       # Lets create a model so we have something to play with
       app_file "app/models/user.rb", <<-MODEL
@@ -76,12 +75,12 @@ module ApplicationTests
 
     def test_runner_detects_syntax_errors
       Dir.chdir(app_path) { `bin/rails runner "puts 'hello world" 2>&1` }
-      refute $?.success? 
+      refute $?.success?
     end
 
     def test_runner_detects_bad_script_name
       Dir.chdir(app_path) { `bin/rails runner "iuiqwiourowe" 2>&1` }
-      refute $?.success? 
+      refute $?.success?
     end
 
     def test_environment_with_rails_env

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -6,7 +6,6 @@ module ApplicationTests
 
     def setup
       build_app
-      boot_rails
     end
 
     def teardown

--- a/railties/test/application/url_generation_test.rb
+++ b/railties/test/application/url_generation_test.rb
@@ -9,7 +9,6 @@ module ApplicationTests
     end
 
     test "it works" do
-      boot_rails
       require "rails"
       require "action_controller/railtie"
       require "action_view/railtie"
@@ -44,7 +43,6 @@ module ApplicationTests
     end
 
     def test_routes_know_the_relative_root
-      boot_rails
       require "rails"
       require "action_controller/railtie"
       require "action_view/railtie"

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -310,9 +310,6 @@ module TestHelpers
 
       $:.reject! {|path| path =~ %r'/(#{to_remove.join('|')})/' }
     end
-
-    def boot_rails
-    end
   end
 end
 

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -28,7 +28,6 @@ module RailtiesTest
     end
 
     def boot_rails
-      super
       require "#{app_path}/config/environment"
     end
 

--- a/railties/test/railties/mounted_engine_test.rb
+++ b/railties/test/railties/mounted_engine_test.rb
@@ -179,8 +179,6 @@ module ApplicationTests
           end
         end
       RUBY
-
-      boot_rails
     end
 
     def teardown

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -6,7 +6,6 @@ module RailtiesTest
 
     def setup
       build_app
-      boot_rails
       FileUtils.rm_rf("#{app_path}/config/environments")
       require "rails/all"
     end


### PR DESCRIPTION
### Summary
- The `boot_rails` method from abstract_unit.rb is empty after 2abcdfd978fdcd491576a237e8c6b.
- So let's remove it and its usage.
