### PR TITLE
Use :git for specifying dependencies from github with https protocol

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,10 +25,10 @@ gem "bcrypt", "~> 3.1.11", require: false
 gem "uglifier", ">= 1.3.0", require: false
 
 # Track stable branch of sass because it doesn't have circular require warnings.
-gem "sass", github: "sass/sass", branch: "stable", require: false
+gem "sass", git: "https://github.com/sass/sass", branch: "stable", require: false
 
 # FIXME: Remove this fork after https://github.com/nex3/rb-inotify/pull/49 is fixed.
-gem "rb-inotify", github: "matthewd/rb-inotify", branch: "close-handling", require: false
+gem "rb-inotify", git: "https://github.com/matthewd/rb-inotify", branch: "close-handling", require: false
 
 group :doc do
   gem "sdoc", "~> 0.4.0"
@@ -43,19 +43,19 @@ gem "listen", "~> 3.0.5", require: false
 
 # Active Job.
 group :job do
-  gem "resque", github: "resque/resque", require: false
+  gem "resque", git: "https://github.com/resque/resque", require: false
   gem "resque-scheduler", require: false
   gem "sidekiq", require: false
   gem "sucker_punch", require: false
-  gem "delayed_job", require: false, github: "collectiveidea/delayed_job"
-  gem "queue_classic", github: "QueueClassic/queue_classic", branch: "master", require: false, platforms: :ruby
+  gem "delayed_job", require: false, git: "https://github.com/collectiveidea/delayed_job"
+  gem "queue_classic", git: "https://github.com/QueueClassic/queue_classic", branch: "master", require: false, platforms: :ruby
   gem "sneakers", require: false
   gem "que", require: false
   gem "backburner", require: false
   #TODO: add qu after it support Rails 5.1
   # gem 'qu-rails', github: "bkeepers/qu", branch: "master", require: false
   gem "qu-redis", require: false
-  gem "delayed_job_active_record", require: false, github: "collectiveidea/delayed_job_active_record"
+  gem "delayed_job_active_record", require: false, git: "https://github.com/collectiveidea/delayed_job_active_record"
   gem "sequel", require: false
 end
 
@@ -109,10 +109,10 @@ end
 
 platforms :jruby do
   if ENV["AR_JDBC"]
-    gem "activerecord-jdbcsqlite3-adapter", github: "jruby/activerecord-jdbc-adapter", branch: "master"
+    gem "activerecord-jdbcsqlite3-adapter", git: "https://github.com/jruby/activerecord-jdbc-adapter", branch: "master"
     group :db do
-      gem "activerecord-jdbcmysql-adapter", github: "jruby/activerecord-jdbc-adapter", branch: "master"
-      gem "activerecord-jdbcpostgresql-adapter", github: "jruby/activerecord-jdbc-adapter", branch: "master"
+      gem "activerecord-jdbcmysql-adapter", git: "https://github.com/jruby/activerecord-jdbc-adapter", branch: "master"
+      gem "activerecord-jdbcpostgresql-adapter", git: "https://github.com/jruby/activerecord-jdbc-adapter", branch: "master"
     end
   else
     gem "activerecord-jdbcsqlite3-adapter", ">= 1.3.0"
@@ -134,7 +134,7 @@ if ENV["ORACLE_ENHANCED"]
   platforms :ruby do
     gem "ruby-oci8", "~> 2.2"
   end
-  gem "activerecord-oracle_enhanced-adapter", github: "rsim/oracle-enhanced", branch: "master"
+  gem "activerecord-oracle_enhanced-adapter", git: "https://github.com/rsim/oracle-enhanced", branch: "master"
 end
 
 # A gem necessary for Active Record tests with IBM DB.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/QueueClassic/queue_classic.git
+  remote: https://github.com/QueueClassic/queue_classic
   revision: c26f2c9f6f6133b946fbcdd7b7ec905a4aca9f94
   branch: master
   specs:
@@ -7,14 +7,14 @@ GIT
       pg (>= 0.17, < 0.19)
 
 GIT
-  remote: git://github.com/collectiveidea/delayed_job.git
+  remote: https://github.com/collectiveidea/delayed_job
   revision: 71f1d5faf934d3057abca942f0d410327bc69087
   specs:
     delayed_job (4.1.1)
       activesupport (>= 3.0, < 5.1)
 
 GIT
-  remote: git://github.com/collectiveidea/delayed_job_active_record.git
+  remote: https://github.com/collectiveidea/delayed_job_active_record
   revision: 61e688e03b2ef4004b08de6d1e0a123fda8fffad
   specs:
     delayed_job_active_record (4.1.0)
@@ -22,7 +22,7 @@ GIT
       delayed_job (>= 3.0, < 5)
 
 GIT
-  remote: git://github.com/matthewd/rb-inotify.git
+  remote: https://github.com/matthewd/rb-inotify
   revision: 90553518d1fb79aedc98a3036c59bd2b6731ac40
   branch: close-handling
   specs:
@@ -30,7 +30,7 @@ GIT
       ffi (>= 0.5.0)
 
 GIT
-  remote: git://github.com/resque/resque.git
+  remote: https://github.com/resque/resque
   revision: 06036388ec61e573c761ac5a25a2ef3c76537ec7
   specs:
     resque (1.27.0)
@@ -41,7 +41,7 @@ GIT
       vegas (~> 0.1.2)
 
 GIT
-  remote: git://github.com/sass/sass.git
+  remote: https://github.com/sass/sass
   revision: 3fda1cbe70d615e7ef96e28db4fd1f8a3ebb5505
   branch: stable
   specs:


### PR DESCRIPTION
### Summary
- This is required for bundler 1.13.0 because of which lot of specs are
  failing on Travis CI.
- Similar to https://travis-ci.org/rails/rails/jobs/158905576#L559
