### PR TITLE
Makes touch_later respects no_touching policy

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -312,8 +312,8 @@ module ActiveRecord #:nodoc:
     include NestedAttributes
     include Aggregations
     include Transactions
-    include NoTouching
     include TouchLater
+    include NoTouching
     include Reflection
     include Serialization
     include Store

--- a/activerecord/lib/active_record/no_touching.rb
+++ b/activerecord/lib/active_record/no_touching.rb
@@ -45,6 +45,10 @@ module ActiveRecord
       NoTouching.applied_to?(self.class)
     end
 
+    def touch_later(*) # :nodoc:
+      super unless no_touching?
+    end
+
     def touch(*) # :nodoc:
       super unless no_touching?
     end

--- a/activerecord/test/cases/touch_later_test.rb
+++ b/activerecord/test/cases/touch_later_test.rb
@@ -24,6 +24,15 @@ class TouchLaterTest < ActiveRecord::TestCase
     assert_not invoice.changed?
   end
 
+  def test_touch_later_respects_no_touching_policy
+    time = Time.now.utc - 25.days
+    topic = Topic.create!(updated_at: time, created_at: time)
+    Topic.no_touching do
+      topic.touch_later
+    end
+    assert_equal time.to_i, topic.updated_at.to_i
+  end
+
   def test_touch_later_update_the_attributes
     time = Time.now.utc - 25.days
     topic = Topic.create!(updated_at: time, created_at: time)


### PR DESCRIPTION
`touch_later` doesn't really respect `no_touching`. It will write attributes regardless of the policy, and then might or might not update the db depending wether the `no_touching` block is outside or inside the `transaction` block.

This PR makes it behave a bit more consistently.

cc @rafaelfranca @sgrif 
