### PR TITLE
Update ActiveModel::Dirty Doc to be simpler to understand

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -26,8 +26,8 @@ module ActiveModel
   #
   #     define_attribute_methods :name
   #
-  #     def initialize(name)
-  #       @name = name
+  #     def initialize
+  #       @name = nil
   #     end
   #
   #     def name
@@ -66,11 +66,11 @@ module ActiveModel
   #   person.name = 'Bob'
   #   person.changed?       # => true
   #   person.name_changed?  # => true
-  #   person.name_changed?(from: "Uncle Bob", to: "Bob") # => true
-  #   person.name_was       # => "Uncle Bob"
-  #   person.name_change    # => ["Uncle Bob", "Bob"]
+  #   person.name_changed?(from: nil, to: "Bob") # => true
+  #   person.name_was       # => nil
+  #   person.name_change    # => [nil, "Bob"]
   #   person.name = 'Bill'
-  #   person.name_change    # => ["Uncle Bob", "Bill"]
+  #   person.name_change    # => [nil, "Bill"]
   #
   # Save the changes:
   #
@@ -80,9 +80,9 @@ module ActiveModel
   #
   # Reset the changes:
   #
-  #   person.previous_changes         # => {"name" => ["Uncle Bob", "Bill"]}
+  #   person.previous_changes         # => {"name" => [nil, "Bill"]}
   #   person.name_previously_changed? # => true
-  #   person.name_previous_change     # => ["Uncle Bob", "Bill"]
+  #   person.name_previous_change     # => [nil, "Bill"]
   #   person.reload!
   #   person.previous_changes         # => {}
   #


### PR DESCRIPTION
Following PR #26508, @y-yagi aptly pointed that I totally missed the example class a couple lines above, which where the basis of the example.

The main reason is that this page is the top Google search for "Rails dirty attributes" or "Rails changed attributes", so this can be confusing for people (like me) coming to this page looking for the way this works in Rails with ActiveRecord. I know the doc is to explain how to implement ActiveModel::Dirty and not really how to use it with Rails, but i think this simple change can help with people coming directly to this page.

I tweaked the sample class, and adjusted the examples. This match more closely the way it work with ActiveRecord and also match more closely [the tests  for the class](https://github.com/rails/rails/blob/b326e82dc012d81e9698cb1f402502af1788c1e9/activemodel/test/cases/dirty_test.rb).

What do you think? cc @maclover7, @y-yagi 
