### PR TITLE
Added register_block_for method to register Railties engines blocks(eg: rake_tasks, generators)

### DIFF
--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -132,19 +132,19 @@ module Rails
       end
 
       def rake_tasks(&blk)
-        register_block_for(@rake_tasks, &blk)
+        register_block_for(@rake_tasks ||= [], &blk)
       end
 
       def console(&blk)
-        register_block_for(@load_console, &blk)
+        register_block_for(@load_console ||= [], &blk)
       end
 
       def runner(&blk)
-        register_block_for(@runner, &blk)
+        register_block_for(@runner ||= [], &blk)
       end
 
       def generators(&blk)
-        register_block_for(@generators, &blk)
+        register_block_for(@generators ||= [], &blk)
       end
 
       def abstract_railtie?

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -144,7 +144,7 @@ module Rails
       end
 
       def generators(&blk)
-        register_block_for(@generators ||= [], &blk)
+        register_block_for(@generators, &blk)
       end
 
       def abstract_railtie?

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -132,19 +132,19 @@ module Rails
       end
 
       def rake_tasks(&blk)
-        register_block_for(@rake_tasks ||= [], &blk)
+        register_block_for(:rake_tasks, &blk)
       end
 
       def console(&blk)
-        register_block_for(@load_console ||= [], &blk)
+        register_block_for(:load_console, &blk)
       end
 
       def runner(&blk)
-        register_block_for(@runner ||= [], &blk)
+        register_block_for(:runner, &blk)
       end
 
       def generators(&blk)
-        register_block_for(@generators ||= [], &blk)
+        register_block_for(:generators, &blk)
       end
 
       def abstract_railtie?
@@ -178,13 +178,14 @@ module Rails
           ActiveSupport::Inflector.underscore(string).tr("/", "_")
         end
 
-        # receives an array-like instance variable as *reference* and append
-        # given block to array result set, which will be used later in
+        # receives an instance variable identifier, set the variable value if is
+        # blank and append given block to value, which will be used later in
         # `#each_registered_block(type, &block)`
-        def register_block_for(variable, &blk)
-          variable ||= []
-          variable << blk if blk
-          variable
+        def register_block_for(type, &blk)
+          var_name = "@#{type}"
+          blocks = instance_variable_get(var_name) || instance_variable_set(var_name, [])
+          blocks << blk if blk
+          blocks
         end
 
 

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -132,27 +132,19 @@ module Rails
       end
 
       def rake_tasks(&blk)
-        @rake_tasks ||= []
-        @rake_tasks << blk if blk
-        @rake_tasks
+        register_block_for(@rake_tasks, &blk)
       end
 
       def console(&blk)
-        @load_console ||= []
-        @load_console << blk if blk
-        @load_console
+        register_block_for(@load_console, &blk)
       end
 
       def runner(&blk)
-        @load_runner ||= []
-        @load_runner << blk if blk
-        @load_runner
+        register_block_for(@runner, &blk)
       end
 
       def generators(&blk)
-        @generators ||= []
-        @generators << blk if blk
-        @generators
+        register_block_for(@generators ||= [], &blk)
       end
 
       def abstract_railtie?
@@ -185,6 +177,16 @@ module Rails
         def generate_railtie_name(string) #:nodoc:
           ActiveSupport::Inflector.underscore(string).tr("/", "_")
         end
+
+        # receives an array-like instance variable as *reference* and append
+        # given block to array result set, which will be used later in
+        # `#each_registered_block(type, &block)`
+        def register_block_for(variable, &blk)
+          variable ||= []
+          variable << blk if blk
+          variable
+        end
+
 
         # If the class method does not have a method, then send the method call
         # to the Railtie instance.
@@ -241,6 +243,7 @@ module Rails
 
     private
 
+    # run `&block` in every registered block in `#register_block_for`
     def each_registered_block(type, &block)
       klass = self.class
       while klass.respond_to?(type)


### PR DESCRIPTION
### Summary

This is only a small improvement I think is valid, I mean, this code can be kept how is today...but this change probably makes code more simple and readable, and my main goal submiting this PR is to create an API method to `register blocks`, since the [`each_registered_block`](https://github.com/rails/rails/blob/master/railties/lib/rails/railtie.rb#L244) is used in code with the similar purpose.
### Other Information

I started this using `instance_eval`, but I know this can't be good, so I benchmarked 4 ways of doing this same thing:
- instance_eval (the slowest, just for reference)
- pass initialized variable as reference (first implementation for this PR)
- symbol as identifier/instance variable get/set   (**current** implementation in this PR)
- current railties implementation

Benchmark code and results are here: https://gist.github.com/fidelisrafael/d8509eea8ddac3e61c4ada2d706ee53b
#### Benchmark results

Please, refer to [this gist](https://gist.github.com/fidelisrafael/d8509eea8ddac3e61c4ada2d706ee53b) to analisys the code behing this benchmark results:
#### simple benchmark

```
==================================================
single `rake_task` method call inside loop
==================================================

                                                         user     system      total        real
instance_eval                                        2.350000   0.020000   2.370000 (  2.366487)
variable init                                        0.180000   0.000000   0.180000 (  0.176445)
instance variable get/set                            0.160000   0.000000   0.160000 (  0.162669)
current railties                                     0.250000   0.000000   0.250000 (  0.252082)

==================================================
Single `generators` method call inside loop
==================================================

                                                         user     system      total        real
instance_eval                                        2.260000   0.020000   2.280000 (  2.273899)
variable init                                        0.120000   0.000000   0.120000 (  0.115172)
instance variable get/set                            0.160000   0.000000   0.160000 (  0.161243)
current railties                                     0.160000   0.000000   0.160000 (  0.160353)

==================================================
4 methods calls inside each loop
==================================================

                                                         user     system      total        real
instance_eval                                        9.090000   0.000000   9.090000 (  9.091285)
variable init                                        0.580000   0.000000   0.580000 (  0.579077)
instance variable get/set                            0.920000   0.000000   0.920000 (  0.915160)
current railties                                     1.160000   0.020000   1.180000 (  1.188045)
```
#### Benchmark/ips results:

```
==================================================
single `rake_task` method call inside loop
==================================================
Warming up --------------------------------------
       instance_eval     4.036k i/100ms
       variable init    39.834k i/100ms
    variable get/set    31.997k i/100ms
    current railties    35.253k i/100ms
Calculating -------------------------------------
       instance_eval     50.476k (±32.1%) i/s -    185.656k in   5.792784s
       variable init    977.498k (±56.9%) i/s -      1.315M in   5.415631s
    variable get/set    651.734k (±48.1%) i/s -      1.056M in   5.033967s
    current railties      1.417M (±37.0%) i/s -      1.128M in   7.740616s
Comparison:
    current railties:  1416776.9 i/s
       variable init:   977498.0 i/s - same-ish: difference falls within error
    variable get/set:   651733.6 i/s - same-ish: difference falls within error
       instance_eval:    50476.3 i/s - 28.07x slower
==================================================
Single `generators` method call inside loop
==================================================
Warming up --------------------------------------
       instance_eval     3.460k i/100ms
       variable init    59.450k i/100ms
    variable get/set    39.731k i/100ms
    current railties    50.625k i/100ms
Calculating -------------------------------------
       instance_eval     56.878k (±24.7%) i/s -    214.520k in   5.362425s
       variable init      1.114M (±53.8%) i/s -      1.784M in   5.180813s
    variable get/set    735.448k (±38.6%) i/s -      1.391M in   5.983204s
    current railties      1.108M (±60.7%) i/s -      1.063M in   5.020838s
Comparison:
       variable init:  1114123.1 i/s
    current railties:  1108297.5 i/s - same-ish: difference falls within error
    variable get/set:   735447.9 i/s - same-ish: difference falls within error
       instance_eval:    56878.4 i/s - 19.59x slower
==================================================
4 methods calls inside each loop
==================================================
Warming up --------------------------------------
       instance_eval     1.159k i/100ms
       variable init    25.411k i/100ms
    variable get/set    17.967k i/100ms
    current railties    19.728k i/100ms
Calculating -------------------------------------
       instance_eval     14.180k (±29.9%) i/s -     53.314k in   5.469904s
       variable init    377.365k (±53.4%) i/s -    736.919k in   6.285703s
    variable get/set    222.860k (±41.0%) i/s -    521.043k in   5.979247s
    current railties    504.417k (±42.5%) i/s -    493.200k in   5.210466s
Comparison:
    current railties:   504417.5 i/s
       variable init:   377364.7 i/s - same-ish: difference falls within error
    variable get/set:   222860.0 i/s - same-ish: difference falls within error
       instance_eval:    14180.2 i/s - 35.57x slower
```
