### PR TITLE
Fix broken alignments caused by auto-correct commit 411ccbd

### DIFF
--- a/actionpack/test/abstract/translation_test.rb
+++ b/actionpack/test/abstract/translation_test.rb
@@ -9,7 +9,8 @@ module AbstractController
     class TranslationControllerTest < ActiveSupport::TestCase
       def setup
         @controller = TranslationController.new
-        I18n.backend.store_translations(:en,           one: {
+        I18n.backend.store_translations(:en,
+          one: {
             two: "bar",
           },
           abstract_controller: {

--- a/actionpack/test/controller/new_base/render_action_test.rb
+++ b/actionpack/test/controller/new_base/render_action_test.rb
@@ -258,7 +258,8 @@ end
 
 module RenderActionWithBothLayouts
   class BasicController < ActionController::Base
-    self.view_paths = [ActionView::FixtureResolver.new(      "render_action_with_both_layouts/basic/hello_world.html.erb" => "Hello World!",
+    self.view_paths = [ActionView::FixtureResolver.new(
+      "render_action_with_both_layouts/basic/hello_world.html.erb"  => "Hello World!",
       "layouts/application.html.erb"                                => "Oh Hi <%= yield %> Bye",
       "layouts/render_action_with_both_layouts/basic.html.erb"      => "With Controller Layout! <%= yield %> Bye")]
 

--- a/actionpack/test/controller/parameters/always_permitted_parameters_test.rb
+++ b/actionpack/test/controller/parameters/always_permitted_parameters_test.rb
@@ -19,7 +19,8 @@ class AlwaysPermittedParametersTest < ActiveSupport::TestCase
   end
 
   test "permits parameters that are whitelisted" do
-    params = ActionController::Parameters.new(      book: { pages: 65 },
+    params = ActionController::Parameters.new(
+      book: { pages: 65 },
       format: "json")
     permitted = params.permit book: [:pages]
     assert permitted.permitted?

--- a/actionpack/test/controller/parameters/log_on_unpermitted_params_test.rb
+++ b/actionpack/test/controller/parameters/log_on_unpermitted_params_test.rb
@@ -11,7 +11,8 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
   end
 
   test "logs on unexpected param" do
-    params = ActionController::Parameters.new(      book: { pages: 65 },
+    params = ActionController::Parameters.new(
+      book: { pages: 65 },
       fishing: "Turnips")
 
     assert_logged("Unpermitted parameter: fishing") do
@@ -20,7 +21,8 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
   end
 
   test "logs on unexpected params" do
-    params = ActionController::Parameters.new(      book: { pages: 65 },
+    params = ActionController::Parameters.new(
+      book: { pages: 65 },
       fishing: "Turnips",
       car: "Mersedes")
 
@@ -30,7 +32,8 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
   end
 
   test "logs on unexpected nested param" do
-    params = ActionController::Parameters.new(      book: { pages: 65, title: "Green Cats and where to find then." })
+    params = ActionController::Parameters.new(
+      book: { pages: 65, title: "Green Cats and where to find then." })
 
     assert_logged("Unpermitted parameter: title") do
       params.permit(book: [:pages])
@@ -38,7 +41,8 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
   end
 
   test "logs on unexpected nested params" do
-    params = ActionController::Parameters.new(      book: { pages: 65, title: "Green Cats and where to find then.", author: "G. A. Dog" })
+    params = ActionController::Parameters.new(
+      book: { pages: 65, title: "Green Cats and where to find then.", author: "G. A. Dog" })
 
     assert_logged("Unpermitted parameters: title, author") do
       params.permit(book: [:pages])

--- a/actionpack/test/controller/parameters/multi_parameter_attributes_test.rb
+++ b/actionpack/test/controller/parameters/multi_parameter_attributes_test.rb
@@ -3,7 +3,8 @@ require "action_controller/metal/strong_parameters"
 
 class MultiParameterAttributesTest < ActiveSupport::TestCase
   test "permitted multi-parameter attribute keys" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         "shipped_at(1i)"   => "2012",
         "shipped_at(2i)"   => "3",
         "shipped_at(3i)"   => "25",

--- a/actionpack/test/controller/parameters/nested_parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/nested_parameters_permit_test.rb
@@ -7,7 +7,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "permitted nested parameters" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         title: "Romeo and Juliet",
         authors: [{
           name: "William Shakespeare",
@@ -43,7 +44,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "permitted nested parameters with a string or a symbol as a key" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         "authors" => [
           { name: "William Shakespeare", born: "1564-04-26" },
           { name: "Christopher Marlowe" }
@@ -66,7 +68,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "nested arrays with strings" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         genres: ["Tragedy"]
       })
 
@@ -75,7 +78,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "permit may specify symbols or strings" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         title: "Romeo and Juliet",
         author: "William Shakespeare"
       },
@@ -88,7 +92,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "nested array with strings that should be hashes" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         genres: ["Tragedy"]
       })
 
@@ -97,7 +102,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "nested array with strings that should be hashes and additional values" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         title: "Romeo and Juliet",
         genres: ["Tragedy"]
       })
@@ -108,7 +114,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "nested string that should be a hash" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         genre: "Tragedy"
       })
 
@@ -117,7 +124,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "fields_for-style nested params" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         authors_attributes: {
           '0': { name: "William Shakespeare", age_of_death: "52" },
           '1': { name: "Unattributed Assistant" },
@@ -136,7 +144,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "fields_for-style nested params with negative numbers" do
-    params = ActionController::Parameters.new(      book: {
+    params = ActionController::Parameters.new(
+      book: {
         authors_attributes: {
           '-1': { name: "William Shakespeare", age_of_death: "52" },
           '-2': { name: "Unattributed Assistant" }
@@ -153,7 +162,8 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "nested number as key" do
-    params = ActionController::Parameters.new(      product: {
+    params = ActionController::Parameters.new(
+      product: {
         properties: {
           "0" => "prop0",
           "1" => "prop1"

--- a/actionpack/test/controller/parameters/raise_on_unpermitted_params_test.rb
+++ b/actionpack/test/controller/parameters/raise_on_unpermitted_params_test.rb
@@ -11,7 +11,8 @@ class RaiseOnUnpermittedParamsTest < ActiveSupport::TestCase
   end
 
   test "raises on unexpected params" do
-    params = ActionController::Parameters.new(      book: { pages: 65 },
+    params = ActionController::Parameters.new(
+      book: { pages: 65 },
       fishing: "Turnips")
 
     assert_raises(ActionController::UnpermittedParameters) do
@@ -20,7 +21,8 @@ class RaiseOnUnpermittedParamsTest < ActiveSupport::TestCase
   end
 
   test "raises on unexpected nested params" do
-    params = ActionController::Parameters.new(      book: { pages: 65, title: "Green Cats and where to find then." })
+    params = ActionController::Parameters.new(
+      book: { pages: 65, title: "Green Cats and where to find then." })
 
     assert_raises(ActionController::UnpermittedParameters) do
       params.permit(book: [:pages])

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -29,7 +29,8 @@ class UriReservedCharactersRoutingTest < ActiveSupport::TestCase
 
   def test_route_generation_escapes_unsafe_path_characters
     assert_equal "/content/act#{@escaped}ion/var#{@escaped}iable/add#{@escaped}itional-1/add#{@escaped}itional-2",
-      url_for(@set,         controller: "content",
+      url_for(@set,
+        controller: "content",
         action: "act#{@segment}ion",
         variable: "var#{@segment}iable",
         additional: ["add#{@segment}itional-1", "add#{@segment}itional-2"])
@@ -45,7 +46,8 @@ class UriReservedCharactersRoutingTest < ActiveSupport::TestCase
 
   def test_route_generation_allows_passing_non_string_values_to_generated_helper
     assert_equal "/content/action/variable/1/2",
-      url_for(@set,         controller: "content",
+      url_for(@set,
+        controller: "content",
         action: "action",
         variable: "variable",
         additional: [1, 2])
@@ -776,7 +778,8 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
       end
     end
 
-    assert_equal "/journal", url_for(rs,       controller: "content",
+    assert_equal "/journal", url_for(rs,
+      controller: "content",
       action: "list_journal",
       date: nil,
       user_id: nil)

--- a/actionpack/test/journey/route_test.rb
+++ b/actionpack/test/journey/route_test.rb
@@ -50,7 +50,8 @@ module ActionDispatch
         path  = Path::Pattern.from_string "/:controller/*extra"
         route = Route.build("name", nil, path, {}, [],
                           controller: "foo", action: "bar")
-        assert_equal "/foo/himom", route.format(          controller: "foo",
+        assert_equal "/foo/himom", route.format(
+          controller: "foo",
           extra: "himom")
       end
 
@@ -58,7 +59,8 @@ module ActionDispatch
         path  = Path::Pattern.from_string "/:controller(/:action(/:id(.:format)))"
         route = Route.build("name", nil, path, {action: "bar"}, [], controller: "foo")
 
-        assert_equal "/foo/bar/10", route.format(          controller: "foo",
+        assert_equal "/foo/bar/10", route.format(
+          controller: "foo",
           action: "bar",
           id: 10)
       end

--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -131,7 +131,7 @@ class ViewLoadPathsTest < ActionController::TestCase
             "Decorated body",
             template.identifier,
             template.handler,
-                          virtual_path: template.virtual_path,
+              virtual_path: template.virtual_path,
               format: template.formats
           )
         end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -16,7 +16,8 @@ class FormHelperTest < ActionView::TestCase
 
   setup do
     # Create "label" locale for testing I18n label helpers
-    I18n.backend.store_translations "label",       activemodel: {
+    I18n.backend.store_translations "label",
+      activemodel: {
         attributes: {
           post: {
             cost: "Total cost"
@@ -47,7 +48,8 @@ class FormHelperTest < ActionView::TestCase
       }
 
     # Create "submit" locale for testing I18n submit helpers
-    I18n.backend.store_translations "submit",       helpers: {
+    I18n.backend.store_translations "submit",
+      helpers: {
         submit: {
           create: "Create %{model}",
           update: "Confirm %{model} changes",
@@ -58,7 +60,8 @@ class FormHelperTest < ActionView::TestCase
         }
       }
 
-    I18n.backend.store_translations "placeholder",       activemodel: {
+    I18n.backend.store_translations "placeholder",
+      activemodel: {
         attributes: {
           post: {
             cost: "Total cost"

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -439,7 +439,8 @@ module ActiveModel
       return message if attribute == :base
       attr_name = attribute.to_s.tr(".", "_").humanize
       attr_name = @base.class.human_attribute_name(attribute, default: attr_name)
-      I18n.t(:"errors.format",         default:  "%{attribute} %{message}",
+      I18n.t(:"errors.format",
+        default:  "%{attribute} %{message}",
         attribute: attr_name,
         message:   message)
     end

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -55,7 +55,8 @@ class ConfirmationValidationTest < ActiveModel::TestCase
       @old_load_path, @old_backend = I18n.load_path.dup, I18n.backend
       I18n.load_path.clear
       I18n.backend = I18n::Backend::Simple.new
-      I18n.backend.store_translations("en",         errors: { messages: { confirmation: "doesn't match %{attribute}" } },
+      I18n.backend.store_translations("en",
+        errors: { messages: { confirmation: "doesn't match %{attribute}" } },
         activemodel: { attributes: { topic: { title: "Test Title"} } })
 
       Topic.validates_confirmation_of(:title)

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -78,10 +78,12 @@ module ActiveRecord
 
           def raw_config
             if uri.opaque
-              query_hash.merge(              "adapter"  => @adapter,
+              query_hash.merge(
+                "adapter"  => @adapter,
                 "database" => uri.opaque)
             else
-              query_hash.merge(              "adapter"  => @adapter,
+              query_hash.merge(
+                "adapter"  => @adapter,
                 "username" => uri.user,
                 "password" => uri.password,
                 "port"     => uri.port,

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -283,7 +283,8 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_habtm_collection_size_from_params
-    devel = Developer.new(      projects_attributes: {
+    devel = Developer.new(
+      projects_attributes: {
         "0" => {}
       })
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -279,7 +279,8 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_initialize_with_attributes
-    topic = Topic.new(      "title" => "initialized from attributes", "written_on" => "2003-12-12 23:23")
+    topic = Topic.new(
+      "title" => "initialized from attributes", "written_on" => "2003-12-12 23:23")
 
     assert_equal("initialized from attributes", topic.title)
   end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -596,7 +596,8 @@ module NestedAttributesOnACollectionAssociationTests
   end
 
   def test_should_save_only_one_association_on_create
-    pirate = Pirate.create!(      :catchphrase => "Arr",
+    pirate = Pirate.create!(
+      :catchphrase => "Arr",
       association_getter => { "foo" => { name: "Grace OMalley" } })
 
     assert_equal 1, pirate.reload.send(@association_name).count

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -967,7 +967,8 @@ class PersistenceTest < ActiveRecord::TestCase
         self.table_name = :widgets
       end
 
-      instance  = widget.create!(        name: "Bob",
+      instance  = widget.create!(
+        name: "Bob",
         created_at: 1.day.ago,
         updated_at: 1.day.ago)
 

--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -54,7 +54,8 @@ module RailsGuides
       end
 
       def engine
-        @engine ||= Redcarpet::Markdown.new(Renderer,           no_intra_emphasis: true,
+        @engine ||= Redcarpet::Markdown.new(Renderer,
+          no_intra_emphasis: true,
           fenced_code_blocks: true,
           autolink: true,
           strikethrough: true,

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -88,7 +88,8 @@ module Rails
     end
 
     def default_options
-      super.merge(        Port:               ENV.fetch("PORT", 3000).to_i,
+      super.merge(
+        Port:               ENV.fetch("PORT", 3000).to_i,
         Host:               ENV.fetch("HOST", "localhost").dup,
         DoNotReverseLookup: true,
         environment:        (ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development").dup,


### PR DESCRIPTION
Hash syntax auto-correcting breaks alignments. 411ccbdab2608c62aabdb320d52cb02d446bb39c

r? @fxn 
