### PR TITLE
Correct usage for acceptance validator in guide

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -290,7 +290,7 @@ You can also pass custom message via the `message` option.
 
 ```ruby
 class Person < ApplicationRecord
-  validates :terms_of_service, acceptance: true, message: 'must be abided'
+  validates :terms_of_service, acceptance: { message: 'must be abided' }
 end
 ```
 


### PR DESCRIPTION
A quick fix for the Active Record Validations guide.
