### PR TITLE
Change Default Primary Keys to BIGINT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ pkg
 /railties/doc
 /railties/tmp
 /guides/output
-/*/.byebug_history

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ pkg
 /railties/doc
 /railties/tmp
 /guides/output
+/*/.byebug_history

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   PostgreSQL & MySQL: Use big integer as primary key type for new tables
+
+    *Jon McCartie*, *Pavel Pravosud*
+
 *   Change the type argument of `ActiveRecord::Base#attribute` to be optional.
     The default is now `ActiveRecord::Type::Value.new`, which provides no type
     casting behavior.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -71,7 +71,7 @@ module ActiveRecord
         polymorphic: false,
         index: true,
         foreign_key: false,
-        type: :integer,
+        type: :bigint,
         **options
       )
         @name = name

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -56,7 +56,7 @@ module ActiveRecord
       private
 
         def default_primary_key?(column)
-          schema_type(column) == :integer
+          schema_type(column) == :bigint
         end
 
         def schema_type(column)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -39,7 +39,7 @@ module ActiveRecord
       self.emulate_booleans = true
 
       NATIVE_DATABASE_TYPES = {
-        primary_key: "BIGINT(8) UNSIGNED DEFAULT NULL auto_increment PRIMARY KEY",
+        primary_key: "BIGINT(8) UNSIGNED auto_increment PRIMARY KEY",
         string:      { name: "varchar", limit: 255 },
         text:        { name: "text", limit: 65535 },
         integer:     { name: "int", limit: 4 },
@@ -736,6 +736,8 @@ module ActiveRecord
         ER_NO_REFERENCED_ROW_2  = 1452
         ER_DATA_TOO_LONG        = 1406
         ER_LOCK_DEADLOCK        = 1213
+        ER_CANNOT_ADD_FOREIGN   = 1215
+        ER_CANNOT_CREATE_TABLE  = 1005
 
         def translate_exception(exception, message)
           case error_number(exception)
@@ -743,6 +745,14 @@ module ActiveRecord
             RecordNotUnique.new(message)
           when ER_NO_REFERENCED_ROW_2
             InvalidForeignKey.new(message)
+          when ER_CANNOT_ADD_FOREIGN
+            mismatched_foreign_key(message)
+          when ER_CANNOT_CREATE_TABLE
+            if message.include?("errno: 150")
+              mismatched_foreign_key(message)
+            else
+              super
+            end
           when ER_DATA_TOO_LONG
             ValueTooLong.new(message)
           when ER_LOCK_DEADLOCK
@@ -912,6 +922,18 @@ module ActiveRecord
 
         def create_table_definition(*args) # :nodoc:
           MySQL::TableDefinition.new(*args)
+        end
+
+        def mismatched_foreign_key(message)
+          parts = message.scan(/`(\w+)`[ $)]/).flatten
+          MismatchedForeignKey.new(
+            self,
+            message: message,
+            table: parts[0],
+            foreign_key: parts[1],
+            target_table: parts[2],
+            primary_key: parts[3],
+          )
         end
 
         def extract_schema_qualified_name(string) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -39,7 +39,7 @@ module ActiveRecord
       self.emulate_booleans = true
 
       NATIVE_DATABASE_TYPES = {
-        primary_key: "int auto_increment PRIMARY KEY",
+        primary_key: "BIGINT(8) UNSIGNED DEFAULT NULL auto_increment PRIMARY KEY",
         string:      { name: "varchar", limit: 255 },
         text:        { name: "text", limit: 65535 },
         integer:     { name: "int", limit: 4 },

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -3,7 +3,10 @@ module ActiveRecord
     module MySQL
       module ColumnMethods
         def primary_key(name, type = :primary_key, **options)
-          options[:auto_increment] = true if type == :bigint && !options.key?(:default)
+          if type == :primary_key && !options.key?(:default)
+            options[:auto_increment] = true
+            options[:limit] = 8
+          end
           super
         end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -3,11 +3,9 @@ module ActiveRecord
     module MySQL
       module ColumnDumper
         def column_spec_for_primary_key(column)
-          if column.bigint?
-            spec = { id: :bigint.inspect }
-            spec[:default] = schema_default(column) || "nil" unless column.auto_increment?
-          else
-            spec = super
+          spec = super
+          if column.type == :integer && !column.auto_increment?
+            spec[:default] = schema_default(column) || "nil"
           end
           spec[:unsigned] = "true" if column.unsigned?
           spec

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         private
 
           def default_primary_key?(column)
-            schema_type(column) == :serial
+            schema_type(column) == :bigserial
           end
 
           def schema_type(column)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -70,7 +70,7 @@ module ActiveRecord
       ADAPTER_NAME = "PostgreSQL".freeze
 
       NATIVE_DATABASE_TYPES = {
-        primary_key: "serial primary key",
+        primary_key: "bigserial primary key",
         string:      { name: "character varying" },
         text:        { name: "text" },
         integer:     { name: "integer" },

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
@@ -1,0 +1,13 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      module ColumnDumper
+        private
+
+          def default_primary_key?(column)
+            schema_type(column) == :integer
+          end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -4,6 +4,7 @@ require "active_record/connection_adapters/sqlite3/explain_pretty_printer"
 require "active_record/connection_adapters/sqlite3/quoting"
 require "active_record/connection_adapters/sqlite3/schema_creation"
 require "active_record/connection_adapters/sqlite3/schema_definitions"
+require "active_record/connection_adapters/sqlite3/schema_dumper"
 
 gem "sqlite3", "~> 1.3.6"
 require "sqlite3"
@@ -53,6 +54,7 @@ module ActiveRecord
       ADAPTER_NAME = "SQLite".freeze
 
       include SQLite3::Quoting
+      include SQLite3::ColumnDumper
 
       NATIVE_DATABASE_TYPES = {
         primary_key:  "INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL",

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -123,6 +123,34 @@ module ActiveRecord
   class InvalidForeignKey < WrappedDatabaseException
   end
 
+  # Raised when a foreign key constraint cannot be added because the column type does not match the referenced column type.
+  class MismatchedForeignKey < WrappedDatabaseException
+    def initialize(adapter = nil, message: nil, table: nil, foreign_key: nil, target_table: nil, primary_key: nil)
+      @adapter = adapter
+      if table
+        msg = <<-EOM.strip_heredoc
+          Column `#{foreign_key}` on table `#{table}` has a type of `#{column_type(table, foreign_key)}`.
+          This does not match column `#{primary_key}` on `#{target_table}`, which has type `#{column_type(target_table, primary_key)}`.
+          To resolve this issue, change the type of the `#{foreign_key}` column on `#{table}` to be :integer. (For example `t.integer #{foreign_key}`).
+        EOM
+      else
+        msg = <<-EOM
+          There is a mismatch between the foreign key and primary key column types.
+          Verify that the foreign key column type and the primary key of the associated table match types.
+        EOM
+      end
+      if message
+        msg << "\nOriginal message: #{message}"
+      end
+      super(msg)
+    end
+
+    private
+      def column_type(table, column)
+        @adapter.columns(table).detect { |c| c.name == column }.sql_type
+      end
+  end
+
   # Raised when a record cannot be inserted or updated because a value too long for a column type.
   class ValueTooLong < StatementInvalid
   end

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -104,11 +104,21 @@ module ActiveRecord
 
       class V5_0 < V5_1
         def create_table(table_name, options = {})
-          if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
+          connection_name = self.connection.adapter_name
+          if connection_name == "PostgreSQL"
             if options[:id] == :uuid && !options[:default]
               options[:default] = "uuid_generate_v4()"
             end
           end
+
+          # Since 5.1 Postgres adapter uses bigserial type for primary
+          # keys by default and MySQL uses bigint. This compat layer makes old migrations utilize
+          # serial/int type instead -- the way it used to work before 5.1.
+          if options[:id].blank?
+            options[:id] = :integer
+            options[:auto_increment] = true
+          end
+
           super
         end
       end

--- a/activerecord/test/cases/adapters/mysql2/legacy_migration_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/legacy_migration_test.rb
@@ -1,0 +1,60 @@
+require "cases/helper"
+
+class MysqlLegacyMigrationTest < ActiveRecord::Mysql2TestCase
+  self.use_transactional_tests = false
+
+  class GenerateTableWithoutBigint < ActiveRecord::Migration[5.0]
+    def change
+      create_table :legacy_integer_pk do |table|
+        table.string :foo
+      end
+
+      create_table :override_pk, id: :bigint do |table|
+        table.string :bar
+      end
+    end
+  end
+
+  def setup
+    super
+    @connection = ActiveRecord::Base.connection
+
+    @migration_verbose_old = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+
+    migrations = [GenerateTableWithoutBigint.new(nil, 1)]
+
+    ActiveRecord::Migrator.new(:up, migrations).migrate
+  end
+
+  def teardown
+    ActiveRecord::Migration.verbose = @migration_verbose_old
+    @connection.drop_table("legacy_integer_pk")
+    @connection.drop_table("override_pk")
+    ActiveRecord::SchemaMigration.delete_all rescue nil
+    super
+  end
+
+  def test_create_table_uses_integer_as_pkey_by_default
+    col = column(:legacy_integer_pk, :id)
+    assert_equal "int(11)", sql_type_for(col)
+    assert col.auto_increment?
+  end
+
+  def test_create_tables_respects_pk_column_type_override
+    col = column(:override_pk, :id)
+    assert_equal "bigint(20)", sql_type_for(col)
+  end
+
+  private
+
+    def column(table_name, column_name)
+      ActiveRecord::Base.connection
+        .columns(table_name.to_s)
+        .detect { |c| c.name == column_name.to_s }
+    end
+
+    def sql_type_for(col)
+      col && col.sql_type
+    end
+end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -65,6 +65,19 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
       @conn.columns_for_distinct("posts.id", [order])
   end
 
+  def test_errors_for_bigint_fks_on_integer_pk_table
+    # table old_cars has primary key of integer
+
+    error = assert_raises(ActiveRecord::MismatchedForeignKey) do
+      @conn.add_reference :engines, :old_car
+      @conn.add_foreign_key :engines, :old_cars
+    end
+
+    assert_match "Column `old_car_id` on table `engines` has a type of `bigint(20)`", error.message
+    assert_not_nil error.cause
+    @conn.exec_query("ALTER TABLE engines DROP COLUMN old_car_id")
+  end
+
   private
 
     def with_example_table(definition = "id int auto_increment primary key, number int, data varchar(255)", &block)

--- a/activerecord/test/cases/adapters/postgresql/legacy_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/legacy_migration_test.rb
@@ -1,0 +1,54 @@
+require "cases/helper"
+
+class PostgresqlLegacyMigrationTest < ActiveRecord::PostgreSQLTestCase
+  class GenerateTableWithoutBigserial < ActiveRecord::Migration[5.0]
+    def change
+      create_table :legacy_integer_pk do |table|
+        table.string :foo
+      end
+
+      create_table :override_pk, id: :bigint do |table|
+        table.string :bar
+      end
+    end
+  end
+
+  def setup
+    super
+
+    @migration_verbose_old = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+
+    migrations = [GenerateTableWithoutBigserial.new(nil, 1)]
+    ActiveRecord::Migrator.new(:up, migrations).migrate
+  end
+
+  def teardown
+    ActiveRecord::Migration.verbose = @migration_verbose_old
+
+    super
+  end
+
+  def test_create_table_uses_serial_as_pkey_by_default
+    col = column(:legacy_integer_pk, :id)
+    assert_equal "integer", sql_type_for(col)
+    assert col.serial?
+  end
+
+  def test_create_tables_respects_pk_column_type_override
+    col = column(:override_pk, :id)
+    assert_equal "bigint", sql_type_for(col)
+  end
+
+  private
+
+    def column(table_name, column_name)
+      ActiveRecord::Base.connection.
+        columns(table_name.to_s).
+        detect { |c| c.name == column_name.to_s }
+    end
+
+    def sql_type_for(col)
+      col && col.sql_type
+    end
+end

--- a/activerecord/test/cases/adapters/sqlite3/legacy_migration_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/legacy_migration_test.rb
@@ -1,0 +1,59 @@
+require "cases/helper"
+
+class SqliteLegacyMigrationTest < ActiveRecord::SQLite3TestCase
+  self.use_transactional_tests = false
+
+  class GenerateTableWithoutBigint < ActiveRecord::Migration[5.0]
+    def change
+      create_table :legacy_integer_pk do |table|
+        table.string :foo
+      end
+
+      create_table :override_pk, id: :bigint do |table|
+        table.string :bar
+      end
+    end
+  end
+
+  def setup
+    super
+    @connection = ActiveRecord::Base.connection
+
+    @migration_verbose_old = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+
+    migrations = [GenerateTableWithoutBigint.new(nil, 1)]
+
+    ActiveRecord::Migrator.new(:up, migrations).migrate
+  end
+
+  def teardown
+    ActiveRecord::Migration.verbose = @migration_verbose_old
+    @connection.drop_table("legacy_integer_pk")
+    @connection.drop_table("override_pk")
+    ActiveRecord::SchemaMigration.delete_all rescue nil
+    super
+  end
+
+  def test_create_table_uses_integer_as_pkey_by_default
+    col = column(:legacy_integer_pk, :id)
+    assert_equal "INTEGER", sql_type_for(col)
+    assert primary_key?(:legacy_integer_pk, "id"), "id is not primary key"
+  end
+
+  private
+
+    def column(table_name, column_name)
+      ActiveRecord::Base.connection
+        .columns(table_name.to_s)
+        .detect { |c| c.name == column_name.to_s }
+    end
+
+    def sql_type_for(col)
+      col && col.sql_type
+    end
+
+    def primary_key?(table_name, column)
+      ActiveRecord::Base.connection.execute("PRAGMA table_info(#{table_name})").find { |col| col["name"] == column }["pk"] == 1
+    end
+end

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -101,7 +101,12 @@ module ActiveRecord
 
       def test_primary_key_creates_primary_key_column
         with_change_table do |t|
-          @connection.expect :add_column, nil, [:delete_me, :id, :primary_key, primary_key: true, first: true]
+          if current_adapter?(:Mysql2Adapter)
+            @connection.expect :add_column, nil, [:delete_me, :id, :primary_key, { first: true, auto_increment: true, limit: 8, primary_key: true }]
+          else
+            @connection.expect :add_column, nil, [:delete_me, :id, :primary_key, primary_key: true, first: true]
+          end
+
           t.primary_key :id, first: true
         end
       end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -76,7 +76,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
         end
 
         def test_add_foreign_key_with_non_standard_primary_key
-          with_example_table @connection, "space_shuttles", "pk integer PRIMARY KEY" do
+          with_example_table @connection, "space_shuttles", "pk BIGINT PRIMARY KEY" do
             @connection.add_foreign_key(:astronauts, :space_shuttles,
                                         column: "rocket_id", primary_key: "pk", name: "custom_pk")
 
@@ -229,7 +229,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
             create_table("cities") { |t| }
 
             create_table("houses") do |t|
-              t.column :city_id, :integer
+              t.column :city_id, :bigint
             end
             add_foreign_key :houses, :cities, column: "city_id"
 
@@ -261,7 +261,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
             create_table(:schools)
 
             create_table(:classes) do |t|
-              t.column :school_id, :integer
+              t.column :school_id, :bigint
             end
             add_foreign_key :classes, :schools
           end

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -42,7 +42,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
 
         test "options hash can be passed" do
           @connection.change_table :testing_parents do |t|
-            t.integer :other_id
+            t.bigint :other_id
             t.index :other_id, unique: true
           end
           @connection.create_table :testings do |t|
@@ -92,7 +92,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
 
         test "foreign keys accept options when changing the table" do
           @connection.change_table :testing_parents do |t|
-            t.integer :other_id
+            t.bigint :other_id
             t.index :other_id, unique: true
           end
           @connection.create_table :testings
@@ -177,8 +177,8 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
 
         test "multiple foreign keys can be added to the same table" do
           @connection.create_table :testings do |t|
-            t.integer :col_1
-            t.integer :col_2
+            t.bigint :col_1
+            t.bigint :col_2
 
             t.foreign_key :testing_parents, column: :col_1
             t.foreign_key :testing_parents, column: :col_2

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -361,6 +361,13 @@ class PrimaryKeyIntegerTest < ActiveRecord::TestCase
     Widget.reset_column_information
   end
 
+  if current_adapter?(:PostgreSQLAdapter, :Mysql2Adapter)
+    test "schema dump primary key with bigserial" do
+      schema = dump_table_schema "widgets"
+      assert_match %r{create_table "widgets", force: :cascade}, schema
+    end
+  end
+
   test "primary key column type" do
     column_type = Widget.type_for_attribute(Widget.primary_key)
     assert_equal :integer, column_type.type

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -316,85 +316,62 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
 end
 
 if current_adapter?(:Mysql2Adapter)
-  class PrimaryKeyBigintNilDefaultTest < ActiveRecord::TestCase
+  class PrimaryKeyIntegerNilDefaultTest < ActiveRecord::TestCase
     include SchemaDumpingHelper
 
     self.use_transactional_tests = false
 
     def setup
       @connection = ActiveRecord::Base.connection
-      @connection.create_table(:bigint_defaults, id: :bigint, default: nil, force: true)
+      @connection.create_table(:int_defaults, id: :integer, default: nil, force: true)
     end
 
     def teardown
-      @connection.drop_table :bigint_defaults, if_exists: true
+      @connection.drop_table :int_defaults, if_exists: true
     end
 
-    test "primary key with bigint allows default override via nil" do
-      column = @connection.columns(:bigint_defaults).find { |c| c.name == "id" }
-      assert column.bigint?
+    test "primary key with integer allows default override via nil" do
+      column = @connection.columns(:int_defaults).find { |c| c.name == "id" }
+      assert_equal :integer, column.type
       assert_not column.auto_increment?
     end
 
-    test "schema dump primary key with bigint default nil" do
-      schema = dump_table_schema "bigint_defaults"
-      assert_match %r{create_table "bigint_defaults", id: :bigint, default: nil}, schema
+    test "schema dump primary key with int default nil" do
+      schema = dump_table_schema "int_defaults"
+      assert_match %r{create_table "int_defaults", id: :integer, default: nil}, schema
     end
   end
 end
 
-if current_adapter?(:PostgreSQLAdapter, :Mysql2Adapter)
-  class PrimaryKeyBigSerialTest < ActiveRecord::TestCase
-    include SchemaDumpingHelper
+class PrimaryKeyIntegerTest < ActiveRecord::TestCase
+  include SchemaDumpingHelper
 
-    self.use_transactional_tests = false
+  self.use_transactional_tests = false
 
-    class Widget < ActiveRecord::Base
-    end
+  class Widget < ActiveRecord::Base
+  end
 
-    setup do
-      @connection = ActiveRecord::Base.connection
-      if current_adapter?(:PostgreSQLAdapter)
-        @connection.create_table(:widgets, id: :bigserial, force: true)
-      else
-        @connection.create_table(:widgets, id: :bigint, force: true)
-      end
-    end
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table(:widgets, force: true)
+  end
 
-    teardown do
-      @connection.drop_table :widgets, if_exists: true
-      Widget.reset_column_information
-    end
+  teardown do
+    @connection.drop_table :widgets, if_exists: true
+    Widget.reset_column_information
+  end
 
-    test "primary key column type with bigserial" do
-      column_type = Widget.type_for_attribute(Widget.primary_key)
-      assert_equal :integer, column_type.type
+  test "primary key column type" do
+    column_type = Widget.type_for_attribute(Widget.primary_key)
+    assert_equal :integer, column_type.type
+
+    if current_adapter?(:PostgreSQLAdapter, :Mysql2Adapter)
       assert_equal 8, column_type.limit
     end
 
-    test "primary key with bigserial are automatically numbered" do
-      widget = Widget.create!
-      assert_not_nil widget.id
-    end
-
-    test "schema dump primary key with bigserial" do
-      schema = dump_table_schema "widgets"
-      if current_adapter?(:PostgreSQLAdapter)
-        assert_match %r{create_table "widgets", id: :bigserial, force: :cascade}, schema
-      else
-        assert_match %r{create_table "widgets", id: :bigint, force: :cascade}, schema
-      end
-    end
-
     if current_adapter?(:Mysql2Adapter)
-      test "primary key column type with options" do
-        @connection.create_table(:widgets, id: :primary_key, limit: 8, unsigned: true, force: true)
-        column = @connection.columns(:widgets).find { |c| c.name == "id" }
-        assert column.auto_increment?
-        assert_equal :integer, column.type
-        assert_equal 8, column.limit
-        assert column.unsigned?
-      end
+      column = @connection.columns(:widgets).find { |c| c.name == "id" }
+      assert column.auto_increment?
     end
   end
 end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -346,7 +346,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
       create_table("dogs") do |t|
         t.column :name, :string
-        t.column :owner_id, :integer
+        t.column :owner_id, :bigint
         t.index [:name]
         t.foreign_key :dog_owners, column: "owner_id" if supports_foreign_keys?
       end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define do
 
   create_table :authors, force: true do |t|
     t.string :name, null: false
-    t.integer :author_address_id
+    t.bigint :author_address_id
     t.integer :author_address_extra_id
     t.string :organization_id
     t.string :owned_essay_id
@@ -303,7 +303,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :engines, force: true do |t|
-    t.integer :car_id
+    t.bigint :car_id
   end
 
   create_table :entrants, force: true do |t|
@@ -1004,7 +1004,7 @@ ActiveRecord::Schema.define do
   if supports_foreign_keys?
     # fk_test_has_fk should be before fk_test_has_pk
     create_table :fk_test_has_fk, force: true do |t|
-      t.integer :fk_id, null: false
+      t.bigint :fk_id, null: false
     end
 
     create_table :fk_test_has_pk, force: true, primary_key: "pk_id" do |t|

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -126,6 +126,9 @@ ActiveRecord::Schema.define do
     t.timestamps null: false
   end
 
+  create_table :old_cars, id: :integer, force: true do |t|
+  end
+
   create_table :carriers, force: true
 
   create_table :categories, force: true do |t|


### PR DESCRIPTION
<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Friends don&#39;t let friends use INT as a primary key. </p>&mdash; Schneems (@schneems) <a href="https://twitter.com/schneems/status/731167572096253952">May 13, 2016</a></blockquote>

### Summary

Per a conversation with @sgrif: changes default primary keys from Integer to BIGINT for both Postgresql and MySQL.  Leaves behavior alone for SQLite since this database does not provide support for BIGINT primary keys.
### Other Information

For obvious reasons, this also requires foreign keys to change from integer to bigints. As a result the test suite's `schema.rb` has been change in the necessary places.

I'll squash and add a CHANGELOG entry once the rest looks ok...
