### PR TITLE
Remove Unnecessary code in AR Dirty

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -101,9 +101,6 @@ module ActiveRecord
       private
 
         def mutation_tracker
-          unless defined?(@mutation_tracker)
-            @mutation_tracker = nil
-          end
           @mutation_tracker ||= AttributeMutationTracker.new(@attributes)
         end
 


### PR DESCRIPTION
Since `@mutation_tracker` will be set in the line below if it doesn't
exist, the proposed removed lines of code are unnecessary.
