### PR TITLE
Remove `config.assets.compress` from documentation

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -139,8 +139,6 @@ pipeline is enabled. It is set to true by default.
 
 * `config.assets.raise_runtime_errors` Set this flag to `true` to enable additional runtime error checking. Recommended in `config/environments/development.rb` to minimize unexpected behavior when deploying to `production`.
 
-* `config.assets.compress` a flag that enables the compression of compiled assets. It is explicitly set to true in `config/environments/production.rb`.
-
 * `config.assets.css_compressor` defines the CSS compressor to use. It is set by default by `sass-rails`. The unique alternative value at the moment is `:yui`, which uses the `yui-compressor` gem.
 
 * `config.assets.js_compressor` defines the JavaScript compressor to use. Possible values are `:closure`, `:uglifier` and `:yui` which require the use of the `closure-compiler`, `uglifier` or `yui-compressor` gems respectively.


### PR DESCRIPTION
It's no longer a valid configuration setting (it has been removed from the Rails codebase).
