### PR TITLE
Only use provided units for number_to_human

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
@@ -20,11 +20,18 @@ module ActiveSupport
         exponent = calculate_exponent(units)
         @number = number / (10 ** exponent)
 
-        until (rounded_number = NumberToRoundedConverter.convert(number, options)) != NumberToRoundedConverter.convert(1000, options)
-          @number = number / 1000.0
-          exponent += 3
+        case units
+        when Hash
+          unit = determine_unit(units, exponent)
+          rounded_number = NumberToRoundedConverter.convert(number, options)
+        else
+          until (rounded_number = NumberToRoundedConverter.convert(number, options)) != NumberToRoundedConverter.convert(1000, options)
+            @number = number / 1000.0
+            exponent += 3
+          end
+          unit = determine_unit(units, exponent)
         end
-        unit = determine_unit(units, exponent)
+
         format.gsub('%n'.freeze, rounded_number).gsub('%u'.freeze, unit).strip
       end
 

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -345,6 +345,9 @@ module ActiveSupport
           #Spaces are stripped from the resulting string
           assert_equal '4', number_helper.number_to_human(4, :units => {:unit => "", :ten => 'tens '})
           assert_equal '4.5  tens', number_helper.number_to_human(45, :units => {:unit => "", :ten => ' tens   '})
+
+          #Uses only the provided units and does not try to use larger ones
+          assert_equal "1000 kilometers", number_helper.number_to_human(1_000_000, :units => {:unit => "meter", :thousand => "kilometers"})
         end
       end
 


### PR DESCRIPTION
Fixes #25664
### Summary

Previous implementation attempted to round numbers past the provided units. For
instance, if the number to be formatted was 1_000_000 and the highest custom
unit exponent was "thousand", the number returned would be reduced to 1, but
with a value for "million" not provided, no unit would be returned along with
the number. This change does not attempt to reduce the number farther than the
provided units.
