### PR TITLE
Creating a new Topic class instead of class_eval for the existing one

### DIFF
--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -156,17 +156,15 @@ class ValidationsTest < ActiveRecord::TestCase
   end
 
   def test_numericality_validation_with_mutation
-    Topic.class_eval do
+    klass = Class.new(Topic) do
       attribute :wibble, :string
       validates_numericality_of :wibble, only_integer: true
     end
 
-    topic = Topic.new(wibble: "123-4567")
+    topic = klass.new(wibble: "123-4567")
     topic.wibble.gsub!("-", "")
 
     assert topic.valid?
-  ensure
-    Topic.reset_column_information
   end
 
   def test_acceptance_validator_doesnt_require_db_connection


### PR DESCRIPTION
### Summary

This pull request addresses #26099 by creating a new Topic class instead of class_eval for the existing one.

This pull request has been tested with all bundled adapters - sqlite3, mysql2 and postgresql.

Thanks @kamipo
