### PR TITLE
Refactored method `ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#default_sequence_name`. Refactored test `HasManyAssociationsTest#test_do_not_call_callbacks_for_delete_all`.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -327,12 +327,12 @@ module ActiveRecord
         end
 
         # Returns the sequence name for a table's primary key or some other specified key.
-        def default_sequence_name(table_name, pk = nil) #:nodoc:
-          result = serial_sequence(table_name, pk || 'id')
+        def default_sequence_name(table_name, pk = 'id') #:nodoc:
+          result = serial_sequence(table_name, pk)
           return nil unless result
           Utils.extract_schema_qualified_name(result).to_s
         rescue ActiveRecord::StatementInvalid
-          PostgreSQL::Name.new(nil, "#{table_name}_#{pk || 'id'}_seq").to_s
+          PostgreSQL::Name.new(nil, "#{table_name}_#{pk}_seq").to_s
         end
 
         def serial_sequence(table, column)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -244,8 +244,9 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_do_not_call_callbacks_for_delete_all
     car = Car.create(:name => 'honda')
     car.funky_bulbs.create!
+    assert_equal 1, car.funky_bulbs.count
     assert_nothing_raised { car.reload.funky_bulbs.delete_all }
-    assert_equal 0, Bulb.count, "bulbs should have been deleted using :delete_all strategy"
+    assert_equal 0, car.funky_bulbs.count, "bulbs should have been deleted using :delete_all strategy"
   end
 
   def test_delete_all_on_association_is_the_same_as_not_loaded


### PR DESCRIPTION
Refactored method `ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#default_sequence_name`
Fixed confusing behavior:

``` ruby
@connection.default_sequence_name('accounts', false)
```

``` ruby
@connection.default_sequence_name('accounts', nil)
```
## 

Refactored test `HasManyAssociationsTest#test_do_not_call_callbacks_for_delete_all`
