### PR TITLE
ActiveRecord: don't query when the condition of exists? is blank

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -316,7 +316,7 @@ module ActiveRecord
         MSG
       end
 
-      return false if !conditions
+      return false if conditions.blank?
 
       relation = apply_join_dependency(self, construct_join_dependency(eager_loading: false))
       return false if ActiveRecord::NullRelation === relation

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -978,6 +978,7 @@ class RelationTest < ActiveRecord::TestCase
     assert ! davids.exists?("42")
     assert ! davids.exists?(42)
     assert ! davids.exists?(davids.new.id)
+    assert ! davids.exists?(" ")
 
     fake  = Author.where(name: "fake author")
     assert ! fake.exists?


### PR DESCRIPTION
### Summary

Currently, when `Opportunity.exists?('')` is executed, `false` is returned but the following query is run
`Opportunity Exists (24.6ms)  SELECT  1 AS one FROM "opportunities"
  WHERE "opportunities"."id" = $1 LIMIT $2  [["id", nil], ["LIMIT",
  1]]`

Instead of checking for the conditions to be `nil`, we can check for its `#blank?`iness in order to avoid that query to be run.
