### PR TITLE
change `Class#descendants` to public API [ci skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -6,7 +6,20 @@ class Class
     # Test if this Ruby supports each_object against singleton_class
     ObjectSpace.each_object(Numeric.singleton_class) {}
 
-    def descendants # :nodoc:
+    # Returns an array with all classes that are < than its receiver.
+    #
+    #   class C; end
+    #   C.descendants # => []
+    #
+    #   class B < C; end
+    #   C.descendants # => [B]
+    #
+    #   class A < B; end
+    #   C.descendants # => [B, A]
+    #
+    #   class D < C; end
+    #   C.descendants # => [B, A, D]
+    def descendants
       descendants = []
       ObjectSpace.each_object(singleton_class) do |k|
         descendants.unshift k unless k == self
@@ -14,7 +27,7 @@ class Class
       descendants
     end
   rescue StandardError # JRuby 9.0.4.0 and earlier
-    def descendants # :nodoc:
+    def descendants
       descendants = []
       ObjectSpace.each_object(Class) do |k|
         descendants.unshift k if k < self


### PR DESCRIPTION
### Summary

`Class#descendants` has already been displayed in Rails guide,
so I think that may be displayed in doc.
http://guides.rubyonrails.org/active_support_core_extensions.html#descendants
