### PR TITLE
Use only units provided in options hash for number_to_human

### DIFF
--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -344,6 +344,9 @@ module ActiveSupport
           #Spaces are stripped from the resulting string
           assert_equal "4", number_helper.number_to_human(4, units: { unit: "", ten: "tens " })
           assert_equal "4.5  tens", number_helper.number_to_human(45, units: { unit: "", ten: " tens   " })
+
+          #Uses only provided units and not larger ones
+          assert_equal "1000 kilometers", number_helper.number_to_human(1_000_000, units: {unit: "meter", thousand: "kilometers"})
         end
       end
 

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -346,7 +346,7 @@ module ActiveSupport
           assert_equal "4.5  tens", number_helper.number_to_human(45, units: { unit: "", ten: " tens   " })
 
           #Uses only provided units and not larger ones
-          assert_equal "1000 kilometers", number_helper.number_to_human(1_000_000, units: {unit: "meter", thousand: "kilometers"})
+          assert_equal "1000 kilometers", number_helper.number_to_human(1_000_000, units: { unit: "meter", thousand: "kilometers" })
         end
       end
 

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -345,7 +345,7 @@ module ActiveSupport
           assert_equal "4", number_helper.number_to_human(4, units: { unit: "", ten: "tens " })
           assert_equal "4.5  tens", number_helper.number_to_human(45, units: { unit: "", ten: " tens   " })
 
-          #Uses only provided units and not larger ones
+          # Uses only provided units and not larger ones
           assert_equal "1000 kilometers", number_helper.number_to_human(1_000_000, units: { unit: "meter", thousand: "kilometers" })
         end
       end


### PR DESCRIPTION
Fixes #25664 

**Summary**
1. This tries to fix the issue caused by #20872 which rounds the input past the provided units. 
2. This tries to fix this behaviour by making sure the units provided in the options hash is used and the `calculate_exponent` method only rounds up to the highest unit when no options are provided.

Also the feedback provided by @matthewd in the previous unclosed PR for this issue(#25742) has been addressed by moving the exponent calculating logic from the `convert` method to `calculate_exponent`.
