### PR TITLE
Fix case insensitive check for text column in pg

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -771,6 +771,10 @@ module ActiveRecord
             sql = <<-end_sql
               SELECT exists(
                 SELECT * FROM pg_proc
+                WHERE proname = 'lower'
+                  AND proargtypes = ARRAY[#{quote column.sql_type}::regtype]::oidvector
+              ) OR exists(
+                SELECT * FROM pg_proc
                 INNER JOIN pg_cast
                   ON ARRAY[casttarget]::oidvector = proargtypes
                 WHERE proname = 'lower'

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -772,9 +772,9 @@ module ActiveRecord
               SELECT exists(
                 SELECT * FROM pg_proc
                 INNER JOIN pg_cast
-                  ON casttarget::text::oidvector = proargtypes
+                  ON ARRAY[casttarget]::oidvector = proargtypes
                 WHERE proname = 'lower'
-                  AND castsource = '#{column.sql_type}'::regtype::oid
+                  AND castsource = #{quote column.sql_type}::regtype
               )
             end_sql
             execute_and_clear(sql, "SCHEMA", []) do |result|

--- a/activerecord/test/cases/adapters/postgresql/case_insensitive_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/case_insensitive_test.rb
@@ -1,0 +1,26 @@
+require "cases/helper"
+
+class PostgresqlCaseInsensitiveTest < ActiveRecord::PostgreSQLTestCase
+  class Default < ActiveRecord::Base; end
+
+  def test_case_insensitiveness
+    connection = ActiveRecord::Base.connection
+    table = Default.arel_table
+
+    column = Default.columns_hash["char1"]
+    comparison = connection.case_insensitive_comparison table, :char1, column, nil
+    assert_match /lower/i, comparison.to_sql
+
+    column = Default.columns_hash["char2"]
+    comparison = connection.case_insensitive_comparison table, :char2, column, nil
+    assert_match /lower/i, comparison.to_sql
+
+    column = Default.columns_hash["char3"]
+    comparison = connection.case_insensitive_comparison table, :char3, column, nil
+    assert_match /lower/i, comparison.to_sql
+
+    column = Default.columns_hash["multiline_default"]
+    comparison = connection.case_insensitive_comparison table, :multiline_default, column, nil
+    assert_match /lower/i, comparison.to_sql
+  end
+end


### PR DESCRIPTION
When column type is `text`, case insensitive validation fails because `can_perform_case_insensitive_comparison_for` returns false.

The casting looks a bit funny since I don't know how else to do it. I'm not that familiar with postgres internals.

Test script:

``` ruby
require 'active_record'

class Person < ActiveRecord::Base
  establish_connection adapter: "postgresql", database: "test1", port: 5433
  connection.drop_table table_name
  connection.create_table table_name, force: true do |t|
    t.text :name
    # t.index "LOWER(name)", :unique => true
  end

  validates_uniqueness_of :name, :case_sensitive => false
end

Person.destroy_all
bob = Person.create(name: "bob")
bob2 = Person.create(name: "Bob") # should fail but not raising anything (if without index)
puts Person.all.inspect
```
