### PR TITLE
Remove unused `require "thread"` in `test/cases/attribute_methods/read_test.rb`

### DIFF
--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -1,5 +1,4 @@
 require "cases/helper"
-require "thread"
 
 module ActiveRecord
   module AttributeMethods


### PR DESCRIPTION
`Mutex` was removed at 8eb7561ac6e8f020ec09608532de310c6b0b8dcd.
