### PR TITLE
Added :fallback_string option to Array#to_sentence

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `:fallback_string` option to `Array#to_sentence`. If an empty array
+    calls the function and a fallback string option is set then it returns the
+    fallback string other than an empty string.
+
+    *Mohamed Osama*
+
 *   Fix `ActiveSupport::TimeZone#strptime`. Now raises `ArgumentError` when the
     given time doesn't match the format. The error is the same as the one given
     by Ruby's `Date.strptime`. Previously it raised

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -40,6 +40,12 @@ class Array
   #   ['one', 'two', 'three'].to_sentence(words_connector: ' or ', last_word_connector: ' or at least ')
   #   # => "one or two or at least three"
   #
+  #   [].to_sentence(fallback_string: 'none')
+  #   # => "none"
+  #
+  #   ['one', 'two'].to_sentence(fallback_string: 'none')
+  #   # => "one and two"
+  #
   # Using <tt>:locale</tt> option:
   #
   #   # Given this locale dictionary:
@@ -57,7 +63,7 @@ class Array
   #   ['uno', 'dos', 'tres'].to_sentence(locale: :es)
   #   # => "uno o dos o al menos tres"
   def to_sentence(options = {})
-    options.assert_valid_keys(:words_connector, :two_words_connector, :last_word_connector, :locale)
+    options.assert_valid_keys(:words_connector, :two_words_connector, :last_word_connector, :locale, :fallback_string)
 
     default_connectors = {
       :words_connector     => ', ',
@@ -72,7 +78,7 @@ class Array
 
     case length
     when 0
-      ''
+      "#{options[:fallback_string] || ''}"
     when 1
       "#{self[0]}"
     when 2

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -25,6 +25,11 @@ class ToSentenceTest < ActiveSupport::TestCase
     assert_equal "one, two and three", ['one', 'two', 'three'].to_sentence(last_word_connector: ' and ')
   end
 
+  def test_to_sentence_with_fallback_string
+    assert_equal "none", [].to_sentence(fallback_string: 'none')
+    assert_equal "one, two, and three", ['one', 'two', 'three'].to_sentence(fallback_string: 'none')
+  end
+
   def test_two_elements
     assert_equal "one and two", ['one', 'two'].to_sentence
     assert_equal "one two", ['one', 'two'].to_sentence(two_words_connector: ' ')
@@ -58,7 +63,7 @@ class ToSentenceTest < ActiveSupport::TestCase
       ['one', 'two'].to_sentence(passing: 'invalid option')
     end
 
-    assert_equal exception.message, "Unknown key: :passing. Valid keys are: :words_connector, :two_words_connector, :last_word_connector, :locale"
+    assert_equal exception.message, "Unknown key: :passing. Valid keys are: :words_connector, :two_words_connector, :last_word_connector, :locale, :fallback_string"
   end
 
   def test_always_returns_string


### PR DESCRIPTION
### Summary

Added a `:fallback_string` option to `Array#to_sentence` when an empty array calls the function.

```
[].to_sentence(fallback_string: 'none')
# => "none"

['one', 'two'].to_sentence(fallback_string: 'none')
# => "one and two"
```
