### PR TITLE
make `fixture_file_upload` work in integration tests

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make `fixture_file_upload` work in integration tests.
+
+    *Yuji Yaginuma*
+
 *   Add `to_param` to `ActionController::Parameters` deprecations.
 
     In the future `ActionController::Parameters` are discouraged from being used

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -179,7 +179,7 @@ module ActionDispatch
       DEFAULT_HOST = "www.example.com"
 
       include Minitest::Assertions
-      include TestProcess, RequestHelpers, Assertions
+      include RequestHelpers, Assertions
 
       %w( status status_message headers body redirect? ).each do |method|
         delegate method, to: :response, allow_nil: true
@@ -711,6 +711,8 @@ module ActionDispatch
   # Consult the Rails Testing Guide for more.
 
   class IntegrationTest < ActiveSupport::TestCase
+    include TestProcess
+
     module UrlOptions
       extend ActiveSupport::Concern
       def url_options

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -1281,3 +1281,39 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
       end
     end
 end
+
+class IntegrationFileUploadTest < ActionDispatch::IntegrationTest
+  class IntegrationController < ActionController::Base
+    def test_file_upload
+      render plain: params[:file].size
+    end
+  end
+
+  def self.routes
+    @routes ||= ActionDispatch::Routing::RouteSet.new
+  end
+
+  def self.call(env)
+    routes.call(env)
+  end
+
+  def app
+    self.class
+  end
+
+  def self.fixture_path
+    File.dirname(__FILE__) + "/../fixtures/multipart"
+  end
+
+  routes.draw do
+    post "test_file_upload", to: "integration_file_upload_test/integration#test_file_upload"
+  end
+
+  def test_fixture_file_upload
+    post "/test_file_upload",
+      params: {
+        file: fixture_file_upload("/mona_lisa.jpg", "image/jpg")
+      }
+    assert_equal "159528", @response.body
+  end
+end


### PR DESCRIPTION
### Summary

Currently, `fixture_file_upload` does not work in integration test.
Because, `TestProcess` module has been include in `Session` class, but
`fixture_path` can not get from `Session` class.

Modify to include `TestProcess` in `IntegrationTest` class in order to get
correct value of `fixture_path`.
