### PR TITLE
Rubocop passing

### DIFF
--- a/actioncable/Rakefile
+++ b/actioncable/Rakefile
@@ -21,7 +21,7 @@ namespace :test do
   task :isolated do
     Dir.glob("test/**/*_test.rb").all? do |file|
       sh(Gem.ruby, "-w", "-Ilib:test", file)
-    end or raise "Failures"
+    end || raise("Failures")
   end
 
   task :integration do

--- a/actioncable/lib/action_cable/connection/client_socket.rb
+++ b/actioncable/lib/action_cable/connection/client_socket.rb
@@ -89,7 +89,7 @@ module ActionCable
         code   ||= 1000
         reason ||= ""
 
-        unless code == 1000 or (code >= 3000 and code <= 4999)
+        unless code == 1000 || (code >= 3000 && code <= 4999)
           raise ArgumentError, "Failed to execute 'close' on WebSocket: " +
                                "The code must be either 1000, or between 3000 and 4999. " +
                                "#{code} is neither."

--- a/actioncable/test/stubs/test_server.rb
+++ b/actioncable/test/stubs/test_server.rb
@@ -11,11 +11,12 @@ class TestServer
 
     @config = OpenStruct.new(log_tags: [], subscription_adapter: subscription_adapter)
     @config.use_faye = ENV["FAYE"].present?
-    @config.client_socket_class = if @config.use_faye
-      ActionCable::Connection::FayeClientSocket
-                                  else
-                                    ActionCable::Connection::ClientSocket
-                                  end
+    @config.client_socket_class =
+      if @config.use_faye
+        ActionCable::Connection::FayeClientSocket
+      else
+        ActionCable::Connection::ClientSocket
+      end
 
     @mutex = Monitor.new
   end
@@ -25,11 +26,12 @@ class TestServer
   end
 
   def event_loop
-    @event_loop ||= if @config.use_faye
-      ActionCable::Connection::FayeEventLoop.new
-                    else
-                      ActionCable::Connection::StreamEventLoop.new
-                    end
+    @event_loop ||=
+      if @config.use_faye
+        ActionCable::Connection::FayeEventLoop.new
+      else
+        ActionCable::Connection::StreamEventLoop.new
+      end
   end
 
   def worker_pool

--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -18,6 +18,6 @@ namespace :test do
   task :isolated do
     Dir.glob("test/**/*_test.rb").all? do |file|
       sh(Gem.ruby, "-w", "-Ilib:test", file)
-    end or raise "Failures"
+    end || raise("Failures")
   end
 end

--- a/actionmailer/lib/action_mailer/preview.rb
+++ b/actionmailer/lib/action_mailer/preview.rb
@@ -34,11 +34,12 @@ module ActionMailer
       # Either a class or a string can be passed in as the Interceptor. If a
       # string is passed in it will be <tt>constantize</tt>d.
       def register_preview_interceptor(interceptor)
-        preview_interceptor = case interceptor
-                              when String, Symbol
-                                interceptor.to_s.camelize.constantize
+        preview_interceptor =
+          case interceptor
+          when String, Symbol
+            interceptor.to_s.camelize.constantize
           else
-                                interceptor
+            interceptor
           end
 
         unless preview_interceptors.include?(preview_interceptor)

--- a/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
+++ b/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
@@ -20,17 +20,20 @@ module Rails
       hook_for :template_engine, :test_framework
 
       protected
+
         def file_name
           @_file_name ||= super.gsub(/_mailer/i, "")
         end
 
       private
+
         def application_mailer_file_name
-          @_application_mailer_file_name ||= if mountable_engine?
-            "app/mailers/#{namespaced_path}/application_mailer.rb"
-                                           else
-                                             "app/mailers/application_mailer.rb"
-                                           end
+          @_application_mailer_file_name ||=
+            if mountable_engine?
+              "app/mailers/#{namespaced_path}/application_mailer.rb"
+            else
+              "app/mailers/application_mailer.rb"
+            end
         end
     end
   end

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -21,7 +21,7 @@ namespace :test do
   task :isolated do
     test_files.all? do |file|
       sh(Gem.ruby, "-w", "-Ilib:test", file)
-    end or raise "Failures"
+    end || raise("Failures")
   end
 end
 

--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -64,7 +64,7 @@ module ActionController #:nodoc:
       # http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
       # for the Cache-Control header spec.
       def send_file(path, options = {}) #:doc:
-        raise MissingFile, "Cannot read file #{path}" unless File.file?(path) and File.readable?(path)
+        raise MissingFile, "Cannot read file #{path}" unless File.file?(path) && File.readable?(path)
 
         options[:filename] ||= File.basename(path) unless options[:url_based_filename]
         send_file_headers! options

--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -62,10 +62,11 @@ module ActionController
     def method_for_action(action_name)
       super || if template_exists?(action_name.to_s, _prefixes)
                  "default_render"
-      end
+               end
     end
 
     private
+
       def interactive_browser_request?
         request.get? && request.format == Mime[:html] && !request.xhr?
       end

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -111,7 +111,7 @@ module ActionController
           `fallback_location` represents the location to use if the request has
           no HTTP referer information.
         MESSAGE
-        request.headers["Referer"] or raise RedirectBackError
+        request.headers["Referer"] || raise(RedirectBackError)
       when Proc
         _compute_redirect_to_location request, options.call
       else

--- a/actionpack/lib/action_dispatch/journey/parser.rb
+++ b/actionpack/lib/action_dispatch/journey/parser.rb
@@ -192,5 +192,5 @@ module ActionDispatch
         val[0]
       end
     end   # class Parser
-    end   # module Journey
-  end   # module ActionDispatch
+  end   # module Journey
+end   # module ActionDispatch

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -372,7 +372,7 @@ module ActionDispatch
 
         handle_options(options)
 
-        if @cookies[name.to_s] != value or options[:expires]
+        if @cookies[name.to_s] != (value || options[:expires])
           @cookies[name.to_s] = value
           @set_cookies[name.to_s] = options
           @delete_cookies.delete(name.to_s)

--- a/actionpack/lib/action_dispatch/middleware/session/cache_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cache_store.rb
@@ -19,7 +19,8 @@ module ActionDispatch
 
       # Get a session from the cache.
       def find_session(env, sid)
-        unless sid and session = @cache.read(cache_key(sid))
+        session = @cache.read(cache_key(sid))
+        unless sid && session
           sid, session = generate_sid, {}
         end
         [sid, session]

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1683,11 +1683,12 @@ to this:
             action = nil
           end
 
-          as = if !options.fetch(:as, true) # if it's set to nil or false
-            options.delete(:as)
-               else
-                 name_for_action(options.delete(:as), action)
-               end
+          as =
+            if !options.fetch(:as, true) # if it's set to nil or false
+              options.delete(:as)
+            else
+              name_for_action(options.delete(:as), action)
+            end
 
           path = Mapping.normalize_path URI.parser.escape(path), formatted
           ast = Journey::Parser.parse path
@@ -1712,7 +1713,7 @@ to this:
         def root(path, options = {})
           if path.is_a?(String)
             options[:to] = path
-          elsif path.is_a?(Hash) and options.empty?
+          elsif path.is_a?(Hash) && options.empty?
             options = path
           else
             raise ArgumentError, "must be called with a path and/or options"

--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -245,12 +245,13 @@ module ActionDispatch
             args  = []
 
             model = record.to_model
-            named_route = if model.persisted?
-              args << model
-              get_method_for_string model.model_name.singular_route_key
-                          else
-                            get_method_for_class model
-                          end
+            named_route =
+              if model.persisted?
+                args << model
+                get_method_for_string model.model_name.singular_route_key
+              else
+                get_method_for_class model
+              end
 
             [named_route, args]
           end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -282,16 +282,17 @@ module ActionDispatch
             mod.module_eval do
               define_method(name) do |*args|
                 last = args.last
-                options = case last
-                          when Hash
-                            args.pop
-                          when ActionController::Parameters
-                            if last.permitted?
-                              args.pop.to_h
-                            else
-                              raise ArgumentError, ActionDispatch::Routing::INSECURE_URL_PARAMETERS_MESSAGE
-                            end
-                          end
+                options =
+                  case last
+                  when Hash
+                    args.pop
+                  when ActionController::Parameters
+                    if last.permitted?
+                      args.pop.to_h
+                    else
+                      raise ArgumentError, ActionDispatch::Routing::INSECURE_URL_PARAMETERS_MESSAGE
+                    end
+                  end
                 helper.call self, args, options
               end
             end
@@ -596,8 +597,8 @@ module ActionDispatch
         # :controller, :action or :id is not found, don't pull any
         # more keys from the recall.
         def normalize_controller_action_id!
-          use_recall_for(:controller) or return
-          use_recall_for(:action) or return
+          return unless use_recall_for(:controller)
+          return unless use_recall_for(:action)
           use_recall_for(:id)
         end
 

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -226,7 +226,7 @@ class TestController < ActionController::Base
   end
 
   def head_and_return
-    head :ok and return
+    head(:ok) && return
     raise "should not reach this line"
   end
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -209,7 +209,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   def test_class_and_lambda_constraints
     subdomain = Class.new {
       def matches?(request)
-        request.subdomain.present? and request.subdomain != "clients"
+        request.subdomain.present? && request.subdomain != "clients"
       end
     }
 
@@ -227,7 +227,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   def test_lambda_constraints
     rs.draw do
       get "/", constraints: lambda { |req|
-        req.subdomain.present? and req.subdomain != "clients" },
+        req.subdomain.present? && req.subdomain != "clients" },
                  to: lambda { |env| [200, {}, %w{default}] }
 
       get "/", constraints: lambda { |req|

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -14,7 +14,7 @@ namespace :test do
   task :isolated do
     Dir.glob("test/{actionpack,activerecord,template}/**/*_test.rb").all? do |file|
       sh(Gem.ruby, "-w", "-Ilib:test", file)
-    end or raise "Failures"
+    end || raise("Failures")
   end
 
   Rake::TestTask.new(:template) do |t|

--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -37,7 +37,9 @@ module ActionView
       def capture(*args)
         value = nil
         buffer = with_output_buffer { value = yield(*args) }
-        if string = buffer.presence || value and string.is_a?(String)
+        string = buffer.presence || value
+
+        if string && string.is_a?(String)
           ERB::Util.html_escape string
         end
       end

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -1011,12 +1011,13 @@ module ActionView
         #  css_class_attribute(:year, 'date optional', { year: 'my-year' })
         #  => "date optional my-year"
         def css_class_attribute(type, html_options_class, options) # :nodoc:
-          css_class = case options
-                      when Hash
-                        options[type.to_sym]
-                      else
-                        type
-                      end
+          css_class =
+            case options
+            when Hash
+              options[type.to_sym]
+            else
+              type
+            end
 
           [html_options_class, css_class].compact.join(" ")
         end

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -466,11 +466,12 @@ module ActionView
           method: method
         )
 
-        options[:url] ||= if options.key?(:format)
-          polymorphic_path(record, format: options.delete(:format))
-                          else
-                            polymorphic_path(record, {})
-                          end
+        options[:url] ||=
+          if options.key?(:format)
+            polymorphic_path(record, format: options.delete(:format))
+          else
+            polymorphic_path(record, {})
+          end
       end
       private :apply_form_for_options!
 
@@ -1286,7 +1287,7 @@ module ActionView
         @object_name, @object, @template, @options = object_name, object, template, options
         @default_options = @options ? @options.slice(:index, :namespace) : {}
         if @object_name.to_s.match(/\[\]$/)
-          if object ||= @template.instance_variable_get("@#{Regexp.last_match.pre_match}") and object.respond_to?(:to_param)
+          if object ||= @template.instance_variable_get("@#{Regexp.last_match.pre_match}") && object.respond_to?(:to_param)
             @auto_index = object.to_param
           else
             raise ArgumentError, "object[] naming but object param and @object var don't exist or don't respond to to_param: #{object.inspect}"
@@ -1572,14 +1573,16 @@ module ActionView
           @auto_index
         end
 
-        record_name = if index
-          "#{object_name}[#{index}][#{record_name}]"
-                      elsif record_name.to_s.end_with?("[]")
-                        record_name = record_name.to_s.sub(/(.*)\[\]$/, "[\\1][#{record_object.id}]")
-                        "#{object_name}#{record_name}"
-                      else
-                        "#{object_name}[#{record_name}]"
-                      end
+        record_name =
+          if index
+            "#{object_name}[#{index}][#{record_name}]"
+          elsif record_name.to_s.end_with?("[]")
+            record_name = record_name.to_s.sub(/(.*)\[\]$/, "[\\1][#{record_object.id}]")
+            "#{object_name}#{record_name}"
+          else
+            "#{object_name}[#{record_name}]"
+          end
+
         fields_options[:child_index] = index
 
         @template.fields_for(record_name, record_object, fields_options, &block)

--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -46,7 +46,7 @@ namespace :test do
         dir = File.dirname(__FILE__)
         Dir.glob("#{dir}/test/cases/**/*_test.rb").all? do |file|
           sh(Gem.ruby, "-w", "-I#{dir}/lib", "-I#{dir}/test", file)
-        end or raise "Failures"
+        end || raise("Failures")
       end
     end
 

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -104,7 +104,7 @@ module ActiveJob
       end
 
       def serialized_global_id?(hash)
-        hash.size == 1 and hash.include?(GLOBALID_KEY)
+        hash.size == 1 && hash.include?(GLOBALID_KEY)
       end
 
       def deserialize_global_id(hash)

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -18,6 +18,6 @@ namespace :test do
   task :isolated do
     Dir.glob("#{dir}/test/**/*_test.rb").all? do |file|
       sh(Gem.ruby, "-w", "-I#{dir}/lib", "-I#{dir}/test", file)
-    end or raise "Failures"
+    end || raise("Failures")
   end
 end

--- a/activemodel/lib/active_model/type/helpers/numeric.rb
+++ b/activemodel/lib/active_model/type/helpers/numeric.rb
@@ -3,12 +3,14 @@ module ActiveModel
     module Helpers
       module Numeric # :nodoc:
         def cast(value)
-          value = case value
-                  when true then 1
-                  when false then 0
-                  when ::String then value.presence
-                  else value
-                  end
+          value =
+            case value
+            when true then 1
+            when false then 0
+            when ::String then value.presence
+            else value
+            end
+
           super(value)
         end
 

--- a/activemodel/lib/active_model/type/immutable_string.rb
+++ b/activemodel/lib/active_model/type/immutable_string.rb
@@ -17,11 +17,13 @@ module ActiveModel
       private
 
         def cast_value(value)
-          result = case value
-                   when true then "t"
-                   when false then "f"
-                   else value.to_s
-                   end
+          result =
+            case value
+            when true then "t"
+            when false then "f"
+            else value.to_s
+            end
+
           result.freeze
         end
     end

--- a/activemodel/lib/active_model/validations/clusivity.rb
+++ b/activemodel/lib/active_model/validations/clusivity.rb
@@ -15,13 +15,14 @@ module ActiveModel
     private
 
       def include?(record, value)
-        members = if delimiter.respond_to?(:call)
-          delimiter.call(record)
-        elsif delimiter.respond_to?(:to_sym)
-          record.send(delimiter)
-        else
-          delimiter
-        end
+        members =
+          if delimiter.respond_to?(:call)
+            delimiter.call(record)
+          elsif delimiter.respond_to?(:to_sym)
+            record.send(delimiter)
+          else
+            delimiter
+          end
 
         members.send(inclusion_method(members), value)
       end

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -67,7 +67,7 @@ end
           |x| x.include?("/adapters/")
         } + Dir["test/cases/adapters/#{adapter_short}/**/*_test.rb"]).all? do |file|
           sh(Gem.ruby, "-w" ,"-Itest", file)
-        end or raise "Failures"
+        end || raise("Failures")
       end
     end
   end

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -219,13 +219,14 @@ module ActiveRecord
           raise ArgumentError, "Valid values are :nullify or :delete_all"
         end
 
-        dependent = if dependent
-          dependent
-        elsif options[:dependent] == :destroy
-          :delete_all
-        else
-          options[:dependent]
-        end
+        dependent =
+          if dependent
+            dependent
+          elsif options[:dependent] == :destroy
+            :delete_all
+          else
+            options[:dependent]
+          end
 
         delete_or_nullify_all_records(dependent).tap do
           reset

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -71,16 +71,20 @@ module ActiveRecord
         # If the collection is empty the target is set to an empty array and
         # the loaded flag is set to true as well.
         def count_records
-          count = if reflection.has_cached_counter?
-            owner._read_attribute reflection.counter_cache_column
-          else
-            scope.count
-          end
+          count =
+            if reflection.has_cached_counter?
+              owner._read_attribute reflection.counter_cache_column
+            else
+              scope.count
+            end
 
           # If there's nothing in the database and @target has no new records
           # we are certain the current target is an empty array. This is a
           # documented side-effect of the method that may avoid an extra SELECT.
-          @target ||= [] and loaded! if count == 0
+          if count == 0
+            loaded!
+            @target ||= []
+          end
 
           [association_scope.limit_value, count].compact.min
         end

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -228,8 +228,8 @@ module ActiveRecord
         end
 
         def find_reflection(klass, name)
-          klass._reflect_on_association(name) or
-            raise ConfigurationError, "Can't join '#{ klass.name }' to association named '#{ name }'; perhaps you misspelled it?"
+          klass._reflect_on_association(name) || \
+            raise(ConfigurationError, "Can't join '#{ klass.name }' to association named '#{ name }'; perhaps you misspelled it?")
         end
 
         def build(associations, base_klass)

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -160,11 +160,12 @@ module ActiveRecord
       #   Person.attribute_names
       #   # => ["id", "created_at", "updated_at", "name", "age"]
       def attribute_names
-        @attribute_names ||= if !abstract_class? && table_exists?
-          attribute_types.keys
-        else
-          []
-        end
+        @attribute_names ||=
+          if !abstract_class? && table_exists?
+            attribute_types.keys
+          else
+            []
+          end
       end
 
       # Returns true if the given attribute exists, otherwise false.

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -49,13 +49,14 @@ module ActiveRecord
           # When ::JSON is used, force it to go through the Active Support JSON encoder
           # to ensure special objects (e.g. Active Record models) are dumped correctly
           # using the #as_json hook.
-          coder = if class_name_or_coder == ::JSON
-            Coders::JSON
-          elsif [:load, :dump].all? { |x| class_name_or_coder.respond_to?(x) }
-            class_name_or_coder
-          else
-            Coders::YAMLColumn.new(class_name_or_coder)
-          end
+          coder =
+            if class_name_or_coder == ::JSON
+              Coders::JSON
+            elsif [:load, :dump].all? { |x| class_name_or_coder.respond_to?(x) }
+              class_name_or_coder
+            else
+              Coders::YAMLColumn.new(class_name_or_coder)
+            end
 
           decorate_attribute_type(attr_name, :serialize) do |type|
             Type::Serialized.new(type, coder)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -966,8 +966,8 @@ module ActiveRecord
       end
 
       def foreign_key_for!(from_table, options_or_to_table = {}) # :nodoc:
-        foreign_key_for(from_table, options_or_to_table) or \
-          raise ArgumentError, "Table '#{from_table}' has no foreign key for #{options_or_to_table}"
+        foreign_key_for(from_table, options_or_to_table) || \
+          raise(ArgumentError, "Table '#{from_table}' has no foreign key for #{options_or_to_table}")
       end
 
       def foreign_key_column_for(table_name) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -360,7 +360,7 @@ module ActiveRecord
 
         # Resets the sequence of a table's primary key to the maximum value.
         def reset_pk_sequence!(table, pk = nil, sequence = nil) #:nodoc:
-          unless pk and sequence
+          unless pk && sequence
             default_pk, default_sequence = pk_and_sequence_for(table)
 
             pk ||= default_pk
@@ -403,7 +403,7 @@ module ActiveRecord
               AND dep.refobjid      = '#{quote_table_name(table)}'::regclass
           end_sql
 
-          if result.nil? or result.empty?
+          if result.nil? || result.empty?
             result = query(<<-end_sql, "SCHEMA")[0]
               SELECT attr.attname, nsp.nspname,
                 CASE

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -109,7 +109,7 @@ module ActiveRecord
     end
 
     def connection_pool
-      connection_handler.retrieve_connection_pool(connection_specification_name) or raise ConnectionNotEstablished
+      connection_handler.retrieve_connection_pool(connection_specification_name) || raise(ConnectionNotEstablished)
     end
 
     def retrieve_connection

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -229,7 +229,7 @@ module ActiveRecord
       end
 
       def find_by!(*args) # :nodoc:
-        find_by(*args) or raise RecordNotFound.new("Couldn't find #{name}", name)
+        find_by(*args) || raise(RecordNotFound.new("Couldn't find #{name}", name))
       end
 
       def initialize_generated_modules # :nodoc:
@@ -497,15 +497,16 @@ module ActiveRecord
     def inspect
       # We check defined?(@attributes) not to issue warnings if the object is
       # allocated but not initialized.
-      inspection = if defined?(@attributes) && @attributes
-        self.class.column_names.collect do |name|
-          if has_attribute?(name)
-            "#{name}: #{attribute_for_inspect(name)}"
-          end
-        end.compact.join(", ")
-     else
-       "not initialized"
-     end
+      inspection =
+        if defined?(@attributes) && @attributes
+          self.class.column_names.collect { |name|
+            if has_attribute?(name)
+              "#{name}: #{attribute_for_inspect(name)}"
+            end
+          }.compact.join(", ")
+        else
+          "not initialized"
+        end
 
       "#<#{self.class} #{inspection}>"
     end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -203,18 +203,20 @@ db_namespace = namespace :db do
 
       base_dir = ActiveRecord::Tasks::DatabaseTasks.fixtures_path
 
-      fixtures_dir = if ENV["FIXTURES_DIR"]
-        File.join base_dir, ENV["FIXTURES_DIR"]
-      else
-        base_dir
-      end
+      fixtures_dir =
+        if ENV["FIXTURES_DIR"]
+          File.join base_dir, ENV["FIXTURES_DIR"]
+        else
+          base_dir
+        end
 
-      fixture_files = if ENV["FIXTURES"]
-        ENV["FIXTURES"].split(",")
-      else
-        # The use of String#[] here is to support namespaced fixtures.
-        Dir["#{fixtures_dir}/**/*.yml"].map {|f| f[(fixtures_dir.size + 1)..-5] }
-      end
+      fixture_files =
+        if ENV["FIXTURES"]
+          ENV["FIXTURES"].split(",")
+        else
+          # The use of String#[] here is to support namespaced fixtures
+          Dir["#{fixtures_dir}/**/*.yml"].map {|f| f[(fixtures_dir.size + 1)..-5] }
+        end
 
       ActiveRecord::FixtureSet.create_fixtures(fixtures_dir, fixture_files)
     end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -14,18 +14,19 @@ module ActiveRecord
     end
 
     def self.create(macro, name, scope, options, ar)
-      klass = case macro
-              when :composed_of
-                AggregateReflection
-              when :has_many
-                HasManyReflection
-              when :has_one
-                HasOneReflection
-              when :belongs_to
-                BelongsToReflection
-              else
-                raise "Unsupported Macro: #{macro}"
-              end
+      klass =
+        case macro
+        when :composed_of
+          AggregateReflection
+        when :has_many
+          HasManyReflection
+        when :has_one
+          HasOneReflection
+        when :belongs_to
+          BelongsToReflection
+        else
+          raise "Unsupported Macro: #{macro}"
+        end
 
       reflection = klass.new(name, scope, options, ar)
       options[:through] ? ThroughReflection.new(reflection) : reflection

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -103,7 +103,7 @@ module ActiveRecord
     # Same as #take but raises ActiveRecord::RecordNotFound if no record
     # is found. Note that #take! accepts no arguments.
     def take!
-      take or raise RecordNotFound.new("Couldn't find #{@klass.name} with [#{arel.where_sql(@klass.arel_engine)}]")
+      take || raise(RecordNotFound.new("Couldn't find #{@klass.name} with [#{arel.where_sql(@klass.arel_engine)}]"))
     end
 
     # Find the first record (or first N records if a parameter is supplied).
@@ -165,7 +165,7 @@ module ActiveRecord
     # Same as #last but raises ActiveRecord::RecordNotFound if no record
     # is found. Note that #last! accepts no arguments.
     def last!
-      last or raise RecordNotFound.new("Couldn't find #{@klass.name} with [#{arel.where_sql(@klass.arel_engine)}]")
+      last || raise(RecordNotFound.new("Couldn't find #{@klass.name} with [#{arel.where_sql(@klass.arel_engine)}]"))
     end
 
     # Find the second record.
@@ -261,7 +261,7 @@ module ActiveRecord
     # Same as #third_to_last but raises ActiveRecord::RecordNotFound if no record
     # is found.
     def third_to_last!
-      find_nth_from_last 3 or raise RecordNotFound.new("Couldn't find #{@klass.name} with [#{arel.where_sql(@klass.arel_engine)}]")
+      find_nth_from_last(3) || raise(RecordNotFound.new("Couldn't find #{@klass.name} with [#{arel.where_sql(@klass.arel_engine)}]"))
     end
 
     # Find the second-to-last record.
@@ -277,7 +277,7 @@ module ActiveRecord
     # Same as #second_to_last but raises ActiveRecord::RecordNotFound if no record
     # is found.
     def second_to_last!
-      find_nth_from_last 2 or raise RecordNotFound.new("Couldn't find #{@klass.name} with [#{arel.where_sql(@klass.arel_engine)}]")
+      find_nth_from_last(2) || raise(RecordNotFound.new("Couldn't find #{@klass.name} with [#{arel.where_sql(@klass.arel_engine)}]"))
     end
 
     # Returns true if a record exists in the table that matches the +id+ or
@@ -539,17 +539,18 @@ module ActiveRecord
       end
 
       def find_nth!(index)
-        find_nth(index) or raise RecordNotFound.new("Couldn't find #{@klass.name} with [#{arel.where_sql(@klass.arel_engine)}]")
+        find_nth(index) || raise(RecordNotFound.new("Couldn't find #{@klass.name} with [#{arel.where_sql(@klass.arel_engine)}]"))
       end
 
       def find_nth_with_limit(index, limit)
         # TODO: once the offset argument is removed from find_nth,
-        # find_nth_with_limit_and_offset can be merged into this method.
-        relation = if order_values.empty? && primary_key
-          order(arel_attribute(primary_key).asc)
-        else
-          self
-        end
+        # find_nth_with_limit_and_offset can be merged into this method
+        relation =
+          if order_values.empty? && primary_key
+            order(arel_attribute(primary_key).asc)
+          else
+            self
+          end
 
         relation = relation.offset(index) unless index.zero?
         relation.limit(limit).to_a
@@ -559,11 +560,12 @@ module ActiveRecord
         if loaded?
           records[-index]
         else
-          relation = if order_values.empty? && primary_key
-            order(arel_attribute(primary_key).asc)
-          else
-            self
-          end
+          relation =
+            if order_values.empty? && primary_key
+              order(arel_attribute(primary_key).asc)
+            else
+              self
+            end
 
           relation.to_a[-index]
           # TODO: can be made more performant on large result sets by

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -76,11 +76,12 @@ module ActiveRecord
       end
 
       def fixtures_path
-        @fixtures_path ||= if ENV["FIXTURES_PATH"]
-          File.join(root, ENV["FIXTURES_PATH"])
-        else
-          File.join(root, "test", "fixtures")
-        end
+        @fixtures_path ||=
+          if ENV["FIXTURES_PATH"]
+            File.join(root, ENV["FIXTURES_PATH"])
+          else
+            File.join(root, "test", "fixtures")
+          end
       end
 
       def root

--- a/activerecord/test/cases/column_alias_test.rb
+++ b/activerecord/test/cases/column_alias_test.rb
@@ -4,11 +4,12 @@ require "models/topic"
 class TestColumnAlias < ActiveRecord::TestCase
   fixtures :topics
 
-  QUERY = if "Oracle" == ActiveRecord::Base.connection.adapter_name
-    "SELECT id AS pk FROM topics WHERE ROWNUM < 2"
-  else
-    "SELECT id AS pk FROM topics"
-  end
+  QUERY =
+    if "Oracle" == ActiveRecord::Base.connection.adapter_name
+      "SELECT id AS pk FROM topics WHERE ROWNUM < 2"
+    else
+      "SELECT id AS pk FROM topics"
+    end
 
   def test_column_alias
     records = Topic.connection.select_all(QUERY)

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -73,11 +73,12 @@ module ActiveRecord
       end
 
       def test_rename_nonexistent_column
-        exception = if current_adapter?(:PostgreSQLAdapter, :OracleAdapter)
-          ActiveRecord::StatementInvalid
-        else
-          ActiveRecord::ActiveRecordError
-        end
+        exception =
+          if current_adapter?(:PostgreSQLAdapter, :OracleAdapter)
+            ActiveRecord::StatementInvalid
+          else
+            ActiveRecord::ActiveRecordError
+          end
 
         assert_raise(exception) do
           rename_column "test_models", "nonexistent", "should_fail"
@@ -192,8 +193,8 @@ module ActiveRecord
 
         new_columns = connection.columns(TestModel.table_name)
 
-        assert_not new_columns.find { |c| c.name == "age" and c.type == :integer }
-        assert new_columns.find { |c| c.name == "age" and c.type == :string }
+        assert_not new_columns.find { |c| c.name == "age" && c.type == :integer }
+        assert new_columns.find { |c| c.name == "age" && c.type == :string }
 
         old_columns = connection.columns(TestModel.table_name)
         assert old_columns.find { |c|
@@ -206,11 +207,11 @@ module ActiveRecord
 
         assert_not new_columns.find { |c|
           default = connection.lookup_cast_type_from_column(c).deserialize(c.default)
-          c.name == "approved" and c.type == :boolean and default == true
+          c.name == "approved" && c.type == :boolean && default == true
         }
         assert new_columns.find { |c|
           default = connection.lookup_cast_type_from_column(c).deserialize(c.default)
-          c.name == "approved" and c.type == :boolean and default == false
+          c.name == "approved" && c.type == :boolean && default == false
         }
         change_column :test_models, :approved, :boolean, default: true
       end

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -16,6 +16,6 @@ namespace :test do
   task :isolated do
     Dir.glob("test/**/*_test.rb").all? do |file|
       sh(Gem.ruby, "-w", "-Ilib:test", file)
-    end or raise "Failures"
+    end || raise("Failures")
   end
 end

--- a/activesupport/bin/generate_tables
+++ b/activesupport/bin/generate_tables
@@ -84,7 +84,10 @@ module ActiveSupport
 
         def create_composition_map
           @ucd.codepoints.each do |_, cp|
-            if !cp.nil? and cp.combining_class == 0 and cp.decomp_type.nil? and !cp.decomp_mapping.nil? and cp.decomp_mapping.length == 2 and @ucd.codepoints[cp.decomp_mapping[0]].combining_class == 0 and !@ucd.composition_exclusion.include?(cp.code)
+            if !cp.nil? && cp.combining_class == 0 && cp.decomp_type.nil? && \
+               !cp.decomp_mapping.nil? && cp.decomp_mapping.length == 2 && \
+               @ucd.codepoints[cp.decomp_mapping[0]].combining_class == 0 && \
+               !@ucd.composition_exclusion.include?(cp.code)
               @ucd.composition_map[cp.decomp_mapping[0]] ||= {}
               @ucd.composition_map[cp.decomp_mapping[0]][cp.decomp_mapping[1]] = cp.code
             end

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -371,7 +371,7 @@ module ActiveSupport #:nodoc:
             load_args = ["#{file_name}.rb"]
             load_args << const_path unless const_path.nil?
 
-            if !warnings_on_first_load or history.include?(expanded)
+            if !warnings_on_first_load || history.include?(expanded)
               result = load_file(*load_args)
             else
               enable_warnings { result = load_file(*load_args) }

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -89,25 +89,25 @@ module ActiveSupport
 
           should_break =
             # GB3. CR X LF
-            if previous == database.boundary[:cr] and current == database.boundary[:lf]
+            if previous == database.boundary[:cr] && current == database.boundary[:lf]
               false
             # GB4. (Control|CR|LF) ÷
-            elsif previous and in_char_class?(previous, [:control,:cr,:lf])
+            elsif previous && in_char_class?(previous, [:control,:cr,:lf])
               true
             # GB5. ÷ (Control|CR|LF)
             elsif in_char_class?(current, [:control,:cr,:lf])
               true
             # GB6. L X (L|V|LV|LVT)
-            elsif database.boundary[:l] === previous and in_char_class?(current, [:l,:v,:lv,:lvt])
+            elsif database.boundary[:l] === previous && in_char_class?(current, [:l,:v,:lv,:lvt])
               false
             # GB7. (LV|V) X (V|T)
-            elsif in_char_class?(previous, [:lv,:v]) and in_char_class?(current, [:v,:t])
+            elsif in_char_class?(previous, [:lv,:v]) && in_char_class?(current, [:v,:t])
               false
             # GB8. (LVT|T) X (T)
-            elsif in_char_class?(previous, [:lvt,:t]) and database.boundary[:t] === current
+            elsif in_char_class?(previous, [:lvt,:t]) && database.boundary[:t] === current
               false
             # GB8a. Regional_Indicator X Regional_Indicator
-            elsif database.boundary[:regional_indicator] === previous and database.boundary[:regional_indicator] === current
+            elsif database.boundary[:regional_indicator] === previous && database.boundary[:regional_indicator] === current
               false
             # GB9. X Extend
             elsif database.boundary[:extend] === current
@@ -158,7 +158,7 @@ module ActiveSupport
       def decompose(type, codepoints)
         codepoints.inject([]) do |decomposed, cp|
           # if it's a hangul syllable starter character
-          if HANGUL_SBASE <= cp and cp < HANGUL_SLAST
+          if HANGUL_SBASE <= cp && cp < HANGUL_SLAST
             sindex = cp - HANGUL_SBASE
             ncp = [] # new codepoints
             ncp << HANGUL_LBASE + sindex / HANGUL_NCOUNT
@@ -167,7 +167,7 @@ module ActiveSupport
             ncp << (HANGUL_TBASE + tindex) unless tindex == 0
             decomposed.concat ncp
           # if the codepoint is decomposable in with the current decomposition type
-          elsif (ncp = database.codepoints[cp].decomp_mapping) and (!database.codepoints[cp].decomp_type || type == :compatibility)
+          elsif (ncp = database.codepoints[cp].decomp_mapping) && (!database.codepoints[cp].decomp_type || type == :compatibility)
             decomposed.concat decompose(type, ncp.dup)
           else
             decomposed << cp
@@ -186,11 +186,11 @@ module ActiveSupport
           pos += 1
           lindex = starter_char - HANGUL_LBASE
           # -- Hangul
-          if 0 <= lindex and lindex < HANGUL_LCOUNT
+          if 0 <= lindex && lindex < HANGUL_LCOUNT
             vindex = codepoints[starter_pos+1] - HANGUL_VBASE rescue vindex = -1
-            if 0 <= vindex and vindex < HANGUL_VCOUNT
+            if 0 <= vindex && vindex < HANGUL_VCOUNT
               tindex = codepoints[starter_pos+2] - HANGUL_TBASE rescue tindex = -1
-              if 0 <= tindex and tindex < HANGUL_TCOUNT
+              if 0 <= tindex && tindex < HANGUL_TCOUNT
                 j = starter_pos + 2
                 eoa -= 2
               else
@@ -392,7 +392,7 @@ module ActiveSupport
           database.codepoints
           string.each_codepoint.map do |codepoint|
             cp = database.codepoints[codepoint]
-            if cp and (ncp = cp.send(mapping)) and ncp > 0
+            if cp && (ncp = cp.send(mapping)) && ncp > 0
               ncp
             else
               codepoint

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -68,7 +68,7 @@ module ActiveSupport
 
       module Subscribers # :nodoc:
         def self.new(pattern, listener)
-          if listener.respond_to?(:start) and listener.respond_to?(:finish)
+          if listener.respond_to?(:start) && listener.respond_to?(:finish)
             subscriber = Evented.new pattern, listener
           else
             subscriber = Timed.new pattern, listener

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -208,7 +208,11 @@ class DurationTest < ActiveSupport::TestCase
   end
 
   def test_case_when
-    cased = case 1.day when 1.day then "ok" end
+    cased =
+      case 1.day
+      when 1.day then "ok"
+      end
+
     assert_equal cased, "ok"
   end
 

--- a/activesupport/test/multibyte_grapheme_break_conformance_test.rb
+++ b/activesupport/test/multibyte_grapheme_break_conformance_test.rb
@@ -33,7 +33,7 @@ class MultibyteGraphemeBreakConformanceTest < ActiveSupport::TestCase
       lines = 0
       max_test_lines = 0 # Don't limit below 21, because that's the header of the testfile
       File.open(File.join(CACHE_DIR, UNIDATA_FILE), "r") do | f |
-        until f.eof? || (max_test_lines > 21 and lines > max_test_lines)
+        until f.eof? || (max_test_lines > 21 && lines > max_test_lines)
           lines += 1
           line = f.gets.chomp!
           next if line.empty? || line.start_with?("#")

--- a/activesupport/test/multibyte_normalization_conformance_test.rb
+++ b/activesupport/test/multibyte_normalization_conformance_test.rb
@@ -88,7 +88,7 @@ class MultibyteNormalizationConformanceTest < ActiveSupport::TestCase
       lines = 0
       max_test_lines = 0 # Don't limit below 38, because that's the header of the testfile
       File.open(File.join(CACHE_DIR, UNIDATA_FILE), "r") do | f |
-        until f.eof? || (max_test_lines > 38 and lines > max_test_lines)
+        until f.eof? || (max_test_lines > 38 && lines > max_test_lines)
           lines += 1
           line = f.gets.chomp!
           next if line.empty? || line.start_with?("#")

--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -67,14 +67,16 @@ HTML
           # as a list item, but as a paragraph starting with a plain
           # asterisk.
           body.gsub(/^(TIP|IMPORTANT|CAUTION|WARNING|NOTE|INFO|TODO)[.:](.*?)(\n(?=\n)|\Z)/m) do
-            css_class = case $1
-                        when "CAUTION", "IMPORTANT"
-                          "warning"
-                        when "TIP"
-                          "info"
-                        else
-                          $1.downcase
-                        end
+            css_class =
+              case $1
+              when "CAUTION", "IMPORTANT"
+                "warning"
+              when "TIP"
+                "info"
+              else
+                $1.downcase
+              end
+
             %(<div class="#{css_class}"><p>#{$2.strip}</p></div>)
           end
         end

--- a/railties/lib/rails/app_loader.rb
+++ b/railties/lib/rails/app_loader.rb
@@ -50,7 +50,7 @@ EOS
 
         # If we exhaust the search there is no executable, this could be a
         # call to generate a new application, so restore the original cwd.
-        Dir.chdir(original_cwd) and return if Pathname.new(Dir.pwd).root?
+        Dir.chdir(original_cwd) && return if Pathname.new(Dir.pwd).root?
 
         # Otherwise keep moving upwards in search of an executable.
         Dir.chdir("..")

--- a/railties/lib/rails/commands/plugin.rb
+++ b/railties/lib/rails/commands/plugin.rb
@@ -4,11 +4,12 @@ else
   ARGV.shift
   unless ARGV.delete("--no-rc")
     customrc = ARGV.index{ |x| x.include?("--rc=") }
-    railsrc = if customrc
-      File.expand_path(ARGV.delete_at(customrc).gsub(/--rc=/, ""))
-    else
-      File.join(File.expand_path("~"), ".railsrc")
-    end
+    railsrc =
+      if customrc
+        File.expand_path(ARGV.delete_at(customrc).gsub(/--rc=/, ""))
+      else
+        File.join(File.expand_path("~"), ".railsrc")
+      end
 
     if File.exist?(railsrc)
       extra_args_string = File.read(railsrc)

--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -41,11 +41,13 @@ module Rails
         "<table>".tap do |table|
           properties.each do |(name, value)|
             table << %(<tr><td class="name">#{CGI.escapeHTML(name.to_s)}</td>)
-            formatted_value = if value.kind_of?(Array)
-              "<ul>" + value.map { |v| "<li>#{CGI.escapeHTML(v.to_s)}</li>" }.join + "</ul>"
-            else
-              CGI.escapeHTML(value.to_s)
-            end
+            formatted_value =
+              if value.kind_of?(Array)
+                "<ul>" + value.map { |v| "<li>#{CGI.escapeHTML(v.to_s)}</li>" }.join + "</ul>"
+              else
+                CGI.escapeHTML(value.to_s)
+              end
+
             table << %(<td class="value">#{formatted_value}</td></tr>)
           end
           table << "</table>"

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -7,11 +7,13 @@ task default: :test
 desc "Runs all tests in test folder"
 task :test do
   $: << "test"
-  pattern = if ENV.key?("TEST")
-    ENV["TEST"]
-  else
-    "test"
-  end
+  pattern =
+    if ENV.key?("TEST")
+      ENV["TEST"]
+    else
+      "test"
+    end
+
   Minitest.rake_run([pattern])
 end
 

--- a/tools/profile
+++ b/tools/profile
@@ -72,7 +72,7 @@ module CodeTools
         fail Error.new("#{path} is a directory") if File.directory?(path)
         ruby_extension = File.extname(path) == ".rb"
         ruby_executable = File.open(path, "rb") {|f| f.readline } =~ [/\A#!.*ruby/]
-        fail Error.new("Not a ruby file") unless ruby_extension or ruby_executable
+        fail Error.new("Not a ruby file") unless ruby_extension || ruby_executable
       end
 
       module RequireProfiler


### PR DESCRIPTION
 I know about [comment](https://github.com/rails/rails/pull/13771#issuecomment-32746700), but now we have RuboCop and this pull request destroy dirty/hard code.
hard code examples: [has_many_association.rb](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/has_many_association.rb#L83), [capture_helper.rb](https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/capture_helper.rb#L40), and [cookies.rb](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/cookies.rb#L375)

 In any case we should to destroy dirty/hard code in RuboCop opinion.
