### PR TITLE
Eager autoloading association classes

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -190,21 +190,26 @@ module ActiveRecord
     extend ActiveSupport::Autoload
     extend ActiveSupport::Concern
 
-    # These classes will be loaded when associations are created.
-    # So there is no need to eager load them.
-    autoload :Association
-    autoload :SingularAssociation
-    autoload :CollectionAssociation
-    autoload :ForeignAssociation
-    autoload :CollectionProxy
+    eager_autoload do
+      autoload :Association
+      autoload :SingularAssociation
+      autoload :CollectionAssociation
+      autoload :ForeignAssociation
+      autoload :CollectionProxy
 
-    autoload :BelongsToAssociation
-    autoload :BelongsToPolymorphicAssociation
-    autoload :HasManyAssociation
-    autoload :HasManyThroughAssociation
-    autoload :HasOneAssociation
-    autoload :HasOneThroughAssociation
-    autoload :ThroughAssociation
+      autoload :BelongsToAssociation
+      autoload :BelongsToPolymorphicAssociation
+      autoload :HasManyAssociation
+      autoload :HasManyThroughAssociation
+      autoload :HasOneAssociation
+      autoload :HasOneThroughAssociation
+      autoload :ThroughAssociation
+
+      autoload :Preloader
+      autoload :JoinDependency
+      autoload :AssociationScope
+      autoload :AliasTracker
+    end
 
     module Builder #:nodoc:
       autoload :Association,           "active_record/associations/builder/association"
@@ -215,13 +220,6 @@ module ActiveRecord
       autoload :HasOne,              "active_record/associations/builder/has_one"
       autoload :HasMany,             "active_record/associations/builder/has_many"
       autoload :HasAndBelongsToMany, "active_record/associations/builder/has_and_belongs_to_many"
-    end
-
-    eager_autoload do
-      autoload :Preloader
-      autoload :JoinDependency
-      autoload :AssociationScope
-      autoload :AliasTracker
     end
 
     # Returns the association instance for the given name, instantiating it if it doesn't already exist


### PR DESCRIPTION
When upgrading rails, `LoadError` like `LoadError: cannot load such file
-- active_record/associations/has_many_through_association` frequently
happend. I'm not sure the root cause, but it seems that caused by
changing symbolic link `/deploy_to/current` to new version before
graceful restart. I believe that eager autoloading solves the issue.

<img width="805" alt="screen shot 2016-08-26 at 08 21 31" src="https://cloud.githubusercontent.com/assets/12642/17990153/4e97c740-6b6e-11e6-8afa-ce004e763a90.png">

![image](https://cloud.githubusercontent.com/assets/12642/17990171/6cee1dc0-6b6e-11e6-8197-bc8468e9f894.png)
