### PR TITLE
Better logging of cached partial renders 

### DIFF
--- a/actionmailer/test/caching_test.rb
+++ b/actionmailer/test/caching_test.rb
@@ -172,6 +172,7 @@ class FunctionalFragmentCachingTest < BaseCachingTest
   end
 
   def test_fragment_cache_instrumentation
+    @mailer.enable_fragment_cache_logging = true
     payload = nil
 
     subscriber = proc do |*args|
@@ -185,6 +186,8 @@ class FunctionalFragmentCachingTest < BaseCachingTest
 
     assert_equal "caching_mailer", payload[:mailer]
     assert_equal "views/caching/#{template_digest("caching_mailer/fragment_cache")}", payload[:key]
+  ensure
+    @mailer.enable_fragment_cache_logging = true
   end
 
   private

--- a/actionpack/lib/abstract_controller/caching.rb
+++ b/actionpack/lib/abstract_controller/caching.rb
@@ -34,6 +34,9 @@ module AbstractController
       config_accessor :perform_caching
       self.perform_caching = true if perform_caching.nil?
 
+      config_accessor :enable_fragment_cache_logging
+      self.enable_fragment_cache_logging = false
+
       class_attribute :_view_cache_dependencies
       self._view_cache_dependencies = []
       helper_method :view_cache_dependencies if respond_to?(:helper_method)

--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -59,14 +59,13 @@ module ActionController
        expire_fragment expire_page write_page).each do |method|
       class_eval <<-METHOD, __FILE__, __LINE__ + 1
         def #{method}(event)
-          return unless logger.info?
+          return unless logger.info? && ActionController::Base.enable_fragment_cache_logging
           key_or_path = event.payload[:key] || event.payload[:path]
           human_name  = #{method.to_s.humanize.inspect}
           info("\#{human_name} \#{key_or_path} (\#{event.duration.round(1)}ms)")
         end
       METHOD
     end
-
     def logger
       ActionController::Base.logger
     end

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -184,6 +184,7 @@ class FunctionalFragmentCachingTest < ActionController::TestCase
     @controller = FunctionalCachingController.new
     @controller.perform_caching = true
     @controller.cache_store = @store
+    @controller.enable_fragment_cache_logging = true
   end
 
   def test_fragment_caching

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -92,6 +92,7 @@ class ACLogSubscriberTest < ActionController::TestCase
 
   def setup
     super
+    @controller.enable_fragment_cache_logging = true
 
     @old_logger = ActionController::Base.logger
 
@@ -105,6 +106,7 @@ class ACLogSubscriberTest < ActionController::TestCase
     ActiveSupport::LogSubscriber.log_subscribers.clear
     FileUtils.rm_rf(@cache_path)
     ActionController::Base.logger = @old_logger
+    ActionController::Base.enable_fragment_cache_logging = true
   end
 
   def set_logger(logger)
@@ -256,6 +258,20 @@ class ACLogSubscriberTest < ActionController::TestCase
     assert_match(/Write fragment views\/foo/, logs[2])
   ensure
     @controller.config.perform_caching = true
+  end
+
+  def test_with_fragment_cache_when_log_disabled
+    @controller.config.perform_caching = true
+    ActionController::Base.enable_fragment_cache_logging = false
+    get :with_fragment_cache
+    wait
+
+    assert_equal 2, logs.size
+    assert_equal "Processing by Another::LogSubscribersController#with_fragment_cache as HTML", logs[0]
+    assert_match(/Completed 200 OK in \d+ms/, logs[1])
+  ensure
+    @controller.config.perform_caching = true
+    ActionController::Base.enable_fragment_cache_logging = true
   end
 
   def test_with_fragment_cache_if_with_true

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -9,6 +9,30 @@
 
     *Steven Harman*
 
+*   Show cache hits and misses when rendering partials.
+
+    Partials using the `cache` helper will show whether a render hit or missed
+    the cache:
+
+    ```
+    Rendered messages/_message.html.erb in 1.2 ms [cache hit]
+    Rendered recordings/threads/_thread.html.erb in 1.5 ms [cache miss]
+    ```
+
+    This removes the need for the old fragment cache logging:
+
+    ```
+    Read fragment views/v1/2914079/v1/2914079/recordings/70182313-20160225015037000000/d0bdf2974e1ef6d31685c3b392ad0b74 (0.6ms)
+    Rendered messages/_message.html.erb in 1.2 ms [cache hit]
+    Write fragment views/v1/2914079/v1/2914079/recordings/70182313-20160225015037000000/3b4e249ac9d168c617e32e84b99218b5 (1.1ms)
+    Rendered recordings/threads/_thread.html.erb in 1.5 ms [cache miss]
+    ```
+
+    Though that full output can be reenabled with
+    `config.action_controller.enable_fragment_cache_logging = true`.
+
+    *Stan Lo*
+
 *   New syntax for tag helpers. Avoid positional parameters and support HTML5 by default.
     Example usage of tag helpers before:
 

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -226,7 +226,13 @@ module ActionView
 
       # TODO: Create an object that has caching read/write on it
       def fragment_for(name = {}, options = nil, &block) #:nodoc:
-        read_fragment_for(name, options) || write_fragment_for(name, options, &block)
+        if content = read_fragment_for(name, options)
+          @log_payload_for_partial_render[:cache_hit] = true if defined?(@log_payload_for_partial_render)
+          content
+        else
+          @log_payload_for_partial_render[:cache_hit] = false if defined?(@log_payload_for_partial_render)
+          write_fragment_for(name, options, &block)
+        end
       end
 
       def read_fragment_for(name, options) #:nodoc:

--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -19,7 +19,16 @@ module ActionView
         message << " (#{event.duration.round(1)}ms)"
       end
     end
-    alias :render_partial :render_template
+
+    def render_partial(event)
+      info do
+        message = "  Rendered #{from_rails_root(event.payload[:identifier])}"
+        message << " within #{from_rails_root(event.payload[:layout])}" if event.payload[:layout]
+        message << " (#{event.duration.round(1)}ms)"
+        message << " #{cache_message(event.payload)}" if event.payload.key?(:cache_hit)
+        message
+      end
+    end
 
     def render_collection(event)
       identifier = event.payload[:identifier] || "templates"
@@ -60,6 +69,14 @@ module ActionView
         "[#{payload[:cache_hits]} / #{payload[:count]} cache hits]"
       else
         "[#{payload[:count]} times]"
+      end
+    end
+
+    def cache_message(payload)
+      if payload[:cache_hit]
+        "[cache hit]"
+      else
+        "[cache miss]"
       end
     end
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -516,6 +516,14 @@ encrypted cookies salt value. Defaults to `'signed encrypted cookie'`.
 
 * `config.action_view.debug_missing_translation` determines whether to wrap the missing translations key in a `<span>` tag or not. This defaults to `true`.
 
+* `config.action_view.enable_fragment_cache_logging` determines whether to log fragment cache reads and writes like:
+
+    ```
+    Read fragment views/v1/2914079/v1/2914079/recordings/70182313-20160225015037000000/d0bdf2974e1ef6d31685c3b392ad0b74 (0.6ms)
+    ```
+
+  Default value is false.
+
 ### Configuring Action Mailer
 
 There are a number of settings available on `config.action_mailer`:


### PR DESCRIPTION
### Summary

This is for #23879 

To get the result of fragment caching, I added `#log_payload` to `ActionView::Base` to store the payload hash. So we can still update the payload when read/write fragment cache.
