### PR TITLE
Update ActiveModel::Dirty Doc [ci skip]

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -58,7 +58,7 @@ module ActiveModel
   #
   # A newly instantiated +Person+ object is unchanged:
   #
-  #   person = Person.new("Uncle Bob")
+  #   person = Person.new
   #   person.changed? # => false
   #
   # Change the name:


### PR DESCRIPTION
This is a small fix to a potentially misleading example. Reading the documentation I thought that dirty attributes weren't triggered when passing attributes on initialization. Since this isn't the case and the example isn't even a valid way to pass attributes, I removed it.
