### PR TITLE
Set ActionCable's allowed_request_origins to include local IPs

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -22,7 +22,12 @@ module ActionCable
 
     initializer "action_cable.set_configs" do |app|
       options = app.config.action_cable
-      options.allowed_request_origins ||= /https?:\/\/localhost:\d+/ if ::Rails.env.development?
+      if ::Rails.env.development? && options.allowed_request_origins.nil?
+        local_ips = ["localhost"] + Socket.ip_address_list.select{|ip| ip.ipv4?}.map do |ip|
+          ip.ip_address
+        end
+        options.allowed_request_origins = local_ips.map {|ip| Regexp.new("https?:\/\/#{ip}:\\d+")}
+      end
 
       app.paths.add "config/cable", with: "config/cable.yml"
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Set ActionCable's allowed_request_origins to include IP addresses during development
+
+    By default when in development, Action Cable's allowed_request_origins
+    includes http://localhost:3000.  Because it is compelling to experiment
+    with Action Cable applications using multiple machines, when running in
+    development this update finds all IPv4 addresses and adds them into
+    allowed_request_origins.  It does not affect test and production
+    environments at all.
+
+    *Lorin Thwaits*
+
 *   A generated app should not include Uglifier with `--skip-javascript` option.
 
     *Ben Pickles*

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -3,6 +3,8 @@ require 'env_helpers'
 require 'server_helpers'
 require 'rails/commands/server'
 
+ActiveSupport::TestCase.test_order = :sorted
+
 class Rails::ServerTest < ActiveSupport::TestCase
   include EnvHelpers, ServerHelpers
 

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -1,9 +1,10 @@
 require 'abstract_unit'
 require 'env_helpers'
+require 'server_helpers'
 require 'rails/commands/server'
 
 class Rails::ServerTest < ActiveSupport::TestCase
-  include EnvHelpers
+  include EnvHelpers, ServerHelpers
 
   def test_environment_with_server_option
     args    = ["thin", "-e", "production"]
@@ -55,6 +56,41 @@ class Rails::ServerTest < ActiveSupport::TestCase
     switch_env "HOST", "1.2.3.4" do
       server = Rails::Server.new
       assert_equal "1.2.3.4", server.options[:Host]
+    end
+  end
+
+  def test_actioncable_allowed_request_origins_get_set_properly_during_development
+    begin
+      primary_ip = "1.2.3.4"
+      server = Rails::Server.new
+      with_rack_env 'development' do
+        switch_env "HOST", primary_ip do
+          initialize_app_for(server, primary_ip)
+
+          allowed_request_origins = server.app.config.action_cable.allowed_request_origins
+          assert_includes allowed_request_origins, Regexp.new("https?:\/\/localhost:\\d+")
+          assert_includes allowed_request_origins, Regexp.new("https?:\/\/127.0.0.1:\\d+")
+          assert_includes allowed_request_origins, Regexp.new("https?:\/\/#{primary_ip}:\\d+")
+        end
+      end
+    ensure
+      teardown_app_for(server)
+    end
+  end
+
+  def test_actioncable_allowed_request_origins_are_not_set_during_production
+    begin
+      primary_ip = "1.2.3.4"
+      server = Rails::Server.new
+      with_rack_env 'production' do
+        switch_env "HOST", primary_ip do
+          initialize_app_for(server, primary_ip)
+
+          assert_equal nil, server.app.config.action_cable.allowed_request_origins
+        end
+      end
+    ensure
+      teardown_app_for(server)
     end
   end
 

--- a/railties/test/config.ru
+++ b/railties/test/config.ru
@@ -1,0 +1,3 @@
+# This file is used by server tests that need to initialize the application.
+
+run Rails.application

--- a/railties/test/server_helpers.rb
+++ b/railties/test/server_helpers.rb
@@ -1,0 +1,39 @@
+require 'minitest/mock'
+
+module ServerHelpers
+  private
+
+  def initialize_app_for(server, primary_ip = "1.2.3.4")
+    server.options[:config].gsub! "/railties/config.ru", "/railties/test/config.ru"
+    server.app.config.eager_load = false
+    server.app.config.session_store :cookie_store, key: '_Test_session'
+
+    fake_ip = Struct.new :ip_address, :ipv4?
+    local_ips = [
+      fake_ip.new("::1", false),
+      fake_ip.new("127.0.0.1", true),
+      fake_ip.new("127.0.0.1", true),
+      fake_ip.new("fe80::1%lo0", false),
+      fake_ip.new("fe80::1234:5678:9abc:def0%en0", false),
+      fake_ip.new(primary_ip, true)
+    ]
+
+    Socket.stub :ip_address_list, lambda { local_ips } do
+      server.app.initialize!
+    end
+  end
+
+  # Tear down just enough of the Rails::Application so it can be fully initialized again.
+  # This approach allows us to examine how parameters are set after going through the
+  # initialization process when running "rails server"
+  def teardown_app_for(server)
+    # This lets us get past "RuntimeError: Application has been already initialized."
+    server.app.instance_variable_set("@initialized", false)
+    # Forget about any instances
+    server.app.class.instance_variable_set(:@instance, nil)
+    # This lets us get to "can't modify frozen array" or past "Expected nil (NilClass) to respond to #include?."
+    server.app.remove_instance_variable(:@ran) if server.app.instance_variable_defined?(:@ran)
+    # This gets us past "can't modify frozen array"
+    server.app.routes_reloader.instance_variable_set(:@paths, [])
+  end
+end


### PR DESCRIPTION
By default when in development, Action Cable's allowed_request_origins
includes http://localhost:3000.  Because it is compelling to experiment
with Action Cable applications using multiple machines, when running in
development this update finds all IPv4 addresses and adds them into
allowed_request_origins.  It does not affect test and production
environments at all.

When running "rails s -b 0.0.0.0" the system will allow other machines
on the same network to easily use Action Cable channels without having
to explicitly configure a static IP address in development.rb.

As a convenience for testing, this new helper file is included:

```
railties/test/server_helpers.rb
```

It allows objects built with the Rails::Server class to go through
the .app.initialize! process, and also be torn back down enough to
have new settings applied for the host, port, and environment and
then be initialized again. (This gets used here to confirm that there
are no changes to allowed_request_origins when in production.)
#25979
