### PR TITLE
Improved creating the test databases for MySQL and PostgreSQL

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -45,7 +45,7 @@ namespace :db do
   task drop: ["db:mysql:drop", "db:postgresql:drop"]
 end
 
-%w( mysql2 postgresql sqlite3 sqlite3_mem db2 oracle jdbcmysql jdbcpostgresql jdbcsqlite3 jdbcderby jdbch2 jdbchsqldb ).each do |adapter|
+%w(mysql2 postgresql sqlite3 sqlite3_mem db2 oracle jdbcmysql jdbcpostgresql jdbcsqlite3 jdbcderby jdbch2 jdbchsqldb).each do |adapter|
   namespace :test do
     Rake::TestTask.new(adapter => "#{adapter}:env") { |t|
       adapter_short = adapter == "db2" ? adapter : adapter[/^[a-z0-9]+/]
@@ -90,15 +90,33 @@ namespace :db do
     desc "Build the MySQL test databases"
     task :build do
       config = ARTest.config["connections"]["mysql2"]
-      %x( mysql --user=#{config["arunit"]["username"]} --password=#{config["arunit"]["password"]} -e "create DATABASE #{config["arunit"]["database"]} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci ")
-      %x( mysql --user=#{config["arunit2"]["username"]} --password=#{config["arunit2"]["password"]} -e "create DATABASE #{config["arunit2"]["database"]} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci ")
+
+      if ENV["TRAVIS"]
+        %x(mysql --user=#{config["arunit"]["username"]} -e "create DATABASE #{config["arunit"]["database"]} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci")
+        %x(mysql --user=#{config["arunit2"]["username"]} -e "create DATABASE #{config["arunit2"]["database"]} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci")
+      else
+        puts "\nCreating database '#{config['arunit']['database']}' as MySQL user '#{config['arunit']['username']}'"
+        %x(mysql --user=#{config["arunit"]["username"]} --password -e "create DATABASE #{config["arunit"]["database"]} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci")
+
+        puts "\nCreating database '#{config['arunit2']['database']}' as MySQL user '#{config['arunit2']['username']}'"
+        %x(mysql --user=#{config["arunit2"]["username"]} --password -e "create DATABASE #{config["arunit2"]["database"]} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci")
+      end
     end
 
     desc "Drop the MySQL test databases"
     task :drop do
       config = ARTest.config["connections"]["mysql2"]
-      %x( mysqladmin --user=#{config["arunit"]["username"]} --password=#{config["arunit"]["password"]} -f drop #{config["arunit"]["database"]} )
-      %x( mysqladmin --user=#{config["arunit2"]["username"]} --password=#{config["arunit2"]["password"]} -f drop #{config["arunit2"]["database"]} )
+
+      if ENV["TRAVIS"]
+        %x(mysqladmin --user=#{config["arunit"]["username"]} -f drop #{config["arunit"]["database"]})
+        %x(mysqladmin --user=#{config["arunit2"]["username"]} -f drop #{config["arunit2"]["database"]})
+      else
+        puts "\nDropping database '#{config['arunit']['database']}' as MySQL user '#{config['arunit']['username']}'"
+        %x(mysqladmin --user=#{config["arunit"]["username"]} --password -f drop #{config["arunit"]["database"]})
+
+        puts "\nDropping database '#{config['arunit2']['database']}' as MySQL user '#{config['arunit2']['username']}'"
+        %x(mysqladmin --user=#{config["arunit2"]["username"]} --password -f drop #{config["arunit2"]["database"]})
+      end
     end
 
     desc "Rebuild the MySQL test databases"
@@ -109,15 +127,38 @@ namespace :db do
     desc "Build the PostgreSQL test databases"
     task :build do
       config = ARTest.config["connections"]["postgresql"]
-      %x( createdb -E UTF8 -T template0 #{config["arunit"]["database"]} )
-      %x( createdb -E UTF8 -T template0 #{config["arunit2"]["database"]} )
+
+      if ENV["TRAVIS"]
+        %x(createdb -E UTF8 -T template0 #{config["arunit"]["database"]})
+        %x(createdb -E UTF8 -T template0 #{config["arunit2"]["database"]})
+      else
+        puts "\nCreating database '#{config['arunit']['database']}' as PostgreSQL user '#{config['arunit']['username']}'"
+        %x(createdb -E UTF8 -T template0 --host=#{config["arunit"]["host"]} --username=#{config["arunit"]["username"]} --password #{config["arunit"]["database"]})
+
+        puts "\nCreating database '#{config['arunit2']['database']}' as PostgreSQL user '#{config['arunit2']['username']}'"
+        %x(createdb -E UTF8 -T template0 --host=#{config["arunit2"]["host"]} --username=#{config["arunit2"]["username"]} --password #{config["arunit2"]["database"]})
+      end
+
+      # prepare hstore
+      if %x(createdb --version).strip.gsub(/(.*)(\d\.\d\.\d)$/, "\\2") < "9.1.0"
+        puts "Please prepare hstore data type. See http://www.postgresql.org/docs/current/static/hstore.html"
+      end
     end
 
     desc "Drop the PostgreSQL test databases"
     task :drop do
       config = ARTest.config["connections"]["postgresql"]
-      %x( dropdb #{config["arunit"]["database"]} )
-      %x( dropdb #{config["arunit2"]["database"]} )
+
+      if ENV["TRAVIS"]
+        %x(dropdb #{config["arunit"]["database"]})
+        %x(dropdb #{config["arunit2"]["database"]})
+      else
+        puts "\nDropping database '#{config['arunit']['database']}' as PostgreSQL user '#{config['arunit']['username']}'"
+        %x(dropdb --host=#{config["arunit"]["host"]} --username=#{config["arunit"]["username"]} --password #{config["arunit"]["database"]})
+
+        puts "\nDropping database '#{config['arunit2']['database']}' as PostgreSQL user '#{config['arunit2']['username']}'"
+        %x(dropdb --host=#{config["arunit2"]["host"]} --username=#{config["arunit2"]["username"]} --password #{config["arunit2"]["database"]})
+      end
     end
 
     desc "Rebuild the PostgreSQL test databases"

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -76,11 +76,15 @@ connections:
 
   postgresql:
     arunit:
+      host: localhost
+      username: rails
       min_messages: warning
     arunit_without_prepared_statements:
       min_messages: warning
       prepared_statements: false
     arunit2:
+      host: localhost
+      username: rails
       min_messages: warning
 
   sqlite3:

--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -232,48 +232,21 @@ $ bundle install
 
 First, we need to delete `.bundle/config` because Bundler remembers in that file that we didn't want to install the "db" group (alternatively you can edit the file).
 
-In order to be able to run the test suite against MySQL you need to create a user named `rails` with privileges on the test databases:
-
-```bash
-$ mysql -uroot -p
-
-mysql> CREATE USER 'rails'@'localhost';
-mysql> GRANT ALL PRIVILEGES ON activerecord_unittest.*
-       to 'rails'@'localhost';
-mysql> GRANT ALL PRIVILEGES ON activerecord_unittest2.*
-       to 'rails'@'localhost';
-mysql> GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.*
-       to 'rails'@'localhost';
-```
-
-and create the test databases:
+In order to create the test databases for MySQL:
 
 ```bash
 $ cd activerecord
 $ bundle exec rake db:mysql:build
 ```
 
-PostgreSQL's authentication works differently. To setup the development environment
-with your development account, on Linux or BSD, you just have to run:
-
-```bash
-$ sudo -u postgres createuser --superuser $USER
-```
-
-and for OS X:
-
-```bash
-$ createuser --superuser $USER
-```
-
-Then you need to create the test databases with
+In order to create the test databases for PostgreSQL:
 
 ```bash
 $ cd activerecord
 $ bundle exec rake db:postgresql:build
 ```
 
-It is possible to build databases for both PostgreSQL and MySQL with
+It is possible to create the databases for both MySQL and PostgreSQL with
 
 ```bash
 $ cd activerecord
@@ -281,6 +254,13 @@ $ bundle exec rake db:create
 ```
 
 You can cleanup the databases using
+```bash
+$ cd activerecord
+$ bundle exec rake db:mysql:drop
+$ bundle exec rake db:postgresql:drop
+```
+
+or same
 
 ```bash
 $ cd activerecord
@@ -291,7 +271,7 @@ NOTE: Using the rake task to create the test databases ensures they have the cor
 
 NOTE: You'll see the following warning (or localized warning) during activating HStore extension in PostgreSQL 9.1.x or earlier: "WARNING: => is deprecated as an operator".
 
-If you're using another database, check the file `activerecord/test/config.yml` or `activerecord/test/config.example.yml` for default connection information. You can edit `activerecord/test/config.yml` to provide different credentials on your machine if you must, but obviously you should not push any such changes back to Rails.
+NOTE: Check the file `activerecord/test/config.yml` or `activerecord/test/config.example.yml` for default connection information. You can edit `activerecord/test/config.yml` to provide different credentials on your machine if you must, but obviously you should not push any such changes back to Rails.
 
 ### Action Cable Setup
 


### PR DESCRIPTION
Added better PostgreSQL's authentication.
Removed difference in authentication work between PostgreSQL and MySQL.
Set default connection information only in one place activerecord/test/config.yml not in development environment.
Added notices when creating/dropping the test databases.
