### PR TITLE
First argument to form_for must not contain nil

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -435,7 +435,8 @@ module ActionView
           object      = nil
         else
           object      = record.is_a?(Array) ? record.last : record
-          raise ArgumentError, "First argument in form cannot contain nil or be empty" unless object
+          contains_nil = record.nil? || (record.is_a?(Array) && record.include?(nil))
+          raise ArgumentError, "First argument in form cannot contain nil or be empty" if contains_nil
           object_name = options[:as] || model_name_from_record_or_class(object).param_key
           apply_form_for_options!(record, object, options)
         end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1501,6 +1501,14 @@ class FormHelperTest < ActionView::TestCase
     assert_equal "First argument in form cannot contain nil or be empty", error.message
   end
 
+  def test_form_for_requires_all_array_elements
+    error = assert_raises(ArgumentError) do
+      form_for([nil, @post], html: { id: "create-post" }) do
+      end
+    end
+    assert_equal "First argument in form cannot contain nil or be empty", error.message
+  end
+
   def test_form_for
     form_for(@post, html: { id: "create-post" }) do |f|
       concat f.label(:title) { "The Title" }


### PR DESCRIPTION
The raised error message when passing an incorrect first argument  to `form_for` says `"First argument in form cannot contain nil or be empty"`. `form_for`however only checks if the last element (if an array is passed) is nil. 

When running`form_for [@document, @comment]` with `@document` as nil creates the
path `/comments` when the user expected `documents/:id/comments`.

I've seen rails devs (especially beginners) stumble across this when building a form for a nested resource and getting confused.  

Solved this by raising the error if any value in the passed array is nil.

_P.S. My first Rails PR_ 
