### PR TITLE
Speed up RDoc generation when it's already been done once

### DIFF
--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -121,6 +121,19 @@ module Rails
             rdoc_files.exclude("#{cdr}/#{pattern}")
           end
         end
+
+        # Only generate documentation for files that have been
+        # changed since the API was generated.
+        if Dir.exist?('doc/rdoc') && !ENV['ALL']
+          last_generation = DateTime.rfc2822(File.open('doc/rdoc/created.rid', &:readline))
+
+          rdoc_files.keep_if do |file|
+            File.mtime(file).to_datetime > last_generation
+          end
+
+          # Nothing to do
+          exit(0) if rdoc_files.empty?
+        end
       end
 
       def setup_horo_variables


### PR DESCRIPTION
Hi,

This pull request speeds up RDoc generation by only including files that contain changes since the last generation of the API documentation running the `rake rdoc` task.

Thus, only modified files are re-generated instead of the whole API.

The `created.rid` file won't contain the whole list of files anymore if we generate several times the API but we don't really care about it, only the generation date and time is important.

I don't know whether this would be a problem for the API site itself, I only tested that locally.

Have a nice day.
