### PR TITLE
Fix behavior of number helpers (`number_to_rounded`, `number_to_human`)

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Fix behavior of number helpers (`number_to_rounded`, `number_to_human`) 
+    with `Float::INFINITY` and `Float::NAN` arguments and `significant: true`
+    option.
+    
+    Previously, following examples would raise `FloatDomainError`:
+        
+        number_to_rounded(Float::INFINITY, precision: 1, significant: true)
+        number_to_rounded(Float::NAN, precision: 1, significant: true)
+        number_to_human(Float::INFINITY)
+        number_to_human(Float::NAN)
+        
+    Now `number_to_rounded` ignores `significant` option if argument is Infinity or NaN,
+    and `number_to_human` returns `'Inf'` or `'NaN'` if argument is Infinity or NaN.
+    
+    *Murad Yusufov*
+    
 *   Since weeks are no longer converted to days, add `:weeks` to the list of
     parts that `ActiveSupport::TimeWithZone` will recognize as possibly being
     of variable duration to take account of DST transitions.

--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -177,6 +177,10 @@ module ActiveSupport
         rescue ArgumentError, TypeError
           false
         end
+
+        def infinity_or_nan?
+          number.infinite? || number.nan?
+        end
     end
   end
 end

--- a/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
@@ -11,6 +11,8 @@ module ActiveSupport
       def convert # :nodoc:
         @number = Float(number)
 
+        return '%00.1f' % BigDecimal(number.to_s) if infinity_or_nan?
+
         # for backwards compatibility with those that didn't add strip_insignificant_zeros to their locale files
         unless options.key?(:strip_insignificant_zeros)
           options[:strip_insignificant_zeros] = true

--- a/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
@@ -17,7 +17,7 @@ module ActiveSupport
             @number = number.to_d
           end
 
-          if options.delete(:significant) && precision > 0
+          if options.delete(:significant) && precision > 0 && !infinity_or_nan?
             digits, rounded_number = digits_and_rounded_number(precision)
             precision -= digits
             precision = 0 if precision < 0 # don't let it be negative

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -195,6 +195,9 @@ module ActiveSupport
           assert_equal "9775.0000000000000000", number_helper.number_to_rounded("9775", :precision => 20, :significant => true )
           assert_equal "9775." + "0"*96, number_helper.number_to_rounded("9775", :precision => 100, :significant => true )
           assert_equal("97.7", number_helper.number_to_rounded(Rational(9772, 100), :precision => 3, :significant => true))
+
+          assert_equal("Inf", number_helper.number_to_rounded(Float::INFINITY, precision: 1, significant: true))
+          assert_equal("NaN", number_helper.number_to_rounded(Float::NAN, precision: 1, significant: true))
         end
       end
 
@@ -311,6 +314,8 @@ module ActiveSupport
           assert_equal '1 Million', number_helper.number_to_human(1234567, :precision => 0, :significant => true, :separator => ',') #significant forced to false
           assert_equal '1 Million', number_helper.number_to_human(999999)
           assert_equal '1 Billion', number_helper.number_to_human(999999999)
+          assert_equal 'Inf', number_helper.number_to_human(Float::INFINITY)
+          assert_equal 'NaN', number_helper.number_to_human(Float::NAN)
         end
       end
 


### PR DESCRIPTION
### Summary

Fix behavior of number helpers (`number_to_rounded`, `number_to_human`) with `Float::INFINITY` and `Float::NAN` arguments and `significant: true` option. Previously, following examples would raise `FloatDomainError`:

```
    number_to_rounded(Float::INFINITY, precision: 1, significant: true)
    number_to_rounded(Float::NAN, precision: 1, significant: true)
    number_to_human(Float::INFINITY)
    number_to_human(Float::NAN)
```

Now `number_to_rounded` ignores `significant` option if argument is `Infinity` or `NaN`, and `number_to_human` returns `'Inf'` or `'NaN'` if argument is `Infinity` or `NaN`.
