### PR TITLE
Fix table name typos [ci skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1020,7 +1020,7 @@ Author.joins("INNER JOIN posts ON posts.author_id = authors.id AND posts.publish
 This will result in the following SQL:
 
 ```sql
-SELECT clients.* FROM clients INNER JOIN posts ON posts.author_id = authors.id AND posts.published = 't'
+SELECT authors.* FROM authors INNER JOIN posts ON posts.author_id = authors.id AND posts.published = 't'
 ```
 
 #### Using Array/Hash of Named Associations


### PR DESCRIPTION
According to Ruby code,  the table names should be `authors` not `clients`.
