### PR TITLE
Use inspected value for errors '%{value}' interpolation

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -496,7 +496,7 @@ module ActiveModel
         default: defaults,
         model: @base.model_name.human,
         attribute: @base.class.human_attribute_name(attribute),
-        value: value,
+        value: value.inspect,
         object: @base
       }.merge!(options)
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -162,6 +162,24 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["cannot be blank"], person.errors[:name]
   end
 
+  test "add an error message with interpolated %{model}" do
+    person = Person.new
+    person.errors.add(:name, :blank, message: "%{model}")
+    assert_equal ["Person"], person.errors[:name]
+  end
+
+  test "add an error message with interpolated %{attribute}" do
+    person = Person.new
+    person.errors.add(:name, :blank, message: "%{attribute}")
+    assert_equal ["name"], person.errors[:name]
+  end
+
+  test "add an error message with interpolated %{value}" do
+    person = Person.new
+    person.errors.add(:name, :blank, message: "%{value}")
+    assert_equal ["nil"], person.errors[:name]
+  end
+
   test "add an error with a symbol" do
     person = Person.new
     person.errors.add(:name, :blank)


### PR DESCRIPTION
Right now '%{value}' interpolation is not so useful, because there is no way to distinguish Symbol from String and `nil` is not visible at all, for example.
Let's use `value.inspect` to have more usable '%{value}'.

The only issue with this change that come to my mind is cases w/ some structure (like Model) that is converted to String in shortened form (i. e. `#<Model:0x007ffa13454a10>`), but I doubt that it's meaningful to have such things in the error messages.
