### PR TITLE
add support to reverse_order! for sql functions with (nested) parentheses

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1124,7 +1124,7 @@ module ActiveRecord
           if does_not_support_reverse?(o)
             raise IrreversibleOrderError, "Order #{o.inspect} can not be reversed automatically"
           end
-          o.split(',').map! do |s|
+          o.scan(/((?>[^,()]+|\((?:[^)(]+|\g<-1>)*\))+)/).flatten.map! do |s|
             s.strip!
             s.gsub!(/\sasc\Z/i, ' DESC') || s.gsub!(/\sdesc\Z/i, ' ASC') || s.concat(' DESC')
           end

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -125,18 +125,19 @@ module ActiveRecord
     end
 
     test 'reverse_order!' do
-      @relation = Post.order('title ASC, comments_count DESC')
+      @relation = Post.order("title ASC, comments_count DESC, pgp_sym_decrypt(bytea(author_name), 'key') DESC")
 
       relation.reverse_order!
 
-      assert_equal 'title DESC', relation.order_values.first
-      assert_equal 'comments_count ASC', relation.order_values.last
-
+      assert_equal 'title DESC', relation.order_values[0]
+      assert_equal 'comments_count ASC', relation.order_values[1]
+      assert_equal "pgp_sym_decrypt(bytea(author_name), 'key') ASC", relation.order_values[2]
 
       relation.reverse_order!
 
-      assert_equal 'title ASC', relation.order_values.first
-      assert_equal 'comments_count DESC', relation.order_values.last
+      assert_equal 'title ASC', relation.order_values[0]
+      assert_equal 'comments_count DESC', relation.order_values[1]
+      assert_equal "pgp_sym_decrypt(bytea(author_name), 'key') DESC", relation.order_values[2]
     end
 
     test 'create_with!' do


### PR DESCRIPTION
### Summary

`reverse_order!` is supposed to sort the relation in the opposite order. However, it doesn't work when ordering by a returning value from a sql function, which has more than one arguments. For instance in PostgreSQL I want to order by the decrypted version of a column with a key, `Post.order("pgp_sym_decrypt(bytea(author_name), 'key') DESC")`. AR doesn't raise `IrreversibleOrderError` but regards there are two order queries separated by the comma, `pgp_sym_decrypt(bytea(author_name)` and `'key') DESC`.

Basically AR takes any commas in order string as separators by using `split(',')`, but we should ignore the commas between any parentheses. Furthermore, I have considered nested the cases with nested parentheses, which requires recursion in regex. My approach is to get the match groups by `scan(/((?>[^,()]+|\((?:[^)(]+|\g<-1>)*\))+)/).flatten`. The detail of its explanation is like:

```
(                        # first capturing group
    (?>                  # open an atomic group (like a non capturing group)
        [^,(]+           # all characters except , and (
      |                  # or
        \(               # (
         (?>             # open a second atomic group
             [^()]+      # all characters except parenthesis
           |             # OR
             \g<-1>      # the last capturing group (you can write \g<2>)
         )*              # close the second atomic group
         \)              # )
    )+                   # close the first atomic group and repeat it
)                        # close the first capturing group
```

The second capturing group describes the nested parentheses that can contain characters that are not parentheses or the capturing group itself. 
### Other Information

Without this fix, `last` method in `Post.order("pgp_sym_decrypt(bytea(author_name), 'key') DESC").last` will raise `PG::UndefinedColumn: ERROR`
