### PR TITLE
move frozen-string-literal to end of file

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -1,5 +1,3 @@
-# -*- frozen-string-literal: true -*-
-
 require "singleton"
 require "active_support/core_ext/module/attribute_accessors"
 require "active_support/core_ext/string/starts_ends_with"
@@ -363,3 +361,4 @@ module Mime
 end
 
 require "action_dispatch/http/mime_types"
+# -*- frozen-string-literal: true -*-


### PR DESCRIPTION
### Summary

Move the magic comment to the end of the file to stop confuse `linguist` from detecting the file as a ruby file. Just eye candy.. You can see the screenshots on the linguist issue.

Related issue: https://github.com/github/linguist/issues/3226

I'd use `# frozen_string_literal: true` but that's only possible when using `>= ruby 2.3.0`
