### PR TITLE
Avoid duplicated `set_inverse_instance` for target scope

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -455,23 +455,20 @@ module ActiveRecord
       end
 
       private
-      def get_records
-        return scope.to_a if skip_statement_cache?
-
-        conn = klass.connection
-        sc = reflection.association_scope_cache(conn, owner) do
-          StatementCache.create(conn) { |params|
-            as = AssociationScope.create { params.bind }
-            target_scope.merge as.scope(self, conn)
-          }
-        end
-
-        binds = AssociationScope.get_bind_values(owner, reflection.chain)
-        sc.execute binds, klass, klass.connection
-      end
 
         def find_target
-          records = get_records
+          return scope.to_a if skip_statement_cache?
+
+          conn = klass.connection
+          sc = reflection.association_scope_cache(conn, owner) do
+            StatementCache.create(conn) { |params|
+              as = AssociationScope.create { params.bind }
+              target_scope.merge as.scope(self, conn)
+            }
+          end
+
+          binds = AssociationScope.get_bind_values(owner, reflection.chain)
+          records = sc.execute(binds, klass, conn)
           records.each { |record| set_inverse_instance(record) }
           records
         end

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -196,7 +196,7 @@ module ActiveRecord
 
         def find_target
           return [] unless target_reflection_has_associated_record?
-          get_records
+          super
         end
 
         # NOTE - not sure that we can actually cope with inverses here

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -44,8 +44,8 @@ module ActiveRecord
           scope.scope_for_create.stringify_keys.except(klass.primary_key)
         end
 
-        def get_records
-          return scope.limit(1).records if skip_statement_cache?
+        def find_target
+          return scope.take if skip_statement_cache?
 
           conn = klass.connection
           sc = reflection.association_scope_cache(conn, owner) do
@@ -56,11 +56,7 @@ module ActiveRecord
           end
 
           binds = AssociationScope.get_bind_values(owner, reflection.chain)
-          sc.execute binds, klass, klass.connection
-        end
-
-        def find_target
-          if record = get_records.first
+          if record = sc.execute(binds, klass, conn).first
             set_inverse_instance record
           end
         end


### PR DESCRIPTION
Because `scope` (`target_scope`) is a `AssociationRelation`.
`AssociationRelation` handles `set_inverse_instance`.

https://github.com/rails/rails/blob/v5.0.0/activerecord/lib/active_record/association_relation.rb#L31-L33

See also #26022.
