### PR TITLE
Add tests for 1xx, 204 and 304 responses to response_test.rb

### DIFF
--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -145,6 +145,26 @@ class ResponseTest < ActiveSupport::TestCase
     }, headers)
   end
 
+  test "content length" do
+    [100, 101, 102, 204].each do |c|
+      @response = ActionDispatch::Response.new
+      @response.status = c.to_s
+      @response.set_header "Content-Length", "0"
+      _, headers, _ = @response.to_a
+      assert !headers.has_key?("Content-Length"), "#{c} must not have a Content-Length header field"
+    end
+  end
+
+  test "does not contain a message-body" do
+    [100, 101, 102, 204, 304].each do |c|
+      @response = ActionDispatch::Response.new
+      @response.status = c.to_s
+      @response.body = "Body must not be included"
+      _, _, body = @response.to_a
+      assert_empty body, "#{c} must not have a message-body but actually contains #{body}"
+    end
+  end
+
   test "content type" do
     [204, 304].each do |c|
       @response = ActionDispatch::Response.new


### PR DESCRIPTION
### Summary

In response_test.rb, we haven't had a test to make sure that

1) these responses don't have a message-body as described in RFC7231[1]

2) 1xx and 204 responses must not have a Content-Length header field as described in RFC7230-section3.3.2[2]

[1] https://tools.ietf.org/html/rfc7231
[2] https://tools.ietf.org/html/rfc7230#section-3.3.2
### Other Information

Even though our implementation doesn't allow users to send a Content-Length header field in a 304 response, sending the header field is valid as mentioned in RFC7230-section3.3.2[2]. So I've decided not to test whether or not a 304 response has the header.

The citation from the section is as follows;

```
A server MAY send a Content-Length header field in a 304 (Not
Modified) response to a conditional GET request (Section 4.1 of
[RFC7232]); a server MUST NOT send Content-Length in such a response
unless its field-value equals the decimal number of octets that would
have been sent in the payload body of a 200 (OK) response to the same
request.
```
