### PR TITLE
When calling association.find RecordNotFound is now raised with the s…

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   RecordNotFound raised by association.find exposes `id`, `primary_key` and
+    `model` methods to be consistent with RecordNotFound raised by Record.find.
+
+    *Michel Pigassou*
+
 *   Hashes can once again be passed to setters of `composed_of`, if all of the
     mapping methods are methods implemented on `Hash`.
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -348,15 +348,17 @@ module ActiveRecord
     def raise_record_not_found_exception!(ids, result_size, expected_size) #:nodoc:
       conditions = arel.where_sql(@klass.arel_engine)
       conditions = " [#{conditions}]" if conditions
+      name = @klass.name
 
       if Array(ids).size == 1
-        error = "Couldn't find #{@klass.name} with '#{primary_key}'=#{ids}#{conditions}"
+        error = "Couldn't find #{name} with '#{primary_key}'=#{ids}#{conditions}"
+        raise RecordNotFound.new(error, name, primary_key, ids)
       else
-        error = "Couldn't find all #{@klass.name.pluralize} with '#{primary_key}': "
+        error = "Couldn't find all #{name.pluralize} with '#{primary_key}': "
         error << "(#{ids.join(", ")})#{conditions} (found #{result_size} results, but was looking for #{expected_size})"
-      end
 
-      raise RecordNotFound, error
+        raise RecordNotFound, error
+      end
     end
 
     private

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -618,6 +618,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::RecordNotFound) { firm.clients.find(2, 99) }
   end
 
+  def test_find_one_message_on_primary_key
+    firm = Firm.all.merge!(order: "id").first
+
+    e = assert_raises(ActiveRecord::RecordNotFound) do
+      firm.clients.find(0)
+    end
+    assert_equal 0, e.id
+    assert_equal "id", e.primary_key
+    assert_equal "Client", e.model
+    assert_match (/\ACouldn't find Client with 'id'=0/), e.message
+  end
+
   def test_find_ids_and_inverse_of
     force_signal37_to_load_all_clients_of_firm
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1119,6 +1119,16 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal [0, 1, 1], posts.map(&:author_id).sort
   end
 
+  def test_find_one_message_on_primary_key
+    e = assert_raises(ActiveRecord::RecordNotFound) do
+      Car.find(0)
+    end
+    assert_equal 0, e.id
+    assert_equal "id", e.primary_key
+    assert_equal "Car", e.model
+    assert_equal "Couldn't find Car with 'id'=0", e.message
+  end
+
   def test_find_one_message_with_custom_primary_key
     table_with_custom_primary_key do |model|
       model.primary_key = :name


### PR DESCRIPTION
### Changelog

> RecordNotFound raised by association.find exposes `id`, `primary_key` and
>     `model` methods to be consistent with RecordNotFound raised by Record.find.
### Summary

`RecordNotFound` reference when doing `Car.find(0)`:

```
(byebug) exception.inspect
"#<ActiveRecord::RecordNotFound: Couldn't find Car with 'id'=0>"
(byebug) exception.id
0
(byebug) exception.primary_key
"id"
(byebug) exception.model
"Car"
```

Before code change when doing `association.find(0)`:

```
(byebug) exception.inspect
"#<ActiveRecord::RecordNotFound: Couldn't find Client with 'id'=0 [WHERE \"companies\".\"type\" IN ('Client', 'SpecialClient', 'VerySpecialClient') AND \"companies\".\"firm_id\" = ? AND \"companies\".\"type\" IN ('Client', 'SpecialClient', 'VerySpecialClient')]>"
(byebug) exception.id
nil
(byebug) exception.model
nil
(byebug) exception.primary_key
nil
```

After code change when doing `association.find(0)`:

```
(byebug) exception.inspect
"#<ActiveRecord::RecordNotFound: Couldn't find Client with 'id'=0 [WHERE \"companies\".\"type\" IN ('Client', 'SpecialClient', 'VerySpecialClient') AND \"companies\".\"firm_id\" = ? AND \"companies\".\"type\" IN ('Client', 'SpecialClient', 'VerySpecialClient')]>"
(byebug) exception.id
0
(byebug) exception.primary_key
"id"
(byebug) exception.model
"Client"
```
