### PR TITLE
Clarify expires_now documentation

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -242,8 +242,9 @@ module ActionController
       response.date = Time.now unless response.date?
     end
 
-    # Sets an HTTP 1.1 Cache-Control header of <tt>no-cache</tt> so no caching should
-    # occur by the browser or intermediate caches (like caching proxy servers).
+    # Sets an HTTP 1.1 Cache-Control header of <tt>no-cache</tt>. This means the
+    # resource will be marked as stale, so clients must always revalidate.
+    # Intermediate/browser caches may still store the asset.
     def expires_now
       response.cache_control.replace(:no_cache => true)
     end


### PR DESCRIPTION
Changed my mind about #19556 to @matthewd's position. For those unfamiliar with HTTP caching, the docs (and the value set in the method) could be confusing. 
#19556 brought up that the documentation for expires_now is somewhat confusing. In most caching contexts (like in Rails fragment caching), saying you're "not caching" something means that the value is not stored anywhere and must be recalculated every time. This is not how it works in HTTP, so a method that sets "no_cache" may be misread as "don't allow the client or intermediate caches to store this value." This change makes that explicit, so no one accidentally uses `expire_now` to try to prevent sensitive information from being cached.
