### PR TITLE
5-0-backport: activerecord/mysql2: Avoid setting @connection to nil, just close it

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Using a mysql2 connection after it fails to reconnect will now have an error message
+    saying the connection is closed rather than an undefined method error message.
+
+    *Dylan Thacker-Smith*
+
 *   Remove unnecessarily association load when a `belongs_to` association has already been
     loaded then the foreign key is changed directly and the record saved.
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -24,11 +24,9 @@ module ActiveRecord
 
         # Executes the SQL statement in the context of this connection.
         def execute(sql, name = nil)
-          if @connection
-            # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been
-            # made since we established the connection
-            @connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
-          end
+          # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been
+          # made since we established the connection
+          @connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
 
           super
         end
@@ -71,11 +69,9 @@ module ActiveRecord
         end
 
         def exec_stmt_and_free(sql, name, binds, cache_stmt: false)
-          if @connection
-            # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been
-            # made since we established the connection
-            @connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
-          end
+          # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been
+          # made since we established the connection
+          @connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
 
           type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -90,7 +90,6 @@ module ActiveRecord
       #++
 
       def active?
-        return false unless @connection
         @connection.ping
       end
 
@@ -105,10 +104,7 @@ module ActiveRecord
       # Otherwise, this method does nothing.
       def disconnect!
         super
-        unless @connection.nil?
-          @connection.close
-          @connection = nil
-        end
+        @connection.close
       end
 
       private

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -63,6 +63,27 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
     assert @connection.active?
   end
 
+  def test_execute_after_disconnect
+    @connection.disconnect!
+    error = assert_raise(ActiveRecord::StatementInvalid) do
+      @connection.execute("SELECT 1")
+    end
+    assert_match /closed MySQL connection/, error.message
+  end
+
+  def test_quote_after_disconnect
+    @connection.disconnect!
+    error = assert_raise(Mysql2::Error) do
+      @connection.quote("string")
+    end
+    assert_match /closed MySQL connection/, error.message
+  end
+
+  def test_active_after_disconnect
+    @connection.disconnect!
+    assert_equal false, @connection.active?
+  end
+
   def test_mysql_connection_collation_is_configured
     assert_equal 'utf8_unicode_ci', @connection.show_variable('collation_connection')
     assert_equal 'utf8_general_ci', ARUnit2Model.connection.show_variable('collation_connection')


### PR DESCRIPTION
@rafaelfranca, @arthurnn please review

Backport #26434 for the 5-0-stable branch
