### PR TITLE
Make has_secure_password configurable with custom fields

### DIFF
--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -28,6 +28,22 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_not_respond_to @visitor, :valid?
   end
 
+  test "secure_password_field should default to :password" do
+    assert_equal :password, @user.secure_password_field
+  end
+
+  test "secure_password_digest_field should default to :password_digest" do
+    assert_equal :password_digest, @user.secure_password_digest_field
+  end
+
+  test "secure_password_field should be set to custom password field" do
+    assert_equal :astalavista, @visitor.secure_password_field
+  end
+
+  test "secure_password_digest_field should be set to custom password digest field" do
+    assert_equal :astalavista_digest, @visitor.secure_password_digest_field
+  end
+
   test "create a new user with validations and valid password/confirmation" do
     @user.password = "password"
     @user.password_confirmation = "password"

--- a/activemodel/test/models/visitor.rb
+++ b/activemodel/test/models/visitor.rb
@@ -4,7 +4,7 @@ class Visitor
 
   define_model_callbacks :create
 
-  has_secure_password(validations: false)
+  has_secure_password(validations: false, password_field: :astalavista)
 
-  attr_accessor :password_digest, :password_confirmation
+  attr_accessor :astalavista_digest
 end


### PR DESCRIPTION
`has_secure_password` expects that the user intends to secure `password`
attribute and expects that there is `password_digest` field present. There
is no way to configure these fields.

This PR enhances `has_secure_password` be configurable by supplying
`password_field` and/or `password_digest_field` arguments. If none is
provided, they default to `password` and `password_digest` respectively.
- It defaults the password_field to :password and password_digest_field to :password_digest
- These can be overridden by passing arguments for :password_filed and/or :password_digest_field

Following are several possible scenarios:

```
class User < ApplicationRecord
  has_secure_password
 # this default :password_field as :password and :password_digest_field as 🔑 _digest
end

class User < ApplicationRecord
  has_secure_password password_field: :pass
  # this sets :password_field as :pass and :password_digest_field as :pass_digest
end

class User < ApplicationRecord
  has_secure_password password_field: :pass, password_digest_field :secret_digest
  # this sets :password_field as :pass and :password_digest_field as :secret_digest
end

class User < ApplicationRecord
  has_secure_password password_digest_field :secret_digest
  # this sets :password_field as :password and :password_digest_field as :secret_digest
end
```
