### PR TITLE
Fix ActionCable "Rebroadcasting a Message" code example

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -329,7 +329,7 @@ other connected clients.
 # app/channels/chat_channel.rb
 class ChatChannel < ApplicationCable::Channel
   def subscribed
-    stream_from "chat_#{params[:room]}"
+    stream_for "chat_#{params[:room]}"
   end
 
   def receive(data)


### PR DESCRIPTION
In ActionCable's guide: [Rebroadcasting a Message](http://guides.rubyonrails.org/action_cable_overview.html#rebroadcasting-a-message), the example does not work.

`stream_for "chat_#{params[:room]}"` will stream from `chat_:room`, but `ChatChannel.broadcast_to("chat_#{params[:room]}", ...)` will broadcast to `chat:chat_:room`.

Switching to `stream_for` will make it stream from `chat:chat_:room` and fix the example.
