### PR TITLE
No need to set `cookie_only` option from Rails

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -64,7 +64,7 @@ module ActionDispatch
     # <tt>:httponly</tt>.
     class CookieStore < AbstractStore
       def initialize(app, options={})
-        super(app, options.merge!(:cookie_only => true))
+        super(app, options.merge!(cookie_only: true))
       end
 
       def delete_session(req, session_id, options)

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -373,5 +373,11 @@ module ApplicationTests
 
       refute Rails.application.middleware.include?(ActionDispatch::Flash)
     end
+
+    test "cookie_only is set to true even if user tries to overwrite it" do
+      add_to_config "config.session_store :cookie_store, key: '_myapp_session', cookie_only: false"
+      require "#{app_path}/config/environment"
+      assert app.config.session_options[:cookie_only], "Expected cookie_only to be set to true"
+    end
   end
 end


### PR DESCRIPTION
### Summary
- Because it is set in Rack here https://github.com/rack/rack/blob/25a549883b85fb33970b4a1530a365c0c9e51f95/lib/rack/session/abstract/id.rb#L201
  and our cookie store is inheriting from Rack::Session::Abstract::Persisted.
