### PR TITLE
Output which file rake log:clear is truncating

### DIFF
--- a/railties/lib/rails/tasks/log.rake
+++ b/railties/lib/rails/tasks/log.rake
@@ -31,6 +31,7 @@ namespace :log do
   
   def clear_log_file(file)
     f = File.open(file, "w")
+    puts "Truncating #{file}"
     f.close
   end
 end


### PR DESCRIPTION
This is a simple change that outputs to the terminal which file the `rake log:clear` is truncating.
