### PR TITLE
Document string database values as supported by ActiveRecord::Enum

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -62,6 +62,12 @@ module ActiveRecord
   # be maintained, and new values should only be added to the end of the array. To
   # remove unused values, the explicit hash syntax should be used.
   #
+  # With the explicit hash syntax, you can also choose to map to database string
+  # values, if you have a database column that was created as a :string or
+  # compatible type:
+  #
+  #     enum status: { active: 'active', archived: 'archived_legacy' }
+  #
   # In rare circumstances you might need to access the mapping directly.
   # The mappings are exposed through a class method with the pluralized attribute
   # name, which return the mapping in a +HashWithIndifferentAccess+:


### PR DESCRIPTION
Many people would like to use ActiveRecord::Enum, but with string values in the database instead of integers. You get all the API of Enum (restricted values, automatically generated query methods and scopes), but with more human-readable database values, and hypothetically some tradeoff in somewhat decreased performance and increased disk storage. Many would like to make that trade-off, you can find various StackOverflow questions over the years, etc. 

Interestingly, this already seems to work just fine in ActiveRecord::Enum, and there are even test cases for it since 67c1719012 (in releases since Rails 5.0.0.beta2).  

But it's un-doc'd. 

This PR adds it to the docs, and by implication 'offiically' supports it. 

Interestingly, in my tests, this also works fine as a cover for a Postgres Enumerated Type (and probably any other database in which ActiveRecord adapter exposes the enumerated type equivalent as if it were a string).   This is actually pretty useful, and part of what motivates this. The Postgres Guide says  "Currently there is no special support for enumerated types. They are mapped as normal text columns." -- which is true technically, but in fact you can use an ActiveRecord::Enum (mapping to string db values) on the top too if it's API is useful to you. But I did not mention that in the doc PR, it would require more analysis and testing. One step at a time. 
