### PR TITLE
Fix accessing provider_job_id inside active jobs for sidekiq adapter

### DIFF
--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -105,6 +105,7 @@ module ActiveJob
     #    end
     def deserialize(job_data)
       self.job_id               = job_data['job_id']
+      self.provider_job_id      = job_data['provider_job_id']
       self.queue_name           = job_data['queue_name']
       self.priority             = job_data['priority']
       self.serialized_arguments = job_data['arguments']

--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -37,7 +37,7 @@ module ActiveJob
         include Sidekiq::Worker
 
         def perform(job_data)
-          Base.execute job_data
+          Base.execute job_data.merge('provider_job_id' => jid)
         end
       end
     end

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -1,6 +1,7 @@
 require 'helper'
 require 'jobs/logging_job'
 require 'jobs/hello_job'
+require 'jobs/provider_jid_job'
 require 'active_support/core_ext/numeric/time'
 
 class QueuingTest < ActiveSupport::TestCase
@@ -31,6 +32,14 @@ class QueuingTest < ActiveSupport::TestCase
       hash = ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper.jobs.first
       assert_equal "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper", hash['class']
       assert_equal "HelloJob", hash['wrapped']
+    end
+  end
+
+  test 'should access provider_job_id inside Sidekiq job' do
+    skip unless adapter_is?(:sidekiq)
+    Sidekiq::Testing.inline! do
+      job = ::ProviderJidJob.perform_later
+      assert_equal "Provider Job ID: #{job.provider_job_id}", JobBuffer.last_value
     end
   end
 

--- a/activejob/test/jobs/provider_jid_job.rb
+++ b/activejob/test/jobs/provider_jid_job.rb
@@ -1,0 +1,7 @@
+require_relative '../support/job_buffer'
+
+class ProviderJidJob < ActiveJob::Base
+  def perform
+    JobBuffer.add("Provider Job ID: #{provider_job_id}")
+  end
+end


### PR DESCRIPTION
Accessing `provider_job_id` attribute inside a job using sidekiq adapter always returns `nil`. I looked at `SidekiqAdapter` class inside `ActiveJob`, and it looks like that enqueue method here already fire the job before assigning its id to `job.provider_job_id`.

```
 def enqueue(job) #:nodoc:
        #Sidekiq::Client does not support symbols as keys
        job.provider_job_id = Sidekiq::Client.push(
          'class'   => JobWrapper,
          'wrapped' => job.class.to_s,
          'queue'   => job.queue_name,
          'args'    => [ job.serialize ])
      end
```

I need to access it so I can use `Sidekiq::Status` [tracking-progress methods](https://github.com/utgarda/sidekiq-status#tracking-progress-saving-and-retrieving-data-associated-with-job). The basic idea behind these methods is to store the progress using the `jid` attribute within `Sidekiq::Worker`. So inside `ActiveJob` while we don't have access to that `jid`attribute, we can easily work around that by using a `before_perform` callback like that

```
class ActiveJob::Base
  attr_accessor :jid

  before_perform do |job|
    job.jid = job.provider_job_id
  end
end
```

but the problem now, is that `provider_job_id` always returns `nil`.

so I fixed this by merging the `jid` to the `job_data` inside `JobWrapper#perform` method, and then assigning it inside `deserialize` method.
