### PR TITLE
Fix documentation of `index` option for the `add_reference` method

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -785,7 +785,7 @@ module ActiveRecord
       # [<tt>:type</tt>]
       #   The reference column type. Defaults to +:integer+.
       # [<tt>:index</tt>]
-      #   Add an appropriate index. Defaults to false.  
+      #   Add an appropriate index. Defaults to true.
       #   See #add_index for usage of this option.
       # [<tt>:foreign_key</tt>]
       #   Add an appropriate foreign key constraint. Defaults to false.


### PR DESCRIPTION
- Followup of https://github.com/rails/rails/pull/23179.

I had made this commit directly on docrails but it needs backport to 5-0-stable.
