### PR TITLE
Add rationale for checking auth_tag length for AEAD ciphers

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -99,6 +99,10 @@ module ActiveSupport
     def _decrypt(encrypted_message)
       cipher = new_cipher
       encrypted_data, iv, auth_tag = encrypted_message.split("--".freeze).map {|v| ::Base64.strict_decode64(v)}
+
+      # Currently the OpenSSL bindings do not raise an error if auth_tag is
+      # truncated, which would allow an attacker to easily forge it. See
+      # https://github.com/ruby/openssl/issues/63
       raise InvalidMessage if aead_mode? && auth_tag.bytes.length != 16
 
       cipher.decrypt


### PR DESCRIPTION
Seems prudent after this Twitter conversation: https://twitter.com/bdewater/status/757917983993761792

r? @jeremy
