### PR TITLE
Consistent examples and template for assets#precompile

### DIFF
--- a/guides/source/3_1_release_notes.md
+++ b/guides/source/3_1_release_notes.md
@@ -99,7 +99,7 @@ gem 'jquery-rails'
     # config.assets.manifest = YOUR_PATH
 
     # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-    # config.assets.precompile `= %w( search.js )
+    # config.assets.precompile `= %w( admin.js admin.css )
 
 
     # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -724,7 +724,7 @@ If you have other manifests or individual stylesheets and JavaScript files to
 include, you can add them to the `precompile` array in `config/initializers/assets.rb`:
 
 ```ruby
-Rails.application.config.assets.precompile += ['admin.js', 'admin.css', 'swfObject.js']
+Rails.application.config.assets.precompile += %w( admin.js admin.css )
 ```
 
 NOTE. Always specify an expected compiled filename that ends with .js or .css,
@@ -1109,9 +1109,9 @@ Windows you have a JavaScript runtime installed in your operating system.
 
 ### Serving GZipped version of assets
 
-By default, gzipped version of compiled assets will be generated, along 
-with the non-gzipped version of assets. Gzipped assets help reduce the transmission of 
-data over the wire. You can configure this by setting the `gzip` flag.
+By default, gzipped version of compiled assets will be generated, along with
+the non-gzipped version of assets. Gzipped assets help reduce the transmission
+of data over the wire. You can configure this by setting the `gzip` flag.
 
 ```ruby
 config.assets.gzip = false # disable gzipped assets generation
@@ -1291,7 +1291,7 @@ config.assets.digest = true
 
 # Precompile additional assets (application.js, application.css, and all
 # non-JS/CSS are already added)
-# config.assets.precompile += %w( search.js )
+# config.assets.precompile += %w( admin.js admin.css )
 ```
 
 Rails 4 and above no longer set default config values for Sprockets in `test.rb`, so

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1364,7 +1364,7 @@ You can define assets for precompilation in `engine.rb`:
 
 ```ruby
 initializer "blorgh.assets.precompile" do |app|
-  app.config.assets.precompile += %w(admin.css admin.js)
+  app.config.assets.precompile += %w( admin.js admin.css )
 end
 ```
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -1424,7 +1424,7 @@ config.assets.digest = true
 # config.assets.manifest = YOUR_PATH
 
 # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-# config.assets.precompile += %w( search.js )
+# config.assets.precompile += %w( admin.js admin.css )
 
 # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
 # config.force_ssl = true

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
@@ -7,5 +7,6 @@ Rails.application.config.assets.version = '1.0'
 # Rails.application.config.assets.paths << Emoji.images_path
 
 # Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+# application.js, application.css, and all non-JS/CSS in the app/assets
+# folder are already added.
+# Rails.application.config.assets.precompile += %w( admin.js admin.css )


### PR DESCRIPTION
Listening to a few developers today discussing their troubles in understanding how to use the asset pipeline, it turns out that the precompile examples in the guides and assets.rb template have over time become a bit inconsistent.

This PR makes the examples consistent in code style, spacing, and asset names, removes the old 'swfObject.js' example, and in a couple of places wraps lines at 80 characters including in the assets.rb template.
