### PR TITLE
Fix SELECT statement in table_comment for MySQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix the SELECT statement in `#table_comment` for MySQL.
+
+    *Takeshi Akima*
+
 *   Support calling the method `merge` in `scope`'s lambda.
 
     *Yasuhiro Sugino*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -413,7 +413,8 @@ module ActiveRecord
         select_value(<<-SQL.strip_heredoc, 'SCHEMA')
           SELECT table_comment
           FROM information_schema.tables
-          WHERE table_name=#{quote(table_name)}
+          WHERE table_schema=#{quote(current_database)}
+            AND table_name=#{quote(table_name)}
         SQL
       end
 


### PR DESCRIPTION
### Summary

Add  `TABLE_SCHEMA` condition to SELECT statement in `#table_comment`
to get correct comment even if there are tables which have same names
in multiple MySQL databases like these:

```
mysql> SELECT TABLE_SCHEMA, TABLE_NAME, table_comment FROM information_schema.tables WHERE table_name='users';
+-------------------------------+------------+---------------+
| TABLE_SCHEMA                  | TABLE_NAME | table_comment |
+-------------------------------+------------+---------------+
| activerecord_unittest         | users      |               |
| activerecord_unittest2        | users      |  Users        |
+-------------------------------+------------+---------------+
```
