### PR TITLE
Remove `prepare_binds_for_database` internal method

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -316,7 +316,7 @@ module ActiveRecord
           end
         end
         key_list = fixture.keys.map { |name| quote_column_name(name) }
-        value_list = prepare_binds_for_database(binds).map do |value|
+        value_list = binds.map(&:value_for_database).map do |value|
           begin
             quote(value)
           rescue TypeError

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -150,10 +150,6 @@ module ActiveRecord
         quoted_date(value).sub(/\A2000-01-01 /, '')
       end
 
-      def prepare_binds_for_database(binds) # :nodoc:
-        binds.map(&:value_for_database)
-      end
-
       private
 
       def type_casted_binds(binds)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -130,7 +130,7 @@ module ActiveRecord
 
       class BindCollector < Arel::Collectors::Bind
         def compile(bvs, conn)
-          casted_binds = conn.prepare_binds_for_database(bvs)
+          casted_binds = bvs.map(&:value_for_database)
           super(casted_binds.map { |value| conn.quote(value) })
         end
       end

--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -49,8 +49,8 @@ module ActiveRecord
 
       def sql_for(binds, connection)
         val = @values.dup
-        binds = connection.prepare_binds_for_database(binds)
-        @indexes.each { |i| val[i] = connection.quote(binds.shift) }
+        casted_binds = binds.map(&:value_for_database)
+        @indexes.each { |i| val[i] = connection.quote(casted_binds.shift) }
         val.join
       end
     end


### PR DESCRIPTION
To avoid relying on the connection adapter for type casting binds.
