### PR TITLE
Model data shouldn't be shown being changed in migration without stub

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -410,13 +410,11 @@ module ActiveRecord
   # <tt>Base#reset_column_information</tt> in order to ensure that the model has the
   # latest column data from after the new column was added. Example:
   #
-  #   class AddPeopleSalary < ActiveRecord::Migration[5.0]
-  #     def up
-  #       add_column :people, :salary, :integer
-  #       Person.reset_column_information
-  #       Person.all.each do |p|
-  #         p.update_attribute :salary, SalaryCalculator.compute(p)
-  #       end
+  #   def up
+  #     add_column :people, :salary, :integer
+  #     Person.reset_column_information
+  #     Person.all.each do |p|
+  #       p.update_attribute :salary, SalaryCalculator.compute(p)
   #     end
   #   end
   #


### PR DESCRIPTION
The documentation for 'Using a model after changing its table' shows model data being changed inside the migration. Removing the class wrapper and leaving the migration intact allows for the possibility of a defined stub before the migration occurred which makes the example clearer. 
