### PR TITLE
Change ids_writer behaviour to use find instead of where

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -72,7 +72,7 @@ module ActiveRecord
         pk_type = reflection.primary_key_type
         ids = Array(ids).reject(&:blank?)
         ids.map! { |i| pk_type.cast(i) }
-        records = klass.where(reflection.association_primary_key => ids).index_by do |r|
+        records = klass.find(ids).index_by do |r|
           r.send(reflection.association_primary_key)
         end.values_at(*ids)
         replace(records)


### PR DESCRIPTION
### Summary

where will produce nils if passed array of ids for non-existing records. Find will raise ActiveRecordNotFound.
### Other Information

Fixes #25719 
