### PR TITLE
Change the behaviour of ids_writter to use find instead of where.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Setting invalid ids with ids_writer now raises a more informative 
+    RecordNotFound exception with invalid or non-existing ids.
+    Fixes #25719
+
+    *Albert Cabré Juan*
+
 *   Inspecting an object with an associated array of over 10 elements no longer
     truncates the array, preventing `inspect` from looping infinitely in some
     cases.

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -72,7 +72,7 @@ module ActiveRecord
         pk_type = reflection.primary_key_type
         ids = Array(ids).reject(&:blank?)
         ids.map! { |i| pk_type.cast(i) }
-        records = klass.where(reflection.association_primary_key => ids).index_by do |r|
+        records = klass.find(ids).index_by do |r|
           r.send(reflection.association_primary_key)
         end.values_at(*ids)
         replace(records)

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -886,7 +886,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   def test_collection_singular_ids_setter_raises_exception_when_invalid_ids_set
     company = companies(:rails_core)
     ids =  [Developer.first.id, -9999]
-    assert_raises(ActiveRecord::AssociationTypeMismatch) {company.developer_ids= ids}
+    assert_raises(ActiveRecord::RecordNotFound) {company.developer_ids= ids}
   end
 
   def test_build_a_model_from_hm_through_association_with_where_clause


### PR DESCRIPTION
### Summary

This will rise a RecordNotFound exception with details about what
failed rather than an unintelligible AssociationTypeMismatch
caused by where returning nils and then ActiveRecord trying to
interpret those as actuall results. 
### Other Information

Fixes #25719
