### PR TITLE
Reset rack.input when the environment is scrubbed for the next request

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -620,6 +620,7 @@ module ActionController
         env.delete_if { |k, v| k =~ /^action_dispatch\.rescue/ }
         env.delete 'action_dispatch.request.query_parameters'
         env.delete 'action_dispatch.request.request_parameters'
+        env['rack.input'] = StringIO.new
         env
       end
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -625,6 +625,20 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_post_then_get_with_parameters_do_not_leak_across_requests
+    with_test_route_set do
+      post '/post', params: { leaks: "does-leak?" }
+
+      get '/get_with_params', params: { foo: "bar" }
+
+      assert request.env['rack.input'].string.empty?
+      assert_equal 'foo=bar', request.env["QUERY_STRING"]
+      assert_equal 'foo=bar', request.query_string
+      assert_equal 'bar', request.parameters['foo']
+      assert request.parameters['leaks'].nil?
+    end
+  end
+
   def test_head
     with_test_route_set do
       head '/get'

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -854,6 +854,14 @@ XML
     assert_nil cookies['foo']
   end
 
+  def test_multiple_mixed_method_process_should_scrub_rack_input
+    post :test_params, params: { id: 1, foo: 'an foo' }
+    assert_equal({"id"=>"1", "foo" => "an foo", "controller"=>"test_case_test/test", "action"=>"test_params"}, ::JSON.parse(@response.body))
+
+    get :test_params, params: { bar: 'an bar' }
+    assert_equal({"bar"=>"an bar", "controller"=>"test_case_test/test", "action"=>"test_params"}, ::JSON.parse(@response.body))
+  end
+
   %w(controller response request).each do |variable|
     %w(get post put delete head process).each do |method|
       define_method("test_#{variable}_missing_for_#{method}_raises_error") do


### PR DESCRIPTION
### Summary

Before this change, posted parameters would leak across requests. The included test case failed like so:

```
  1) Failure:
TestCaseTest#test_multiple_mixed_method_process_should_scrub_rack_input:
--- expected
+++ actual
@@ -1 +1 @@
-{"bar"=>"an bar", "controller"=>"test_case_test/test", "action"=>"test_params"}
+{"foo"=>"an foo", "bar"=>"an bar", "controller"=>"test_case_test/test", "action"=>"test_params"}
```

An argument could be made that this situation isn't encountered often and that one should limit the number of requests per test case, but I still think the parameter leaking is an unexpected side-effect.
