### PR TITLE
Added Yangon as a key in time_zone.rb MAPPING

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -136,6 +136,7 @@ module ActiveSupport
       "Almaty"                       => "Asia/Almaty",
       "Novosibirsk"                  => "Asia/Novosibirsk",
       "Rangoon"                      => "Asia/Rangoon",
+      "Yangon"                       => "Asia/Rangoon",
       "Bangkok"                      => "Asia/Bangkok",
       "Hanoi"                        => "Asia/Bangkok",
       "Jakarta"                      => "Asia/Jakarta",


### PR DESCRIPTION
### Summary

Added Yangon as a key for 'Asia/Rangoon'. Rangoon is the former name of Yangon. This changed in 1989, when Burma was renamed Myanmar. (source: https://www.theguardian.com/world/2012/nov/19/burma-myanmar-obama-name-visit)
### Other Information

This request is also pending with IANA's tz, who maintain the database the values come from.
