### PR TITLE
Remove text default treated as an empty string in non-strict mode

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,35 @@
+*   Remove text default treated as an empty string in non-strict mode for
+    consistency with other types.
+
+    Strict mode controls how MySQL handles invalid or missing values in
+    data-change statements such as INSERT or UPDATE. If strict mode is not
+    in effect, MySQL inserts adjusted values for invalid or missing values
+    and produces warnings.
+
+        def test_mysql_not_null_defaults_non_strict
+          using_strict(false) do
+            with_mysql_not_null_table do |klass|
+              record = klass.new
+              assert_nil record.non_null_integer
+              assert_nil record.non_null_string
+              assert_nil record.non_null_text
+              assert_nil record.non_null_blob
+
+              record.save!
+              record.reload
+
+              assert_equal 0,  record.non_null_integer
+              assert_equal "", record.non_null_string
+              assert_equal "", record.non_null_text
+              assert_equal "", record.non_null_blob
+            end
+          end
+        end
+
+    https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-strict
+
+    *Ryuta Kamizono*
+
 *   Deprecate `sanitize_conditions`. Use `sanitize_sql` instead.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -709,7 +709,7 @@ module ActiveRecord
         end
 
         def fetch_type_metadata(sql_type, extra = "")
-          MySQL::TypeMetadata.new(super(sql_type), extra: extra, strict: strict_mode?)
+          MySQL::TypeMetadata.new(super(sql_type), extra: extra)
         end
 
         def add_index_length(quoted_columns, **options)

--- a/activerecord/lib/active_record/connection_adapters/mysql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/column.rb
@@ -2,17 +2,7 @@ module ActiveRecord
   module ConnectionAdapters
     module MySQL
       class Column < ConnectionAdapters::Column # :nodoc:
-        delegate :strict, :extra, to: :sql_type_metadata, allow_nil: true
-
-        def initialize(*)
-          super
-          extract_default
-        end
-
-        def has_default?
-          return false if blob_or_text_column? # MySQL forbids defaults on blob and text columns
-          super
-        end
+        delegate :extra, to: :sql_type_metadata, allow_nil: true
 
         def blob_or_text_column?
           /\A(?:tiny|medium|long)?blob\b/ === sql_type || type == :text
@@ -29,14 +19,6 @@ module ActiveRecord
         def auto_increment?
           extra == "auto_increment"
         end
-
-        private
-
-          def extract_default
-            if blob_or_text_column?
-              @default = null || strict ? nil : ""
-            end
-          end
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/mysql/type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/type_metadata.rb
@@ -2,13 +2,12 @@ module ActiveRecord
   module ConnectionAdapters
     module MySQL
       class TypeMetadata < DelegateClass(SqlTypeMetadata) # :nodoc:
-        attr_reader :extra, :strict
+        attr_reader :extra
 
-        def initialize(type_metadata, extra: "", strict: false)
+        def initialize(type_metadata, extra: "")
           super(type_metadata)
           @type_metadata = type_metadata
           @extra = extra
-          @strict = strict
         end
 
         def ==(other)
@@ -24,7 +23,7 @@ module ActiveRecord
         protected
 
           def attributes_for_hash
-            [self.class, @type_metadata, extra, strict]
+            [self.class, @type_metadata, extra]
           end
       end
     end

--- a/activerecord/test/cases/column_definition_test.rb
+++ b/activerecord/test/cases/column_definition_test.rb
@@ -60,14 +60,13 @@ module ActiveRecord
         end
 
         def test_should_not_set_default_for_blob_and_text_data_types
-          text_type = MySQL::TypeMetadata.new(
-            SqlTypeMetadata.new(type: :text))
+          text_type = MySQL::TypeMetadata.new(SqlTypeMetadata.new(type: :text))
 
           text_column = MySQL::Column.new("title", nil, text_type)
-          assert_equal nil, text_column.default
+          assert_nil text_column.default
 
           not_null_text_column = MySQL::Column.new("title", nil, text_type, false)
-          assert_equal "", not_null_text_column.default
+          assert_nil not_null_text_column.default
         end
 
         def test_has_default_should_return_false_for_blob_and_text_data_types


### PR DESCRIPTION
Strict mode controls how MySQL handles invalid or missing values in
data-change statements such as INSERT or UPDATE. If strict mode is not
in effect, MySQL inserts adjusted values for invalid or missing values
and produces warnings.

``` ruby
  def test_mysql_not_null_defaults_non_strict
    using_strict(false) do
      with_mysql_not_null_table do |klass|
        record = klass.new
        assert_nil record.non_null_integer
        assert_nil record.non_null_string
        assert_nil record.non_null_text
        assert_nil record.non_null_blob

        record.save!
        record.reload

        assert_equal 0,  record.non_null_integer
        assert_equal "", record.non_null_string
        assert_equal "", record.non_null_text
        assert_equal "", record.non_null_blob
      end
    end
  end
```

It is inconsistent with other types that only text/blob defaults treated
as an empty string. This commit fixes the inconsistency.

https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-strict
