### PR TITLE
Backport #25146 to 5-0-stable

### DIFF
--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -42,7 +42,7 @@ module ActiveRecord
     end
 
     def associated_table(table_name)
-      association = klass._reflect_on_association(table_name)
+      association = klass._reflect_on_association(table_name) || klass._reflect_on_association(table_name.singularize)
 
       if !association && table_name == arel_table.name
         return self

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -659,4 +659,22 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
     assert_deprecated { firm.account(true) }
   end
+
+  class SpecialBook < ActiveRecord::Base
+    self.table_name = 'books'
+    belongs_to :author, class_name: 'SpecialAuthor'
+  end
+
+  class SpecialAuthor < ActiveRecord::Base
+    self.table_name = 'authors'
+    has_one :book, class_name: 'SpecialBook', foreign_key: 'author_id'
+  end
+
+  def test_assocation_enum_works_properly
+    author = SpecialAuthor.create!(name: 'Test')
+    book = SpecialBook.create!(status: 'published')
+    author.book = book
+
+    refute_equal 0, SpecialAuthor.joins(:book).where(books: { status: 'published' } ).count
+  end
 end


### PR DESCRIPTION
Backports #25146

Fix `has_one` `enum` `where` queries
