### PR TITLE
Add newline between each migration in `structure.sql`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add newline between each migration in `structure.sql`
+
+    Keeps schema migration inserts as a single commit, but allows for easier
+    git diff-ing. Fixes #25504.
+
+    *Grey Baker*, *Norberto Lopes*
+
 *   The flag `error_on_ignored_order_or_limit` has been deprecated in favor of
     the current `error_on_ignored_order`.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -998,8 +998,8 @@ module ActiveRecord
         sm_table = ActiveRecord::Migrator.schema_migrations_table_name
 
         if supports_multi_insert?
-          sql = "INSERT INTO #{sm_table} (version) VALUES "
-          sql << versions.map {|v| "('#{v}')" }.join(', ')
+          sql = "INSERT INTO #{sm_table} (version) VALUES\n"
+          sql << versions.map {|v| "('#{v}')" }.join(",\n")
           sql << ";\n\n"
           sql
         else


### PR DESCRIPTION
Keeps schema migration inserts as a single commit, so we still get all of the benefits of https://github.com/rails/rails/commit/42dd2336b31a8d98776d039a2b9fd7f834156a78, but allows for easier git diff-ing. Fixes #25504.
