### PR TITLE
remove useless `gemfile` option

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -117,11 +117,6 @@ module TestHelpers
         end
       end
 
-      gemfile_path = "#{app_path}/Gemfile"
-      if options[:gemfile].blank? && File.exist?(gemfile_path)
-        File.delete gemfile_path
-      end
-
       routes = File.read("#{app_path}/config/routes.rb")
       if routes =~ /(\n\s*end\s*)\Z/
         File.open("#{app_path}/config/routes.rb", "w") do |f|


### PR DESCRIPTION
Rails application for test creates with `--skip-gemfile` option.
https://github.com/rails/rails/blob/master/railties/test/isolation/abstract_unit.rb#L333

Therefore, regardless of the option, Gemfile is not created.
