### PR TITLE
Remove odd ivar from ActiveRecord::LogSubscriber

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -15,11 +15,6 @@ module ActiveRecord
       rt
     end
 
-    def initialize
-      super
-      @odd = false
-    end
-
     def render_bind(attr, type_casted_value)
       value = if attr.type.binary? && attr.value
         "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"


### PR DESCRIPTION
This was used to alternate the output colour between log lines, but since https://github.com/rails/rails/pull/20607 the output colour is based on the type of statement being logged instead.
