### PR TITLE
Don't use unnecessary metaprogramming in numericality validator

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -17,10 +17,11 @@ module ActiveModel
       end
 
       def validate_each(record, attr_name, value)
-        before_type_cast = :"#{attr_name}_before_type_cast"
-
-        raw_value = record.send(before_type_cast) if record.respond_to?(before_type_cast) && record.send(before_type_cast) != value
-        raw_value ||= value
+        raw_value = if record.respond_to?(:read_attribute_before_type_cast)
+          record.read_attribute_before_type_cast(attr_name)
+        else
+          value
+        end
 
         if record_attribute_changed_in_place?(record, attr_name)
           raw_value = value


### PR DESCRIPTION
### Summary

Don't use unnecessary metaprogramming in numericality validator

It seems that generating the method name and sending is an overkill here and we can use `read_attribute_before_type_cast`. Very brief benchmark showed that `read_attribute_before_type_cast` version was over twice as fast. Probably not a significant speed improvement overall since it's not a hotspot and there are way havier operations around, but it also seems more readable and less magical.

Moreover, this commit also removes questionable `before_type_cast != value` condition as I could not figure out a scenario where it would help (and no tests provied it either).
### Other Information

Not sure if the usage of "*_before_type_cast"  was dictated by the fact that someone may have defined method for particular attribute on their model, but it's unlikely. This ActiveRecord's API is not very popular and advertised. 
