### PR TITLE
Fix activerecord group method string param with multiple columns

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -310,6 +310,9 @@ module ActiveRecord
     end
 
     def group!(*args) # :nodoc:
+      args.map! do |arg|
+        arg.split(",")
+      end
       args.flatten!
 
       self.group_values += args

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -311,7 +311,7 @@ module ActiveRecord
 
     def group!(*args) # :nodoc:
       args.map! do |arg|
-        arg.split(",")
+        arg.split(",") if arg.is_a? String
       end
       args.flatten!
 


### PR DESCRIPTION
### Summary

The `group` method in Active Record might take a string as a param
(i)  `group("name")`

The string might include many columns
(ii) `group("a.id, b.first_name, b.last_name, c.first_name, c.last_name")`

In scenario (ii), the method `ActiveRecord::Calculations#execute_grouped_calculation` treat the argument as grouping by only 1 column. It gives only 1 alias, which makes the select part become `select a.id, b.first_name, b.last_name, c.first_name, c.last_name as ALIAS_NAME`. After receiving results from the DB, the function then group by the ALIAS_NAME on code again, which means grouping by `c.last_name` only. It makes the calculation wrong.

This PR is to convert a single string param to an array of string in order to make the calculation right.
