### PR TITLE
Revert passing arel node with splat binds for `where`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -434,11 +434,7 @@ module ActiveRecord
       end
 
       def case_sensitive_comparison(table, attribute, column, value)
-        if value.nil?
-          table[attribute].eq(value)
-        else
-          table[attribute].eq(Arel::Nodes::BindParam.new)
-        end
+        table[attribute].eq(Arel::Nodes::BindParam.new)
       end
 
       def case_insensitive_comparison(table, attribute, column, value)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -614,7 +614,7 @@ module ActiveRecord
       end
 
       def case_sensitive_comparison(table, attribute, column, value)
-        if !value.nil? && column.collation && !column.case_sensitive?
+        if column.collation && !column.case_sensitive?
           table[attribute].eq(Arel::Nodes::Bin.new(Arel::Nodes::BindParam.new))
         else
           super

--- a/activerecord/lib/active_record/relation/where_clause_factory.rb
+++ b/activerecord/lib/active_record/relation/where_clause_factory.rb
@@ -22,7 +22,6 @@ module ActiveRecord
           parts = predicate_builder.build_from_hash(attributes)
         when Arel::Nodes::Node
           parts = [opts]
-          binds = other
         else
           raise ArgumentError, "Unsupported argument type: #{opts} (#{opts.class})"
         end

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -55,6 +55,10 @@ module ActiveRecord
           value = value.attributes[reflection.klass.primary_key] unless value.nil?
         end
 
+        if value.nil?
+          return klass.unscoped.where!(attribute => value)
+        end
+
         # the attribute may be an aliased attribute
         if klass.attribute_alias?(attribute)
           attribute = klass.attribute_alias(attribute)
@@ -66,18 +70,14 @@ module ActiveRecord
         column = klass.columns_hash[attribute_name]
         cast_type = klass.type_for_attribute(attribute_name)
 
-        comparison = if !options[:case_sensitive] && !value.nil?
+        comparison = if !options[:case_sensitive]
           # will use SQL LOWER function before comparison, unless it detects a case insensitive collation
           klass.connection.case_insensitive_comparison(table, attribute, column, value)
         else
           klass.connection.case_sensitive_comparison(table, attribute, column, value)
         end
-        if value.nil?
-          klass.unscoped.where(comparison)
-        else
-          bind = Relation::QueryAttribute.new(attribute_name, value, cast_type)
-          klass.unscoped.where(comparison, bind)
-        end
+        bind = Relation::QueryAttribute.new(attribute_name, value, cast_type)
+        klass.unscoped.where!(comparison, bind)
       end
 
       def scope_relation(record, relation)

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -76,8 +76,11 @@ module ActiveRecord
         else
           klass.connection.case_sensitive_comparison(table, attribute, column, value)
         end
-        bind = Relation::QueryAttribute.new(attribute_name, value, cast_type)
-        klass.unscoped.where!(comparison, bind)
+        klass.unscoped.tap do |scope|
+          parts = [comparison]
+          binds = [Relation::QueryAttribute.new(attribute_name, value, cast_type)]
+          scope.where_clause += Relation::WhereClause.new(parts, binds)
+        end
       end
 
       def scope_relation(record, relation)


### PR DESCRIPTION
Passing arel node with splat binds for `where` was introduced at #22877
for uniqueness validator supports prepared statement. But I'd not like
to introduce the following usage:

``` ruby
  Foo.where(arel, *binds)
```

I'd like to revert this internal usage.
