### PR TITLE
new method that only cache_if_truthy

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -443,7 +443,7 @@ module ActiveSupport
             write(key, result, options) if result || (options && options[:force])
           end
         elsif options && options[:force]
-          raise ArgumentError, 'Missing block: Calling `Cache#cache_if_true` with `force: true` requires a block.'
+          raise ArgumentError, 'Missing block: Calling `Cache#cache_if_truthy` with `force: true` requires a block.'
         else
           result = read(name, options)
         end

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -422,6 +422,34 @@ module ActiveSupport
         end
       end
 
+      # Caches the result of a method if the result is truthy
+      #
+      # Hence if you do this the result will not be cached:
+      #   cache_if_truthy("User:#{id}:falsy_method") { nil }
+      #
+      # On the other hand this would be cached.
+      #   cache_if_truthy("User:#{id}:truthy_method") { 'a string is truthy in ruby' }
+      #
+      # Note if you only care about a boolean method then the above method should be implemented like this:
+      #   cache_if_truthy("User:#{id}:truthy_method") { !!'a string is truthy in ruby' }
+      #
+      # Thus a large string is not cached, only true or false is returned
+      #
+      def cache_if_truthy(key, options = nil)
+        if block_given?
+          result = read(key, options)
+          if !result || (options && options[:force])
+            result = yield
+            write(key, result, options) if result || (options && options[:force])
+          end
+        elsif options && options[:force]
+          raise ArgumentError, 'Missing block: Calling `Cache#cache_if_true` with `force: true` requires a block.'
+        else
+          result = read(name, options)
+        end
+        result
+      end
+
       # Deletes all entries with keys matching the pattern.
       #
       # Options are passed to the underlying cache implementation.

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -236,6 +236,42 @@ module CacheStoreBehavior
     end
   end
 
+  def test_cache_if_truthy_write
+    assert_called_with(@cache, :write) do
+      assert_equal 'bar', @cache.cache_if_truthy('foo') { 'bar' }
+    end
+  end
+
+  def test_cache_if_truthy_2nd_truthy_write
+    @cache.cache_if_truthy('foo') { 'bar' }
+    assert_equal 'bar', @cache.read('foo')
+
+    assert_not_called(@cache, :write) do
+      assert_equal 'bar', @cache.cache_if_truthy('foo') { 'baz' }
+    end
+  end
+
+  def test_cache_if_truthy_without_false_write
+    assert_not_called(@cache, :write) do
+      assert_equal false, @cache.cache_if_truthy('foo') { false }
+    end
+    assert_equal nil, @cache.read('foo')
+  end
+
+  def test_cache_if_truthy_without_nil_write
+    assert_not_called(@cache, :write) do
+      assert_equal nil, @cache.cache_if_truthy('foo') { nil }
+    end
+    assert_equal nil, @cache.read('foo')
+  end
+
+  def test_cache_if_truthy_without_2nd_false_write
+    @cache.cache_if_truthy('foo') { 'true string' }
+    assert_not_called(@cache, :write) do
+      assert_equal 'true string', @cache.cache_if_truthy('foo') { false }
+    end
+  end
+
   def test_fetch_with_cache_miss
     assert_called_with(@cache, :write, ['foo', 'baz', @cache.options]) do
       assert_equal 'baz', @cache.fetch('foo') { 'baz' }


### PR DESCRIPTION
### Summary

Caches the result of a method if the result is truthy

Hence if you do this the result will not be cached:
  cache_if_truthy("User:#{id}:falsy_method") { nil }

On the other hand this would be cached.
  cache_if_truthy("User:#{id}:truthy_method") { 'a string is truthy in ruby' }

Best used for things like `def has_user_visited_page?`
