### PR TITLE
Stop changes to a dupped `ActionController::Parameters` mutating the original

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -572,20 +572,6 @@ module ActionController
       convert_value_to_parameters(@parameters.values_at(*keys))
     end
 
-    # Returns an exact copy of the <tt>ActionController::Parameters</tt>
-    # instance. +permitted+ state is kept on the duped object.
-    #
-    #   params = ActionController::Parameters.new(a: 1)
-    #   params.permit!
-    #   params.permitted?        # => true
-    #   copy_params = params.dup # => <ActionController::Parameters {"a"=>1} permitted: true>
-    #   copy_params.permitted?   # => true
-    def dup
-      super.tap do |duplicate|
-        duplicate.permitted = @permitted
-      end
-    end
-
     # Returns a new <tt>ActionController::Parameters</tt> with all keys from
     # +other_hash+ merges into current hash.
     def merge(other_hash)
@@ -786,7 +772,7 @@ module ActionController
 
       def initialize_copy(source)
         super
-        @parameters = source.instance_variable_get(:@parameters).dup
+        @parameters = @parameters.dup
       end
   end
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -783,6 +783,11 @@ module ActionController
           end
         end
       end
+
+      def initialize_copy(source)
+        super
+        @parameters = source.instance_variable_get(:@parameters).dup
+      end
   end
 
   # == Strong \Parameters

--- a/actionpack/test/controller/parameters/dup_test.rb
+++ b/actionpack/test/controller/parameters/dup_test.rb
@@ -17,9 +17,27 @@ class ParametersDupTest < ActiveSupport::TestCase
     )
   end
 
-  test "changes on a duplicate do not affect the original" do
+  test "a duplicate maintains the original's permitted status" do
+    @params.permit!
+    dupped_params = @params.dup
+    assert dupped_params.permitted?
+  end
+
+  test "a duplicate maintains the original's parameters" do
+    @params.permit!
+    dupped_params = @params.dup
+    assert_equal @params.to_h, dupped_params.to_h
+  end
+
+  test "changes to a duplicate's parameters do not affect the original" do
     dupped_params = @params.dup
     dupped_params.delete(:person)
+    assert_not_equal @params, dupped_params
+  end
+
+  test "changes tp a duplicate's permitted status do not affect the original" do
+    dupped_params = @params.dup
+    dupped_params.permit!
     assert_not_equal @params, dupped_params
   end
 end

--- a/actionpack/test/controller/parameters/dup_test.rb
+++ b/actionpack/test/controller/parameters/dup_test.rb
@@ -1,0 +1,25 @@
+require 'abstract_unit'
+require 'action_controller/metal/strong_parameters'
+
+class ParametersDupTest < ActiveSupport::TestCase
+  setup do
+    ActionController::Parameters.permit_all_parameters = false
+
+    @params = ActionController::Parameters.new(
+      person: {
+        age: '32',
+        name: {
+          first: 'David',
+          last: 'Heinemeier Hansson'
+        },
+        addresses: [{city: 'Chicago', state: 'Illinois'}]
+      }
+    )
+  end
+
+  test "changes on a duplicate do not affect the original" do
+    dupped_params = @params.dup
+    dupped_params.delete(:person)
+    assert_not_equal @params, dupped_params
+  end
+end


### PR DESCRIPTION
When `ActionController::Parameters` is duplicated with `#dup`, it doesn't create a duplicate of the instance variables (e.g. `@parameters`) but rather maintains the reference (see http://ruby-doc.org/core-2.3.1/Object.html). Given that the parameters object is often manipulated as if it were a hash (e.g. with `#delete` and similar methods), this leads to unexpected behaviour, like the following:

```
params = ActionController::Parameters.new(foo: "bar")
duplicated_params = params.dup
duplicated_params.delete(:foo)

params == duplicated_params
```

This fixes the bug by defining a private `#initialize_copy` method, used internally by `#dup`, which makes a copy of `@parameters`.
