### PR TITLE
Don't instantiate attribute values in `column_defaults`

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -247,7 +247,7 @@ module ActiveRecord
       # Returns a hash where the keys are column names and the values are
       # default values when instantiating the AR object for this table.
       def column_defaults
-        _default_attributes.to_hash
+        _default_attributes.dup.to_hash
       end
 
       def _default_attributes # :nodoc:


### PR DESCRIPTION
This bug only occurs on 4-2-stable. The conditions to make it occur
require doing a number of pretty dirty things. All of the following must
be true (roughly in order)
- The column is of a type which coerces to a complex data structure
- The data structure has mutability which is not protected by a shallow
  copy
- You are calling `.dup` on records which have never read or assigned
  that field
- You are mutating values deep inside the datastructure on records which
  have never had a value assigned

The reason this manifested through `.dup` on an Active Record model was
due to how we calculated changes in 4.2, which forced values to be
assigned on the defaults, and as per our documentation we only perform a
shallow copy of attributes, not a deep one. This issue does not occur on
5.0 and later due to sweeping changes in how duplication and dirty
tracking occur.

Fixes #25954
