### PR TITLE
Fix for issue #25926, integrations failing on JRuby due to nil @@app

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -717,7 +717,11 @@ module ActionDispatch
 
       module ClassMethods
         def app
-          defined?(@@app) ? @@app : ActionDispatch.test_app
+          if defined?(@@app) && !@@app.nil?
+            @@app
+          else
+            ActionDispatch.test_app
+          end
         end
 
         def app=(app)


### PR DESCRIPTION
### Summary

The class variable @@app is nil but defined causing integration tests to fail JRuby / Rails 5. This fix checks against both defined and nil?. This is for issue #25926. 
### Other Information

A sample project reproducing the error can be viewed at https://github.com/jkuchta/rails5_test 
