### PR TITLE
Remove unused activerecord requirement in actionpack.

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -33,7 +33,6 @@ require 'action_view/testing/resolvers'
 require 'action_dispatch'
 require 'active_support/dependencies'
 require 'active_model'
-require 'active_record'
 
 require 'pp' # require 'pp' early to prevent hidden_methods from not picking up the pretty-print methods until too late
 


### PR DESCRIPTION
### Summary

I found actionpack did not depends on activerecord from actionpack.gemspec file.
https://github.com/rails/rails/blob/master/actionpack/actionpack.gemspec

However I found the activerecord is required in below file.
actionpack/test/abstract_unit.rb

So, I removed the line.

The actionpack test is no problem after the modification.

```
bundle exec ruby -e 'system(%(cd actionpack && rake test --trace))'
...
2991 runs, 14718 assertions, 0 failures, 0 errors, 1 skips
```

Could you merge this?
Thanks.
