### PR TITLE
Remove internal `sanitize` method

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -5,13 +5,6 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
-      # Used to sanitize objects before they're used in an SQL SELECT statement.
-      # Delegates to {connection.quote}[rdoc-ref:ConnectionAdapters::Quoting#quote].
-      def sanitize(object) # :nodoc:
-        connection.quote(object)
-      end
-      alias_method :quote_value, :sanitize
-
       protected
 
       # Accepts an array or string of SQL conditions and sanitizes
@@ -216,7 +209,7 @@ module ActiveRecord
 
     # TODO: Deprecate this
     def quoted_id # :nodoc:
-      self.class.quote_value(@attributes[self.class.primary_key].value_for_database)
+      self.class.connection.quote(@attributes[self.class.primary_key].value_for_database)
     end
   end
 end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -877,11 +877,6 @@ class FinderTest < ActiveRecord::TestCase
     assert_kind_of Time, Topic.where(["id = :id", { id: 1 }]).first.written_on
   end
 
-  def test_string_sanitation
-    assert_not_equal "'something ' 1=1'", ActiveRecord::Base.sanitize("something ' 1=1")
-    assert_equal "'something; select table'", ActiveRecord::Base.sanitize("something; select table")
-  end
-
   def test_count_by_sql
     assert_equal(0, Entrant.count_by_sql("SELECT COUNT(*) FROM entrants WHERE id > 3"))
     assert_equal(1, Entrant.count_by_sql(["SELECT COUNT(*) FROM entrants WHERE id > ?", 2]))


### PR DESCRIPTION
Currently internal `sanitize`/`quote_value` method is only used for `quoted_id`.
Simply it is enough to use `connection.quote` public API instead.
