### PR TITLE
Handle `Rack::QueryParser` errors in `ActionDispatch::ExceptionWrapper`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,2 +1,8 @@
+*   Handle `Rack::QueryParser` errors in `ActionDispatch::ExceptionWrapper`
+
+    Updated `ActionDispatch::ExceptionWrapper` to handle the Rack 2.0 namespace
+    for `ParameterTypeError` and `InvalidParameterError` errors.
+
+    *Grey Baker*
 
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -17,8 +17,8 @@ module ActionDispatch
       'ActionDispatch::ParamsParser::ParseError'      => :bad_request,
       'ActionController::BadRequest'                  => :bad_request,
       'ActionController::ParameterMissing'            => :bad_request,
-      'Rack::Utils::ParameterTypeError'               => :bad_request,
-      'Rack::Utils::InvalidParameterError'            => :bad_request
+      'Rack::QueryParser::ParameterTypeError'         => :bad_request,
+      'Rack::QueryParser::InvalidParameterError'      => :bad_request
     )
 
     cattr_accessor :rescue_templates

--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -57,6 +57,12 @@ module ActionDispatch
       assert_equal [ "lib/file.rb:42:in `index'" ], wrapper.application_trace
     end
 
+    test '#status_code returns 400 for Rack::Utils::ParameterTypeError' do
+      exception = Rack::Utils::ParameterTypeError.new
+      wrapper = ExceptionWrapper.new(@cleaner, exception)
+      assert_equal 400, wrapper.status_code
+    end
+
     test '#application_trace cannot be nil' do
       nil_backtrace_wrapper = ExceptionWrapper.new(@cleaner, BadlyDefinedError.new)
       nil_cleaner_wrapper = ExceptionWrapper.new(nil, BadlyDefinedError.new)


### PR DESCRIPTION
Rack [recently](https://github.com/rack/rack/commit/7e7a3890449b5cf5b86929c79373506e5f1909fb) moved the namespace of its `ParameterTypeError` and `InvalidParameterError` errors. Whilst an alias for the old name was added, the logic in `ActionDispatch::ExceptionWrapper` was still broken by this change, since it relies on the class name.

This PR updates `ActionDispatch::ExceptionWrapper` to handle the Rack 2.0 namespaced errors correctly. We no longer need to worry about the old names, since Rails specifies Rack ~> 2.0.
