### PR TITLE
Remove unnecessary `any?` and `many?` methods for collection proxy

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -286,28 +286,6 @@ module ActiveRecord
         end
       end
 
-      # Returns true if the collections is not empty.
-      # If block given, loads all records and checks for one or more matches.
-      # Otherwise, equivalent to +!collection.empty?+.
-      def any?
-        if block_given?
-          load_target.any? { |*block_args| yield(*block_args) }
-        else
-          !empty?
-        end
-      end
-
-      # Returns true if the collection has more than 1 record.
-      # If block given, loads all records and checks for two or more matches.
-      # Otherwise, equivalent to +collection.size > 1+.
-      def many?
-        if block_given?
-          load_target.many? { |*block_args| yield(*block_args) }
-        else
-          size > 1
-        end
-      end
-
       def distinct
         seen = {}
         load_target.find_all do |record|

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -851,6 +851,12 @@ module ActiveRecord
         @association.empty?
       end
 
+      ##
+      # :method: any?
+      #
+      # :call-seq:
+      #   any?()
+      #
       # Returns +true+ if the collection is not empty.
       #
       #   class Person < ActiveRecord::Base
@@ -880,10 +886,13 @@ module ActiveRecord
       #     pet.group == 'dogs'
       #   end
       #   # => true
-      def any?(&block)
-        @association.any?(&block)
-      end
 
+      ##
+      # :method: many?
+      #
+      # :call-seq:
+      #   many?()
+      #
       # Returns true if the collection has more than one record.
       # Equivalent to <tt>collection.size > 1</tt>.
       #
@@ -918,9 +927,6 @@ module ActiveRecord
       #     pet.group == 'cats'
       #   end
       #   # => true
-      def many?(&block)
-        @association.many?(&block)
-      end
 
       # Returns +true+ if the given +record+ is present in the collection.
       #


### PR DESCRIPTION
Simply use its own methods because `CollectionProxy` inherits `Relation`.
