### PR TITLE
Extend ActionDispatch::Integration::Session keyword arguments warning

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -293,6 +293,7 @@ module ActionDispatch
 
         def process_with_kwargs(http_method, path, *args)
           if kwarg_request?(args)
+            unsupported_kwarg_request_warning if unsupported_kwargs?(args)
             process(http_method, path, *args)
           else
             non_kwarg_request_warning if args.any?
@@ -303,6 +304,10 @@ module ActionDispatch
         REQUEST_KWARGS = %i(params headers env xhr as)
         def kwarg_request?(args)
           args[0].respond_to?(:keys) && args[0].keys.any? { |k| REQUEST_KWARGS.include?(k) }
+        end
+
+        def unsupported_kwargs?(args)
+          args[0].keys.any? { |k| !REQUEST_KWARGS.include?(k) }
         end
 
         def non_kwarg_request_warning
@@ -321,6 +326,7 @@ module ActionDispatch
               as: :json
           MSG
         end
+        alias :unsupported_kwarg_request_warning :non_kwarg_request_warning
 
         # Performs the actual request.
         def process(method, path, params: nil, headers: nil, env: nil, xhr: false, as: nil)

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -148,16 +148,25 @@ class SessionTest < ActiveSupport::TestCase
   def test_post
     path = "/index"; params = "blah"; headers = { location: 'blah' }
     assert_called_with @session, :process, [:post, path, params: params, headers: headers] do
-      assert_deprecated {
-        @session.post(path, params, headers)
-      }
+      @session.post(path, params: params, headers: headers)
     end
   end
 
   def test_deprecated_post
     path = "/index"; params = "blah"; headers = { location: 'blah' }
     assert_called_with @session, :process, [:post, path, params: params, headers: headers] do
-      @session.post(path, params: params, headers: headers)
+      assert_deprecated {
+        @session.post(path, params, headers)
+      }
+    end
+  end
+
+  def test_unsupported_kwarg_post
+    path = "/index"; params = "blah"; headers = { location: 'blah' }
+    assert_called_with @session, :process, [:post, path, params: params, headers: headers, foo: "bar"] do
+      assert_deprecated {
+        @session.post(path, params: params, headers: headers, foo: "bar")
+      }
     end
   end
 


### PR DESCRIPTION
Previously, the keyword arguments warning was only shown when non-keyword
arguments were used. After this change, the deprecation warning will also be
shown when unsupported keyword arguments are used.
