### PR TITLE
Allow `send_file` to declare a charset

### DIFF
--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -70,6 +70,7 @@ module ActionController #:nodoc:
         send_file_headers! options
 
         self.status = options[:status] || 200
+        self.content_type = options[:type] if options.key?(:type)
         self.content_type = options[:content_type] if options.key?(:content_type)
         response.send_file path
       end

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -224,8 +224,10 @@ module ActionDispatch # :nodoc:
 
     # Sets the HTTP content type.
     def content_type=(content_type)
-      header_info = parse_content_type
-      set_content_type content_type.to_s, header_info.charset || self.class.default_charset
+      return unless content_type
+      new_header_info = parse_content_type(content_type.to_s)
+      prev_header_info = parse_content_type(get_header(CONTENT_TYPE))
+      set_content_type new_header_info.mime_type, new_header_info.charset || prev_header_info.charset || self.class.default_charset
     end
 
     # Sets the HTTP response's content MIME type. For example, in the controller
@@ -403,8 +405,7 @@ module ActionDispatch # :nodoc:
     ContentTypeHeader = Struct.new :mime_type, :charset
     NullContentTypeHeader = ContentTypeHeader.new nil, nil
 
-    def parse_content_type
-      content_type = get_header CONTENT_TYPE
+    def parse_content_type(content_type = get_header(CONTENT_TYPE))
       if content_type
         type, charset = content_type.split(/;\s*charset=/)
         type = nil if type.empty?

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -226,7 +226,7 @@ module ActionDispatch # :nodoc:
     def content_type=(content_type)
       return unless content_type
       new_header_info = parse_content_type(content_type.to_s)
-      prev_header_info = parse_content_type(get_header(CONTENT_TYPE))
+      prev_header_info = parsed_content_type_header
       set_content_type new_header_info.mime_type, new_header_info.charset || prev_header_info.charset || self.class.default_charset
     end
 
@@ -240,7 +240,7 @@ module ActionDispatch # :nodoc:
     # information.
 
     def content_type
-      parse_content_type.mime_type
+      parsed_content_type_header.mime_type
     end
 
     def sending_file=(v)
@@ -255,7 +255,7 @@ module ActionDispatch # :nodoc:
     #   response.charset = 'utf-16' # => 'utf-16'
     #   response.charset = nil      # => 'utf-8'
     def charset=(charset)
-      header_info = parse_content_type
+      header_info = parsed_content_type_header
       if false == charset
         set_header CONTENT_TYPE, header_info.mime_type
       else
@@ -267,7 +267,7 @@ module ActionDispatch # :nodoc:
     # The charset of the response. HTML wants to know the encoding of the
     # content you're giving them, so we need to send that along.
     def charset
-      header_info = parse_content_type
+      header_info = parsed_content_type_header
       header_info.charset || self.class.default_charset
     end
 
@@ -405,7 +405,7 @@ module ActionDispatch # :nodoc:
     ContentTypeHeader = Struct.new :mime_type, :charset
     NullContentTypeHeader = ContentTypeHeader.new nil, nil
 
-    def parse_content_type(content_type = get_header(CONTENT_TYPE))
+    def parse_content_type(content_type)
       if content_type
         type, charset = content_type.split(/;\s*charset=/)
         type = nil if type.empty?
@@ -413,6 +413,12 @@ module ActionDispatch # :nodoc:
       else
         NullContentTypeHeader
       end
+    end
+
+    # Small internal convenience method to get the parsed version of the current
+    # content type header.
+    def parsed_content_type_header
+      parse_content_type(get_header(CONTENT_TYPE))
     end
 
     def set_content_type(content_type, charset)
@@ -451,7 +457,7 @@ module ActionDispatch # :nodoc:
     def assign_default_content_type_and_charset!
       return if content_type
 
-      ct = parse_content_type
+      ct = parsed_content_type_header
       set_content_type(ct.mime_type || Mime[:html].to_s,
                        ct.charset || self.class.default_charset)
     end

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -233,4 +233,18 @@ class SendFileTest < ActionController::TestCase
     response = process("file")
     assert_equal 200, response.status
   end
+
+  def test_send_file_charset_with_type_options_key
+    @controller = SendFileWithActionControllerLive.new
+    @controller.options = { type: "text/calendar; charset=utf-8" }
+    response = process("file")
+    assert_equal "text/calendar; charset=utf-8", response.headers["Content-Type"]
+  end
+
+  def test_send_file_charset_with_content_type_options_key
+    @controller = SendFileWithActionControllerLive.new
+    @controller.options = { content_type: "text/calendar" }
+    response = process("file")
+    assert_equal "text/calendar; charset=utf-8", response.headers["Content-Type"]
+  end
 end


### PR DESCRIPTION
### Summary

Before this PR, if you tried to do the pass in `type: "text/calendar; charset=utf-8"` as an option to `send_file`:, the charset would be deleted. This PR ensures that the user provided charset is not cleared.
### Other Information

This helps restore behavior that was altered by 1cc315c83c6d823a6041361bf468b82c541d31ee.
