### PR TITLE
add missing require rake

### DIFF
--- a/railties/lib/rails/engine/commands_tasks.rb
+++ b/railties/lib/rails/engine/commands_tasks.rb
@@ -103,6 +103,8 @@ In addition to those commands, there are:
         end
 
         def rake_tasks
+          require_rake
+
           return @rake_tasks if defined?(@rake_tasks)
 
           load_generators

--- a/railties/test/engine/commands_tasks_test.rb
+++ b/railties/test/engine/commands_tasks_test.rb
@@ -1,0 +1,24 @@
+require "abstract_unit"
+
+class Rails::Engine::CommandsTasksTest < ActiveSupport::TestCase
+  def setup
+    @destination_root = Dir.mktmpdir("bukkits")
+    Dir.chdir(@destination_root) { `bundle exec rails plugin new bukkits --mountable` }
+  end
+
+  def teardown
+    FileUtils.rm_rf(@destination_root)
+  end
+
+  def test_help_command_work_inside_engine
+    output = capture(:stderr) do
+      Dir.chdir(plugin_path) { `bin/rails --help` }
+    end
+    assert_no_match "NameError", output
+  end
+
+  private
+    def plugin_path
+      "#{@destination_root}/bukkits"
+    end
+end


### PR DESCRIPTION
In ff8035dfeed8c86594c32ef8e9204806e190cb58, require rake is deferred.
Therefore, it is necessary to require rake even `Engine::CommandsTasks.
