### PR TITLE
use `descendants` to get class that inherited `ActiveJob::Base`

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -11,7 +11,7 @@ module ActiveJob
     def before_setup # :nodoc:
       test_adapter = queue_adapter_for_test
 
-      @old_queue_adapters = (ActiveJob::Base.subclasses << ActiveJob::Base).select do |klass|
+      @old_queue_adapters = (ActiveJob::Base.descendants << ActiveJob::Base).select do |klass|
         # only override explicitly set adapters, a quirk of `class_attribute`
         klass.singleton_class.public_instance_methods(false).include?(:_queue_adapter)
       end.map do |klass|

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -5,6 +5,7 @@ require "jobs/hello_job"
 require "jobs/logging_job"
 require "jobs/nested_job"
 require "jobs/rescue_job"
+require "jobs/inherited_job"
 require "models/person"
 
 class EnqueuedJobsTest < ActiveJob::TestCase
@@ -519,5 +520,11 @@ class OverrideQueueAdapterTest < ActiveJob::TestCase
 
   def test_assert_job_has_custom_queue_adapter_set
     assert_instance_of CustomQueueAdapter, HelloJob.queue_adapter
+  end
+end
+
+class InheritedJobTest < ActiveJob::TestCase
+  def test_queue_adapter_is_test_adapter
+    assert_instance_of ActiveJob::QueueAdapters::TestAdapter, InheritedJob.queue_adapter
   end
 end

--- a/activejob/test/jobs/application_job.rb
+++ b/activejob/test/jobs/application_job.rb
@@ -1,0 +1,4 @@
+require_relative "../support/job_buffer"
+
+class ApplicationJob < ActiveJob::Base
+end

--- a/activejob/test/jobs/inherited_job.rb
+++ b/activejob/test/jobs/inherited_job.rb
@@ -1,0 +1,5 @@
+require_relative "application_job"
+
+class InheritedJob < ApplicationJob
+  self.queue_adapter = :inline
+end


### PR DESCRIPTION
### Summary

`subclasses` get only child classes.
Therefore, if create a job common parent class as `ApplicationJob`,
inherited class does not get properly.
