### PR TITLE
Fix AJ tests on ruby 2.4 being caused since classes are unified for Integer

### DIFF
--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -14,7 +14,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     [ 1, 'a' ],
     { 'a' => 1 }
   ].each do |arg|
-    test "serializes #{arg.class} verbatim" do
+    test "serializes #{arg.class} - #{arg} verbatim" do
       assert_arguments_unchanged arg
     end
   end


### PR DESCRIPTION
Fix AJ tests on ruby 2.4 being caused since classes are unified for Integer, and we create test name named on arg class. Append arg as well to the test name to avoid name conflicts.
