### PR TITLE
Clarify that mattr_* creates public methods

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
@@ -8,6 +8,8 @@ class Module
   # Defines a class attribute and creates a class and instance reader methods.
   # The underlying class variable is set to +nil+, if it is not previously
   # defined.
+  # Note: Both methods will be public even if this method is called from
+  # inside a private or protected block.
   #
   #   module HairColors
   #     mattr_reader :hair_colors
@@ -77,6 +79,8 @@ class Module
 
   # Defines a class attribute and creates a class and instance writer methods to
   # allow assignment to the attribute.
+  # Note: Both methods will be public even if this method is called from
+  # inside a private or protected block.
   #
   #   module HairColors
   #     mattr_writer :hair_colors
@@ -142,6 +146,8 @@ class Module
   alias :cattr_writer :mattr_writer
 
   # Defines both class and instance accessors for class attributes.
+  # Note: All methods will be public even if this method is called from
+  # inside a private or protected block.
   #
   #   module HairColors
   #     mattr_accessor :hair_colors

--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
@@ -7,9 +7,8 @@ require "active_support/core_ext/regexp"
 class Module
   # Defines a class attribute and creates a class and instance reader methods.
   # The underlying class variable is set to +nil+, if it is not previously
-  # defined.
-  # Note: Both methods will be public even if this method is called from
-  # inside a private or protected block.
+  # defined. All class and instance methods created will be public, even if
+  # this method is called with a private or protected access modifier.
   #
   #   module HairColors
   #     mattr_reader :hair_colors
@@ -78,9 +77,9 @@ class Module
   alias :cattr_reader :mattr_reader
 
   # Defines a class attribute and creates a class and instance writer methods to
-  # allow assignment to the attribute.
-  # Note: Both methods will be public even if this method is called from
-  # inside a private or protected block.
+  # allow assignment to the attribute. All class and instance methods created
+  # will be public, even if this method is called with a private or protected
+  # access modifier.
   #
   #   module HairColors
   #     mattr_writer :hair_colors
@@ -146,8 +145,8 @@ class Module
   alias :cattr_writer :mattr_writer
 
   # Defines both class and instance accessors for class attributes.
-  # Note: All methods will be public even if this method is called from
-  # inside a private or protected block.
+  # All class and instance methods created will be public, even if
+  # this method is called with a private or protected access modifier.
   #
   #   module HairColors
   #     mattr_accessor :hair_colors


### PR DESCRIPTION
### Summary

I was surprised when a call to mattr_accessor inside a private block created a public method. This seems to be by design, however was not mentioned anywhere in the docs.
See https://github.com/rails/rails/issues/26461 for more information.
