### PR TITLE
Enforce minimal web-console version for Rails 5

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -35,7 +35,7 @@ group :development do
   <%- if options.dev? || options.edge? -%>
   gem 'web-console', github: 'rails/web-console'
   <%- else -%>
-  gem 'web-console'
+  gem 'web-console', '>= 3.3.0'
   <%- end -%>
 <%- end -%>
 <% if depend_on_listen? -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -574,7 +574,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_match(/gem 'web-console',\s+github: 'rails\/web-console'/, content)
-      assert_no_match(/\Agem 'web-console'\z/, content)
+      assert_no_match(/\Agem 'web-console', '>= 3.3.0'\z/, content)
     end
   end
 
@@ -583,7 +583,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_match(/gem 'web-console',\s+github: 'rails\/web-console'/, content)
-      assert_no_match(/\Agem 'web-console'\z/, content)
+      assert_no_match(/\Agem 'web-console', '>= 3.3.0'\z/, content)
     end
   end
 


### PR DESCRIPTION
I dropped the version constraint in web-console with the idea it will be
easier to upgrade the console between Rails releases. However, issues
like #25899 started popping up.

I'm reintroducing the constraint, but this time, I don't set an upper
limit to the major version. This will keep the web-console in a version
that always works for the current Rails and can be easily upgraded
to the last one with `bundle update`.

We may need to backport this for Rails 5.0.1.

Fixes #25899.
