### PR TITLE
`@quoted_{column,table}_names` should cache a frozen string

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -5,11 +5,11 @@ module ActiveRecord
         QUOTED_TRUE, QUOTED_FALSE = '1'.freeze, '0'.freeze
 
         def quote_column_name(name)
-          @quoted_column_names[name] ||= "`#{super.gsub('`', '``')}`"
+          @quoted_column_names[name] ||= "`#{super.gsub('`', '``')}`".freeze
         end
 
         def quote_table_name(name)
-          @quoted_table_names[name] ||= super.gsub('.', '`.`')
+          @quoted_table_names[name] ||= super.gsub('.', '`.`').freeze
         end
 
         def quoted_true

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -28,7 +28,7 @@ module ActiveRecord
         # - "schema.name".table_name
         # - "schema.name"."table.name"
         def quote_table_name(name) # :nodoc:
-          @quoted_table_names[name] ||= Utils.extract_schema_qualified_name(name.to_s).quoted
+          @quoted_table_names[name] ||= Utils.extract_schema_qualified_name(name.to_s).quoted.freeze
         end
 
         # Quotes schema names for use in SQL queries.
@@ -42,7 +42,7 @@ module ActiveRecord
 
         # Quotes column names for use in SQL queries.
         def quote_column_name(name) # :nodoc:
-          @quoted_column_names[name] ||= PGconn.quote_ident(super)
+          @quoted_column_names[name] ||= PGconn.quote_ident(super).freeze
         end
 
         # Quote date/time values for use in SQL input.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -11,7 +11,7 @@ module ActiveRecord
         end
 
         def quote_column_name(name)
-          @quoted_column_names[name] ||= %Q("#{super.gsub('"', '""')}")
+          @quoted_column_names[name] ||= %Q("#{super.gsub('"', '""')}").freeze
         end
 
         def quoted_time(value)


### PR DESCRIPTION
Caching a mutable string causes the following issue.

```
Loading development environment (Rails 5.1.0.alpha)
irb(main):001:0> ActiveRecord::Base.connection.quote_table_name('foo') << '!!'
=> "`foo`!!"
irb(main):002:0> ActiveRecord::Base.connection.quote_table_name('foo') << '!!'
=> "`foo`!!!!"
irb(main):003:0> ActiveRecord::Base.connection.quote_table_name('foo') << '!!'
=> "`foo`!!!!!!"
```
