### PR TITLE
Set config in ActiveRecord after initialize

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -26,6 +26,7 @@ module ActiveRecord
 
     config.active_record.use_schema_cache_dump = true
     config.active_record.maintain_test_schema = true
+    config.active_record.belongs_to_required_by_default = true
 
     config.eager_load_namespaces << ActiveRecord
 
@@ -107,10 +108,12 @@ module ActiveRecord
       end
     end
 
-    initializer "active_record.set_configs" do |app|
-      ActiveSupport.on_load(:active_record) do
-        app.config.active_record.each do |k,v|
-          send "#{k}=", v
+    initializer "active_record.set_configs" do
+      config.after_initialize do |app|
+        ActiveSupport.on_load(:active_record) do
+          app.config.active_record.each do |k,v|
+            send "#{k}=", v
+          end
         end
       end
     end


### PR DESCRIPTION
### Summary

Related to #23589.

When there is a hook like `ActiveRecord::Base.extend`, `ActiveRecord::Base.send :include` etc in config/initializers, some values get into a mess.

Example 1)

```
# config/initializers/a.rb
module Foo; end
ActiveRecord::Base.send :include, Foo

Rails.application.config.active_record.belongs_to_required_by_default = true
Rails.application.config.active_record.maintain_test_schema = true

% rails c
Loading development environment (Rails 5.0.0)
irb(main):001:0> Rails.application.config.active_record.belongs_to_required_by_default
=> true
irb(main):002:0> ActiveRecord::Base.belongs_to_required_by_default
=> nil
irb(main):003:0> Rails.application.config.active_record.maintain_test_schema
=> true
irb(main):004:0> ActiveRecord::Base.maintain_test_schema
=> true
```

Example 2)

```
# config/initializers/a.rb
module Foo; end
ActiveRecord::Base.send :include, Foo

Rails.application.config.active_record.belongs_to_required_by_default = false
Rails.application.config.active_record.maintain_test_schema = false

% rails c
Loading development environment (Rails 5.0.0)
irb(main):001:0> Rails.application.config.active_record.belongs_to_required_by_default
=> false
irb(main):002:0> ActiveRecord::Base.belongs_to_required_by_default
=> nil
irb(main):003:0> Rails.application.config.active_record.maintain_test_schema
=> false
irb(main):004:0> ActiveRecord::Base.maintain_test_schema
=> true
```

I shouldn't call ActiveRecord::Base directly, but some gems do and it's not a easy to find why some values are different. So I tried to set config in ActiveRecord after initialize to resolve this.
