### PR TITLE
Fix broken link

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -1120,7 +1120,7 @@ Contributing to Rails I18n
 
 I18n support in Ruby on Rails was introduced in the release 2.2 and is still evolving. The project follows the good Ruby on Rails development tradition of evolving solutions in gems and real applications first, and only then cherry-picking the best-of-breed of most widely useful features for inclusion in the core.
 
-Thus we encourage everybody to experiment with new ideas and features in gems or other libraries and make them available to the community. (Don't forget to announce your work on our [mailing list](http://groups.google.com/group/rails-i18n!))
+Thus we encourage everybody to experiment with new ideas and features in gems or other libraries and make them available to the community. (Don't forget to announce your work on our [mailing list](http://groups.google.com/group/rails-i18n)!)
 
 If you find your own locale (language) missing from our [example translations data](https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale) repository for Ruby on Rails, please [_fork_](https://github.com/guides/fork-a-project-and-submit-your-modifications) the repository, add your data and send a [pull request](https://github.com/guides/pull-requests).
 


### PR DESCRIPTION
I found broken link in http://railsguides.jp/i18n.html#rails-i18n%E3%81%B8%E3%81%AE%E8%B2%A2%E7%8C%AE%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6 and its upstream version http://guides.rubyonrails.org/i18n.html#contributing-to-rails-i18n .
