### PR TITLE
call `.to_h` to avoid using deprecated method

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -578,7 +578,7 @@ module ActionController
     # +other_hash+ merges into current hash.
     def merge(other_hash)
       new_instance_with_inherited_permitted_status(
-        @parameters.merge(other_hash)
+        @parameters.merge(other_hash.to_h)
       )
     end
 

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -237,6 +237,13 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert @params.merge(a: "b").permitted?
   end
 
+  test "merge with parameters" do
+    other_params = ActionController::Parameters.new(id: "1234").permit!
+    merged_params = @params.merge(other_params)
+
+    assert merged_params[:id]
+  end
+
   test "modifying the parameters" do
     @params[:person][:hometown] = "Chicago"
     @params[:person][:family] = { brother: "Jonas" }


### PR DESCRIPTION
### Summary

`ActionController::Parameters#merge` call `HashWithIndifferentAccess#merge`.
In addition, it calls `HashWithIndifferentAccess#update` from
`HashWithIndifferentAccess#merge`,  where it is called the `#to_hash` of argument.
But `ActionController::Parameters#to_hash` is deprecated, warning message is
displayed.
To avoid this, modify to convert object to `Hash`.

Fixes #26415
