### PR TITLE
Cleanup CHANGELOGs [ci skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,11 +1,11 @@
-*   Fix the generated `#to_param` method to use `omission:''` so that
+*   Fix the generated `#to_param` method to use `omission: ''` so that
     the resulting output is actually up to 20 characters, not
     effectively 17 to leave room for the default "...".
     Also call `#parameterize` before `#truncate` and make the
     `separator: /-/` to maximize the information included in the
     output.
 
-    Fixes #23635
+    Fixes #23635.
 
     *Rob Biedenharn*
 
@@ -23,7 +23,7 @@
     *Kevin McPhillips*
 
 *   Removed the unused methods `ActiveRecord::Base.connection_id` and
-    `ActiveRecord::Base.connection_id=`
+    `ActiveRecord::Base.connection_id=`.
 
     *Sean Griffin*
 
@@ -42,15 +42,15 @@
 
     *Johannes Opper*
 
-*   Introduce ActiveRecord::TransactionSerializationError for catching
+*   Introduce `ActiveRecord::TransactionSerializationError` for catching
     transaction serialization failures or deadlocks.
 
     *Erol Fornoles*
 
-*   PostgreSQL: Fix db:structure:load silent failure on SQL error
+*   PostgreSQL: Fix db:structure:load silent failure on SQL error.
 
-    The command line flag "-v ON_ERROR_STOP=1" should be used
-    when invoking psql to make sure errors are not suppressed.
+    The command line flag `-v ON_ERROR_STOP=1` should be used
+    when invoking `psql` to make sure errors are not suppressed.
 
     Example:
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Set the server host using the `HOST` environment variable.
+
+    *mahnunchik*
+
 *   Add public API to register new folders for `rake notes`:
 
         config.annotations.register_directories('spec', 'features')
@@ -13,7 +17,7 @@
     *Rafael Mendonça França*
 
 *   Default `config.assets.quiet = true` in the development environment. Suppress
-    logging of `sprockets-rails` requests by default.
+    logging of assets requests by default.
 
     *Kevin McPhillips*
 


### PR DESCRIPTION
### Summary
- Cleanup Active Record CHANGELOG.
- Add missing CHANGELOG for https://github.com/rails/rails/pull/25688.
- Clarify that assets requests logging is suppressed.
