### PR TITLE
Remove unnecessary `count` method for collection proxy

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -183,31 +183,6 @@ module ActiveRecord
         end
       end
 
-      # Returns the number of records. If no arguments are given, it counts all
-      # columns using SQL. If one argument is given, it counts only the passed
-      # column using SQL. If a block is given, it counts the number of records
-      # yielding a true value.
-      def count(column_name = nil)
-        return super if block_given?
-        relation = scope
-        if association_scope.distinct_value
-          # This is needed because 'SELECT count(DISTINCT *)..' is not valid SQL.
-          column_name ||= reflection.klass.primary_key
-          relation = relation.distinct
-        end
-
-        value = relation.count(column_name)
-
-        limit  = options[:limit]
-        offset = options[:offset]
-
-        if limit || offset
-          [ [value - offset.to_i, 0].max, limit.to_i ].min
-        else
-          value
-        end
-      end
-
       # Removes +records+ from this association calling +before_remove+ and
       # +after_remove+ callbacks.
       #

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -743,6 +743,20 @@ module ActiveRecord
       end
       alias uniq distinct
 
+      def calculate(operation, column_name)
+        null_scope? ? scope.calculate(operation, column_name) : super
+      end
+
+      def pluck(*column_names)
+        null_scope? ? scope.pluck(*column_names) : super
+      end
+
+      ##
+      # :method: count
+      #
+      # :call-seq:
+      #   count(column_name = nil, &block)
+      #
       # Count all records.
       #
       #   class Person < ActiveRecord::Base
@@ -762,17 +776,6 @@ module ActiveRecord
       # perform the count using Ruby.
       #
       #   person.pets.count { |pet| pet.name.include?('-') } # => 2
-      def count(column_name = nil, &block)
-        @association.count(column_name, &block)
-      end
-
-      def calculate(operation, column_name)
-        null_scope? ? scope.calculate(operation, column_name) : super
-      end
-
-      def pluck(*column_names)
-        null_scope? ? scope.pluck(*column_names) : super
-      end
 
       # Returns the size of the collection. If the collection hasn't been loaded,
       # it executes a <tt>SELECT COUNT(*)</tt> query. Else it calls <tt>collection.size</tt>.


### PR DESCRIPTION
Simply use its own method because `CollectionProxy` inherits `Relation`.
