### PR TITLE
Fix adding implicitly rendered namespaced template digests to ETags

### DIFF
--- a/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
+++ b/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
@@ -45,7 +45,7 @@ module ActionController
     # template digest from the ETag.
     def pick_template_for_etag(options)
       unless options[:template] == false
-        options[:template] || "#{controller_name}/#{action_name}"
+        options[:template] || "#{controller_path}/#{action_name}"
       end
     end
 

--- a/actionpack/test/fixtures/namespaced/implicit_render_test/hello_world.erb
+++ b/actionpack/test/fixtures/namespaced/implicit_render_test/hello_world.erb
@@ -1,0 +1,1 @@
+Hello world!


### PR DESCRIPTION
Extends the fix from https://github.com/rails/rails/pull/25546 to namespaced controllers and their templates.

New test failing without this change:

```
$ bundle exec rake test TEST=test/controller/render_test.rb 
Run options: --seed 59446

# Running:

.....S...............................F.......................

Finished in 0.498034s, 122.4816 runs/s, 614.4159 assertions/s.

  1) Failure:
NamespacedEtagRenderTest#test_etag_reflects_template_digest [.../actionpack/test/controller/render_test.rb:611]:
Expected response to be a <200: ok>, but was a <304: Not Modified>.
Expected: 200
  Actual: 304

61 runs, 306 assertions, 1 failures, 0 errors, 1 skips
```

/cc @jeremy 
