### PR TITLE
Backport Logger#initialize kwargs from Ruby 2.4

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1234,8 +1234,7 @@ class BasicsTest < ActiveRecord::TestCase
   def test_benchmark_with_log_level
     original_logger = ActiveRecord::Base.logger
     log = StringIO.new
-    ActiveRecord::Base.logger = ActiveSupport::Logger.new(log)
-    ActiveRecord::Base.logger.level = Logger::WARN
+    ActiveRecord::Base.logger = ActiveSupport::Logger.new(log, level: Logger::WARN)
     ActiveRecord::Base.benchmark("Debug Topic Count", level: :debug) { Topic.count }
     ActiveRecord::Base.benchmark("Warn Topic Count",  level: :warn)  { Topic.count }
     ActiveRecord::Base.benchmark("Error Topic Count", level: :error) { Topic.count }
@@ -1249,8 +1248,7 @@ class BasicsTest < ActiveRecord::TestCase
   def test_benchmark_with_use_silence
     original_logger = ActiveRecord::Base.logger
     log = StringIO.new
-    ActiveRecord::Base.logger = ActiveSupport::Logger.new(log)
-    ActiveRecord::Base.logger.level = Logger::DEBUG
+    ActiveRecord::Base.logger = ActiveSupport::Logger.new(log, level: Logger::DEBUG)
     ActiveRecord::Base.benchmark("Logging", level: :debug, silence: false)  { ActiveRecord::Base.logger.debug "Quiet" }
     assert_match(/Quiet/, log.string)
   ensure

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Backport keyword argument support for `Logger#initialize` from Ruby 2.4
+
+    Before:
+
+        logger = Logger.new(STDOUT)
+        logger.level = Logger::WARN
+        logger.formatter = MyFormatter.new
+
+    After:
+
+        logger = Logger.new(STDOUT, level: Logger::WARN, formatter: MyFormatter.new)
+
+    *Matt Larraz*
+
 *   Remove unused parameter `options = nil` for `#clear` of
     `ActiveSupport::Cache::Strategy::LocalCache::LocalStore` and
     `ActiveSupport::Cache::Strategy::LocalCache`.

--- a/activesupport/lib/active_support/core_ext/logger.rb
+++ b/activesupport/lib/active_support/core_ext/logger.rb
@@ -1,0 +1,18 @@
+require 'logger'
+
+module ActiveSupport
+  module InitializeWithKwargs
+    if RUBY_VERSION < '2.4'.freeze
+      def initialize(*args, level: Logger::DEBUG, **kwargs)
+        super(*args)
+
+        self.level           = level
+        self.progname        = kwargs[:progname]
+        self.datetime_format = kwargs[:datetime_format]
+        self.formatter       = kwargs[:formatter]
+      end
+    end
+  end
+end
+
+Logger.prepend(ActiveSupport::InitializeWithKwargs)

--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -1,3 +1,4 @@
+require "active_support/core_ext/logger"
 require "active_support/logger_silence"
 require "active_support/logger_thread_safe_level"
 require "logger"
@@ -76,9 +77,9 @@ module ActiveSupport
       end
     end
 
-    def initialize(*args)
+    def initialize(*args, formatter: SimpleFormatter.new, **kwargs)
       super
-      @formatter = SimpleFormatter.new
+
       after_initialize if respond_to? :after_initialize
     end
 

--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -34,8 +34,7 @@ class LoggerTest < ActiveSupport::TestCase
     f = File.open(t.path, "w")
     f.binmode
 
-    logger = Logger.new f
-    logger.level = Logger::DEBUG
+    logger = Logger.new f, level: Logger::DEBUG
 
     str = "\x80"
     str.force_encoding("ASCII-8BIT")

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -129,8 +129,7 @@ defaults to `:debug` for all environments. The available log levels are: `:debug
       include LoggerSilence
     end
 
-    mylogger           = MyLogger.new(STDOUT)
-    mylogger.formatter = config.log_formatter
+    mylogger      = MyLogger.new(STDOUT, formatter: config.log_formatter)
     config.logger = ActiveSupport::TaggedLogging.new(mylogger)
     ```
 

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -40,13 +40,11 @@ INFO
           f.binmode
           f.sync = config.autoflush_log # if true make sure every write flushes
 
-          logger = ActiveSupport::Logger.new f
-          logger.formatter = config.log_formatter
-          logger = ActiveSupport::TaggedLogging.new(logger)
-          logger
+          logger = ActiveSupport::Logger.new f, formatter: config.log_formatter
+          ActiveSupport::TaggedLogging.new(logger)
         rescue StandardError
-          logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDERR))
-          logger.level = ActiveSupport::Logger::WARN
+          logger = ActiveSupport::Logger.new(STDERR, level: ActiveSupport::Logger::WARN)
+          logger = ActiveSupport::TaggedLogging.new(logger)
           logger.warn(
             "Rails Error: Unable to access log file. Please ensure that #{path} exists and is writable " +
             "(ie, make it writable for user and group: chmod 0664 #{path}). " +

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -123,9 +123,7 @@ module Rails
       def log_to_stdout
         wrapped_app # touch the app so the logger is set up
 
-        console = ActiveSupport::Logger.new(STDOUT)
-        console.formatter = Rails.logger.formatter
-        console.level = Rails.logger.level
+        console = ActiveSupport::Logger.new(STDOUT, level: Rails.logger.level, formatter: Rails.logger.formatter)
 
         unless ActiveSupport::Logger.logger_outputs_to?(Rails.logger, STDOUT)
           Rails.logger.extend(ActiveSupport::Logger.broadcast(console))


### PR DESCRIPTION
### Summary

Backports feature introduced in https://github.com/ruby/ruby/commit/a0409533866991529136224b549f53f2ab61c8e4 so we can start using it now.

Assuming from https://github.com/rails/rails/commit/575dbeeefcaafeb566afc07cdd8b55603b698d9f that backporting Ruby 2.4 features is acceptable.
### Other Information

Copied from the CHANGELOG

Before:

``` ruby
logger = Logger.new(STDOUT)
logger.level = Logger::WARN
logger.formatter = MyFormatter.new
```

After:

``` ruby
logger = Logger.new(STDOUT, level: Logger::WARN, formatter: MyFormatter.new)
```
