### PR TITLE
Show unpermitted parameters as symbols in logs (so they could be copy…

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -51,7 +51,7 @@ module ActionController
     def unpermitted_parameters(event)
       debug do
         unpermitted_keys = event.payload[:keys]
-        "Unpermitted parameter#{'s' if unpermitted_keys.size > 1}: #{unpermitted_keys.join(", ")}"
+        "Unpermitted parameter#{'s' if unpermitted_keys.size > 1}: #{unpermitted_keys.map { |e| ":#{e}" }.join(", ")}"
       end
     end
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -32,13 +32,13 @@ module ActionController
   #
   #   params = ActionController::Parameters.new(a: "123", b: "456")
   #   params.permit(:c)
-  #   # => ActionController::UnpermittedParameters: found unpermitted parameters: a, b
+  #   # => ActionController::UnpermittedParameters: found unpermitted parameters: :a, :b
   class UnpermittedParameters < IndexError
     attr_reader :params # :nodoc:
 
     def initialize(params) # :nodoc:
       @params = params
-      super("found unpermitted parameter#{'s' if params.size > 1 }: #{params.join(", ")}")
+      super("found unpermitted parameter#{'s' if params.size > 1 }: #{params.map { |e| ":#{e}" }.join(", ")}")
     end
   end
 

--- a/actionpack/test/controller/parameters/log_on_unpermitted_params_test.rb
+++ b/actionpack/test/controller/parameters/log_on_unpermitted_params_test.rb
@@ -14,7 +14,7 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
     params = ActionController::Parameters.new(      book: { pages: 65 },
       fishing: "Turnips")
 
-    assert_logged("Unpermitted parameter: fishing") do
+    assert_logged("Unpermitted parameter: :fishing") do
       params.permit(book: [:pages])
     end
   end
@@ -24,7 +24,7 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
       fishing: "Turnips",
       car: "Mersedes")
 
-    assert_logged("Unpermitted parameters: fishing, car") do
+    assert_logged("Unpermitted parameters: :fishing, :car") do
       params.permit(book: [:pages])
     end
   end
@@ -32,7 +32,7 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
   test "logs on unexpected nested param" do
     params = ActionController::Parameters.new(      book: { pages: 65, title: "Green Cats and where to find then." })
 
-    assert_logged("Unpermitted parameter: title") do
+    assert_logged("Unpermitted parameter: :title") do
       params.permit(book: [:pages])
     end
   end
@@ -40,7 +40,7 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
   test "logs on unexpected nested params" do
     params = ActionController::Parameters.new(      book: { pages: 65, title: "Green Cats and where to find then.", author: "G. A. Dog" })
 
-    assert_logged("Unpermitted parameters: title, author") do
+    assert_logged("Unpermitted parameters: :title, :author") do
       params.permit(book: [:pages])
     end
   end


### PR DESCRIPTION
### Summary

Very often during development we need to add permitted parameters to the controller. Currently we can see in logs something like: `Unpermitted parameters: avatar_cache, top_weekly_digest_email, improve_profile_email, statistics_email`. When developer see such error, usually they are copying string of parameters from console and then adding ":".

So the idea of this PR is to copy-paste string with already provided ":".
