### PR TITLE
Fix the calling `merge` method at first in a scope

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support calling the method `merge` in `scope`'s lambda.
+
+    *Yasuhiro Sugino*
+
 *   Add newline between each migration in `structure.sql`.
 
     Keeps schema migration inserts as a single commit, but allows for easier

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -9,7 +9,7 @@ module ActiveRecord
     delegate :find_each, :find_in_batches, :in_batches, to: :all
     delegate :select, :group, :order, :except, :reorder, :limit, :offset, :joins, :left_joins, :left_outer_joins, :or,
              :where, :rewhere, :preload, :eager_load, :includes, :from, :lock, :readonly,
-             :having, :create_with, :uniq, :distinct, :references, :none, :unscope, to: :all
+             :having, :create_with, :uniq, :distinct, :references, :none, :unscope, :merge, to: :all
     delegate :count, :average, :minimum, :maximum, :sum, :calculate, to: :all
     delegate :pluck, :ids, to: :all
 

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -46,6 +46,13 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert_equal Topic.average(:replies_count), Topic.base.average(:replies_count)
   end
 
+  def test_calling_merge_at_first_in_scope
+    Topic.class_eval do
+      scope :calling_merge_at_first_in_scope, Proc.new { merge(Topic.replied) }
+    end
+    assert_equal Topic.calling_merge_at_first_in_scope.to_a, Topic.replied.to_a
+  end
+
   def test_method_missing_priority_when_delegating
     klazz = Class.new(ActiveRecord::Base) do
       self.table_name = "topics"


### PR DESCRIPTION
### Summary

Calling the `merge` method at first in a scope raises `NoMethodError`.

``` ruby
scope :unsafe_chaininig, -> { merge(Comment.newest) } #=> NoMethodError: undefined method `merge'
```
### Other Information

Changing the order of method chaining `merge` and other query
method such as `joins` should produce the same result.

``` ruby
class Topic < ApplicationRecord
  scope :safe_chaininig,   -> { joins(:comments).merge(Comment.newest) } # => OK
  scope :unsafe_chaininig, -> { merge(Comment.newest).joins(:comments) } # => NoMethodError
end
```
