### PR TITLE
Raise ArgumentError when ActionController::TestCase receives unknown params

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Raise ArgumentError when ActionController::TestCase receives unknown params
+
+    Previously, unknown parameters passed to `ActionController::TestCase` methods
+    were silently ignored. Now they will raise, with a helpful error message.
+
+    *Grey Baker*
+
 *   Check `request.path_parameters` encoding at the point they're set
 
     Check for any non-UTF8 characters in path parameters at the point they're

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -461,6 +461,14 @@ module ActionController
 
         if kwarg_request?(args)
           parameters, session, body, flash, http_method, format, xhr = args[0].values_at(:params, :session, :body, :flash, :method, :format, :xhr)
+
+          unexpected_args = (args[0].keys - %i(params session body flash method format xhr))
+          if unexpected_args.any?
+            msg = "unknown keywords received: #{unexpected_args.join(', ')}. " \
+                  "These keyword arguments can be safely removed from your " \
+                  "test: in previous Rails versions they were silently ignored."
+            raise ArgumentError, msg
+          end
         else
           http_method, parameters, session, flash = args
           format = nil

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -336,6 +336,10 @@ XML
     assert_equal 'baz', session[:bar]
   end
 
+  def test_process_with_unknown_kwarg
+    assert_raises(ArgumentError) { process :no_op, method: "GET", foo: "bar" }
+  end
+
   def test_process_merges_session_arg
     session[:foo] = 'bar'
     get :no_op, session: { bar: 'baz' }


### PR DESCRIPTION
Previously, unknown parameters passed to `ActionController::TestCase` methods
were silently ignored, and `get :url, foo: "bar"` would execute as `get :url`.
That was inconsistent with `ActionDispatch::Integration`, which raises an
argument error in this case (making debugging easier).

This PR adds an instructive error message to `ActionController::TestCase`, and
brings it further in line with `ActionDispatch::Integration`.
