### PR TITLE
Add railties as a actionpack development_dependency.

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'actionview', version
 
   s.add_development_dependency 'activemodel', version
+  s.add_development_dependency 'railties', version
 end


### PR DESCRIPTION
### Summary

actionpack test depends on railties rails/engine.

https://github.com/rails/rails/blob/master/actionpack/test/controller/integration_test.rb#L3

Should we add it as the development_dependency?

Thanks.
