### PR TITLE
Test that AR query cache isn't busted when types are not same object

### DIFF
--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -212,6 +212,26 @@ class QueryCacheTest < ActiveRecord::TestCase
     end
   end
 
+  def test_query_cached_even_when_types_are_reset
+    Task.cache do
+      # Warm the cache
+      task = Task.find(1)
+
+      Task.connection.type_map.clear
+
+      # Preload the type cache again (so we don't have those queries issued during our assertions)
+      Task.connection.send(:initialize_type_map, Task.connection.type_map)
+
+      # Clear places where type information is cached
+      Task.reset_column_information
+      Task.initialize_find_by_cache
+
+      assert_queries(0) do
+        Task.find(1)
+      end
+    end
+  end
+
   private
     def middleware(&app)
       executor = Class.new(ActiveSupport::Executor)


### PR DESCRIPTION
### Summary

This is fixed in 5.0 as an ancillary part of 574f255629a45cd67babcfb9bb8e163e091a53b8
but here I also add a test for the condition.

I'd previously backported the fix (and added a test) in the below
commit which was merged in #26261; this brings the fix back up to master.

(cherry picked from commit fce3dbf30241f2a65c777e192a7171b0eea81453)
