### PR TITLE
run `before_configuration` callbacks as soon as application constant inherits from Rails::Application

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Run `before_configuration` callbacks as soon as application constant
+    inherits from `Rails::Application`.
+
+    Fixes #19880.
+
+    *Yuji Yaginuma*
+
 *   A generated app should not include Uglifier with `--skip-javascript` option.
 
     *Ben Pickles*
@@ -17,7 +24,7 @@
 
     *John Meehan*
 
-*   Display name of the class defining the initializer along with the initializer 
+*   Display name of the class defining the initializer along with the initializer
     name in the output of `rails initializers`.
 
     Before:

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -87,6 +87,7 @@ module Rails
         super
         Rails.app_class = base
         add_lib_to_load_path!(find_root(base.called_from))
+        ActiveSupport.run_load_hooks(:before_configuration, base)
       end
 
       def instance
@@ -146,7 +147,6 @@ module Rails
     def run_load_hooks! # :nodoc:
       return self if @ran_load_hooks
       @ran_load_hooks = true
-      ActiveSupport.run_load_hooks(:before_configuration, self)
 
       @initial_variable_values.each do |variable_name, value|
         if INITIAL_VARIABLES.include?(variable_name)

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -79,6 +79,13 @@ module RailtiesTest
       assert_equal app_path, $before_configuration
     end
 
+    test "before_configuration callbacks run as soon as the application constant inherits from Rails::Application" do
+      $before_configuration = false
+      class Foo < Rails::Railtie ; config.before_configuration { $before_configuration = true } ; end
+      class Application < Rails::Application ; end
+      assert $before_configuration
+    end
+
     test "railtie can add after_initialize callbacks" do
       $after_initialize = false
       class Foo < Rails::Railtie ; config.after_initialize { $after_initialize = true } ; end


### PR DESCRIPTION
Until Rails 4.1, `before_configuration` run as soon as the application constant
inherits from `Rails::Application`.
However, in d25fe31c40928712b5e08fe0afb567c3bc88eddf, it has been modified to
run at instantiation process.

This modify to `before_configuration` is run at same timing as to Rails 4.1.

Fixes #19880
