### PR TITLE
Improve #tag_option performance

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -86,11 +86,11 @@ module ActionView
 
         def tag_option(key, value, escape)
           if value.is_a?(Array)
-            value = escape ? safe_join(value, " ") : value.join(" ")
+            value = escape ? safe_join(value, " ".freeze) : value.join(" ".freeze)
           else
             value = escape ? ERB::Util.unwrapped_html_escape(value) : value.to_s
           end
-          %(#{key}="#{value.gsub(/"/, '&quot;'.freeze)}")
+          %(#{key}="#{value.gsub('"'.freeze, '&quot;'.freeze)}")
         end
 
         private


### PR DESCRIPTION
After running stackprof on my production application homepage I noticed that `TagHelper#tag_option` is the second occurrence:

```
  Mode: wall(50)
  Samples: 43496 (2.11% miss rate)
  GC: 713 (1.64%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      2459   (5.7%)        2459   (5.7%)     ActiveSupport::SafeBuffer#initialize
      3273   (7.5%)        1810   (4.2%)     ActionView::Helpers::TagHelper#tag_option
      2177   (5.0%)        1754   (4.0%)     #<Module:0x0055667655fe60>.unwrapped_html_escape
      1746   (4.0%)        1746   (4.0%)     ThreadSafe::NonConcurrentCacheBackend#[]
       889   (2.0%)         889   (2.0%)     ActiveSupport::Notifications::Event#initialize
```

I performed some tests with `benchmark-ips` and noticed that `String#gsub` with a String input is almost 2x faster than with a Regex (in this specific case).

I also benchmarked this change and `#tag_option` speed is improved from 20-45% on the most common cases (when escape is true, with or without quotes present) and up to 50% when escape is false.

I noticed as well that by freezing the string literals I was able to extract a little bit more of performance when an array of values is passed.

Given that this is an internal method and the diff is very trivial I can't see any reason not to change this and have a little performance improvement for free.
