### PR TITLE
Clarify Postgres initials. [skip ci]

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -34,10 +34,10 @@ module ActiveRecord
       # is not passed, the previous default value (if any) will be used.
       # Otherwise, the default will be +nil+.
       #
-      # +array+ (PG only) specifies that the type should be an array (see the
+      # +array+ (PostgreSQL only) specifies that the type should be an array (see the
       # examples below).
       #
-      # +range+ (PG only) specifies that the type should be a range (see the
+      # +range+ (PostgreSQL only) specifies that the type should be a range (see the
       # examples below).
       #
       # ==== Examples


### PR DESCRIPTION
Related to https://github.com/rails/rails/issues/25660

I was reading the docs in http://api.rubyonrails.org/classes/ActiveRecord/Attributes/ClassMethods.html and took about 10 minutes of searching before I realized that "PG" means PostgreSQL. This patch simply expands the initials.
