### PR TITLE
Do not call db in pluck  when collection is already loaded

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -369,6 +369,13 @@ module ActiveRecord
         @association.concat(*records)
       end
 
+      def pluck(*attributes)
+        return records.pluck(*attributes) if loaded?
+
+        scope.pluck(*attributes)
+      end
+
+
       # Replaces this collection with +other_array+. This will perform a diff
       # and delete/add only records that have changed.
       #


### PR DESCRIPTION
Hi. 

I am more then sure this is not a bug, but probably somebody will tell me how to do it in correct way.
### What do I have

In REST controller I try to show all models of specific type. One method of this model is dependent on has_many relationship

```
  def my_method
    has_many_relation.pluck(:my_method)
  end
```

So, I try to preload this relationship in controller

```
def index
  render json: Model.include(:has_many_relation)
end
```

Eager loading works but pluck does not care about it, so I came with this hack

```
has_many_relation.loaded? ? offers.map(&:has_many_relation) : offers.pluck(:has_many_relation)
```

This works but looks like dirty hack. PR fix works but of course it is not correct.

We also notice that pluck itself has more of less common functionality

```
    def pluck(*column_names)
      if loaded? && (column_names.map(&:to_s) - @klass.attribute_names - @klass.attribute_aliases.keys).empty?
        return @records.pluck(*column_names)
      end
```

but it does not work because it is different loaded? and here it is false in case of my eager load

Question is "How to do it in correct way?"
