### PR TITLE
Fixes fixture_file_upload's fixture_path regression

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -214,6 +214,9 @@ module ActionDispatch
       # A reference to the response instance used by the last request.
       attr_reader :response
 
+      # A reference to the TestCase path to be used by fixture_file_upload.
+      attr_accessor :fixture_path
+
       # A running counter of the number of requests processed.
       attr_accessor :request_count
 
@@ -489,7 +492,7 @@ module ActionDispatch
             include app.routes.mounted_helpers
           end
         }
-        klass.new(app)
+        klass.new(app).tap {|instance| instance.fixture_path = fixture_path }
       end
 
       def remove! # :nodoc:

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -492,7 +492,11 @@ module ActionDispatch
             include app.routes.mounted_helpers
           end
         }
-        klass.new(app).tap {|instance| instance.fixture_path = fixture_path }
+        klass.new(app).tap {|instance|
+          if self.class.respond_to?(:fixture_path)
+            instance.fixture_path = self.class.fixture_path
+          end
+        }
       end
 
       def remove! # :nodoc:

--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -34,8 +34,8 @@ module ActionDispatch
     #
     #   post :change_avatar, avatar: fixture_file_upload('files/spongebob.png', 'image/png', :binary)
     def fixture_file_upload(path, mime_type = nil, binary = false)
-      if self.class.respond_to?(:fixture_path) && self.class.fixture_path
-        path = File.join(self.class.fixture_path, path)
+      if respond_to?(:fixture_path) && fixture_path
+        path = File.join(fixture_path, path)
       end
       Rack::Test::UploadedFile.new(path, mime_type, binary)
     end


### PR DESCRIPTION
Given the following example when I try to use `fixture_file_upload` in a controller spec:

```
require 'test_helper'

class FooControllerTest < ActionDispatch::IntegrationTest
  test 'file' do
    puts fixture_path  # This outputs correctly #{Rails.root}/test/fixtures/
    byebug
    x = fixture_file_upload 'test.jpg', 'image/jpeg'
  end
end
```

The test fails with output:

```
Error:
FooControllerTest#test_file:
RuntimeError: test.jpg file does not exist
    test/controllers/foo_controller_test.rb:11:in `block in <class:FooControllerTest>'
```

Stepping into fixture_file_upload using byebug to track what is causing the failure:

```
/rails-968b59af872e/actionpack/lib/action_dispatch/testing/integration.rb
   549:       # Delegate unhandled messages to the current session instance.
   550:       def method_missing(sym, *args, &block)
=> 551:         if integration_session.respond_to?(sym)
   552:           integration_session.__send__(sym, *args, &block).tap do
   553:             copy_session_variables!
   554:           end
   555:         else
```

This is the method missing inside `ActionDispatch::Integration::Runner` module, that
delegates `fixture_file_upload` message to an `integration_session` object:

```
   473:       def integration_session
=> 474:         @integration_session ||= create_session(app)
   475:       end

   ...

   483:       def create_session(app)
=> 484:         klass = APP_SESSIONS[app] ||= Class.new(Integration::Session) {
   485:           # If the app is a Rails app, make url_helpers available on the session
   486:           # This makes app.url_for and app.foo_path available in the console
   487:           if app.respond_to?(:routes)
   488:             include app.routes.url_helpers
   489:             include app.routes.mounted_helpers
   490:           end
   491:         }
   492:         klass.new(app)
   493:       end
```

`Integration::Session` responds to `fixture_file_upload` because it
includes `TestProcess`:

```
   176:     class Session
   177:       DEFAULT_HOST = "www.example.com"
   178:
   179:       include Minitest::Assertions
   180:       include TestProcess, RequestHelpers, Assertions
```

But because the session keeps no knowledge about the testing class, it won't be able
to inspect the test's class.fixture_path inside the `fixture_file_upload` call:

```
/rails-968b59af872e/actionpack/lib/action_dispatch/testing/test_process.rb
   36:     def fixture_file_upload(path, mime_type = nil, binary = false)
=> 37:       if self.class.respond_to?(:fixture_path) && self.class.fixture_path
   38:         path = File.join(self.class.fixture_path, path)
   39:       end
   40:       Rack::Test::UploadedFile.new(path, mime_type, binary)
   41:     end
```

Actually, I expect `self.class.respond_to?(:fixture_path)` to never evaluate `true`, is that right?

The documentation comments of `fixture_file_upload` says:

```
    # Shortcut for <tt>Rack::Test::UploadedFile.new(File.join(ActionDispatch::IntegrationTest.fixture_path, path), type)</tt>:
    #
    #   post :change_avatar, avatar: fixture_file_upload('files/spongebob.png', 'image/png')
    #
    # To upload binary files on Windows, pass <tt>:binary</tt> as the last parameter.
    # This will not affect other platforms:
    #
    #   post :change_avatar, avatar: fixture_file_upload('files/spongebob.png', 'image/png', :binary)
```

So the easiest way to solve this problem would be short-circuiting the logic to:

```
   36:     def fixture_file_upload(path, mime_type = nil, binary = false)
   37:       path = File.join(ActionDispatch::IntegrationTest.fixture_path, path)
   38:       Rack::Test::UploadedFile.new(path, mime_type, binary)
   41:     end
```

But this approach would not allow a test to redefine its own value of `TestClass.fixture_path`.

The simplest suggestion I propose in this PR is to let session instance keep the `fixture_path` value.
