### PR TITLE
support minitest after_run

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Run `Minitest.after_run` hooks when running `rails test`.
+
+    *Michael Grosser*
+
 *   Run `before_configuration` callbacks as soon as application constant
     inherits from `Rails::Application`.
 

--- a/railties/lib/rails/commands/test.rb
+++ b/railties/lib/rails/commands/test.rb
@@ -1,9 +1,9 @@
 require "rails/test_unit/minitest_plugin"
 
 if defined?(ENGINE_ROOT)
-  $: << File.expand_path("test", ENGINE_ROOT)
+  $LOAD_PATH << File.expand_path("test", ENGINE_ROOT)
 else
-  $: << File.expand_path("../../test", APP_PATH)
+  $LOAD_PATH << File.expand_path("../../test", APP_PATH)
 end
 
 exit Minitest.run(ARGV)

--- a/railties/lib/rails/commands/test.rb
+++ b/railties/lib/rails/commands/test.rb
@@ -6,6 +6,4 @@ else
   $LOAD_PATH << File.expand_path("../../test", APP_PATH)
 end
 
-result = Minitest.run(ARGV)
-Minitest.class_variable_get(:@@after_run).reverse_each(&:call)
-exit result
+require "minitest/autorun"

--- a/railties/lib/rails/commands/test.rb
+++ b/railties/lib/rails/commands/test.rb
@@ -6,4 +6,6 @@ else
   $LOAD_PATH << File.expand_path("../../test", APP_PATH)
 end
 
-exit Minitest.run(ARGV)
+result = Minitest.run(ARGV)
+Minitest.class_variable_get(:@@after_run).reverse_each(&:call)
+exit result

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -12,7 +12,7 @@ module ApplicationTests
       teardown_app
     end
 
-    test "truth" do
+    test "simple successful test" do
       app_file "test/unit/foo_test.rb", <<-RUBY
         require 'test_helper'
 
@@ -24,6 +24,20 @@ module ApplicationTests
       RUBY
 
       assert_successful_test_run "unit/foo_test.rb"
+    end
+
+    test "simple failed test" do
+      app_file "test/unit/foo_test.rb", <<-RUBY
+        require 'test_helper'
+
+        class FooTest < ActiveSupport::TestCase
+          def test_truth
+            assert false
+          end
+        end
+      RUBY
+
+      assert_unsuccessful_run "unit/foo_test.rb", "Failed assertion"
     end
 
     test "integration test" do
@@ -289,7 +303,7 @@ Expected: ["id", "name"]
       def assert_unsuccessful_run(name, message)
         result = run_test_file(name)
         assert_not_equal 0, $?.to_i
-        assert result.include?(message)
+        assert_includes result, message
         result
       end
 

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -26,6 +26,24 @@ module ApplicationTests
       assert_successful_test_run "unit/foo_test.rb"
     end
 
+    test "after_run" do
+      app_file "test/unit/foo_test.rb", <<-RUBY
+        require 'test_helper'
+
+        Minitest.after_run { puts "WORLD" }
+        Minitest.after_run { puts "HELLO" }
+
+        class FooTest < ActiveSupport::TestCase
+          def test_truth
+            assert true
+          end
+        end
+      RUBY
+
+      result = assert_successful_test_run "unit/foo_test.rb"
+      assert_equal ["HELLO", "WORLD"], result.scan(/HELLO|WORLD/) # only once and in correct order
+    end
+
     test "simple failed test" do
       app_file "test/unit/foo_test.rb", <<-RUBY
         require 'test_helper'


### PR DESCRIPTION
Currently rails does not call after_run hooks, which means tests that use them work differently when run with `ruby test.rb` vs `rails test test.rb`

see https://github.com/seattlerb/minitest/blob/f9605387e4af7d657921a83aaf0ae364f6d26a57/lib/minitest.rb#L51-L65
