### PR TITLE
Use splat hash args rather than `extract_options!`

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -278,9 +278,8 @@ module ActiveRecord
       # provided by descendants. Note this method does not imply the records
       # are actually removed from the database, that depends precisely on
       # +delete_records+. They are in any case removed from the collection.
-      def delete(*records)
+      def delete(*records, **_options)
         return if records.empty?
-        _options = records.extract_options!
         dependent = _options[:dependent] || options[:dependent]
 
         records = find(records) if records.any? { |record| record.kind_of?(Integer) || record.kind_of?(String) }

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -342,9 +342,7 @@ module ActiveRecord
       # <tt>:updated_at</tt> to the table. See {connection.add_timestamps}[rdoc-ref:SchemaStatements#add_timestamps]
       #
       #   t.timestamps null: false
-      def timestamps(*args)
-        options = args.extract_options!
-
+      def timestamps(*, **options)
         options[:null] = false if options[:null].nil?
 
         column(:created_at, :datetime, options)
@@ -592,8 +590,7 @@ module ActiveRecord
       #  t.belongs_to(:supplier, foreign_key: true)
       #
       # See {connection.add_reference}[rdoc-ref:SchemaStatements#add_reference] for details of the options you can use.
-      def references(*args)
-        options = args.extract_options!
+      def references(*args, **options)
         args.each do |ref_name|
           @base.add_reference(name, ref_name, options)
         end
@@ -606,8 +603,7 @@ module ActiveRecord
       #  t.remove_belongs_to(:supplier, polymorphic: true)
       #
       # See {connection.remove_reference}[rdoc-ref:SchemaStatements#remove_reference]
-      def remove_references(*args)
-        options = args.extract_options!
+      def remove_references(*args, **options)
         args.each do |ref_name|
           @base.remove_reference(name, ref_name, options)
         end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -732,8 +732,7 @@ module ActiveRecord
     # Last argument can specify options:
     # - :direction (default is :up)
     # - :revert (default is false)
-    def run(*migration_classes)
-      opts = migration_classes.extract_options!
+    def run(*migration_classes, **opts)
       dir = opts[:direction] || :up
       dir = (dir == :down ? :up : :down) if opts[:revert]
       if reverting?

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -316,9 +316,8 @@ module ActiveRecord
       #   accepts_nested_attributes_for :avatar, reject_if: :all_blank
       #   # creates avatar_attributes= and posts_attributes=
       #   accepts_nested_attributes_for :avatar, :posts, allow_destroy: true
-      def accepts_nested_attributes_for(*attr_names)
-        options = { :allow_destroy => false, :update_only => false }
-        options.update(attr_names.extract_options!)
+      def accepts_nested_attributes_for(*attr_names, **options)
+        options = { allow_destroy: false, update_only: false }.merge!(options)
         options.assert_valid_keys(:allow_destroy, :reject_if, :limit, :update_only)
         options[:reject_if] = REJECT_ALL_BLANK_PROC if options[:reject_if] == :all_blank
 


### PR DESCRIPTION
We can use the better way of passing options hash since dropped Ruby 1.9 support.
