### PR TITLE
Uglifier should not be included when generating a new app with `--skip-javascript`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   A generated app should not include Uglifier with `--skip-javascript` option.
+
+    *Ben Pickles*
+
 *   Set session store to cookie store internally and remove the initializer from
     the generated app.
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -299,9 +299,11 @@ module Rails
         gems << GemfileEntry.github('sass-rails', 'rails/sass-rails', nil,
                                      'Use SCSS for stylesheets')
 
-        gems << GemfileEntry.version('uglifier',
-                                   '>= 1.3.0',
-                                   'Use Uglifier as compressor for JavaScript assets')
+        if !options[:skip_javascript]
+          gems << GemfileEntry.version('uglifier',
+                                     '>= 1.3.0',
+                                     'Use Uglifier as compressor for JavaScript assets')
+        end
 
         gems
       end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -19,8 +19,12 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   <%- unless options.skip_sprockets? -%>
+  <%- if options.skip_javascript? -%>
+  # Compress CSS.
+  <%- else -%>
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
+  <%- end -%>
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -468,6 +468,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile" do |content|
       assert_no_match(/coffee-rails/, content)
       assert_no_match(/jquery-rails/, content)
+      assert_no_match(/uglifier/, content)
+    end
+
+    assert_file "config/environments/production.rb" do |content|
+      assert_no_match(/config\.assets\.js_compressor = :uglifier/, content)
     end
   end
 


### PR DESCRIPTION
### Summary

When generating a new Rails app with `--skip-javascript` it includes the Uglifier gem and config which seems erroneous. This pull request ensures that these are not included when generating a new app with `--skip-javascript`.
