### PR TITLE
Clarify use of update task on 4.2 and earlier [ci skip]

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -44,7 +44,7 @@ TIP: Ruby 1.8.7 p248 and p249 have marshaling bugs that crash Rails. Ruby Enterp
 
 ### The Update Task
 
-Rails provides the `app:update` task (`rails:update` on 4.2 and earlier). After updating the Rails version
+Rails provides the `app:update` task (`rake rails:update` on 4.2 and earlier). After updating the Rails version
 in the Gemfile, run this task.
 This will help you with the creation of new files and changes of old files in an
 interactive session.


### PR DESCRIPTION
A small clarification in the upgrade guides:

The update task has to be invoked with "**rake** rails:update" for 4.2 and earlier, but the current guide gives the impression "**rails** rails:update" would work (instead of "rails app:update" for 5.0, like shown in the example).

At least that's what I kept trying for some time (with admittedly only a very basic knowledge of Rails).
