### PR TITLE
Fix a NoMethodError schema_statements.rb

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1208,7 +1208,7 @@ module ActiveRecord
             checks << lambda { |i| i.columns.join("_and_") == column_names.join("_and_") }
           end
 
-          raise ArgumentError "No name or columns specified" if checks.none?
+          raise ArgumentError, "No name or columns specified" if checks.none?
 
           matching_indexes = indexes(table_name).select { |i| checks.all? { |check| check[i] } }
 

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -81,6 +81,12 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
     assert_equal expected, remove_index(:people, name: "index_people_on_last_name", algorithm: :concurrently)
   end
 
+  def test_remove_index_with_wrong_option
+    assert_raises ArgumentError do
+      remove_index(:people, coulmn: :last_name)
+    end
+  end
+
   private
     def method_missing(method_symbol, *arguments)
       ActiveRecord::Base.connection.send(method_symbol, *arguments)


### PR DESCRIPTION
If you call `remove_index` with wrong options, say a typo, like I did,
you get:

```
== 20160810072541 RemoveUniqueIndexOnGoals: migrating =========================
-- remove_index(:goal, {:coulmn=>:kid_id, :unique=>true})
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

undefined method `ArgumentError' for #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter:0x007fb7dec91b28>
```

What happened is that I mistyped column (coulmn) and got a
`NoMethodError`, because of a missing comma during the raise. This made
Ruby think we're calling the method `ArgumentError`.
