### PR TITLE
create not_in? method

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/exclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/exclusion.rb
@@ -1,0 +1,29 @@
+require "active_support/core_ext/string"
+
+class Object
+  # Returns true if this object is not included in the argument. Argument must be
+  # any object which responds to +#include?+. Usage:
+  #
+  #   characters = ["Konata", "Kagami", "Tsukasa"]
+  #   "Konata".not_in?(characters) # => false
+  #
+  # This will throw an +ArgumentError+ if the argument doesn't respond
+  # to +#include?+.
+  def not_in?(another_object)
+    !another_object.include?(self)
+  rescue NoMethodError
+    raise ArgumentError.new("The parameter passed to #not_in? must respond to #include?")
+  end
+
+  # Returns the receiver if it's not included in the argument otherwise returns +nil+.
+  # Argument must be any object which responds to +#include?+. Usage:
+  #
+  #   params[:bucket_type].absence_in %w( project calendar )
+  #
+  # This will throw an +ArgumentError+ if the argument doesn't respond to +#include?+.
+  #
+  # @return [Object]
+  def absence_in(another_object)
+    not_in?(another_object) ? self : nil
+  end
+end

--- a/activesupport/test/core_ext/object/exclusion_test.rb
+++ b/activesupport/test/core_ext/object/exclusion_test.rb
@@ -1,0 +1,59 @@
+require "abstract_unit"
+require "active_support/core_ext/object/exclusion"
+
+class NotInTest < ActiveSupport::TestCase
+  def test_in_array
+    assert !1.not_in?([1,2])
+    assert 3.not_in?([1,2])
+  end
+
+  def test_in_hash
+    h = { "a" => 100, "b" => 200 }
+    assert !"a".not_in?(h)
+    assert "z".not_in?(h)
+  end
+
+  def test_in_string
+    assert !"lo".not_in?("hello")
+    assert "ol".not_in?("hello")
+    assert !?h.not_in?("hello")
+  end
+
+  def test_in_range
+    assert !25.not_in?(1..50)
+    assert 75.not_in?(1..50)
+  end
+
+  def test_in_set
+    s = Set.new([1,2])
+    assert !1.not_in?(s)
+    assert 3.not_in?(s)
+  end
+
+  module A
+  end
+  class B
+    include A
+  end
+  class C < B
+  end
+  class D
+  end
+
+  def test_in_module
+    assert !A.not_in?(B)
+    assert !A.not_in?(C)
+    assert A.not_in?(A)
+    assert A.not_in?(D)
+  end
+
+  def test_no_method_catching
+    assert_raise(ArgumentError) { 1.not_in?(1) }
+  end
+
+  def test_absence_in
+    assert_nil "stuff".absence_in(%w( lots of stuff ))
+    assert_equal "stuff", "stuff".absence_in(%w( lots of crap ))
+    assert_raise(ArgumentError) { 1.absence_in(1) }
+  end
+end


### PR DESCRIPTION
### Summary

Rails has two convenient methods for simplifying syntax around Ruby's `include?` method.

1) [The `exclude?` method](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/string/exclude.rb) (`A.exclude?  B` instead of `!A.include? B`); and

2) [The `in?` method](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/object/inclusion.rb) (`A.in? B` instead of `B.include? A`).

I thought it might be nice to round out this set of methods with `not_in?`. This would offer `A.not_in? B`, instead of resorting to either `!A.in? B`, or `B.exclude? A`, or `!B.include? A`.

Here’s an implementation of a `not_in?` method, along with a passing test suite.
### Notes

The `not_in?` method is currently implemented as `!another_object.include?(self)`. I think it would be perhaps cleaner to implement it as `another_object.exclude?(self)` but the test suite wasn’t passing when I did this.

I believe it’s related to the fact that the `exclude?` method is defined as an [extension of String](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/string/exclude.rb). When I ran the test suite, the String tests passed, but the Array and Hash tests did not. I know that in Rails, Arrays and Hashes _do_ respond to the `exclude?` method, so maybe I’m missing something in how to set up the test here (missing a `require`, for instance).

If anyone has any insights here, I’d be happy to update this PR with a commit changing the implementation from `!include?` to `exclude?`. Thanks in advance!
