### PR TITLE
Underscore environment variable in database configuration

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/frontbase.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/frontbase.yml
@@ -47,4 +47,4 @@ production:
   <<: *default
   database: <%= app_name %>_production
   username: <%= app_name %>
-  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>
+  password: <%%= ENV['<%= app_name.underscore.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
@@ -83,4 +83,4 @@ production:
   <<: *default
   database: <%= app_name %>_production
   username: <%= app_name %>
-  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>
+  password: <%%= ENV['<%= app_name.underscore.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml
@@ -66,4 +66,4 @@ test:
 production:
   url: jdbc:db://localhost/<%= app_name %>_production
   username: <%= app_name %>
-  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>
+  password: <%%= ENV['<%= app_name.underscore.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
@@ -50,4 +50,4 @@ production:
   <<: *default
   database: <%= app_name %>_production
   username: <%= app_name %>
-  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>
+  password: <%%= ENV['<%= app_name.underscore.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml
@@ -66,4 +66,4 @@ production:
   <<: *default
   database: <%= app_name %>_production
   username: <%= app_name %>
-  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>
+  password: <%%= ENV['<%= app_name.underscore.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
@@ -55,4 +55,4 @@ production:
   <<: *default
   database: <%= app_name %>_production
   username: <%= app_name %>
-  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>
+  password: <%%= ENV['<%= app_name.underscore.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
@@ -56,4 +56,4 @@ production:
   <<: *default
   database: <%= app_name %>_production
   username: <%= app_name %>
-  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>
+  password: <%%= ENV['<%= app_name.underscore.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
@@ -82,4 +82,4 @@ production:
   <<: *default
   database: <%= app_name %>_production
   username: <%= app_name %>
-  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>
+  password: <%%= ENV['<%= app_name.underscore.upcase %>_DATABASE_PASSWORD'] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
@@ -66,4 +66,4 @@ production:
   <<: *default
   database: <%= app_name %>_production
   username: <%= app_name %>
-  password: <%%= ENV['<%= app_name.upcase %>_DATABASE_PASSWORD'] %>
+  password: <%%= ENV['<%= app_name.underscore.upcase %>_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
### Summary

Environment variables are not allowed to have dashes, so when someone generates a new project like `rails new my-test-project`, the variable became `MY-TEST-PROJECT_DATABASE_PASSWORD`, which is invalid.
