### PR TITLE
Avoid accidental recursion in 2.4.0

### DIFF
--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -119,6 +119,7 @@ class Numeric
   end
 
   [Float, Fixnum, Bignum, BigDecimal].each do |klass|
+    next if klass.method_defined?(:to_default_s)
     klass.send(:alias_method, :to_default_s, :to_s)
 
     klass.send(:define_method, :to_s) do |*args|


### PR DESCRIPTION
Avoid accidental recursion in 2.4.0

Fixnum == Bignum in Ruby 2.4.0. Due to this we define the method `to_s` and then we alias to the same method. This causes infinite recursion. This PR solves the problem by first seeing if the class instance has a to `to_default_s` method before trying to define one.
