### PR TITLE
Prevents a bug when using ActionController::Live with no session

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -217,7 +217,7 @@ module ActionController
 
       def before_committed
         super
-        jar = request.cookie_jar
+        return unless jar = request.cookie_jar
         # The response can be committed multiple times
         jar.write self unless committed?
       end


### PR DESCRIPTION
I noticed this bug after removing Devise and Warden from the application. I guess Warden middleware would ensure that cookie_jar always existed before. After removing it I noticed one of my tests failure in such scenario since this request does not require authentication and was able to confirm in an anonymous session by accessing the address for the first time and it crashed the application server.
