### PR TITLE
reestablish current environment connection after creating all databases

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -88,7 +88,7 @@ module ActiveRecord
       end
 
       def env
-        @env ||= Rails.env
+        @env ||= Rails.env if defined?(Rails.env)
       end
 
       def seed_loader
@@ -117,11 +117,8 @@ module ActiveRecord
       end
 
       def create_all
-        old_pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(ActiveRecord::Base.connection_specification_name)
         each_local_configuration { |configuration| create configuration }
-        if old_pool
-          ActiveRecord::Base.connection_handler.establish_connection(old_pool.spec.to_hash)
-        end
+        ActiveRecord::Base.establish_connection(env.to_sym) if env
       end
 
       def create_current(environment = env)

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -307,6 +307,51 @@ module ApplicationTests
           ENV["RACK_ENV"] = @old_rack_env
         end
       end
+
+      def test_rails_db_create_all_restores_db_connection
+        output =  Dir.chdir(app_path) { `bin/rails db:create:all db:migrate && echo ".tables" | rails dbconsole` }
+        assert_match "ar_internal_metadata", output, "tables should be dumped"
+      end
+
+      def test_rails_db_create_all_restores_db_connection_after_drop
+        Dir.chdir(app_path) { `bin/rails db:create:all` } # create all to avoid warnings
+        output =  Dir.chdir(app_path) { `bin/rails db:drop:all db:create:all db:migrate && echo ".tables" | rails dbconsole` }
+        assert_match "ar_internal_metadata", output, "tables should be dumped"
+      end
+
+      def test_rails_db_create_all_restores_db_connection_with_postgresql
+        use_postgresql
+        output =  Dir.chdir(app_path) { `bin/rails db:create:all db:migrate && echo "\\d+" | rails dbconsole` }
+        assert_match "ar_internal_metadata", output, "tables should be dumped"
+      ensure
+        Dir.chdir(app_path) { `bin/rails db:drop:all` }
+      end
+
+      def test_rails_db_create_all_restores_db_connection_after_drop_with_postgresql
+        use_postgresql
+        Dir.chdir(app_path) { `bin/rails db:create:all` } # create all to avoid warnings
+        output =  Dir.chdir(app_path) { `bin/rails db:drop:all db:create:all db:migrate && echo "\\d+" | rails dbconsole` }
+        assert_match "ar_internal_metadata", output, "tables should be dumped"
+      ensure
+        Dir.chdir(app_path) { `bin/rails db:drop:all` }
+      end
+
+      def test_rails_db_create_all_restores_db_connection_with_mysql
+        use_mysql
+        output =  Dir.chdir(app_path) { `bin/rails db:create:all db:migrate && echo "show tables" | rails dbconsole` }
+        assert_match "ar_internal_metadata", output, "tables should be dumped"
+      ensure
+        Dir.chdir(app_path) { `bin/rails db:drop:all` }
+      end
+
+      def test_rails_db_create_all_restores_db_connection_after_drop_with_mysql
+        use_mysql
+        Dir.chdir(app_path) { `bin/rails db:create:all` } # create all to avoid warnings
+        output =  Dir.chdir(app_path) { `bin/rails db:drop:all db:create:all db:migrate && echo "show tables" | rails dbconsole` }
+        assert_match "ar_internal_metadata", output, "tables should be dumped"
+      ensure
+        Dir.chdir(app_path) { `bin/rails db:drop:all` }
+      end
     end
   end
 end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -523,6 +523,44 @@ module ApplicationTests
       assert_match "ar_internal_metadata", output, "tables should be dumped"
     end
 
+    def test_rails_db_create_all_restores_db_connection_with_postgresql
+      use_postgresql
+      create_test_file :models, 'account'
+      output =  Dir.chdir(app_path) { `bin/rails db:create:all db:migrate && echo "\\d+" | rails dbconsole` }
+      assert_match "ar_internal_metadata", output, "tables should be dumped"
+    ensure
+      Dir.chdir(app_path) { `bin/rails db:drop:all` }
+    end
+
+    def test_rails_db_create_all_restores_db_connection_after_drop_with_postgresql
+      use_postgresql
+      create_test_file :models, 'account'
+      Dir.chdir(app_path) { `bin/rails db:create:all` } # create all to avoid warnings
+      output =  Dir.chdir(app_path) { `bin/rails db:drop:all db:create:all db:migrate && echo "\\d+" | rails dbconsole` }
+      assert_match "ar_internal_metadata", output, "tables should be dumped"
+    ensure
+      Dir.chdir(app_path) { `bin/rails db:drop:all` }
+    end
+
+    def test_rails_db_create_all_restores_db_connection_with_mysql
+      use_mysql
+      create_test_file :models, 'account'
+      output =  Dir.chdir(app_path) { `bin/rails db:create:all db:migrate && echo "show tables" | rails dbconsole` }
+      assert_match "ar_internal_metadata", output, "tables should be dumped"
+    ensure
+      Dir.chdir(app_path) { `bin/rails db:drop:all` }
+    end
+
+    def test_rails_db_create_all_restores_db_connection_after_drop_with_mysql
+      use_mysql
+      create_test_file :models, 'account'
+      Dir.chdir(app_path) { `bin/rails db:create:all` } # create all to avoid warnings
+      output =  Dir.chdir(app_path) { `bin/rails db:drop:all db:create:all db:migrate && echo "show tables" | rails dbconsole` }
+      assert_match "ar_internal_metadata", output, "tables should be dumped"
+    ensure
+      Dir.chdir(app_path) { `bin/rails db:drop:all` }
+    end
+
     def test_rake_passes_TESTOPTS_to_minitest
       create_test_file :models, "account"
       output =  Dir.chdir(app_path) { `bin/rake test TESTOPTS=-v` }

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -510,57 +510,6 @@ module ApplicationTests
       assert_match "Execute test", output
     end
 
-    def test_rails_db_create_all_restores_db_connection
-      create_test_file :models, "account"
-      output =  Dir.chdir(app_path) { `bin/rails db:create:all db:migrate && echo ".tables" | rails dbconsole` }
-      assert_match "ar_internal_metadata", output, "tables should be dumped"
-    end
-
-    def test_rails_db_create_all_restores_db_connection_after_drop
-      create_test_file :models, "account"
-      Dir.chdir(app_path) { `bin/rails db:create:all` } # create all to avoid warnings
-      output =  Dir.chdir(app_path) { `bin/rails db:drop:all db:create:all db:migrate && echo ".tables" | rails dbconsole` }
-      assert_match "ar_internal_metadata", output, "tables should be dumped"
-    end
-
-    def test_rails_db_create_all_restores_db_connection_with_postgresql
-      use_postgresql
-      create_test_file :models, 'account'
-      output =  Dir.chdir(app_path) { `bin/rails db:create:all db:migrate && echo "\\d+" | rails dbconsole` }
-      assert_match "ar_internal_metadata", output, "tables should be dumped"
-    ensure
-      Dir.chdir(app_path) { `bin/rails db:drop:all` }
-    end
-
-    def test_rails_db_create_all_restores_db_connection_after_drop_with_postgresql
-      use_postgresql
-      create_test_file :models, 'account'
-      Dir.chdir(app_path) { `bin/rails db:create:all` } # create all to avoid warnings
-      output =  Dir.chdir(app_path) { `bin/rails db:drop:all db:create:all db:migrate && echo "\\d+" | rails dbconsole` }
-      assert_match "ar_internal_metadata", output, "tables should be dumped"
-    ensure
-      Dir.chdir(app_path) { `bin/rails db:drop:all` }
-    end
-
-    def test_rails_db_create_all_restores_db_connection_with_mysql
-      use_mysql
-      create_test_file :models, 'account'
-      output =  Dir.chdir(app_path) { `bin/rails db:create:all db:migrate && echo "show tables" | rails dbconsole` }
-      assert_match "ar_internal_metadata", output, "tables should be dumped"
-    ensure
-      Dir.chdir(app_path) { `bin/rails db:drop:all` }
-    end
-
-    def test_rails_db_create_all_restores_db_connection_after_drop_with_mysql
-      use_mysql
-      create_test_file :models, 'account'
-      Dir.chdir(app_path) { `bin/rails db:create:all` } # create all to avoid warnings
-      output =  Dir.chdir(app_path) { `bin/rails db:drop:all db:create:all db:migrate && echo "show tables" | rails dbconsole` }
-      assert_match "ar_internal_metadata", output, "tables should be dumped"
-    ensure
-      Dir.chdir(app_path) { `bin/rails db:drop:all` }
-    end
-
     def test_rake_passes_TESTOPTS_to_minitest
       create_test_file :models, "account"
       output =  Dir.chdir(app_path) { `bin/rake test TESTOPTS=-v` }

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -204,6 +204,44 @@ module TestHelpers
       RUBY
     end
 
+    def use_postgresql
+      File.open("#{app_path}/config/database.yml", "w") do |f|
+        f.puts <<-YAML
+        default: &default
+          adapter: postgresql
+          pool: 5
+        development:
+          <<: *default
+          database: railties_development
+        test:
+          <<: *default
+          database: railties_test
+        production:
+          <<: *default
+          database: railties_production
+        YAML
+      end
+    end
+
+    def use_mysql
+      File.open("#{app_path}/config/database.yml", "w") do |f|
+        f.puts <<-YAML
+        default: &default
+          adapter: mysql2
+          pool: 5
+        development:
+          <<: *default
+          database: railties_development
+        test:
+          <<: *default
+          database: railties_test
+        production:
+          <<: *default
+          database: railties_production
+        YAML
+      end
+    end
+
     class Bukkit
       attr_reader :path
 


### PR DESCRIPTION
### Summary

Using `db:create:all` with `db:drop:all`, connection pool is last to have
information of the processing was carried out environment is held,
it may not match the environment for now processing.
In case of default `databases.yml`, it is probably left connection pool for
production environment.

Therefore, instead of reusing the connection pool, it fixes to perform reestablish
for current environment.

Fixes #24813
