### PR TITLE
Add Enumerable#single

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -90,7 +90,8 @@ module Enumerable
     end
   end
 
-  # Return one and only one element. Raise an error if there are none or more than one.
+  # Return one and only one item. Raise an error if there are none or more than one.
+  # Optinally return a default value from a block if there are no items in the enumerable.
   #
   #   [1].single
   #     => 1
@@ -100,6 +101,9 @@ module Enumerable
   #
   #   [].single
   #     => Enumerable::SingleItemExpectedError: The sequence is empty (expected one and only one item)
+  #
+  #   [].single { 99 }
+  #     => 99
   def single
     found = false
     result = nil
@@ -108,8 +112,9 @@ module Enumerable
       found = true
       result = item
     end
-    raise SingleItemExpectedError, "The sequence is empty (expected one and only one item)" unless found
-    result
+    return result if found
+    raise SingleItemExpectedError, "The sequence is empty (expected one and only one item)" unless block_given?
+    yield
   end
 
   class SingleItemExpectedError < StandardError

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -96,21 +96,20 @@ module Enumerable
   #     => 1
   #
   #   [1, 2].single
-  #     => Enumerable::SingleItemExpectedError: The sequence contains more than one element (expected one and only one)
+  #     => Enumerable::SingleItemExpectedError: The sequence contains more than one item (expected one and only one)
   #
   #   [].single
   #     => Enumerable::SingleItemExpectedError: The sequence is empty (expected one and only one item)
   def single
-    enumerator = self.map
-    val = enumerator.next
-    begin
-      enumerator.next
-      raise SingleItemExpectedError, 'The sequence contains more than one element (expected one and only one)'
-    rescue StopIteration
-      val
+    found = false
+    result = nil
+    each do |item|
+      raise SingleItemExpectedError, "The sequence contains more than one item (expected one and only one)" if found
+      found = true
+      result = item
     end
-  rescue StopIteration
-    raise SingleItemExpectedError, 'The sequence is empty (expected one and only one item)'
+    raise SingleItemExpectedError, "The sequence is empty (expected one and only one item)" unless found
+    result
   end
 
   class SingleItemExpectedError < StandardError

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -89,6 +89,32 @@ module Enumerable
       map { |element| element[keys.first] }
     end
   end
+
+  # Return one and only one element. Raise an error if there are none or more than one.
+  #
+  #   [1].single
+  #     => 1
+  #
+  #   [1, 2].single
+  #     => Enumerable::SingleItemExpectedError: The sequence contains more than one element (expected one and only one)
+  #
+  #   [].single
+  #     => Enumerable::SingleItemExpectedError: The sequence is empty (expected one and only one item)
+  def single
+    enumerator = self.map
+    val = enumerator.next
+    begin
+      enumerator.next
+      raise SingleItemExpectedError, 'The sequence contains more than one element (expected one and only one)'
+    rescue StopIteration
+      val
+    end
+  rescue StopIteration
+    raise SingleItemExpectedError, 'The sequence is empty (expected one and only one item)'
+  end
+
+  class SingleItemExpectedError < StandardError
+  end
 end
 
 class Range #:nodoc:

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -220,4 +220,25 @@ class EnumerableTests < ActiveSupport::TestCase
     ])
     assert_equal [[5, 99], [15, 0], [10, 50]], payments.pluck(:dollars, :cents)
   end
+
+  def test_single_with_a_single_item
+    assert_equal 11, [11].single
+    assert_equal 11, (11..11).single
+    assert_equal [:a, 11], { a: 11 }.single
+    assert_equal 12, GenericEnumerable.new([12]).single
+  end
+
+  def test_single_with_no_items
+    assert_raise(Enumerable::SingleItemExpectedError) { [].single }
+    assert_raise(Enumerable::SingleItemExpectedError) { (2..1).single }
+    assert_raise(Enumerable::SingleItemExpectedError) { {}.single }
+    assert_raise(Enumerable::SingleItemExpectedError) { GenericEnumerable.new([]).single }
+  end
+
+  def test_single_with_more_than_one_item
+    assert_raise(Enumerable::SingleItemExpectedError) { [1, 2].single }
+    assert_raise(Enumerable::SingleItemExpectedError) { (1..10).single }
+    assert_raise(Enumerable::SingleItemExpectedError) { { a: 1, b: 2 }.single }
+    assert_raise(Enumerable::SingleItemExpectedError) { GenericEnumerable.new(%w(a b c)).single }
+  end
 end

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -226,6 +226,7 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal 11, (11..11).single
     assert_equal [:a, 11], { a: 11 }.single
     assert_equal 12, GenericEnumerable.new([12]).single
+    assert_equal 11, [11].single { 22 }
   end
 
   def test_single_with_no_items
@@ -233,6 +234,7 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_raise(Enumerable::SingleItemExpectedError) { (2..1).single }
     assert_raise(Enumerable::SingleItemExpectedError) { {}.single }
     assert_raise(Enumerable::SingleItemExpectedError) { GenericEnumerable.new([]).single }
+    assert_equal 99, [].single { 99 }
   end
 
   def test_single_with_more_than_one_item
@@ -240,5 +242,6 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_raise(Enumerable::SingleItemExpectedError) { (1..10).single }
     assert_raise(Enumerable::SingleItemExpectedError) { { a: 1, b: 2 }.single }
     assert_raise(Enumerable::SingleItemExpectedError) { GenericEnumerable.new(%w(a b c)).single }
+    assert_raise(Enumerable::SingleItemExpectedError) { [1, 2].single { 99 } }
   end
 end


### PR DESCRIPTION
### Summary

This is inspired by other languages and frameworks, such as LINQ's [Single](https://msdn.microsoft.com/en-us/library/bb155325%28v=vs.110%29.aspx) (pardon from MSDN reference), which has very big distinction between `first` and `single` element of a
collection.
- `first` normally returns the top element, and the developer assumes
  there could be many;
- `single` returns one and only one element, and it is an error if there
  are none or more than one.

We, in Ruby world, very often write `Account.where(name: 'foo').first`
assuming there's only one element that can be returned there.

But in majority of the cases, we really want a `single` element.

The problems with using `first` in this case:
- developer needs to explicitly double check the result isn't `nil`
- in case of corrupted data (more than one item returned), it will never
  be noticed

`Enumerable#single` addresses those problems in a very strong and
specific way that may save the world by simply switching from `first` to
`single`.

Also, we have the answer to universe - `fourty_two`, may as well save the
world with a `single` before waiting for that answer :)
### Other information

We may come with a better internal implementation (than `self.map`), but happy to discuss and fix. `self.map` seems to be pragmatic, performant enough for the typical use case. So may not be an issue at all.
