### PR TITLE
Simplify and speed up the generation of random base58 strings

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*    Simplified and sped up the generation of `SecureRandom.base58` strings by
+     removing a conditional extra call to generate a random number.
+
+     *Bart de Water*
+
 *   `travel/travel_to` travel time helpers, now raise on nested calls, 
      as this can lead to confusing time stubbing.
        

--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -15,8 +15,7 @@ module SecureRandom
   #
   def self.base58(n = 16)
     SecureRandom.random_bytes(n).unpack("C*").map do |byte|
-      idx = byte % 64
-      idx = SecureRandom.random_number(58) if idx >= 58
+      idx = byte % 58
       BASE58_ALPHABET[idx]
     end.join
   end


### PR DESCRIPTION
While reading the code to find out how `has_secure_token` is exactly generated, the base58 generation looked more complicated than necessary to me. For good measure I've tried a couple of different ways of solving this and benchmarked them:

Benchmark script:

``` ruby
require 'benchmark/ips'
require 'securerandom'

BASE58_ALPHABET = ('0'..'9').to_a + ('A'..'Z').to_a + ('a'..'z').to_a - ['0', 'O', 'I', 'l']
N = 16

Benchmark.ips do |x|

  x.report("current") do
    SecureRandom.random_bytes(N).unpack("C*").map do |byte|
      idx = byte % 64
      idx = SecureRandom.random_number(58) if idx >= 58
      BASE58_ALPHABET[idx]
    end.join
  end

  x.report("array-idx") do
    N.times.map do
      idx = SecureRandom.random_number(58)
      BASE58_ALPHABET[idx]
    end.join
  end

  x.report("modulo-58") do
    SecureRandom.random_bytes(N).unpack("C*").map do |byte|
      idx = byte % 58
      BASE58_ALPHABET[idx]
    end.join
  end

  # do not use!
  #x.report("array-sample") do
    #BASE58_ALPHABET.sample(N, random: SecureRandom.random_number).join
  #end

  x.compare!
end
```

Results on my MacBook Pro:

```
Warming up --------------------------------------
             current    15.720k i/100ms
           array-idx    13.528k i/100ms
           modulo-58    17.598k i/100ms
        array-sample    17.926k i/100ms
Calculating -------------------------------------
             current    169.741k (± 2.1%) i/s -    848.880k in   5.003228s
           array-idx    139.549k (± 5.3%) i/s -    703.456k in   5.057171s
           modulo-58    186.053k (± 2.0%) i/s -    932.694k in   5.015150s
        array-sample    188.423k (± 4.5%) i/s -    950.078k in   5.054607s

Comparison:
        array-sample:   188423.1 i/s
           modulo-58:   186053.2 i/s - same-ish: difference falls within error
             current:   169740.6 i/s - 1.11x slower
           array-idx:   139549.0 i/s - 1.35x slower
```

Results on a CentOS 6 server:

```
Warming up --------------------------------------
             current     9.004k i/100ms
           array-idx     7.890k i/100ms
           modulo-58    10.574k i/100ms
        array-sample    12.621k i/100ms
Calculating -------------------------------------
             current     99.205k (± 1.8%) i/s -    504.224k in   5.084382s
           array-idx     82.115k (± 4.3%) i/s -    410.280k in   5.006679s
           modulo-58    118.533k (± 1.5%) i/s -    602.718k in   5.085956s
        array-sample    139.912k (± 3.0%) i/s -    706.776k in   5.056209s

Comparison:
        array-sample:   139911.7 i/s
           modulo-58:   118532.8 i/s - 1.18x slower
             current:    99204.6 i/s - 1.41x slower
           array-idx:    82114.9 i/s - 1.70x slower
```

The results stay the same after a couple of runs: array-sample and modulo-58 are same-ish on the MacBook while array-sample is faster on the server.
