### PR TITLE
Remove dead code and ensure values are strings before calling gsub

### DIFF
--- a/actionpack/lib/action_view/helpers/tag_helper.rb
+++ b/actionpack/lib/action_view/helpers/tag_helper.rb
@@ -147,7 +147,6 @@ module ActionView
               elsif BOOLEAN_ATTRIBUTES.include?(key)
                 attrs << %(#{key}="#{key}") if value
               elsif !value.nil?
-                final_value = value.is_a?(Array) ? value.join(" ") : value
                 attrs << tag_option(key, value, escape)
               end
             end
@@ -159,7 +158,7 @@ module ActionView
           if value.is_a?(Array)
             value = escape ? safe_join(value, " ") : value.join(" ")
           else
-            value = escape ? ERB::Util.html_escape(value) : value
+            value = escape ? ERB::Util.html_escape(value) : value.to_s
           end
           %(#{key}="#{value.gsub(/"/, '&quot;'.freeze)}")
         end

--- a/actionpack/test/template/tag_helper_test.rb
+++ b/actionpack/test/template/tag_helper_test.rb
@@ -29,6 +29,14 @@ class TagHelperTest < ActionView::TestCase
     assert_equal "<p included=\"\" />", tag("p", :included => '')
   end
 
+  def test_tag_options_accepts_symbol_option_when_not_escaping
+    assert_equal "<p value=\"symbol\" />", tag("p", { :value => :symbol }, false, false)
+  end
+
+  def test_tag_options_accepts_integer_option_when_not_escaping
+    assert_equal "<p value=\"42\" />", tag("p", { :value => 42 }, false, false)
+  end
+
   def test_tag_options_converts_boolean_option
     assert_equal '<p disabled="disabled" multiple="multiple" readonly="readonly" />',
       tag("p", :disabled => true, :multiple => true, :readonly => true)


### PR DESCRIPTION
There is a new bug introduced from this recent commit: https://github.com/rails/rails/commit/4bcccf5ecd81a6272479537911b7d9760c5be164

If you are not escaping and you have an attribute value that isn't a string, this used to work, but now the `gsub` call will cause an error.

I also noticed a dead line of code added from that commit, which I've removed.

Thanks to @esb for this comment: https://github.com/rails/rails/commit/4bcccf5ecd81a6272479537911b7d9760c5be164#commitcomment-18616328

I found this in our usage of 3.2, but it appears like this will affect the other stable releases too (minus the dead code bit it appears). Please let me know if you would rather I open this against master instead.

/cc @andrewcarpenter @tenderlove 
