### PR TITLE
Dry downloader

### DIFF
--- a/activesupport/test/multibyte_conformance_test.rb
+++ b/activesupport/test/multibyte_conformance_test.rb
@@ -8,9 +8,7 @@ require 'tmpdir'
 class MultibyteConformanceTest < ActiveSupport::TestCase
   include MultibyteTestHelpers
 
-  UNIDATA_URL = "http://www.unicode.org/Public/#{ActiveSupport::Multibyte::Unicode::UNICODE_VERSION}/ucd"
   UNIDATA_FILE = '/NormalizationTest.txt'
-  CACHE_DIR = "#{Dir.tmpdir}/cache/unicode_conformance"
   FileUtils.mkdir_p(CACHE_DIR)
   RUN_P = begin
             Downloader.download(UNIDATA_URL + UNIDATA_FILE, CACHE_DIR + UNIDATA_FILE)

--- a/activesupport/test/multibyte_conformance_test.rb
+++ b/activesupport/test/multibyte_conformance_test.rb
@@ -6,24 +6,6 @@ require 'open-uri'
 require 'tmpdir'
 
 class MultibyteConformanceTest < ActiveSupport::TestCase
-  class Downloader
-    def self.download(from, to)
-      unless File.exist?(to)
-        unless File.exist?(File.dirname(to))
-          system "mkdir -p #{File.dirname(to)}"
-        end
-        open(from) do |source|
-          File.open(to, 'w') do |target|
-            source.each_line do |l|
-              target.write l
-            end
-          end
-        end
-      end
-      true
-    end
-  end
-
   include MultibyteTestHelpers
 
   UNIDATA_URL = "http://www.unicode.org/Public/#{ActiveSupport::Multibyte::Unicode::UNICODE_VERSION}/ucd"

--- a/activesupport/test/multibyte_grapheme_break_conformance_test.rb
+++ b/activesupport/test/multibyte_grapheme_break_conformance_test.rb
@@ -1,29 +1,14 @@
 # encoding: utf-8
 
 require 'abstract_unit'
+require 'multibyte_test_helpers'
 
 require 'fileutils'
 require 'open-uri'
 require 'tmpdir'
 
 class MultibyteGraphemeBreakConformanceTest < ActiveSupport::TestCase
-  class Downloader
-    def self.download(from, to)
-      unless File.exist?(to)
-        $stderr.puts "Downloading #{from} to #{to}"
-        unless File.exist?(File.dirname(to))
-          system "mkdir -p #{File.dirname(to)}"
-        end
-        open(from) do |source|
-          File.open(to, 'w') do |target|
-            source.each_line do |l|
-              target.write l
-            end
-          end
-        end
-      end
-    end
-  end
+  include MultibyteTestHelpers
 
   TEST_DATA_URL = "http://www.unicode.org/Public/#{ActiveSupport::Multibyte::Unicode::UNICODE_VERSION}/ucd/auxiliary"
   TEST_DATA_FILE = '/GraphemeBreakTest.txt'

--- a/activesupport/test/multibyte_grapheme_break_conformance_test.rb
+++ b/activesupport/test/multibyte_grapheme_break_conformance_test.rb
@@ -10,13 +10,14 @@ require 'tmpdir'
 class MultibyteGraphemeBreakConformanceTest < ActiveSupport::TestCase
   include MultibyteTestHelpers
 
-  TEST_DATA_URL = "http://www.unicode.org/Public/#{ActiveSupport::Multibyte::Unicode::UNICODE_VERSION}/ucd/auxiliary"
-  TEST_DATA_FILE = '/GraphemeBreakTest.txt'
-  CACHE_DIR = "#{Dir.tmpdir}/cache/unicode_conformance"
+  UNIDATA_FILE = '/auxiliary/GraphemeBreakTest.txt'
+  RUN_P = begin
+            Downloader.download(UNIDATA_URL + UNIDATA_FILE, CACHE_DIR + UNIDATA_FILE)
+          rescue
+          end
 
   def setup
-    FileUtils.mkdir_p(CACHE_DIR)
-    Downloader.download(TEST_DATA_URL + TEST_DATA_FILE, CACHE_DIR + TEST_DATA_FILE)
+    skip "Unable to download test data" unless RUN_P
   end
 
   def test_breaks
@@ -31,7 +32,7 @@ class MultibyteGraphemeBreakConformanceTest < ActiveSupport::TestCase
     def each_line_of_break_tests(&block)
       lines = 0
       max_test_lines = 0 # Don't limit below 21, because that's the header of the testfile
-      File.open(File.join(CACHE_DIR, TEST_DATA_FILE), 'r') do | f |
+      File.open(File.join(CACHE_DIR, UNIDATA_FILE), 'r') do | f |
         until f.eof? || (max_test_lines > 21 and lines > max_test_lines)
           lines += 1
           line = f.gets.chomp!

--- a/activesupport/test/multibyte_normalization_conformance_test.rb
+++ b/activesupport/test/multibyte_normalization_conformance_test.rb
@@ -10,14 +10,15 @@ require 'tmpdir'
 class MultibyteNormalizationConformanceTest < ActiveSupport::TestCase
   include MultibyteTestHelpers
 
-  UNIDATA_URL = "http://www.unicode.org/Public/#{ActiveSupport::Multibyte::Unicode::UNICODE_VERSION}/ucd"
   UNIDATA_FILE = '/NormalizationTest.txt'
-  CACHE_DIR = "#{Dir.tmpdir}/cache/unicode_conformance"
+  RUN_P = begin
+            Downloader.download(UNIDATA_URL + UNIDATA_FILE, CACHE_DIR + UNIDATA_FILE)
+          rescue
+          end
 
   def setup
-    FileUtils.mkdir_p(CACHE_DIR)
-    Downloader.download(UNIDATA_URL + UNIDATA_FILE, CACHE_DIR + UNIDATA_FILE)
     @proxy = ActiveSupport::Multibyte::Chars
+    skip "Unable to download test data" unless RUN_P
   end
 
   def test_normalizations_C

--- a/activesupport/test/multibyte_normalization_conformance_test.rb
+++ b/activesupport/test/multibyte_normalization_conformance_test.rb
@@ -8,24 +8,6 @@ require 'open-uri'
 require 'tmpdir'
 
 class MultibyteNormalizationConformanceTest < ActiveSupport::TestCase
-  class Downloader
-    def self.download(from, to)
-      unless File.exist?(to)
-        $stderr.puts "Downloading #{from} to #{to}"
-        unless File.exist?(File.dirname(to))
-          system "mkdir -p #{File.dirname(to)}"
-        end
-        open(from) do |source|
-          File.open(to, 'w') do |target|
-            source.each_line do |l|
-              target.write l
-            end
-          end
-        end
-      end
-    end
-  end
-
   include MultibyteTestHelpers
 
   UNIDATA_URL = "http://www.unicode.org/Public/#{ActiveSupport::Multibyte::Unicode::UNICODE_VERSION}/ucd"

--- a/activesupport/test/multibyte_test_helpers.rb
+++ b/activesupport/test/multibyte_test_helpers.rb
@@ -1,4 +1,22 @@
 module MultibyteTestHelpers
+  class Downloader
+    def self.download(from, to)
+      unless File.exist?(to)
+        unless File.exist?(File.dirname(to))
+          system "mkdir -p #{File.dirname(to)}"
+        end
+        open(from) do |source|
+          File.open(to, 'w') do |target|
+            source.each_line do |l|
+              target.write l
+            end
+          end
+        end
+      end
+      true
+    end
+  end
+
   UNICODE_STRING = 'こにちわ'.freeze
   ASCII_STRING = 'ohayo'.freeze
   BYTE_STRING = "\270\236\010\210\245".force_encoding("ASCII-8BIT").freeze

--- a/activesupport/test/multibyte_test_helpers.rb
+++ b/activesupport/test/multibyte_test_helpers.rb
@@ -17,6 +17,10 @@ module MultibyteTestHelpers
     end
   end
 
+  UNIDATA_URL = "http://www.unicode.org/Public/#{ActiveSupport::Multibyte::Unicode::UNICODE_VERSION}/ucd"
+  CACHE_DIR = "#{Dir.tmpdir}/cache/unicode_conformance"
+  FileUtils.mkdir_p(CACHE_DIR)
+
   UNICODE_STRING = 'こにちわ'.freeze
   ASCII_STRING = 'ohayo'.freeze
   BYTE_STRING = "\270\236\010\210\245".force_encoding("ASCII-8BIT").freeze


### PR DESCRIPTION
### Summary

DRY the Downloader and skip the tests when the donwload fails for some reason (similarly to what MultibyteGraphemeBreakConformanceTest already did).

BTW wouldn't it be better to keep the copies of the files locally then downloading them again and again?
