### PR TITLE
Check that migration file exist before showing status by `db:migrate:…

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -114,6 +114,7 @@ db_namespace = namespace :db do
 
       file_list =
           ActiveRecord::Tasks::DatabaseTasks.migrations_paths.flat_map do |path|
+            next unless File.readable? path
             Dir.foreach(path).map do |file|
               next unless ActiveRecord::Migrator.match_to_migration_filename?(file)
 
@@ -122,7 +123,11 @@ db_namespace = namespace :db do
               status = db_list.delete(version) ? 'up' : 'down'
               [status, version, (name + scope).humanize]
             end.compact
-          end
+          end.compact
+
+      if file_list.empty?
+        abort 'Migration files do not exist yet.'
+      end
 
       db_list.map! do |version|
         ['up', version, '********** NO FILE **********']


### PR DESCRIPTION
### Summary

If there are no migration files, `db:migrate:status` cause Errno::ENOENT.
This PR fix it.
### Steps to reproduce

```
rails new _5.0.0_ new some_app
cd some_app
bin/rake db:migrate
bin/rake db:migrate:status
```
### Expected behavior

Exception should not occur.
### Actual behavior

Errno::ENOENT is occurred like this:

```
Running via Spring preloader in process 52533
rake aborted!
Errno::ENOENT: No such file or directory @ dir_initialize - /Users/yasuyk/temp/some_app/db/migrate
/Users/yasuyk/temp/some_app/vendor/bundle/gems/activerecord-5.0.0/lib/active_record/railties/databases.rake:117:in `open'
/Users/yasuyk/temp/some_app/vendor/bundle/gems/activerecord-5.0.0/lib/active_record/railties/databases.rake:117:in `foreach'
/Users/yasuyk/temp/some_app/vendor/bundle/gems/activerecord-5.0.0/lib/active_record/railties/databases.rake:117:in `each'
/Users/yasuyk/temp/some_app/vendor/bundle/gems/activerecord-5.0.0/lib/active_record/railties/databases.rake:117:in `map'
/Users/yasuyk/temp/some_app/vendor/bundle/gems/activerecord-5.0.0/lib/active_record/railties/databases.rake:117:in `block (4 levels) in <top (required)>'
/Users/yasuyk/temp/some_app/vendor/bundle/gems/activerecord-5.0.0/lib/active_record/railties/databases.rake:116:in `each'
/Users/yasuyk/temp/some_app/vendor/bundle/gems/activerecord-5.0.0/lib/active_record/railties/databases.rake:116:in `flat_map'
/Users/yasuyk/temp/some_app/vendor/bundle/gems/activerecord-5.0.0/lib/active_record/railties/databases.rake:116:in `block (3 levels) in <top (required)>'
/Users/yasuyk/temp/some_app/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/dependencies.rb:287:in `load'
/Users/yasuyk/temp/some_app/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/dependencies.rb:287:in `block in load'
/Users/yasuyk/temp/some_app/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/dependencies.rb:259:in `load_dependency'
/Users/yasuyk/temp/some_app/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/dependencies.rb:287:in `load'
-e:1:in `<main>'
Tasks: TOP => db:migrate:status
(See full trace by running task with --trace)
```
### System configuration

**Rails version**:

5.0.0

**Ruby version**:

ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin14]
