### PR TITLE
Deprecate usage of nil as route path

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1562,6 +1562,12 @@ module ActionDispatch
             options  = path
             path, to = options.find { |name, _value| name.is_a?(String) }
 
+            if path.nil?
+              ActiveSupport::Deprecation.warn 'Omitting the route path is deprecated. '\
+                'Specify the path with a String or a Symbol instead.'
+              path = ''
+            end
+
             case to
             when Symbol
               options[:action] = to

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -373,6 +373,9 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
         post "create", :as => ""
         put  "update"
         get  "remove", :action => :destroy, :as => :remove
+        tc.assert_deprecated do
+          get action: :show, as: :show
+        end
       end
     end
 
@@ -391,6 +394,10 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     get '/pagemark/remove'
     assert_equal 'pagemarks#destroy', @response.body
     assert_equal '/pagemark/remove', pagemark_remove_path
+
+    get '/pagemark'
+    assert_equal 'pagemarks#show', @response.body
+    assert_equal '/pagemark', pagemark_show_path
   end
 
   def test_admin


### PR DESCRIPTION
In Rails 4, routes with implicit `nil` paths used to work:

``` ruby
scope '/*id', controller: :builds, as: :build do
  get action: :show # => works as expected in Rails 4
end
```

But since 1a830cbd830c7f80936dff7e3c8b26f60dcc371d, routes are only created for paths specified as strings or symbols. Implicit `nil` paths are just ignored, with no deprecation warnings or errors. Routes are simply not created. This comes as a surprise for people migrating to Rails 5, since the lack of logs or errors makes hard to understand where the problem is.

This commit introduces a deprecation warning in case of path as `nil`, while still allowing the route definition as an empty path.

Please let me know if raising an error would be preferred.
