### PR TITLE
Fix `payload[:class_name]` to `payload[:spec_name]`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -855,7 +855,7 @@ module ActiveRecord
           connection_id: object_id
         }
         if spec
-          payload[:class_name] = spec.name
+          payload[:spec_name] = spec.name
           payload[:config] = spec.config
         end
 

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -987,16 +987,11 @@ module ActiveRecord
 
         # When connections are established in the future, begin a transaction too
         @connection_subscriber = ActiveSupport::Notifications.subscribe('!connection.active_record') do |_, _, _, _, payload|
-          model_class = nil
-          begin
-            model_class = payload[:class_name].constantize if payload[:class_name]
-          rescue NameError
-            model_class = nil
-          end
+          spec_name = payload[:spec_name] if payload.key?(:spec_name)
 
-          if model_class
+          if spec_name
             begin
-              connection = ActiveRecord::Base.connection_handler.retrieve_connection(model_class)
+              connection = ActiveRecord::Base.connection_handler.retrieve_connection(spec_name)
             rescue ConnectionNotEstablished
               connection = nil
             end

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -347,8 +347,8 @@ module ActiveRecord
           payloads << payload
         end
         ActiveRecord::Base.establish_connection :arunit
-        assert_equal [:class_name, :config, :connection_id], payloads[0].keys.sort
-        assert_equal 'primary', payloads[0][:class_name]
+        assert_equal [:config, :connection_id, :spec_name], payloads[0].keys.sort
+        assert_equal 'primary', payloads[0][:spec_name]
       ensure
         ActiveSupport::Notifications.unsubscribe(subscription) if subscription
       end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -650,10 +650,10 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
   private
 
     def fire_connection_notification(connection)
-      ActiveRecord::Base.connection_handler.stubs(:retrieve_connection).with(Book).returns(connection)
+      ActiveRecord::Base.connection_handler.stubs(:retrieve_connection).with('book').returns(connection)
       message_bus = ActiveSupport::Notifications.instrumenter
       payload = {
-        class_name: 'Book',
+        spec_name: 'book',
         config: nil,
         connection_id: connection.object_id
       }

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -6,6 +6,8 @@ require 'models/post'
 require 'rack'
 
 class QueryCacheTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
   fixtures :tasks, :topics, :categories, :posts, :categories_posts
 
   teardown do


### PR DESCRIPTION
Follow up to #20818.

`retrieve_connection` is passed `spec_name` instead of `klass` since #24844.
