### PR TITLE
Convert column_name to string while detecting binds

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -83,7 +83,7 @@ module ActiveRecord
 
       def column_for(table_name, column_name, alias_tracker)
         columns = alias_tracker.connection.schema_cache.columns_hash(table_name)
-        columns[column_name]
+        columns[column_name.to_s]
       end
 
       def bind_value(scope, column, value, alias_tracker)
@@ -100,7 +100,7 @@ module ActiveRecord
         key = join_keys.key
         foreign_key = join_keys.foreign_key
 
-        bind_val = bind scope, table.table_name, key.to_s, owner[foreign_key], tracker
+        bind_val = bind scope, table.table_name, key, owner[foreign_key], tracker
         scope    = scope.where(table[key].eq(bind_val))
 
         if reflection.type


### PR DESCRIPTION
### Summary

If you specify `foreign_type` with Symbol for polymorphic association, binds will be corrupted for the type column.
I noticed strange `nil` value instead of `"owner_type"` in logs, so I decided to find out what caused this behavior. 
`SELECT "addresses".* FROM "addresses" WHERE "addresses"."owner_id" = $1 AND "addresses"."owner_type" = $2  [["owner_id", 9845], [nil, "Customer"]]`

I found out that method `column_for` was called with `reflection.type` aka `foreign_type` (Symbol) attribute from `last_chain_scope` method, but the `alias_tracker.connection.schema_cache.columns_hash` used Hash with String keys and returned nil.
This was the reason why binds was corrupted: `[["owner_id", 1], [nil, "Customer"]]` instead of `[["owner_id", 1], ["owner_type", "Customer"]]`
ActiveRecord logger used this values through ActiveSupport::Notifications.
### Other Information

I open PR to 4-2-stable branch because this part of AssociationScope was rewritten in Rails 5.
