### PR TITLE
Fix: Scope raises error when array is passed as argument.

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -156,7 +156,13 @@ module ActiveRecord
 
           if body.respond_to?(:to_proc)
             singleton_class.send(:define_method, name) do |*args|
-              scope = all.scoping { instance_exec(*args, &body) }
+
+              scope = if args.length == 1 && args.first.is_a?(Array)
+                        all.scoping { instance_exec(args, &body) }
+                      else
+                        all.scoping { instance_exec(*args, &body) }
+                      end
+
               scope = scope.extending(extension) if extension
 
               scope || all

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -349,6 +349,11 @@ class HasManyScopingTest < ActiveRecord::TestCase
     magician = BadReference.find(1)
     assert_equal [magician], michael.bad_references
   end
+
+  def test_array_as_argument_to_scope
+    assert Comment.by_post_ids([1, 2, 3])
+  end
+
 end
 
 class HasAndBelongsToManyScopingTest < ActiveRecord::TestCase

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -19,6 +19,8 @@ class Comment < ActiveRecord::Base
   has_many :children, :class_name => 'Comment', :foreign_key => :parent_id
   belongs_to :parent, :class_name => 'Comment', :counter_cache => :children_count
 
+  scope :by_post_ids, -> (post_ids = []) { where(post_id: post_ids) }
+
   def self.what_are_you
     'a comment...'
   end


### PR DESCRIPTION
Fixes #25654

~~Pass scope's arguments as it is to the proc body.~~

Update: Don't splat the args if argument size is 1 and that argument is an array. 
