### PR TITLE
Add documentation about `ActiveSupport.on_load`

### DIFF
--- a/activesupport/lib/active_support/lazy_load_hooks.rb
+++ b/activesupport/lib/active_support/lazy_load_hooks.rb
@@ -28,6 +28,8 @@ module ActiveSupport
       end
     end
 
+    # Declares a block that will be executed when a Rails component is fully
+    # loaded.
     def on_load(name, options = {}, &block)
       @loaded[name].each do |base|
         execute_hook(base, options, block)


### PR DESCRIPTION
### Summary

Prior to this PR I don't think a lot of people understood that they're supposed to use the load hooks when extending functionality of Rails components.

This commit adds some docs that state what the load hooks  can be used for and the docs also explain how `LazyLoadHooks.on_load` method works.
works.

Fixes #25784
