### PR TITLE
Use the HOST environment variable for rails server #25677

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -90,6 +90,7 @@ module Rails
     def default_options
       super.merge({
         Port:               ENV.fetch('PORT', 3000).to_i,
+        Host:               ENV.fetch('HOST', 'localhost').dup,
         DoNotReverseLookup: true,
         environment:        (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || "development").dup,
         daemonize:          false,

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -51,6 +51,13 @@ class Rails::ServerTest < ActiveSupport::TestCase
     end
   end
 
+  def test_environment_with_host
+    switch_env "HOST", "1.2.3.4" do
+      server = Rails::Server.new
+      assert_equal "1.2.3.4", server.options[:Host]
+    end
+  end
+
   def test_caching_without_option
     args = []
     options = Rails::Server::Options.new.parse!(args)


### PR DESCRIPTION
### Summary

Allow the server host to be set with the HOST environment variable.
