### PR TITLE
Rename test to match what it does

### DIFF
--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1808,7 +1808,7 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
-  def test_form_for_with_symbol_object_name
+  def test_form_for_with_symbol_as
     form_for(@post, as: "other_name", html: { id: "create-post" }) do |f|
       concat f.label(:title, class: "post_title")
       concat f.text_field(:title)


### PR DESCRIPTION
Commit d270da569 changed the `form_for` API from `:object_name` to `:as`.
It also change the related test body, but not its title, which is changed here.

See https://github.com/rails/rails/commit/d270da569efeabd7cd563028816452236713aa9f#diff-52455f1e82acf12551bc5e7e26b82008

I realize this is a small commit but I was having trouble understanding what
the test was about since there is no "object_name" in the code.
I imagine the same may happen to other developers, therefore this commit.
