### PR TITLE
Move Rails' custom assertion method `assert_nothing_raised` to its proper place.

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -65,16 +65,5 @@ module ActiveSupport
     alias :assert_not_predicate :refute_predicate
     alias :assert_not_respond_to :refute_respond_to
     alias :assert_not_same :refute_same
-
-    # Assertion that the block should not raise an exception.
-    #
-    # Passes if evaluated code in the yielded block raises no exception.
-    #
-    #   assert_nothing_raised do
-    #     perform_service(param: 'no_exception')
-    #   end
-    def assert_nothing_raised
-      yield
-    end
   end
 end

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -19,6 +19,17 @@ module ActiveSupport
         assert !object, message
       end
 
+      # Assertion that the block should not raise an exception.
+      #
+      # Passes if evaluated code in the yielded block raises no exception.
+      #
+      #   assert_nothing_raised do
+      #     perform_service(param: 'no_exception')
+      #   end
+      def assert_nothing_raised
+        yield
+      end
+
       # Test numeric difference between the return value of an expression as a
       # result of what is evaluated in the yielded block.
       #


### PR DESCRIPTION
We have a separate module `ActiveSupport::Testing::Assertions` in which
we have defined Rails' own custom assertions. So it would be good to keep
all custom Rails' assertions in one place.
