### PR TITLE
Format and send logs to logger.fatal from DebugExceptions 

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fixes multiple calls to `logger.fatal` instead of a single call, 
+    for every line in an exception backtrace, when printing trace 
+    from `DebugExceptions` middleware.
+      
+    Fixes #26134  
+
+    *Vipul A M*
+   
 *   Add support for arbitrary hashes in strong parameters:
 
     ```ruby

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -175,7 +175,11 @@ module ActionDispatch
       end
 
       def log_array(logger, array)
-        array.map { |line| logger.fatal line }
+        if logger.formatter && logger.formatter.respond_to?(:tags_text)
+          logger.fatal array.join("\n#{logger.formatter.tags_text}")
+        else
+          logger.fatal array.join("\n")
+        end
       end
 
       def logger(request)

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -48,13 +48,12 @@ module ActiveSupport
         Thread.current[thread_key] ||= []
       end
 
-      private
-        def tags_text
-          tags = current_tags
-          if tags.any?
-            tags.collect { |tag| "[#{tag}] " }.join
-          end
+      def tags_text
+        tags = current_tags
+        if tags.any?
+          tags.collect { |tag| "[#{tag}] " }.join
         end
+      end
     end
 
     def self.new(logger)


### PR DESCRIPTION
- Format and send logs to logger.fatal from DebugExceptions instead of calling fatal multiple times. 
- Expose tags_text from TaggedLogging to be used for log formatting.

Fixes #26134
