### PR TITLE
Eager autoload ActiveRecord::TableMetadata

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -68,7 +68,6 @@ module ActiveRecord
   autoload :StatementCache
   autoload :Store
   autoload :Suppressor
-  autoload :TableMetadata
   autoload :Timestamp
   autoload :Transactions
   autoload :Translation
@@ -101,6 +100,7 @@ module ActiveRecord
     end
 
     autoload :Result
+    autoload :TableMetadata
   end
 
   module Coders


### PR DESCRIPTION
Fixes a bug that can occur when ActiveJob tries to access ActiveRecord.

Specifically, I had an Active Job process fail on Sidekiq with this error:

```
ActiveJob::DeserializationError: Error while trying to deserialize arguments:
uninitialized constant ActiveRecord::Core::ClassMethods::TableMetadata
Did you mean? ActiveRecord::TableMetadata
```

raised by these lines of code:

```
[GEM_ROOT]/gems/activerecord-5.0.0.1/lib/active_record/core.rb:300 :in `table_metadata`
298
299       def table_metadata # :nodoc:
300         TableMetadata.new(self, arel_table)
301       end
302     end
[GEM_ROOT]/gems/activerecord-5.0.0.1/lib/active_record/core.rb:273 :in `predicate_builder`
[GEM_ROOT]/gems/activerecord-5.0.0.1/lib/active_record/core.rb:290 :in `relation`
```

The problem seems to be that, inside ActiveRecord::Core, the `TableMetadata`
class has not been loaded and, therefore, Rails tries to access the constant
`ActiveRecord::Core::ClassMethods::TableMetadata` which does not exist.

Eager loading `ActiveRecord::TableMetadata` should fix the issue.

@rafaelfranca -- see our Campfire discussion
