### PR TITLE
introduce take_or_create and friends

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Introduce take_or_create, take_or_create!, and take_or_initialize
+
+    *Alex Boyd*
+
 *   Hashes can once again be passed to setters of `composed_of`, if all of the
     mapping methods are methods implemented on `Hash`.
 

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -3,6 +3,7 @@ module ActiveRecord
     delegate :find, :take, :take!, :first, :first!, :last, :last!, :exists?, :any?, :many?, :none?, :one?, to: :all
     delegate :second, :second!, :third, :third!, :fourth, :fourth!, :fifth, :fifth!, :forty_two, :forty_two!, :third_to_last, :third_to_last!, :second_to_last, :second_to_last!, to: :all
     delegate :first_or_create, :first_or_create!, :first_or_initialize, to: :all
+    delegate :take_or_create, :take_or_create!, :take_or_initialize, to: :all
     delegate :find_or_create_by, :find_or_create_by!, :find_or_initialize_by, to: :all
     delegate :find_by, :find_by!, to: :all
     delegate :destroy, :destroy_all, :delete, :delete_all, :update, :update_all, to: :all

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -170,6 +170,18 @@ module ActiveRecord
       first || new(attributes, &block)
     end
 
+    def take_or_create(attributes = nil, &block) # :nodoc:
+      take || create(attributes, &block)
+    end
+
+    def take_or_create!(attributes = nil, &block) # :nodoc:
+      take || create!(attributes, &block)
+    end
+
+    def take_or_initialize(attributes = nil, &block) # :nodoc:
+      take || new(attributes, &block)
+    end
+
     # Finds the first record with the given attributes, or creates a record
     # with the attributes if one is not found:
     #

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1453,6 +1453,128 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal "parrot", parrot.name
   end
 
+  def test_take_or_create
+    parrot = Bird.where(color: "green").take_or_create(name: "parrot")
+    assert_kind_of Bird, parrot
+    assert parrot.persisted?
+    assert_equal "parrot", parrot.name
+    assert_equal "green", parrot.color
+
+    same_parrot = Bird.where(color: "green").take_or_create(name: "parakeet")
+    assert_kind_of Bird, same_parrot
+    assert same_parrot.persisted?
+    assert_equal parrot, same_parrot
+  end
+
+  def test_take_or_create_with_no_parameters
+    parrot = Bird.where(color: "green").take_or_create
+    assert_kind_of Bird, parrot
+    assert !parrot.persisted?
+    assert_equal "green", parrot.color
+  end
+
+  def test_take_or_create_with_block
+    parrot = Bird.where(color: "green").take_or_create { |bird| bird.name = "parrot" }
+    assert_kind_of Bird, parrot
+    assert parrot.persisted?
+    assert_equal "green", parrot.color
+    assert_equal "parrot", parrot.name
+
+    same_parrot = Bird.where(color: "green").take_or_create { |bird| bird.name = "parakeet" }
+    assert_equal parrot, same_parrot
+  end
+
+  def test_take_or_create_with_array
+    several_green_birds = Bird.where(color: "green").take_or_create([{name: "parrot"}, {name: "parakeet"}])
+    assert_kind_of Array, several_green_birds
+    several_green_birds.each { |bird| assert bird.persisted? }
+
+    same_bird = Bird.where(color: "green").take_or_create([{name: "hummingbird"}, {name: "macaw"}])
+    assert_kind_of Bird, same_bird
+    assert several_green_birds.include?(same_bird)
+  end
+
+  def test_take_or_create_bang_with_valid_options
+    parrot = Bird.where(color: "green").take_or_create!(name: "parrot")
+    assert_kind_of Bird, parrot
+    assert parrot.persisted?
+    assert_equal "parrot", parrot.name
+    assert_equal "green", parrot.color
+
+    same_parrot = Bird.where(color: "green").take_or_create!(name: "parakeet")
+    assert_kind_of Bird, same_parrot
+    assert same_parrot.persisted?
+    assert_equal parrot, same_parrot
+  end
+
+  def test_take_or_create_bang_with_invalid_options
+    assert_raises(ActiveRecord::RecordInvalid) { Bird.where(color: "green").take_or_create!(pirate_id: 1) }
+  end
+
+  def test_take_or_create_bang_with_no_parameters
+    assert_raises(ActiveRecord::RecordInvalid) { Bird.where(color: "green").take_or_create! }
+  end
+
+  def test_take_or_create_bang_with_valid_block
+    parrot = Bird.where(color: "green").take_or_create! { |bird| bird.name = "parrot" }
+    assert_kind_of Bird, parrot
+    assert parrot.persisted?
+    assert_equal "green", parrot.color
+    assert_equal "parrot", parrot.name
+
+    same_parrot = Bird.where(color: "green").take_or_create! { |bird| bird.name = "parakeet" }
+    assert_equal parrot, same_parrot
+  end
+
+  def test_take_or_create_bang_with_invalid_block
+    assert_raise(ActiveRecord::RecordInvalid) do
+      Bird.where(color: "green").take_or_create! { |bird| bird.pirate_id = 1 }
+    end
+  end
+
+  def test_take_or_create_with_valid_array
+    several_green_birds = Bird.where(color: "green").take_or_create!([{name: "parrot"}, {name: "parakeet"}])
+    assert_kind_of Array, several_green_birds
+    several_green_birds.each { |bird| assert bird.persisted? }
+
+    same_bird = Bird.where(color: "green").take_or_create!([{name: "hummingbird"}, {name: "macaw"}])
+    assert_kind_of Bird, same_bird
+    assert several_green_birds.include?(same_bird)
+  end
+
+  def test_take_or_create_with_invalid_array
+    assert_raises(ActiveRecord::RecordInvalid) { Bird.where(color: "green").take_or_create!([ {name: "parrot"}, {pirate_id: 1} ]) }
+  end
+
+  def test_take_or_initialize
+    parrot = Bird.where(color: "green").take_or_initialize(name: "parrot")
+    assert_kind_of Bird, parrot
+    assert !parrot.persisted?
+    assert parrot.valid?
+    assert parrot.new_record?
+    assert_equal "parrot", parrot.name
+    assert_equal "green", parrot.color
+  end
+
+  def test_take_or_initialize_with_no_parameters
+    parrot = Bird.where(color: "green").take_or_initialize
+    assert_kind_of Bird, parrot
+    assert !parrot.persisted?
+    assert !parrot.valid?
+    assert parrot.new_record?
+    assert_equal "green", parrot.color
+  end
+
+  def test_take_or_initialize_with_block
+    parrot = Bird.where(color: "green").take_or_initialize { |bird| bird.name = "parrot" }
+    assert_kind_of Bird, parrot
+    assert !parrot.persisted?
+    assert parrot.valid?
+    assert parrot.new_record?
+    assert_equal "green", parrot.color
+    assert_equal "parrot", parrot.name
+  end
+
   def test_find_or_create_by
     assert_nil Bird.find_by(name: "bob")
 


### PR DESCRIPTION
This adds take_or_create, take_or_create!, and take_or_initialize, which are analogous to their first_or_\* counterparts.
