### PR TITLE
Add generator for environments

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -20,6 +20,7 @@ module Rails
     autoload :NamedBase,       'rails/generators/named_base'
     autoload :ResourceHelpers, 'rails/generators/resource_helpers'
     autoload :TestCase,        'rails/generators/test_case'
+    autoload :Environment,     'rails/generators/environment'
 
     mattr_accessor :namespace
 

--- a/railties/lib/rails/generators/rails/environment/USAGE
+++ b/railties/lib/rails/generators/rails/environment/USAGE
@@ -1,0 +1,9 @@
+Description:
+    Creates a new environment, take new name as parameter
+
+Example:
+    `rails generate environment abcd`
+
+      append  config/database.yml
+      create  config/environments/abcd.rb
+      append  config/secrets.yml

--- a/railties/lib/rails/generators/rails/environment/environment_generator.rb
+++ b/railties/lib/rails/generators/rails/environment/environment_generator.rb
@@ -1,0 +1,41 @@
+module Rails
+  module Generators
+    class EnvironmentGenerator < Base # :nodoc:
+      argument :name, type: :string
+      class_option :from, type: :string, default: "development", desc: "Choose which environment to base the new environment off of"
+      class_option :copy, type: :boolean, default: false, desc: "Copy the existing environment file instead of requiring it"
+                              
+      def add_database_yml_entry
+        adapter = ActiveRecord::Base.connection_config[:adapter]
+        append_template "config/database.yml", "databases/#{adapter}.yml"
+      end
+            
+      def add_environment_file
+        if copy? 
+          create_file "config/environments/#{name}.rb", File.read(Rails.root.join("config", "environments", "#{options[:from]}.rb"))
+        else
+          template "inherited_environment.rb", "config/environments/#{name}.rb"
+        end
+      end
+      
+      def add_secrets_yml_entry
+        append_template "config/secrets.yml", "secrets.yml"
+      end
+      
+      
+      protected
+      
+      def append_template(dst, template_name)
+        source  = File.expand_path(find_in_source_paths(template_name))
+        content = ERB.new(::File.binread(source), nil, "-", "@output_buffer").result(instance_eval("binding"))
+        append_file dst, content      
+      end
+      
+      
+      def copy?
+        options[:copy]
+      end
+      
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/environment/templates/databases/frontbase.yml
+++ b/railties/lib/rails/generators/rails/environment/templates/databases/frontbase.yml
@@ -1,0 +1,3 @@
+<%= name %>:
+  <<: *default
+  database: <%= app_name %>_<%= name %>

--- a/railties/lib/rails/generators/rails/environment/templates/databases/ibm_db.yml
+++ b/railties/lib/rails/generators/rails/environment/templates/databases/ibm_db.yml
@@ -1,0 +1,3 @@
+development:
+  <<: *default
+  database: <%= app_name[0,4] %>_<%= name[0,3] %>

--- a/railties/lib/rails/generators/rails/environment/templates/databases/jdbc.yml
+++ b/railties/lib/rails/generators/rails/environment/templates/databases/jdbc.yml
@@ -1,0 +1,3 @@
+<%= name %>:
+  <<: *default
+  url: jdbc:db://localhost/<%= app_name %>_<%= name %>

--- a/railties/lib/rails/generators/rails/environment/templates/databases/jdbcmysql.yml
+++ b/railties/lib/rails/generators/rails/environment/templates/databases/jdbcmysql.yml
@@ -1,0 +1,3 @@
+<%= name %>:
+  <<: *default
+  database: <%= app_name %>_<%=name %>

--- a/railties/lib/rails/generators/rails/environment/templates/databases/jdbcpostgresql.yml
+++ b/railties/lib/rails/generators/rails/environment/templates/databases/jdbcpostgresql.yml
@@ -1,0 +1,3 @@
+<%= name %>:
+  <<: *default
+  database: <%= app_name %>_<%=name %>

--- a/railties/lib/rails/generators/rails/environment/templates/databases/jdbcsqlite3.yml
+++ b/railties/lib/rails/generators/rails/environment/templates/databases/jdbcsqlite3.yml
@@ -1,0 +1,4 @@
+<%= name %>:
+  <<: *default
+  database: db/<%= name %>.sqlite3
+

--- a/railties/lib/rails/generators/rails/environment/templates/databases/mysql.yml
+++ b/railties/lib/rails/generators/rails/environment/templates/databases/mysql.yml
@@ -1,0 +1,3 @@
+<%= name %>:
+  <<: *default
+  database: <%= app_name %>_<%=name %>

--- a/railties/lib/rails/generators/rails/environment/templates/databases/oracle.yml
+++ b/railties/lib/rails/generators/rails/environment/templates/databases/oracle.yml
@@ -1,0 +1,3 @@
+<%= name %>:
+  <<: *default
+  database: <%= app_name %>_<%=name %>

--- a/railties/lib/rails/generators/rails/environment/templates/databases/postgresql.yml
+++ b/railties/lib/rails/generators/rails/environment/templates/databases/postgresql.yml
@@ -1,0 +1,3 @@
+<%= name %>:
+  <<: *default
+  database: <%= app_name %>_<%=name %>

--- a/railties/lib/rails/generators/rails/environment/templates/databases/sqlite3.yml
+++ b/railties/lib/rails/generators/rails/environment/templates/databases/sqlite3.yml
@@ -1,0 +1,5 @@
+
+<%= name %>:
+  <<: *default
+  database: db/<%= name %>.sqlite3
+

--- a/railties/lib/rails/generators/rails/environment/templates/databases/sqlserver.yml
+++ b/railties/lib/rails/generators/rails/environment/templates/databases/sqlserver.yml
@@ -1,0 +1,3 @@
+<%= name %>:
+  <<: *default
+  database: <%= app_name %>_<%=name %>

--- a/railties/lib/rails/generators/rails/environment/templates/inherited_environment.rb
+++ b/railties/lib/rails/generators/rails/environment/templates/inherited_environment.rb
@@ -1,0 +1,5 @@
+require_relative 'config/environments/<%= options[:from] %>.rb'
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+end

--- a/railties/lib/rails/generators/rails/environment/templates/inherited_environment.rb
+++ b/railties/lib/rails/generators/rails/environment/templates/inherited_environment.rb
@@ -1,5 +1,6 @@
 require_relative 'config/environments/<%= options[:from] %>.rb'
 
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
+  # Settings specified here will take precedence over those in config/environments/<%= options[:from] %>.rb
+
 end

--- a/railties/lib/rails/generators/rails/environment/templates/secrets.yml
+++ b/railties/lib/rails/generators/rails/environment/templates/secrets.yml
@@ -1,0 +1,4 @@
+        
+<%= name %>:
+  secret_key_base: <%= SecureRandom.hex(64) %>
+  


### PR DESCRIPTION
This PR is still a work in progress - I was hoping to get some feedback as to whether this is something that could be merged if I complete the feature.

It adds a generator for environments..

So

`rails g environment abcd`

Would:
- Create an entry in config/databases.yml based on the adapter currently being used
- Create an entry in config/secrets.yml
- Create a new environment file in config/environments/abcd.rb

If you do not pass any options, the assumption is you are creating a copy of a dev environment and the file would look like this:

```
require_relative 'config/environments/development.rb'

Rails.application.configure do
  # Settings specified here will take precedence over those in config/application.rb.
end
```

However if `--copy` is specified, it simply copies the entire existing file.

If you want to copy an environment besides development, you can specify which to use with the `--from` option, e.g.

`rails g environment abcd --from production`
