### PR TITLE
Add @queue variable to JobWrapper

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -24,4 +24,12 @@
 
     *DHH*
 
+*   Added instance variable `@queue` to JobWrapper.
+
+    This will fix issues in [resque-scheduler](https://github.com/resque/resque-scheduler) `#job_to_hash` method,
+    so we can use `#enqueue_delayed_selection`, `#remove_delayed` method in resque-scheduler smoothly.
+
+    *mu29*
+
+
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/activejob/CHANGELOG.md) for previous changes.

--- a/activejob/lib/active_job/queue_adapters/resque_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/resque_adapter.rb
@@ -27,6 +27,7 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :resque
     class ResqueAdapter
       def enqueue(job) #:nodoc:
+        JobWrapper.instance_variable_set(:@queue, job.queue_name)
         Resque.enqueue_to job.queue_name, JobWrapper, job.serialize
       end
 

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -43,6 +43,13 @@ class QueuingTest < ActiveSupport::TestCase
     end
   end
 
+  test "resque JobWrapper should have instance variable queue" do
+    skip unless adapter_is?(:resque)
+    job = ::HelloJob.set(wait: 5.seconds).perform_later
+    hash = Resque.decode(Resque.find_delayed_selection { true }[0])
+    assert_equal hash["queue"], job.queue_name
+  end
+
   test "should not run job enqueued in the future" do
     begin
       TestJob.set(wait: 10.minutes).perform_later @id


### PR DESCRIPTION
Fix errors when using resque-scheduler's `#enqueue_delayed_selection` method.

In resque-scheduler, `#enqueue_delayed_selection`, or `remove_delayed` use `#job_to_hash` to pick item in redis list. 

```
def job_to_hash(klass, args)
  { class: klass.to_s, args: args, queue: queue_from_class(klass) }
end
```

This method call `#queue_from_class`

```
def queue_from_class(klass)
  klass.instance_variable_get(:@queue) ||
    (klass.respond_to?(:queue) and klass.queue)
end
```

However, current `JobWrapper` class does not have instance variable `@queue`, so the return value of `#job_to_hash` method is not equal to redis item that we want to catch. As a result, we cannot use `#enqueue_delayed_selection`, or `remove_delayed` method when our job extends ActiveJob.
I just put instance variable `@queue` to `JobWrapper` class.
