### PR TITLE
`where` by `array|range` attribute with array or range value

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -290,6 +290,12 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
     assert_equal record.tags, record.reload.tags
   end
 
+  def test_where_by_attribute_with_array
+    tags = ["black", "blue"]
+    record = PgArray.create!(tags: tags)
+    assert_equal record, PgArray.where(tags: tags).take
+  end
+
   def test_uniqueness_validation
     klass = Class.new(PgArray) do
       validates_uniqueness_of :tags

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -282,6 +282,12 @@ _SQL
       assert_raises(ArgumentError) { PostgresqlRange.create!(tstz_range: "(''2010-01-01 14:30:00+05'', ''2011-01-01 14:30:00-03'']") }
     end
 
+    def test_where_by_attribute_with_range
+      range = 1..100
+      record = PostgresqlRange.create!(int4_range: range)
+      assert_equal record, PostgresqlRange.where(int4_range: range).take
+    end
+
     def test_update_all_with_ranges
       PostgresqlRange.create!
 


### PR DESCRIPTION
Currently predicate builder cannot build a predicate for `array|range`
attribute. This commit fixes the issue.

Related #25671.
