### PR TITLE
Prevent `MissingAttributeError` for nonexistent attribute in database

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -27,13 +27,14 @@ module ActiveRecord
         def define_method_attribute(name)
           safe_name = name.unpack('h*'.freeze).first
           temp_method = "__temp__#{safe_name}"
+          has_column = columns_hash[name]
 
           ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
 
           generated_attribute_methods.module_eval <<-STR, __FILE__, __LINE__ + 1
             def #{temp_method}
               name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
-              _read_attribute(name) { |n| missing_attribute(n, caller) }
+              _read_attribute(name) #{ "{ |n| missing_attribute(n, caller) }" if has_column }
             end
           STR
 

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -58,6 +58,11 @@ module ActiveRecord
       data = OverloadedType.new(non_existent_decimal: 1)
 
       assert_equal BigDecimal.new(1), data.non_existent_decimal
+      assert_nothing_raised do
+        data.save!
+        data = OverloadedType.find(data.id)
+        assert_nil data.non_existent_decimal
+      end
       assert_raise ActiveRecord::UnknownAttributeError do
         UnoverloadedType.new(non_existent_decimal: 1)
       end

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -3,7 +3,7 @@ require 'cases/helper'
 class OverloadedType < ActiveRecord::Base
   attribute :overloaded_float, :integer
   attribute :overloaded_string_with_limit, :string, limit: 50
-  attribute :non_existent_decimal, :decimal
+  attribute :non_existent_decimal, :decimal, default: 0
   attribute :string_with_default, :string, default: 'the overloaded default'
 end
 
@@ -61,7 +61,7 @@ module ActiveRecord
       assert_nothing_raised do
         data.save!
         data = OverloadedType.find(data.id)
-        assert_nil data.non_existent_decimal
+        assert_equal BigDecimal.new(0), data.non_existent_decimal
       end
       assert_raise ActiveRecord::UnknownAttributeError do
         UnoverloadedType.new(non_existent_decimal: 1)


### PR DESCRIPTION
Because nonexistent attribute does not be initialized by finding from
database.

Fixes #25787.
