### PR TITLE
Do not mutate AC::TestRequest::DEFAULT_OPTIONS

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -51,7 +51,7 @@ module ActionController
       super(env)
 
       self.session = session
-      self.session_options = TestSession::DEFAULT_OPTIONS
+      self.session_options = TestSession::DEFAULT_OPTIONS.dup
       @controller_class = controller_class
       @custom_param_parsers = {
         xml: lambda { |raw_post| Hash.from_xml(raw_post)["hash"] }

--- a/actionpack/test/controller/request/test_request_test.rb
+++ b/actionpack/test/controller/request/test_request_test.rb
@@ -6,6 +6,11 @@ class ActionController::TestRequestTest < ActionController::TestCase
     assert @request.session_options
   end
 
+  def test_mutating_session_options_does_not_affect_default_options
+    @request.session_options[:myparam] = 123
+    assert_equal nil, ActionController::TestSession::DEFAULT_OPTIONS[:myparam]
+  end
+
   ActionDispatch::Session::AbstractStore::DEFAULT_OPTIONS.each_key do |option|
     test "rack default session options #{option} exists in session options and is default" do
       assert_equal(ActionDispatch::Session::AbstractStore::DEFAULT_OPTIONS[option],


### PR DESCRIPTION
Long story short: at Shopify, I've been hunting the reason why `ActionDispatch::IntegrationTest`-backed tests always fails when it's executed after any controller test.

In our app controllers, we modify `request.session_options` a lot to store metadata.
I found that the Rails 5 implementation of `ActionController::TestCase` is assigning `session_options` from `TestSession::DEFAULT_OPTIONS`, which originally comes from Rack: https://github.com/rack/rack/blob/master/lib/rack/session/abstract/id.rb#L191

In this case, every time you manipulate `request.session_options`, `ActionController::TestSession::DEFAULT_OPTIONS` gets mutated ( 😱 ). As a result, `Rack::Session::Abstract::Persisted::DEFAULT_OPTIONS` got mutated as well.
Writing to `session_options` from controller test made integration test inherit that value and everything broke.

I've also sent a PR to Rack to avoid the issue in future: https://github.com/rack/rack/pull/1110
We should `dup` it to avoid the issue.

review @rafaelfranca 
