### PR TITLE
Fix keyed defaults with root

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix 'defaults' option for root route
+
+    A regression from some refactoring for the 5.0 release, this change
+    fixes the use of 'defaults' (default parameters) in the 'root' routing method
+
+    *Chris Arcand*
+
 *   Check `request.path_parameters` encoding at the point they're set.
 
     Check for any non-UTF8 characters in path parameters at the point they're

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1923,7 +1923,14 @@ to this:
 
         def match_root_route(options)
           name = has_named_route?(:root) ? nil : :root
-          match '/', { :as => name, :via => :get }.merge!(options)
+          defaults_option = options.delete(:defaults)
+          args = ['/', { :as => name, :via => :get }.merge!(options)]
+
+          if defaults_option
+            defaults(defaults_option) { match(*args) }
+          else
+            match(*args)
+          end
         end
       end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1759,6 +1759,24 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal 1, @request.params[:page]
   end
 
+  def test_keyed_default_string_params_with_root
+    draw do
+      root :to => 'pages#show', :defaults => { :id => 'home' }
+    end
+
+    get '/'
+    assert_equal 'home', @request.params[:id]
+  end
+
+  def test_default_string_params_with_root
+    draw do
+      root :to => 'pages#show', :id => 'home'
+    end
+
+    get '/'
+    assert_equal 'home', @request.params[:id]
+  end
+
   def test_resource_constraints
     draw do
       resources :products, :constraints => { :id => /\d{4}/ } do


### PR DESCRIPTION
### Summary

The merging of the 'defaults' option was moved up the stack in e852daa. This allows us to see where these options originate from the standard `HttpHelpers` (`get`, `post`, `patch`, `put`, `delete`)

Unfortunately this move didn't incorporate the 'root' method, which has always allowed the same 'defaults' option.

In short, these routes should be the same (Tested in Rails 3.2, 4.2, 5.0)

```
get "/", to: "something#show", defaults: { something: "something" }

root to: "something#show", defaults: { something: "something" } # defaults broken in 5.0
```

My thanks to @jrafanie for helping bisect this issue and find the regression!
