### PR TITLE
Exception throw when new record column increment!

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -334,6 +334,9 @@ module ActiveRecord
     # Saving is not subjected to validation checks. Returns +true+ if the
     # record could be saved.
     def increment!(attribute, by = 1)
+      raise ActiveRecordError, "cannot increment! a new record" if new_record?
+      raise ActiveRecordError, "cannot increment! a destroyed record" if destroyed?
+
       increment(attribute, by)
       change = public_send(attribute) - (attribute_was(attribute.to_s) || 0)
       self.class.update_counters(id, attribute => change)

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -138,6 +138,14 @@ class PersistenceTest < ActiveRecord::TestCase
     end
   end
 
+  def test_increment_destroyed_record
+    account = accounts(:signals37)
+    account.destroy!
+    assert_raise ActiveRecord::ActiveRecordError do
+      account.increment!(:credit_limit)
+    end
+  end
+
   def test_destroy_all
     conditions = "author_name = 'Mary'"
     topics_by_mary = Topic.all.merge!(where: conditions, order: "id").to_a

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -131,6 +131,13 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal initial_credit + 2, a1.reload.credit_limit
   end
 
+  def test_increment_new_record
+    account = Account.new
+    assert_raise ActiveRecord::ActiveRecordError do
+      account.increment!(:credit_limit)
+    end
+  end
+
   def test_destroy_all
     conditions = "author_name = 'Mary'"
     topics_by_mary = Topic.all.merge!(where: conditions, order: "id").to_a

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -131,14 +131,14 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal initial_credit + 2, a1.reload.credit_limit
   end
 
-  def test_increment_new_record
+  def test_increment_update_for_new_record
     account = Account.new
     assert_raise ActiveRecord::ActiveRecordError do
       account.increment!(:credit_limit)
     end
   end
 
-  def test_increment_destroyed_record
+  def test_increment_update_for_destroyed_record
     account = accounts(:signals37)
     account.destroy!
     assert_raise ActiveRecord::ActiveRecordError do


### PR DESCRIPTION
https://github.com/rails/rails/issues/26420

As of Rails4, I tried so as to save.
https://github.com/akicho8/rails/commit/7ca004fda5e971e978dabf7e8521a4ed1e884936

But, I thought it was not good specification.
This is because, a new record, do not notice, without validation, because the will to save. This is dangerous.

So, I think in the same way as update_columns, in the case of the new record, it is good to throw an exception.

How about that?
