### PR TITLE
Make preload query to prepared statements

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -112,6 +112,12 @@ module ActiveRecord
               binds.concat(bvs)
               attrs
             end
+          when value.is_a?(Array) && !table.type(column_name).respond_to?(:subtype)
+            if value.size == 1
+              attrs, bvs = create_binds_for_hash(column_name => value.first)
+              binds.concat(bvs)
+              result[column_name] = attrs[column_name]
+            end
           when value.is_a?(Range) && !table.type(column_name).respond_to?(:subtype)
             first = value.begin
             last = value.end
@@ -126,6 +132,7 @@ module ActiveRecord
 
             result[column_name] = RangeHandler::RangeWithBinds.new(first, last, value.exclude_end?)
           else
+            value = value.id if value.is_a?(Base)
             if can_be_bound?(column_name, value)
               result[column_name] = Arel::Nodes::BindParam.new
               binds << build_bind_param(column_name, value)

--- a/activerecord/test/cases/adapters/postgresql/explain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/explain_test.rb
@@ -15,6 +15,6 @@ class PostgreSQLExplainTest < ActiveRecord::PostgreSQLTestCase
     explain = Developer.where(id: 1).includes(:audit_logs).explain
     assert_match %(QUERY PLAN), explain
     assert_match %r(EXPLAIN for: SELECT "developers"\.\* FROM "developers" WHERE "developers"\."id" = (?:\$1 \[\["id", 1\]\]|1)), explain
-    assert_match %(EXPLAIN for: SELECT "audit_logs".* FROM "audit_logs" WHERE "audit_logs"."developer_id" = 1), explain
+    assert_match %r(EXPLAIN for: SELECT "audit_logs"\.\* FROM "audit_logs" WHERE "audit_logs"\."developer_id" = (?:\$1 \[\["developer_id", 1\]\]|1)), explain
   end
 end

--- a/activerecord/test/cases/adapters/sqlite3/explain_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/explain_test.rb
@@ -15,7 +15,7 @@ class SQLite3ExplainTest < ActiveRecord::SQLite3TestCase
     explain = Developer.where(id: 1).includes(:audit_logs).explain
     assert_match %r(EXPLAIN for: SELECT "developers"\.\* FROM "developers" WHERE "developers"\."id" = (?:\? \[\["id", 1\]\]|1)), explain
     assert_match(/(SEARCH )?TABLE developers USING (INTEGER )?PRIMARY KEY/, explain)
-    assert_match %(EXPLAIN for: SELECT "audit_logs".* FROM "audit_logs" WHERE "audit_logs"."developer_id" = 1), explain
+    assert_match %r(EXPLAIN for: SELECT "audit_logs"\.\* FROM "audit_logs" WHERE "audit_logs"\."developer_id" = (?:\? \[\["developer_id", 1\]\]|1)), explain
     assert_match(/(SCAN )?TABLE audit_logs/, explain)
   end
 end

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -417,7 +417,7 @@ class InheritanceTest < ActiveRecord::TestCase
 
   def test_eager_load_belongs_to_primary_key_quoting
     con = Account.connection
-    assert_sql(/#{con.quote_table_name('companies')}\.#{con.quote_column_name('id')} = 1/) do
+    assert_sql(/#{con.quote_table_name('companies')}\.#{con.quote_column_name('id')} = (?:#{Regexp.quote(bind_param.to_sql)}|1)/) do
       Account.all.merge!(includes: :firm).find(1)
     end
   end


### PR DESCRIPTION
Currently preload query cannot be prepared statements even if
`prepared_statements: true`. This commit fixes the issue.
