### PR TITLE
Avoid to call `set_inverse_instance` twice for `has_many` association

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -307,6 +307,8 @@ module ActiveRecord
             target << record
           end
 
+          set_inverse_instance(record)
+
           yield(record) if block_given?
         rescue
           if index
@@ -319,7 +321,6 @@ module ActiveRecord
         end
 
         callback(:after_add, record) unless skip_callbacks
-        set_inverse_instance(record)
 
         record
       end

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -38,7 +38,6 @@ module ActiveRecord
 
       def insert_record(record, validate = true, raise = false)
         set_owner_attributes(record)
-        set_inverse_instance(record)
 
         if raise
           record.save!(validate: validate)


### PR DESCRIPTION
`create`, `create!`, and `concat` in `has_many` association hits
`set_inverse_instance` twice. It is enough to hit only once.
