### PR TITLE
Remove unnecessary `set_inverse_instance` in finder methods

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -152,9 +152,7 @@ module ActiveRecord
         if loaded?
           n ? target.take(n) : target.first
         else
-          scope.take(n).tap do |record|
-            set_inverse_instance record if record.is_a? ActiveRecord::Base
-          end
+          scope.take(n)
         end
       end
 
@@ -656,9 +654,7 @@ module ActiveRecord
           args.shift if args.first.is_a?(Hash) && args.first.empty?
 
           collection = fetch_first_nth_or_last_using_find?(args) ? scope : load_target
-          collection.send(type, *args).tap do |record|
-            set_inverse_instance record if record.is_a? ActiveRecord::Base
-          end
+          collection.send(type, *args)
         end
     end
   end


### PR DESCRIPTION
Because `scope` (`target_scope`) is a `AssociationRelation`.
`AssociationRelation` handles `set_inverse_instance`.

https://github.com/rails/rails/blob/v5.0.0/activerecord/lib/active_record/association_relation.rb#L31-L33
