### PR TITLE
Fix ActionController::Live deadlock

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -205,7 +205,12 @@ module ActionController
       private
 
         def each_chunk(&block)
-          while str = @buf.pop
+          loop do
+            str = nil
+            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+              str = @buf.pop
+            end
+            break unless str
             yield str
           end
         end

--- a/actionpack/test/fixtures/load_me.rb
+++ b/actionpack/test/fixtures/load_me.rb
@@ -1,0 +1,2 @@
+class LoadMe
+end


### PR DESCRIPTION
Fixes #26123.
The base thread now releases the shared lock while waiting for more data so that the child thread can get an exclusive lock and continue execution.
@matthewd 
