### PR TITLE
[ci skip] Update branch version in Contributing Guide

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -677,7 +677,7 @@ $ git format-patch master --stdout > ~/my_changes.patch
 Switch over to the target branch and apply your changes:
 
 ```bash
-$ git checkout -b my_backport_branch 3-2-stable
+$ git checkout -b my_backport_branch 4-2-stable
 $ git apply ~/my_changes.patch
 ```
 


### PR DESCRIPTION
Since only Rails 4 and above are currently supported, this updates a
3-2-stable example to be consistent with the Maintenance Policy.

![before](https://cloud.githubusercontent.com/assets/5634381/18058080/5a80699c-6dd8-11e6-8067-77855be7e834.png)
