### PR TITLE
`CollectionProxy#take` should respect dirty target

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -262,8 +262,8 @@ module ActiveRecord
       #   another_person_without.pets         # => []
       #   another_person_without.pets.take    # => nil
       #   another_person_without.pets.take(2) # => []
-      def take(n = nil)
-        @association.take(n)
+      def take(limit = nil)
+        @association.take(limit)
       end
 
       # Returns a new object of the collection type that has been instantiated

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -525,14 +525,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_taking_with_a_number
     # taking from unloaded Relation
     bob = Author.find(authors(:bob).id)
+    new_post = bob.posts.build
+    assert_not bob.posts.loaded?
     assert_equal [posts(:misc_by_bob)], bob.posts.take(1)
-    bob = Author.find(authors(:bob).id)
     assert_equal [posts(:misc_by_bob), posts(:other_by_bob)], bob.posts.take(2)
+    assert_equal [posts(:misc_by_bob), posts(:other_by_bob), new_post], bob.posts.take(3)
 
     # taking from loaded Relation
-    bob.posts.to_a
-    assert_equal [posts(:misc_by_bob)], authors(:bob).posts.take(1)
-    assert_equal [posts(:misc_by_bob), posts(:other_by_bob)], authors(:bob).posts.take(2)
+    bob.posts.load
+    assert bob.posts.loaded?
+    assert_equal [posts(:misc_by_bob)], bob.posts.take(1)
+    assert_equal [posts(:misc_by_bob), posts(:other_by_bob)], bob.posts.take(2)
+    assert_equal [posts(:misc_by_bob), posts(:other_by_bob), new_post], bob.posts.take(3)
   end
 
   def test_taking_with_inverse_of


### PR DESCRIPTION
`#first`, `#second`, ..., `#last` methods respects dirty target. But
`#take` doesn't respect it. This commit fixes the inconsistent behavior.
