### PR TITLE
Include the content of the flash in the auto-generated etag

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,12 @@
-*   Include the content of the flash in the auto-generated etag.
+*   Include the content of the flash in the auto-generated etag. This solves the following problem:
+
+      1. POST /messages
+      2. redirect_to messages_url, notice: 'Message was created'
+      3. GET /messages/1
+      4. GET /messages
+      
+      Step 4 would before still include the flash message, even though it's no longer relevant,
+      because the etag cache was recorded with the flash in place and didn't change when it was gone.
 
     *DHH*
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Include the content of the flash in the auto-generated etag.
+
+    *DHH*
+
 *   Show cache hits and misses when rendering partials.
 
     Partials using the `cache` helper will show whether a render hit or missed

--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -23,6 +23,7 @@ module ActionController
     autoload :Cookies
     autoload :DataStreaming
     autoload :EtagWithTemplateDigest
+    autoload :EtagWithFlash
     autoload :Flash
     autoload :ForceSSL
     autoload :Head

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -213,6 +213,7 @@ module ActionController
       Renderers::All,
       ConditionalGet,
       EtagWithTemplateDigest,
+      EtagWithFlash,
       Caching,
       MimeResponds,
       ImplicitRender,

--- a/actionpack/lib/action_controller/metal/etag_with_flash.rb
+++ b/actionpack/lib/action_controller/metal/etag_with_flash.rb
@@ -1,0 +1,16 @@
+module ActionController
+  # When you're using the flash, it's generally used as a conditional on the view.
+  # This means the content of the view depends on the flash. Which in turn means
+  # that the etag for a response should be computed with the content of the flash
+  # in mind. This does that by including the content of the flash as a component
+  # in the etag that's generated for a response.
+  module EtagWithFlash
+    extend ActiveSupport::Concern
+
+    include ActionController::ConditionalGet
+
+    included do
+      etag { flash }
+    end
+  end
+end

--- a/actionpack/lib/action_controller/metal/etag_with_flash.rb
+++ b/actionpack/lib/action_controller/metal/etag_with_flash.rb
@@ -10,7 +10,7 @@ module ActionController
     include ActionController::ConditionalGet
 
     included do
-      etag { flash }
+      etag { flash unless flash.empty? }
     end
   end
 end

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -266,7 +266,7 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
 
     def set_flash_optionally
       flash.now.notice = params[:flash]
-      if stale? etag: 'abe'
+      if stale? etag: "abe"
         render inline: "maybe flash"
       end
     end
@@ -322,17 +322,17 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
       get "/set_flash_optionally"
       no_flash_etag = response.etag
 
-      get "/set_flash_optionally", params: { flash: 'hello!' }
+      get "/set_flash_optionally", params: { flash: "hello!" }
       hello_flash_etag = response.etag
 
       assert_not_equal no_flash_etag, hello_flash_etag
 
-      get "/set_flash_optionally", params: { flash: 'hello!' }
+      get "/set_flash_optionally", params: { flash: "hello!" }
       another_hello_flash_etag = response.etag
 
       assert_equal another_hello_flash_etag, hello_flash_etag
-      
-      get "/set_flash_optionally", params: { flash: 'goodbye!' }
+
+      get "/set_flash_optionally", params: { flash: "goodbye!" }
       goodbye_flash_etag = response.etag
 
       assert_not_equal another_hello_flash_etag, goodbye_flash_etag

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -263,6 +263,13 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
       flash[:bar] = "for great justice"
       head :ok
     end
+
+    def set_flash_optionally
+      flash.now.notice = params[:flash]
+      if stale? etag: 'abe'
+        render inline: "maybe flash"
+      end
+    end
   end
 
   def test_flash
@@ -307,6 +314,28 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
       get "/set_bar"
       assert_response :success
       assert_equal "for great justice", @controller.bar
+    end
+  end
+
+  def test_flash_factored_into_etag
+    with_test_route_set do
+      get "/set_flash_optionally"
+      no_flash_etag = response.etag
+
+      get "/set_flash_optionally", params: { flash: 'hello!' }
+      hello_flash_etag = response.etag
+
+      assert_not_equal no_flash_etag, hello_flash_etag
+
+      get "/set_flash_optionally", params: { flash: 'hello!' }
+      another_hello_flash_etag = response.etag
+
+      assert_equal another_hello_flash_etag, hello_flash_etag
+      
+      get "/set_flash_optionally", params: { flash: 'goodbye!' }
+      goodbye_flash_etag = response.etag
+
+      assert_not_equal another_hello_flash_etag, goodbye_flash_etag
     end
   end
 


### PR DESCRIPTION
When you're using the flash, it's generally used as a conditional on the view. This means the content of the view depends on the flash. Which in turn means that the etag for a response should be computed with the content of the flash in mind. This does that by including the content of the flash as a component in the etag that's generated for a response.
