### PR TITLE
Suppress warnings

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -34,6 +34,7 @@ module Rails
         @public_file_server.index_name   = "index"
         @force_ssl                       = false
         @ssl_options                     = {}
+        @session_store                   = nil
         @time_zone                       = "UTC"
         @beginning_of_week               = :monday
         @log_level                       = nil


### PR DESCRIPTION
This commit suppressed
`warning: instance variable @session_store not initialized`.
e5a6f7ee9e951dbe0e4e9ea2c0743b4dfb135c57 introduced these
warnings.
