### PR TITLE
Pathname might not be always initialized.

### DIFF
--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -3,6 +3,8 @@ require 'abstract_unit'
 require 'active_support/cache'
 require 'dependencies_test_helpers'
 
+require 'pathname'
+
 module ActiveSupport
   module Cache
     module Strategy


### PR DESCRIPTION
### Summary

Running just part of the test suite, Pathname might not be initialized:

```
$ cd activesupport
$ ruby -Ilib:test -e 'Dir.glob('\''./test/caching_test.rb'\'').sort.each {|t| require t}'
Skipping memcached tests. Start memcached and try again.
I, [2016-07-07T12:20:40.118547 #1976]  INFO -- : localhost:11211 failed (count: 0) Errno::ECONNREFUSED: Connection refused - connect(2) for "localhost" port 11211
Run options: --seed 43852

# Running:

......................SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE.................................................................

Finished in 0.122848s, 2629.2661 runs/s, 1628.0285 assertions/s.

  1) Error:
FileStoreTest#test_clear_also_clears_local_cache:
NameError: uninitialized constant FileStoreTest::Pathname
    /builddir/build/BUILD/rubygem-activesupport-5.0.0/usr/share/gems/gems/activesupport-5.0.0/test/caching_test.rb:775:in `setup'


  2) Error:
FileStoreTest#test_delete_matched_when_cache_directory_does_not_exist:
NameError: uninitialized constant FileStoreTest::Pathname
    /builddir/build/BUILD/rubygem-activesupport-5.0.0/usr/share/gems/gems/activesupport-5.0.0/test/caching_test.rb:775:in `setup'

... snip ...

 71) Error:
FileStoreTest#test_cache_hit_instrumentation:
NameError: uninitialized constant FileStoreTest::Pathname
    /builddir/build/BUILD/rubygem-activesupport-5.0.0/usr/share/gems/gems/activesupport-5.0.0/test/caching_test.rb:775:in `setup'

323 runs, 200 assertions, 0 failures, 71 errors, 165 skips
```

Fix this by requiring pathname explicitly.
