### PR TITLE
Correct defaults in documentation for ActionDispatch::SSL

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -18,17 +18,18 @@ module ActionDispatch
   #      Enabled by default. Configure `config.ssl_options` with `hsts: false` to disable.
   #
   # Set `config.ssl_options` with `hsts: { … }` to configure HSTS:
-  #   * `expires`: How long, in seconds, these settings will stick. Defaults to
-  #     `180.days` (recommended). The minimum required to qualify for browser
-  #     preload lists is `18.weeks`.
+  #   * `expires`: How long, in seconds, these settings will stick. The minimum
+  #     required to qualify for browser preload lists is `18.weeks`. Defaults to
+  #     `180.days` (recommended).
   #   * `subdomains`: Set to `true` to tell the browser to apply these settings
   #     to all subdomains. This protects your cookies from interception by a
-  #     vulnerable site on a subdomain. Defaults to `true`.
+  #     vulnerable site on a subdomain. Defaults to `false`.
   #   * `preload`: Advertise that this site may be included in browsers'
   #     preloaded HSTS lists. HSTS protects your site on every visit *except the
   #     first visit* since it hasn't seen your HSTS header yet. To close this
   #     gap, browser vendors include a baked-in list of HSTS-enabled sites.
   #     Go to https://hstspreload.appspot.com to submit your site for inclusion.
+  #     Defaults to `false`.
   #
   # To turn off HSTS, omitting the header is not enough. Browsers will remember the
   # original HSTS directive until it expires. Instead, use the header to tell browsers to


### PR DESCRIPTION
`config.ssl_options` permits configuring various options for the middleware. 

Default options for HSTS (specified with the `:hsts` key in the options hash) are specified in `.default_hsts_options`. The documentation did not make clear these defaults, and in one case was wrong.
