### PR TITLE
Keep arguments when re-serializing an ActiveJob after deserialization error

### DIFF
--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -82,7 +82,7 @@ module ActiveJob
         "job_id"     => job_id,
         "queue_name" => queue_name,
         "priority"   => priority,
-        "arguments"  => serialize_arguments(arguments),
+        "arguments"  => serialize_arguments_if_needed,
         "executions" => executions,
         "locale"     => I18n.locale.to_s
       }
@@ -123,6 +123,14 @@ module ActiveJob
         if defined?(@serialized_arguments) && @serialized_arguments.present?
           @arguments = deserialize_arguments(@serialized_arguments)
           @serialized_arguments = nil
+        end
+      end
+
+      def serialize_arguments_if_needed
+        if defined?(@serialized_arguments) && @serialized_arguments.present?
+          @serialized_arguments
+        else
+          serialize_arguments(arguments)
         end
       end
 

--- a/activejob/test/cases/rescue_test.rb
+++ b/activejob/test/cases/rescue_test.rb
@@ -31,4 +31,11 @@ class RescueTest < ActiveSupport::TestCase
     RescueJob.perform_later [Person.new(404)]
     assert_includes JobBuffer.values, "DeserializationError original exception was Person::RecordNotFound"
   end
+
+  test "should not lose information when re-serializing" do
+    job = RescueJob.new([Person.new(404)])
+    job.enqueue
+
+    assert_equal job.serialize, JobBuffer.last_value
+  end
 end

--- a/activejob/test/jobs/rescue_job.rb
+++ b/activejob/test/jobs/rescue_job.rb
@@ -12,6 +12,7 @@ class RescueJob < ActiveJob::Base
   rescue_from(ActiveJob::DeserializationError) do |e|
     JobBuffer.add("rescued from DeserializationError")
     JobBuffer.add("DeserializationError original exception was #{e.cause.class.name}")
+    JobBuffer.add(serialize)
   end
 
   def perform(person = "david")


### PR DESCRIPTION
### Summary

When an ActiveJob has a deserialization error, a call to `serialize` will serialize into a job with no arguments. This should fix that, and thus also https://github.com/rails/rails/issues/22044.
### Other Information

This might affect other pull requests:
- [ ] https://github.com/rails/rails/pull/24727 (Sanitization of AJ args for logger)
- [ ] https://github.com/rails/rails/pull/23031 (Allow filtering of non-Global ID ActiveJob args)
- [ ] https://github.com/rails/rails/pull/21885 (Allows any object to implement custom serialization for ActiveJob arguments)

Unfortunately I don't have time to read through them properly to assess impact.
