### PR TITLE
Make SecureToken#regenerate_token a bang! method

### DIFF
--- a/activerecord/lib/active_record/secure_token.rb
+++ b/activerecord/lib/active_record/secure_token.rb
@@ -26,8 +26,8 @@ module ActiveRecord
       def has_secure_token(attribute = :token)
         # Load securerandom only when has_secure_token is used.
         require 'active_support/core_ext/securerandom'
-        define_method("regenerate_#{attribute}") { update! attribute => self.class.generate_unique_secure_token }
-        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token) unless self.send("#{attribute}?")}
+        define_method("regenerate_#{attribute}!") { update! attribute => self.class.generate_unique_secure_token }
+        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token!) unless self.send("#{attribute}?")}
       end
 
       def generate_unique_secure_token

--- a/activerecord/test/cases/secure_token_test.rb
+++ b/activerecord/test/cases/secure_token_test.rb
@@ -16,8 +16,8 @@ class SecureTokenTest < ActiveRecord::TestCase
     @user.save
     old_token = @user.token
     old_auth_token = @user.auth_token
-    @user.regenerate_token
-    @user.regenerate_auth_token
+    @user.regenerate_token!
+    @user.regenerate_auth_token!
 
     assert_not_equal @user.token, old_token
     assert_not_equal @user.auth_token, old_auth_token


### PR DESCRIPTION
ActiveRecord::SecureToken#regenerate_token is at its a core a wrapper of a bang method, in which it updates the model right away and persists the change to the db

Keeping in convention with what bang! methods should be, I think this is definitely a good candidate
