### PR TITLE
Raise ArgumentError for bad strptime arguments

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `ActiveSupport::TimeZone#strptime`. Now raises `ArgumentError` when the
+    given time doesn't match the format. The error is the same as the one given
+    by Ruby's `Date.strptime`. Previously it raised
+    `NoMethodError: undefined method empty? for nil:NilClass.` due to a bug.
+
+    Fixes #25701.
+
+    *John Gesimondo*
+
 *   `travel/travel_to` travel time helpers, now raise on nested calls, 
      as this can lead to confusing time stubbing.
        

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -447,6 +447,7 @@ module ActiveSupport
 
     private
       def parts_to_time(parts, now)
+        raise ArgumentError, "invalid date" if parts.nil?
         return if parts.empty?
 
         time = Time.new(

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -388,6 +388,13 @@ class TimeZoneTest < ActiveSupport::TestCase
     end
   end
 
+  def test_strptime_with_malformed_string
+    with_env_tz 'US/Eastern' do
+      zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
+      assert_raise(ArgumentError) { zone.strptime('1999-12-31', '%Y/%m/%d') }
+    end
+  end
+
   def test_utc_offset_lazy_loaded_from_tzinfo_when_not_passed_in_to_initialize
     tzinfo = TZInfo::Timezone.get('America/New_York')
     zone = ActiveSupport::TimeZone.create(tzinfo.name, nil, tzinfo)


### PR DESCRIPTION
Fix `ActiveSupport::TimeZone#strptime`. Now raises `ArgumentError` when the given time doesn't match the format. The error is the same as the one given by Ruby's `Date.strptime`.

Previously it raised `NoMethodError: undefined method empty? for nil:NilClass.` due to a bug.
Fixes #25701.
