### PR TITLE
Fix Remaining Case-In-Assignment Statement Formatting

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -1026,15 +1026,16 @@ module ActionView
         #  prompt_option_tag(:month, prompt: 'Select month')
         #  => "<option value="">Select month</option>"
         def prompt_option_tag(type, options)
-          prompt = case options
-                   when Hash
-                     default_options = { year: false, month: false, day: false, hour: false, minute: false, second: false }
-                     default_options.merge!(options)[type.to_sym]
-                   when String
-                     options
+          prompt = \
+            case options
+            when Hash
+              default_options = { year: false, month: false, day: false, hour: false, minute: false, second: false }
+              default_options.merge!(options)[type.to_sym]
+            when String
+              options
             else
-                     I18n.translate(:"datetime.prompts.#{type}", locale: @options[:locale])
-          end
+              I18n.translate(:"datetime.prompts.#{type}", locale: @options[:locale])
+            end
 
           prompt ? content_tag("option".freeze, prompt, value: "") : ""
         end

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -857,23 +857,24 @@ module ActionView
           authenticity_token = html_options.delete("authenticity_token")
           method = html_options.delete("method").to_s.downcase
 
-          method_tag = case method
-                       when "get"
-                         html_options["method"] = "get"
-                         ""
-                       when "post", ""
-                         html_options["method"] = "post"
-                         token_tag(authenticity_token, form_options: {
-                           action: html_options["action"],
-                           method: "post"
-                         })
+          method_tag = \
+            case method
+            when "get"
+              html_options["method"] = "get"
+              ""
+            when "post", ""
+              html_options["method"] = "post"
+              token_tag(authenticity_token, form_options: {
+                action: html_options["action"],
+                method: "post"
+              })
             else
-                         html_options["method"] = "post"
-                         method_tag(method) + token_tag(authenticity_token, form_options: {
-                           action: html_options["action"],
-                           method: method
-                         })
-          end
+              html_options["method"] = "post"
+              method_tag(method) + token_tag(authenticity_token, form_options: {
+                action: html_options["action"],
+                method: method
+              })
+            end
 
           if html_options.delete("enforce_utf8") { true }
             utf8_enforcer_tag + method_tag

--- a/activemodel/lib/active_model/type/decimal.rb
+++ b/activemodel/lib/active_model/type/decimal.rb
@@ -16,18 +16,19 @@ module ActiveModel
       private
 
         def cast_value(value)
-          casted_value = case value
-                         when ::Float
-                           convert_float_to_big_decimal(value)
-                         when ::Numeric, ::String
-                           BigDecimal(value, precision.to_i)
-          else
-                           if value.respond_to?(:to_d)
-                             value.to_d
-                           else
-                             cast_value(value.to_s)
-                           end
-          end
+          casted_value = \
+            case value
+            when ::Float
+              convert_float_to_big_decimal(value)
+            when ::Numeric, ::String
+              BigDecimal(value, precision.to_i)
+            else
+              if value.respond_to?(:to_d)
+                value.to_d
+              else
+                cast_value(value.to_s)
+              end
+            end
 
           apply_scale(casted_value)
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -570,22 +570,23 @@ module ActiveRecord
 
       # Maps logical Rails types to MySQL-specific data types.
       def type_to_sql(type, limit = nil, precision = nil, scale = nil, unsigned = nil)
-        sql = case type.to_s
-              when "integer"
-                integer_to_sql(limit)
-              when "text"
-                text_to_sql(limit)
-              when "blob"
-                binary_to_sql(limit)
-              when "binary"
-                if (0..0xfff) === limit
-                  "varbinary(#{limit})"
-                else
-                  binary_to_sql(limit)
-                end
-        else
-                super(type, limit, precision, scale)
-        end
+        sql = \
+          case type.to_s
+          when "integer"
+            integer_to_sql(limit)
+          when "text"
+            text_to_sql(limit)
+          when "blob"
+            binary_to_sql(limit)
+          when "binary"
+            if (0..0xfff) === limit
+              "varbinary(#{limit})"
+            else
+              binary_to_sql(limit)
+            end
+          else
+            super(type, limit, precision, scale)
+          end
 
         sql << " unsigned" if unsigned && type != :primary_key
         sql

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -625,31 +625,32 @@ module ActiveRecord
 
         # Maps logical Rails types to PostgreSQL-specific data types.
         def type_to_sql(type, limit = nil, precision = nil, scale = nil, array = nil)
-          sql = case type.to_s
-                when "binary"
-            # PostgreSQL doesn't support limits on binary (bytea) columns.
-            # The hard limit is 1GB, because of a 32-bit size field, and TOAST.
-                  case limit
-                  when nil, 0..0x3fffffff; super(type)
-                  else raise(ActiveRecordError, "No binary type has byte size #{limit}.")
-                  end
-                when "text"
-            # PostgreSQL doesn't support limits on text columns.
-            # The hard limit is 1GB, according to section 8.3 in the manual.
-                  case limit
-                  when nil, 0..0x3fffffff; super(type)
-                  else raise(ActiveRecordError, "The limit on text can be at most 1GB - 1byte.")
-                  end
-                when "integer"
-                  case limit
-                  when 1, 2; "smallint"
-                  when nil, 3, 4; "integer"
-                  when 5..8; "bigint"
-                  else raise(ActiveRecordError, "No integer type has byte size #{limit}. Use a numeric with scale 0 instead.")
-                  end
-          else
-                  super(type, limit, precision, scale)
-          end
+          sql = \
+            case type.to_s
+            when "binary"
+              # PostgreSQL doesn't support limits on binary (bytea) columns.
+              # The hard limit is 1GB, because of a 32-bit size field, and TOAST.
+              case limit
+              when nil, 0..0x3fffffff; super(type)
+              else raise(ActiveRecordError, "No binary type has byte size #{limit}.")
+              end
+            when "text"
+              # PostgreSQL doesn't support limits on text columns.
+              # The hard limit is 1GB, according to section 8.3 in the manual.
+              case limit
+              when nil, 0..0x3fffffff; super(type)
+              else raise(ActiveRecordError, "The limit on text can be at most 1GB - 1byte.")
+              end
+            when "integer"
+              case limit
+              when 1, 2; "smallint"
+              when nil, 3, 4; "integer"
+              when 5..8; "bigint"
+              else raise(ActiveRecordError, "No integer type has byte size #{limit}. Use a numeric with scale 0 instead.")
+              end
+            else
+              super(type, limit, precision, scale)
+            end
 
           sql << "[]" if array && type != :primary_key
           sql

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -519,14 +519,15 @@ module ActiveRecord
     # larger than the limit.
       def check_record_limit!(limit, attributes_collection)
         if limit
-          limit = case limit
-                  when Symbol
-                    send(limit)
-                  when Proc
-                    limit.call
-          else
-                    limit
-          end
+          limit = \
+            case limit
+            when Symbol
+              send(limit)
+            when Proc
+              limit.call
+            else
+              limit
+            end
 
           if limit && attributes_collection.size > limit
             raise TooManyRecords, "Maximum #{limit} records are allowed. Got #{attributes_collection.size} records instead."

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -59,11 +59,12 @@ module ActiveRecord
     FROZEN_EMPTY_HASH = {}.freeze
 
     Relation::VALUE_METHODS.each do |name|
-      method_name = case name
-                    when *Relation::MULTI_VALUE_METHODS then "#{name}_values"
-                    when *Relation::SINGLE_VALUE_METHODS then "#{name}_value"
-                    when *Relation::CLAUSE_METHODS then "#{name}_clause"
-      end
+      method_name = \
+        case name
+        when *Relation::MULTI_VALUE_METHODS then "#{name}_values"
+        when *Relation::SINGLE_VALUE_METHODS then "#{name}_value"
+        when *Relation::CLAUSE_METHODS then "#{name}_clause"
+        end
       class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{method_name}                   # def includes_values
           get_value(#{name.inspect})         #   get_value(:includes)

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -46,14 +46,15 @@ module ActiveRecord
       def structure_dump(filename)
         set_psql_env
 
-        search_path = case ActiveRecord::Base.dump_schemas
-                      when :schema_search_path
-                        configuration["schema_search_path"]
-                      when :all
-                        nil
-                      when String
-                        ActiveRecord::Base.dump_schemas
-        end
+        search_path = \
+          case ActiveRecord::Base.dump_schemas
+          when :schema_search_path
+            configuration["schema_search_path"]
+          when :all
+            nil
+          when String
+            ActiveRecord::Base.dump_schemas
+          end
 
         args = ["-s", "-x", "-O", "-f", filename]
         unless search_path.blank?

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -83,14 +83,15 @@ module I18n
     def self.init_fallbacks(fallbacks)
       include_fallbacks_module
 
-      args = case fallbacks
-             when ActiveSupport::OrderedOptions
-               [*(fallbacks[:defaults] || []) << fallbacks[:map]].compact
-             when Hash, Array
-               Array.wrap(fallbacks)
-      else # TrueClass
-               []
-      end
+      args = \
+        case fallbacks
+        when ActiveSupport::OrderedOptions
+          [*(fallbacks[:defaults] || []) << fallbacks[:map]].compact
+        when Hash, Array
+          Array.wrap(fallbacks)
+        else # TrueClass
+          []
+        end
 
       I18n.fallbacks = I18n::Locale::Fallbacks.new(*args)
     end

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -162,14 +162,15 @@ module Rails
 
       def set_default_accessors!
         self.destination_root = File.expand_path(app_path, destination_root)
-        self.rails_template = case options[:template]
-                              when /^https?:\/\//
-                                options[:template]
-                              when String
-                                File.expand_path(options[:template], Dir.pwd)
+        self.rails_template = \
+          case options[:template]
+          when /^https?:\/\//
+            options[:template]
+          when String
+            File.expand_path(options[:template], Dir.pwd)
           else
-                                options[:template]
-        end
+            options[:template]
+          end
       end
 
       def database_gemfile_entry


### PR DESCRIPTION
Recently, the Rails team made an effort to keep the source code consistent, using Rubocop
(bb1ecdcc677bf6e68e0252505509c089619b5b90 and below). I found some of the case statements that were missed.

This changes the case statements' formatting and is consistent with changes in 810dff7c9fa9b2a38eb1560ce0378d760529ee6b and db63406cb007ab3756d2a96d2e0b5d4e777f8231.

_**This is cosmetic and does not change functionality**_
