### PR TITLE
Show supported keyword arguments also in the deprecation message for non-kwarg test requests

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -655,6 +655,8 @@ module ActionController
           New keyword style:
           get :show, params: { id: 1 }, flash: { notice: "This is a flash message" },
             session: nil # Can safely be omitted.
+
+          Supported keyword arguments: params, session, flash, xhr.
         MSG
       end
 

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -305,6 +305,8 @@ module ActionDispatch
 
             New keyword style:
             get "/profile", params: { id: 1 }, headers: { "X-Extra-Header" => "123" }
+
+            Supported keyword arguments: params, env, headers, xhr, as.
           MSG
         end
 


### PR DESCRIPTION
- Because AC::ControllerTest and AD::IntegrationTest both accept
  different arguments and as such people upgrading to 5.0 will have mix
  of old style controller tests and all the documentation will be about
  new style integration tests, mentioning which keyword arguments are
  supported by which tests will be useful.

r? @kaspth 
