### PR TITLE
Fix a test that breaks on Windows

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1027,7 +1027,7 @@ class CopyMigrationsTest < ActiveRecord::TestCase
     assert_equal [@migrations_path + "/4_currencies_have_symbols.bukkits.rb"], copied.map(&:filename)
 
     expected = "# coding: ISO-8859-15\n# This migration comes from bukkits (originally 1)"
-    assert_equal expected, IO.readlines(@migrations_path + "/4_currencies_have_symbols.bukkits.rb")[0..1].join.chomp
+    assert_equal expected, IO.readlines(@migrations_path + "/4_currencies_have_symbols.bukkits.rb")[0..1].join.chomp.gsub(/\r\n?/, "\n")
 
     files_count = Dir[@migrations_path + "/*.rb"].length
     copied = ActiveRecord::Migration.copy(@migrations_path, bukkits: MIGRATIONS_ROOT + "/magic")


### PR DESCRIPTION
This test breaks on windows because Git automatically makes the
newlines \r\n. When using vagrant with a shared directory to run the
tests, the copied file, which is then read includes the \r\n, but the
expected value is hardcoded to contain only a \n.

This change applies the well known gsub(/\r\n?/, "\n") to normalize the
line ending that is read.
