### PR TITLE
Set default tld length to 2 if TLD is a known second-level domain

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -6,7 +6,7 @@ module ActionDispatch
       IP_HOST_REGEXP  = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
       HOST_REGEXP     = /(^[^:]+:\/\/)?(\[[^\]]+\]|[^:]+)(?::(\d+$))?/
       PROTOCOL_REGEXP = /^([^:]+)(:)?(\/\/)?$/
-      SECOND_LVL_DOMAINS = ["asn.au", "com.au", "net.au", "id.au", "org.au", "edu.au", "gov.au", 
+      SECOND_LVL_DOMAINS = ["asn.au", "com.au", "net.au", "id.au", "org.au", "edu.au", "gov.au",
         "csiro.au", "act.au", "nsw.au", "nt.au", "qld.au", "sa.au", "tas.au", "vic.au", "wa.au",
         "co.at", "or.at", "priv.at", "ac.at", "avocat.fr", "aeroport.fr", "veterinaire.fr", "co.hu",
         "film.hu", "lakas.hu", "ingatlan.hu", "sport.hu", "hotel.hu", "ac.nz", "co.nz", "geek.nz",

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -6,9 +6,17 @@ module ActionDispatch
       IP_HOST_REGEXP  = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
       HOST_REGEXP     = /(^[^:]+:\/\/)?(\[[^\]]+\]|[^:]+)(?::(\d+$))?/
       PROTOCOL_REGEXP = /^([^:]+)(:)?(\/\/)?$/
+      SECOND_LVL_DOMAINS = ['asn.au', 'com.au', 'net.au', 'id.au', 'org.au', 'edu.au', 'gov.au', 
+        'csiro.au', 'act.au', 'nsw.au', 'nt.au', 'qld.au', 'sa.au', 'tas.au', 'vic.au', 'wa.au',
+        'co.at', 'or.at', 'priv.at', 'ac.at', 'avocat.fr', 'aeroport.fr', 'veterinaire.fr', 'co.hu',
+        'film.hu', 'lakas.hu', 'ingatlan.hu', 'sport.hu', 'hotel.hu', 'ac.nz', 'co.nz', 'geek.nz',
+        'gen.nz', 'kiwi.nz', 'maori.nz', 'net.nz', 'org.nz', 'school.nz', 'cri.nz', 'govt.nz',
+        'health.nz', 'iwi.nz', 'mil.nz', 'parliament.nz', 'ac.il', 'co.il', 'org.il', 'net.il',
+        'k12.il', 'gov.il', 'muni.il', 'idf.il', 'ac.za', 'gov.za', 'law.za', 'mil.za', 'nom.za',
+        'school.za', 'net.za', 'co.uk', 'org.uk', 'me.uk', 'ltd.uk', 'plc.uk', 'net.uk', 'sch.uk',
+        'ac.uk', 'gov.uk', 'mod.uk', 'mil.uk', 'nhs.uk', 'police.uk']
 
       mattr_accessor :tld_length
-      self.tld_length = 1
 
       class << self
         # Returns the domain part of a host given the domain level.
@@ -185,6 +193,9 @@ module ActionDispatch
       end
 
       def initialize
+        # Set tld length to 2 if TLD is a known second-level domain
+        self.tld_length = SECOND_LVL_DOMAINS.include?(host.split(".").last(2).join(".")) ? 2 : 1
+
         super
         @protocol = nil
         @port     = nil

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -6,15 +6,15 @@ module ActionDispatch
       IP_HOST_REGEXP  = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
       HOST_REGEXP     = /(^[^:]+:\/\/)?(\[[^\]]+\]|[^:]+)(?::(\d+$))?/
       PROTOCOL_REGEXP = /^([^:]+)(:)?(\/\/)?$/
-      SECOND_LVL_DOMAINS = ['asn.au', 'com.au', 'net.au', 'id.au', 'org.au', 'edu.au', 'gov.au', 
-        'csiro.au', 'act.au', 'nsw.au', 'nt.au', 'qld.au', 'sa.au', 'tas.au', 'vic.au', 'wa.au',
-        'co.at', 'or.at', 'priv.at', 'ac.at', 'avocat.fr', 'aeroport.fr', 'veterinaire.fr', 'co.hu',
-        'film.hu', 'lakas.hu', 'ingatlan.hu', 'sport.hu', 'hotel.hu', 'ac.nz', 'co.nz', 'geek.nz',
-        'gen.nz', 'kiwi.nz', 'maori.nz', 'net.nz', 'org.nz', 'school.nz', 'cri.nz', 'govt.nz',
-        'health.nz', 'iwi.nz', 'mil.nz', 'parliament.nz', 'ac.il', 'co.il', 'org.il', 'net.il',
-        'k12.il', 'gov.il', 'muni.il', 'idf.il', 'ac.za', 'gov.za', 'law.za', 'mil.za', 'nom.za',
-        'school.za', 'net.za', 'co.uk', 'org.uk', 'me.uk', 'ltd.uk', 'plc.uk', 'net.uk', 'sch.uk',
-        'ac.uk', 'gov.uk', 'mod.uk', 'mil.uk', 'nhs.uk', 'police.uk']
+      SECOND_LVL_DOMAINS = ["asn.au", "com.au", "net.au", "id.au", "org.au", "edu.au", "gov.au", 
+        "csiro.au", "act.au", "nsw.au", "nt.au", "qld.au", "sa.au", "tas.au", "vic.au", "wa.au",
+        "co.at", "or.at", "priv.at", "ac.at", "avocat.fr", "aeroport.fr", "veterinaire.fr", "co.hu",
+        "film.hu", "lakas.hu", "ingatlan.hu", "sport.hu", "hotel.hu", "ac.nz", "co.nz", "geek.nz",
+        "gen.nz", "kiwi.nz", "maori.nz", "net.nz", "org.nz", "school.nz", "cri.nz", "govt.nz",
+        "health.nz", "iwi.nz", "mil.nz", "parliament.nz", "ac.il", "co.il", "org.il", "net.il",
+        "k12.il", "gov.il", "muni.il", "idf.il", "ac.za", "gov.za", "law.za", "mil.za", "nom.za",
+        "school.za", "net.za", "co.uk", "org.uk", "me.uk", "ltd.uk", "plc.uk", "net.uk", "sch.uk",
+        "ac.uk", "gov.uk", "mod.uk", "mil.uk", "nhs.uk", "police.uk"]
 
       mattr_accessor :tld_length
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -271,6 +271,12 @@ class RequestDomain < BaseRequestTest
     assert_equal "rubyonrails.org", request.domain
 
     request = stub_request "HTTP_HOST" => "www.rubyonrails.co.uk"
+    assert_equal "rubyonrails.co.uk", request.domain
+
+    request = stub_request "HTTP_HOST" => "www.rubyonrails.co.uk"
+    assert_equal "co.uk", request.domain(1)
+
+    request = stub_request "HTTP_HOST" => "www.rubyonrails.co.uk"
     assert_equal "rubyonrails.co.uk", request.domain(2)
 
     request = stub_request "HTTP_HOST" => "www.rubyonrails.co.uk", :tld_length => 2


### PR DESCRIPTION
### Summary

Set default tld_length value to 2 if TLD is a known second-level domain to prevent bugs such as:

``` ruby
request.domain => co.uk
request.subdomain => domain.co.uk
```

There is a parameter for the TLD length. But why would you use request.domain if you have a static domain that you already know? By setting the default value to 2 if TLD is a known second-level domain the user don't need to know the TLD length before calling `request.domain`
## Results with my changes:

``` ruby
request.domain => "domain.co.uk"
request.domain(1) => "co.uk"
request.domain(2) => "domain.co.uk"

request.subdomain => "subdomain.domain.co.uk"
request.subdomain(1) => "domain.co.uk"
request.subdomain(2) => "subdomain.domain.co.uk"
```
#26304
