### PR TITLE
Improve assert_response helper

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -79,7 +79,12 @@ module ActionDispatch
         def generate_response_message(expected, actual = @response.response_code)
           "Expected response to be a <#{code_with_name(expected)}>,"\
           " but was a <#{code_with_name(actual)}>"
-          .concat location_if_redirected
+            .concat(location_if_redirected).concat(response_body_if_short)
+        end
+
+        def response_body_if_short
+          return "" if @response.body.size > 500
+          "\nResponse body: #{@response.body}"
         end
 
         def location_if_redirected


### PR DESCRIPTION
When the assertion is failed, print the actual response body if it's not too large.
This could improve productivity when writing new tests.

Before:

```
ThemeEditorIntegrationTest#test_whatever
    Expected response to be a <200: ok>, but was a <422: Unprocessable Entity>.
Expected: 200
  Actual: 422
```

After:

```
ThemeEditorIntegrationTest#test_whatever
    Expected response to be a <200: ok>, but was a <422: Unprocessable Entity>.
Expected: 200
  Actual: 422
Response body: {"errors":["Invalid settings object for section '1'"]}
```
