### PR TITLE
Fix bug in method AR TimeZoneConverter#set_time_zone_without_conversion

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fixes multi-parameter attributes conversion with invalid params.
+
+    *Hiroyuki Ishii*
+
 *   Add newline between each migration in `structure.sql`.
 
     Keeps schema migration inserts as a single commit, but allows for easier

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -39,7 +39,7 @@ module ActiveRecord
         end
 
         def set_time_zone_without_conversion(value)
-          ::Time.zone.local_to_utc(value).in_time_zone
+          ::Time.zone.local_to_utc(value).in_time_zone if value
         end
 
         def map_avoiding_infinite_recursion(value)

--- a/activerecord/test/cases/multiparameter_attributes_test.rb
+++ b/activerecord/test/cases/multiparameter_attributes_test.rb
@@ -202,6 +202,20 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
     Topic.reset_column_information
   end
 
+  def test_multiparameter_attributes_on_time_with_time_zone_aware_attributes_and_invalid_time_params
+    with_timezone_config aware_attributes: true do
+      Topic.reset_column_information
+      attributes = {
+        "written_on(1i)" => "2004", "written_on(2i)" => "", "written_on(3i)" => ""
+      }
+      topic = Topic.find(1)
+      topic.attributes = attributes
+      assert_nil topic.written_on
+    end
+  ensure
+    Topic.reset_column_information
+  end
+
   def test_multiparameter_attributes_on_time_with_time_zone_aware_attributes_false
     with_timezone_config default: :local, aware_attributes: false, zone: -28800 do
       attributes = {


### PR DESCRIPTION
### Summary

Multi-parameter attributes conversion with invalid params doesn't work when `time_zone_aware_attributes` is enabled, because when invalid params is given to Multi-parameter attributes conversion, `set_time_zone_without_conversion` is assigned to `nil`.
