### PR TITLE
remove unnecessary require and extend

### DIFF
--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -36,8 +36,6 @@ module RailtiesTest
       add_to_env_config "development", "config.assets.digest = false"
 
       boot_rails
-      require 'rack/test'
-      extend Rack::Test::Methods
 
       get "/assets/engine.js"
       assert_match "alert()", last_response.body
@@ -321,8 +319,6 @@ module RailtiesTest
       RUBY
 
       boot_rails
-      require 'rack/test'
-      extend Rack::Test::Methods
 
       get "/sprokkit"
       assert_equal "I am a Sprokkit", last_response.body
@@ -359,8 +355,6 @@ module RailtiesTest
       RUBY
 
       boot_rails
-      require 'rack/test'
-      extend Rack::Test::Methods
 
       get '/foo'
       assert_equal 'foo', last_response.body
@@ -449,8 +443,6 @@ YAML
       RUBY
 
       boot_rails
-      require 'rack/test'
-      extend Rack::Test::Methods
 
       get "/admin/foo/bar"
       assert_equal 200, last_response.status


### PR DESCRIPTION
`rack/test` is require at the top of file.
https://github.com/rails/rails/blob/master/railties/test/railties/engine_test.rb#L3

In addtion, `Rack::Test::Methods` is include in class, extend is unnecessary.
https://github.com/rails/rails/blob/master/railties/test/railties/engine_test.rb#L9
