### PR TITLE
check for values before generating insert_versions sql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -994,6 +994,8 @@ module ActiveRecord
       end
 
       def insert_versions_sql(versions) # :nodoc:
+        return unless versions.any?
+
         sm_table = ActiveRecord::Migrator.schema_migrations_table_name
 
         if supports_multi_insert?

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -47,6 +47,11 @@ class SchemaDumperTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_versions_with_empty_versions
+    schema_info = ActiveRecord::Base.connection.dump_schema_information
+    assert_no_match /VALUES\s+\;/mi, schema_info
+  end
+
   def test_schema_dump
     output = standard_dump
     assert_match %r{create_table "accounts"}, output


### PR DESCRIPTION
### Summary

When running `rails db:structure:dump` on a database that has a `schema_migrations` table but no records in that table, the output would contain the following sql:

``` sql
INSERT INTO schema_migrations (version) VALUES\n;\n\n
```

This would cause an error when the structure is loaded.

This PR adds a check to ensure that there are schema migration versions before we try to generate the sql to insert them
