### PR TITLE
Bump Arel to fix few failing tests on Ruby 2.4 related to the Integer unification

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
   specs:
     addressable (2.4.0)
     amq-protocol (2.0.1)
-    arel (7.0.0)
+    arel (7.1.0)
     backburner (1.3.0)
       beaneater (~> 1.0)
       dante (> 0.1.5)


### PR DESCRIPTION
### Summary
- Following tests were failing on Ruby edge 2.4 version -
- RelationTest#test_update_all_with_joins_and_offset_and_order:
- RelationTest#test_update_all_with_joins_and_offset:
- BasicsTest#test_no_limit_offset:
- CalculationsTest#test_offset_is_kept:
- ActiveRecord::CollectionCacheKeyTest#test_cache_key_for_queries_with_offset_which_return_0_rows:
- FinderTest#test_third_to_last:
- As Arel 7.1 supports Integer unification after https://github.com/rails/arel/pull/437 we can use it.
