### PR TITLE
test with latest resque

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'listen', '~> 3.0.5', require: false
 
 # Active Job.
 group :job do
-  gem 'resque', '< 1.26', require: false
+  gem 'resque', github: 'resque/resque', require: false
   gem 'resque-scheduler', require: false
   gem 'sidekiq', require: false
   gem 'sucker_punch', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,17 @@ GIT
       delayed_job (>= 3.0, < 5)
 
 GIT
+  remote: git://github.com/resque/resque.git
+  revision: 06036388ec61e573c761ac5a25a2ef3c76537ec7
+  specs:
+    resque (1.27.0)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.3)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
+
+GIT
   remote: git://github.com/sass/sass.git
   revision: 3fda1cbe70d615e7ef96e28db4fd1f8a3ebb5505
   branch: stable
@@ -251,12 +262,6 @@ GEM
     redis (3.3.0)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    resque (1.25.2)
-      mono_logger (~> 1.0)
-      multi_json (~> 1.0)
-      redis-namespace (~> 1.3)
-      sinatra (>= 0.9.2)
-      vegas (~> 0.1.2)
     resque-scheduler (4.2.0)
       mono_logger (~> 1.0)
       redis (~> 3.0)
@@ -378,7 +383,7 @@ DEPENDENCIES
   rake (>= 11.1)
   redcarpet (~> 3.2.3)
   redis
-  resque (< 1.26)
+  resque!
   resque-scheduler
   sass!
   sass-rails


### PR DESCRIPTION
### Summary

When run test of Active Job with resque 1.26, occurs following error.

```
QueuingTest#test_current_locale_is_kept_while_running_perform_later:
NoMethodError: undefined method `current_tags' for #<Resque::QuietFormatter:0x0055b44f63ed50>
    /home/yaginuma/program/rails/master_y_yagi/rails/activejob/lib/active_job/logging.rb:51:in `logger_tagged_by_active_job?'
```

This was happening for the formatter class of resque not the formatter class of Rails is they've been used to logger.formatter.
This was happening because become fomatter is changed during the instantiation of worker in the resque 1.26.
In the master, unless the environment variable is set, fomatter is so as not to be changed, test will pass.

Ref: https://github.com/resque/resque/pull/1439
