### PR TITLE
Remove unnecessary `target.uniq.size` in `CollectionAssociation#size`

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -222,11 +222,7 @@ module ActiveRecord
       # +count_records+, which is a method descendants have to provide.
       def size
         if !find_target? || loaded?
-          if association_scope.distinct_value
-            target.uniq.size
-          else
-            target.size
-          end
+          target.size
         elsif !association_scope.group_values.empty?
           load_target.size
         elsif !association_scope.distinct_value && target.is_a?(Array)


### PR DESCRIPTION
If `association_scope` have `distinct_value`, same record cannot exist
in `target`.

https://github.com/rails/rails/blob/v5.0.0/activerecord/lib/active_record/associations/collection_association.rb#L419-L424

``` ruby
      def add_to_target(record, skip_callbacks = false, &block)
        if association_scope.distinct_value
          index = @target.index(record)
        end
        replace_on_target(record, index, skip_callbacks, &block)
      end
```
