### PR TITLE
remove  unnessary `session_store` setting

### DIFF
--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -14,7 +14,6 @@ require "action_controller/railtie"
 
 class TestApp < Rails::Application
   config.root = File.dirname(__FILE__)
-  config.session_store :cookie_store, key: "cookie_store_key"
   secrets.secret_token    = "secret_token"
   secrets.secret_key_base = "secret_key_base"
 


### PR DESCRIPTION
Since e5a6f7ee9e951dbe0e4e9ea2c0743b4dfb135c57, by default the session store
will be set to cookie store with application name as session key.
