### PR TITLE
Handle destroyed assets with id on new record via nested_assets

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -405,7 +405,9 @@ module ActiveRecord
         assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy]) unless call_reject_if(association_name, attributes)
 
       elsif attributes['id'].present?
-        raise_nested_attributes_record_not_found!(association_name, attributes['id'])
+        unless has_destroy_flag?(attributes)
+          raise_nested_attributes_record_not_found!(association_name, attributes['id'])
+        end
 
       elsif !reject_new_record?(association_name, attributes)
         assignable_attributes = attributes.except(*UNASSIGNABLE_KEYS)
@@ -505,7 +507,7 @@ module ActiveRecord
 
             assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy])
           end
-        else
+        elsif !has_destroy_flag?(attributes)
           raise_nested_attributes_record_not_found!(association_name, attributes['id'])
         end
       end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -4,6 +4,7 @@ require "models/ship"
 require "models/ship_part"
 require "models/bird"
 require "models/parrot"
+require "models/face"
 require "models/treasure"
 require "models/man"
 require "models/interest"
@@ -164,6 +165,20 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
 
     pirate.update!(ship_attributes: { id: pirate.ship.id, name: "Black Pearl", _destroy: "1" })
     assert_equal "Black Pearl", pirate.reload.ship.name
+  end
+
+  def test_destroyed_existing_has_many_entries_ignored_on_create
+    Man.accepts_nested_attributes_for(:interests)
+    interest = Interest.create(topic: 'test topic')
+    man = Man.create(name: 'John', interests_attributes: { '0' => { 'id' => interest.id, '_destroy' => '1' } })
+    assert man.interests.empty?
+  end
+
+  def test_destroyed_existing_has_one_entry_ignored_on_create
+    Man.accepts_nested_attributes_for(:face)
+    face = Face.create(description: 'test face')
+    man = Man.create(name: 'John', face_attributes: { 'id' => face.id, '_destroy' => '1' })
+    assert man.face.nil?
   end
 
   def test_has_many_association_updating_a_single_record


### PR DESCRIPTION
_Rebase of https://github.com/rails/rails/pull/24509 against master._

My use case is that I have a form which takes a source record and uses it to prefill a creation form for a new record. The source record has child records, and when it fills the form and the user (using the nested_forms gem) removes the child records, the child records are passed to the create action with an ID and _destroy=1. Rails throws an error at this point, something like: `Couldn't find ChildModel with ID=275425 for ParentModel with ID=`.

I worked around this in my app by rejecting any entries with _destroy==1. However, this seems like something Rails may like to handle upstream. This PR contains a code patch and test case to this end.

I'm using Rails 4.2, so I patched that version. If desired, I'll try to rebase this against master.

Thanks!
