### PR TITLE
fixes #26030: const_get with autoloading

### DIFF
--- a/activesupport/test/autoloading_fixtures/should_not_be_const_gettable_from_module_folder.rb
+++ b/activesupport/test/autoloading_fixtures/should_not_be_const_gettable_from_module_folder.rb
@@ -1,0 +1,2 @@
+class ShouldNotBeConstGettableFromModuleFolder
+end

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -1069,4 +1069,14 @@ class DependenciesTest < ActiveSupport::TestCase
   ensure
     ActiveSupport::Dependencies.hook!
   end
+
+  def test_const_get_for_non_existent_class_in_module
+    with_autoloading_fixtures do
+      assert_raises NameError do
+        ModuleFolder.const_get(:ShouldNotBeConstGettableFromModuleFolder, false)
+      end
+    end
+  ensure
+    remove_constants(:ModuleFolder)
+  end
 end


### PR DESCRIPTION
### Summary

fix for #26030 (autoloading causes Module#const_get to incorrectly return constants from nesting parent of the receiver module) 
