### PR TITLE
Fix inconsistent the signature of finder methods for collection association

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -111,40 +111,40 @@ module ActiveRecord
         end
       end
 
-      def first(*args)
-        first_nth_or_last(:first, *args)
+      def first(limit = nil)
+        find_nth_or_last(:first, limit)
       end
 
-      def second(*args)
-        first_nth_or_last(:second, *args)
+      def second
+        find_nth_or_last(:second)
       end
 
-      def third(*args)
-        first_nth_or_last(:third, *args)
+      def third
+        find_nth_or_last(:third)
       end
 
-      def fourth(*args)
-        first_nth_or_last(:fourth, *args)
+      def fourth
+        find_nth_or_last(:fourth)
       end
 
-      def fifth(*args)
-        first_nth_or_last(:fifth, *args)
+      def fifth
+        find_nth_or_last(:fifth)
       end
 
-      def forty_two(*args)
-        first_nth_or_last(:forty_two, *args)
+      def forty_two
+        find_nth_or_last(:forty_two)
       end
 
-      def third_to_last(*args)
-        first_nth_or_last(:third_to_last, *args)
+      def third_to_last
+        find_nth_or_last(:third_to_last)
       end
 
-      def second_to_last(*args)
-        first_nth_or_last(:second_to_last, *args)
+      def second_to_last
+        find_nth_or_last(:second_to_last)
       end
 
-      def last(*args)
-        first_nth_or_last(:last, *args)
+      def last(limit = nil)
+        find_nth_or_last(:last, limit)
       end
 
       def take(limit = nil)
@@ -642,11 +642,9 @@ module ActiveRecord
         end
 
         # Fetches the first/last using SQL if possible, otherwise from the target array.
-        def first_nth_or_last(type, *args)
-          args.shift if args.first.is_a?(Hash) && args.first.empty?
-
+        def find_nth_or_last(ordinal, limit = nil)
           collection = find_from_target? ? load_target : scope
-          collection.send(type, *args)
+          limit ? collection.send(ordinal, limit) : collection.send(ordinal)
         end
     end
   end

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -167,44 +167,44 @@ module ActiveRecord
       #   another_person_without.pets          # => []
       #   another_person_without.pets.first    # => nil
       #   another_person_without.pets.first(3) # => []
-      def first(*args)
-        @association.first(*args)
+      def first(limit = nil)
+        @association.first(limit)
       end
 
       # Same as #first except returns only the second record.
-      def second(*args)
-        @association.second(*args)
+      def second
+        @association.second
       end
 
       # Same as #first except returns only the third record.
-      def third(*args)
-        @association.third(*args)
+      def third
+        @association.third
       end
 
       # Same as #first except returns only the fourth record.
-      def fourth(*args)
-        @association.fourth(*args)
+      def fourth
+        @association.fourth
       end
 
       # Same as #first except returns only the fifth record.
-      def fifth(*args)
-        @association.fifth(*args)
+      def fifth
+        @association.fifth
       end
 
       # Same as #first except returns only the forty second record.
       # Also known as accessing "the reddit".
-      def forty_two(*args)
-        @association.forty_two(*args)
+      def forty_two
+        @association.forty_two
       end
 
       # Same as #first except returns only the third-to-last record.
-      def third_to_last(*args)
-        @association.third_to_last(*args)
+      def third_to_last
+        @association.third_to_last
       end
 
       # Same as #first except returns only the second-to-last record.
-      def second_to_last(*args)
-        @association.second_to_last(*args)
+      def second_to_last
+        @association.second_to_last
       end
 
       # Returns the last record, or the last +n+ records, from the collection.
@@ -233,8 +233,8 @@ module ActiveRecord
       #   another_person_without.pets         # => []
       #   another_person_without.pets.last    # => nil
       #   another_person_without.pets.last(3) # => []
-      def last(*args)
-        @association.last(*args)
+      def last(limit = nil)
+        @association.last(limit)
       end
 
       # Gives a record (or N records if a parameter is supplied) from the collection

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -380,47 +380,38 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_no_queries do
       bulbs.first()
-      bulbs.first({})
     end
 
     assert_no_queries do
       bulbs.second()
-      bulbs.second({})
     end
 
     assert_no_queries do
       bulbs.third()
-      bulbs.third({})
     end
 
     assert_no_queries do
       bulbs.fourth()
-      bulbs.fourth({})
     end
 
     assert_no_queries do
       bulbs.fifth()
-      bulbs.fifth({})
     end
 
     assert_no_queries do
       bulbs.forty_two()
-      bulbs.forty_two({})
     end
 
     assert_no_queries do
       bulbs.third_to_last()
-      bulbs.third_to_last({})
     end
 
     assert_no_queries do
       bulbs.second_to_last()
-      bulbs.second_to_last({})
     end
 
     assert_no_queries do
       bulbs.last()
-      bulbs.last({})
     end
   end
 


### PR DESCRIPTION
`#second`, `#third`, etc finder methods was added in 03855e790de2224519f55382e3c32118be31eeff.
But the signature of these methods is inconsistent with the original
finder methods. And also the signature of `#first` and `#last` methods
is different from the original. This commit fixes the inconsistency.
