### PR TITLE
Update ActionCable Rebroadcasting a Message documentation

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -333,7 +333,7 @@ class ChatChannel < ApplicationCable::Channel
   end
 
   def receive(data)
-    ChatChannel.broadcast_to("chat_#{params[:room]}", data)
+    ActionCable.server.broadcast("chat_#{params[:room]}", data)
   end
 end
 ```


### PR DESCRIPTION
### Summary

Replace broadcast_to with ActionCable.server.broadcast to be inline with its partner, #stream_from.
