### PR TITLE
Remove unnecessary `test_sql_for_insert_with_returning_disabled`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -124,14 +124,13 @@ module ActiveRecord
             pk = primary_key(table_ref) if table_ref
           end
 
-          pk = suppress_composite_primary_key(pk)
-
-          if pk && use_insert_returning?
+          if pk = suppress_composite_primary_key(pk)
             sql = "#{sql} RETURNING #{quote_column_name(pk)}"
           end
 
           super
         end
+        protected :sql_for_insert
 
         def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil)
           if use_insert_returning? || pk == false

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -88,12 +88,6 @@ module ActiveRecord
         assert_equal expect.to_i, result.rows.first.first
       end
 
-      def test_sql_for_insert_with_returning_disabled
-        connection = connection_without_insert_returning
-        sql, binds = connection.sql_for_insert("sql", nil, nil, nil, "binds")
-        assert_equal ["sql", "binds"], [sql, binds]
-      end
-
       def test_serial_sequence
         assert_equal "public.accounts_id_seq",
           @connection.serial_sequence("accounts", "id")


### PR DESCRIPTION
Because `sql_for_insert` is only called in `use_insert_returning?` is
true since #26002.
