### PR TITLE
Support calling `render xml:` where `#to_xml` does not accept options

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support calling `render xml:` where `#to_xml` does not accept options
+
+    *Ben Woosley*
+
 *   Check `request.path_parameters` encoding at the point they're set.
 
     Check for any non-UTF8 characters in path parameters at the point they're

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -94,7 +94,6 @@ module ActionController
     end
 
     module ClassMethods
-
       # Adds, by name, a renderer or renderers to the +_renderers+ available
       # to call within controller actions.
       #
@@ -177,7 +176,13 @@ module ActionController
 
     add :xml do |xml, options|
       self.content_type ||= Mime[:xml]
-      xml.respond_to?(:to_xml) ? xml.to_xml(options) : xml
+      if !xml.respond_to?(:to_xml)
+        xml
+      elsif xml.method(:to_xml).arity == 0
+        xml.to_xml
+      else
+        xml.to_xml(options)
+      end
     end
   end
 end

--- a/actionpack/test/controller/render_xml_test.rb
+++ b/actionpack/test/controller/render_xml_test.rb
@@ -10,6 +10,12 @@ class RenderXmlTest < ActionController::TestCase
     end
   end
 
+  class XmlRenderableWithoutOptions
+    def to_xml
+      '<i-am-xml-without-options/>'
+    end
+  end
+
   class TestController < ActionController::Base
     protect_from_forgery
 
@@ -28,6 +34,10 @@ class RenderXmlTest < ActionController::TestCase
 
     def render_with_to_xml
       render :xml => XmlRenderable.new
+    end
+
+    def render_with_to_xml_without_options
+      render :xml => XmlRenderableWithoutOptions.new
     end
 
     def formatted_xml_erb
@@ -66,6 +76,11 @@ class RenderXmlTest < ActionController::TestCase
   def test_rendering_xml_should_call_to_xml_with_extra_options
     get :render_xml_with_custom_options
     assert_equal "<i-am-THE-xml/>", @response.body
+  end
+
+  def test_rendering_xml_without_options
+    get :render_with_to_xml_without_options
+    assert_equal "<i-am-xml-without-options/>", @response.body
   end
 
   def test_rendering_with_object_location_should_set_header_with_url_for


### PR DESCRIPTION
There are plenty of libraries that include objects with non-parametric
`#to_xml` implementations. Any such method that does not accept any arguments
will have an arity of 0. Not passing the options in this case is an easy
way to support interoperability with these other libraries.

https://github.com/search?l=ruby&q=def+to_xml&type=Code&utf8=%E2%9C%93
