### PR TITLE
Restore strong params to_hash behavior

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Restore ActionController::Parameters `to_hash` behavior
+
+    The `to_hash` method provides safe, implicit type conversion.
+
+    *Blake Sawyer*
+
 *   Include the content of the flash in the auto-generated etag. This solves the following problem:
 
       1. POST /messages

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -198,6 +198,20 @@ module ActionController
     end
     alias_method :to_unsafe_hash, :to_unsafe_h
 
+    # Returns a safe <tt>ActiveSupport::HashWithIndifferentAccess</tt>
+    # representation of this parameter with all unpermitted keys removed
+    # for implicit type conversion.
+    #
+    #   params = ActionController::Parameters.new({
+    #     food: "Pizza",
+    #     type: "Pepperoni"
+    #   })
+    #   params.to_hash # => {}
+    #
+    #   safe_params = params.permit(:food)
+    #   safe_params.to_hash # => {"food"=>"Pizza"}
+    alias_method :to_hash, :to_h
+
     # Convert all hashes in values into parameters, then yield each pair in
     # the same way as <tt>Hash#each_pair</tt>
     def each_pair(&block)

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -350,6 +350,46 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert_not company.dupped
   end
 
+  test "to_hash returns empty hash on unpermitted params" do
+    assert @params.to_hash.is_a? Hash
+    assert_not @params.to_hash.is_a? ActionController::Parameters
+    assert @params.to_hash.empty?
+  end
+
+  test "to_hash returns converted hash on permitted params" do
+    @params.permit!
+
+    assert @params.to_hash.is_a? Hash
+    assert_not @params.to_hash.is_a? ActionController::Parameters
+  end
+
+  test "to_hash returns converted hash when .permit_all_parameters is set" do
+    begin
+      ActionController::Parameters.permit_all_parameters = true
+      orig_hash = {
+        "food" => "Pizza",
+        "options" => { "type" => "Pepperoni" }
+      }
+      params = ActionController::Parameters.new(orig_hash)
+
+      assert params.to_hash.is_a? Hash
+      assert_not params.to_hash.is_a? ActionController::Parameters
+      assert_equal(params.to_hash, orig_hash)
+    ensure
+      ActionController::Parameters.permit_all_parameters = false
+    end
+  end
+
+  test "to_hash returns always permitted parameter on unpermitted params" do
+    params = ActionController::Parameters.new(
+      "controller" => "users",
+      "action" => "create",
+      "food" => "Pizza"
+    )
+
+    assert_equal({ "controller" => "users", "action" => "create" }, params.to_hash)
+  end
+
   test "include? returns true when the key is present" do
     assert @params.include? :person
     assert @params.include? "person"


### PR DESCRIPTION
This pull request restores strong parameters ability to work with double splat operators and named parameters, fixing issue #26201.
