### PR TITLE
Remove extracting `polymorphic_base_class` for `Array` in `AssociationQueryValue`

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
@@ -68,9 +68,6 @@ module ActiveRecord
           case value
           when Relation
             value.klass.base_class
-          when Array
-            val = value.compact.first
-            val.class.base_class if val.is_a?(Base)
           when Base
             value.class.base_class
           end


### PR DESCRIPTION
It is handled by `PolymorphicArrayValue`.
