### PR TITLE
Address warning: ambiguous first argument

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -68,7 +68,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
     error = assert_raise(ActiveRecord::StatementInvalid) do
       @connection.execute("SELECT 1")
     end
-    assert_match /closed MySQL connection/, error.message
+    assert_match(/closed MySQL connection/, error.message)
   end
 
   def test_quote_after_disconnect
@@ -76,7 +76,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
     error = assert_raise(Mysql2::Error) do
       @connection.quote("string")
     end
-    assert_match /closed MySQL connection/, error.message
+    assert_match(/closed MySQL connection/, error.message)
   end
 
   def test_active_after_disconnect


### PR DESCRIPTION
### Summary

This pull request addresses two  `warning: ambiguous first argument; put parentheses or a space even after `/' operator`  warnings:

``` ruby
$ ARCONN=mysql2 bundle exec ruby -w -Itest test/cases/adapters/mysql2/connection_test.rb
test/cases/adapters/mysql2/connection_test.rb:71: warning: ambiguous first argument; put parentheses or a space even after `/' operator
test/cases/adapters/mysql2/connection_test.rb:79: warning: ambiguous first argument; put parentheses or a space even after `/' operator
Using mysql2
Run options: --seed 14025

# Running:

.....................

Finished in 6.240082s, 3.3653 runs/s, 5.7692 assertions/s.

21 runs, 36 assertions, 0 failures, 0 errors, 0 skips
```
