### PR TITLE
Allow setting of request CONTENT-TYPE with as: in controller tests

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `:as` option to `ActionController:TestCase#process` and related methods.
+    
+    Specifying as: :mime_type allows the `CONTENT_TYPE` header to be specified
+    in controller tests without manually doing this through `@request.headers...`   
+
 *   Show cache hits and misses when rendering partials.
 
     Partials using the `cache` helper will show whether a render hit or missed

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -449,6 +449,8 @@ module ActionController
       # - +session+: A hash of parameters to store in the session. This may be +nil+.
       # - +flash+: A hash of parameters to store in the flash. This may be +nil+.
       # - +format+: Request format. Defaults to +nil+. Can be string or symbol.
+      # - +as+: Content type. Defaults to +nil+. Must be a symbol that corresponds
+      #   to a mime type
       #
       # Example calling +create+ action and sending two params:
       #
@@ -469,7 +471,7 @@ module ActionController
         check_required_ivars
 
         if kwarg_request?(args)
-          parameters, session, body, flash, http_method, format, xhr = args[0].values_at(:params, :session, :body, :flash, :method, :format, :xhr)
+          parameters, session, body, flash, http_method, format, xhr, as = args[0].values_at(:params, :session, :body, :flash, :method, :format, :xhr, :as)
         else
           http_method, parameters, session, flash = args
           format = nil
@@ -513,6 +515,11 @@ module ActionController
         @controller.recycle!
 
         @request.set_header "REQUEST_METHOD", http_method
+
+        if as
+          @request.content_type = Mime[as].to_s
+          format ||= as
+        end
 
         parameters = parameters.symbolize_keys
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -637,6 +637,15 @@ XML
     assert_equal "application/json", parsed_env["CONTENT_TYPE"]
   end
 
+  def test_using_as_json_sets_request_content_type_to_json
+    post :render_body, params: { bool_value: true, str_value: "string", num_value: 2 }, as: :json
+
+    assert_equal "application/json", @request.headers["CONTENT_TYPE"]
+    assert_equal true, @request.request_parameters[:bool_value]
+    assert_equal "string", @request.request_parameters[:str_value]
+    assert_equal 2, @request.request_parameters[:num_value]
+  end
+
   def test_mutating_content_type_headers_for_plain_text_files_sets_the_header
     @request.headers["Content-Type"] = "text/plain"
     post :render_body, params: { name: "foo.txt" }


### PR DESCRIPTION
### Summary

Adds the option for specifications such as `as: :json` to set the request header, for `get, post,...` etc methods in controller tests.

For example: `post :action, params: { ... }, as: :json` sets the `CONTENT-TYPE` of the request to `application/json`.

r? @rafaelfranca
