### PR TITLE
Serialize JSON attribute value nil as SQL NULL, not JSON 'null'

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Serialize JSON attribute value `nil` as SQL `NULL`, not JSON `null`
+
+    *Trung Duc Tran*
+
 *   Return `true` from `update_attribute` when the value of the attribute
     to be updated is unchanged.
 

--- a/activerecord/lib/active_record/type/internal/abstract_json.rb
+++ b/activerecord/lib/active_record/type/internal/abstract_json.rb
@@ -17,7 +17,11 @@ module ActiveRecord
         end
 
         def serialize(value)
-          ::ActiveSupport::JSON.encode(value)
+          if value.nil?
+            nil
+          else
+            ::ActiveSupport::JSON.encode(value)
+          end
         end
 
         def accessor

--- a/activerecord/test/cases/adapters/mysql2/json_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/json_test.rb
@@ -102,6 +102,22 @@ if ActiveRecord::Base.connection.supports_json?
       assert_equal(["v0", { "k1" => "v1" }], x.payload)
     end
 
+    def test_select_nil_json_after_create
+      json = JsonDataType.create(payload: nil)
+      x = JsonDataType.where(payload:nil).first
+      assert_equal(json, x)
+    end
+
+    def test_select_nil_json_after_update
+      json = JsonDataType.create(payload: "foo")
+      x = JsonDataType.where(payload:nil).first
+      assert_equal(nil, x)
+
+      json.update_attributes payload: nil
+      x = JsonDataType.where(payload:nil).first
+      assert_equal(json.reload, x)
+    end
+
     def test_rewrite_array_json_value
       @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
       x = JsonDataType.first

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -113,6 +113,22 @@ module PostgresqlJSONSharedTestCases
     assert_equal(nil, x.payload)
   end
 
+  def test_select_nil_json_after_create
+    json = JsonDataType.create(payload: nil)
+    x = JsonDataType.where(payload:nil).first
+    assert_equal(json, x)
+  end
+
+  def test_select_nil_json_after_update
+    json = JsonDataType.create(payload: "foo")
+    x = JsonDataType.where(payload:nil).first
+    assert_equal(nil, x)
+
+    json.update_attributes payload: nil
+    x = JsonDataType.where(payload:nil).first
+    assert_equal(json.reload, x)
+  end
+
   def test_select_array_json_value
     @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
     x = JsonDataType.first


### PR DESCRIPTION
Assume `payload` is a table column of JSON type. A Ruby `nil` value of `payload` can be stored in the database in one of two ways
- SQL `NULL`
- JSON value `'null'`

When loading data from the database both `NULL` and `'null'` are deserialized correctly into Ruby `nil`. This part is fine.

When data are persisted into the DB `nil` is translated to `'null'`, not SQL `NULL`. This leads to several problems:

Although `x.update_attributes(payload: nil`) translates to SQL `UPDATE products SET payload = 'null'`, a query `Product.where(payload: nil)` translates to `SELECT * from products WHERE payload IS NULL`. Such a SQL query returns nothing because `'null' IS NOT NULL`. This is demonstrated by the failed test I added in this PR.

One way to fix this bug is to translate `where(payload: nil)` to `WHERE payload IS NULL OR payload = 'null'`. We'd have to check if `payload` type is JSON first and such a SQL statement is slower than the simpler `payload IS NOT NULL`.

Support for JSON types in Postgresql in Rails 4.x translates `nil` to SQL `NULL`, not JSON `'null'`. This change of behavior was introduced when AR added JSON support for MySQL (https://github.com/rails/rails/pull/21110). In our code base we have a few complicated SQL statements which rely on the old behavior. They are broken when we upgrade to Rails 5.0. Queries for `nil`, not `nil` are pretty common, I suspect we are not the only ones affected.

I think the preferred fix is to map `nil` to SQL `NULL`, exactly as how it used to work in Rails 4.x.
