### PR TITLE
Fix error of `require 'active_support/core_ext/load_error'`

### DIFF
--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -1,4 +1,4 @@
-require 'active_support/deprecation/proxy_wrappers'
+require 'active_support/deprecation'
 
 class LoadError
   REGEXPS = [


### PR DESCRIPTION
### Summary

Require `active_support/deprecation` instead of `active_support/depreppcation/proxy_wrappers`
### Other Information

In active_support `5.0.0.beta1` ~ `5.0.0`, This exception throw when called `require 'active_support/core_ext/load_error'`

``` ruby
>> require 'active_support/core_ext/load_error'
NoMethodError: undefined method `instance' for ActiveSupport::Deprecation:Class
Did you mean?  instance_of?
from /Users/argerich/dev/sample-active-support5/vendor/bundle/gems/activesupport-5.0.0/lib/active_support/deprecation/proxy_wrappers.rb:124:in `initialize'
```

Because you can't have `ActiveSupport::Deprecation.instance` without calling `include Singleton` in `active_support/deprecation`.
And `require 'active_support/deprecation/proxy_wrapper'` is called in `active_support/deprecation`, so I think that the problem is fixed.
### Confirmation
#### Before

``` sh
$ irb
```

``` ruby
>> require 'bundler/setup'
=> true
>> require 'active_support/core_ext/load_error'
NoMethodError: undefined method `instance' for ActiveSupport::Deprecation:Class
Did you mean?  instance_of?
        from /Users/argerich/dev/rails/activesupport/lib/active_support/deprecation/proxy_wrappers.rb:124:in `initialize'
        from /Users/argerich/dev/rails/activesupport/lib/active_support/deprecation/proxy_wrappers.rb:10:in `new'
        from /Users/argerich/dev/rails/activesupport/lib/active_support/deprecation/proxy_wrappers.rb:10:in `new'
        from /Users/argerich/dev/rails/activesupport/lib/active_support/core_ext/load_error.rb:30:in `<top (required)>'
        from (irb):2:in `require'
        from (irb):2
        from /Users/argerich/.rbenv/versions/2.3.0/bin/irb:11:in `<main>'
```
#### After

``` sh
$ irb
```

``` ruby
>> require 'bundler/setup'
=> true
>> require 'active_support/core_ext/load_error'
=> true
```
