### PR TITLE
Support multiple indexes on the same column when loading the schema

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -212,7 +212,7 @@ module ActiveRecord
 
       def initialize(name, temporary = false, options = nil, as = nil, comment: nil)
         @columns_hash = {}
-        @indexes = {}
+        @indexes = []
         @foreign_keys = []
         @primary_keys = nil
         @temporary = temporary
@@ -328,7 +328,7 @@ module ActiveRecord
       #
       #   index(:account_id, name: 'index_projects_on_account_id')
       def index(column_name, options = {})
-        indexes[column_name] = options
+        indexes << [column_name, options]
       end
 
       def foreign_key(table_name, options = {}) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -278,7 +278,7 @@ module ActiveRecord
         result = execute schema_creation.accept td
 
         unless supports_indexes_in_create?
-          td.indexes.each_pair do |column_name, index_options|
+          td.indexes.each do |column_name, index_options|
             add_index(table_name, column_name, index_options)
           end
         end


### PR DESCRIPTION
We use Postgres for quite a few of our Rails applications, and one of the things we use constantly are partial unique indices, allowing us to have multiple indices on 1 column with different restrictions based on other column data. While everything in our production systems works fine, and adding new partial unique indices via migrations also works fine, loading multiple indices on the same column (String or Array) via our `db/schema.rb` file turns out to not work quite as expected.

If you have a schema like this:

``` ruby
ActiveRecord::Schema.define do
  create_table :sponsorships do |t|
    t.string "user_id"
    t.index ["user_id"], name: "index_sponsorships_on_user_id_unique", unique: true, where: "(status = 1)", using: :btree
    t.index ["user_id"], name: "index_sponsorships_on_user_id", using: :btree
  end
end
```

When you run `rails db:schema:load` without this patch, your local database will only include the `index_sponsorships_on_user_id` index, skipping the `index_sponsorships_on_user_id_unique` index.

With this patch, all indices are loaded into the database, regardless of whether the columns in question already have an index.

As far as I can tell, this bug affects at least Rails 4.0+.
