### PR TITLE
Avoid `RangeError` without explicit `limit`

### DIFF
--- a/activemodel/lib/active_model/type/big_integer.rb
+++ b/activemodel/lib/active_model/type/big_integer.rb
@@ -5,11 +5,12 @@ require_relative "integer"
 module ActiveModel
   module Type
     class BigInteger < Integer # :nodoc:
-      private
-
-        def max_value
-          ::Float::INFINITY
-        end
+      def initialize(*)
+        ActiveSupport::Deprecation.warn \
+          "#{self.class} is deprecated and will be removed in Rails 6.0. " \
+          "Please use #{self.class.superclass} instead."
+        super
+      end
     end
   end
 end

--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -5,10 +5,6 @@ module ActiveModel
     class Integer < Value # :nodoc:
       include Helpers::Numeric
 
-      # Column storage size in bytes.
-      # 4 bytes means an integer as opposed to smallint etc.
-      DEFAULT_LIMIT = 4
-
       def initialize(*)
         super
         @range = min_value...max_value
@@ -63,7 +59,7 @@ module ActiveModel
         end
 
         def _limit
-          limit || DEFAULT_LIMIT
+          limit || 8 # 8 bytes means a bigint as opposed to smallint etc.
         end
     end
   end

--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -46,20 +46,20 @@ module ActiveModel
 
         def ensure_in_range(value)
           unless range.cover?(value)
-            raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
+            raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{limit} bytes"
           end
         end
 
         def max_value
-          1 << (_limit * 8 - 1) # 8 bits per byte with one bit for sign
+          if limit
+            1 << (limit * 8 - 1) # 8 bits per byte with one bit for sign
+          else
+            ::Float::INFINITY
+          end
         end
 
         def min_value
           -max_value
-        end
-
-        def _limit
-          limit || 8 # 8 bytes means a bigint as opposed to smallint etc.
         end
     end
   end

--- a/activemodel/test/cases/type/integer_test.rb
+++ b/activemodel/test/cases/type/integer_test.rb
@@ -76,13 +76,13 @@ module ActiveModel
 
       test "very small numbers are out of range" do
         assert_raises(ActiveModel::RangeError) do
-          Integer.new.serialize(-9999999999999999999999999999999)
+          Integer.new(limit: 8).serialize(-9999999999999999999999999999999)
         end
       end
 
       test "very large numbers are out of range" do
         assert_raises(ActiveModel::RangeError) do
-          Integer.new.serialize(9999999999999999999999999999999)
+          Integer.new(limit: 8).serialize(9999999999999999999999999999999)
         end
       end
 
@@ -94,11 +94,11 @@ module ActiveModel
       end
 
       test "int max value is in range" do
-        assert_equal(2147483647, Integer.new.serialize(2147483647))
+        assert_equal(2147483647, Integer.new(limit: 4).serialize(2147483647))
       end
 
       test "int min value is in range" do
-        assert_equal(-2147483648, Integer.new.serialize(-2147483648))
+        assert_equal(-2147483648, Integer.new(limit: 4).serialize(-2147483648))
       end
 
       test "columns with a larger limit have larger ranges" do
@@ -112,6 +112,10 @@ module ActiveModel
         assert_raises(ActiveModel::RangeError) do
           type.serialize(9999999999999999999999999999999)
         end
+      end
+
+      test "deprecated integer types" do
+        assert_deprecated { Type::BigInteger.new }
       end
     end
   end

--- a/activemodel/test/cases/type/integer_test.rb
+++ b/activemodel/test/cases/type/integer_test.rb
@@ -64,13 +64,13 @@ module ActiveModel
 
       test "values below int min value are out of range" do
         assert_raises(ActiveModel::RangeError) do
-          Integer.new.serialize(-2147483649)
+          Integer.new(limit: 4).serialize(-2147483649)
         end
       end
 
       test "values above int max value are out of range" do
         assert_raises(ActiveModel::RangeError) do
-          Integer.new.serialize(2147483648)
+          Integer.new(limit: 4).serialize(2147483648)
         end
       end
 

--- a/activerecord/lib/active_record/type/decimal_without_scale.rb
+++ b/activerecord/lib/active_record/type/decimal_without_scale.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   module Type
-    class DecimalWithoutScale < ActiveModel::Type::BigInteger # :nodoc:
+    class DecimalWithoutScale < ActiveModel::Type::Integer # :nodoc:
       def type
         :decimal
       end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -891,11 +891,9 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal 2147483648, company.rating
   end
 
-  unless current_adapter?(:SQLite3Adapter)
-    def test_bignum_pk
-      company = Company.create!(id: 2147483648, name: "foo")
-      assert_equal company, Company.find(company.id)
-    end
+  def test_bignum_pk
+    company = Company.create!(id: 2147483648, name: "foo")
+    assert_equal company, Company.find(company.id)
   end
 
   # TODO: extend defaults tests to other databases!


### PR DESCRIPTION
Raising `RangeError` was introduced in order to ease to handle out of
range numbers for `find` and `find_by` in postgresql adapter with
prepared statements since #17459. At that time, `Type::Integer` assumed
implicit default byte size is 4 bytes due to `extract_limit` in
postgresql adapter did not extract an integer byte size correctly.
That assumption is harmful for other adapters and caused #22594.
In #26386, it is fixed to register integer types limit correctly.
The handling whether out of range or not is only needed with explicit
`limit`, and `Type::BigInteger` is no longer needed.

Fixes #22594.
