### PR TITLE
i18n documentation for required belongs_to message

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -888,6 +888,7 @@ So, for example, instead of the default error message `"cannot be blank"` you co
 | inclusion    | -                         | :inclusion                | -             |
 | exclusion    | -                         | :exclusion                | -             |
 | associated   | -                         | :invalid                  | -             |
+| non-optional association | -             | :required                 | -             |
 | numericality | -                         | :not_a_number             | -             |
 | numericality | :greater_than             | :greater_than             | count         |
 | numericality | :greater_than_or_equal_to | :greater_than_or_equal_to | count         |


### PR DESCRIPTION
### Summary

This PR adds the "required association" validation to the i18n validations table in the guides, so rails users know how to override the message for this validation. The default message is "must exist".
### Other Information

When you don't explicitly provide `optional: true` to a `belongs_to` definition, rails adds a validation to ensure presence of the `belongs_to` validation.

However, when the validation is added, it is added with a message key of `:required`, which was not documented in the "Translations for Active Record Models" section of the i18n guides.

Here are the lines that add the `:required` message:
https://github.com/rails/rails/blob/c3e3577f9d5058382504773bf0d32afa15cb131e/activerecord/lib/active_record/associations/builder/belongs_to.rb#L136-L138
### Other ideas

Maybe "required association" isn't the best name, since the `:required` parameter is now deprecated in favor of the `:optional` option? Should it be "non-optional association"?

Or maybe it makes sense to remove the `message: :required` option when adding the presence validation for the `belongs_to`, so it will use the default message for `validates_presence_of`? (`:blank`).

Feedback and suggestions are welcome 😄 
