### PR TITLE
Clarify migration to ApplicationRecord in upgrade guides [ci skip]

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -94,6 +94,8 @@ class ApplicationRecord < ActiveRecord::Base
 end
 ```
 
+Then make sure that all your models inherit from it.
+
 ### Halting Callback Chains via `throw(:abort)`
 
 In Rails 4.2, when a 'before' callback returns `false` in Active Record


### PR DESCRIPTION
A small addition to the upgrade guides:

For 5.0, after creating `application_record.rb` the existing models should be changed to inherit from `ApplicationRecord` instead of `ActiveRecord::Base`.

(That's what I guess should be done; but my knowledge of Rails is very basic.)
