### PR TITLE
Fix incorrect indentation in method comment

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -109,10 +109,10 @@ module ActionController #:nodoc:
       # * <tt>:only/:except</tt> - Only apply forgery protection to a subset of actions. For example <tt>only: [ :create, :create_all ]</tt>.
       # * <tt>:if/:unless</tt> - Turn off the forgery protection entirely depending on the passed Proc or method reference.
       # * <tt>:prepend</tt> - By default, the verification of the authentication token will be added at the position of the
-      #    protect_from_forgery call in your application. This means any callbacks added before are run first. This is useful
-      #    when you want your forgery protection to depend on other callbacks, like authentication methods (Oauth vs Cookie auth).
+      #   protect_from_forgery call in your application. This means any callbacks added before are run first. This is useful
+      #   when you want your forgery protection to depend on other callbacks, like authentication methods (Oauth vs Cookie auth).
       #
-      #    If you need to add verification to the beginning of the callback chain, use <tt>prepend: true</tt>.
+      #   If you need to add verification to the beginning of the callback chain, use <tt>prepend: true</tt>.
       # * <tt>:with</tt> - Set the method to handle unverified request.
       #
       # Valid unverified request handling methods are:


### PR DESCRIPTION
Fix incorrect indentation in method comment of [protect_from_forgery](http://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection/ClassMethods.html#method-i-protect_from_forgery)'s valid options.
## Before

<img width="861" alt="screen shot 2016-07-21 at 23 39 55" src="https://cloud.githubusercontent.com/assets/5352/17027113/95436a4c-4f9d-11e6-9870-16e9be63b6d7.png">
## After

<img width="817" alt="screen shot 2016-07-21 at 23 40 08" src="https://cloud.githubusercontent.com/assets/5352/17027122/9ba19ddc-4f9d-11e6-92aa-37d56711d267.png">
