### PR TITLE
add more array methods to straight delegation to speed up calling them

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -38,7 +38,7 @@ module ActiveRecord
 
     delegate :to_xml, :encode_with, :length, :collect, :map, :each, :all?, :include?, :to_ary, :join,
              :[], :&, :|, :+, :-, :sample, :reverse, :compact, :in_groups, :in_groups_of,
-             :shuffle, :split, to: :records
+             :shuffle, :split, :index, to: :records
 
     delegate :table_name, :quoted_table_name, :primary_key, :quoted_primary_key,
              :connection, :columns_hash, :to => :klass


### PR DESCRIPTION
Noticed a big slowdown when upgrading from rails 3 ... tracked it down to `collection.index` taking a very long time because it hits method_missing ... so adding more of the obvious array methods to straight up delegations.
