### PR TITLE
implemented allow_blank for numericality validation

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -27,6 +27,7 @@ module ActiveModel
         end
 
         return if options[:allow_nil] && raw_value.nil?
+        return if options[:allow_blank] && raw_value.blank?
 
         unless is_number?(raw_value)
           record.errors.add(attr_name, :not_a_number, filtered_options(raw_value))

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -35,6 +35,13 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!(NIL + FLOATS + INTEGERS + BIGDECIMAL + INFINITY)
   end
 
+  def test_validates_numericality_of_with_blank_allowed
+    Topic.validates_numericality_of :approved, allow_blank: true
+
+    invalid!(JUNK)
+    valid!(NIL + BLANK + FLOATS + INTEGERS + BIGDECIMAL + INFINITY)
+  end
+
   def test_validates_numericality_of_with_integer_only
     Topic.validates_numericality_of :approved, only_integer: true
 


### PR DESCRIPTION
### Summary

This PR implements <tt>:allow_blank</tt> option for numericality validation.
This relates somewhat to #11247 where documentation was added without code.
