### PR TITLE
Use log method instead of `ActiveSupport::Notifications.instrument`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -76,14 +76,7 @@ module ActiveRecord
         def cache_sql(sql, name, binds)
           result =
             if @query_cache[sql].key?(binds)
-              ActiveSupport::Notifications.instrument(
-                "sql.active_record",
-                sql: sql,
-                binds: binds,
-                name: name,
-                connection_id: object_id,
-                cached: true,
-              )
+              log(sql, name, binds) {}
               @query_cache[sql][binds]
             else
               @query_cache[sql][binds] = yield


### PR DESCRIPTION
### Summary

I encountered the following error.

```
Could not log "sql.active_record" event. TypeError: wrong argument type NilClass (must respond to :each) ["/home/mtsmfm/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/rails-0ca595ea6e3a/activerecord/l
ib/active_record/log_subscriber.rb:42:in `zip'"
```

It seems that we forgot to care about `#cache_sql` in https://github.com/rails/rails/pull/25886
