### PR TITLE
Use applications db/migrate paths when available

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,1 +1,8 @@
+*  `Migrator::migrations_paths` will now use the application's `db/migrate` paths
+    instead of assuming `'db/migrate'`.
+
+    Fixes #22261.
+
+    *Nate Salisbury*
+
 Please check [5-1-stable](https://github.com/rails/rails/blob/5-1-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1052,7 +1052,11 @@ module ActiveRecord
       end
 
       def migrations_paths
-        @migrations_paths ||= ["db/migrate"]
+        @migrations_paths ||= if defined?(Rails) && Rails.application
+                                Rails.application.paths["db/migrate"].to_a
+                              else
+                                ["db/migrate"]
+                              end
         # just to not break things if someone uses: migrations_path = some_string
         Array(@migrations_paths)
       end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -152,6 +152,16 @@ module ApplicationTests
       end
     end
 
+    test "migrations_paths uses path from config" do
+      add_to_config <<-RUBY
+        config.paths["db/migrate"] = "custom/db/migrate"
+      RUBY
+
+      app "development"
+
+      assert_includes ActiveRecord::Migrator.migrations_paths.first, "custom/db/migrate"
+    end
+
     test "Rails.groups returns available groups" do
       require "rails"
 


### PR DESCRIPTION
`ActiveRecord::Migrator::migrations_paths` defaults to 'db/migrate' when no other `migrations_paths` have been set. If your application uses a folder other than db/migrate for migrations, `ActiveRecord::Migration.maintain_test_schema!` in rails/test_help will trigger `rake db:test:prepare` at the start of each test run. 

When running database rake tasks this usually isn't an issue because they are dependent on the db:load_config task which will set `migrations_paths` based on an application's config. This is an issue however when calling `ActiveRecord::Migration.maintain_test_schema!` from rails/test_help which doesn't load the app's config, which then triggers db:test:prepare since `any_migrations?` will return false.

I noticed this after upgrading my application to rails 4.2 and each time I ran my cucumber tests, `rake db:test:prepare` was getting triggered at the start. This application has a large db schema so it was adding about 30 seconds to the beginning of each run.  

Fixes #22261
