### PR TITLE
Remove over meta programming in AR::Relation

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -504,15 +504,10 @@ module ActiveRecord
     #   Post.limit(100).delete_all
     #   # => ActiveRecord::ActiveRecordError: delete_all doesn't support limit
     def delete_all(conditions = nil)
-      invalid_methods = INVALID_METHODS_FOR_DELETE_ALL.select { |method|
-        if MULTI_VALUE_METHODS.include?(method)
-          send("#{method}_values").any?
-        elsif SINGLE_VALUE_METHODS.include?(method)
-          send("#{method}_value")
-        elsif CLAUSE_METHODS.include?(method)
-          send("#{method}_clause").any?
-        end
-      }
+      invalid_methods = INVALID_METHODS_FOR_DELETE_ALL.select do |method|
+        value = get_value(method)
+        SINGLE_VALUE_METHODS.include?(method) ? value : value.any?
+      end
       if invalid_methods.any?
         raise ActiveRecordError.new("delete_all doesn't support #{invalid_methods.join(', ')}")
       end

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -151,15 +151,11 @@ module ActiveRecord
           end
         end
 
-        CLAUSE_METHOD_NAMES = CLAUSE_METHODS.map do |name|
-          ["#{name}_clause", "#{name}_clause="]
-        end
-
         def merge_clauses
-          CLAUSE_METHOD_NAMES.each do |(reader, writer)|
-            clause = relation.send(reader)
-            other_clause = other.send(reader)
-            relation.send(writer, clause.merge(other_clause))
+          CLAUSE_METHODS.each do |method|
+            clause = relation.get_value(method)
+            other_clause = other.get_value(method)
+            relation.set_value(method, clause.merge(other_clause))
           end
         end
     end

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -40,9 +40,10 @@ module ActiveRecord
 
     def test_initialize_single_values
       relation = Relation.new(FakeKlass, :b, nil)
-      (Relation::SINGLE_VALUE_METHODS - [:create_with]).each do |method|
+      (Relation::SINGLE_VALUE_METHODS - [:create_with, :readonly]).each do |method|
         assert_nil relation.send("#{method}_value"), method.to_s
       end
+      assert_equal false, relation.readonly_value
       value = relation.create_with_value
       assert_equal({}, value)
       assert_predicate value, :frozen?


### PR DESCRIPTION
### Summary

Introduced low level methods #set and #get for setting query attributes:

  relation.set(:where, {id: 1})
  relation.get(:includes)

Used those internally when working with relation's attributes
at the abstract level
