### PR TITLE
Correct `render text:` deprecation message

### DIFF
--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -90,7 +90,7 @@ module ActionController
           render as `text/plain`, `render html: '<strong>HTML</strong>'` to
           render as `text/html`, or `render body: 'raw'` to match the deprecated
           behavior and render with the default Content-Type, which is
-          `text/plain`.
+          `text/html`.
         WARNING
         end
 


### PR DESCRIPTION
### Summary

This message warns against using `render text:` "because it does not render `text/plain` as you would expect, it uses the default Content-Type, which is `text/plain`"

This is a typo, it should say `text/html` which is the default Content-Type.
