### PR TITLE
Don't bust AR query cache when types are not same object (backport bug fix)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix query caching when type information is reset
+
+    Backports ancillary fix in 5.0.
+
+    *James Coleman*
+
 *   Allow `joins` to be unscoped.
 
     Fixes #13775.

--- a/activerecord/lib/active_record/type/value.rb
+++ b/activerecord/lib/active_record/type/value.rb
@@ -86,6 +86,11 @@ module ActiveRecord
           scale == other.scale &&
           limit == other.limit
       end
+      alias eql? ==
+
+      def hash
+        [self.class, precision, scale, limit].hash
+      end
 
       private
 


### PR DESCRIPTION
### Summary

AR's query cache currently depends on the type objects being not only
equivalent but also to be the same object. Either reloading the type
information or using custom type objects that aren't cached will
unnecessarily bust the cache.

The problem is that `ActiveRecord::Type::Value` didn't implement `#eql?`
or `#hash`.
### Other Information

This is fixed in 5.0 as an ancillary part of 574f255
but here I also add a test for the condition.
