### PR TITLE
Let TestResponse assign a parser.

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -6,6 +6,8 @@ require 'active_support/core_ext/string/strip'
 require 'rack/test'
 require 'minitest'
 
+require 'action_dispatch/testing/request_encoder'
+
 module ActionDispatch
   module Integration #:nodoc:
     module RequestHelpers
@@ -383,7 +385,6 @@ module ActionDispatch
           response = _mock_session.last_response
           @response = ActionDispatch::TestResponse.from_response(response)
           @response.request = @request
-          @response.response_parser = RequestEncoder.parser(@response.content_type)
           @html_document = nil
           @url_options = nil
 
@@ -401,59 +402,6 @@ module ActionDispatch
           yield location if block_given?
           path = request_encoder.append_format_to location.path
           location.query ? "#{path}?#{location.query}" : path
-        end
-
-        class RequestEncoder # :nodoc:
-          @encoders = {}
-
-          attr_reader :response_parser
-
-          def initialize(mime_name, param_encoder, response_parser, url_encoded_form = false)
-            @mime = Mime[mime_name]
-
-            unless @mime
-              raise ArgumentError, "Can't register a request encoder for " \
-                "unregistered MIME Type: #{mime_name}. See `Mime::Type.register`."
-            end
-
-            @url_encoded_form = url_encoded_form
-            @path_format      = ".#{@mime.symbol}" unless @url_encoded_form
-            @response_parser  = response_parser || -> body { body }
-            @param_encoder    = param_encoder   || :"to_#{@mime.symbol}".to_proc
-          end
-
-          def append_format_to(path)
-            if @url_encoded_form
-              path
-            else
-              path + @path_format
-            end
-          end
-
-          def content_type
-            @mime.to_s
-          end
-
-          def encode_params(params)
-            @param_encoder.call(params)
-          end
-
-          def self.parser(content_type)
-            mime = Mime::Type.lookup(content_type)
-            encoder(mime ? mime.ref : nil).response_parser
-          end
-
-          def self.encoder(name)
-            @encoders[name] || WWWFormEncoder
-          end
-
-          def self.register_encoder(mime_name, param_encoder: nil, response_parser: nil)
-            @encoders[mime_name] = new(mime_name, param_encoder, response_parser)
-          end
-
-          register_encoder :json, response_parser: -> body { JSON.parse(body) }
-
-          WWWFormEncoder = new(:url_encoded_form, -> params { params }, nil, true)
         end
     end
 
@@ -777,7 +725,7 @@ module ActionDispatch
         end
 
         def register_encoder(*args)
-          Integration::Session::RequestEncoder.register_encoder(*args)
+          RequestEncoder.register_encoder(*args)
         end
       end
 

--- a/actionpack/lib/action_dispatch/testing/request_encoder.rb
+++ b/actionpack/lib/action_dispatch/testing/request_encoder.rb
@@ -1,0 +1,54 @@
+module ActionDispatch
+  class RequestEncoder # :nodoc:
+    @encoders = {}
+
+    attr_reader :response_parser
+
+    def initialize(mime_name, param_encoder, response_parser, url_encoded_form = false)
+      @mime = Mime[mime_name]
+
+      unless @mime
+        raise ArgumentError, "Can't register a request encoder for " \
+          "unregistered MIME Type: #{mime_name}. See `Mime::Type.register`."
+      end
+
+      @url_encoded_form = url_encoded_form
+      @path_format      = ".#{@mime.symbol}" unless @url_encoded_form
+      @response_parser  = response_parser || -> body { body }
+      @param_encoder    = param_encoder   || :"to_#{@mime.symbol}".to_proc
+    end
+
+    def append_format_to(path)
+      if @url_encoded_form
+        path
+      else
+        path + @path_format
+      end
+    end
+
+    def content_type
+      @mime.to_s
+    end
+
+    def encode_params(params)
+      @param_encoder.call(params)
+    end
+
+    def self.parser(content_type)
+      mime = Mime::Type.lookup(content_type)
+      encoder(mime ? mime.ref : nil).response_parser
+    end
+
+    def self.encoder(name)
+      @encoders[name] || WWWFormEncoder
+    end
+
+    def self.register_encoder(mime_name, param_encoder: nil, response_parser: nil)
+      @encoders[mime_name] = new(mime_name, param_encoder, response_parser)
+    end
+
+    register_encoder :json, response_parser: -> body { JSON.parse(body) }
+
+    WWWFormEncoder = new(:url_encoded_form, -> params { params }, nil, true)
+  end
+end

--- a/actionpack/lib/action_dispatch/testing/test_response.rb
+++ b/actionpack/lib/action_dispatch/testing/test_response.rb
@@ -1,3 +1,5 @@
+require 'action_dispatch/testing/request_encoder'
+
 module ActionDispatch
   # Integration test methods such as ActionDispatch::Integration::Session#get
   # and ActionDispatch::Integration::Session#post return objects of class
@@ -10,6 +12,11 @@ module ActionDispatch
       new response.status, response.headers, response.body
     end
 
+    def initialize(*) # :nodoc:
+      super
+      @response_parser = RequestEncoder.parser(content_type)
+    end
+
     # Was the response successful?
     alias_method :success?, :successful?
 
@@ -18,8 +25,6 @@ module ActionDispatch
 
     # Was there a server-side error?
     alias_method :error?, :server_error?
-
-    attr_writer :response_parser # :nodoc:
 
     def parsed_body
       @parsed_body ||= @response_parser.call(body)

--- a/actionpack/test/dispatch/test_response_test.rb
+++ b/actionpack/test/dispatch/test_response_test.rb
@@ -17,4 +17,12 @@ class TestResponseTest < ActiveSupport::TestCase
     assert_response_code_range 500..599, :server_error?
     assert_response_code_range 400..499, :client_error?
   end
+
+  test "response parsing" do
+    response = ActionDispatch::TestResponse.create(200, {}, '')
+    assert_equal response.body, response.parsed_body
+
+    response = ActionDispatch::TestResponse.create(200, { 'Content-Type' => 'application/json' }, '{ "foo": "fighters" }')
+    assert_equal({ 'foo' => 'fighters' }, response.parsed_body)
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/25762

Previously we'd only assign a response parser when a request came through
Action Dispatch integration tests. This made calls to `parsed_body` when a TestResponse
was manually instantiated — though own doing or perhaps from a framework — unintentionally
blow up because no parser was set at that time.

The response can lookup a parser entirely through its own ivars. Extract request encoder to
its own file and assume that a viable content type is present at TestResponse instantiation.

Since the default response parser is a no-op, making `parsed_body` equal to `body`, no
exceptions will be thrown.
