### PR TITLE
Escape colon in conditional strings with placeholders

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Colons in conditions with placeholders can be escaped with `%`.
+
+    *Ilya Smelkov*
+
 *   Using a mysql2 connection after it fails to reconnect will now have an error message
     saying the connection is closed rather than an undefined method error message.
 

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -178,9 +178,11 @@ module ActiveRecord
         end
 
         def replace_named_bind_variables(statement, bind_vars) # :nodoc:
-          statement.gsub(/(:?):([a-zA-Z]\w*)/) do |match|
+          statement.gsub(/(:|%)?:([a-zA-Z]\w*)/) do |match|
             if $1 == ":" # skip postgresql casts
               match # return the whole match
+            elsif $1 == "%" # skip escape char
+              match[1..-1] # return match including leading colon
             elsif bind_vars.include?(match = $2.to_sym)
               replace_bind_variable(bind_vars[match])
             else

--- a/activerecord/test/cases/sanitize_test.rb
+++ b/activerecord/test/cases/sanitize_test.rb
@@ -165,6 +165,12 @@ class SanitizeTest < ActiveRecord::TestCase
     assert_equal "#{ActiveRecord::Base.connection.quote('10')}::integer '2009-01-01'::date", l.call
   end
 
+  def test_named_bind_with_escaped_colon
+    l = Proc.new { bind("attrs->>'user%:age' = :age", age: 10) }
+    assert_nothing_raised(&l)
+    assert_equal "attrs->>'user:age' = 10", l.call
+  end
+
   private
     def bind(statement, *vars)
       if vars.first.is_a?(Hash)

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -483,6 +483,12 @@ Client.where("created_at >= :start_date AND created_at <= :end_date",
 
 This makes for clearer readability if you have a large number of variable conditions.
 
+In case you need to escape a colon in your conditions string you can do it with `%`:
+
+```ruby
+User.where("login = :login OR login = '%:fake'", {login: params[:login]})
+```
+
 ### Hash Conditions
 
 Active Record also allows you to pass in hash conditions which can increase the readability of your conditions syntax. With hash conditions, you pass in a hash with keys of the fields you want qualified and the values of how you want to qualify them:


### PR DESCRIPTION
### Summary

In conditions strings with hash params there is no way to escape a colon that looks like a placeholder:

``` ruby
where("params->>'namescape:key' = :foo", foo: 'bar'")
```

This will fail because `:key` is considered as a placeholder. This PR allows to ignore such cases and replace only desired placeholders. To do this prepend it with `%`, example:

``` ruby
where("params->>'namescape%:key' = :foo", foo: 'bar'")
```
### Other Information

The most obvious char for escaping the colon would be `:` like `::`, but this is postgresql's typecasting operator, so it's already taken. And having one more colon `:::key` seems odd.

Another option is to escape like `\:` but in double quotes in ruby there is no need to escape a colon, so ruby wipes it out `"\:" == ":"`. Meanwhile, in single quotes it's fine, `'\:' == "\\:"` and to me it's frustrating that changing quotes from single to double can break my query.

So, I suggest to do it in a manner of `sprintf`: `%%s` -> `%s`
