### PR TITLE
Modify callbacks execution sequence

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -504,7 +504,7 @@ module ActiveSupport
         def compile
           @callbacks || @mutex.synchronize do
             final_sequence = CallbackSequence.new { |env| Filters::ENDING.call(env) }
-            @callbacks ||= @chain.reverse.inject(final_sequence) do |callback_sequence, callback|
+            @callbacks ||= @chain.inject(final_sequence) do |callback_sequence, callback|
               callback.apply callback_sequence
             end
           end


### PR DESCRIPTION
### dependent => :destroy deletes children before "before_destroy" is executed

It executes rails written callback first, idealy it should executes callback from application them from framework, due to reverse it is executing first from framework then from user application.

Issues logged related to same
#3458, #20954, #670
