### PR TITLE
fixes - Only first object saved in has_many with accepts_nested_attributes_for on both sides #26358

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -380,8 +380,9 @@ module ActiveRecord
       def save_collection_association(reflection)
         if association = association_instance_get(reflection.name)
           autosave = reflection.options[:autosave]
+          new_record_before_save_flag = @new_record_before_save
 
-          if records = associated_records_to_validate_or_save(association, @new_record_before_save, autosave)
+          if records = associated_records_to_validate_or_save(association, new_record_before_save_flag, autosave)
             if autosave
               records_to_destroy = records.select(&:marked_for_destruction?)
               records_to_destroy.each { |record| association.destroy(record) }
@@ -393,7 +394,7 @@ module ActiveRecord
 
               saved = true
 
-              if autosave != false && (@new_record_before_save || record.new_record?)
+              if autosave != false && (new_record_before_save_flag || record.new_record?)
                 if autosave
                   saved = association.insert_record(record, false)
                 else

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -9,6 +9,7 @@ require "models/man"
 require "models/interest"
 require "models/owner"
 require "models/pet"
+require "models/zine"
 require "active_support/hash_with_indifferent_access"
 
 class TestNestedAttributesInGeneral < ActiveRecord::TestCase
@@ -172,6 +173,17 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     interest = man.interests.create(topic: "photography")
     man.update(interests_attributes: { topic: "gardening", id: interest.id })
     assert_equal "gardening", interest.reload.topic
+  end
+
+  def test_has_many_inverse_of_should_save_all_associated_records
+    zine = Zine.new
+    zine.interests << Interest.create(topic: "photography")
+    zine.interests << Interest.create(topic: "IoT")
+    zine.interests << Interest.create(topic: "3D printing")
+
+    zine.save!
+
+    assert_equal 3, zine.interests.count
   end
 
   def test_reject_if_with_blank_nested_attributes_id

--- a/activerecord/test/models/interest.rb
+++ b/activerecord/test/models/interest.rb
@@ -2,4 +2,6 @@ class Interest < ActiveRecord::Base
   belongs_to :man, inverse_of: :interests
   belongs_to :polymorphic_man, polymorphic: true, inverse_of: :polymorphic_interests
   belongs_to :zine, inverse_of: :interests
+
+  accepts_nested_attributes_for :zine
 end

--- a/activerecord/test/models/zine.rb
+++ b/activerecord/test/models/zine.rb
@@ -1,3 +1,4 @@
 class Zine < ActiveRecord::Base
   has_many :interests, inverse_of: :zine
+  accepts_nested_attributes_for :interests
 end


### PR DESCRIPTION
### Summary

This PR fixes issue #26358.  I found that `@new_record_before_save` was getting reset to false after first record was saved.
