### PR TITLE
remove unnecessary send

### DIFF
--- a/actionpack/test/abstract/collector_test.rb
+++ b/actionpack/test/abstract/collector_test.rb
@@ -28,7 +28,7 @@ module AbstractController
       end
 
       test "register mime types on method missing" do
-        AbstractController::Collector.send(:remove_method, :js)
+        AbstractController::Collector.remove_method(:js)
         begin
           collector = MyCollector.new
           assert_not_respond_to collector, :js

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -212,7 +212,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
     invalid!([3, 4])
     valid!([5, 6])
   ensure
-    Topic.send(:remove_method, :min_approved)
+    Topic.remove_method(:min_approved)
   end
 
   def test_validates_numericality_with_symbol
@@ -222,7 +222,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
     invalid!([6])
     valid!([4, 5])
   ensure
-    Topic.send(:remove_method, :max_approved)
+    Topic.remove_method(:max_approved)
   end
 
   def test_validates_numericality_with_numeric_message

--- a/activerecord/test/cases/finder_respond_to_test.rb
+++ b/activerecord/test/cases/finder_respond_to_test.rb
@@ -14,7 +14,7 @@ class FinderRespondToTest < ActiveRecord::TestCase
     class << Topic; self; end.send(:define_method, :method_added_for_finder_respond_to_test) { }
     assert_respond_to Topic, :method_added_for_finder_respond_to_test
   ensure
-    class << Topic; self; end.send(:remove_method, :method_added_for_finder_respond_to_test)
+    class << Topic; self; end.remove_method(:method_added_for_finder_respond_to_test)
   end
 
   def test_should_preserve_normal_respond_to_behaviour_and_respond_to_standard_object_method
@@ -55,6 +55,6 @@ class FinderRespondToTest < ActiveRecord::TestCase
   private
 
   def ensure_topic_method_is_not_cached(method_id)
-    class << Topic; self; end.send(:remove_method, method_id) if Topic.public_methods.include? method_id
+    class << Topic; self; end.remove_method(method_id) if Topic.public_methods.include? method_id
   end
 end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -957,7 +957,7 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_dynamic_finder_on_one_attribute_with_conditions_returns_same_results_after_caching
     # ensure this test can run independently of order
-    class << Account; self; end.send(:remove_method, :find_by_credit_limit) if Account.public_methods.include?(:find_by_credit_limit)
+    class << Account; self; end.remove_method(:find_by_credit_limit) if Account.public_methods.include?(:find_by_credit_limit)
     a = Account.where('firm_id = ?', 6).find_by_credit_limit(50)
     assert_equal a, Account.where('firm_id = ?', 6).find_by_credit_limit(50) # find_by_credit_limit has been cached
   end

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -27,7 +27,7 @@ class ERB
 
     module_function :h
 
-    singleton_class.send(:remove_method, :html_escape)
+    singleton_class.remove_method(:html_escape)
     module_function :html_escape
 
     # HTML escapes strings but doesn't wrap them with an ActiveSupport::SafeBuffer.


### PR DESCRIPTION
`remove_method`  is public in Ruby 2.2.2+.
Ref: http://ruby-doc.org/core-2.2.0/Module.html#method-i-remove_method
