### PR TITLE
[ci skip] Increase margin-bottom for doc's code syntax highlighter

### DIFF
--- a/guides/assets/stylesheets/syntaxhighlighter/shCore.css
+++ b/guides/assets/stylesheets/syntaxhighlighter/shCore.css
@@ -33,7 +33,7 @@
   height: auto !important;
   left: auto !important;
   line-height: 1.1em !important;
-  margin: 0 !important;
+  margin: 0 0 0.5px 0 !important;
   outline: 0 !important;
   overflow: visible !important;
   padding: 0 !important;


### PR DESCRIPTION
Fixes #25744 by slightly increasing the margin in code syntax highlights. With a margin of 0, it was cutting off underscores in Linux browsers, so I slightly increased it to 0.5px.
