### PR TITLE
Make `ActiveRecord::Base` object to preparable for predicate builder

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -121,6 +121,7 @@ module ActiveRecord
           when value.is_a?(Relation)
             binds.concat(value.bound_attributes)
           else
+            value = value.id if value.is_a?(Base)
             if can_be_bound?(column_name, value)
               bind_attribute = build_bind_attribute(column_name, value)
               if value.is_a?(StatementCache::Substitute) || !bind_attribute.value_for_database.nil?

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1879,6 +1879,15 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal [20], merged.bound_attributes.map(&:value)
   end
 
+  def test_where_with_ar_object_makes_binds
+    post = posts(:welcome)
+    bind = ActiveRecord::Relation::QueryAttribute.new("id", post.id, Post.type_for_attribute("id"))
+
+    relation = Post.where(id: post)
+
+    assert_equal [bind], relation.bound_attributes
+  end
+
   def test_locked_should_not_build_arel
     posts = Post.locked
     assert posts.locked?


### PR DESCRIPTION
``` ruby
  # Before
  Post.where(author_id: author).to_a
  # => SELECT "posts".* FROM "posts" WHERE "posts"."author_id" = 1

  # After
  Post.where(author_id: author).to_a
  # => SELECT "posts".* FROM "posts" WHERE "posts"."author_id" = ?  [["author_id", 1]]
```
