### PR TITLE
Decouple statement cache from connection adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -18,11 +18,12 @@ module ActiveRecord
 
       # This is used in the StatementCache object. It returns an object that
       # can be used to query the database repeatedly.
-      def cacheable_query(arel) # :nodoc:
+      def cacheable_query(klass, arel) # :nodoc:
+        collected = visitor.accept(arel.ast, collector)
         if prepared_statements
-          ActiveRecord::StatementCache.query visitor, arel.ast
+          klass.query(collected.value)
         else
-          ActiveRecord::StatementCache.partial_query visitor, arel.ast, collector
+          klass.partial_query(collected.value)
         end
       end
 

--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -40,7 +40,7 @@ module ActiveRecord
     end
 
     class PartialQuery < Query # :nodoc:
-      def initialize values
+      def initialize(values)
         @values = values
         @indexes = values.each_with_index.find_all { |thing,i|
           Arel::Nodes::BindParam === thing
@@ -55,13 +55,12 @@ module ActiveRecord
       end
     end
 
-    def self.query(visitor, ast)
-      Query.new visitor.accept(ast, Arel::Collectors::SQLString.new).value
+    def self.query(sql)
+      Query.new(sql)
     end
 
-    def self.partial_query(visitor, ast, collector)
-      collected = visitor.accept(ast, collector).value
-      PartialQuery.new collected
+    def self.partial_query(values)
+      PartialQuery.new(values)
     end
 
     class Params # :nodoc:
@@ -92,7 +91,7 @@ module ActiveRecord
     def self.create(connection, block = Proc.new)
       relation      = block.call Params.new
       bind_map      = BindMap.new relation.bound_attributes
-      query_builder = connection.cacheable_query relation.arel
+      query_builder = connection.cacheable_query(self, relation.arel)
       new query_builder, bind_map
     end
 


### PR DESCRIPTION
`StatementCache` is hard-coded in `cacheable_query` and be passed
`visitor` and `collector` from connection adapter. Simply it is
enough to pass a collected value.
