### PR TITLE
Support custom protocol in options passed to asset_url

### DIFF
--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -168,13 +168,7 @@ module ActionView
       #   asset_url "application.js", host: "http://cdn.example.com" # => http://cdn.example.com/assets/application.js
       #
       def asset_url(source, options = {})
-        default_proto = if defined? config.default_asset_host_protocol
-          config.default_asset_host_protocol || :request
-        else
-          :request
-        end
-
-        path_to_asset(source, { protocol: default_proto }.merge(options))
+        path_to_asset(source, { protocol: default_asset_protocol }.merge(options))
       end
       alias_method :url_to_asset, :asset_url # aliased to avoid conflicts with an asset_url named route
 
@@ -234,7 +228,7 @@ module ActionView
         if host =~ URI_REGEXP
           host
         else
-          protocol = options[:protocol] || config.default_asset_host_protocol || (request ? :request : :relative)
+          protocol = options[:protocol] || default_asset_protocol(!!request)
           case protocol
           when :relative
             "//#{host}"
@@ -243,6 +237,15 @@ module ActionView
           else
             "#{protocol}://#{host}"
           end
+        end
+      end
+
+      def default_asset_protocol(assume_request = true)
+        unconfigured_default = assume_request ? :request : :relative
+        if defined? config.default_asset_host_protocol
+          config.default_asset_host_protocol || unconfigured_default
+        else
+          unconfigured_default
         end
       end
 

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -168,7 +168,13 @@ module ActionView
       #   asset_url "application.js", host: "http://cdn.example.com" # => http://cdn.example.com/assets/application.js
       #
       def asset_url(source, options = {})
-        path_to_asset(source, options.merge(:protocol => :request))
+        default_proto = if defined? config.default_asset_host_protocol
+          config.default_asset_host_protocol || :request
+        else
+          :request
+        end
+
+        path_to_asset(source, { protocol: default_proto }.merge(options))
       end
       alias_method :url_to_asset, :asset_url # aliased to avoid conflicts with an asset_url named route
 

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -815,4 +815,15 @@ class AssetUrlHelperEmptyModuleTest < ActionView::TestCase
     assert @module.config.asset_host
     assert_equal "http://custom.example.com/foo", @module.asset_url("foo", :host => "http://custom.example.com")
   end
+
+  def test_asset_url_with_specific_protocol
+    @module.instance_eval do
+      def config
+        Struct.new(:asset_host).new("www.example.com")
+      end
+    end
+
+    assert @module.config.asset_host
+    assert_equal "//www.example.com/foo", @module.asset_url("foo", protocol: :relative)
+  end
 end


### PR DESCRIPTION
### Summary

Allows specifying e.g. `protocol: :relative` when calling the `asset_url` helper, instead of always using `request` protocol.

This is useful if, for example, you have a fragment that is served over both http and https and you want to use a relative protocol so the same cache can be used in both cases.
