### PR TITLE
[ci skip] Fix the wrong ActionCable documentation in the guide.

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -313,7 +313,7 @@ App.cable.subscriptions.create { channel: "ChatChannel", room: "Best Room" },
 ```ruby
 # Somewhere in your app this is called, perhaps
 # from a NewCommentJob.
-ChatChannel.broadcast_to(
+ActionCable.server.broadcast(
   "chat_#{room}",
   sent_by: 'Paul',
   body: 'This is a cool chat app.'

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -242,10 +242,10 @@ WebNotificationsChannel.broadcast_to(
 The `WebNotificationsChannel.broadcast_to` call places a message in the current
 subscription adapter (Redis by default)'s pubsub queue under a separate
 broadcasting name for each user. For a user with an ID of 1, the broadcasting
-name would be `web_notifications_1`.
+name would be `web_notifications:1`.
 
 The channel has been instructed to stream everything that arrives at
-`web_notifications_1` directly to the client by invoking the `received`
+`web_notifications:1` directly to the client by invoking the `received`
 callback.
 
 ### Subscriptions


### PR DESCRIPTION
1. Reference to https://github.com/rails/rails/blob/master/actioncable/lib/action_cable/channel/broadcasting.rb#L12 and https://github.com/rails/rails/blob/master/actioncable/lib/action_cable/channel/broadcasting.rb#L16, the broadcasting name generated by `ActionCable::Channel.broadcast_to` would be split by `:` instead of `_`. So in the documentation, it should be `web_notifications:1` instead of `web_notifications_1`
2. In the same code referenced by No.1, the `ActionCable::Channel#broadcast_to` method should accept a model instance instead of a broadcasting name string. So there should be `ActionCable.server.broadcast` instead of `ChatChannel.broadcast_to` in the guide. If using `ChatChannel.broadcast_to` here, the generated broadcasting name would be `chat:chat_#{room}`, it's different from the name used in `stream_from`.
