### PR TITLE
Remove Oracle specific tests based on deprecated behaviors

### DIFF
--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -156,14 +156,7 @@ module ActiveRecord
           assert_equal String, bob.bio.class
           assert_kind_of Integer, bob.age
           assert_equal Time, bob.birthday.class
-
-          if current_adapter?(:OracleAdapter)
-            # Oracle doesn't differentiate between date/time
-            assert_equal Time, bob.favorite_day.class
-          else
-            assert_equal Date, bob.favorite_day.class
-          end
-
+          assert_equal Date, bob.favorite_day.class
           assert_instance_of TrueClass, bob.male?
           assert_kind_of BigDecimal, bob.wealth
         end

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -43,12 +43,6 @@ class Topic < ActiveRecord::Base
   before_create  :default_written_on
   before_destroy :destroy_children
 
-  # Explicitly define as :date column so that returned Oracle DATE values would be typecasted to Date and not Time.
-  # Some tests depend on assumption that this attribute will have Date values.
-  if current_adapter?(:OracleEnhancedAdapter)
-    set_date_columns :last_read
-  end
-
   def parent
     Topic.find(parent_id)
   end


### PR DESCRIPTION
### Summary

This pull request removes two Oracle specific implementations which has been deprecated in Oracle enhanced adapter 1.7.0.beta1 supporting Rails 5:
- Oracle TIMESTAMP sql type is associated with Rails `DateTime` type

In the previous version of Oracle enhanced adapter 1.6 or earlier which supports Rails 4.2, Rails `DateTime` was mapped to Oracle `DATE` sql type which actually stores date and time, but does not store subsecond.   Starting from Rails 5 to support `supports_datetime_with_precision?`  Rails `DateTime` is mapped to Oracle `TIMESTAMP` which can store date and time including subsecond.

Refer https://github.com/rsim/oracle-enhanced/pull/845
- Deprecate `set_date_columns`

Also to support Rails 5 attribute API, Oracle enhaced adapter has deprecated `set_date_columns` which set Rails `Date` type for Oracle `DATE` sql type.  We do not have to set explicit attribute since Rails `Date` type is mapped to Oracle `DATE` sql type by default in Rails 5.

Oracle TIMESTAMP sql type is associated with Rails `DateTime` type now
- 
  Remove `set_date_columns` which has been deprecated in Oracle enhanced adapter
- Refer https://github.com/rsim/oracle-enhanced/pull/869
### Other Information
- This pull request addresses this failure and removes the DEPRECATION WARNING below.

``` ruby
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/migration/column_attributes_test.rb -n test_native_types
... snip ...

# Running:

F

Finished in 0.284317s, 3.5172 runs/s, 42.2064 assertions/s.

  1) Failure:
ActiveRecord::Migration::ColumnAttributesTest#test_native_types [test/cases/migration/column_attributes_test.rb:162]:
Expected: Time
  Actual: Date

1 runs, 12 assertions, 1 failures, 0 errors, 0 skips
$
```

``` ruby
$ bundle exec rake test_oracle
... snip ...
DEPRECATION WARNING: 'set_date_columns` has been deprecated. Please use Rails attribute API. (called from set_date_columns at /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:61)
/home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:61:in `set_date_columns'
  /home/yahonda/git/rails/activerecord/test/models/topic.rb:49:in `<class:Topic>'
  /home/yahonda/git/rails/activerecord/test/models/topic.rb:1:in `<top (required)>'
  /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:293:in `require'
  /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:293:in `block in require'
  /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:259:in `load_dependency'
  /home/yahonda/git/rails/activesupport/lib/active_support/dependencies.rb:293:in `require'
  /home/yahonda/git/rails/activerecord/test/cases/relations_test.rb:5:in `<top (required)>'
  /home/yahonda/.rbenv/versions/2.4.0-dev/lib/ruby/gems/2.4.0/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in `require'
  /home/yahonda/.rbenv/versions/2.4.0-dev/lib/ruby/gems/2.4.0/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in `block in <main>'
  /home/yahonda/.rbenv/versions/2.4.0-dev/lib/ruby/gems/2.4.0/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in `select'
  /home/yahonda/.rbenv/versions/2.4.0-dev/lib/ruby/gems/2.4.0/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in `<main>'
...
```
