### PR TITLE
Register integer types limit correctly for postgresql adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -76,7 +76,7 @@ module ActiveRecord
         primary_key: "bigserial primary key",
         string:      { name: "character varying" },
         text:        { name: "text" },
-        integer:     { name: "integer" },
+        integer:     { name: "integer", limit: 4 },
         float:       { name: "float" },
         decimal:     { name: "decimal" },
         datetime:    { name: "timestamp" },
@@ -439,9 +439,9 @@ module ActiveRecord
         end
 
         def initialize_type_map(m = type_map)
-          register_class_with_limit m, "int2", Type::Integer
-          register_class_with_limit m, "int4", Type::Integer
-          register_class_with_limit m, "int8", Type::Integer
+          m.register_type "int2", Type::Integer.new(limit: 2)
+          m.register_type "int4", Type::Integer.new(limit: 4)
+          m.register_type "int8", Type::Integer.new(limit: 8)
           m.register_type "oid", OID::Oid.new
           m.register_type "float4", Type::Float.new
           m.alias_type "float8", "float4"
@@ -506,17 +506,6 @@ module ActiveRecord
           end
 
           load_additional_types
-        end
-
-        def extract_limit(sql_type)
-          case sql_type
-          when /^bigint/i, /^int8/i
-            8
-          when /^smallint/i
-            2
-          else
-            super
-          end
         end
 
         # Extracts the value from a PostgreSQL column default definition.


### PR DESCRIPTION
currently integer types extracts the `limit` from `sql_type`. But the
lookup key of type map is the `oid` in postgresql adapter. So in most
case `sql_type` is passed to `extract_limit` as `""` and `limit` is
extracted as `nil`.

https://github.com/rails/rails/blob/v5.1.0.beta1/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L445

In mysql2 adapter, `limit` is registered correctly without extracting
from `sql_type`.

https://github.com/rails/rails/blob/v5.1.0.beta1/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L678-L682

Postgresql adapter should also be registered correctly.

``` ruby
  conn = ActiveRecord::Base.connection
  conn.select_all("SELECT 1::smallint, 2::integer, 3::bigint").column_types.map do |name, type|
    [name, type.limit]
  end
```

Before:

``` ruby
  # => [["int2", nil], ["int4", nil], ["int8", nil]]
```

After:

``` ruby
  # => [["int2", 2], ["int4", 4], ["int8", 8]]
```