### PR TITLE
Avoid to allow unused splat args for `t.timestamps` in `create_table`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -341,9 +341,7 @@ module ActiveRecord
       # <tt>:updated_at</tt> to the table. See {connection.add_timestamps}[rdoc-ref:SchemaStatements#add_timestamps]
       #
       #   t.timestamps null: false
-      def timestamps(*args)
-        options = args.extract_options!
-
+      def timestamps(**options)
         options[:null] = false if options[:null].nil?
 
         column(:created_at, :datetime, options)

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -21,7 +21,7 @@ module ActiveRecord
           end
           alias :belongs_to :references
 
-          def timestamps(*, **options)
+          def timestamps(**options)
             options[:null] = true if options[:null].nil?
             super
           end
@@ -59,7 +59,7 @@ module ActiveRecord
         end
         alias :add_belongs_to :add_reference
 
-        def add_timestamps(*, **options)
+        def add_timestamps(_, **options)
           options[:null] = true if options[:null].nil?
           super
         end

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -462,7 +462,7 @@ class TimestampTest < ActiveRecord::TestCase
 
   def test_index_is_created_for_both_timestamps
     ActiveRecord::Base.connection.create_table(:foos, force: true) do |t|
-      t.timestamps(:foos, null: true, index: true)
+      t.timestamps null: true, index: true
     end
 
     indexes = ActiveRecord::Base.connection.indexes("foos")


### PR DESCRIPTION
Unfortunately `t.timestamps` in `create_table` allows unused splat args.
But the same one in `change_table` does not allow them.
This commit fixes the inconsistent behavior.
