### PR TITLE
Cache key checks delegations

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -57,7 +57,7 @@ module ActiveRecord
       when new_record?
         "#{model_name.cache_key}/new"
       when timestamp_names.any?
-        timestamp = max_updated_column_timestamp(timestamp_names)
+        timestamp = max_updated_column_timestamp([], timestamp_names)
         timestamp = timestamp.utc.to_s(cache_timestamp_format)
         "#{model_name.cache_key}/#{id}-#{timestamp}"
       when timestamp = max_updated_column_timestamp

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -2,6 +2,7 @@
 require 'cases/helper'
 require 'models/company'
 require 'models/developer'
+require 'models/ship'
 require 'models/computer'
 require 'models/owner'
 require 'models/pet'
@@ -126,6 +127,18 @@ class IntegrationTest < ActiveRecord::TestCase
       assert pet.touch
     end
     assert_not_equal key, owner.reload.cache_key
+  end
+
+  def test_cache_key_changes_when_target_of_delegated_method_touched
+    dev = Developer.first
+    ship = Ship.create!(name: 'mcboatface', developer: dev, updated_at: Time.now)
+    key = ship.cache_key
+    travel(1.second) do
+      assert dev.touch
+    end
+
+    assert_equal dev.reload.cache_key.last(20), ship.reload.cache_key.last(20)
+    assert_not_equal key, ship.reload.cache_key
   end
 
   def test_cache_key_format_for_existing_record_with_nil_updated_timestamps

--- a/activerecord/test/models/cake_designer.rb
+++ b/activerecord/test/models/cake_designer.rb
@@ -1,3 +1,5 @@
 class CakeDesigner < ActiveRecord::Base
   has_one :chef, as: :employable
+
+  delegate :department_id, to: :employable
 end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -64,6 +64,9 @@ class Developer < ActiveRecord::Base
   validates_inclusion_of :salary, :in => 50000..200000
   validates_length_of    :name, :within => 3..20
 
+  delegate :treasures_count, to: :ship
+  delegate :count, :to => :class
+
   before_create do |developer|
     developer.audit_logs.build :message => "Computer created"
   end

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -13,6 +13,8 @@ class Ship < ActiveRecord::Base
 
   validates_presence_of :name
 
+  delegate :salary, to: :developer
+
   attr_accessor :cancel_save_from_callback
   before_save :cancel_save_callback_method, :if => :cancel_save_from_callback
   def cancel_save_callback_method

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -12,6 +12,8 @@ class Module
        yield)
   ).freeze
 
+  attr_reader :delegation_targets
+
   # Provides a +delegate+ class method to easily expose contained objects'
   # public methods as your own.
   #
@@ -83,6 +85,15 @@ class Module
   #   end
   #
   #   Foo.new.hello # => "world"
+  #
+  # Delegation targets are accessible through +delegation_targets+ class method:
+  #
+  #   class Foo < ActiveRecord::Base
+  #     belongs_to :greeter
+  #     delegate :hello, to: :greeter
+  #   end
+  #
+  #   Foo.delegation_targets #=> [:greeter]
   #
   # Delegates can optionally be prefixed using the <tt>:prefix</tt> option. If the value
   # is <tt>true</tt>, the delegate methods are prefixed with the name of the object being
@@ -207,6 +218,11 @@ class Module
           "end"
         ].join ';'
       end
+
+      @delegation_targets ||= []
+      delegation_target = to.to_s.split('.', 2).first.to_sym
+
+      @delegation_targets << delegation_target unless @delegation_targets.index(delegation_target)
 
       module_eval(method_def, file, line)
     end

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -154,6 +154,13 @@ class ModuleTest < ActiveSupport::TestCase
     assert_equal "Chicago", @david.city
   end
 
+  def test_delegate_keeps_track_of_delegated_methods
+    someone_delegation_targets = [:place, :self]
+    invoice_delegation_targets = [:client]
+    assert_equal Someone.delegation_targets, someone_delegation_targets
+    assert_equal Invoice.delegation_targets, invoice_delegation_targets
+  end
+
   def test_delegation_to_assignment_method
     @david.place_name = "Fred"
     assert_equal "Fred", @david.place.name


### PR DESCRIPTION
### Summary

This PR helps preventing very subtle and hard to detect bugs in Rails applications. I've encountered this issue in real world production app and it took hours to debug.
#### Problem

Let's say we have following models:

``` ruby
class User < ActiveRecord::Base
  belongs_to: :profile
end


class Profile < ActiveRecord::Base
  has_one :user

  delegate :email, to: :user
end
```

Issue happens in the following way:
1. Serialized `Profile` record is cached.
2. Associated `User` record's `email` gets updated.
3. Profile is served from cache and its `email` value is **outdated**.

Although I wouldn't call it a bug in Rails itself, it is a place where Rails magic abandons a developer - allowing him to get into hard to detect issue without providing any warnings nor easy fix.
#### Solution

This PR proposes a solution to this. First it adds keeping track of `delegation_targets` for each model class that uses `delegate` method. Then its adds checking timestamps of `delegation_targets` during `cache_key` generation.

The obvious drawback is that _when there are delegations_ defined on a model then `cache_key` generation will take more time. But that's the hidden cost of having delegations to associations - you need to check associated model to invalidate the cache correctly anyway.

Alternative approach would be to add option `belongs_to: :profile, touch: true`. However it works only one way `user` -> `profile` while delegation can be bidirectional (`touch` option is not enough to pass tests added in this PR). It also requires additional database write. In proposed solution there's one less parameter to worry about.

Happy to hear your feedback!
