### PR TITLE
Removed json dependency from ActiveSupport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,6 @@ platforms :ruby do
 end
 
 platforms :jruby do
-  gem 'json'
   if ENV['AR_JDBC']
     gem 'activerecord-jdbcsqlite3-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: 'master'
     group :db do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,6 @@ PATH
       arel (~> 6.0)
     activesupport (4.2.7.1)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
@@ -259,7 +258,6 @@ DEPENDENCIES
   delayed_job_active_record
   execjs (< 2.5)
   jquery-rails (~> 4.0)
-  json
   kindlerb (= 0.1.1)
   mime-types (< 3)
   minitest (< 5.3.4)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.rdoc_options.concat ['--encoding',  'UTF-8']
 
   s.add_dependency 'i18n',       '~> 0.7'
-  s.add_dependency 'json',       '~> 1.7', '>= 1.7.7'
   s.add_dependency 'tzinfo',     '~> 1.1'
   s.add_dependency 'minitest',   '~> 5.1'
   s.add_dependency 'thread_safe','~> 0.3', '>= 0.3.4'


### PR DESCRIPTION
### Summary

This is backport request from Rails 5. I cherry-picked f3433f7c757ef8352c3ea3796a9b350b4454a2b6

Because json-1.x didn't support Ruby 2.4.0. So ActiveSupport 4.x will not works Ruby 2.4.0 when it release at 2016/12. 
### Other Information

I faced a lot of gems that depends on activesupport 4.2. ex https://github.com/jekyll/jemoji/pull/49

I hope to work these gems with Ruby 2.4.0.
