### PR TITLE
allow the :converter of composed_of to be run with nil as an argument

### DIFF
--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -205,8 +205,9 @@ module ActiveRecord
       # * <tt>:converter</tt> - A symbol specifying the name of a class method of <tt>:class_name</tt>
       #   or a Proc that is called when a new value is assigned to the value object. The converter is
       #   passed the single value that is used in the assignment and is only called if the new value is
-      #   not an instance of <tt>:class_name</tt>. If <tt>:allow_nil</tt> is set to true, the converter
-      #   can return nil to skip the assignment.
+      #   not an instance of <tt>:class_name</tt>. If <tt>:allow_nil</tt> is set to true and assigned value is nil,
+      #   the converter can return nil to skip the assignment. If <tt>:allow_nil</tt> is set to false,
+      #   the converter is executed.
       #
       # Option examples:
       #   composed_of :temperature, mapping: %w(reading celsius)
@@ -257,7 +258,7 @@ module ActiveRecord
           define_method("#{name}=") do |part|
             klass = class_name.constantize
 
-            unless part.is_a?(klass) || converter.nil? || part.nil?
+            unless part.is_a?(klass) || converter.nil? || (part.nil? && allow_nil)
               part = converter.respond_to?(:call) ? converter.call(part) : klass.send(converter, part)
             end
 

--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -128,6 +128,18 @@ class AggregationsTest < ActiveRecord::TestCase
     assert_nil Customer.gps_conversion_was_run
   end
 
+  def test_do_run_the_converter_when_nil_was_set_and_allow_nil_is_false
+    customers(:david).null_gps_location = nil
+    assert_not_nil Customer.gps_conversion_was_run
+    assert_kind_of NullGpsLocation, customers(:david).null_gps_location
+  ensure
+    Customer.gps_conversion_was_run = nil
+  end
+
+  def test_do_run_the_constructor_when_nil_was_set_and_allow_nil_is_false
+    assert_kind_of NullGpsLocation, customers(:zaphod).null_gps_location
+  end
+
   def test_custom_constructor
     assert_equal 'Barney GUMBLE', customers(:barney).fullname.to_s
     assert_kind_of Fullname, customers(:barney).fullname

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -7,6 +7,11 @@ class Customer < ActiveRecord::Base
   composed_of :non_blank_gps_location, :class_name => "GpsLocation", :allow_nil => true, :mapping => %w(gps_location gps_location),
               :converter => lambda { |gps| self.gps_conversion_was_run = true; gps.blank? ? nil : GpsLocation.new(gps)}
   composed_of :fullname, :mapping => %w(name to_s), :constructor => Proc.new { |name| Fullname.parse(name) }, :converter => :parse
+  composed_of :null_gps_location,
+              class_name: "NullGpsLocation",
+              mapping: %w(gps_location gps_location),
+              allow_nil: false,
+              converter: lambda { |gps| self.gps_conversion_was_run = true; NullGpsLocation.new(gps) }
 end
 
 class Address
@@ -56,6 +61,16 @@ class GpsLocation
 
   def ==(other)
     self.latitude == other.latitude && self.longitude == other.longitude
+  end
+end
+
+class NullGpsLocation < GpsLocation
+  def latitude
+    nil
+  end
+
+  def longitude
+    nil
   end
 end
 


### PR DESCRIPTION
In order to follow principle ["Tell don't ask"](http://www.sandimetz.com/blog/2014/12/19/suspicions-of-nil) it is nice to use NullObject pattern. Before https://github.com/rails/rails/pull/6143/commits/fa5f037551dfb860bf6359acf901915856646fea it was possible to build a NullObject as a `composed_of` attribute from nil value like

```
class GpsLocation
  attr_reader :coordinates

  def initialize(coordinates)
    @coordinates = coordinates
  end
end


class NullGpsLocation < GpsLocation 
  def initialize(_)
    @coordinates = nil
  end
end
```

```
# models/customer.rb
class Customer < ApplicationRecord
  composed_of :gps_location,
              class_name: "GpsLocation",
              constructor: proc { |value| value.nil? ? NullGpsLocation.new(value) : GpsLocation.new(value) },
              converter: proc { |value| value.nil? ? NullGpsLocation.new(value) : GpsLocation.new(value) },
              mapping: %w(coordinates coordinates),
              allow_nil: false
end
```

```
# somewhere.rb
customer.gps_location = nil
customer.gps_location.is_a? NullGpsLocation
  # => true
customer.gps_location.coordinates 
  # => nil

customer.gps_location = some_location
customer.gps_location.is_a? GpsLocation
  # => true
customer.gps_location.coordinates 
  # => some_location
```

and avoid annoying guards to check if gps_location is `nil`. 

This PR reverts back the behavior and supports compatibility with `allow_nil: true` option.
