### PR TITLE
Remove unused `alias :call :execute` for `StatementCache`

### DIFF
--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -108,6 +108,5 @@ module ActiveRecord
 
       klass.find_by_sql(sql, bind_values, preparable: true)
     end
-    alias :call :execute
   end
 end


### PR DESCRIPTION
`StatementCache` is an internal class and `alias :call :execute` is
unused.
