### PR TITLE
Add README badge with results of MIT-compatibility scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Everyone interacting in Rails and its sub-projects' codebases, issue trackers, c
 ## Code Status
 
 [![Build Status](https://travis-ci.org/rails/rails.svg?branch=master)](https://travis-ci.org/rails/rails)
+[![git.legal](https://git.legal/projects/1346/badge.svg?key=e187481e8d940aeb55a4 "Number of libraries approved")](https://git.legal/projects/1346)
 
 ## License
 


### PR DESCRIPTION
### Summary

I ran an analysis of all the gem libraries used by Rails to confirm compatibility with Rails' MIT license.  There are just two weak copyleft (LGPL) licenses; I took a look at how these are used and there's no problem there.

This PR adds a badge showing that 119 of the 119 libs check-out as compatible.  It's kept up-to-date based off of scans of _master_.
### Other Information

I am a lawyer, but should note that this isn't legal advice -- just a helping hand in running and looking over the automated scan!  I should also disclose that I'm involved with git.legal, the license scanner to which the badge link, but I'm just keen to contribute in putting an eye to license compatibility and the stated wishes of OSS authors (I'd would be equally willing to setup another scanner!).
