### PR TITLE
Fix broken heredoc indentation caused by rubocop auto-correct

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -663,14 +663,14 @@ module ActionController
 
         def non_kwarg_request_warning
           ActiveSupport::Deprecation.warn(<<-MSG.strip_heredoc)
-          ActionController::TestCase HTTP request methods will accept only
-          keyword arguments in future Rails versions.
+            ActionController::TestCase HTTP request methods will accept only
+            keyword arguments in future Rails versions.
 
-          Examples:
+            Examples:
 
-          get :show, params: { id: 1 }, session: { user_id: 1 }
-          process :update, method: :post, params: { id: 1 }
-        MSG
+            get :show, params: { id: 1 }, session: { user_id: 1 }
+            process :update, method: :post, params: { id: 1 }
+          MSG
         end
 
         def document_root_element

--- a/actionpack/lib/action_dispatch/journey/nfa/dot.rb
+++ b/actionpack/lib/action_dispatch/journey/nfa/dot.rb
@@ -26,7 +26,7 @@ digraph nfa {
   node [shape = circle];
 #{edges.join "\n"}
 }
-        eodot
+          eodot
         end
       end
     end

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -119,7 +119,7 @@ them to actual class references.  For example:
 
   "#{klass}" => #{converted_klass}
 
-        eowarn
+          eowarn
           converted_klass
         else
           klass

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -290,11 +290,12 @@ module ActionView
           RUBY
         end
 
-        layout_definition = case _layout
-                            when String
-                              _layout.inspect
-                            when Symbol
-                              <<-RUBY
+        layout_definition = \
+          case _layout
+          when String
+            _layout.inspect
+          when Symbol
+            <<-RUBY
               #{_layout}.tap do |layout|
                 return #{default_behavior} if layout.nil?
                 unless layout.is_a?(String) || !layout
@@ -303,21 +304,21 @@ module ActionView
                 end
               end
             RUBY
-                            when Proc
-                              define_method :_layout_from_proc, &_layout
-                              protected :_layout_from_proc
-                              <<-RUBY
+          when Proc
+            define_method :_layout_from_proc, &_layout
+            protected :_layout_from_proc
+            <<-RUBY
               result = _layout_from_proc(#{_layout.arity == 0 ? '' : 'self'})
               return #{default_behavior} if result.nil?
               result
             RUBY
-                            when false
-                              nil
-                            when true
-                              raise ArgumentError, "Layouts must be specified as a String, Symbol, Proc, false, or nil"
-                            when nil
-                              name_clause
-        end
+          when false
+            nil
+          when true
+            raise ArgumentError, "Layouts must be specified as a String, Symbol, Proc, false, or nil"
+          when nil
+            name_clause
+          end
 
         self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def _layout(formats)

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1810,12 +1810,12 @@ module ActiveRecord
 
           include Module.new {
             class_eval <<-RUBY, __FILE__, __LINE__ + 1
-          def destroy_associations
-            association(:#{middle_reflection.name}).delete_all(:delete_all)
-            association(:#{name}).reset
-            super
-          end
-          RUBY
+              def destroy_associations
+                association(:#{middle_reflection.name}).delete_all(:delete_all)
+                association(:#{name}).reset
+                super
+              end
+            RUBY
           }
 
           hm_options = {}

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -130,10 +130,10 @@ module ActiveRecord
               return pk unless pk.is_a?(Array)
 
               warn <<-WARNING.strip_heredoc
-            WARNING: Active Record does not support composite primary key.
+                WARNING: Active Record does not support composite primary key.
 
-            #{table_name} has composite primary key. Composite primary key is ignored.
-          WARNING
+                #{table_name} has composite primary key. Composite primary key is ignored.
+              WARNING
             end
         end
     end

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -31,11 +31,11 @@ module ActiveRecord
             ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
 
             generated_attribute_methods.module_eval <<-STR, __FILE__, __LINE__ + 1
-            def #{temp_method}
-              name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
-              _read_attribute(name) { |n| missing_attribute(n, caller) }
-            end
-          STR
+              def #{temp_method}
+                name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
+                _read_attribute(name) { |n| missing_attribute(n, caller) }
+              end
+            STR
 
             generated_attribute_methods.module_eval do
               alias_method name, temp_method

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -94,18 +94,18 @@ module ActiveRecord
               cast_type.type == :time &&
               time_zone_aware_types.include?(:not_explicitly_configured)
               ActiveSupport::Deprecation.warn(<<-MESSAGE.strip_heredoc)
-              Time columns will become time zone aware in Rails 5.1. This
-              still causes `String`s to be parsed as if they were in `Time.zone`,
-              and `Time`s to be converted to `Time.zone`.
+                Time columns will become time zone aware in Rails 5.1. This
+                still causes `String`s to be parsed as if they were in `Time.zone`,
+                and `Time`s to be converted to `Time.zone`.
 
-              To keep the old behavior, you must add the following to your initializer:
+                To keep the old behavior, you must add the following to your initializer:
 
-                  config.active_record.time_zone_aware_types = [:datetime]
+                    config.active_record.time_zone_aware_types = [:datetime]
 
-              To silence this deprecation warning, add the following:
+                To silence this deprecation warning, add the following:
 
-                  config.active_record.time_zone_aware_types = [:datetime, :time]
-            MESSAGE
+                    config.active_record.time_zone_aware_types = [:datetime, :time]
+              MESSAGE
             end
 
             result

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -15,13 +15,13 @@ module ActiveRecord
             ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
 
             generated_attribute_methods.module_eval <<-STR, __FILE__, __LINE__ + 1
-            def __temp__#{safe_name}=(value)
-              name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
-              write_attribute(name, value)
-            end
-            alias_method #{(name + '=').inspect}, :__temp__#{safe_name}=
-            undef_method :__temp__#{safe_name}=
-          STR
+              def __temp__#{safe_name}=(value)
+                name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
+                write_attribute(name, value)
+              end
+              alias_method #{(name + '=').inspect}, :__temp__#{safe_name}=
+              undef_method :__temp__#{safe_name}=
+            STR
           end
       end
 

--- a/activerecord/lib/active_record/dynamic_matchers.rb
+++ b/activerecord/lib/active_record/dynamic_matchers.rb
@@ -63,10 +63,10 @@ module ActiveRecord
 
         def define
           model.class_eval <<-CODE, __FILE__, __LINE__ + 1
-          def self.#{name}(#{signature})
-            #{body}
-          end
-        CODE
+            def self.#{name}(#{signature})
+              #{body}
+            end
+          CODE
         end
 
         private

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -125,10 +125,10 @@ module ActiveRecord
             }.each do |cmd, inv|
               [[inv, cmd], [cmd, inv]].uniq.each do |method, inverse|
                 class_eval <<-EOV, __FILE__, __LINE__ + 1
-              def invert_#{method}(args, &block)    # def invert_create_table(args, &block)
-                [:#{inverse}, args, block]          #   [:drop_table, args, block]
-              end                                   # end
-            EOV
+                  def invert_#{method}(args, &block)    # def invert_create_table(args, &block)
+                    [:#{inverse}, args, block]          #   [:drop_table, args, block]
+                  end                                   # end
+                EOV
               end
             end
         end

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -354,13 +354,13 @@ module ActiveRecord
       # associations are just regular associations.
         def generate_association_writer(association_name, type)
           generated_association_methods.module_eval <<-eoruby, __FILE__, __LINE__ + 1
-          if method_defined?(:#{association_name}_attributes=)
-            remove_method(:#{association_name}_attributes=)
-          end
-          def #{association_name}_attributes=(attributes)
-            assign_nested_attributes_for_#{type}_association(:#{association_name}, attributes)
-          end
-        eoruby
+            if method_defined?(:#{association_name}_attributes=)
+              remove_method(:#{association_name}_attributes=)
+            end
+            def #{association_name}_attributes=(attributes)
+              assign_nested_attributes_for_#{type}_association(:#{association_name}, attributes)
+            end
+          eoruby
         end
     end
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -466,9 +466,9 @@ module ActiveRecord
         if ActiveRecord::Base === id
           id = id.id
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
-          You are passing an instance of ActiveRecord::Base to `find`.
-          Please pass the id of the object by calling `.id`.
-        MSG
+            You are passing an instance of ActiveRecord::Base to `find`.
+            Please pass the id of the object by calling `.id`.
+          MSG
         end
 
         relation = where(primary_key => id)

--- a/activerecord/lib/active_record/relation/predicate_builder/class_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/class_handler.rb
@@ -18,9 +18,9 @@ module ActiveRecord
 
         def print_deprecation_warning
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
-          Passing a class as a value in an Active Record query is deprecated and
-          will be removed. Pass a string instead.
-        MSG
+            Passing a class as a value in an Active Record query is deprecated and
+            will be removed. Pass a string instead.
+          MSG
         end
     end
   end

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -105,7 +105,7 @@ module ActiveRecord
 GRANT ALL PRIVILEGES ON #{configuration['database']}.*
   TO '#{configuration['username']}'@'localhost'
 IDENTIFIED BY '#{configuration['password']}' WITH GRANT OPTION;
-        SQL
+          SQL
         end
 
         def root_configuration_without_database

--- a/activerecord/test/cases/adapters/postgresql/rename_table_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/rename_table_test.rb
@@ -26,9 +26,9 @@ class PostgresqlRenameTableTest < ActiveRecord::PostgreSQLTestCase
 
     def num_indices_named(name)
       @connection.execute(<<-SQL).values.length
-      SELECT 1 FROM "pg_index"
-        JOIN "pg_class" ON "pg_index"."indexrelid" = "pg_class"."oid"
-        WHERE "pg_class"."relname" = '#{name}'
-    SQL
+        SELECT 1 FROM "pg_index"
+          JOIN "pg_class" ON "pg_index"."indexrelid" = "pg_class"."oid"
+          WHERE "pg_class"."relname" = '#{name}'
+      SQL
     end
 end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -431,9 +431,9 @@ module ActiveRecord
 
         def with_example_table(definition = nil, table_name = "ex", &block)
           definition ||= <<-SQL
-          id integer PRIMARY KEY AUTOINCREMENT,
-          number integer
-        SQL
+            id integer PRIMARY KEY AUTOINCREMENT,
+            number integer
+          SQL
           super(@conn, table_name, definition, &block)
         end
     end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1003,10 +1003,10 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
     def privatize(method_signature)
       @target.class_eval(<<-private_method, __FILE__, __LINE__ + 1)
-      private
-      def #{method_signature}
-        "I'm private"
-      end
-    private_method
+        private
+        def #{method_signature}
+          "I'm private"
+        end
+      private_method
     end
 end

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -310,10 +310,10 @@ module ActiveRecord
       def skip_if_sqlite3_version_includes_quoting_bug
         if sqlite3_version_includes_quoting_bug?
           skip <<-ERROR.squish
-          You are using an outdated version of SQLite3 which has a bug in
-          quoted column names. Please update SQLite3 and rebuild the sqlite3
-          ruby gem
-        ERROR
+            You are using an outdated version of SQLite3 which has a bug in
+            quoted column names. Please update SQLite3 and rebuild the sqlite3
+            ruby gem
+          ERROR
         end
       end
 

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -100,9 +100,9 @@ if ActiveRecord::Base.connection.supports_views?
     setup do
       @connection = ActiveRecord::Base.connection
       @connection.execute <<-SQL
-      CREATE VIEW paperbacks
-        AS SELECT name, status FROM books WHERE format = 'paperback'
-    SQL
+        CREATE VIEW paperbacks
+          AS SELECT name, status FROM books WHERE format = 'paperback'
+      SQL
     end
 
     teardown do
@@ -162,9 +162,9 @@ if ActiveRecord::Base.connection.supports_views?
       setup do
         @connection = ActiveRecord::Base.connection
         @connection.execute <<-SQL
-      CREATE VIEW printed_books
-        AS SELECT id, name, status, format FROM books WHERE format = 'paperback'
-    SQL
+          CREATE VIEW printed_books
+            AS SELECT id, name, status, format FROM books WHERE format = 'paperback'
+        SQL
       end
 
       teardown do

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -297,9 +297,9 @@ module ActiveSupport
         def self.build(chain, filter, kind, options)
           if filter.is_a?(String)
             ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            Passing string to define callback is deprecated and will be removed
-            in Rails 5.1 without replacement.
-          MSG
+              Passing string to define callback is deprecated and will be removed
+              in Rails 5.1 without replacement.
+            MSG
           end
 
           new chain.name, filter, kind, options, chain.config
@@ -751,10 +751,10 @@ module ActiveSupport
             set_callbacks name, CallbackChain.new(name, options)
 
             module_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def _run_#{name}_callbacks(&block)
-              __run_callbacks__(_#{name}_callbacks, &block)
-            end
-          RUBY
+              def _run_#{name}_callbacks(&block)
+                __run_callbacks__(_#{name}_callbacks, &block)
+              end
+            RUBY
           end
         end
 
@@ -787,9 +787,9 @@ module ActiveSupport
 
           def display_deprecation_warning_for_false_terminator
             ActiveSupport::Deprecation.warn(<<-MSG.squish)
-          Returning `false` in Active Record and Active Model callbacks will not implicitly halt a callback chain in Rails 5.1.
-          To explicitly halt the callback chain, please use `throw :abort` instead.
-        MSG
+              Returning `false` in Active Record and Active Model callbacks will not implicitly halt a callback chain in Rails 5.1.
+              To explicitly halt the callback chain, please use `throw :abort` instead.
+            MSG
           end
       end
   end


### PR DESCRIPTION
All indentation was normalized by rubocop auto-correct at 80e66cc4d90bf8c15d1a5f6e3152e90147f00772.
But heredocs was still kept absolute position. This commit aligns
heredocs indentation for consistency.
