### PR TITLE
Ignore primary keys in default scopes

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -48,7 +48,8 @@ module ActiveRecord
         equalities = predicates.grep(Arel::Nodes::Equality)
         if table_name
           equalities = equalities.select do |node|
-            node.left.relation.name == table_name
+            primary_key = respond_to?(:klass) && klass || 'id'
+            node.left.relation.name == table_name && node.left.name != primary_key
           end
         end
 

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -5,6 +5,7 @@ require "models/developer"
 require "models/computer"
 require "models/vehicle"
 require "models/cat"
+require "models/rat"
 require "active_support/core_ext/regexp"
 
 class DefaultScopingTest < ActiveRecord::TestCase
@@ -497,5 +498,9 @@ class DefaultScopingTest < ActiveRecord::TestCase
 
     assert_match vegetarian_pattern, Lion.all.to_sql
     assert_match gender_pattern, Lion.female.to_sql
+  end
+
+  def test_default_scope_ignores_primary_key
+    assert Rat.new.id.nil?
   end
 end

--- a/activerecord/test/models/rat.rb
+++ b/activerecord/test/models/rat.rb
@@ -1,0 +1,3 @@
+class Rat < ActiveRecord::Base
+  default_scope -> { where(id: 1) }
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -767,6 +767,9 @@ ActiveRecord::Schema.define do
     t.belongs_to :ship
   end
 
+  create_table :rats, force: true do |t|
+  end
+
   create_table :shop_accounts, force: true do |t|
     t.references :customer
     t.references :customer_carrier


### PR DESCRIPTION
### Summary

if part of default scope defines a where condition including primary key, whenever a new instance of model is build, it inherits this

``` ruby
class Rat < ActiveRecord::Base
  default_scope lambda {
    where(id: 1)
  }
end

# I'd expect to get nil here
Rat.new.id # => 1
```
### Other Information

the reproducer with current master branch (tested and broken also with rails 4.2.17.1)
https://gist.github.com/ares/e10aed8786782a2228187c3973986da1
