### PR TITLE
Changed partial rendering to allow collections which don't implement `#to_ary`.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Changed partial rendering with a collection to allow collections which
+    don't implement `to_ary`.
+
+    Extracting the collection option has an optimization to avoid unnecessary
+    queries of ActiveRecord Relations by calling `to_ary` on the given
+    collection. Instances of `Enumerator` or `Enumerable` are valid
+    collections, but they do not implement `#to_ary`. They will now be
+    extracted and rendered as expected.
+
+    *Steven Harman*
+
 *   New syntax for tag helpers. Avoid positional parameters and support HTML5 by default.
     Example usage of tag helpers before:
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,11 +1,11 @@
 *   Changed partial rendering with a collection to allow collections which
-    don't implement `to_ary`.
+    implement `to_a`.
 
-    Extracting the collection option has an optimization to avoid unnecessary
-    queries of ActiveRecord Relations by calling `to_ary` on the given
+    Extracting the collection option had an optimization to avoid unnecessary
+    queries of ActiveRecord Relations by calling `#to_ary` on the given
     collection. Instances of `Enumerator` or `Enumerable` are valid
-    collections, but they do not implement `#to_ary`. They will now be
-    extracted and rendered as expected.
+    collections, but they do not implement `#to_ary`. By changing this to
+    `#to_a`, they will now be extracted and rendered as expected.
 
     *Steven Harman*
 

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -404,7 +404,8 @@ module ActionView
     def collection_from_options
       if @options.key?(:collection)
         collection = @options[:collection]
-        collection.respond_to?(:to_ary) ? collection.to_ary : []
+        collection = collection.to_ary if collection.respond_to?(:to_ary)
+        collection
       end
     end
 

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -403,7 +403,7 @@ module ActionView
 
     def collection_from_options
       if @options.key?(:collection)
-        collection = @options[:collection]
+        collection = @options[:collection] || []
         collection = collection.to_ary if collection.respond_to?(:to_ary)
         collection
       end

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -403,9 +403,8 @@ module ActionView
 
     def collection_from_options
       if @options.key?(:collection)
-        collection = @options[:collection] || []
-        collection = collection.to_ary if collection.respond_to?(:to_ary)
-        collection
+        collection = @options[:collection]
+        collection ? collection.to_a : []
       end
     end
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -314,7 +314,7 @@ module RenderTestCases
       y.yield(Customer.new("david"))
       y.yield(Customer.new("mary"))
     end
-    assert_equal "Hello: davidHello: mary", @view.render(:partial => "test/customer", collection: customers)
+    assert_equal "Hello: davidHello: mary", @view.render(partial: "test/customer", collection: customers)
   end
 
   def test_render_partial_without_object_does_not_put_partial_name_to_local_assigns

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -309,6 +309,14 @@ module RenderTestCases
     assert_nil @view.render(:partial => "test/customer", :collection => nil)
   end
 
+  def test_render_partial_collection_for_non_array
+    customers = Enumerator.new do |y|
+      y.yield(Customer.new("david"))
+      y.yield(Customer.new("mary"))
+    end
+    assert_equal "Hello: davidHello: mary", @view.render(:partial => "test/customer", collection: customers)
+  end
+
   def test_render_partial_without_object_does_not_put_partial_name_to_local_assigns
     assert_equal 'false', @view.render(partial: 'test/partial_name_in_local_assigns')
   end


### PR DESCRIPTION
An optimization was introduced in https://github.com/rails/rails/commit/27f4ffd11a91b534fde9b484cb7c4e515ec0fe77 which will call `#to_ary` on the collection to prevent unnecessary queries for ActiveRecord scopes/relations. If the given collection did not respond to `#to_ary`, an empty collection was returned. That meant you couldn't use collections built from `Enumerator` nor `Enumerable`.

With this change, `#collection_from_options` will attempt the optimization, but fall back to passing along the given collection, as-is. This is an alternative to #22005 which will raise an exception if you attempt to use something like an `Enumerator` or `Enumerable` instance.
