### PR TITLE
Add link to 'Pry' in debugging guide [ci skip]

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -946,6 +946,7 @@ development that will end your tailing of development.log. Have all information
 about your Rails app requests in the browser — in the Developer Tools panel.
 Provides insight to db/rendering/total times, parameter list, rendered views and
 more.
+* [Pry](https://github.com/pry/pry) An IRB alternative and runtime developer console.
 
 References
 ----------


### PR DESCRIPTION
Add link to [Pry](https://github.com/pry/pry) in "Debugging Rails Applications" guide
