### PR TITLE
Point to the correct documentation

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
@@ -6,7 +6,7 @@
 # Once upgraded flip defaults one by one to migrate to the new default.
 #
 <%- end -%>
-# Read the Rails 5.0 release notes for more info on each option.
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
 <%- unless options[:api] -%>
 
 # Enable per-form CSRF tokens. Previous versions had false.


### PR DESCRIPTION
The options used in this file are _not_ directly described in the [Rails 5.0 release notes](http://edgeguides.rubyonrails.org/5_0_release_notes.html), but instead in section 2 of the [Guide for Upgrading Ruby on Rails](http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html) document.

cc/ @prathamesh-sonpatki @kaspth 

Should I open a PR for backporting to 5-0-0-stable?
