### PR TITLE
Quoting booleans should return a quoted value

### DIFF
--- a/activemodel/lib/active_model/type/immutable_string.rb
+++ b/activemodel/lib/active_model/type/immutable_string.rb
@@ -8,8 +8,13 @@ module ActiveModel
       def serialize(value)
         case value
         when ::Numeric, ActiveSupport::Duration then value.to_s
-        when true then "t"
-        when false then "f"
+        else super
+        end
+      end
+
+      def cast(value)
+        case value
+        when true, false then value
         else super
         end
       end
@@ -17,13 +22,7 @@ module ActiveModel
       private
 
         def cast_value(value)
-          result = \
-            case value
-            when true then "t"
-            when false then "f"
-            else value.to_s
-            end
-          result.freeze
+          value.to_s.freeze
         end
     end
   end

--- a/activemodel/test/cases/type/string_test.rb
+++ b/activemodel/test/cases/type/string_test.rb
@@ -6,8 +6,8 @@ module ActiveModel
     class StringTest < ActiveModel::TestCase
       test "type casting" do
         type = Type::String.new
-        assert_equal "t", type.cast(true)
-        assert_equal "f", type.cast(false)
+        assert_equal true, type.cast(true)
+        assert_equal false, type.cast(false)
         assert_equal "123", type.cast(123)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -860,8 +860,8 @@ module ActiveRecord
         class MysqlString < Type::String # :nodoc:
           def serialize(value)
             case value
-            when true then MySQL::Quoting::QUOTED_TRUE
-            when false then MySQL::Quoting::QUOTED_FALSE
+            when true then "1"
+            when false then "0"
             else super
             end
           end
@@ -870,8 +870,8 @@ module ActiveRecord
 
             def cast_value(value)
               case value
-              when true then MySQL::Quoting::QUOTED_TRUE
-              when false then MySQL::Quoting::QUOTED_FALSE
+              when true then "1"
+              when false then "0"
               else super
               end
             end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -548,8 +548,6 @@ module ActiveRecord
         def initialize_type_map(m)
           super
 
-          register_class_with_limit m, %r(char)i, MysqlString
-
           m.register_type %r(tinytext)i,   Type::Text.new(limit: 2**8 - 1)
           m.register_type %r(tinyblob)i,   Type::Binary.new(limit: 2**8 - 1)
           m.register_type %r(text)i,       Type::Text.new(limit: 2**16 - 1)
@@ -575,13 +573,13 @@ module ActiveRecord
           m.register_type(%r(enum)i) do |sql_type|
             limit = sql_type[/^enum\((.+)\)/i, 1]
               .split(",").map { |enum| enum.strip.length - 2 }.max
-            MysqlString.new(limit: limit)
+            Type::String.new(limit: limit)
           end
 
           m.register_type(%r(^set)i) do |sql_type|
             limit = sql_type[/^set\((.+)\)/i, 1]
               .split(",").map { |set| set.strip.length - 1 }.sum - 1
-            MysqlString.new(limit: limit)
+            Type::String.new(limit: limit)
           end
         end
 
@@ -857,27 +855,6 @@ module ActiveRecord
         class MysqlJson < Type::Json # :nodoc:
         end
 
-        class MysqlString < Type::String # :nodoc:
-          def serialize(value)
-            case value
-            when true then "1"
-            when false then "0"
-            else super
-            end
-          end
-
-          private
-
-            def cast_value(value)
-              case value
-              when true then "1"
-              when false then "0"
-              else super
-              end
-            end
-        end
-
-        ActiveRecord::Type.register(:string, MysqlString, adapter: :mysql2)
         ActiveRecord::Type.register(:unsigned_integer, Type::UnsignedInteger, adapter: :mysql2)
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -2,8 +2,6 @@ module ActiveRecord
   module ConnectionAdapters
     module MySQL
       module Quoting # :nodoc:
-        QUOTED_TRUE, QUOTED_FALSE = "1".freeze, "0".freeze
-
         def quote_column_name(name)
           @quoted_column_names[name] ||= "`#{super.gsub('`', '``')}`".freeze
         end
@@ -13,19 +11,19 @@ module ActiveRecord
         end
 
         def quoted_true
-          QUOTED_TRUE
+          "'1'".freeze
         end
 
         def unquoted_true
-          1
+          "1".freeze
         end
 
         def quoted_false
-          QUOTED_FALSE
+          "'0'".freeze
         end
 
         def unquoted_false
-          0
+          "0".freeze
         end
 
         def quoted_date(value)

--- a/activerecord/test/cases/adapters/mysql2/boolean_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/boolean_test.rb
@@ -51,8 +51,8 @@ class Mysql2BooleanTest < ActiveRecord::Mysql2TestCase
     assert_equal 0, attributes["archived"]
     assert_equal "0", attributes["published"]
 
-    assert_equal 1, @connection.type_cast(true)
-    assert_equal 0, @connection.type_cast(false)
+    assert_equal "1", @connection.type_cast(true)
+    assert_equal "0", @connection.type_cast(false)
   end
 
   test "type casting without emulated booleans" do
@@ -68,8 +68,8 @@ class Mysql2BooleanTest < ActiveRecord::Mysql2TestCase
     assert_equal 0, attributes["archived"]
     assert_equal "0", attributes["published"]
 
-    assert_equal 1, @connection.type_cast(true)
-    assert_equal 0, @connection.type_cast(false)
+    assert_equal "1", @connection.type_cast(true)
+    assert_equal "0", @connection.type_cast(false)
   end
 
   test "with booleans stored as 1 and 0" do

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -12,7 +12,6 @@ require "models/computer"
 require "models/project"
 require "models/default"
 require "models/auto_id"
-require "models/boolean"
 require "models/column_name"
 require "models/subscriber"
 require "models/comment"
@@ -712,48 +711,6 @@ class BasicsTest < ActiveRecord::TestCase
 
     assert_instance_of Hash, category.attributes
     assert_equal expected_attributes, category.attributes
-  end
-
-  def test_boolean
-    b_nil = Boolean.create("value" => nil)
-    nil_id = b_nil.id
-    b_false = Boolean.create("value" => false)
-    false_id = b_false.id
-    b_true = Boolean.create("value" => true)
-    true_id = b_true.id
-
-    b_nil = Boolean.find(nil_id)
-    assert_nil b_nil.value
-    b_false = Boolean.find(false_id)
-    assert !b_false.value?
-    b_true = Boolean.find(true_id)
-    assert b_true.value?
-  end
-
-  def test_boolean_without_questionmark
-    b_true = Boolean.create("value" => true)
-    true_id = b_true.id
-
-    subclass   = Class.new(Boolean).find true_id
-    superclass = Boolean.find true_id
-
-    assert_equal superclass.read_attribute(:has_fun), subclass.read_attribute(:has_fun)
-  end
-
-  def test_boolean_cast_from_string
-    b_blank = Boolean.create("value" => "")
-    blank_id = b_blank.id
-    b_false = Boolean.create("value" => "0")
-    false_id = b_false.id
-    b_true = Boolean.create("value" => "1")
-    true_id = b_true.id
-
-    b_blank = Boolean.find(blank_id)
-    assert_nil b_blank.value
-    b_false = Boolean.find(false_id)
-    assert !b_false.value?
-    b_true = Boolean.find(true_id)
-    assert b_true.value?
   end
 
   def test_new_record_returns_boolean

--- a/activerecord/test/cases/boolean_test.rb
+++ b/activerecord/test/cases/boolean_test.rb
@@ -30,4 +30,14 @@ class BooleanTest < ActiveRecord::TestCase
     assert !Boolean.find(b_false.id).value?
     assert Boolean.find(b_true.id).value?
   end
+
+  def test_find_by_boolean
+    b_nil   = Boolean.create!(value: nil)
+    b_false = Boolean.create!(value: false)
+    b_true  = Boolean.create!(value: true)
+
+    assert_nil Boolean.find_by(value: b_nil.value).value
+    assert !Boolean.find_by(value: b_false.value).value?
+    assert Boolean.find_by(value: b_true.value).value?
+  end
 end

--- a/activerecord/test/cases/boolean_test.rb
+++ b/activerecord/test/cases/boolean_test.rb
@@ -1,0 +1,33 @@
+require "cases/helper"
+require "models/boolean"
+
+class BooleanTest < ActiveRecord::TestCase
+  def test_boolean
+    b_nil   = Boolean.create!(value: nil)
+    b_false = Boolean.create!(value: false)
+    b_true  = Boolean.create!(value: true)
+
+    assert_nil Boolean.find(b_nil.id).value
+    assert !Boolean.find(b_false.id).value?
+    assert Boolean.find(b_true.id).value?
+  end
+
+  def test_boolean_without_questionmark
+    b_true = Boolean.create!(value: true)
+
+    subclass   = Class.new(Boolean).find(b_true.id)
+    superclass = Boolean.find(b_true.id)
+
+    assert_equal superclass.read_attribute(:has_fun), subclass.read_attribute(:has_fun)
+  end
+
+  def test_boolean_cast_from_string
+    b_blank = Boolean.create!(value: "")
+    b_false = Boolean.create!(value: "0")
+    b_true  = Boolean.create!(value: "1")
+
+    assert_nil Boolean.find(b_blank.id).value
+    assert !Boolean.find(b_false.id).value?
+    assert Boolean.find(b_true.id).value?
+  end
+end

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -222,6 +222,7 @@ module ActiveRecord
     class QuoteBooleanTest < ActiveRecord::TestCase
       def setup
         @connection = ActiveRecord::Base.connection
+        @string = ActiveRecord::Type.lookup(:string)
       end
 
       def test_quote_returns_frozen_string
@@ -232,6 +233,16 @@ module ActiveRecord
       def test_type_cast_returns_frozen_value
         assert_predicate @connection.type_cast(true), :frozen?
         assert_predicate @connection.type_cast(false), :frozen?
+      end
+
+      def test_quote_serialized_stirng_returns_same_value
+        assert_equal @connection.quote(true), @connection.quote(@string.serialize(true))
+        assert_equal @connection.quote(false), @connection.quote(@string.serialize(false))
+      end
+
+      def test_type_cast_serialized_string_returns_same_value
+        assert_equal @connection.type_cast(true), @connection.type_cast(@string.serialize(true))
+        assert_equal @connection.type_cast(false), @connection.type_cast(@string.serialize(false))
       end
     end
 

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -241,6 +241,9 @@ module ActiveRecord
     def test_where_with_boolean_for_string_column
       count = Post.where(title: false).count
       assert_equal 0, count
+
+      count = Post.where("title = ?", false).count
+      assert_equal 0, count
     end
 
     def test_where_with_decimal_for_string_column


### PR DESCRIPTION
Quoting booleans returns a quoted value in postgresql and sqlite3
adapters. But mysql2 adapter does not return a quoted value without
serialized by a string type. This commit fixes the inconsistent
behavior.
