### PR TITLE
Allow rake notes to work with other directories.

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -18,6 +18,12 @@ class SourceAnnotationExtractor
       @@directories ||= %w(app config db lib test) + (ENV['SOURCE_ANNOTATION_DIRECTORIES'] || '').split(',')
     end
 
+    # Registers additional directories to be included
+    #  SourceAnnotationExtractor::Annotation.register_directories("spec","another")
+    def self.register_directories(*dirs)
+      directories.push(*dirs)
+    end
+
     def self.extensions
       @@extensions ||= {}
     end

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -127,8 +127,8 @@ module ApplicationTests
       end
 
       test 'register additional directories' do
-        app_file "app/spec/spec_helper.rb", "# TODO: note in spec"
-        app_file "app/spec/models/user_spec.rb", "# TODO: note in model spec"
+        app_file "spec/spec_helper.rb", "# TODO: note in spec"
+        app_file "spec/models/user_spec.rb", "# TODO: note in model spec"
         add_to_config %q{ config.annotations.register_directories("spec") }
 
         run_rake_notes do |output, lines|

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -131,7 +131,6 @@ module ApplicationTests
         app_file "app/spec/models/user_spec.rb", "# TODO: note in model spec"
         add_to_config %q{ config.annotations.register_directories("spec") }
 
-
         run_rake_notes do |output, lines|
           assert_match(/note in spec/, output)
           assert_match(/note in model spec/, output)

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -126,6 +126,19 @@ module ApplicationTests
         end
       end
 
+      test 'register additional directories' do
+        app_file "app/spec/spec_helper.rb", "# TODO: note in spec"
+        app_file "app/spec/models/user_spec.rb", "# TODO: note in model spec"
+        add_to_config %q{ config.annotations.register_directories("spec") }
+
+
+        run_rake_notes do |output, lines|
+          assert_match(/note in spec/, output)
+          assert_match(/note in model spec/, output)
+          assert_equal 2, lines.size
+        end
+      end
+
       private
 
       def run_rake_notes(command = 'bin/rails notes')


### PR DESCRIPTION
`rake notes` is a very useful tool lets make it more useful.

The SourceAnnotationExtractor currently has no way of extracting notes from directories other than the predefind directories (app, config, db, lib, test).

The trouble is I would like to be able to extract notes from other folders in the project such as the `/spec` folder ( if using RSpec ).

This pull request will allow you/gems to register other directories with the SourceAnnotationExtractor.

Currently it is possible to register file extensions. So why not directories?

Registers additional directories to be included
`SourceAnnotationExtractor::Annotation.register_directories("spec","another")`

Tested in `test/application/rake/notes_test.rb`

Result:

``` bash
$ rake notes
app/spec/models/article_spec.rb:
  * [2] [TODO] add more specs
  * [3] [FIXME] Spec A is broken
  * [4] [OPTIMIZE] improve this test

```

John

also discussed here #25576

Additional directories can be added using
SourceAnnotationExtractor::Annotation.register_directories("spec", "other_dir")

Result: rake notes will now extract notes from these directories.
