### PR TITLE
Allow specifying encoding of parameters by action

### DIFF
--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -40,6 +40,7 @@ module ActionController
     autoload :Rescue
     autoload :Streaming
     autoload :StrongParameters
+    autoload :ParameterEncoding
     autoload :Testing
     autoload :UrlFor
   end

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -217,7 +217,7 @@ module ActionController
       MimeResponds,
       ImplicitRender,
       StrongParameters,
-
+      ParameterEncoding,
       Cookies,
       Flash,
       FormBuilder,

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -139,6 +139,10 @@ module ActionController
       end
     end
 
+    def self.encoding_for_param(action, param) # :nodoc:
+      ::Encoding::UTF_8
+    end
+
     # Delegates to the class' <tt>controller_name</tt>
     def controller_name
       self.class.controller_name

--- a/actionpack/lib/action_controller/metal/parameter_encoding.rb
+++ b/actionpack/lib/action_controller/metal/parameter_encoding.rb
@@ -1,0 +1,29 @@
+module ActionController
+  module ParameterEncoding
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def inherited(klass)
+        super
+        klass.setup_param_encode
+      end
+
+      def setup_param_encode
+        @_parameter_encodings = {}
+      end
+
+      def encoding_for_param(action, param)
+        if @_parameter_encodings[action.to_s] && @_parameter_encodings[action.to_s][param.to_s]
+          @_parameter_encodings[action.to_s][param.to_s]
+        else
+          ::Encoding::UTF_8
+        end
+      end
+
+      def parameter_encoding(action, param_name, encoding)
+        @_parameter_encodings[action.to_s] ||= {}
+        @_parameter_encodings[action.to_s][param_name.to_s] = encoding
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -69,6 +69,7 @@ module ActionDispatch
     PASS_NOT_FOUND = Class.new { # :nodoc:
       def self.action(_); self; end
       def self.call(_); [404, {"X-Cascade" => "pass"}, []]; end
+      def self.encoding_for_param(action, param); ::Encoding::UTF_8; end
     }
 
     def controller_class

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -184,7 +184,7 @@ module ActionDispatch
           end
 
           # Assume given controller
-          request = ActionController::TestRequest.create
+          request = ActionController::TestRequest.create @controller.class
 
           if path =~ %r{://}
             fail_on(URI::InvalidURIError, msg) do

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -122,27 +122,19 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
     # Stub Rails dispatcher so it does not get controller references and
     # simply return the controller#action as Rack::Body.
     class NullController < ::ActionController::Metal
-      def initialize(controller_name)
-        @controller = controller_name
-      end
-
-      def make_response!(request)
-        self.class.make_response! request
-      end
-
-      def dispatch(action, req, res)
-        [200, {"Content-Type" => "text/html"}, ["#{@controller}##{action}"]]
+      def self.dispatch(action, req, res)
+        [200, {"Content-Type" => "text/html"}, ["#{req.params[:controller]}##{action}"]]
       end
     end
 
-    class NullControllerRequest < DelegateClass(ActionDispatch::Request)
+    class NullControllerRequest < ActionDispatch::Request
       def controller_class
-        NullController.new params[:controller]
+        NullController
       end
     end
 
     def make_request(env)
-      NullControllerRequest.new super
+      NullControllerRequest.new env
     end
   end
 

--- a/actionpack/test/controller/parameter_encoding_test.rb
+++ b/actionpack/test/controller/parameter_encoding_test.rb
@@ -1,0 +1,73 @@
+require "abstract_unit"
+
+class ParameterEncodingController < ActionController::Base
+  parameter_encoding :test_bar,          :bar, Encoding::ASCII_8BIT
+  parameter_encoding :test_baz,          :baz, Encoding::ISO_8859_1
+  parameter_encoding :test_baz_to_ascii, :baz, Encoding::ASCII_8BIT
+
+  def test_foo
+    render body: params[:foo].encoding
+  end
+
+  def test_bar
+    render body: params[:bar].encoding
+  end
+
+  def test_baz
+    render body: params[:baz].encoding
+  end
+
+  def test_no_change_to_baz
+    render body: params[:baz].encoding
+  end
+
+  def test_baz_to_ascii
+    render body: params[:baz].encoding
+  end
+end
+
+class ParameterEncodingTest < ActionController::TestCase
+  tests ParameterEncodingController
+
+  test "properly transcodes UTF8 parameters into declared encodings" do
+    post :test_foo, params: {"foo" => "foo", "bar" => "bar", "baz" => "baz"}
+
+    assert_response :success
+    assert_equal "UTF-8", @response.body
+  end
+
+  test "properly transcodes ASCII_8BIT parameters into declared encodings" do
+    post :test_bar, params: {"foo" => "foo", "bar" => "bar", "baz" => "baz"}
+
+    assert_response :success
+    assert_equal "ASCII-8BIT", @response.body
+  end
+
+  test "properly transcodes ISO_8859_1 parameters into declared encodings" do
+    post :test_baz, params: {"foo" => "foo", "bar" => "bar", "baz" => "baz"}
+
+    assert_response :success
+    assert_equal "ISO-8859-1", @response.body
+  end
+
+  test "does not transcode parameters when not specified" do
+    post :test_no_change_to_baz, params: {"foo" => "foo", "bar" => "bar", "baz" => "baz"}
+
+    assert_response :success
+    assert_equal "UTF-8", @response.body
+  end
+
+  test "respects different encoding declarations for a param per action" do
+    post :test_baz_to_ascii, params: {"foo" => "foo", "bar" => "bar", "baz" => "baz"}
+
+    assert_response :success
+    assert_equal "ASCII-8BIT", @response.body
+  end
+
+  test "does not raise an error when passed a param declared as ASCII-8BIT that contains invalid bytes" do
+    get :test_bar, params: { "bar" => URI.parser.escape("bar\xE2baz".b) }
+
+    assert_response :success
+    assert_equal "ASCII-8BIT", @response.body
+  end
+end


### PR DESCRIPTION
At GitHub we need to handle parameter encodings that are not UTF-8. This
patch allows us to specify encodings per parameter per action.

"We know that this doesn't handle nested parameters, but we don't really need that right now." -- @tenderlove 
