### PR TITLE
Pathname might not be always initialized.

### DIFF
--- a/activesupport/test/testing/file_fixtures_test.rb
+++ b/activesupport/test/testing/file_fixtures_test.rb
@@ -1,5 +1,7 @@
 require 'abstract_unit'
 
+require 'pathname'
+
 class FileFixturesTest < ActiveSupport::TestCase
   self.file_fixture_path = File.expand_path("../../file_fixtures", __FILE__)
 


### PR DESCRIPTION
### Summary

Pathname might not be always initialized. This solve error such as:

```
$ ruby -Ilib:test -e 'Dir.glob "./test/**/*_test.rb", &method(:require)'
/builddir/build/BUILD/rubygem-activesupport-5.0.0/usr/share/gems/gems/activesupport-5.0.0/test/testing/file_fixtures_test.rb:21:in `<class:FileFixturesPathnameDirectoryTest>': uninitialized constant FileFixturesPathnameDirectoryTest::Pathname (NameError)
    from /builddir/build/BUILD/rubygem-activesupport-5.0.0/usr/share/gems/gems/activesupport-5.0.0/test/testing/file_fixtures_test.rb:20:in `<top (required)>'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
    from -e:1:in `glob'
    from -e:1:in `<main>'
```
