### PR TITLE
Option not to line up column attributes in schema.rb

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Option to remove standardized column types/arguments spaces in schema dump
+    with `ActiveRecord::SchemaDumper.standardized_argument_widths` and
+    `ActiveRecord::SchemaDumper.standardized_type_widths` methods.
+
+    *Tim Petricola*
+
 *   Doing count on relations that contain LEFT OUTER JOIN Arel node no longer
     force a DISTINCT. This solves issues when using count after a left_joins.
 
@@ -57,8 +63,8 @@
     *Xavier Noria*
 
 *   Using `group` with an attribute that has a custom type will properly cast
-    the hash keys after calling a calculation method like `count`. 
-    
+    the hash keys after calling a calculation method like `count`.
+
     Fixes #25595.
 
     *Sean Griffin*
@@ -93,7 +99,7 @@
     *Sean Griffin*
 
 *   Ensure hashes can be assigned to attributes created using `composed_of`.
-    
+
     Fixes #25210.
 
     *Sean Griffin*

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -368,9 +368,11 @@ The MySQL adapter adds one additional configuration option:
 
 * `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans` controls whether Active Record will consider all `tinyint(1)` columns as booleans. Defaults to `true`.
 
-The schema dumper adds one additional configuration option:
+The schema dumper adds additional configuration options:
 
 * `ActiveRecord::SchemaDumper.ignore_tables` accepts an array of tables that should _not_ be included in any generated schema file. This setting is ignored unless `config.active_record.schema_format == :ruby`.
+* `ActiveRecord::SchemaDumper.standardized_argument_widths` configures whether colum arguments should be lined up or not in dump. By default this is `true`. This setting is ignored unless `config.active_record.schema_format == :ruby`.
+* `ActiveRecord::SchemaDumper.standardized_type_widths` configures whether colum types should be lined up or not in dump. By default this is `true`. This setting is ignored unless `config.active_record.schema_format == :ruby`.
 
 ### Configuring Action Controller
 


### PR DESCRIPTION
Column arguments are lined up for a given table in `schema.rb`. It is intended as a feature but it can get confusing in git diffs where whitespace are often added for columns with no changes. This PR adds a `ActiveRecord::SchemaDumper.standardized_argument_widths = false` option to avoid that.

Let's say we have an `address` table with the following schema:

``` rb
create_table "address", force: :cascade do |t|
  t.string "zipcode", limit: 5
end
```

Adding another column with a longer name would also change the line for `zipcode`:

``` diff
-   t.string "zipcode", limit: 5
+   t.string "zipcode",           limit: 5
+   t.string "extra_information", limit: 255
```

And generated `schema.rb` would now be:

``` rb
create_table "address", force: :cascade do |t|
  t.string "zipcode",           limit: 5
  t.string "extra_information", limit: 255
end
```

By setting `ActiveRecord::SchemaDumper.standardized_argument_widths` to `false`, we would have the following diff and schema instead:

``` diff
+   t.string "extra_information", limit: 255
```

``` rb
create_table "address", force: :cascade do |t|
  t.string "zipcode", limit: 5
  t.string "extra_information", limit: 255
end
```
