### PR TITLE
Add header demarcation to Action Cable guide

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -9,7 +9,9 @@ After reading this guide, you will know:
 * What Action Cable is and its integration on backend and frontend  
 * How to setup Action Cable
 * How to setup channels
-* Deployment and Architecture setup for running Action Cable 
+* Deployment and Architecture setup for running Action Cable
+
+--------------------------------------------------------------------------------
 
 Introduction
 ------------


### PR DESCRIPTION
#25697 identified an issue where the header/prologue of the Action Cable guides was not being identified, so the title of the page wasn't being supplied to the doc HTML or Kindle generators. This also meant that the prologue section of the guide was not set off in blue. This adds the header demarcation line to the markdown, so that all of these are fixed.
