### PR TITLE
Correct link for model generator field types

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -209,7 +209,7 @@ Description:
     Create rails files for model generator.
 ```
 
-NOTE: For a list of available field types, refer to the [API documentation](http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/TableDefinition.html#method-i-column) for the column method for the `TableDefinition` class.
+NOTE: For a list of available field types for the `type` parameter, refer to the [API documentation](http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_column) for the add_column method for the `SchemaStatements` module. The `index` parameter generates a corresponding index for the column.
 
 But instead of generating a model directly (which we'll be doing later), let's set up a scaffold. A **scaffold** in Rails is a full set of model, database migration for that model, controller to manipulate it, views to view and manipulate the data, and a test suite for each of the above.
 


### PR DESCRIPTION
It's common to want to look up the field types that can be used in model generators. The Command Line guide provides a link to "a list of available field types", but the page it links to ([the API docs for `TableDefinition#column`](http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/TableDefinition.html#method-i-column)) doesn't actually show that list. Instead, it provides another link to [the docs for `SchemaStatements#add_column` "for available options"](http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_column), which includes the list of field types (":primary_key, :string, :text,...").

This PR changes the link on the command line guide to go directly to `SchemaStatements#add_column`, since showing that list of field types seems to be the intent of linking and because `TableDefinition#column` doesn't appear to add anything to that goal.
