### PR TITLE
[ci skip] Add documentation to Parameter Encoding

### DIFF
--- a/actionpack/lib/action_controller/metal/parameter_encoding.rb
+++ b/actionpack/lib/action_controller/metal/parameter_encoding.rb
@@ -1,4 +1,5 @@
 module ActionController
+  # Allows encoding to be specified per parameter per action.
   module ParameterEncoding
     extend ActiveSupport::Concern
 


### PR DESCRIPTION
Adds a short summary to the new Parameter Encoding Module.
