### PR TITLE
Robots.txt removed disallow all instructions

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/public/robots.txt
+++ b/railties/lib/rails/generators/rails/app/templates/public/robots.txt
@@ -1,5 +1,1 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /


### PR DESCRIPTION
### Summary

The default robots.txt file includes instructions on how to disallow all spiders. While this itself is fine, it can confuse some spiders to incorrectly read the comments as instructions, such as archive.org.

As such, rails applications wont be archived by archive.org unless they remove the instructions from the robots.txt file themselves.

While this isn't a problem with rails, I find the payoff of including the instructions not worth it, considering there's already a link inside the file to find such instructions.

To remedy this, I have simply removed the offending lines, while retaining the helpful link.
