### PR TITLE
Add tests for ActiveRecord::Enum#enum when suffix specified

### DIFF
--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -18,6 +18,7 @@ class EnumTest < ActiveRecord::TestCase
     assert @book.author_visibility_visible?
     assert @book.illustrator_visibility_visible?
     assert @book.with_medium_font_size?
+    assert @book.medium_to_read?
   end
 
   test "query state with strings" do
@@ -26,6 +27,7 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal "english", @book.language
     assert_equal "visible", @book.author_visibility
     assert_equal "visible", @book.illustrator_visibility
+    assert_equal "medium", @book.difficulty
   end
 
   test "find via scope" do
@@ -34,6 +36,7 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal @book, Book.in_english.first
     assert_equal @book, Book.author_visibility_visible.first
     assert_equal @book, Book.illustrator_visibility_visible.first
+    assert_equal @book, Book.medium_to_read.first
   end
 
   test "find via where with values" do
@@ -420,6 +423,43 @@ class EnumTest < ActiveRecord::TestCase
     assert @book.in_english?
     assert_not @book.in_spanish?
     assert_not @book.in_french?
+  end
+
+  test "query state by predicate with custom suffix" do
+    assert     @book.medium_to_read?
+    assert_not @book.easy_to_read?
+    assert_not @book.hard_to_read?
+  end
+
+  test "enum methods with custom suffix defined" do
+    assert @book.class.respond_to?(:easy_to_read)
+    assert @book.class.respond_to?(:medium_to_read)
+    assert @book.class.respond_to?(:hard_to_read)
+
+    assert @book.respond_to?(:easy_to_read?)
+    assert @book.respond_to?(:medium_to_read?)
+    assert @book.respond_to?(:hard_to_read?)
+
+    assert @book.respond_to?(:easy_to_read!)
+    assert @book.respond_to?(:medium_to_read!)
+    assert @book.respond_to?(:hard_to_read!)
+  end
+
+  test "update enum attributes with custom suffix" do
+    @book.medium_to_read!
+    assert_not @book.easy_to_read?
+    assert     @book.medium_to_read?
+    assert_not @book.hard_to_read?
+
+    @book.easy_to_read!
+    assert     @book.easy_to_read?
+    assert_not @book.medium_to_read?
+    assert_not @book.hard_to_read?
+
+    @book.hard_to_read!
+    assert_not @book.easy_to_read?
+    assert_not @book.medium_to_read?
+    assert     @book.hard_to_read?
   end
 
   test "uses default status when no status is provided in fixtures" do

--- a/activerecord/test/fixtures/books.yml
+++ b/activerecord/test/fixtures/books.yml
@@ -9,6 +9,7 @@ awdr:
   author_visibility: :visible
   illustrator_visibility: :visible
   font_size: :medium
+  difficulty: :medium
 
 rfr:
   author_id: 1

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -14,6 +14,7 @@ class Book < ActiveRecord::Base
   enum author_visibility: [:visible, :invisible], _prefix: true
   enum illustrator_visibility: [:visible, :invisible], _prefix: true
   enum font_size: [:small, :medium, :large], _prefix: :with, _suffix: true
+  enum difficulty: [:easy, :medium, :hard], _suffix: :to_read
   enum cover: { hard: "hard", soft: "soft" }
 
   def published!

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define do
     t.column :author_visibility, :integer, default: 0
     t.column :illustrator_visibility, :integer, default: 0
     t.column :font_size, :integer, default: 0
+    t.column :difficulty, :integer, default: 0
     t.column :cover, :string, default: "hard"
   end
 


### PR DESCRIPTION
### Summary

Add some tests when `ActiveRecord::Enum#enum` called with specific suffix since there was none.
### Other Information

Additional tests are testing:
-  class method(scope) is defined and working
-  instance methods are defined and working such as
  - `object#enum_name` returns its attribute in string
  -  `#hogehoge!` to update
  - `#hogehoge?` to predicate
