### PR TITLE
Specify conditions for ArrayInquirer and StringInquirer [ci skip]

### DIFF
--- a/activesupport/lib/active_support/array_inquirer.rb
+++ b/activesupport/lib/active_support/array_inquirer.rb
@@ -7,6 +7,9 @@ module ActiveSupport
   #   variants.phone?    # => true
   #   variants.tablet?   # => true
   #   variants.desktop?  # => false
+  #
+  # It works only for Array whose string-like contents comprises of no
+  # whitespaces or special characters except underscore.
   class ArrayInquirer < Array
     # Passes each element of +candidates+ collection to ArrayInquirer collection.
     # The method returns true if any element from the ArrayInquirer collection

--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -8,6 +8,9 @@ module ActiveSupport
   # you can call this:
   #
   #   Rails.env.production?
+  #
+  # It works only for the simple String that comprises of no whitespaces
+  # or special characters except underscore.
   class StringInquirer < String
     private
 


### PR DESCRIPTION
ArrayInquirer and StringInquirer won't be working for contents having whitespaces or special characters. Albiet a simple thing, but it doesn't clicks to reader while going through docs. So adding a line about it explictly, will make things bit clear on first go itself.
