### PR TITLE
Added link to Code Climate from README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Everyone interacting in Rails and its sub-projects' codebases, issue trackers, c
 ## Code Status
 
 [![Build Status](https://travis-ci.org/rails/rails.svg?branch=master)](https://travis-ci.org/rails/rails)
+[![Code Climate](https://codeclimate.com/github/rails/rails/badges/gpa.svg)](https://codeclimate.com/github/rails/rails)
 
 ## License
 


### PR DESCRIPTION
Added link [![Code Climate](https://codeclimate.com/github/rails/rails/badges/gpa.svg)](https://codeclimate.com/github/rails/rails) to section 'Code Status' in README
