### PR TITLE
load only changed locale files when updated

### DIFF
--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -76,9 +76,10 @@ module ActiveSupport
     # Executes the given block and updates the latest watched files and
     # timestamp.
     def execute
-      @last_watched   = watched
+      @last_watched = watched
+      @last_updated = @last_watched.reject { |path| File.mtime(path) <= @last_update_at }
       @last_update_at = updated_at(@last_watched)
-      @block.call
+      @block.arity == 1 ? @block.call(@last_updated) : @block.call
     ensure
       @watched = nil
       @updated_at = nil

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -56,11 +56,11 @@ module I18n
       I18n.enforce_available_locales = enforce_available_locales
 
       directories = watched_dirs_with_extensions(reloadable_paths)
-      reloader = app.config.file_watcher.new(I18n.load_path.dup, directories) do
+      reloader = app.config.file_watcher.new(I18n.load_path.dup, directories) do |files|
         I18n.load_path.keep_if { |p| File.exist?(p) }
         I18n.load_path |= reloadable_paths.map(&:existent).flatten
 
-        I18n.reload!
+        I18n.backend.load_translations(files)
       end
 
       app.reloaders << reloader

--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -279,4 +279,18 @@ module FileUpdateCheckerSharedTests
       new_checker([])
     end
   end
+
+  test "should pass modified files as block parameter" do
+    FileUtils.touch(tmpfiles)
+
+    modified_files = []
+    checker = new_checker(tmpfiles) { |paths| modified_files.concat paths }
+
+    refute_predicate checker, :updated?
+
+    touch(tmpfiles[1..-1])
+
+    assert checker.execute_if_updated
+    assert_equal tmpfiles[1..-1], modified_files
+  end
 end


### PR DESCRIPTION
### Summary

In Rails projects with large sets of localized strings, the amount of time to reload the entire set of translations following `I18n.reload!` can grow quite large. In development (or when `cache_classes` is `false`), `I18n.reload!` is called on the next page load, causing all translations in the entire `load_path` to be reloaded whenever any single file is modified. (In my use case, a full `I18n.reload!` could take ~10-20 seconds, and changes to translation files could happen multiple times per minute.)

This PR optimizes the i18n auto-reloading performance by adjusting the `FileUpdateChecker` hook configured by the i18n railtie to call `I18n.backend.load_translations(files)`, only reloading the (much smaller) set of translation files that have actually been changed.
### Other Information

In order to make this optimization possible, this PR adjusts the `FileUpdateChecker` API in a backwards-compatible way to allow an optional single parameter to the `execute` block containing the set of files that were changed. (The block parameter is made optional by only passing it when `block.arity == 1`).

This changes the behavior slightly in the case of deleted translations (which will remain loaded until `I18n.reload!` is manually invoked), but considering the auto-reloading feature is most useful for quick iterations in development, I think the change in behavior is worth the added performance gain.
