### PR TITLE
Use UUIDs as IDs for prepared statements in Postgresql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -180,15 +180,10 @@ module ActiveRecord
         def initialize(connection, max)
           super(max)
           @connection = connection
-          @counter = 0
         end
 
         def next_key
-          "a#{@counter + 1}"
-        end
-
-        def []=(sql, key)
-          super.tap { @counter += 1 }
+          "a" + SecureRandom.uuid.delete("-")
         end
 
         private


### PR DESCRIPTION
### Summary

Due to certain [third-party interrupts (e.g. through Rack::Timeout)](http://stackoverflow.com/questions/24458105/rails-3-2-frequent-postgres-prepared-statement-already-exists-errors), it's possible a prepared statement is generated in Postgresql, but never "stored" in Rails. Since the code was interrupted before storing the statement, the `@counter` variable was never incremented even though it was used to generate a prepared statement.

Next time a prepared statement is tried to be generated, the generated name is identical to the previous "orphaned" prepared statement since the same `@counter` was used. This culminates in hundreds of the same "prepared statement already exists" error as Rails is unable to move past this one already-in-use name.

This update fixes this problem by using UUID as the prepared-statement name and not relying on the `@counter`.
