### PR TITLE
Allow the `integration_sesion` to be set early on ActionDispatch::Integration::Runner.

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -422,7 +422,7 @@ module ActionDispatch
 
       def before_setup # :nodoc:
         @app = nil
-        @integration_session = nil
+        @integration_session ||= nil
         super
       end
 

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -420,9 +420,13 @@ module ActionDispatch
 
       attr_reader :app
 
+      def initialize(*args, &blk)
+        super(*args, &blk)
+        @integration_session = nil
+      end
+
       def before_setup # :nodoc:
         @app = nil
-        @integration_session ||= nil
         super
       end
 

--- a/actionpack/test/dispatch/runner_test.rb
+++ b/actionpack/test/dispatch/runner_test.rb
@@ -1,0 +1,18 @@
+require "abstract_unit"
+
+class RunnerTest < ActiveSupport::TestCase
+  test "runner preserves the setting of integration_session" do
+    runner = Class.new do
+      def before_setup
+
+      end
+    end.new
+
+    runner.extend(ActionDispatch::Integration::Runner)
+    runner.integration_session.host! "lvh.me"
+
+    runner.before_setup
+
+    assert_equal "lvh.me", runner.integration_session.host
+  end
+end


### PR DESCRIPTION
In commit fa63448420d3385dbd043aca22dba973b45b8bb2, @tenderlove changed
the behaviour of the way `integration_session` is set up in this object.
It used to be the case that the first time it was accessed, it was
memoized with nil, however, this means that if it had already been set
it was not replaced. After that commit, it is now always set to `nil` in
the execution of `before_setup`.

In RSpec, users are able to invoke `host!` in `before(:all)` blocks,
which execute well before `before_setup` is ever invoked (which happens
in what is equivalent to a `before(:each)` block, for each test. `host!`
causes the integration session to be set up to correctly change the
host, but after fa63448420d3385dbd043aca22dba973b45b8bb2 the
`integration_session` gets overwritten, meaning that users lose their
`host!` configuration (see https://github.com/rspec/rspec-rails/issues/1662).

This commit changes the behaviour back to memoizing with `nil`, as
opposed to directly overwriting with `nil`. This causes the correct
behaviour to occur in RSpec, and unless I'm mistaken will also ensure
that users who want to modify their integration sessions early in rails
will also be able to do so.
