### PR TITLE
Fix does_not_support_reverse? to find sql functions with commas in nested brackets

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1137,7 +1137,7 @@ module ActiveRecord
 
     def does_not_support_reverse?(order)
       # Uses SQL function with multiple arguments.
-      /\([^()]*,[^()]*\)/.match?(order)  ||
+      order.split(',').find { |section| section.count('(') != section.count(')')}   ||
       # Uses "nulls first" like construction.
       /nulls (first|last)\Z/i.match?(order)
     end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1137,7 +1137,7 @@ module ActiveRecord
 
     def does_not_support_reverse?(order)
       # Uses SQL function with multiple arguments.
-      order.split(',').find { |section| section.count('(') != section.count(')')}   ||
+      (order.include?(',') && order.split(',').find { |section| section.count('(') != section.count(')')})   ||
       # Uses "nulls first" like construction.
       /nulls (first|last)\Z/i.match?(order)
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -240,6 +240,15 @@ class RelationTest < ActiveRecord::TestCase
     assert_raises(ActiveRecord::IrreversibleOrderError) do
       Topic.order("concat(author_name, title)").reverse_order
     end
+    assert_raises(ActiveRecord::IrreversibleOrderError) do
+      Topic.order("concat(lower(author_name), title)").reverse_order
+    end
+    assert_raises(ActiveRecord::IrreversibleOrderError) do
+      Topic.order("concat(author_name, lower(title))").reverse_order
+    end
+    assert_raises(ActiveRecord::IrreversibleOrderError) do
+      Topic.order("concat(lower(author_name), title, length(title)").reverse_order
+    end
   end
 
   def test_reverse_order_with_nulls_first_or_last


### PR DESCRIPTION
### Summary

`does_not_support_reverse?` is supposed to check if a query statement is too complex to reverse its order. One of the scenarios is if there is a sql function with multiple arguments, by using `/\([^()]*,[^()]*\)/` to match. However, it doesn't catch the case when a query statement has nested parentheses. For instance, `concat(author_name, lower(title))` is regarded as supported to do reverse, and `User.order(concat(author_name, lower(title))).last`will raise a sql syntax or undefined column error that is quite confusing, because it does try to reverse the order
### Other Information

The new implementation is a bit longer but is not necessarily slower. Here's the benchmark for order statements in different complexity levels:

``` ruby
def new_does_not_support_reverse?(order)
    (order.include?(',') && order.split(',').find { |section| section.count('(') != section.count(')')}) || /nulls (first|last)\Z/i.match?(order)
end

def does_not_support_reverse?(order)
    /\([^()]*,[^()]*\)/.match?(order) || /nulls (first|last)\Z/i.match?(order)
end

single_order = 'author_name DESC'
multiple_order = 'author_name ASC, lower(title)'
complex_order = 'concat(author_name, lower(title)) ASC'

Benchmark.bm do |x|
    x.report { 10_000.times do; does_not_support_reverse?(single_order); end }
    x.report { 10_000.times do; new_does_not_support_reverse?(single_order); end }
end
#       user     system      total        real
#   0.010000   0.000000   0.010000 (  0.014889)
#   0.010000   0.000000   0.010000 (  0.006995)

Benchmark.bm do |x|
    x.report { 10_000.times do; does_not_support_reverse?(multiple_order); end }
    x.report { 10_000.times do; new_does_not_support_reverse?(multiple_order); end }
end
#       user     system      total        real
#   0.010000   0.000000   0.010000 (  0.013635)
#   0.020000   0.000000   0.020000 (  0.022306)

Benchmark.bm do |x|
    x.report { 10_000.times do; does_not_support_reverse?(complex_order); end }
    x.report { 10_000.times do; new_does_not_support_reverse?(complex_order); end }
end
#       user     system      total        real
#   0.020000   0.000000   0.020000 (  0.021635)
#   0.010000   0.000000   0.010000 (  0.011312)
```
