### PR TITLE
Use size instead of count

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -127,7 +127,7 @@ module ActionDispatch
           File.open(full_path, "r") do |file|
             start = [line - 3, 0].max
             lines = file.each_line.drop(start).take(6)
-            Hash[*(start+1..(lines.count+start)).zip(lines).flatten]
+            Hash[*(start+1..(lines.size+start)).zip(lines).flatten]
           end
         end
       end

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -135,7 +135,7 @@ module ActionView
               fyear += 1 if from_time.month >= 3
               tyear = to_time.year
               tyear -= 1 if to_time.month < 3
-              leap_years = (fyear > tyear) ? 0 : (fyear..tyear).count { |x| Date.leap?(x) }
+              leap_years = (fyear > tyear) ? 0 : (fyear..tyear).size { |x| Date.leap?(x) }
               minute_offset_for_leap_year = leap_years * 1440
               # Discount the leap year days when calculating year distance.
               # e.g. if there are 20 leap year days between 2 dates having the same day

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -135,7 +135,7 @@ module ActionView
               fyear += 1 if from_time.month >= 3
               tyear = to_time.year
               tyear -= 1 if to_time.month < 3
-              leap_years = (fyear > tyear) ? 0 : (fyear..tyear).size { |x| Date.leap?(x) }
+              leap_years = (fyear > tyear) ? 0 : (fyear..tyear).count { |x| Date.leap?(x) }
               minute_offset_for_leap_year = leap_years * 1440
               # Discount the leap year days when calculating year distance.
               # e.g. if there are 20 leap year days between 2 dates having the same day


### PR DESCRIPTION
### Summary

changes a single usage of `.count` to `.size` which is more efficient, and conventional

note: I screwed this up in a previous PR, and was burned super hard.... https://github.com/rails/rails/pull/26504

```
[8] pry(main)> Benchmark.bmbm do |x|
[8] pry(main)*   x.report('size') { (1..20000).size }
[8] pry(main)*   x.report('count') { (1..20000).count }
[8] pry(main)* end
Rehearsal -----------------------------------------
size    0.000000   0.000000   0.000000 (  0.000004)
count   0.000000   0.000000   0.000000 (  0.000388)
-------------------------------- total: 0.000000sec

            user     system      total        real
size    0.000000   0.000000   0.000000 (  0.000004)
count   0.000000   0.000000   0.000000 (  0.000349)
```
