### PR TITLE
Change Hash#transform_values to return a Hash instance for subclasses of Hash

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/transform_values.rb
+++ b/activesupport/lib/active_support/core_ext/hash/transform_values.rb
@@ -10,8 +10,7 @@ class Hash
   #   { a: 1, b: 2 }.transform_values.with_index { |v, i| [v, i].join.to_i } # => { a: 10, b: 21 }
   def transform_values
     return enum_for(:transform_values) { size } unless block_given?
-    return {} if empty?
-    result = self.class.new
+    result = {}
     each do |key, value|
       result[key] = yield(value)
     end

--- a/activesupport/test/core_ext/hash/transform_values_test.rb
+++ b/activesupport/test/core_ext/hash/transform_values_test.rb
@@ -19,12 +19,20 @@ class TransformValuesTest < ActiveSupport::TestCase
     assert_same original, mapped
   end
 
-  test "indifferent access is still indifferent after mapping values" do
-    original = { a: "a", b: "b" }.with_indifferent_access
-    mapped = original.transform_values { |v| v + "!" }
+  test "transform_values returns a Hash instance when self is inherited from Hash" do
+    class HashDescendant < ::Hash
+      def initialize(elements = nil)
+        super(elements)
+        (elements || {}).each_pair { |key, value| self[key] = value }
+      end
+    end
 
-    assert_equal "a!", mapped[:a]
-    assert_equal "a!", mapped["a"]
+    original = HashDescendant.new(a: "a", b: "b")
+    mapped = original.transform_values { |v| v.to_sym }
+
+    assert_equal({ a: "a", b: "b" }, original)
+    assert_equal({ a: :a, b: :b }, mapped)
+    assert_equal(::Hash, mapped.class)
   end
 
   # This is to be consistent with the behavior of Ruby's built in methods


### PR DESCRIPTION
### Summary

In #24517, `Hash#transform_keys' returns a`Hash`instance. Then, I think that`Hash#transform_values` should do the same.

Additionally, when it is empty, `Hash#transform_keys' already returns`{}`.
