### PR TITLE
Eliminate extra template lookup in ActionView::Digestor

### DIFF
--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -41,8 +41,7 @@ module ActionView
         options = {}
         options[:formats] = [finder.rendered_format] if finder.rendered_format
 
-        if finder.disable_cache { finder.exists?(logical_name, [], partial, [], options) }
-          template = finder.disable_cache { finder.find(logical_name, [], partial, [], options) }
+        if template = finder.disable_cache { finder.find_all(logical_name, [], partial, [], options).first }
           finder.rendered_format ||= template.formats.first
 
           if node = seen[template.identifier] # handle cycles in the tree


### PR DESCRIPTION
[`PathSet#exists?`](https://github.com/rails/rails/blob/master/actionview/lib/action_view/path_set.rb#L57-L59) and [`PathSet#find`](https://github.com/rails/rails/blob/master/actionview/lib/action_view/path_set.rb#L45-L47) both do the same thing (`PathSet#find_all`). The `exists?` avoids `MissingTemplate` errors when no template is found. This change avoids it by using `find_all.first` instead. No behavior change, just one less template lookup. 

Noticed this while working on https://github.com/rails/rails/pull/25411. 

/cc @dhh @matthewd 
