### PR TITLE
Wrap module around lazy load hooks

### DIFF
--- a/activesupport/lib/active_support/lazy_load_hooks.rb
+++ b/activesupport/lib/active_support/lazy_load_hooks.rb
@@ -20,29 +20,37 @@ module ActiveSupport
   # +activerecord/lib/active_record/base.rb+ is:
   #
   #   ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
-  @load_hooks = Hash.new { |h,k| h[k] = [] }
-  @loaded = Hash.new { |h,k| h[k] = [] }
-
-  def self.on_load(name, options = {}, &block)
-    @loaded[name].each do |base|
-      execute_hook(base, options, block)
+  module LazyLoadHooks
+    def self.extended(base) # :nodoc:
+      base.class_eval do
+        @load_hooks = Hash.new { |h,k| h[k] = [] }
+        @loaded     = Hash.new { |h,k| h[k] = [] }
+      end
     end
 
-    @load_hooks[name] << [block, options]
-  end
+    def on_load(name, options = {}, &block)
+      @loaded[name].each do |base|
+        execute_hook(base, options, block)
+      end
 
-  def self.execute_hook(base, options, block)
-    if options[:yield]
-      block.call(base)
-    else
-      base.instance_eval(&block)
+      @load_hooks[name] << [block, options]
+    end
+
+    def execute_hook(base, options, block)
+      if options[:yield]
+        block.call(base)
+      else
+        base.instance_eval(&block)
+      end
+    end
+
+    def run_load_hooks(name, base = Object)
+      @loaded[name] << base
+      @load_hooks[name].each do |hook, options|
+        execute_hook(base, options, hook)
+      end
     end
   end
 
-  def self.run_load_hooks(name, base = Object)
-    @loaded[name] << base
-    @load_hooks[name].each do |hook, options|
-      execute_hook(base, options, hook)
-    end
-  end
+  extend LazyLoadHooks
 end


### PR DESCRIPTION
### Summary

Fix for issue https://github.com/rails/rails/issues/25784

Prior to this commit the lazy_load_hooks.rb file contained important lazy load
hooks. Since [7c90d91](https://github.com/rails/rails/commit/7c90d91c3c43bdbba25d38589aed0e2940af3bc8) the [documentation](http://api.rubyonrails.org/files/activesupport/lib/active_support/lazy_load_hooks_rb.html) did not display the comments in this file as the docs for load hooks.

This commit wraps the code within this file in a module so we can display the
documentation for `ActiveSupport` load hooks. By extending `ActiveSupport` with
this module, all the methods within it should be accessible thorugh
`ActiveSupport`.
