### PR TITLE
Support the MIME type symbol for the file_field's accept option

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -33,6 +33,27 @@
 
     *Steven Harman*
 
+*   `file_field`'s and `file_field_tag`'s `accept` option supports the same MIME type symbol as the
+     `send_file`'s `type` option.
+
+    Example usages of file_field and file_field_tag helpers before:
+
+    ```ruby
+    file_field :attached, accept: 'text/csv'
+
+    file_field_tag :attached, accept: 'text/csv'
+    ```
+
+    Example usages after:
+
+    ```ruby
+    file_field :attached, accept: :csv
+
+    file_field_tag :attached, accept: :csv
+    ```
+
+    *Yasuhiro Sugino*
+
 *   New syntax for tag helpers. Avoid positional parameters and support HTML5 by default.
     Example usage of tag helpers before:
 

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -843,7 +843,7 @@ module ActionView
       # * Creates standard HTML attributes for the tag.
       # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
       # * <tt>:multiple</tt> - If set to true, *in most updated browsers* the user will be allowed to select multiple files.
-      # * <tt>:accept</tt> - If set to one or multiple mime-types, the user will be suggested a filter when choosing a file. You still need to set up model validations.
+      # * <tt>:accept</tt> - If set to either a string or a symbol for a registered type with <tt>Mime::Type.register</tt>, the user will be suggested a filter when choosing a file. You still need to set up model validations.
       #
       # ==== Examples
       #   file_field(:user, :avatar)
@@ -854,6 +854,9 @@ module ActionView
       #
       #   file_field(:post, :attached, accept: 'text/html')
       #   # => <input accept="text/html" type="file" id="post_attached" name="post[attached]" />
+      #
+      #   file_field(:post, :attached, accept: :csv)
+      #   # => <input accept="text/csv" type="file" id="post_attached" name="post[attached]" />
       #
       #   file_field(:post, :image, accept: 'image/png,image/gif,image/jpeg')
       #   # => <input type="file" id="post_image" name="post[image]" accept="image/png,image/gif,image/jpeg" />

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -251,7 +251,7 @@ module ActionView
       # * Creates standard HTML attributes for the tag.
       # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
       # * <tt>:multiple</tt> - If set to true, *in most updated browsers* the user will be allowed to select multiple files.
-      # * <tt>:accept</tt> - If set to one or multiple mime-types, the user will be suggested a filter when choosing a file. You still need to set up model validations.
+      # * <tt>:accept</tt> - If set to one or multiple mime-types, the user will be suggested a filter when choosing a file. You can use custom MIME Type symbols that you've registered in the file `config/initializers/mime_types.rb`. You still need to set up model validations.
       #
       # ==== Examples
       #   file_field_tag 'attachment'
@@ -272,6 +272,12 @@ module ActionView
       #   file_field_tag 'file', accept: 'text/html', class: 'upload', value: 'index.html'
       #   # => <input accept="text/html" class="upload" id="file" name="file" type="file" value="index.html" />
       def file_field_tag(name, options = {})
+        options = options.stringify_keys
+
+        if accept = options["accept"]
+          options["accept"] = Mime[accept] || accept
+        end
+
         text_field_tag(name, nil, options.merge(type: :file))
       end
 

--- a/actionview/lib/action_view/helpers/tags/file_field.rb
+++ b/actionview/lib/action_view/helpers/tags/file_field.rb
@@ -2,6 +2,16 @@ module ActionView
   module Helpers
     module Tags # :nodoc:
       class FileField < TextField # :nodoc:
+        def render
+          options = @options.stringify_keys
+
+          if accept = options["accept"]
+            options["accept"] = Mime[accept] || accept
+            @options = options
+          end
+
+          super
+        end
       end
     end
   end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -540,6 +540,17 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, file_field("import", "file", multiple: true, name: "custom")
   end
 
+  def test_file_field_with_mime_type_string
+    expected = '<input accept="image/png,image/gif,image/jpeg" type="file" name="import[file]" id="import_file" />'
+    assert_dom_equal expected, file_field("import", "file", accept: "image/png,image/gif,image/jpeg")
+  end
+
+  def test_file_field_with_mime_type_symbol
+    Mime::Type.register "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", :xlsx
+    expected = '<input accept="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" type="file" name="import[file]" id="import_file" />'
+    assert_dom_equal expected, file_field("import", "file", accept: :xlsx)
+  end
+
   def test_hidden_field
     assert_dom_equal(
       '<input id="post_title" name="post[title]" type="hidden" value="Hello World" />',

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -173,7 +173,12 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_file_field_tag_with_options
-    assert_dom_equal "<input name=\"picsplz\" type=\"file\" id=\"picsplz\" class=\"pix\"/>", file_field_tag("picsplz", class: "pix")
+    assert_dom_equal "<input accept=\"image\/jpeg\" name=\"picsplz\" type=\"file\" id=\"picsplz\" class=\"pix\"/>", file_field_tag("picsplz", class: "pix", accept: "image/jpeg")
+  end
+
+  def test_file_field_tag_with_mime_type_accept_option
+    Mime::Type.register "image/png,image/gif,image/jpeg", :pics
+    assert_dom_equal "<input accept=\"image\/png,image\/gif,image\/jpeg\" name=\"picsplz\" type=\"file\" id=\"picsplz\" />", file_field_tag("picsplz", accept: :pics)
   end
 
   def test_password_field_tag


### PR DESCRIPTION
### Summary

This allows you to use the same symbol for `file_field`'s and `file_field_tag`'s `accept` option as `send_file`'s `type` option.
