### PR TITLE
Do not allow to_param on AC::Parameters

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -2,6 +2,7 @@ require "active_support/core_ext/hash/indifferent_access"
 require "active_support/core_ext/hash/transform_values"
 require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/string/filters"
+require "active_support/core_ext/object/to_query"
 require "active_support/rescuable"
 require "action_dispatch/http/upload"
 require "rack/test"
@@ -409,6 +410,8 @@ module ActionController
     def [](key)
       convert_hashes_to_parameters(key, @parameters[key])
     end
+
+    undef_method :to_param
 
     # Assigns a value to a given +key+. The given key may still get filtered out
     # when +permit+ is called.

--- a/actionpack/test/controller/required_params_test.rb
+++ b/actionpack/test/controller/required_params_test.rb
@@ -77,4 +77,10 @@ class ParametersRequireTest < ActiveSupport::TestCase
       ActionController::Parameters.new(foo: "bar").merge!(bar: "foo")
     end
   end
+
+  test "to_query is not supported" do
+    assert_deprecated do
+      ActionController::Parameters.new(foo: "bar").to_param
+    end
+  end
 end


### PR DESCRIPTION
### Summary

During upgrade to Rails 5, I've noticed a common pattern that no longer worked on 5:

``` ruby
redirect_params = params.require(:form).permit(:return_url, :result_id)
redirect_to "/another/action?#{redirect_params.to_param}"
```

On Rails 4, the result was `/another/action?return_url=foo&result_id=bar`.
On Rails 5, the result was `/another/action?#<ActionController::Parameters:0x007fb5e1d1bae8>`

This happens siletly and unless you have a test that asserts `redirect_url`, you'll spend time finding the source of issue.

I propose that we don't allow to call `to_param` on `AC::Parameters` with explicit message.
This especially makes sense since we don't allow other Hash methods like `merge!` on `AC::Parameters`.

review @rafaelfranca 
