### PR TITLE
`TransactionSerializationError` should inherit `StatementInvalid` for backward compatibility

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -292,7 +292,7 @@ module ActiveRecord
   #
   # * http://www.postgresql.org/docs/current/static/transaction-iso.html
   # * https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html#error_er_lock_deadlock
-  class TransactionSerializationError < ActiveRecordError
+  class TransactionSerializationError < StatementInvalid
   end
 
   # IrreversibleOrderError is raised when a relation's order is too complex for


### PR DESCRIPTION
`TransactionSerializationError` was introduced at #25093.
Originally `TransactionSerializationError` was `StatementInvalid` in
Rails 5.0. It should keep backward compatibility.
