### PR TITLE
Fix display of unsorted list in release notes of 5.0 [ci skip]

### DIFF
--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -91,9 +91,9 @@ without having to rely on implementation details or monkey patching.
 
 Some things that you can achieve with this:
 
-* The type detected by Active Record can be overridden.
-* A default can also be provided.
-* Attributes do not need to be backed by a database column.
+- The type detected by Active Record can be overridden.
+- A default can also be provided.
+- Attributes do not need to be backed by a database column.
 
 ```ruby
 


### PR DESCRIPTION
Currently it doesn't display a list, just *-concatenated sentences.

http://guides.rubyonrails.org/5_0_release_notes.html#active-record-attributes-api
