### PR TITLE
Keep INNER JOIN when merging relations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Merging two relations which have joins no longer transforms the joins of
+    the merged relation into LEFT OUTER JOIN.
+
+    *Maxime Handfield Lapointe*
+
 *   Made ActiveRecord consistently use `ActiveRecord::Type` (not `ActiveModel::Type`)
 
     *Iain Beeston*

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -104,7 +104,7 @@ module ActiveRecord
         join_root.drop(1).map!(&:reflection)
       end
 
-      def join_constraints(outer_joins, join_type)
+      def join_constraints(joins_to_add, join_type)
         joins = join_root.children.flat_map { |child|
 
           if join_type == Arel::Nodes::OuterJoin
@@ -114,12 +114,16 @@ module ActiveRecord
           end
         }
 
-        joins.concat outer_joins.flat_map { |oj|
+        joins.concat joins_to_add.flat_map { |oj|
           if join_root.match? oj.join_root
             walk join_root, oj.join_root
           else
             oj.join_root.children.flat_map { |child|
-              make_outer_joins oj.join_root, child
+              if join_type == Arel::Nodes::OuterJoin
+                make_left_outer_joins oj.join_root, child
+              else
+                make_inner_joins oj.join_root, child
+              end
             }
           end
         }

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -6,7 +6,7 @@ require "models/rating"
 
 module ActiveRecord
   class RelationTest < ActiveRecord::TestCase
-    fixtures :posts, :comments, :authors
+    fixtures :posts, :comments, :authors, :ratings
 
     class FakeKlass < Struct.new(:table_name, :name)
       extend ActiveRecord::Delegation::DelegateCache
@@ -224,7 +224,26 @@ module ActiveRecord
     def test_relation_merging_with_merged_joins_as_symbols
       special_comments_with_ratings = SpecialComment.joins(:ratings)
       posts_with_special_comments_with_ratings = Post.group("posts.id").joins(:special_comments).merge(special_comments_with_ratings)
-      assert_equal({ 2=>1, 4=>3, 5=>1 }, authors(:david).posts.merge(posts_with_special_comments_with_ratings).count)
+      assert_equal({ 4=>2 }, authors(:david).posts.merge(posts_with_special_comments_with_ratings).count)
+    end
+
+    def test_relation_merging_with_merged_symbol_joins_keeps_inner_joins
+      queries = capture_sql { authors_with_commented_posts = Author.joins(:posts).merge(Post.joins(:comments)).to_a }
+
+      nb_inner_join = queries.sum { |sql| sql.scan(/INNER\s+JOIN/i).size }
+      assert_equal 2, nb_inner_join, "Wrong amount of INNER JOIN in query"
+      assert queries.none? { |sql| /LEFT\s+(OUTER)?\s+JOIN/i.match?(sql) }, "Shouldn't have any LEFT JOIN in query"
+    end
+
+    def test_relation_merging_with_merged_symbol_joins_has_correct_size_and_count
+      # Has one entry per comment
+      merged_authors_with_commented_posts_relation = Author.joins(:posts).merge(Post.joins(:comments))
+
+      post_ids_with_author = Post.joins(:author).pluck(:id)
+      manual_comments_on_post_that_have_author = Comment.where(post_id: post_ids_with_author).pluck(:id)
+
+      assert_equal manual_comments_on_post_that_have_author.size, merged_authors_with_commented_posts_relation.count
+      assert_equal manual_comments_on_post_that_have_author.size, merged_authors_with_commented_posts_relation.to_a.size
     end
 
     def test_relation_merging_with_joins_as_join_dependency_pick_proper_parent


### PR DESCRIPTION
Doing `Author.joins(:posts).merge(Post.joins(:comments))` does this
`SELECT ... INNER JOIN posts ON... LEFT OUTER JOIN comments ON...`
instead of doing
`SELECT ... INNER JOIN posts ON... INNER JOIN comments ON...`.

This behavior is unexpected and makes little sense as, basically, doing
`Post.joins(:comments)` means I want posts that have comments. Turning
it to a LEFT JOIN means I want posts and join the comments data, if
any.

We can see this problem directly in the existing tests.
The test_relation_merging_with_merged_joins_as_symbols only does joins
from posts to comments to ratings while the ratings fixture isn't
loaded, but the count is non-zero.

I did a bit of searching for the rationale of doing this transformation
and posted the result of it in issue #16140. tl;dr: it's most likely an
oversight.

Do only thing I'm not sure about is if my fix should use `make_outer_joins`  as it was before and as is used in `walk` or if it should use `make_left_outer_joins` which is used above in the same method.

This fixes #16140
