### PR TITLE
Check if the logger is not nil before using it

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -174,7 +174,7 @@ module ActiveRecord
       protected
 
         def valid_scope_name?(name)
-          if respond_to?(name, true)
+          if respond_to?(name, true) && logger
             logger.warn "Creating scope :#{name}. " \
                         "Overwriting existing method #{self.name}.#{name}."
           end


### PR DESCRIPTION
### Summary

When a duplicating named scope definitions exist in a model, Rails tries to log a warn message,
but it fails if logger is set to nil in the configuration file like:

```
  config.active_record.logger = nil
```
