### PR TITLE
Fix: after_update callback should not get called while creating a record.

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -86,7 +86,11 @@ module ActiveRecord
         end
 
         def save_through_record(record)
-          build_through_record(record).save!
+          associated_record = build_through_record(record)
+
+          if associated_record.new_record? || associated_record.changed?
+            associated_record.save!
+          end
         ensure
           @through_records.delete(record.object_id)
         end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1215,4 +1215,18 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   ensure
     TenantMembership.current_member = nil
   end
+
+  def test_after_update_callback_should_not_get_called_after_creating_a_record
+    lesson, lesson_student, student = make_no_pk_hm_t
+
+    after_update_called = false
+    lesson_student.after_update do
+      after_update_called = true
+    end
+
+    john = student.create(name: "John")
+    lesson.create(name: "SICP", student_ids: [john.id])
+
+    assert_not after_update_called, "after update should not be called"
+  end
 end


### PR DESCRIPTION
Associated record's `after_update` callback was getting called after
the main record was created. This happened for 'HMTA' association.

Fixes #26270
