### PR TITLE
Register media type for web application manifest

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_types.rb
+++ b/actionpack/lib/action_dispatch/http/mime_types.rb
@@ -30,6 +30,9 @@ Mime::Type.register "application/x-www-form-urlencoded", :url_encoded_form
 # http://www.json.org/JSONRequest.html
 Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest )
 
+# https://w3c.github.io/manifest/#media-type-registration
+Mime::Type.register "application/manifest+json", :webmanifest
+
 Mime::Type.register "application/pdf", :pdf, [], %w(pdf)
 Mime::Type.register "application/zip", :zip, [], %w(zip)
 Mime::Type.register "application/gzip", :gzip, %w(application/x-gzip), %w(gz)


### PR DESCRIPTION
### Summary

Register a new default media/MIME type for web application manifest

The media type is `application/manifest+json`, and the recommended file extension is `.webmanifest`
### Other Information
- https://w3c.github.io/manifest/#media-type-registration
