### PR TITLE
Fix link in Rails 5.0 Release Note 

### DIFF
--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -1002,7 +1002,7 @@ Please refer to the [Changelog][active-support] for detailed changes.
 
 *   Added `#prev_day` and `#next_day` counterparts to `#yesterday` and
     `#tomorrow` for `Date`, `Time`, and `DateTime`.
-    ([Pull Request](httpshttps://github.com/rails/rails/pull/18335))
+    ([Pull Request](https://github.com/rails/rails/pull/18335))
 
 *   Added `SecureRandom.base58` for generation of random base58 strings.
     ([commit](https://github.com/rails/rails/commit/b1093977110f18ae0cafe56c3d99fc22a7d54d1b))


### PR DESCRIPTION
This PR fixes a broken link in Rails 5.0 Release Note.
