### PR TITLE
Use `FETCH FIRST` for Oracle12 and test `ROWNUM <=` for Oracle 11g or older version to test sql limit behavior

### DIFF
--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -562,9 +562,9 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_take_and_first_and_last_with_integer_should_use_sql_limit
-    assert_sql(/LIMIT|ROWNUM <=/) { Topic.take(3).entries }
-    assert_sql(/LIMIT|ROWNUM <=/) { Topic.first(2).entries }
-    assert_sql(/LIMIT|ROWNUM <=/) { Topic.last(5).entries }
+    assert_sql(/LIMIT|ROWNUM <=|FETCH FIRST/) { Topic.take(3).entries }
+    assert_sql(/LIMIT|ROWNUM <=|FETCH FIRST/) { Topic.first(2).entries }
+    assert_sql(/LIMIT|ROWNUM <=|FETCH FIRST/) { Topic.last(5).entries }
   end
 
   def test_last_with_integer_and_order_should_keep_the_order

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -246,7 +246,7 @@ class NestedRelationScopingTest < ActiveRecord::TestCase
         devs = Developer.all
         sql = devs.to_sql
         assert_match "(salary = 80000)", sql
-        assert_match "LIMIT 10", sql
+        assert_match /LIMIT 10|ROWNUM <= 10|FETCH FIRST 10 ROWS ONLY/, sql
       end
     end
   end


### PR DESCRIPTION
### Summary

This pull request addresses this following failure when tested with Oracle Database 12c.

``` ruby
$ cd activerecord
$ ARCONN=oracle bundle exec ruby -W -w -I"lib:test" test/cases/finder_test.rb -n test_take_and_first_and_last_with_integer_should_use_sql_limit

... snip ...

# Running:

F

Finished in 0.826707s, 1.2096 runs/s, 1.2096 assertions/s.

  1) Failure:
FinderTest#test_take_and_first_and_last_with_integer_should_use_sql_limit [test/cases/finder_test.rb:568]:
Query pattern(s) /LIMIT|ROWNUM <=/ not found.
Queries:
SELECT  "TOPICS".* FROM "TOPICS" FETCH FIRST :a1 ROWS ONLY

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

Since Oracle 12c database introduces better top N query using `FETCH FIRST n ROWS` and Arel supports [this syntax](https://github.com/rails/arel/blob/master/lib/arel/visitors/oracle12.rb)
### Other Information

```
* Rails `master` branch
* Oracle enhanced adapter `rails51` branch
* Oracle Database 12c Enterprise Edition Release 12.1.0.2.0 - 64bit Production
* ruby 2.4.0dev (2016-08-04 trunk 55812) [x86_64-linux]
```
