### PR TITLE
Rename the title of comand_line.md in index

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -100,9 +100,9 @@
       url: configuring.html
       description: This guide covers the basic configuration settings for a Rails application.
     -
-      name: Rails Command Line Tools and Rake Tasks
+      name: The Rails Command Line
       url: command_line.html
-      description: This guide covers the command line tools and rake tasks provided by Rails.
+      description: This guide covers the command line tools provided by Rails.
     -
       name: Asset Pipeline
       url: asset_pipeline.html


### PR DESCRIPTION
In Rails 5.0, rake tasks was merged to `rails` command,
hence the document's title has been updated to `The Rails Command Line`.
However, in index, `Rake Tasks` remains so I just remove a mention about rake tasks. XD
