### PR TITLE
Fix bug in method `ActiveRecord::Relation#in_batches`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix bug in method `ActiveRecord::Relation#in_batches`.
+
+    Method does not work if `primary_key` is not 'id'.
+
+    Example:
+
+        Post.primary_key = 'title'
+        Post.in_batches(of: 1, load: true) do |relation|
+          # uninterrupted cycle
+        end
+
+    *bogdanvlviv*
+
 *   Add newline between each migration in `structure.sql`.
 
     Keeps schema migration inserts as a single commit, but allows for easier

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -214,7 +214,7 @@ module ActiveRecord
       loop do
         if load
           records = batch_relation.records
-          ids = records.map(&:id)
+          ids = records.map(&primary_key.to_sym)
           yielded_relation = where(primary_key => ids)
           yielded_relation.load_records(records)
         else


### PR DESCRIPTION
Bug:

``` ruby
Post.primary_key = 'title'
Post.in_batches(of: 1, load: true) do |relation|
  # uninterrupted cycle
end
```
