### PR TITLE
Don't validate the associated object, when validate: false is set.

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -587,7 +587,7 @@ module ActiveRecord
           records.each do |record|
             raise_on_type_mismatch!(record)
             add_to_target(record) do |rec|
-              result &&= insert_record(rec, true, should_raise) unless owner.new_record?
+              result &&= insert_record(rec, reflection.validate?, should_raise) unless owner.new_record?
             end
           end
 


### PR DESCRIPTION
### Summary

An associated object shouldn't be validated when `validate: false` is set in a collection association during creation and update.

During creation, the behavior is working as intended and the associated only gets validated if `validate: true`. Although, during concat_records/updates the associated object always get validated, ignoring  `validate: false` set.
