### PR TITLE
Remove not used alias method

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -470,7 +470,6 @@ module ActiveRecord
       self.left_outer_joins_values += args
       self
     end
-    alias :left_joins! :left_outer_joins!
 
     # Returns a new relation, which is the result of filtering the current relation
     # according to the conditions in the arguments.


### PR DESCRIPTION
Bang methods of `AR::QueryMethods` are used only internally.
We only use `left_outer_joins!`, so we can remove this alias.
