### PR TITLE
Fix typo in mailer previews test description [ci skip]

### DIFF
--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -27,7 +27,7 @@ module ApplicationTests
       assert_equal 404, last_response.status
     end
 
-    test "/rails/mailers is accessible with correct configuraiton" do
+    test "/rails/mailers is accessible with correct configuration" do
       add_to_config "config.action_mailer.show_previews = true"
       app("production")
       get "/rails/mailers", {}, {"REMOTE_ADDR" => "4.2.42.42"}


### PR DESCRIPTION
A mailer preview test description misspelled the word configuration.
This commit updates the test description to spell the word correctly.
