### PR TITLE
Fix docs in collection_radio_buttons

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -651,12 +651,12 @@ module ActionView
       # The HTML specification says when nothing is select on a collection of radio buttons
       # web browsers do not send any value to server.
       # Unfortunately this introduces a gotcha:
-      # if a +User+ model has a +category_id+ field, and in the form none category is selected no +category_id+ parameter is sent. So,
-      # any strong parameters idiom like
+      # if a +User+ model has a +category_id+ field and in the form no category is selected, no +category_id+ parameter is sent. So,
+      # any strong parameters idiom like:
       #
       #   params.require(:user).permit(...)
       #
-      # will raise an error since no +{user: ...}+ will be present.
+      # will raise an error since no <tt>{user: ...}</tt> will be present.
       #
       # To prevent this the helper generates an auxiliary hidden field before
       # every collection of radio buttons. The hidden field has the same name as collection radio button and blank value.


### PR DESCRIPTION
[ci skip] 
Just some english and `<tt>` tags.

Before:

<img width="1047" alt="screen shot 2016-07-18 at 4 39 15 pm" src="https://cloud.githubusercontent.com/assets/10076/16933927/bd61c4cc-4d06-11e6-8c20-b63254ea3ca0.png">

After:

<img width="1036" alt="screen shot 2016-07-18 at 4 42 55 pm" src="https://cloud.githubusercontent.com/assets/10076/16933931/c1d69578-4d06-11e6-8579-4963f3cdad66.png">
