### PR TITLE
Switch back to `Hash.dup`

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -29,9 +29,7 @@ module ActiveRecord
     end
 
     def initialize_copy(other)
-      # This method is a hot spot, so for now, use Hash[] to dup the hash.
-      #   https://bugs.ruby-lang.org/issues/7166
-      @values        = Hash[@values]
+      @values = @values.dup
       reset
     end
 
@@ -661,7 +659,7 @@ module ActiveRecord
     end
 
     def values
-      Hash[@values]
+      @values.dup
     end
 
     def inspect


### PR DESCRIPTION
### Summary

The performance difference between `Hash[]` and `Hash.dup` looks to have
been narrowed by @tenderlove via this commit --> https://github.com/ruby/ruby/commit/b3803cc49ad382e23291d75ce57ffb2b74bb9577#diff-eff9999082c8ce7d8ba1fc1d79f439cf.
Since this commit first appeared in Ruby 2.0.0, and since Rails now
requires a minimum Ruby version of 2.2.2, this performance boost should
be available for all users.

cc @tenderlove 

Relevant links:
- This behavior was originally added via https://github.com/rails/rails/commit/02174a3efc6fa8f2e5e6f114e4cf0d8a06305b6a
- The conversation on the Ruby issue tracker lives here --> https://bugs.ruby-lang.org/issues/7166
