### PR TITLE
Fix override issue for scope and limit in find_in_batches

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -239,6 +239,5 @@ module ActiveRecord
     def batch_order
       "#{quoted_table_name}.#{quoted_primary_key} ASC"
     end
-
   end
 end


### PR DESCRIPTION
I've added a argument key for both `find_in_batches` and `find_each` named as `ignore_order_and_limit`. 

If no value is provided by user then its default value is assumed to be true and the scopes `limit` and `order` are ignored. So the record are sorted by primary key(id by default).

But if its value is false then the scopes `limit` and `order` provided by user are not ignored and the records are sorted by the column user has provided in the order scope.

Now user can call both the methods `find_in_batches` and `find_each` with an extra argument `ignore_order_and_limit: false` in order to have the scopes `order` and `limit` to be considered.

Reslove #26006 
