### PR TITLE
remove duplicated fixture set names

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -902,7 +902,7 @@ module ActiveRecord
 
       def fixtures(*fixture_set_names)
         if fixture_set_names.first == :all
-          fixture_set_names = Dir["#{fixture_path}/{**,*}/*.{yml}"]
+          fixture_set_names = Dir["#{fixture_path}/{**,*}/*.{yml}"].uniq
           fixture_set_names.map! { |f| f[(fixture_path.to_s.size + 1)..-5] }
         else
           fixture_set_names = fixture_set_names.flatten.map(&:to_s)

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -728,7 +728,7 @@ class LoadAllFixturesTest < ActiveRecord::TestCase
     self.class.fixtures :all
 
     if File.symlink? FIXTURES_ROOT + "/all/admin"
-      assert_equal %w(admin/accounts admin/users developers people tasks), fixture_table_names.sort
+      assert_equal %w(admin/accounts admin/users developers namespaced/accounts people tasks), fixture_table_names.sort
     end
   ensure
     ActiveRecord::FixtureSet.reset_cache
@@ -741,7 +741,7 @@ class LoadAllFixturesWithPathnameTest < ActiveRecord::TestCase
     self.class.fixtures :all
 
     if File.symlink? FIXTURES_ROOT + "/all/admin"
-      assert_equal %w(admin/accounts admin/users developers people tasks), fixture_table_names.sort
+      assert_equal %w(admin/accounts admin/users developers namespaced/accounts people tasks), fixture_table_names.sort
     end
   ensure
     ActiveRecord::FixtureSet.reset_cache

--- a/activerecord/test/fixtures/all/namespaced/accounts.yml
+++ b/activerecord/test/fixtures/all/namespaced/accounts.yml
@@ -1,0 +1,2 @@
+signals37:
+  name: 37signals


### PR DESCRIPTION
If using namespaced fixtures, get following Ruby warning.

```
activerecord/lib/active_record/fixtures.rb:922: warning: method redefined; discarding old admin_foos
activerecord/lib/active_record/fixtures.rb:922: warning: previous definition of admin_foos was here
```

This is happening because of the multiple set the same path when setting the
fixture name. Fix to remove the duplicate path.
