### PR TITLE
Sqlite3 Migration Error Fixed (issue #26087)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Sqlite3 migrations to add a column to an existing table can now be
+    successfully rolled back when the column was given and invalid column
+    type.
+
+    Fixes #26087
+
+    *Travis O'Neill*
+
 *   Doing count on relations that contain LEFT OUTER JOIN Arel node no longer
     force a DISTINCT. This solves issues when using count after a left_joins.
 
@@ -57,8 +65,8 @@
     *Xavier Noria*
 
 *   Using `group` with an attribute that has a custom type will properly cast
-    the hash keys after calling a calculation method like `count`. 
-    
+    the hash keys after calling a calculation method like `count`.
+
     Fixes #25595.
 
     *Sean Griffin*
@@ -93,7 +101,7 @@
     *Sean Griffin*
 
 *   Ensure hashes can be assigned to attributes created using `composed_of`.
-    
+
     Fixes #25210.
 
     *Sean Griffin*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -303,7 +303,7 @@ module ActiveRecord
       #   end
       def column(name, type, options = {})
         name = name.to_s
-        type = type.to_sym
+        type = type.to_sym if type
         options = options.dup
 
         if @columns_hash[name] && @columns_hash[name].primary_key?

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1047,7 +1047,8 @@ module ActiveRecord
       end
 
       def type_to_sql(type, limit = nil, precision = nil, scale = nil) #:nodoc:
-        if native = native_database_types[type.to_sym]
+        type = type.to_sym if type
+        if native = native_database_types[type]
           column_type_sql = (native.is_a?(Hash) ? native[:name] : native).dup
 
           if type == :decimal # ignore limit, use precision and scale


### PR DESCRIPTION
### Summary

Fixed error in issue #26087
### Other Information

Error seems to be coming from an undefined method error when 'type' = nil on line 306:

``` Ruby
type = type.to_sym
```

~~Changed to the following to handle nil case~~
    ~~type = type&.to_sym || :placeholder~~

Now handles nil by passing it through without type error rather than assigning a placeholder on suggestion of @rafaelfranca:

``` Ruby
type = type.to_sym if type
```

Sqlite3 test suite runs with 0 errors and 3 skips (same as when run on unmodified code)
