### PR TITLE
Improve SecureToken by adding generate_#{attribute}

### DIFF
--- a/activerecord/lib/active_record/secure_token.rb
+++ b/activerecord/lib/active_record/secure_token.rb
@@ -26,8 +26,9 @@ module ActiveRecord
       def has_secure_token(attribute = :token)
         # Load securerandom only when has_secure_token is used.
         require "active_support/core_ext/securerandom"
+        define_method("generate_#{attribute}") { self.send("#{attribute}=", self.class.generate_unique_secure_token) unless self.send("#{attribute}?") }
         define_method("regenerate_#{attribute}") { update! attribute => self.class.generate_unique_secure_token }
-        before_create { self.send("#{attribute}=", self.class.generate_unique_secure_token) unless self.send("#{attribute}?") }
+        before_create :"generate_#{attribute}"
       end
 
       def generate_unique_secure_token

--- a/activerecord/test/cases/secure_token_test.rb
+++ b/activerecord/test/cases/secure_token_test.rb
@@ -29,4 +29,13 @@ class SecureTokenTest < ActiveRecord::TestCase
 
     assert_equal @user.token, "custom-secure-token"
   end
+
+  def test_generating_the_secure_token
+    @user = User.new
+    @user.generate_token
+    @user.generate_auth_token
+
+    assert_not_nil @user.token
+    assert_not_nil @user.auth_token
+  end
 end


### PR DESCRIPTION
I needed the callback which is generated by SecureToken in a `before_validation` callback, so I could do some validations on it. Instead of copying the code from SecureToken, I thought it would be easier to extract it into its own method: `generate_#{attribute}`

This allows me to do:

```
has_secure_token
before_validation :generate_token
```
