### PR TITLE
Add documentation for ActiveSupport::StringInquirer [ci skip]

### DIFF
--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -8,6 +8,12 @@ module ActiveSupport
   # you can call this:
   #
   #   Rails.env.production?
+  #
+  # == Instantiating a new StringInquirer
+  #
+  #   vehicle = ActiveSupport::StringInquirer.new('car')
+  #   vehicle.car?   # => true
+  #   vehicle.bike?  # => false
   class StringInquirer < String
     private
 


### PR DESCRIPTION
Added an instantiation example in documentation for StringInquirer. Previously it consisted of only a use case of it.
