### PR TITLE
Errors#add_on_blank: Fix typo in deprecation message

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -372,7 +372,7 @@ module ActiveModel
 
         To achieve the same use:
 
-          errors.add(attribute, :empty, options) if value.blank?
+          errors.add(attribute, :blank, options) if value.blank?
       MESSAGE
 
       Array(attributes).each do |attribute|


### PR DESCRIPTION
In #18996, `#add_on_blank` and `#add_on_empty` got deprecated. The warning message in `#add_on_blank` seems to be copied from `#add_on_empty`, but there is a typo.
