### PR TITLE
[ci skip] Remove reference to Rails 4 in the initialization guide.

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -16,7 +16,7 @@ After reading this guide, you will know:
 --------------------------------------------------------------------------------
 
 This guide goes through every method call that is
-required to boot up the Ruby on Rails stack for a default Rails 4
+required to boot up the Ruby on Rails stack for a default Rails
 application, explaining each part in detail along the way. For this
 guide, we will be focusing on what happens when you execute `rails server`
 to boot your app.


### PR DESCRIPTION
### Summary

Following commit removed reference to rails 4, but there is one left.

https://github.com/rails/rails/commit/a9f50f87c38659d0e9425f86f613cf5328d55d27
