### PR TITLE
Make `name` and `binds` to optional args for `exec_{insert,update,delete}`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -89,14 +89,14 @@ module ActiveRecord
       # Executes insert +sql+ statement in the context of this connection using
       # +binds+ as the bind substitutes. +name+ is logged along with
       # the executed +sql+ statement.
-      def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
+      def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil)
         exec_query(sql, name, binds)
       end
 
       # Executes delete +sql+ statement in the context of this connection using
       # +binds+ as the bind substitutes. +name+ is logged along with
       # the executed +sql+ statement.
-      def exec_delete(sql, name, binds)
+      def exec_delete(sql, name = nil, binds = [])
         exec_query(sql, name, binds)
       end
 
@@ -108,7 +108,7 @@ module ActiveRecord
       # Executes update +sql+ statement in the context of this connection using
       # +binds+ as the bind substitutes. +name+ is logged along with
       # the executed +sql+ statement.
-      def exec_update(sql, name, binds)
+      def exec_update(sql, name = nil, binds = [])
         exec_query(sql, name, binds)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -45,7 +45,7 @@ module ActiveRecord
           end
         end
 
-        def exec_delete(sql, name, binds)
+        def exec_delete(sql, name = nil, binds = [])
           if without_prepared_statement?(binds)
             execute_and_free(sql, name) { @connection.affected_rows }
           else

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -112,7 +112,7 @@ module ActiveRecord
           end
         end
 
-        def exec_delete(sql, name = 'SQL', binds = [])
+        def exec_delete(sql, name = nil, binds = [])
           execute_and_clear(sql, name, binds) {|result| result.cmd_tuples }
         end
         alias :exec_update :exec_delete
@@ -133,7 +133,7 @@ module ActiveRecord
           super
         end
 
-        def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
+        def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil)
           val = exec_query(sql, name, binds)
           if !use_insert_returning? && pk
             unless sequence_name


### PR DESCRIPTION
`select_all`, `select_one`, `select_value`, `select_values`, `select_rows`,
`insert`, `update`, `delete`, and `exec_query` have a default value
against `name` and `binds`. But `exec_insert`, `exec_update`, and
`exec_delete` not have. It is an inconvenience and inconsistent.
