### PR TITLE
Fixes: Missing URL helper for namespaced `root` route

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1922,9 +1922,8 @@ to this:
           end
 
           def match_root_route(options)
-            name = has_named_route?(:root) ? nil : :root
             defaults_option = options.delete(:defaults)
-            args = ["/", { as: name, via: :get }.merge!(options)]
+            args = ["/", { as: :root, via: :get }.merge!(options)]
 
             if defaults_option
               defaults(defaults_option) { match(*args) }

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3342,6 +3342,24 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "/foo", foo_root_path
   end
 
+  def test_namespaced_root_path
+    draw do
+      namespace :foo do
+        root "test#index"
+      end
+
+      root "test#index"
+
+      namespace :bar do
+        root "test#index"
+      end
+    end
+
+    assert_equal "/foo", foo_root_path
+    assert_equal "/", root_path
+    assert_equal "/bar", bar_root_path
+  end
+
   def test_trailing_slash
     draw do
       resources :streams
@@ -4271,6 +4289,35 @@ class TestNamedRouteUrlHelpers < ActionDispatch::IntegrationTest
       assert_response :success
       assert_raises(ActionController::UrlGenerationError) { product_path(nil) }
     end
+  end
+end
+
+class TestRootUrlHelpers < ActionDispatch::IntegrationTest
+  Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
+    app.draw do
+      namespace :foo do
+        root "test#index"
+      end
+
+      root "test#index"
+
+      namespace :bar do
+        root "test#index"
+      end
+    end
+  end
+
+  APP = build_app Routes
+  def app; APP end
+
+  include Routes.url_helpers
+
+  test "url helpers defined" do
+    helpers = app.routes.url_helpers
+
+    assert_respond_to helpers, :foo_root_url
+    assert_respond_to helpers, :root_url
+    assert_respond_to helpers, :bar_root_url
   end
 end
 


### PR DESCRIPTION
### Summary

Fixes: Missing URL helper for namespaced `root` route #26148

`match_root_route` was unnecessarily preventing the definition of additional namespaced URL helpers with the name `:root`.
### Other Information

Adds spec to validate change
