### PR TITLE
`sql_for_insert` should be called inside `exec_insert`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -90,6 +90,7 @@ module ActiveRecord
       # +binds+ as the bind substitutes. +name+ is logged along with
       # the executed +sql+ statement.
       def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil)
+        sql, binds = sql_for_insert(sql, pk, nil, sequence_name, binds)
         exec_query(sql, name, binds)
       end
 
@@ -121,8 +122,7 @@ module ActiveRecord
       # If the next id was calculated in advance (as in Oracle), it should be
       # passed in as +id_value+.
       def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [])
-        sql, binds, pk, sequence_name = sql_for_insert(to_sql(arel, binds), pk, id_value, sequence_name, binds)
-        value = exec_insert(sql, name, binds, pk, sequence_name)
+        value = exec_insert(to_sql(arel, binds), name, binds, pk, sequence_name)
         id_value || last_inserted_id(value)
       end
       alias create insert

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -134,16 +134,20 @@ module ActiveRecord
         end
 
         def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil)
-          val = exec_query(sql, name, binds)
-          if !use_insert_returning? && pk
+          if use_insert_returning? || pk == false
+            super
+          else
+            result = exec_query(sql, name, binds)
             unless sequence_name
               table_ref = extract_table_ref_from_insert_sql(sql)
-              sequence_name = default_sequence_name(table_ref, pk)
-              return val unless sequence_name
+              if table_ref
+                pk = primary_key(table_ref) if pk.nil?
+                pk = suppress_composite_primary_key(pk)
+                sequence_name = default_sequence_name(table_ref, pk)
+              end
+              return result unless sequence_name
             end
             last_insert_id_result(sequence_name)
-          else
-            val
           end
         end
 

--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -5,6 +5,13 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
     @connection = ActiveRecord::Base.connection
   end
 
+  unless current_adapter?(:OracleAdapter)
+    def test_exec_insert
+      result = @connection.exec_insert("INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)", nil, [])
+      assert_not_nil @connection.send(:last_inserted_id, result)
+    end
+  end
+
   def test_insert_should_return_the_inserted_id
     assert_not_nil return_the_inserted_id(method: :insert)
   end


### PR DESCRIPTION
`exec_insert` cannot return last inserted id if `use_insert_returning?`
is true. `sql_for_insert` should be called inside `exec_insert`.
