### PR TITLE
Revert "`sql_for_insert` returns values for passing to `exec_insert`"

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -379,7 +379,7 @@ module ActiveRecord
         end
 
         def sql_for_insert(sql, pk, id_value, sequence_name, binds)
-          [sql, binds, pk, sequence_name]
+          [sql, binds]
         end
 
         def last_inserted_id(result)


### PR DESCRIPTION
This reverts #23067. #23067 is for propagating `pk` value from
`sql_for_insert` to `exec_insert` (avoiding extra query for pg adapter).
Now `exec_insert` includes `sql_for_insert` since #26002 therefore this
propagating is no longer needed.
