### PR TITLE
Fixes rails/rails#26229 - ruby 2.3 compat Duration

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -85,6 +85,10 @@ module ActiveSupport
       to_i
     end
 
+    def respond_to_missing?(method, include_private=false) #:nodoc
+      @value.respond_to?(method, include_private)
+    end
+
     protected
 
       def sum(sign, time = ::Time.current) #:nodoc:

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -144,6 +144,12 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal '172800', 2.days.to_json
   end
 
+  def test_flatten_duration
+    assert_nothing_raised do
+      [1.minute].flatten(1)
+    end
+  end
+
   protected
     def with_env_tz(new_tz = 'US/Eastern')
       old_tz, ENV['TZ'] = ENV['TZ'], new_tz


### PR DESCRIPTION
### Summary

This fixes a compatibility issue #26229 with rails 3.2 and ruby 2.3 related to flatten and the Duration class e.g. 
[10.minutes].flatten
