### PR TITLE
Update example in Http::Headers object to use `.from_hash`

### DIFF
--- a/actionpack/lib/action_dispatch/http/headers.rb
+++ b/actionpack/lib/action_dispatch/http/headers.rb
@@ -3,7 +3,7 @@ module ActionDispatch
     # Provides access to the request's HTTP headers from the environment.
     #
     #   env     = { "CONTENT_TYPE" => "text/plain", "HTTP_USER_AGENT" => "curl/7.43.0" }
-    #   headers = ActionDispatch::Http::Headers.new(env)
+    #   headers = ActionDispatch::Http::Headers.from_hash(env)
     #   headers["Content-Type"] # => "text/plain"
     #   headers["User-Agent"] # => "curl/7.43.0"
     #


### PR DESCRIPTION
### Summary

The documented example at the top of `ActionDispatch::Http::Headers` definition provided a hash for the constructor but in Rails 5 this has changed to now take a request object. An earlier commit introduced a `ActionDispatch::Http::Headers.from_hash()` method that the example should now be using.
### Other Information

When initializing an `ActionDispatch::Http::Headers` object it takes a request object (Rails 5) whereas before it took a hash (Rails 4.x) but the documented example still shows a hash given to the constructor (due to commit 34fa6658dd1b779b21e586f01ee64c6f59ca1537 by @tenderlove) so this is just a documentation change to use the new `from_hash` method introduced in that earlier commit.

This is my first PR (I've reported an issue or two before) so I might have the process wrong. Sorry, I was confused with the guidelines on doc changes since this is for the documented example in the code file rather than pages in the guides. I take it its done in the right place. If not let me know what I have to do and be happy to update. Thanks.
