### PR TITLE
implement respond_to_missing? to match method_missing

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -206,6 +206,10 @@ module Rails
             }
           end
         end
+
+        def respond_to_missing?(symbol, *)
+          true
+        end
       end
     end
   end

--- a/railties/test/application/configuration/custom_test.rb
+++ b/railties/test/application/configuration/custom_test.rb
@@ -33,6 +33,13 @@ module ApplicationTests
         assert_nil x.i_do_not_exist.zomg
       end
 
+      test 'custom configuration responds to all messages' do
+        x = Rails.configuration.x
+        assert_equal true, x.respond_to?(:i_do_not_exist)
+        assert_kind_of Method, x.method(:i_do_not_exist)
+        assert_kind_of ActiveSupport::OrderedOptions, x.i_do_not_exist
+      end
+
       private
         def new_app
           File.expand_path("#{app_path}/../new_app")


### PR DESCRIPTION
### Summary

from issue #25542

[Rails::Application::Configuration::Custom](https://github.com/rails/rails/blob/master/railties/lib/rails/application/configuration.rb#L195) (the backing class of `Rails.configuration.x`)
has a `method-missing` implementation that responds to **all** messages.

This PR adds a matching `respond_to_missing?` implementation.
