### PR TITLE
Handle short CSRF tokens when building a new token

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   CSRF: When the `:_csrf_token` is shorter than `AUTHENTICITY_TOKEN_LENGTH`,
+    use the available bytes to generate a new token instead of failing with a `TypeError`.
+
+    *Robert Mosolgo*
+
 *   Include the content of the flash in the auto-generated etag. This solves the following problem:
 
       1. POST /messages

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -379,10 +379,11 @@ module ActionController #:nodoc:
         )
       end
 
+      # Merge +s2+ into +s1+ by +XOR+ing their bytes.
       def xor_byte_strings(s1, s2)
-        s2_bytes = s2.bytes
-        s1.each_byte.with_index { |c1, i| s2_bytes[i] ^= c1 }
-        s2_bytes.pack("C*")
+        s1_bytes = s1.bytes
+        s2.each_byte.with_index { |c1, i| s1_bytes[i] ^= c1 }
+        s1_bytes.pack("C*")
       end
 
       # The form's authenticity parameter. Override to provide your own.

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -516,6 +516,11 @@ class RequestForgeryProtectionControllerUsingResetSessionTest < ActionController
       assert_match(/#{regexp}/, @response.body)
     end
   end
+
+  def test_should_not_raise_error_if_token_is_too_short
+    session[:_csrf_token] = "c9/MY8OvP7aVbxB2/ksCQw=="
+    assert_nothing_raised { get :meta }
+  end
 end
 
 class RequestForgeryProtectionControllerUsingNullSessionTest < ActionController::TestCase


### PR DESCRIPTION
### Summary

I'm trying to integrate a non-Rails (Elixir Plug) app into an "ecosystem" of pre-existing Rails apps. I'm trying to share a session cookie between apps. 

I found that Plug writes its _own_ `:_csrf_token` into the session, then, when returning to Rails, the Rails app would fail to handle the new value. I also described the problem [in a Plug issue](https://github.com/elixir-lang/plug/issues/442).

At first, I suggested that Plug allow users to customize the name of the token, to avoid naming conflicts. However, the maintainer there suggested that a more robust approach to this issue would be to handle unexpected session values more gracefully in Rails. 

So, I determined that Plug's authenticity token is only 16 bytes long, but Rails' token is 32 bytes long. This was causing `^` to behave in a funny way -- who knew that `nil ^ 1 # => true`? This ended up as `TypeError` when we tried to reserialize the bytes with `.pack`. 

My first attempt was to pad the incoming token if it was too short, something like this: 

``` ruby
# If s2_bytes is shorter than expected, then pad it with zeroes
if s2_bytes.length != AUTHENTICITY_TOKEN_LENGTH
  s2_bytes.fill(0, s2_bytes.length, AUTHENTICITY_TOKEN_LENGTH - s2_bytes.length)
end
```

But then I realized, what if we just performed the merge the other way? That is, instead of merging bytes from `s1` into `s2`, we could merge bytes from `s2` into `s1`, and if `s2` is too short, then we just leave the end of `s1` unchanged. 

This seems like a simple solution, but I wonder, does this weaken the security of the system? My understanding of CSRF protection is not very good 😢  

Thanks for reviewing, please let me know if there's anything else I can do to improve this submission!
