### PR TITLE
Fully reset fixtures after a non-transactional test has run

### DIFF
--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -168,6 +168,9 @@ module ActiveRecord
         end
         @fixture_connections.clear
       else
+        # It's impossible to know which fixtures were modified or not,
+        # so the only safe thing to do is to invalidate them all.
+        @@already_loaded_fixtures.clear
         ActiveRecord::FixtureSet.reset_cache
       end
 


### PR DESCRIPTION
### Context

That change might seem weird and the bug improbable, so I think a bit of context is in order.

Our test suite is very large, so to speed it up we parallelize it over a couple hundreds of workers. When you do that, if you don't want workers to finish while others still have a lot more work to do you need to balance your tests across the workers. In our case we dispatch individual test cases and not whole suites. So we can have the following case:

``` ruby
class FooTest < AS::TestCase
  test "bar" do
    assert_equal 3, Person.count
  end

  test "baz" do
    assert_equal 3, Person.count
  end
end

class EggTest < AS::TestCase
  self.use_transactional_tests = false

  test "spam" do
    Person.delete_all
  end
```

With one test worker runnings cases in the following order:

```
FooTest#test_baz
EggTest#test_spam
FooTest#test_bar
```

What happens then is:
- `test_baz` load the fixtures and mark in `@@already_loaded_fixtures` that `FooTest` has it's fixtures loaded.
- `test_spam` totally mess with the database state since it doesn't run in a transaction.
- `test_bar` look into `@@already_loaded_fixtures` and see it doesn't have to reload fixtures, but it's wrong and the database state is corrupted.
### Summary

Basically `setup_fixtures` and `teardown_fixtures` assumes all the test cases in one class will be run consecutively, which in our case isn't true. If you don't assume this, then once a non-transactional test has run, all bets are off fixtures wise.
### Questions
- Is this a use case Rails want to support?
- Is there a better way to implement this? (To be honest I'm not sure I understand how much of a performance impact this change has).

cc @rafaelfranca @sgrif 
