### PR TITLE
Support for unified Integer class in Ruby 2.4+

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -110,7 +110,7 @@ module ActionDispatch
           if options_constraints.is_a?(Hash)
             split_constraints path_params, options_constraints
             options_constraints.each do |key, default|
-              if URL_OPTIONS.include?(key) && (String === default || Fixnum === default)
+              if URL_OPTIONS.include?(key) && (String === default || Integer === default)
                 @defaults[key] ||= default
               end
             end
@@ -790,8 +790,8 @@ module ActionDispatch
           end
 
           if options[:constraints].is_a?(Hash)
-            defaults = options[:constraints].select do
-              |k, v| URL_OPTIONS.include?(k) && (v.is_a?(String) || v.is_a?(Fixnum))
+            defaults = options[:constraints].select do |k, v|
+              URL_OPTIONS.include?(k) && (v.is_a?(String) || v.is_a?(Integer))
             end
 
             (options[:defaults] ||= {}).reverse_merge!(defaults)

--- a/actionpack/test/assertions/response_assertions_test.rb
+++ b/actionpack/test/assertions/response_assertions_test.rb
@@ -25,7 +25,7 @@ module ActionDispatch
         end
       end
 
-      def test_assert_response_fixnum
+      def test_assert_response_integer
         @response = FakeResponse.new 400
         assert_response 400
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -606,7 +606,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     assert_equal '/pages/boo', url_for(rs, { :controller => 'pages', :action => 'boo' })
   end
 
-  def test_route_with_fixnum_default
+  def test_route_with_integer_default
     rs.draw do
       get 'page(/:id)' => 'content#show_page', :id => 1
       get ':controller/:action/:id'

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -437,7 +437,7 @@ XML
     )
   end
 
-  def test_params_passing_with_fixnums
+  def test_params_passing_with_integer
     get :test_params, :page => {:name => "Page name", :month => 4, :year => 2004, :day => 6}
     parsed_params = eval(@response.body)
     assert_equal(
@@ -447,7 +447,7 @@ XML
     )
   end
 
-  def test_params_passing_with_fixnums_when_not_html_request
+  def test_params_passing_with_integers_when_not_html_request
     get :test_params, :format => 'json', :count => 999
     parsed_params = eval(@response.body)
     assert_equal(

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -767,7 +767,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
-  def test_select_with_fixnum
+  def test_select_with_integer
     @post = Post.new
     @post.category = ""
     assert_dom_equal(

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -15,7 +15,7 @@ module ActiveJob
   end
 
   # Raised when an unsupported argument type is being set as job argument. We
-  # currently support NilClass, Fixnum, Float, String, TrueClass, FalseClass,
+  # currently support NilClass, Integer, Fixnum, Float, String, TrueClass, FalseClass,
   # Bignum and object that can be represented as GlobalIDs (ex: Active Record).
   # Also raised if you set the key for a Hash something else than a string or
   # a symbol.
@@ -24,7 +24,7 @@ module ActiveJob
 
   module Arguments
     extend self
-    TYPE_WHITELIST = [ NilClass, Fixnum, Float, String, TrueClass, FalseClass, Bignum ]
+    TYPE_WHITELIST = [ NilClass, String, Integer, Fixnum, Bignum, Float, BigDecimal, TrueClass, FalseClass ].uniq
 
     # Serializes a set of arguments. Whitelisted types are returned
     # as-is. Arrays/Hashes are serialized element by element.

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -114,7 +114,7 @@ module ActiveModel
       # * <tt>:only_integer</tt> - Specifies whether the value has to be an
       #   integer, e.g. an integral value (default is +false+).
       # * <tt>:allow_nil</tt> - Skip validation if attribute is +nil+ (default is
-      #   +false+). Notice that for fixnum and float columns empty strings are
+      #   +false+). Notice that for Integer and Float columns empty strings are
       #   converted to +nil+.
       # * <tt>:greater_than</tt> - Specifies the value must be greater than the
       #   supplied value.

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -331,7 +331,7 @@ class LengthValidationTest < ActiveModel::TestCase
     assert_equal ["Your essay must be at least 5 words."], t.errors[:content]
   end
 
-  def test_validates_length_of_for_fixnum
+  def test_validates_length_of_for_integer
     Topic.validates_length_of(:approved, is: 4)
 
     t = Topic.new("title" => "uhohuhoh", "content" => "whatever", approved: 1)

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -264,7 +264,7 @@ module ActiveRecord
         _options = records.extract_options!
         dependent = _options[:dependent] || options[:dependent]
 
-        records = find(records) if records.any? { |record| record.kind_of?(Fixnum) || record.kind_of?(String) }
+        records = find(records) if records.any? { |record| record.kind_of?(Integer) || record.kind_of?(String) }
         delete_or_destroy(records, dependent)
       end
 
@@ -275,7 +275,7 @@ module ActiveRecord
       # +:dependent+ option.
       def destroy(*records)
         return if records.empty?
-        records = find(records) if records.any? { |record| record.kind_of?(Fixnum) || record.kind_of?(String) }
+        records = find(records) if records.any? { |record| record.kind_of?(Integer) || record.kind_of?(String) }
         delete_or_destroy(records, :destroy)
       end
 

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -562,7 +562,7 @@ module ActiveRecord
       #   Pet.find(1)
       #   # => ActiveRecord::RecordNotFound: Couldn't find Pet with id=1
       #
-      # You can pass +Fixnum+ or +String+ values, it finds the records
+      # You can pass +Integer+ or +String+ values, it finds the records
       # responding to the +id+ and executes delete on them.
       #
       #   class Person < ActiveRecord::Base
@@ -626,7 +626,7 @@ module ActiveRecord
       #
       #   Pet.find(1, 2, 3) # => ActiveRecord::RecordNotFound: Couldn't find all Pets with IDs (1, 2, 3)
       #
-      # You can pass +Fixnum+ or +String+ values, it finds the records
+      # You can pass +Integer+ or +String+ values, it finds the records
       # responding to the +id+ and then deletes them from the database.
       #
       #   person.pets.size # => 3

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -69,7 +69,7 @@ module ActiveRecord
     # by calling new on the column type or aggregation type (through composed_of) object with these parameters.
     # So having the pairs written_on(1) = "2004", written_on(2) = "6", written_on(3) = "24", will instantiate
     # written_on (a date type) with Date.new("2004", "6", "24"). You can also specify a typecast character in the
-    # parentheses to have the parameters typecasted before they're used in the constructor. Use i for Fixnum and
+    # parentheses to have the parameters typecasted before they're used in the constructor. Use i for Integer and
     # f for Float. If all the values for a given attribute are empty, the attribute will be set to +nil+.
     def assign_multiparameter_attributes(pairs)
       execute_callstack_for_multiparameter_attributes(

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -364,7 +364,7 @@ module ActiveRecord
     #   person = Person.new
     #   person[:age] = '22'
     #   person[:age] # => 22
-    #   person[:age] # => Fixnum
+    #   person[:age].class # => Integer
     def []=(attr_name, value)
       write_attribute(attr_name, value)
     end

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -50,7 +50,7 @@ module ActiveRecord
       end
 
       # Updates the attribute identified by <tt>attr_name</tt> with the
-      # specified +value+. Empty strings for fixnum and float columns are
+      # specified +value+. Empty strings for Integer and Float columns are
       # turned into +nil+.
       def write_attribute(attr_name, value)
         write_attribute_with_type_cast(attr_name, value, true)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -750,7 +750,7 @@ module ActiveRecord
           case length
           when Hash
             column_names.each {|name| option_strings[name] += "(#{length[name]})" if length.has_key?(name) && length[name].present?}
-          when Fixnum
+          when Integer
             column_names.each {|name| option_strings[name] += "(#{length})"}
           end
         end
@@ -864,7 +864,7 @@ module ActiveRecord
 
         # Increase timeout so the server doesn't disconnect us.
         wait_timeout = @config[:wait_timeout]
-        wait_timeout = 2147483 unless wait_timeout.is_a?(Fixnum)
+        wait_timeout = 2147483 unless wait_timeout.is_a?(Integer)
         variables['wait_timeout'] = self.class.type_cast_config_to_integer(wait_timeout)
 
         # Make MySQL reject illegal values rather than truncating or blanking them, see

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -94,7 +94,7 @@ module ActiveRecord
     #
     # There are two basic forms of output:
     #
-    #   * Single aggregate value: The single value is type cast to Fixnum for COUNT, Float
+    #   * Single aggregate value: The single value is type cast to Integer for COUNT, Float
     #     for AVG, and the given column's type for everything else.
     #
     #   * Grouped values: This returns an ordered hash of the values and groups them. It

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1253,7 +1253,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 2, summit.client_of
   end
 
-  def test_deleting_by_fixnum_id
+  def test_deleting_by_integer_id
     david = Developer.find(1)
 
     assert_difference 'david.projects.count', -1 do
@@ -1290,7 +1290,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, companies(:first_firm).clients_of_firm(true).size
   end
 
-  def test_destroying_by_fixnum_id
+  def test_destroying_by_integer_id
     force_signal37_to_load_all_clients_of_firm
 
     assert_difference "Client.count", -1 do

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -589,7 +589,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::AssociationTypeMismatch) { posts(:thinking).tags.delete(Object.new) }
   end
 
-  def test_deleting_by_fixnum_id_from_has_many_through
+  def test_deleting_by_integer_id_from_has_many_through
     post = posts(:thinking)
 
     assert_difference 'post.tags.count', -1 do

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -38,7 +38,7 @@ module ActiveRecord
       data.reload
 
       assert_equal 2, data.overloaded_float
-      assert_kind_of Fixnum, OverloadedType.last.overloaded_float
+      assert_kind_of Integer, OverloadedType.last.overloaded_float
       assert_equal 2.0, UnoverloadedType.last.overloaded_float
       assert_kind_of Float, UnoverloadedType.last.overloaded_float
     end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1023,7 +1023,7 @@ class BasicsTest < ActiveRecord::TestCase
     assert_kind_of Integer, m1.world_population
     assert_equal 6000000000, m1.world_population
 
-    assert_kind_of Fixnum, m1.my_house_population
+    assert_kind_of Integer, m1.my_house_population
     assert_equal 3, m1.my_house_population
 
     assert_kind_of BigDecimal, m1.bank_balance
@@ -1051,7 +1051,7 @@ class BasicsTest < ActiveRecord::TestCase
     assert_kind_of Integer, m1.world_population
     assert_equal 6000000000, m1.world_population
 
-    assert_kind_of Fixnum, m1.my_house_population
+    assert_kind_of Integer, m1.my_house_population
     assert_equal 3, m1.my_house_population
 
     assert_kind_of BigDecimal, m1.bank_balance

--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -156,7 +156,7 @@ module ActiveRecord
           assert_equal String, bob.first_name.class
           assert_equal String, bob.last_name.class
           assert_equal String, bob.bio.class
-          assert_equal Fixnum, bob.age.class
+          assert_kind_of Integer, bob.age
           assert_equal Time, bob.birthday.class
 
           if current_adapter?(:OracleAdapter)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -184,7 +184,7 @@ class MigrationTest < ActiveRecord::TestCase
     # is_a?(Bignum)
     assert_kind_of Integer, b.world_population
     assert_equal 6000000000, b.world_population
-    assert_kind_of Fixnum, b.my_house_population
+    assert_kind_of Integer, b.my_house_population
     assert_equal 3, b.my_house_population
     assert_kind_of BigDecimal, b.bank_balance
     assert_equal BigDecimal("1586.43"), b.bank_balance
@@ -210,7 +210,7 @@ class MigrationTest < ActiveRecord::TestCase
       assert_in_delta BigDecimal("2.71828182845905"), b.value_of_e, 0.00000000000001
     else
       # - SQL standard is an integer
-      assert_kind_of Fixnum, b.value_of_e
+      assert_kind_of Integer, b.value_of_e
       assert_equal 2, b.value_of_e
     end
 

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -181,13 +181,12 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_cache_does_not_wrap_string_results_in_arrays
     Task.cache do
-      # Oracle adapter returns count() as Fixnum or Float
+      # Oracle adapter returns count() as Integer or Float
       if current_adapter?(:OracleAdapter)
         assert_kind_of Numeric, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
       elsif current_adapter?(:SQLite3Adapter, :Mysql2Adapter)
         # Future versions of the sqlite3 adapter will return numeric
-        assert_instance_of Fixnum,
-         Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
+        assert_instance_of Fixnum, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
       else
         assert_instance_of String, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
       end

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -102,9 +102,9 @@ module ActiveRecord
         assert_equal float.to_s, @quoter.quote(float, nil)
       end
 
-      def test_quote_fixnum
-        fixnum = 1
-        assert_equal fixnum.to_s, @quoter.quote(fixnum, nil)
+      def test_quote_integer
+        integer = 1
+        assert_equal integer.to_s, @quoter.quote(integer, nil)
       end
 
       def test_quote_bignum

--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -25,8 +25,6 @@ class Class
 
   # Returns an array with the direct children of +self+.
   #
-  #   Integer.subclasses # => [Fixnum, Bignum]
-  #
   #   class Foo; end
   #   class Bar < Foo; end
   #   class Baz < Bar; end

--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -55,8 +55,7 @@ class Hash
   #
   #     XML_TYPE_NAMES = {
   #       "Symbol"     => "symbol",
-  #       "Fixnum"     => "integer",
-  #       "Bignum"     => "integer",
+  #       "Integer"    => "integer",
   #       "BigDecimal" => "decimal",
   #       "Float"      => "float",
   #       "TrueClass"  => "boolean",

--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -118,8 +118,15 @@ class Numeric
     end
   end
 
-  [Float, Fixnum, Bignum, BigDecimal].each do |klass|
+  [Float, Integer, Fixnum, Bignum, BigDecimal].each do |klass|
     klass.send(:alias_method, :to_default_s, :to_s)
+
+    # Ruby 2.4+ unifies Fixnum & Bignum into Integer.
+    if Integer == Fixnum
+      next if klass == Fixnum || klass == Bignum
+    else
+      next if klass == Fixnum
+    end
 
     klass.send(:define_method, :to_s) do |*args|
       if args[0].is_a?(Symbol)

--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -70,7 +70,7 @@ class Numeric
   # Numbers are not duplicable:
   #
   #  3.duplicable? # => false
-  #  3.dup         # => TypeError: can't dup Fixnum
+  #  3.dup         # => TypeError: can't dup Integer
   def duplicable?
     false
   end

--- a/activesupport/lib/active_support/core_ext/string/access.rb
+++ b/activesupport/lib/active_support/core_ext/string/access.rb
@@ -1,5 +1,5 @@
 class String
-  # If you pass a single Fixnum, returns a substring of one character at that
+  # If you pass a single integer, returns a substring of one character at that
   # position. The first character of the string is at position 0, the next at
   # position 1, and so on. If a range is supplied, a substring containing
   # characters at offsets given by the range is returned. In both cases, if an

--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -32,20 +32,25 @@ module ActiveSupport
       "binary" => "base64"
     } unless defined?(DEFAULT_ENCODINGS)
 
-    TYPE_NAMES = {
-      "Symbol"     => "symbol",
-      "Fixnum"     => "integer",
-      "Bignum"     => "integer",
-      "BigDecimal" => "decimal",
-      "Float"      => "float",
-      "TrueClass"  => "boolean",
-      "FalseClass" => "boolean",
-      "Date"       => "date",
-      "DateTime"   => "dateTime",
-      "Time"       => "dateTime",
-      "Array"      => "array",
-      "Hash"       => "hash"
-    } unless defined?(TYPE_NAMES)
+    unless defined?(TYPE_NAMES)
+      TYPE_NAMES = {
+        "Symbol"     => "symbol",
+        "Integer"    => "integer",
+        "BigDecimal" => "decimal",
+        "Float"      => "float",
+        "TrueClass"  => "boolean",
+        "FalseClass" => "boolean",
+        "Date"       => "date",
+        "DateTime"   => "dateTime",
+        "Time"       => "dateTime",
+        "Array"      => "array",
+        "Hash"       => "hash"
+      }
+
+      # No need to map these on Ruby 2.4+
+      TYPE_NAMES["Fixnum"] = "integer" unless Fixnum == Integer
+      TYPE_NAMES["Bignum"] = "integer" unless Bignum == Integer
+    end
 
     FORMATTING = {
       "symbol"   => Proc.new { |symbol| symbol.to_s },

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -95,10 +95,10 @@ class ToXmlTest < ActiveSupport::TestCase
   end
 
   def test_to_xml_with_non_hash_elements
-    xml = [1, 2, 3].to_xml(skip_instruct: true, indent: 0)
+    xml = %w[1 2 3].to_xml(skip_instruct: true, indent: 0)
 
-    assert_equal '<fixnums type="array"><fixnum', xml.first(29)
-    assert xml.include?(%(<fixnum type="integer">2</fixnum>)), xml
+    assert_equal '<strings type="array"><string', xml.first(29)
+    assert xml.include?(%(<string>2</string>)), xml
   end
 
   def test_to_xml_with_non_hash_different_type_elements

--- a/activesupport/test/core_ext/array/grouping_test.rb
+++ b/activesupport/test/core_ext/array/grouping_test.rb
@@ -3,11 +3,12 @@ require 'active_support/core_ext/array'
 
 class GroupingTest < ActiveSupport::TestCase
   def setup
-    Fixnum.send :private, :/  # test we avoid Integer#/ (redefined by mathn)
+    # In Ruby < 2.4, test we avoid Integer#/ (redefined by mathn)
+    Fixnum.send :private, :/ unless Fixnum == Integer
   end
 
   def teardown
-    Fixnum.send :public, :/
+    Fixnum.send :public, :/ unless Fixnum == Integer
   end
 
   def test_in_groups_of_with_perfect_fit

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -12,7 +12,7 @@ class DurationTest < ActiveSupport::TestCase
     assert d.is_a?(ActiveSupport::Duration)
     assert_kind_of ActiveSupport::Duration, d
     assert_kind_of Numeric, d
-    assert_kind_of Fixnum, d
+    assert_kind_of Integer, d
     assert !d.is_a?(Hash)
 
     k = Class.new

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -36,12 +36,12 @@ class HashExtTest < ActiveSupport::TestCase
   def setup
     @strings = { 'a' => 1, 'b' => 2 }
     @nested_strings = { 'a' => { 'b' => { 'c' => 3 } } }
-    @symbols = { :a  => 1, :b  => 2 }
+    @symbols = { :a => 1, :b => 2 }
     @nested_symbols = { :a => { :b => { :c => 3 } } }
-    @mixed   = { :a  => 1, 'b' => 2 }
-    @nested_mixed   = { 'a' => { :b => { 'c' => 3 } } }
-    @fixnums = {  0  => 1,  1  => 2 }
-    @nested_fixnums = {  0  => { 1  => { 2 => 3} } }
+    @mixed = { :a => 1, 'b' => 2 }
+    @nested_mixed = { 'a' => { :b => { 'c' => 3 } } }
+    @integers = { 0 => 1, 1 => 2 }
+    @nested_integers = { 0 => { 1 => { 2 => 3} } }
     @illegal_symbols = { [] => 3 }
     @nested_illegal_symbols = { [] => { [] => 3} }
     @upcase_strings = { 'A' => 1, 'B' => 2 }
@@ -196,14 +196,14 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal @nested_illegal_symbols, @nested_illegal_symbols.deep_dup.deep_symbolize_keys!
   end
 
-  def test_symbolize_keys_preserves_fixnum_keys
-    assert_equal @fixnums, @fixnums.symbolize_keys
-    assert_equal @fixnums, @fixnums.dup.symbolize_keys!
+  def test_symbolize_keys_preserves_integer_keys
+    assert_equal @integers, @integers.symbolize_keys
+    assert_equal @integers, @integers.dup.symbolize_keys!
   end
 
-  def test_deep_symbolize_keys_preserves_fixnum_keys
-    assert_equal @nested_fixnums, @nested_fixnums.deep_symbolize_keys
-    assert_equal @nested_fixnums, @nested_fixnums.deep_dup.deep_symbolize_keys!
+  def test_deep_symbolize_keys_preserves_integer_keys
+    assert_equal @nested_integers, @nested_integers.deep_symbolize_keys
+    assert_equal @nested_integers, @nested_integers.deep_dup.deep_symbolize_keys!
   end
 
   def test_stringify_keys
@@ -299,14 +299,14 @@ class HashExtTest < ActiveSupport::TestCase
     assert_raise(NoMethodError) { @nested_illegal_symbols.with_indifferent_access.deep_dup.deep_symbolize_keys! }
   end
 
-  def test_symbolize_keys_preserves_fixnum_keys_for_hash_with_indifferent_access
-    assert_equal @fixnums, @fixnums.with_indifferent_access.symbolize_keys
-    assert_raise(NoMethodError) { @fixnums.with_indifferent_access.dup.symbolize_keys! }
+  def test_symbolize_keys_preserves_integer_keys_for_hash_with_indifferent_access
+    assert_equal @integers, @integers.with_indifferent_access.symbolize_keys
+    assert_raise(NoMethodError) { @integers.with_indifferent_access.dup.symbolize_keys! }
   end
 
-  def test_deep_symbolize_keys_preserves_fixnum_keys_for_hash_with_indifferent_access
-    assert_equal @nested_fixnums, @nested_fixnums.with_indifferent_access.deep_symbolize_keys
-    assert_raise(NoMethodError) { @nested_fixnums.with_indifferent_access.deep_dup.deep_symbolize_keys! }
+  def test_deep_symbolize_keys_preserves_integer_keys_for_hash_with_indifferent_access
+    assert_equal @nested_integers, @nested_integers.with_indifferent_access.deep_symbolize_keys
+    assert_raise(NoMethodError) { @nested_integers.with_indifferent_access.deep_dup.deep_symbolize_keys! }
   end
 
   def test_stringify_keys_for_hash_with_indifferent_access

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -373,16 +373,9 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
   end
 
   def test_to_s__injected_on_proper_types
-    assert_equal Fixnum, 1230.class
     assert_equal '1.23 Thousand', 1230.to_s(:human)
-
-    assert_equal Float, Float(1230).class
     assert_equal '1.23 Thousand', Float(1230).to_s(:human)
-
-    assert_equal Bignum, (100**10).class
     assert_equal '100000 Quadrillion', (100**10).to_s(:human)
-
-    assert_equal BigDecimal, BigDecimal("1000010").class
     assert_equal '1 Million', BigDecimal("1000010").to_s(:human)
   end
 

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -303,7 +303,7 @@ class StringInflectionsTest < ActiveSupport::TestCase
 end
 
 class StringAccessTest < ActiveSupport::TestCase
-  test "#at with Fixnum, returns a substring of one character at that position" do
+  test "#at with Integer, returns a substring of one character at that position" do
     assert_equal "h", "hello".at(0)
   end
 
@@ -316,19 +316,19 @@ class StringAccessTest < ActiveSupport::TestCase
     assert_equal nil, "hello".at(/nonexisting/)
   end
 
-  test "#from with positive Fixnum, returns substring from the given position to the end" do
+  test "#from with positive Integer, returns substring from the given position to the end" do
     assert_equal "llo", "hello".from(2)
   end
 
-  test "#from with negative Fixnum, position is counted from the end" do
+  test "#from with negative Integer, position is counted from the end" do
     assert_equal "lo", "hello".from(-2)
   end
 
-  test "#to with positive Fixnum, substring from the beginning to the given position" do
+  test "#to with positive Integer, substring from the beginning to the given position" do
     assert_equal "hel", "hello".to(2)
   end
 
-  test "#to with negative Fixnum, position is counted from the end" do
+  test "#to with negative Integer, position is counted from the end" do
     assert_equal "hell", "hello".to(-2)
   end
 
@@ -342,14 +342,14 @@ class StringAccessTest < ActiveSupport::TestCase
     assert_equal 'x', 'x'.first
   end
 
-  test "#first with Fixnum, returns a substring from the beginning to position" do
+  test "#first with Integer, returns a substring from the beginning to position" do
     assert_equal "he", "hello".first(2)
     assert_equal "", "hello".first(0)
     assert_equal "hello", "hello".first(10)
     assert_equal 'x', 'x'.first(4)
   end
 
-  test "#first with Fixnum >= string length still returns a new string" do
+  test "#first with Integer >= string length still returns a new string" do
     string = "hello"
     different_string = string.first(5)
     assert_not_same different_string, string
@@ -360,14 +360,14 @@ class StringAccessTest < ActiveSupport::TestCase
     assert_equal 'x', 'x'.last
   end
 
-  test "#last with Fixnum, returns a substring from the end to position" do
+  test "#last with Integer, returns a substring from the end to position" do
     assert_equal "llo", "hello".last(3)
     assert_equal "hello", "hello".last(10)
     assert_equal "", "hello".last(0)
     assert_equal 'x', 'x'.last(4)
   end
 
-  test "#last with Fixnum >= string length still returns a new string" do
+  test "#last with Integer >= string length still returns a new string" do
     string = "hello"
     different_string = string.last(5)
     assert_not_same different_string, string
@@ -626,7 +626,7 @@ class OutputSafetyTest < ActiveSupport::TestCase
     assert_equal @string, @string.html_safe
   end
 
-  test "A fixnum is safe by default" do
+  test "An integer is safe by default" do
     assert 5.html_safe?
   end
 
@@ -767,7 +767,7 @@ class OutputSafetyTest < ActiveSupport::TestCase
     assert_equal ["<p>", "<b>", "<h1>"], @other_string
   end
 
-  test "Concatting a fixnum to safe always yields safe" do
+  test "Concatting an integer to safe always yields safe" do
     string = @string.html_safe
     string = string.concat(13)
     assert_equal "hello".concat(13), string

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1760,7 +1760,7 @@ NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
 The method `constantize` resolves the constant reference expression in its receiver:
 
 ```ruby
-"Fixnum".constantize # => Fixnum
+"Integer".constantize # => Integer
 
 module M
   X = 1
@@ -2612,8 +2612,7 @@ To do so, the method loops over the pairs and builds nodes that depend on the _v
 ```ruby
 XML_TYPE_NAMES = {
   "Symbol"     => "symbol",
-  "Fixnum"     => "integer",
-  "Bignum"     => "integer",
+  "Integer"    => "integer",
   "BigDecimal" => "decimal",
   "Float"      => "float",
   "TrueClass"  => "boolean",

--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -111,7 +111,7 @@ On the other hand, big chunks of structured documentation may have a separate "E
 The results of expressions follow them and are introduced by "# => ", vertically aligned:
 
 ```ruby
-# For checking if a fixnum is even or odd.
+# For checking if an integer is even or odd.
 #
 #   1.even? # => false
 #   1.odd?  # => true

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -793,7 +793,7 @@ Rails 4.0 no longer supports loading plugins from `vendor/plugins`. You must rep
 
 * Rails 4.0 has removed the identity map from Active Record, due to [some inconsistencies with associations](https://github.com/rails/rails/commit/302c912bf6bcd0fa200d964ec2dc4a44abe328a6). If you have manually enabled it in your application, you will have to remove the following config that has no effect anymore: `config.active_record.identity_map`.
 
-* The `delete` method in collection associations can now receive `Fixnum` or `String` arguments as record ids, besides records, pretty much like the `destroy` method does. Previously it raised `ActiveRecord::AssociationTypeMismatch` for such arguments. From Rails 4.0 on `delete` automatically tries to find the records matching the given ids before deleting them.
+* The `delete` method in collection associations can now receive `Integer` or `String` arguments as record ids, besides records, pretty much like the `destroy` method does. Previously it raised `ActiveRecord::AssociationTypeMismatch` for such arguments. From Rails 4.0 on `delete` automatically tries to find the records matching the given ids before deleting them.
 
 * In Rails 4.0 when a column or a table is renamed the related indexes are also renamed. If you have migrations which rename the indexes, they are no longer needed.
 


### PR DESCRIPTION
Ruby 2.4 unifies Fixnum and Bignum into Integer: https://bugs.ruby-lang.org/issues/12005
- Forward compat with new unified Integer class in Ruby 2.4+.
- Backward compat with separate Fixnum/Bignum in Ruby 2.2 & 2.3.
- Drops needless Fixnum distinction in docs, preferring Integer.
