### PR TITLE
Remove duplicate test and fix a typo in the test

### DIFF
--- a/actionpack/test/controller/parameters/dup_test.rb
+++ b/actionpack/test/controller/parameters/dup_test.rb
@@ -35,7 +35,7 @@ class ParametersDupTest < ActiveSupport::TestCase
     assert_not_equal @params, dupped_params
   end
 
-  test "changes tp a duplicate's permitted status do not affect the original" do
+  test "changes to a duplicate's permitted status do not affect the original" do
     dupped_params = @params.dup
     dupped_params.permit!
     assert_not_equal @params, dupped_params

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -245,11 +245,6 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert_equal "Jonas", @params[:person][:family][:brother]
   end
 
-  test "permit state is kept on a dup" do
-    @params.permit!
-    assert_equal @params.permitted?, @params.dup.permitted?
-  end
-
   test "permit is recursive" do
     @params.permit!
     assert @params.permitted?


### PR DESCRIPTION
### Summary
- Tests for dup'ing params was separately added in a separate file in
  https://github.com/rails/rails/pull/25735.
