### PR TITLE
Backport fixes to SchemaDumper for unsigned columns in the Mysql2Adapter from Rails 5

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -76,8 +76,12 @@ module ActiveRecord
             @conn.quote_table_name name
           end
 
-          def type_to_sql(type, limit, precision, scale)
-            @conn.type_to_sql type.to_sym, limit, precision, scale
+          def type_to_sql(type, limit, precision, scale, unsigned = nil)
+            if unsigned.nil?
+              @conn.type_to_sql type.to_sym, limit, precision, scale
+            else
+              @conn.type_to_sql type.to_sym, limit, precision, scale, unsigned
+            end
           end
 
           def add_column_options!(sql, options)

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -287,19 +287,23 @@ module ActiveRecord
       end
 
       module ColumnMethods
-        def unsigned_integer(*args, **options)
+        def unsigned_integer(*args)
+          options = args.last.is_a?( Hash ) ? args.pop : {}
           args.each { |name| column(name, :unsigned_integer, options) }
         end
 
-        def unsigned_bigint(*args, **options)
+        def unsigned_bigint(*args)
+          options = args.last.is_a?( Hash ) ? args.pop : {}
           args.each { |name| column(name, :unsigned_bigint, options) }
         end
 
-        def unsigned_float(*args, **options)
+        def unsigned_float(*args)
+          options = args.last.is_a?( Hash ) ? args.pop : {}
           args.each { |name| column(name, :unsigned_float, options) }
         end
 
-        def unsigned_decimal(*args, **options)
+        def unsigned_decimal(*args)
+          options = args.last.is_a?( Hash ) ? args.pop : {}
           args.each { |name| column(name, :unsigned_decimal, options) }
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -277,6 +277,109 @@ module ActiveRecord
       def set_field_encoding field_name
         field_name
       end
+
+      #--
+      # BACKPORTED FROM 5.0 ======================================
+      #++
+
+      def create_table_definition(name, temporary, options, as = nil) # :nodoc:
+        Mysql2Adapter::TableDefinition.new native_database_types, name, temporary, options, as
+      end
+
+      module ColumnMethods
+        def unsigned_integer(*args, **options)
+          args.each { |name| column(name, :unsigned_integer, options) }
+        end
+
+        def unsigned_bigint(*args, **options)
+          args.each { |name| column(name, :unsigned_bigint, options) }
+        end
+
+        def unsigned_float(*args, **options)
+          args.each { |name| column(name, :unsigned_float, options) }
+        end
+
+        def unsigned_decimal(*args, **options)
+          args.each { |name| column(name, :unsigned_decimal, options) }
+        end
+      end
+
+      class ColumnDefinition < ActiveRecord::ConnectionAdapters::ColumnDefinition
+        attr_accessor :charset, :unsigned
+      end
+
+      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+        include ColumnMethods
+
+        def new_column_definition(name, type, options) # :nodoc:
+          column = super
+          if column.type =~ /\Aunsigned_(?<type>.+)\z/
+            column.type = $~[:type].to_sym
+            column.unsigned = true
+          end
+          column.unsigned ||= options[:unsigned]
+          column.charset = options[:charset]
+          column
+        end
+
+        private
+
+        def create_column_definition(name, type)
+          Mysql2Adapter::ColumnDefinition.new(name, type)
+        end
+      end
+
+      class Table < ActiveRecord::ConnectionAdapters::Table
+        include ColumnMethods
+      end
+
+      module ColumnDumper
+        def prepare_column_options(column,_)
+          spec = super
+          spec[:unsigned] = 'true' if column.unsigned?
+          spec
+        end
+        def migration_keys
+          super + [:unsigned]
+        end
+      end
+      include ColumnDumper
+
+      class SchemaCreation < AbstractMysqlAdapter::SchemaCreation
+        # Backported from 5.0
+        def visit_ColumnDefinition(o)
+          sql_type = type_to_sql(o.type, o.limit, o.precision, o.scale, o.unsigned)
+          column_sql = "#{quote_column_name(o.name)} #{sql_type}"
+          add_column_options!(column_sql, column_options(o)) unless o.primary_key?
+          column_sql
+        end
+      end
+
+      def schema_creation
+        Mysql2Adapter::SchemaCreation.new self
+      end
+
+      class Column < AbstractMysqlAdapter::Column
+        def unsigned?
+          /\bunsigned\z/ === sql_type
+        end
+      end
+
+      public
+
+      def update_table_definition(table_name, base) #:nodoc:
+        Mysql2Adapter::Table.new(table_name, base)
+      end
+
+      def new_column(field, default, cast_type, sql_type = nil, null = true, collation = "", extra = "") # :nodoc:
+        Mysql2Adapter::Column.new(field, default, cast_type, sql_type, null, collation, strict_mode?, extra)
+      end
+
+      def type_to_sql(type, limit = nil, precision = nil, scale = nil, unsigned = nil)
+        sql = super(type, limit, precision, scale)
+        sql << ' unsigned' if unsigned && type != :primary_key
+        sql
+      end
     end
   end
 end

--- a/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
@@ -1,6 +1,18 @@
 require "cases/helper"
+require "support/schema_dumping_helper"
 
-class UnsignedTypeTest < ActiveRecord::TestCase
+# Backported from Rails 5
+require "cases/test_case"
+module ActiveRecord
+  class Mysql2TestCase < TestCase
+    def self.run(*args)
+      super if current_adapter?(:Mysql2Adapter)
+    end
+  end
+end
+
+class Mysql2UnsignedTypeTest < ActiveRecord::Mysql2TestCase
+  include SchemaDumpingHelper
   self.use_transactional_fixtures = false
 
   class UnsignedType < ActiveRecord::Base
@@ -9,7 +21,10 @@ class UnsignedTypeTest < ActiveRecord::TestCase
   setup do
     @connection = ActiveRecord::Base.connection
     @connection.create_table("unsigned_types", force: true) do |t|
-      t.column :unsigned_integer, "int unsigned"
+      t.integer :unsigned_integer, unsigned: true
+      t.bigint  :unsigned_bigint,  unsigned: true
+      t.float   :unsigned_float,   unsigned: true
+      t.decimal :unsigned_decimal, unsigned: true, precision: 10, scale: 2
     end
   end
 
@@ -26,5 +41,35 @@ class UnsignedTypeTest < ActiveRecord::TestCase
     assert_raise(RangeError) do
       UnsignedType.create(unsigned_integer: -10)
     end
+    assert_raise(RangeError) do
+      UnsignedType.create(unsigned_bigint: -10)
+    end
+    assert_raise(ActiveRecord::StatementInvalid) do
+      UnsignedType.create(unsigned_float: -10.0)
+    end
+    assert_raise(ActiveRecord::StatementInvalid) do
+      UnsignedType.create(unsigned_decimal: -10.0)
+    end
+  end
+
+  test "schema definition can use unsigned as the type" do
+    @connection.change_table("unsigned_types") do |t|
+      t.unsigned_integer :unsigned_integer_t
+      t.unsigned_bigint  :unsigned_bigint_t
+      t.unsigned_float   :unsigned_float_t
+      t.unsigned_decimal :unsigned_decimal_t, precision: 10, scale: 2
+    end
+
+    @connection.columns("unsigned_types").select { |c| /^unsigned_/ === c.name }.each do |column|
+      assert column.unsigned?
+    end
+  end
+
+  test "schema dump includes unsigned option" do
+    schema = dump_table_schema "unsigned_types"
+    assert_match %r{t.integer\s+"unsigned_integer",\s+limit: 4,\s+unsigned: true$}, schema
+    assert_match %r{t.integer\s+"unsigned_bigint",\s+limit: 8,\s+unsigned: true$}, schema
+    assert_match %r{t.float\s+"unsigned_float",\s+limit: 24,\s+unsigned: true$}, schema
+    assert_match %r{t.decimal\s+"unsigned_decimal",\s+precision: 10,\s+scale: 2,\s+unsigned: true$}, schema
   end
 end


### PR DESCRIPTION
### Summary

Backports support in `MySQL2Adapter`'s for `t.integer unsigned: true` (and friends) in migrations. Properly handles schema dumps for unsigned numeric columns by applying the `unsigned: true` option as appropriate.
