### PR TITLE
rename test method to avoid overriding

### DIFF
--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3693,7 +3693,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "admin/pages#index", @response.body
   end
 
-  def test_namespaced_roots
+  def test_multiple_namespaced_roots
     draw do
       namespace :foo do
         root "test#index"


### PR DESCRIPTION
This removes the following warning.

```
./test/dispatch/routing_test.rb:3696: warning: method redefined; discarding old test_namespaced_roots
./test/dispatch/routing_test.rb:1632: warning: previous definition of test_namespaced_roots was here
```
