### PR TITLE
Change parameters logger level to debug

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -6,12 +6,14 @@ module ActionController
       return unless logger.info?
 
       payload = event.payload
-      params  = payload[:params].except(*INTERNAL_PARAMS)
       format  = payload[:format]
       format  = format.to_s.upcase if format.is_a?(Symbol)
 
       info "Processing by #{payload[:controller]}##{payload[:action]} as #{format}"
-      info "  Parameters: #{params.inspect}" unless params.empty?
+
+      return unless logger.debug?
+      params = payload[:params].except(*INTERNAL_PARAMS)
+      debug "  Parameters: #{params.inspect}" unless params.empty?
     end
 
     def process_action(event)


### PR DESCRIPTION
Logging all input parameters at info level seems to be an overkill for larger
sets of input data. There is a mechanism to filter out parameters as a result
of hardcoding this to info level.

This patch changes the default level to debug and it's meant only to start some
discussion about this. I can carry carry on with adding a configuration option
to specify logger to use that would be saner for people who want to stick with
the current behavior. This would be opt-in of course.

There is a way to disable parameters logging and that is set the threshold to
warn level, but this way you also loose request logging. I think it is worth to
differentiate between request logging and parameters.
