### PR TITLE
Remove tab chars before commands to be run

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -126,9 +126,9 @@ module ActiveRecord
   class PendingMigrationError < MigrationError#:nodoc:
     def initialize(message = nil)
       if !message && defined?(Rails.env)
-        super("Migrations are pending. To resolve this issue, run:\n\n\tbin/rails db:migrate RAILS_ENV=#{::Rails.env}")
+        super("Migrations are pending. To resolve this issue, run:\n\n        bin/rails db:migrate RAILS_ENV=#{::Rails.env}")
       elsif !message
-        super("Migrations are pending. To resolve this issue, run:\n\n\tbin/rails db:migrate")
+        super("Migrations are pending. To resolve this issue, run:\n\n        bin/rails db:migrate")
       else
         super
       end
@@ -145,7 +145,7 @@ module ActiveRecord
 
   class NoEnvironmentInSchemaError < MigrationError #:nodoc:
     def initialize
-      msg = "Environment data not found in the schema. To resolve this issue, run: \n\n\tbin/rails db:environment:set"
+      msg = "Environment data not found in the schema. To resolve this issue, run: \n\n        bin/rails db:environment:set"
       if defined?(Rails.env)
         super("#{msg} RAILS_ENV=#{::Rails.env}")
       else
@@ -168,7 +168,7 @@ module ActiveRecord
       msg =  "You are attempting to modify a database that was last run in `#{ stored }` environment.\n"
       msg << "You are running in `#{ current }` environment. "
       msg << "If you are sure you want to continue, first set the environment using:\n\n"
-      msg << "\tbin/rails db:environment:set"
+      msg << "        bin/rails db:environment:set"
       if defined?(Rails.env)
         super("#{msg} RAILS_ENV=#{::Rails.env}\n\n")
       else


### PR DESCRIPTION
### Summary

When you have an environment mismatch in the DB before running migrations, Rails helpfully gives the command to run to fix the issue.
The output includes a tab character though, and if you select the whole line (e.g. using trip-click on MacOS) and copy/paste, using bash, the <tab> results in bash asking you if you want to see all completions:

```
$ 
Display all 2459 possibilities? (y or n)
```

After the tab, the line starts with `bin/rails`, `b` and `i` have no consequence, but `n` answers no to that prompt, then the prompt ends up being:

```
$ /rails db:environment:set RAILS_ENV=test
-bash: /rails: No such file or directory
```

which fails.
### Other Information
- Only applies to Rails 5 AFAIK.
- Changed the \t into 8 spaces, which AFAIK is the default (see `man tabs` on mac os or [FreeBSD](http://www.freebsd.org/cgi/man.cgi?query=tabs&apropos=0&sektion=0&manpath=FreeBSD+10.3-RELEASE+and+Ports&arch=default&format=html), the linux tabs man page doesn't mention a default)
- The test commands shown by `rails test` don't have this issue.
- I looked for other occurrences of `\t` and couldn't find anything else similar.
- I also left the one in that file on line 119 because it didn't have a command, tell me if you'd like that one changed too
  
  ``` ruby
  super("Illegal name for migration file: #{name}\n\t(only lower case letters, numbers, and '_' allowed).")
  ```

@rafaelfranca 
