### PR TITLE
Running rails s -b 0.0.0.0 sets allowed_request_origins with IPs

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   ActionCable's allowed_request_origins includes private IPs during development
+
+    By default when in development, Action Cable's allowed_request_origins
+    includes http://localhost:3000.  Because it is compelling to run
+
+      rails s -b 0.0.0.0
+
+    in development to experiment with Action Cable applications using
+    multiple machines, we find all _private_ IPv4 addresses and add them
+    into allowed_request_origins.  (No public Internet IP addresses, and
+    do nothing in test and production environments.)
+
+    *Lorin Thwaits*
+
 *   Protect against concurrent writes to a websocket connection from
     multiple threads; the underlying OS write is not always threadsafe.
 

--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,2 +1,10 @@
+*   ActionCable's allowed_request_origins includes private IPs during development
+
+    Describe the new behavior of rails s -b 0.0.0.0 in command_line.md
+    and action_cable_overview.md to automatically set Action Cable's
+    allowed_request_origins with private IPv4 addresses.
+
+    *Lorin Thwaits*
+
 
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/guides/CHANGELOG.md) for previous changes.

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -561,8 +561,9 @@ To disable and allow requests from any origin:
 config.action_cable.disable_request_forgery_protection = true
 ```
 
-By default, Action Cable allows all requests from localhost:3000 when running
-in the development environment.
+By default, Action Cable allows all requests from localhost:3000 (and all other
+ports) when running in the development environment.  Additionally, if you start
+your rails server with -b 0.0.0.0 then all private IP addresses will be added.
 
 ### Consumer Configuration
 

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -83,7 +83,9 @@ The server can be run on a different port using the `-p` option. The default dev
 $ bin/rails server -e production -p 4000
 ```
 
-The `-b` option binds Rails to the specified IP, by default it is localhost. You can run a server as a daemon by passing a `-d` option.
+The `-b` option binds Rails to the specified IP, by default it is localhost. Using
+`-b 0.0.0.0` causes the server to listen on all IPs. You can run a server as a daemon by
+passing a `-d` option.
 
 ### `rails generate`
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Action Cable should set allowed_request_origins with static IPs if rails s
+    is run with -b 0.0.0.0 or -b <static IP>.
+
+    Action Cable should not modify allowed_request_origins if rails s is run
+    in test or production.
+
+    railties/test/server_helpers.rb is added as a convenience for testing.
+    It allows Rails::Server objects to go through server.app.initialize!
+    and then be torn back down enough to have initialize! called again.
+
+    *Lorin Thwaits*
+
 *   A generated app should not include Uglifier with `--skip-javascript` option.
 
     *Ben Pickles*

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -1,9 +1,11 @@
 require 'abstract_unit'
 require 'env_helpers'
+require 'server_helpers'
 require 'rails/commands/server'
 
 class Rails::ServerTest < ActiveSupport::TestCase
   include EnvHelpers
+  include ServerHelpers
 
   def test_environment_with_server_option
     args    = ["thin", "-e", "production"]
@@ -55,6 +57,62 @@ class Rails::ServerTest < ActiveSupport::TestCase
     switch_env "HOST", "1.2.3.4" do
       server = Rails::Server.new
       assert_equal "1.2.3.4", server.options[:Host]
+    end
+  end
+
+  def test_actioncable_allowed_request_origins_includes_localhost_and_static_ip_during_development
+    primary_ip = "2.3.4.5"
+    second_ip = "10.0.0.5"
+    with_rack_env 'development' do
+      run_with_custom_args ["-b", primary_ip] do
+        server = build_server_with_ips [primary_ip, second_ip]
+        begin
+          allowed_request_origins = server.app.config.action_cable.allowed_request_origins
+          assert_not_includes allowed_request_origins, Regexp.new("https?:\/\/localhost:\\d+")
+          assert_not_includes allowed_request_origins, Regexp.new("https?:\/\/127.0.0.1:\\d+")
+          # Should include any static IP referenced with -b, even those routable on the Internet
+          assert_includes allowed_request_origins, Regexp.new("https?:\/\/#{primary_ip}:\\d+")
+          # Should not include any additional IP on the machine, even those not routable on the Internet
+          assert_not_includes allowed_request_origins, Regexp.new("https?:\/\/#{second_ip}:\\d+")
+        ensure
+          teardown_app_for(server)
+        end
+      end
+    end
+  end
+
+  def test_actioncable_allowed_request_origins_get_set_properly_when_binding_0_0_0_0_during_development
+    primary_ip = "3.4.5.6"
+    second_ip = "10.0.0.5"
+    with_rack_env 'development' do
+      run_with_custom_args ["-b", "0.0.0.0"] do
+        server = build_server_with_ips [primary_ip, second_ip]
+        begin
+          allowed_request_origins = server.app.config.action_cable.allowed_request_origins
+          assert_includes allowed_request_origins, Regexp.new("https?:\/\/localhost:\\d+")
+          assert_includes allowed_request_origins, Regexp.new("https?:\/\/127.0.0.1:\\d+")
+          # Should not include any IPs that are routable on the Internet
+          assert_not_includes allowed_request_origins, Regexp.new("https?:\/\/#{primary_ip}:\\d+")
+          # Should include all intranet IPs, i.e. those not routable on the Internet
+          assert_includes allowed_request_origins, Regexp.new("https?:\/\/#{second_ip}:\\d+")
+        ensure
+          teardown_app_for(server)
+        end
+      end
+    end
+  end
+
+  def test_actioncable_allowed_request_origins_are_not_set_during_production
+    primary_ip = "4.5.6.7"
+    with_rack_env 'production' do
+      run_with_custom_args ["-b", primary_ip] do
+        server = build_server_with_ips [primary_ip]
+        begin
+          assert_equal nil, server.app.config.action_cable.allowed_request_origins
+        ensure
+          teardown_app_for(server)
+        end
+      end
     end
   end
 

--- a/railties/test/config.ru
+++ b/railties/test/config.ru
@@ -1,0 +1,3 @@
+# This file is used by server tests that need to initialize the application.
+
+run Rails.application

--- a/railties/test/server_helpers.rb
+++ b/railties/test/server_helpers.rb
@@ -1,0 +1,58 @@
+require 'minitest/mock'
+
+module ServerHelpers
+private
+
+  # Capture the earliest starting state of server.app.config
+  @@original_options ||= Rails::Railtie::Configuration.class_variable_get(:@@options).deep_dup
+
+  def build_server_with_ips(host_ips = ["192.168.0.10"])
+    # Make sure any cached version of options are gone
+    GC.start
+    sleep 0.1
+
+    # Revert server.app.config back to its original state
+    Rails::Railtie::Configuration.class_variable_set(:@@options, @@original_options.deep_dup)
+
+    server = Rails::Server.new
+    server.options[:config].gsub! "/railties/config.ru", "/railties/test/config.ru"
+    # Quiet the "config.eager_load is set to nil" warning
+    server.app.config.eager_load = false
+
+    fake_ip = Struct.new :ip_address, :ipv4?
+    local_ips = [
+      fake_ip.new("::1", false),
+      fake_ip.new("127.0.0.1", true),
+      fake_ip.new("fe80::1%lo0", false),
+      fake_ip.new("fe80::1234:5678:9abc:def0%en0", false)
+    ]
+    host_ips.each { |ip| local_ips << fake_ip.new(ip, true) }
+
+    Socket.stub :ip_address_list, lambda { local_ips } do
+      server.app.initialize!
+    end
+    server
+  end
+
+  def run_with_custom_args(args, &block)
+    original_args = ARGV.dup
+    ARGV.replace args
+    yield
+  ensure
+    ARGV.replace original_args
+  end
+
+  # Tear down just enough of the Rails::Application so it can be fully initialized again.
+  # This approach allows us to examine how parameters are set after going through the
+  # initialization process when running "rails server"
+  def teardown_app_for(server)
+    # This lets us get past "RuntimeError: Application has been already initialized."
+    server.app.instance_variable_set("@initialized", false)
+    # Forget about the server instance
+    server.app.class.instance_variable_set(:@instance, nil)
+    # This lets us get past "Expected nil (NilClass) to respond to #include?."
+    server.app.remove_instance_variable(:@ran) if server.app.instance_variable_defined?(:@ran)
+    # This gets us past "can't modify frozen array"
+    server.app.routes_reloader.instance_variable_set(:@paths, [])
+  end
+end


### PR DESCRIPTION
(my first rails contribution ... must confess that
I'm hopeful.  I find it quite useful, but YMMV :)

By default when in development, Action Cable's allowed_request_origins
only includes http://localhost:3000.  This does not help if you like
to run:

```
rails s -b 0.0.0.0
```

in order to develop on a virtual machine or to experiment with Action
Cable apps across multiple machines, you do to not have to worry about
what IP address your development machine has.  A message appears in
this case indicating the private IPv4 addresses that were added to
allowed_request_origins.  It does not affect test and production
environments at all.
