### PR TITLE
Add `disabled_blank` to `select_tag`'s and `date`'s

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,32 @@
+*   `select_tag`'s and `date`'s `disabled_blank` can generate a blank tag option's with selected and
+    disabled.
+
+    Generation of option:
+
+    ```html
+    <option value="" disabled="disabled" selected="selected"></option>
+    ```
+
+    If it pass a value beyond true it change the title for this value and keep the option's selected and
+    disabled.
+
+    Generation of option:
+
+    ```html
+    <option value="" disabled="disabled" selected="selected">None</option>
+    ```
+
+    If it pass a value to default to come selected option's will only contain the disabled option's.
+
+    Generation of option:
+
+    ```html
+    <option value="" disabled="disabled"></option>
+    <option value="1" selected="selected">1</option>
+    ```
+
+    *Herminio Torres*
+
 *   New syntax for tag helpers. Avoid positional parameters and support HTML5 by default.
     Example usage of tag helpers before:
 

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -16,6 +16,7 @@ module ActionView
     # * <tt>:prefix</tt> - overwrites the default prefix of "date" used for the select names. So specifying "birthday"
     #   would give \birthday[month] instead of \date[month] if passed to the <tt>select_month</tt> method.
     # * <tt>:include_blank</tt> - set to true if it should be possible to set an empty date.
+    # * <tt>:disabled_blank</tt> - set to true if it should be possible to set an empty date.
     # * <tt>:discard_type</tt> - set to true if you want to discard the type part of the select name. If set to true,
     #   the <tt>select_month</tt> method would use simply "date" (which can be overwritten using <tt>:prefix</tt>) instead
     #   of \date[month].
@@ -219,6 +220,8 @@ module ActionView
       #   select will not be shown (like when you set <tt>discard_xxx: true</tt>. Defaults to the order defined in
       #   the respective locale (e.g. [:year, :month, :day] in the en locale that ships with Rails).
       # * <tt>:include_blank</tt>     - Include a blank option in every select field so it's possible to set empty
+      #   dates.
+      # * <tt>:disabled_blank</tt>    - Include a blank, disabled and selected option in every select field so it's possible to set empty
       #   dates.
       # * <tt>:default</tt>           - Set a default date if the affected date isn't set or is nil.
       # * <tt>:selected</tt>          - Set a date that overrides the actual value.
@@ -1001,6 +1004,7 @@ module ActionView
 
           select_html = "\n"
           select_html << content_tag("option".freeze, '', :value => '') + "\n" if @options[:include_blank]
+          select_html << content_tag("option".freeze, '', value: '', disabled: true) + "\n" if @options[:disabled_blank]
           select_html << prompt_option_tag(type, @options[:prompt]) + "\n" if @options[:prompt]
           select_html << select_options_as_html
 

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -83,6 +83,7 @@ module ActionView
       # * <tt>:multiple</tt> - If set to true, the selection will allow multiple choices.
       # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
       # * <tt>:include_blank</tt> - If set to true, an empty option will be created. If set to a string, the string will be used as the option's content and the value will be empty.
+      # * <tt>:disabled_blank</tt> - If set to true, an empty option will be created. If set to a string, the string will be used as the option's content and the value will be empty. The option's will come selected by default. It just will not come selected if you pass an option's selection.
       # * <tt>:prompt</tt> - Create a prompt option with blank value and the text asking user to select something.
       # * Any other key creates standard HTML attributes for the tag.
       #
@@ -118,6 +119,17 @@ module ActionView
       #   select_tag "people", options_from_collection_for_select(@people, "id", "name"), include_blank: "All"
       #   # => <select id="people" name="people"><option value="">All</option><option value="1">David</option></select>
       #
+      #   select_tag "people", options_from_collection_for_select(@people, "id", "name"), disabled_blank: true
+      #   # => <select id="people" name="people"><option value="" disabled='disabled' selected='selected'></option><option value="1">David</option></select>
+      #
+      #   select_tag "people", options_from_collection_for_select(@people, "id", "name"), disabled_blank: "All"
+      #   # => <select id="people" name="people"><option value="" disabled='disabled' selected='selected'>All</option><option value="1">David</option></select>
+      #
+      #   select_tag "credit_card", options_for_select([ "VISA", "MasterCard" ], "MasterCard"), disabled_blank: true
+      #   # => <select id="credit_card" name="credit_card"><option value="" disabled='disabled'>
+      #   #    </option><option>VISA</option>
+      #   #    <option selected="selected">MasterCard</option></select>
+      #
       #   select_tag "people", options_from_collection_for_select(@people, "id", "name"), prompt: "Select something"
       #   # => <select id="people" name="people"><option value="">Select something</option><option value="1">David</option></select>
       #
@@ -143,6 +155,20 @@ module ActionView
 
           if include_blank
             option_tags = content_tag("option".freeze, include_blank, options_for_blank_options_tag).safe_concat(option_tags)
+          end
+        end
+
+        if options.include?(:disabled_blank)
+          disabled_blank = options.delete(:disabled_blank)
+          options_for_disabled_blank_options_tag = { value: '', disabled: true, selected: true }
+
+          if disabled_blank == true
+            disabled_blank = ''
+            options_for_disabled_blank_options_tag[:label] = ' '
+          end
+
+          if disabled_blank
+            option_tags = content_tag("option".freeze, disabled_blank, options_for_disabled_blank_options_tag).safe_concat(option_tags)
           end
         end
 

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -145,6 +145,15 @@ module ActionView
           if options[:include_blank]
             option_tags = tag_builder.content_tag_string('option', options[:include_blank].kind_of?(String) ? options[:include_blank] : nil, :value => '') + "\n" + option_tags
           end
+          if options[:disabled_blank]
+            if value.present?
+              option_disabled_blank = { value: '', disabled: true }
+            else
+              option_disabled_blank = { value: '', selected: true , disabled: true }
+            end
+
+            option_tags = tag_builder.content_tag_string('option', options[:disabled_blank].kind_of?(String) ? options[:disabled_blank] : nil, option_disabled_blank) + "\n" + option_tags
+          end
           if value.blank? && options[:prompt]
             option_tags = tag_builder.content_tag_string('option', prompt_text(options[:prompt]), :value => '') + "\n" + option_tags
           end

--- a/actionview/lib/action_view/helpers/tags/date_select.rb
+++ b/actionview/lib/action_view/helpers/tags/date_select.rb
@@ -40,7 +40,7 @@ module ActionView
         end
 
         def default_datetime(options)
-          return if options[:include_blank] || options[:prompt]
+          return if options[:disabled_blank] || options[:include_blank] || options[:prompt]
 
           case options[:default]
           when nil

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -204,6 +204,15 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, select_day(16)
   end
 
+  def test_select_day_with_disabled_blank
+    expected = %(<select id="date_day" name="date[day]">\n)
+    expected << %(<option value="" disabled="disabled"></option>\n<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
+    expected << "</select>\n"
+
+    assert_dom_equal expected, select_day(Time.mktime(2003, 8, 16), disabled_blank: true)
+    assert_dom_equal expected, select_day(16, disabled_blank: true)
+  end
+
   def test_select_day_with_blank
     expected = %(<select id="date_day" name="date[day]">\n)
     expected << %(<option value=""></option>\n<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
@@ -305,6 +314,15 @@ class DateHelperTest < ActionView::TestCase
 
     assert_dom_equal expected, select_month(Time.mktime(2003, 8, 16), :field_name => 'mois')
     assert_dom_equal expected, select_month(8, :field_name => 'mois')
+  end
+
+  def test_select_month_with_disabled_blank
+    expected = %(<select id="date_month" name="date[month]">\n)
+    expected << %(<option value="" disabled="disabled"></option>\n<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
+    expected << "</select>\n"
+
+    assert_dom_equal expected, select_month(Time.mktime(2003, 8, 16), disabled_blank: true)
+    assert_dom_equal expected, select_month(8, disabled_blank: true)
   end
 
   def test_select_month_with_blank
@@ -574,6 +592,14 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, select_hour(Time.mktime(2003, 8, 16, 8, 4, 18), :field_name => 'heure')
   end
 
+  def test_select_hour_with_disabled_blank
+    expected = %(<select id="date_hour" name="date[hour]">\n)
+    expected << %(<option value="" disabled="disabled"></option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
+    expected << "</select>\n"
+
+    assert_dom_equal expected, select_hour(Time.mktime(2003, 8, 16, 8, 4, 18), disabled_blank: true)
+  end
+
   def test_select_hour_with_blank
     expected = %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value=""></option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -652,6 +678,14 @@ class DateHelperTest < ActionView::TestCase
     expected << "</select>\n"
 
     assert_dom_equal expected, select_minute(Time.mktime(2003, 8, 16, 8, 4, 18), :field_name => 'minuto')
+  end
+
+  def test_select_minute_with_disabled_blank
+    expected = %(<select id="date_minute" name="date[minute]">\n)
+    expected << %(<option value="" disabled="disabled"></option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04" selected="selected">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
+    expected << "</select>\n"
+
+    assert_dom_equal expected, select_minute(Time.mktime(2003, 8, 16, 8, 4, 18), disabled_blank: true)
   end
 
   def test_select_minute_with_blank
@@ -756,6 +790,14 @@ class DateHelperTest < ActionView::TestCase
     expected << "</select>\n"
 
     assert_dom_equal expected, select_second(Time.mktime(2003, 8, 16, 8, 4, 18), :field_name => 'segundo')
+  end
+
+  def test_select_second_with_disabled_blank
+    expected = %(<select id="date_second" name="date[second]">\n)
+    expected << %(<option value="" disabled="disabled"></option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18" selected="selected">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
+    expected << "</select>\n"
+
+    assert_dom_equal expected, select_second(Time.mktime(2003, 8, 16, 8, 4, 18), disabled_blank: true)
   end
 
   def test_select_second_with_blank
@@ -2038,6 +2080,29 @@ class DateHelperTest < ActionView::TestCase
     expected << "</select>\n"
 
     assert_dom_equal expected, date_select("post", "written_on")
+  end
+
+  def test_date_select_with_nil_and_with_disabled_blank
+    @post = Post.new
+
+    start_year = Time.now.year-5
+    end_year   = Time.now.year+5
+    expected =   %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
+    expected << "<option value=\"\" disabled=\"disabled\"></option>\n"
+    start_year.upto(end_year) { |i| expected << %(<option value="#{i}">#{i}</option>\n) }
+    expected << "</select>\n"
+
+    expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
+    expected << "<option value=\"\" disabled=\"disabled\"></option>\n"
+    1.upto(12) { |i| expected << %(<option value="#{i}">#{Date::MONTHNAMES[i]}</option>\n) }
+    expected << "</select>\n"
+
+    expected << %{<select id="post_written_on_3i" name="post[written_on(3i)]">\n}
+    expected << "<option value=\"\" disabled=\"disabled\"></option>\n"
+    1.upto(31) { |i| expected << %(<option value="#{i}">#{i}</option>\n) }
+    expected << "</select>\n"
+
+    assert_dom_equal expected, date_select("post", "written_on", :disabled_blank => true)
   end
 
   def test_date_select_with_nil_and_blank

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -660,6 +660,20 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_with_disabled_blank
+    assert_dom_equal(
+      %(<select id="post_category" name="post[category]"><option value="" selected="selected" disabled="disabled"></option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
+      select("post", "category", %w( abe mus hest), disabled_blank: true)
+    )
+  end
+
+  def test_select_with_disabled_blank_as_string
+    assert_dom_equal(
+      %(<select id="post_category" name="post[category]"><option value="" selected="selected" disabled="disabled">None</option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
+      select("post", "category", %w( abe mus hest), disabled_blank: 'None')
+    )
+  end
+
   def test_select_with_blank
     @post = Post.new
     @post.category = "<mus>"
@@ -958,6 +972,36 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_collection_select_with_disabled_blank_and_style
+    @post = Post.new
+    @post.author_name = "Babe"
+
+    assert_dom_equal(
+      "<select id=\"post_author_name\" name=\"post[author_name]\" style=\"width: 200px\"><option value=\"\" disabled=\"disabled\"></option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { disabled_blank: true }, "style" => "width: 200px")
+    )
+  end
+
+  def test_collection_select_with_disabled_blank_and_style_as_string
+    @post = Post.new
+    @post.author_name = "Babe"
+
+    assert_dom_equal(
+      "<select id=\"post_author_name\" name=\"post[author_name]\" style=\"width: 200px\"><option value=\"\" disabled=\"disabled\">None</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { disabled_blank: 'None' }, "style" => "width: 200px")
+    )
+  end
+
+  def test_collection_select_with_disabled_blank_and_selected
+    @post = Post.new
+    @post.author_name = "Babe"
+
+    assert_dom_equal(
+      %{<select id="post_author_name" name="post[author_name]"><option value="" disabled="disabled"></option>\n<option value="&lt;Abe&gt;" selected="selected">&lt;Abe&gt;</option>\n<option value="Babe">Babe</option>\n<option value="Cabe">Cabe</option></select>},
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { disabled_blank: true, selected: "<Abe>" })
+    )
+  end
+
   def test_collection_select_with_blank_and_style
     @post = Post.new
     @post.author_name = "Babe"
@@ -1098,6 +1142,34 @@ class FormOptionsHelperTest < ActionView::TestCase
       "</select>",
       output_buffer
     )
+  end
+
+  def test_time_zone_select_with_disabled_blank
+    @firm = Firm.new("D")
+    html = time_zone_select("firm", "time_zone", nil, disabled_blank: true)
+    assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" +
+                 "<option value=\"\" disabled=\"disabled\"></option>\n" +
+                 "<option value=\"A\">A</option>\n" +
+                 "<option value=\"B\">B</option>\n" +
+                 "<option value=\"C\">C</option>\n" +
+                 "<option value=\"D\" selected=\"selected\">D</option>\n" +
+                 "<option value=\"E\">E</option>" +
+                 "</select>",
+                 html
+  end
+
+  def test_time_zone_select_with_disabled_blank_as_string
+    @firm = Firm.new("D")
+    html = time_zone_select("firm", "time_zone", nil, disabled_blank: 'None')
+    assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" +
+                 "<option value=\"\" disabled=\"disabled\">None</option>\n" +
+                 "<option value=\"A\">A</option>\n" +
+                 "<option value=\"B\">B</option>\n" +
+                 "<option value=\"C\">C</option>\n" +
+                 "<option value=\"D\" selected=\"selected\">D</option>\n" +
+                 "<option value=\"E\">E</option>" +
+                 "</select>",
+                 html
   end
 
   def test_time_zone_select_with_blank

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -238,6 +238,18 @@ class FormTagHelperTest < ActionView::TestCase
     assert_match VALID_HTML_ID, input_elem['id']
   end
 
+  def test_select_tag_with_disabled_blank
+    actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), disabled_blank: true
+    expected = %(<select id="places" name="places"><option value="" label=" " selected="selected" disabled="disabled"></option><option>Home</option><option>Work</option><option>Pub</option></select>)
+    assert_dom_equal expected, actual
+  end
+
+  def test_select_tag_with_disabled_blank_as_string
+    actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), disabled_blank: 'None'
+    expected = %(<select id="places" name="places"><option value="" selected="selected" disabled="disabled">None</option><option>Home</option><option>Work</option><option>Pub</option></select>)
+    assert_dom_equal expected, actual
+  end
+
   def test_select_tag_with_include_blank
     actual = select_tag "places", raw("<option>Home</option><option>Work</option><option>Pub</option>"), include_blank: true
     expected = %(<select id="places" name="places"><option value="" label=" "></option><option>Home</option><option>Work</option><option>Pub</option></select>)


### PR DESCRIPTION
`select_tag`'s and `date`'s `disabled_blank` can generate a blank tag option's with selected and
disabled.

Generation of option:

``` html
<option value="" disabled="disabled" selected="selected"></option>
```

If it pass a value beyond true it change the title for this value and keep the option's selected and
disabled.

Generation of option:

``` html
<option value="" disabled="disabled" selected="selected">None</option>
```

If it pass a value to default to come selected option's will only contain the disabled option's.

Generation of option:

``` html
<option value="" disabled="disabled"></option>
<option value="1" selected="selected">1</option>
```
