### PR TITLE
ENV['WEB_CONCURRENCY'] should be converted to integer [ci skip]

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb
@@ -21,7 +21,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+# workers ENV.fetch("WEB_CONCURRENCY") { 2 }.to_i
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
this is to make sure that the commented code for `ENV.fetch('WEB_CONCURRENCY')` is being converted to integer which is what `puma` expects when the code is being used.

this is also consistent with line 7 of this `puma` config file.

example of puma config file can be found here: https://github.com/puma/puma/blob/master/examples/config.rb#L111
