### PR TITLE
Fixed unnecessary nesting in handle_dependency

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -27,14 +27,12 @@ module ActiveRecord
             throw(:abort)
           end
 
+        when :destroy
+          # No point in executing the counter update since we're going to destroy the parent anyway
+          load_target.each { |t| t.destroyed_by_association = reflection }
+          destroy_all
         else
-          if options[:dependent] == :destroy
-            # No point in executing the counter update since we're going to destroy the parent anyway
-            load_target.each { |t| t.destroyed_by_association = reflection }
-            destroy_all
-          else
-            delete_all
-          end
+          delete_all
         end
       end
 


### PR DESCRIPTION
### Summary

This nested if checked the same value as the containing case statement.
Moved the code in the if/else into when/else in the containing case.
