### PR TITLE
Fixed issue with `where.not()` with polymorphic value

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -45,13 +45,7 @@ module ActiveRecord
       #    User.where.not(name: "Jon", role: "admin")
       #    # SELECT * FROM users WHERE name != 'Jon' AND role != 'admin'
       def not(opts, *rest)
-        opts = sanitize_forbidden_attributes(opts)
-
-        where_clause = @scope.send(:where_clause_factory).build(opts, rest)
-
-        @scope.references!(PredicateBuilder.references(opts)) if Hash === opts
-        @scope.where_clause += where_clause.invert
-        @scope
+        @scope.where_not!(opts, *rest)
       end
     end
 
@@ -605,6 +599,13 @@ module ActiveRecord
       opts = sanitize_forbidden_attributes(opts)
       references!(PredicateBuilder.references(opts)) if Hash === opts
       self.where_clause += where_clause_factory.build(opts, rest)
+      self
+    end
+
+    def where_not!(opts, *rest) # :nodoc:
+      opts = sanitize_forbidden_attributes(opts)
+      references!(PredicateBuilder.references(opts)) if Hash === opts
+      self.where_clause += where_clause_factory.inverted.build(opts, rest)
       self
     end
 

--- a/activerecord/lib/active_record/relation/where_clause_factory.rb
+++ b/activerecord/lib/active_record/relation/where_clause_factory.rb
@@ -27,9 +27,27 @@ module ActiveRecord
         WhereClause.new(parts, binds || [])
       end
 
+      def inverted
+        @inverted ||= WhereClauseInvertedFactory.new(klass, predicate_builder)
+      end
+
       protected
 
         attr_reader :klass, :predicate_builder
+
+      private
+
+        class WhereClauseInvertedFactory < self # :nodoc:
+          def initialize(klass, predicate_builder)
+            super
+            @predicate_builder = @predicate_builder.dup
+            @predicate_builder.of_inverted_clause = true
+          end
+
+          def build(opts, other)
+            super.invert
+          end
+        end
     end
   end
 end

--- a/activerecord/test/cases/relation/where_inverted_test.rb
+++ b/activerecord/test/cases/relation/where_inverted_test.rb
@@ -1,0 +1,81 @@
+require "cases/helper"
+require "models/cake_designer"
+require "models/drink_designer"
+require "models/chef"
+
+module ActiveRecord
+  class WhereInvertedTest < ActiveRecord::TestCase
+    test "test inverted with polymorphic value" do
+      chef1 = Chef.create!
+      chef2 = Chef.create!
+      chef3 = Chef.create!
+
+      cake_designer = CakeDesigner.create!(chef: chef1)
+      CakeDesigner.create!(chef: chef2)
+      DrinkDesigner.create!(chef: chef3)
+
+      chefs = Chef.where.not(employable: cake_designer)
+
+      assert_not_includes chefs, chef1
+      assert_includes chefs, chef2
+      assert_includes chefs, chef3
+    end
+
+    test "test inverted with array of polymorphic values of different type" do
+      chef1 = Chef.create!
+      chef2 = Chef.create!
+      chef3 = Chef.create!
+      chef4 = Chef.create!
+
+      cake_designer = CakeDesigner.create!(chef: chef1)
+      drink_designer = DrinkDesigner.create!(chef: chef2)
+      CakeDesigner.create!(chef: chef3)
+      DrinkDesigner.create!(chef: chef4)
+
+      chefs = Chef.where.not(employable: [cake_designer, drink_designer])
+
+      assert_not_includes chefs, chef1
+      assert_not_includes chefs, chef2
+      assert_includes chefs, chef3
+      assert_includes chefs, chef4
+    end
+
+    test "test inverted with array of polymorphic values of the same type" do
+      chef1 = Chef.create!
+      chef2 = Chef.create!
+      chef3 = Chef.create!
+      chef4 = Chef.create!
+
+      cake_designer1 = CakeDesigner.create!(chef: chef1)
+      cake_designer2 = CakeDesigner.create!(chef: chef2)
+      CakeDesigner.create!(chef: chef3)
+      DrinkDesigner.create!(chef: chef4)
+
+      chefs = Chef.where.not(employable: [cake_designer1, cake_designer2])
+
+      assert_not_includes chefs, chef1
+      assert_not_includes chefs, chef2
+      assert_includes chefs, chef3
+      assert_includes chefs, chef4
+    end
+
+    test "test inverted with array of polymorphic values of different and the same types" do
+      chef1 = Chef.create!
+      chef2 = Chef.create!
+      chef3 = Chef.create!
+      chef4 = Chef.create!
+
+      cake_designer1 = CakeDesigner.create!(chef: chef1)
+      cake_designer2 = CakeDesigner.create!(chef: chef2)
+      drink_designer = DrinkDesigner.create!(chef: chef3)
+      DrinkDesigner.create!(chef: chef4)
+
+      chefs = Chef.where.not(employable: [cake_designer1, cake_designer2, drink_designer])
+
+      assert_not_includes chefs, chef1
+      assert_not_includes chefs, chef2
+      assert_not_includes chefs, chef3
+      assert_includes chefs, chef4
+    end
+  end
+end


### PR DESCRIPTION
This pull request is related to this issue https://github.com/rails/rails/issues/16983

Problem: 

```
class Article < ActiveRecord::Base
  has_many :comments, as: :content
end

class Comment < ActiveRecord::Base
  belongs_to :content, polymorphic: true
end

@article = Article.find(10)
Comment.where.not(content: @article)
```

This should create SQL like this:

```
SELECT * FROM comments WHERE NOT (content_type = 'Article' AND content_id = 10)
# or 
SELECT * FROM comments WHERE content_type != 'Article' OR content_id != 10
```

Instead, it generates:

```
SELECT * FROM comments WHERE content_type != 'Article' AND content_id != 10
```

Queries with array of polymorphic values don't work properly too:

```
Comment.where.not(content: [@article1, @article2])
```

This problem is related to the unexpected behaviour of `where.not()` method with multiple condition. And there was a try to solve the problem by changing this behaviour https://github.com/rails/rails/pull/26058 . But it seems to be a huge breaking change. 

This pull request fixes the problem without changing `where.not()` behaviour.
