### PR TITLE
Correctly return `associated_table` when `associated_with?` is true

### DIFF
--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -42,11 +42,11 @@ module ActiveRecord
     end
 
     def associated_table(table_name)
-      return self if table_name == arel_table.name
-
       association = klass._reflect_on_association(table_name) || klass._reflect_on_association(table_name.singularize)
 
-      if association && !association.polymorphic?
+      if !association && table_name == arel_table.name
+        return self
+      elsif association && !association.polymorphic?
         association_klass = association.klass
         arel_table = association_klass.arel_table.alias(table_name)
       else

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -19,6 +19,7 @@ require 'models/professor'
 require 'models/treasure'
 require 'models/price_estimate'
 require 'models/club'
+require 'models/user'
 require 'models/member'
 require 'models/membership'
 require 'models/sponsor'
@@ -994,5 +995,10 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_difference "Project.first.developers_required_by_default.size", 1 do
       Project.first.developers_required_by_default.create!(name: "Sean", salary: 50000)
     end
+  end
+
+  def test_association_name_is_the_same_as_join_table_name
+    user = User.create!
+    assert_nothing_raised { user.jobs_pool.clear }
   end
 end

--- a/activerecord/test/models/user.rb
+++ b/activerecord/test/models/user.rb
@@ -1,6 +1,12 @@
+require 'models/job'
+
 class User < ActiveRecord::Base
   has_secure_token
   has_secure_token :auth_token
+
+  has_and_belongs_to_many :jobs_pool,
+    class_name: Job,
+    join_table: 'jobs_pool'
 end
 
 class UserWithNotification < User

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -390,6 +390,11 @@ ActiveRecord::Schema.define do
     t.integer :ideal_reference_id
   end
 
+  create_table :jobs_pool, force: true, id: false do |t|
+    t.references :job, null: false, index: true
+    t.references :user, null: false, index: true
+  end
+
   create_table :keyboards, force: true, id: false do |t|
     t.primary_key :key_number
     t.string      :name


### PR DESCRIPTION
`AssociationQueryHandler` requires `association` initialized
`TableMetadata` even if `table_name == arel_table.name`.

Fixes #25689.
