### PR TITLE
Fix AR adapter PostgreSQL::OID::Bit #to_s to return a String

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/bit.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/bit.rb
@@ -30,7 +30,7 @@ module ActiveRecord
             end
 
             def to_s
-              value
+              value.to_s
             end
 
             def binary?

--- a/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
@@ -43,6 +43,13 @@ class PostgresqlBitStringTest < ActiveRecord::PostgreSQLTestCase
     assert_not type.binary?
   end
 
+  def test_bit_to_string_after_save
+    record = PostgresqlBitString.create!
+    record.save
+
+    assert_equal "00000011", record.a_bit.to_s
+  end
+
   def test_default
     assert_equal "00000011", PostgresqlBitString.column_defaults["a_bit"]
     assert_equal "00000011", PostgresqlBitString.new.a_bit


### PR DESCRIPTION
**ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bit** #to_s was passing back an **ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bit::Data** object rather than a string, and this corrects it. This fixes issue #26137.
