### PR TITLE
Fixed issue with where.not with polymorphic association. Changed behaviour of where.not() with multiple condition

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -43,15 +43,12 @@ module ActiveRecord
       #    # SELECT * FROM users WHERE name NOT IN ('Ko1', 'Nobu')
       #
       #    User.where.not(name: "Jon", role: "admin")
+      #    # SELECT * FROM users WHERE NOT (name = 'Jon' AND role = 'admin')
+      #
+      #    User.where.not(name: "Jon").where.not(role: "admin")
       #    # SELECT * FROM users WHERE name != 'Jon' AND role != 'admin'
       def not(opts, *rest)
-        opts = sanitize_forbidden_attributes(opts)
-
-        where_clause = @scope.send(:where_clause_factory).build(opts, rest)
-
-        @scope.references!(PredicateBuilder.references(opts)) if Hash === opts
-        @scope.where_clause += where_clause.invert
-        @scope
+        @scope.where_not!(opts, rest)
       end
     end
 
@@ -588,6 +585,14 @@ module ActiveRecord
       opts = sanitize_forbidden_attributes(opts)
       references!(PredicateBuilder.references(opts)) if Hash === opts
       self.where_clause += where_clause_factory.build(opts, rest)
+      self
+    end
+
+    def where_not!(opts, *rest) # :nodoc:
+      opts = sanitize_forbidden_attributes(opts)
+      references!(PredicateBuilder.references(opts)) if Hash === opts
+      where_clause = where_clause_factory.build(opts, rest)
+      self.where_clause += where_clause.invert
       self
     end
 

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -102,7 +102,13 @@ module ActiveRecord
         end
 
         def inverted_predicates
-          predicates.map { |node| invert_predicate(node) }
+          node = if predicates.size == 1
+            invert_predicate(predicates[0])
+          else
+            Arel::Nodes::Not.new(ast)
+          end
+
+          [node]
         end
 
         def invert_predicate(node)

--- a/activerecord/test/cases/relation/where_not_test.rb
+++ b/activerecord/test/cases/relation/where_not_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/cake_designer"
+require "models/drink_designer"
+require "models/chef"
+require "models/post"
+
+module ActiveRecord
+  class WhereNotTest < ActiveRecord::TestCase
+    def test_where_not_with_polymorphic_association
+      chef1 = Chef.create!
+      chef2 = Chef.create!
+      chef3 = Chef.create!
+
+      cake_designer1 = CakeDesigner.create!(chef: chef1)
+      cake_designer2 = CakeDesigner.create!(chef: chef2)
+      drink_designer3 = DrinkDesigner.create!(chef: chef3)
+
+      chefs = Chef.where.not(employable: cake_designer1)
+
+      assert_not_includes chefs, chef1
+      assert_includes chefs, chef2
+      assert_includes chefs, chef3
+    end
+
+    def test_where_not_with_multiple_condition
+      post1 = Post.create(title: "t1", body: "b1")
+      post2 = Post.create(title: "t2", body: "b2")
+
+      scope = Post.where.not(title: "t1", body: "b1")
+      assert_not_includes scope, post1
+      assert_includes scope, post2
+
+      scope = Post.where.not(title: "t1", body: "b2")
+      assert_includes scope, post1
+      assert_includes scope, post2
+    end
+
+    def test_where_not_with_multiple_condition_eq_inverted_where_clause
+      relation = Post.where.not(author_id: [1, 2], title: "ruby on rails")
+      expected_where_clause =
+        Post.where(author_id: [1, 2], title: "ruby on rails").where_clause.invert
+      assert_equal expected_where_clause, relation.where_clause
+    end
+
+    def test_where_not_with_multiple_condition_not_eq_few_where_not_with_single_condition
+      relation1 = Post.where.not(author_id: [1, 2], title: "ruby on rails")
+      relation2 = Post.where.not(author_id: [1, 2]).where.not(title: "ruby on rails")
+      assert_not_equal relation1.where_clause, relation2.where_clause
+    end
+  end
+end


### PR DESCRIPTION
The expression `User.where.not(name: "Jon", role: "admin")` should create SQL like this:

```
SELECT * FROM users WHERE NOT (name = 'Jon' AND role = 'admin')
# or
SELECT * FROM users WHERE (name != 'Jon' OR role != 'admin')
```

Instead, it produces:

```
SELECT * FROM users WHERE name != 'Jon' AND role != 'admin'
```

This behaviour also causes this problem https://github.com/rails/rails/issues/16983

This commit fixes the problem and changes where.not() behaviour to expected
