### PR TITLE
Added `#datalist_field_tag` to ActionView::Helpers::FormTagHelper and…

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -147,4 +147,46 @@
 
     *Vipul A M*
 
+*   Added `#datalist_field_tag` to ActionView::Helpers::FormTagHelper and `#datalist_field` to
+    ActionView::Helpers::FormHelper. Methods create a text input tag linked to a datalist tag. Datalist is an input
+    type in HTML5 that represents a list of predefined options, available in the text input.
+    Ref: https://www.w3.org/wiki/HTML/Elements/datalist.
+
+    `#datalist_field_tag` Usage:
+
+    ```ruby
+    datalist_field_tag 'browser', nil, options_from_collection_for_select(@browsers, 'id', 'name'), placeholder: "placeholder"
+    # or
+    datalist_field_tag 'browser', nil, '<option value="1">Chrome</option>'.html_safe, placeholder: "placeholder"
+    ```
+
+    `#datalist_field_tag` Result:
+
+    ```html
+    <input type="text" name="browser" id="browser" placeholder="placeholder" class="browser-input" list="browsers"></input>
+    <datalist id="browsers">
+      <option value="1">Chrome</option>
+    </datalist>
+    ```    
+
+    `#datalist_field` Usage:
+
+    ```ruby
+    datalist_field(:user, :favorite_color, options_from_collection_for_select(Colors.all, 'id', 'name'), placeholder: "placeholder")
+    # or
+    datalist_field(:user, :favorite_color, '<option value="1">Red</option><option value="2">Blue</option>'.html_safe, placeholder: "placeholder")
+    ```
+
+    `#datalist_field` Result:
+
+    ```html
+    <input placeholder="placeholder" name="user[favorite_color]" id="user_favorite_color" type="text" list="user_favorite_colors"></input>
+    <datalist id="user_favorite_colors">
+      <option value="1">Red</option>
+      <option value="2">Blue</option>
+    </datalist>
+    ```
+
+    *Andy Zheng*
+
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1466,6 +1466,23 @@ module ActionView
         Tags::RangeField.new(object_name, method, self, options).render
       end
 
+      # Returns an input tag of type "text" and datalist tag with option tags
+      #
+      # === Options
+      # * Accepts options to be put in input tag
+      #
+      # === Example
+      #   datalist_field :home, :type, '<option value="1">House</option><option value="2">Aparement</option>'.html_safe, placeholder: "placeholder"
+      #   # => <input placeholder="placeholder" name="home[type]" id="home_type" type="text" list="home_types"></input>
+      #   # => <datalist id="home_types"><option value="1">House</option><option value="2">Aparement</option></datalist>
+      #
+      #   datalist_field :user, :favorite_color, options_from_collection_for_select(Color.all, "id", "name"), placeholder: "placeholder"
+      #   # => <input placeholder="placeholder" name="user[favorite_color]" id="user_favorite_color" type="text" list="user_favorite_colors"></input>
+      #   # => <datalist id="user_favorite_colors"><option value="1">Red</option><option value="2">Blue</option></datalist>
+      def datalist_field(object_name, method, option_tags, options = {})
+        Tags::DatalistField.new(object_name, method, self, option_tags, options).render
+      end
+
       private
         def html_options_for_form_with(url_for_options = nil, model = nil, html: {}, local: false,
           skip_enforcing_utf8: false, **options)
@@ -1573,7 +1590,7 @@ module ActionView
                             :telephone_field, :phone_field, :date_field,
                             :time_field, :datetime_field, :datetime_local_field,
                             :month_field, :week_field, :url_field, :email_field,
-                            :number_field, :range_field]
+                            :number_field, :range_field, :datalist_field]
 
       attr_accessor :object_name, :object, :options
 

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -829,6 +829,39 @@ module ActionView
         '<input name="utf8" type="hidden" value="&#x2713;" />'.html_safe
       end
 
+      # Creates a text input linked to a datalist. A datalist contains a set of option tags.
+      # The datalist's bahavior is similar to a select tag. Datalists allow a selection from predefined values
+      # but are not constraint to those values. The text input can chosen from the datalist options or entered normally.
+      #
+      # === Examples
+      #   datalist_field_tag 'browser'
+      #   # => <input type="text" name="browser" id="browser" list="browsers"><datalist id="browsers"></datalist>
+      #
+      #   datalist_field_tag 'browser', 'default browser'
+      #   # => <input type="text" name="browser" id="browser" value="default browser" list="browsers"><datalist id="browsers"></datalist>
+      #
+      #   datalist_field_tag 'browser', nil, '<option value="Chrome"></option><option value="Firefox"></option>'.html_safe
+      #   # => <input type="text" name="browser" id="browser" list="browsers"><datalist id="browsers"><option value="Chrome"></option><option value="Firefox"></option></datalist>
+      #
+      #   datalist_field_tag 'browser', nil, '<option>Chrome</option><option>Firefox</option>'.html_safe
+      #   # => <input type="text" name="browser" id="browser" list="browsers"><datalist id="browsers"><option>Chrome</option><option>Firefox</option></datalist>
+      #
+      #   datalist_field_tag 'browser', nil, options_from_collection_for_select(@browsers, 'id', 'name')
+      #   # => <input type="text" name="browser" id="browser" list="browsers"><datalist id="browsers"><option value="1">Chrome</option><option value="2">Firefox</option></datalist>
+      #
+      #   datalist_field_tag 'browser', nil, options_from_collection_for_select(@browsers, 'id', 'name'), placeholder: "placeholder", class: "browser-input"
+      #   # => <input type="text" name="browser" id="browser" placeholder="placeholder" class="browser-input" list="browsers"><datalist id="browsers"><option value="1">Chrome</option><option value="2">Firefox</option></datalist>
+      def datalist_field_tag(name, value = nil, option_tags = nil, options = {})
+        option_tags ||= ""
+        list_name = sanitize_to_id(name.to_s).pluralize
+
+        # Delete :list from text_field_options if they tried to include them
+        # Text field's list attribute should correspond to the datalist's id
+        options.delete(:list)
+
+        (text_field_tag name, value, { list: list_name }.update(options.stringify_keys)) + (content_tag "datalist", option_tags, id: list_name)
+      end
+
       private
         def html_options_for_form(url_for_options, options)
           options.stringify_keys.tap do |html_options|

--- a/actionview/lib/action_view/helpers/tags.rb
+++ b/actionview/lib/action_view/helpers/tags.rb
@@ -11,6 +11,7 @@ module ActionView
         autoload :CollectionRadioButtons
         autoload :CollectionSelect
         autoload :ColorField
+        autoload :DatalistField
         autoload :DateField
         autoload :DateSelect
         autoload :DatetimeField

--- a/actionview/lib/action_view/helpers/tags/datalist_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datalist_field.rb
@@ -1,0 +1,28 @@
+require "action_view/helpers/tags/placeholderable"
+require "action_view/helpers/text_helper"
+
+module ActionView
+  module Helpers
+    module Tags # :nodoc:
+      class DatalistField < Base # :nodoc:
+        include Placeholderable
+        include TextHelper
+
+        def initialize(object_name, method_name, template_object, option_tags, options = {})
+          @option_tags = option_tags
+
+          super(object_name, method_name, template_object, options)
+        end
+
+        def render
+          add_default_name_and_id(@options)
+          list_name = @object_name.to_s + "_" + @method_name.to_s.pluralize
+          @options["type"] = "text"
+          @options["list"] = list_name
+
+          content_tag("input", nil, @options) + content_tag("datalist", @option_tags, id: @options["list"])
+        end
+      end
+    end
+  end
+end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -3443,6 +3443,11 @@ class FormHelperTest < ActionView::TestCase
     assert_equal 1, initialization_count, "form builder instantiated more than once"
   end
 
+  def test_datalist_field
+    expected = %{<input class="input" placeholder="placeholder" name="user[favorite_color]" id="user_favorite_color" type="text" list="user_favorite_colors"></input><datalist id="user_favorite_colors"><option value="1">Red</option><option value="2">Blue</option></datalist>}
+    assert_dom_equal(expected, datalist_field(:user, :favorite_color, '<option value="1">Red</option><option value="2">Blue</option>'.html_safe, placeholder: "placeholder", class: "input"))
+  end
+
   protected
 
     def hidden_fields(options = {})

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -721,6 +721,11 @@ class FormTagHelperTest < ActionView::TestCase
     assert_equal options, option: "random_option"
   end
 
+  def test_datalist_field_tag
+    expected = %{<input type="text" name="browser" id="browser" placeholder="placeholder" class="browser-input" list="browsers"><datalist id="browsers"><option value="Chrome"></option><option value="Firefox"></option></datalist>}
+    assert_dom_equal(expected, datalist_field_tag("browser", nil, raw('<option value="Chrome"></option><option value="Firefox"></option>'), placeholder: "placeholder", class: "browser-input", list: "cookies"))
+  end
+
   def protect_against_forgery?
     false
   end


### PR DESCRIPTION
Added `#datalist_field_tag` to ActionView::Helpers::FormTagHelper and `#datalist_field` to ActionView::Helpers::FormHelper. Methods create a text input tag linked to a datalist tag. Datalist is an input type in HTML5 that represents a list of predefined options, available in the text input.
Ref: https://www.w3.org/wiki/HTML/Elements/datalist.

`#datalist_field_tag` Usage:

``` ruby
datalist_field_tag 'browser', nil, options_from_collection_for_select(@browsers, 'id', 'name'), placeholder: "placeholder"

datalist_field_tag 'browser', nil, '<option value="1">Chrome</option>'.html_safe, placeholder: "placeholder"
```

`#datalist_field_tag` Result:

``` html
<input type="text" name="browser" id="browser" placeholder="placeholder" class="browser-input" list="browsers"></input>
<datalist id="browsers">
  <option value="1">Chrome</option>
</datalist>
```

`#datalist_field` Usage:

``` ruby
datalist_field(:user, :favorite_color, options_from_collection_for_select(Colors.all, 'id', 'name'), placeholder: "placeholder")

datalist_field(:user, :favorite_color, '<option value="1">Red</option><option value="2">Blue</option>'.html_safe, placeholder: "placeholder")
```

`#datalist_field` Result:

``` html
<input placeholder="placeholder" name="user[favorite_color]" id="user_favorite_color" type="text" list="user_favorite_colors"></input>
<datalist id="user_favorite_colors">
  <option value="1">Red</option>
  <option value="2">Blue</option>
</datalist>
```

Noticed that several HTML5 input tags were included in Rails but the datalist has yet to be implemented. Could not find an issue or pull request about this, but thought it would useful to have.
