### PR TITLE
Fix diffrent naming in getting_started.md

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1154,7 +1154,7 @@ new articles. Create a file called `app/views/articles/edit.html.erb` and make
 it look as follows:
 
 ```html+erb
-<h1>Editing article</h1>
+<h1>Edit article</h1>
 
 <%= form_for :article, url: article_path(@article), method: :patch do |f| %>
 


### PR DESCRIPTION
I've noticed that once `<h1>Editing article</h1>` L1157 was the title and then later on it's `<h1>Edit article</h1>` L1358 which kind of makes more sense...

[ci skip]
