### PR TITLE
Clear attribute changes after handling locking

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Calling `touch` on a model using optimistic locking will now leave the model
+    in a non-dirty state with no attribute changes.
+
+    Fixes #26496.
+
+    *Jakob Skjerning*
+
 *   Using a mysql2 connection after it fails to reconnect will now have an error message
     saying the connection is closed rather than an undefined method error message.
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -498,7 +498,6 @@ module ActiveRecord
           changes[column] = write_attribute(column, time)
         end
 
-        clear_attribute_changes(changes.keys)
         primary_key = self.class.primary_key
         scope = self.class.unscoped.where(primary_key => _read_attribute(primary_key))
 
@@ -508,6 +507,7 @@ module ActiveRecord
           changes[locking_column] = increment_lock
         end
 
+        clear_attribute_changes(changes.keys)
         result = scope.update_all(changes) == 1
 
         if !result && locking_enabled?

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -181,6 +181,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
 
     p1.touch
     assert_equal 1, p1.lock_version
+    assert_not p1.changed?, "Changes should have been cleared"
   end
 
   def test_touch_stale_object


### PR DESCRIPTION
Calling `touch` on a model using optimistic locking will now leave the model in a non-dirty state with no attribute changes. Without this the changes to the lock version column would stick around even after `touch` returns.

Fixes #26496.

Before:

```
model.touch
model.changes
# => {"lock_version"=>[0, "1"]}
```

With this pull request:

```
model.touch
model.changes
# => {}
```

I suspect the previous was accidentally introduced in commit 5e8d96c5234d3f378f9048bf6c0077bb1139ce9a.
