### PR TITLE
Fix issue with `cache_key` when the named timestamp column has value nil

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -53,18 +53,21 @@ module ActiveRecord
     #
     #   Person.find(5).cache_key(:updated_at, :last_reviewed_at)
     def cache_key(*timestamp_names)
-      case
-      when new_record?
+      if new_record?
         "#{model_name.cache_key}/new"
-      when timestamp_names.any?
-        timestamp = max_updated_column_timestamp(timestamp_names)
-        timestamp = timestamp.utc.to_s(cache_timestamp_format)
-        "#{model_name.cache_key}/#{id}-#{timestamp}"
-      when timestamp = max_updated_column_timestamp
-        timestamp = timestamp.utc.to_s(cache_timestamp_format)
-        "#{model_name.cache_key}/#{id}-#{timestamp}"
       else
-        "#{model_name.cache_key}/#{id}"
+        timestamp = if timestamp_names.any?
+          max_updated_column_timestamp(timestamp_names)
+        else
+          max_updated_column_timestamp
+        end
+
+        if timestamp
+          timestamp = timestamp.utc.to_s(cache_timestamp_format)
+          "#{model_name.cache_key}/#{id}-#{timestamp}"
+        else
+          "#{model_name.cache_key}/#{id}"
+        end
       end
     end
 

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -172,4 +172,10 @@ class IntegrationTest < ActiveRecord::TestCase
     owner = owners(:blackbeard)
     assert_equal "owners/#{owner.id}-#{owner.happy_at.utc.to_s(:usec)}", owner.cache_key(:updated_at, :happy_at)
   end
+
+  def test_cache_key_when_named_timestamp_is_nil
+    owner = owners(:blackbeard)
+    owner.happy_at = nil
+    assert_equal "owners/#{owner.id}", owner.cache_key(:happy_at)
+  end
 end


### PR DESCRIPTION
### Summary
- When the named timestamp column is nil, we should just return the
  cache_key with model name and id similar to the behavior of implicit
  timestamp columns.
- Fixed one of the issue mentioned in https://github.com/rails/rails/issues/26417.
