### PR TITLE
Fix `pluck` with `limit` and `having` query for MySQL

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -407,7 +407,7 @@ module ActiveRecord
         relation = relation.except(:includes, :eager_load, :preload)
         relation = relation.joins join_dependency
 
-        if using_limitable_reflections?(join_dependency.reflections)
+        if using_limitable_reflections?(join_dependency.reflections) || relation.having_clause.any?
           relation
         else
           if relation.limit_value

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -1,4 +1,5 @@
 require "cases/helper"
+require "models/author"
 require "models/book"
 require "models/club"
 require "models/company"
@@ -26,7 +27,7 @@ class NumericData < ActiveRecord::Base
 end
 
 class CalculationsTest < ActiveRecord::TestCase
-  fixtures :companies, :accounts, :topics, :speedometers, :minivans, :books
+  fixtures :companies, :accounts, :topics, :speedometers, :minivans, :books, :authors
 
   def test_should_sum_field
     assert_equal 318, Account.sum(:credit_limit)
@@ -644,6 +645,13 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_pluck_with_includes_limit_and_empty_result
     assert_equal [], Topic.includes(:replies).limit(0).pluck(:id)
     assert_equal [], Topic.includes(:replies).limit(1).where("0 = 1").pluck(:id)
+  end
+
+  def test_pluck_with_limit_and_having
+    expected = [["David", 4]]
+    actual = Author.includes(:books).group(:id).limit(1)
+      .having("authors.name = 'David'").pluck("authors.name, COUNT(books.id)")
+    assert_equal expected, actual
   end
 
   def test_pluck_not_auto_table_name_prefix_if_column_included


### PR DESCRIPTION
MySQL have the limitation of columns that can be used in having clause.
Therefore It should not replace the select list when having clause exists.

Fixes #8103.
