### PR TITLE
remove needless warning for hstore

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -111,11 +111,6 @@ namespace :db do
       config = ARTest.config["connections"]["postgresql"]
       %x( createdb -E UTF8 -T template0 #{config["arunit"]["database"]} )
       %x( createdb -E UTF8 -T template0 #{config["arunit2"]["database"]} )
-
-      # prepare hstore
-      if %x( createdb --version ).strip.gsub(/(.*)(\d\.\d\.\d)$/, "\\2") < "9.1.0"
-        puts "Please prepare hstore data type. See http://www.postgresql.org/docs/current/static/hstore.html"
-      end
     end
 
     desc "Drop the PostgreSQL test databases"


### PR DESCRIPTION
### Summary

Rails 5 supports only Postgresql 9.1 or higher, warning is needless because
in the case of Postgresql 9.0 or less does not work.
