### PR TITLE
Pass `set_inverse_instance` block to `sc.execute` for `SingularAssociation`

### DIFF
--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -56,9 +56,9 @@ module ActiveRecord
           end
 
           binds = AssociationScope.get_bind_values(owner, reflection.chain)
-          if record = sc.execute(binds, klass, conn).first
+          sc.execute(binds, klass, conn) do |record|
             set_inverse_instance record
-          end
+          end.first
         end
 
         def replace(record)


### PR DESCRIPTION
Follow up to caa178c.

caa178c updated all code which sets inverse instances on newly loaded
associations to use block. But `SingularAssociation` was forgotten it.
