### PR TITLE
fix Rails.application.routes.router.visualizer for router debugging

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -72,7 +72,9 @@ module ActionDispatch
       private
 
         def partitioned_routes
-          routes.partitioned_routes
+          routes.partition { |r|
+            r.path.anchored && r.ast.grep(Nodes::Symbol).all? { |n| n.default_regexp?  }
+          }
         end
 
         def ast


### PR DESCRIPTION
### Summary

In the Journey router the method `Routes#partitioned_routes` was removed, while `Router#partitioned_routes` depended on it. This moves the previous `Routes#partitioned_routes` logic into `Router#partitioned_routes`.
### Other Information

To replicate the current bug just launch an app and call:
`Rails.application.routes.router.visualizer`
