### PR TITLE
Allow MessageEncryptor to take advantage authenticated encryption modes

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Allow MessageEncryptor to take advantage authenticated encryption modes.
+*   Allow MessageEncryptor to take advantage of authenticated encryption modes.
 
     AEAD modes like `aes-256-gcm` provide both confidentiality and data
     authenticity, eliminating the need to use MessageVerifier to check if the

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow MessageEncryptor to take advantage authenticated encryption modes.
+
+    AEAD modes like `aes-256-gcm` provide both confidentiality and data
+    authenticity, eliminating the need to use MessageVerifier to check if the
+    encrypted data has been tampered with. This speeds up encryption/decryption
+    and results in shorter cipher text.
+
+    *Bart de Water*
+
 *   Introduce `assert_changes` and `assert_no_changes`.
 
     `assert_changes` is a more general `assert_difference` that works with any

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -19,8 +19,6 @@ module ActiveSupport
   #   encrypted_data = crypt.encrypt_and_sign('my secret data')              # => "NlFBTTMwOUV5UlA1QlNEN2xkY2d6eThYWWh..."
   #   crypt.decrypt_and_verify(encrypted_data)                               # => "my secret data"
   class MessageEncryptor
-    AEAD_MODES = %w(ccm ocb eax gcm poly1305)
-
     module NullSerializer #:nodoc:
       def self.load(value)
         value
@@ -127,10 +125,7 @@ module ActiveSupport
     end
 
     def aead_mode?
-      @aead_mode ||= begin
-        cipher_mode = @cipher.split('-'.freeze).last
-        AEAD_MODES.include?(cipher_mode)
-      end
+      @aead_mode ||= new_cipher.authenticated?
     end
 
     def resolve_verifier

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -99,6 +99,7 @@ module ActiveSupport
     def _decrypt(encrypted_message)
       cipher = new_cipher
       encrypted_data, iv, auth_tag = encrypted_message.split("--".freeze).map {|v| ::Base64.strict_decode64(v)}
+      raise InvalidMessage if aead_mode? && auth_tag.bytes.length != 16
 
       cipher.decrypt
       cipher.key = @secret

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -29,7 +29,7 @@ module ActiveSupport
       end
     end
 
-    module AeadVerifier #:nodoc:
+    module NullVerifier #:nodoc:
       def self.verify(value)
         value
       end
@@ -131,7 +131,7 @@ module ActiveSupport
 
     def resolve_verifier
       if aead_mode?
-        AeadVerifier
+        NullVerifier
       else
         MessageVerifier.new(@sign_secret || @secret, digest: @digest, serializer: NullSerializer)
       end

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -85,6 +85,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     assert_not_decrypted([text, iv, munge(auth_tag)] * "--")
     assert_not_decrypted([munge(text), munge(iv), munge(auth_tag)] * "--")
     assert_not_decrypted([text, iv] * "--")
+    assert_not_decrypted([text, iv, auth_tag[0..14]] * "--")
   end
 
   private

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -70,6 +70,23 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     assert_not_verified([iv,  message] * bad_encoding_characters)
   end
 
+  def test_aead_mode_encryption
+    encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: 'aes-256-gcm')
+    message = encryptor.encrypt_and_sign(@data)
+    assert_equal @data, encryptor.decrypt_and_verify(message)
+  end
+
+  def test_messing_with_aead_values_causes_failures
+    encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: 'aes-256-gcm')
+    text, iv, auth_tag = encryptor.encrypt_and_sign(@data).split("--")
+    assert_not_decrypted([iv, text, auth_tag] * "--")
+    assert_not_decrypted([munge(text), iv, auth_tag] * "--")
+    assert_not_decrypted([text, munge(iv), auth_tag] * "--")
+    assert_not_decrypted([text, iv, munge(auth_tag)] * "--")
+    assert_not_decrypted([munge(text), munge(iv), munge(auth_tag)] * "--")
+    assert_not_decrypted([text, iv] * "--")
+  end
+
   private
 
   def assert_not_decrypted(value)

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -85,7 +85,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     assert_not_decrypted([text, iv, munge(auth_tag)] * "--")
     assert_not_decrypted([munge(text), munge(iv), munge(auth_tag)] * "--")
     assert_not_decrypted([text, iv] * "--")
-    assert_not_decrypted([text, iv, auth_tag[0..14]] * "--")
+    assert_not_decrypted([text, iv, auth_tag[0..-2]] * "--")
   end
 
   private


### PR DESCRIPTION
AEAD modes have been [supported since Ruby 2.0](https://bugs.ruby-lang.org/issues/6980) ([doc](http://ruby-doc.org/stdlib-2.3.0/libdoc/openssl/rdoc/OpenSSL/Cipher.html#class-OpenSSL::Cipher-label-Authenticated+Encryption+and+Associated+Data+-28AEAD-29)) and OpenSSL 1.0.1. It is faster:

``` ruby
require 'benchmark/ips'
require 'active_support/message_encryptor'
require 'active_support/key_generator'

Benchmark.ips do |x|
  salt  = SecureRandom.random_bytes(64)
  key   = ActiveSupport::KeyGenerator.new('password').generate_key(salt)
  data  = 'my secret data'

  x.report("default roundtrip") do
    crypt = ActiveSupport::MessageEncryptor.new(key)
    encrypted_data = crypt.encrypt_and_sign(data)
    crypt.decrypt_and_verify(encrypted_data)
  end

  x.report("aes-256-gcm roundtrip") do
    crypt = ActiveSupport::MessageEncryptor.new(key, cipher: 'aes-256-gcm')
    encrypted_data = crypt.encrypt_and_sign(data)
    crypt.decrypt_and_verify(encrypted_data)
  end

  x.compare!
end
```

```
Warming up --------------------------------------
   default roundtrip     2.148k i/100ms
aes-256-gcm roundtrip
                         4.698k i/100ms
Calculating -------------------------------------
   default roundtrip     21.947k (± 3.4%) i/s -    111.696k in   5.095390s
aes-256-gcm roundtrip
                         48.374k (± 4.2%) i/s -    244.296k in   5.058709s

Comparison:
aes-256-gcm roundtrip:    48374.4 i/s
   default roundtrip:    21946.7 i/s - 2.20x slower
```

And it produces smaller ciphertexts:

```
irb(main):090:0> ActiveSupport::MessageEncryptor.new(key).encrypt_and_sign(data).length
=> 138
irb(main):091:0> ActiveSupport::MessageEncryptor.new(key, cipher: 'aes-256-gcm').encrypt_and_sign(data).length
=> 76
```
