### PR TITLE
AS::Duration should serialize empty values correctly.

### DIFF
--- a/activesupport/lib/active_support/duration/iso8601_serializer.rb
+++ b/activesupport/lib/active_support/duration/iso8601_serializer.rb
@@ -42,7 +42,7 @@ module ActiveSupport
           end
           # If all parts are negative - let's make a negative duration
           sign = ''
-          if !parts.empty? && parts.values.all? { |v| v < 0 }
+          if parts.values.all? { |v| v < 0 }
             sign = '-'
             parts.transform_values!(&:-@)
           end

--- a/activesupport/lib/active_support/duration/iso8601_serializer.rb
+++ b/activesupport/lib/active_support/duration/iso8601_serializer.rb
@@ -12,9 +12,10 @@ module ActiveSupport
 
       # Builds and returns output string.
       def serialize
-        output = 'P'
         parts, sign = normalize
-        return output << "T0S" if parts.empty?
+        return "PT0S".freeze if parts.empty?
+
+        output = 'P'
         output << "#{parts[:years]}Y"   if parts.key?(:years)
         output << "#{parts[:months]}M"  if parts.key?(:months)
         output << "#{parts[:weeks]}W"   if parts.key?(:weeks)

--- a/activesupport/lib/active_support/duration/iso8601_serializer.rb
+++ b/activesupport/lib/active_support/duration/iso8601_serializer.rb
@@ -14,6 +14,7 @@ module ActiveSupport
       def serialize
         output = 'P'
         parts, sign = normalize
+        return output << "T0S" if parts.empty?
         output << "#{parts[:years]}Y"   if parts.key?(:years)
         output << "#{parts[:months]}M"  if parts.key?(:months)
         output << "#{parts[:weeks]}W"   if parts.key?(:weeks)
@@ -40,7 +41,7 @@ module ActiveSupport
           end
           # If all parts are negative - let's make a negative duration
           sign = ''
-          if parts.values.all? { |v| v < 0 }
+          if !parts.empty? && parts.values.all? { |v| v < 0 }
             sign = '-'
             parts.transform_values!(&:-@)
           end

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -279,6 +279,7 @@ class DurationTest < ActiveSupport::TestCase
       ['PT1S',          1.second                         ],
       ['PT1.4S',        (1.4).seconds                    ],
       ['P1Y1M1DT1H',    1.year + 1.month + 1.day + 1.hour],
+      ['PT0S',          0.minutes                        ],
     ]
     expectations.each do |expected_output, duration|
       assert_equal expected_output, duration.iso8601, expected_output.inspect


### PR DESCRIPTION
### Summary

The current implementation of `ActiveSupport::Duration::ISO8601Serializer` serializes zero-length durations incorrectly (it serializes as `"-P"`), and cannot un-serialize itself:

```
[1] pry(main)> ActiveSupport::Duration.parse(0.minutes.iso8601)
ActiveSupport::Duration::ISO8601Parser::ParsingError: Invalid ISO 8601 duration: "-P" is empty duration
from /Users/rando/.gem/ruby/2.3.1/gems/activesupport-5.0.0/lib/active_support/duration/iso8601_parser.rb:96:in `raise_parsing_error'
```

Postgres empty intervals are serialized as `"PT0S"`, which is also parseable by the Duration deserializer, so I've modified the `ISO8601Serializer` to do the same.

Additionally, the `#normalize` function returned a negative sign if `parts` was blank (all zero). Even though this fix does not rely on the sign, I've gone ahead and corrected that, too, in case a future refactoring of `#serialize` uses it.
