### PR TITLE
Fix an exception where content-type is nil

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -65,7 +65,7 @@ module ActionDispatch
       private
 
       def parse_formatted_parameters(parsers)
-        return yield if content_length.zero?
+        return yield if content_length.zero? || content_mime_type.nil?
 
         strategy = parsers.fetch(content_mime_type.symbol) { return yield }
 


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/24827

Rails 5 introduced a new way to handle mime types, unfortunately a nil check was not done, so the call on the next line with `.symbol` caused an exception on [this line](https://github.com/rails/rails/blob/9f38a3fb0c9c71102da283b014503ccad92da581/actionpack/lib/action_dispatch/http/parameters.rb#L70).

I was able to reproduce the bug with a curl request: `curl -d "this is body" -X POST http://localhost:3000/path/to/post -H 'Content-Type:'`. The body is required to pass the content_length check.

I confirmed with a local application that this check fixes the bug. Unit tests are not exactly possible in this case, unfortunately. All of Rails test cases set a default encoding
### Other Information

No Content-Type is totally valid HTTP, as per https://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html#sec7.2.1. 

This also re-introduces behaviour from Rails 4 that was lost in the transition.

cc @rafaelfranca @sgrif 
