### PR TITLE
Test Active Record & MariaDB on 2.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,13 @@ rvm:
 
 matrix:
   include:
-    # Latest compiled version in http://rubies.travis-ci.org
+    # MariaDB on Ruby 2.2.5
+    - rvm: 2.2.5
+      env:
+        - "GEM=ar:mysql2"
+      addons:
+        mariadb: 10.0
+    # MariaDB on Ruby 2.3.1
     - rvm: 2.3.1
       env:
         - "GEM=ar:mysql2"


### PR DESCRIPTION
We are testing this on 2.3.x, we should also be testing it on 2.2.x, the
other currently supported Ruby version.
