### PR TITLE
Change `predicate_builder` attr of Handlers to be private

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -29,7 +29,7 @@ module ActiveRecord
         array_predicates.inject { |composite, predicate| composite.or(predicate) }
       end
 
-      protected
+      private
 
         attr_reader :predicate_builder
 

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
@@ -28,7 +28,7 @@ module ActiveRecord
         predicate_builder.build_from_hash(queries)
       end
 
-      protected
+      private
 
         attr_reader :predicate_builder
     end

--- a/activerecord/lib/active_record/relation/predicate_builder/base_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/base_handler.rb
@@ -9,7 +9,7 @@ module ActiveRecord
         predicate_builder.build(attribute, value.id)
       end
 
-      protected
+      private
 
         attr_reader :predicate_builder
     end

--- a/activerecord/lib/active_record/relation/predicate_builder/class_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/class_handler.rb
@@ -10,11 +10,9 @@ module ActiveRecord
         predicate_builder.build(attribute, value.name)
       end
 
-      protected
+      private
 
         attr_reader :predicate_builder
-
-      private
 
         def print_deprecation_warning
           ActiveSupport::Deprecation.warn(<<-MSG.squish)

--- a/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_handler.rb
@@ -21,7 +21,7 @@ module ActiveRecord
         end
       end
 
-      protected
+      private
 
         attr_reader :predicate_builder
     end


### PR DESCRIPTION
These attributes are used only internally, so it can be private.
