### PR TITLE
Remove circular join references in join_dependency

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -56,7 +56,9 @@ module ActiveRecord
 
             klass_scope =
               if klass.current_scope
-                klass.current_scope.clone
+                klass.current_scope.clone.tap { |scope|
+                  scope.joins_values = []
+                }
               else
                 relation = ActiveRecord::Relation.create(
                   klass,

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -228,6 +228,13 @@ class RelationScopingTest < ActiveRecord::TestCase
       assert SpecialComment.all.any?
     end
   end
+
+  def test_circular_joins_with_current_scope_does_not_crash
+    posts = Post.joins(comments: :post).scoping do
+      Post.current_scope.first(10)
+    end
+    assert_equal posts, Post.joins(comments: :post).first(10)
+  end
 end
 
 class NestedRelationScopingTest < ActiveRecord::TestCase


### PR DESCRIPTION
### Summary

This patch fixes stack level too deep error introduced in https://github.com/rails/rails/pull/18109.
### Other Information

See #25653 for detail.
