### PR TITLE
Whitelist non-scalar types without filtering in ActionController::Parameters

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -749,6 +749,14 @@ module ActionController
         Rack::Test::UploadedFile,
       ]
 
+      #
+      # -- Whitelisting  -------------------------------------------------------
+      #
+
+      # If the value is a permitted non-scalar type, and the filter
+      # value is true, then the entire value is permitted.
+      PERMIT_ALL_VALUE = true
+
       def permitted_scalar?(value)
         PERMITTED_SCALAR_TYPES.any? { |type| value.is_a?(type) }
       end
@@ -789,6 +797,8 @@ module ActionController
             array_of_permitted_scalars?(self[key]) do |val|
               params[key] = val
             end
+          elsif non_scalar?(value) && filter[key] === PERMIT_ALL_VALUE
+            params[key] = value
           elsif non_scalar?(value)
             # Declaration { user: :name } or { user: [:name, :age, { address: ... }] }.
             params[key] = each_element(value) do |element|


### PR DESCRIPTION
### Summary

This adds the ability to whitelist and automatically permit a non-scalar value (and all child values) in `ActionController::Parameters` when the filter value is explicitly `true`.
### Example

``` ruby
params = ActionController::Parameters.new({:data => {:foo => "bar"}, :meta => "blahblah"})
params.permit([{:data => true}])
# permits {:data => {:foo => :bar }}
```
### Other Information

The need for this arises when you want an unfiltered `Hash` or `Array` of hashes as a parameter value in a filtered set of parameters, but you don't have a defined schema for the hash. It is currently not possible to say that you explicitly trust whatever values are in a parameter.

An example is if you are submitting arbitrary data that will go into a document-store database or a database, such as Postgres, which supports JSON/JSONB type columns. In this case, you may want to filter all parameter keys that you do not know about, but under certain conditions, non-known keys are permissible.

As such, this does not change the current behavior (you can still filter) and is unlikely to be accidentally used or abused for unsafe usage.

A previous discussion about this issue is here: https://github.com/rails/rails/issues/9454
