### PR TITLE
Restore the ability to pass Active Record objects to `update_all`

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -116,7 +116,17 @@ module ActiveRecord
       def sanitize_sql_hash_for_assignment(attrs, table)
         c = connection
         attrs.map do |attr, value|
-          value = type_for_attribute(attr.to_s).serialize(value)
+          if value.is_a?(Base)
+            require "active_support/core_ext/string/filters"
+            ActiveSupport::Deprecation.warn(<<-WARNING.squish)
+              Passing `ActiveRecord::Base` objects to
+              `sanitize_sql_hash_for_assignment` (or methods which call it,
+              such as `update_all`) is deprecated. Please pass the id directly,
+              instead.
+            WARNING
+          else
+            value = type_for_attribute(attr.to_s).serialize(value)
+          end
           "#{c.quote_table_name_for_assignment(table, attr)} = #{c.quote(value)}"
         end.join(', ')
       end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2007,4 +2007,11 @@ class RelationTest < ActiveRecord::TestCase
 
     assert_equal 2, posts.to_a.length
   end
+
+  def test_update_all_can_receive_active_record_objects
+    assert_deprecated do
+      Comment.update_all(post_id: Post.first)
+      assert(Comment.all.all? { |c| c.post_id == Post.first.id })
+    end
+  end
 end


### PR DESCRIPTION
The ability to do this was mostly unintentional, and relied on other code which
is slated to be deprecated soon. In 5.0.0 attempting to pass an Active
Record object to `update_all` will cast it to `nil` instead of grabbing
the ID. This is because we are going through `Type#serialize` sooner in
the stack, and not hitting the `quoted_id` call in the connection
adapter. This mirrors the behavior that would occur if you attempted to
assign the record to the foreign key.

While this behavior wasn't really intentional, it was a breaking change
that I didn't intend to make without deprecation. The behavior is
restored, but immediately deprecated. While this does introduce a
deprecation warning in a patch release, it deprecates behavior that was
not working in the last major, so no working code could have been
relying on it.

The implementation checks for `Base` explicitly instead of objects which
respond to `quoted_id` to avoid collisions with any other code which
overrides `quoted_id`. I'd like to deprecate `quoted_id` entirely in the
next release.
