### PR TITLE
Make Parameters support legacy YAML encodings.

### DIFF
--- a/actionpack/test/controller/parameters/serialization_test.rb
+++ b/actionpack/test/controller/parameters/serialization_test.rb
@@ -1,0 +1,32 @@
+require 'abstract_unit'
+require 'action_controller/metal/strong_parameters'
+require 'active_support/core_ext/string/strip'
+
+class ParametersSerializationTest < ActiveSupport::TestCase
+  test 'yaml serialization' do
+    assert_equal <<-end_of_yaml.strip_heredoc, YAML.dump(ActionController::Parameters.new(key: :value))
+      --- !ruby/object:ActionController::Parameters
+      parameters: !ruby/hash:ActiveSupport::HashWithIndifferentAccess
+        key: :value
+      permitted: false
+    end_of_yaml
+  end
+
+  test 'yaml deserialization' do
+    params = ActionController::Parameters.new(key: :value)
+    roundtripped = YAML.load(YAML.dump(params))
+
+    assert_equal params, roundtripped
+    assert_not roundtripped.permitted?
+  end
+
+  test 'yaml backwardscompatible with hash inheriting parameters' do
+    assert_equal ActionController::Parameters.new(key: :value), YAML.load(<<-end_of_yaml.strip_heredoc)
+      --- !ruby/hash-with-ivars:ActionController::Parameters
+      elements:
+        key: :value
+      ivars:
+        :@permitted: false
+    end_of_yaml
+  end
+end


### PR DESCRIPTION
By changing ActionController::Parameter's superclass, Rails 5 also changed
the YAML serialization format.

Since YAML doesn't know how to handle parameters it would fallback to its
routine for the superclass, which in Rails 4.2 was Hash while just Object
in Rails 5. As evident in the tags YAML would spit out:

4.2: !ruby/hash-with-ivars:ActionController::Parameters
5.0: !ruby/object:ActionController::Parameters

Thus when loading parameters YAML from 4.2 in Rails 5, it would parse a
hash dump as it would an Object class.

To fix this we have to provide our own `init_with` to be aware of the past
format as well as the new one. Then we add a `load_tags` mapping, such that
when the YAML parser sees `!ruby/hash-with-ivars:ActionController::Parameters`,
it knows to call our `init_with` function and not try to instantiate it as
a normal hash subclass.
