### PR TITLE
Allow download of email attachments in the Mailer Preview template.

### DIFF
--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -88,7 +88,10 @@
     <% unless @email.attachments.nil? || @email.attachments.empty? %>
       <dt>Attachments:</dt>
       <dd>
-        <%= @email.attachments.map { |a| a.respond_to?(:original_filename) ? a.original_filename : a.filename }.join(', ') %>
+        <% @email.attachments.each do |a| %>
+          <% filename = a.respond_to?(:original_filename) ? a.original_filename : a.filename %>
+          <%= link_to filename, "data:application/octet-stream;charset=utf-8;base64,#{Base64.encode64(a.body.to_s)}", download: filename %>
+        <% end %>
       </dd>
     <% end %>
 


### PR DESCRIPTION
### Summary

Allows download of attachments in the Mailer Previews by base64 encoding them within the preview template.
### Other Information

Demo App: https://github.com/duffyjp/mailer_preview_downloads
### Screenshot

![screen shot 2016-09-02 at 4 02 33 pm](https://cloud.githubusercontent.com/assets/382216/18218207/c8f0cb50-7126-11e6-846e-e9c28565c33d.png)
