### PR TITLE
Disconnects all connections in the pool before forking.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb
@@ -42,6 +42,14 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # on_worker_boot do
 #   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
 # end
+#
+# If you are preloading your application and using ActiveRecord, it's
+# recommended that you close any connections to the database before workers
+# are forked to prevent connection leakage.
+#
+# before_fork do
+#   ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
+# end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
Taken from this discussion: https://github.com/puma/puma/issues/1001

> If you're preloading your application and using ActiveRecord, it's recommended that you close   any connections to the database here to prevent connection leakage:
> 
> ``` ruby
> # config/puma.rb
> before_fork do
>   ActiveRecord::Base.connection_pool.disconnect!
> end
> ```

/cc @schneems 
