### PR TITLE
Adds `not_in?` onto Object

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Introduce `not_in?` on `Object`.
+
+    As an opposite method for `in?`, `not_in?` provides equivalent support for exclusion. This turns this:
+
+        [1,2].exclude?(user_id)
+
+    ...into this:
+
+        user_id.not_in?([1,2])
+
+    *Jon McCartie*
+
 *   Defines `Regexp.match?` for Ruby versions prior to 2.4. The predicate
     has the same interface, but it does not have the performance boost. It's
     purpose is to be able to write 2.4 compatible code.

--- a/activesupport/lib/active_support/core_ext/object.rb
+++ b/activesupport/lib/active_support/core_ext/object.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/object/duplicable'
 require 'active_support/core_ext/object/deep_dup'
 require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/object/inclusion'
+require 'active_support/core_ext/object/exclusion'
 
 require 'active_support/core_ext/object/conversions'
 require 'active_support/core_ext/object/instance_variables'

--- a/activesupport/lib/active_support/core_ext/object/exclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/exclusion.rb
@@ -1,0 +1,15 @@
+class Object
+  # Returns true if this object is excluded in the argument. Argument must be
+  # any object which responds to +#include?+. Usage:
+  #
+  #   characters = ["Konata", "Kagami", "Tsukasa"]
+  #   "MoshiMoshi".not_in?(characters) # => true
+  #
+  # This will throw an +ArgumentError+ if the argument doesn't respond
+  # to +#include?+.
+  def not_in?(another_object)
+    !another_object.include?(self)
+  rescue NoMethodError
+    raise ArgumentError.new("The parameter passed to #not_in? must respond to #include?")
+  end
+end

--- a/activesupport/test/core_ext/object/exclusion_test.rb
+++ b/activesupport/test/core_ext/object/exclusion_test.rb
@@ -1,0 +1,53 @@
+require 'abstract_unit'
+require 'active_support/core_ext/object/exclusion'
+
+class NotInTest < ActiveSupport::TestCase
+  def test_not_in_array
+    assert 1.not_in?([2, 3])
+    assert_not 2.not_in?([1,2])
+  end
+
+  def test_not_in_hash
+    h = { "a" => 100, "b" => 200 }
+    assert "z".not_in?(h)
+    assert_not "a".not_in?(h)
+  end
+
+  def test_not_in_string
+    assert "ol".not_in?("hello")
+    assert_not "lo".not_in?("hello")
+    assert ?z.not_in?("hello")
+  end
+
+  def test_not_in_range
+    assert 75.not_in?(1..50)
+    assert_not 25.not_in?(1..50)
+  end
+
+  def test_not_in_set
+    s = Set.new([1,2])
+    assert 3.not_in?(s)
+    assert_not 1.not_in?(s)
+  end
+
+  module A
+  end
+  class B
+    include A
+  end
+  class C < B
+  end
+  class D
+  end
+
+  def test_not_in_module
+    assert A.not_in?(D)
+    assert A.not_in?(A)
+    assert_not A.not_in?(B)
+    assert_not A.not_in?(C)
+  end
+
+  def test_no_method_catching
+    assert_raise(ArgumentError) { 1.not_in?(1) }
+  end
+end


### PR DESCRIPTION
## Introduce `not_in?` on `Object`.

As an opposite method for `in?`, `not_in?` provides equivalent support for exclusion. This turns this:

```
    [1,2].exclude?(user_id)
```

...into this:

```
    user_id.not_in?([1,2])
```
