### PR TITLE
make calling simple methods on collection proxies fast

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1092,14 +1092,7 @@ end
 ActiveRecord::Associations::CollectionProxy.class_eval do
   # all values that are modified by lib/active_record/relation/merger.rb
   # will merge on demand when accessed
-
-  needs_merge = (ActiveRecord::Relation::Merger::NORMAL_VALUES - [:readonly, :limit, :offset, :distinct, :join]).map { |v| :"#{v}_values" }
-  needs_merge.concat([:readonly_value, :limit_value, :offset_value, :distinct_value, :order_values, :joins_values, :includes_values, :preload_values, :create_with_value, :lock_value])
-  needs_merge.concat(ActiveRecord::Relation::CLAUSE_METHODS.map { |c| :"#{c}_clause" })
-  bad = (needs_merge - instance_methods)
-  raise "Unnecessary overrides: #{bad}" if bad.any?
-
-  needs_merge.each do |m|
+  instance_methods.grep(/_values?$/).each do |m|
     define_method(m) do |*args, &block|
       unless @merged
         @merged = true


### PR DESCRIPTION
I understand that this is a horrible PR, but it unblocks our rails upgrade ... hopefully kicks of a move/discussion in a better direction ...

basically what I'm seeing is a massive slowdown upgrading from rails 3.2 to 4.2 / 5.0 for included or pre-loaded associations

```
GC.enable; GC.disable; x = Array.new(100).map { Ticket.all.to_a }.flatten; Benchmark.realtime { x.each{ |t| t.ticket_field_entries.to_a; nil } } # 2600 AR objects total

3.2: 0.23s
4.2: 1.12s
```

which I dug down into and found to be the `loaded?` call which only delegates to `@association.loaded?` taking up all the time since the association already includes :ticket_field_entries ... to make this faster I made the merge lazy ... which is ugly ... but brings us back down to 0.3s for this usecase ... leaving this here in case anyone has a better idea how to improve this ...
