### PR TITLE
improve error message when include assertions fail

### DIFF
--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -194,7 +194,7 @@ class UrlOptionsTest < ActionController::TestCase
         get "account/overview"
       end
 
-      assert !@controller.class.action_methods.include?("account_overview_path")
+      assert_not_includes @controller.class.action_methods, "account_overview_path"
     end
   end
 end

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -227,7 +227,7 @@ class FlashTest < ActionController::TestCase
       add_flash_types :foo
     end
     subclass_controller_with_no_flash_type = Class.new(test_controller_with_flash_type_foo)
-    assert subclass_controller_with_no_flash_type._flash_types.include?(:foo)
+    assert_includes subclass_controller_with_no_flash_type._flash_types, :foo
   end
 
   def test_does_not_add_flash_type_to_parent_class

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -125,13 +125,13 @@ class HelperTest < ActiveSupport::TestCase
 
   def test_helper_method
     assert_nothing_raised { @controller_class.helper_method :delegate_method }
-    assert master_helper_methods.include?(:delegate_method)
+    assert_includes master_helper_methods, :delegate_method
   end
 
   def test_helper_attr
     assert_nothing_raised { @controller_class.helper_attr :delegate_attr }
-    assert master_helper_methods.include?(:delegate_attr)
-    assert master_helper_methods.include?(:delegate_attr=)
+    assert_includes master_helper_methods, :delegate_attr
+    assert_includes master_helper_methods, :delegate_attr=
   end
 
   def call_controller(klass, action)
@@ -168,13 +168,13 @@ class HelperTest < ActiveSupport::TestCase
     methods = AllHelpersController._helpers.instance_methods
 
     # abc_helper.rb
-    assert methods.include?(:bare_a)
+    assert_includes methods, :bare_a
 
     # fun/games_helper.rb
-    assert methods.include?(:stratego)
+    assert_includes methods, :stratego
 
     # fun/pdf_helper.rb
-    assert methods.include?(:foobar)
+    assert_includes methods, :foobar
   end
 
   def test_all_helpers_with_alternate_helper_dir
@@ -185,26 +185,26 @@ class HelperTest < ActiveSupport::TestCase
     @controller_class.helper :all
 
     # helpers/abc_helper.rb should not be included
-    assert !master_helper_methods.include?(:bare_a)
+    assert_not_includes master_helper_methods, :bare_a
 
     # alternate_helpers/foo_helper.rb
-    assert master_helper_methods.include?(:baz)
+    assert_includes master_helper_methods, :baz
   end
 
   def test_helper_proxy
     methods = AllHelpersController.helpers.methods
 
     # Action View
-    assert methods.include?(:pluralize)
+    assert_includes methods, :pluralize
 
     # abc_helper.rb
-    assert methods.include?(:bare_a)
+    assert_includes methods, :bare_a
 
     # fun/games_helper.rb
-    assert methods.include?(:stratego)
+    assert_includes methods, :stratego
 
     # fun/pdf_helper.rb
-    assert methods.include?(:foobar)
+    assert_includes methods, :foobar
   end
 
   def test_helper_proxy_in_instance

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -746,7 +746,7 @@ class HeadRenderTest < ActionController::TestCase
 
     get :head_with_symbolic_status, params: { status: "no_content" }
     assert_equal 204, @response.status
-    assert !@response.headers.include?("Content-Length")
+    assert_not_includes @response.headers, "Content-Length"
     assert_response :no_content
 
     Rack::Utils::SYMBOL_TO_STATUS_CODE.each do |status, code|

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -1313,7 +1313,7 @@ class ResourcesTest < ActionController::TestCase
     def assert_resource_methods(expected, resource, action_method, method)
       assert_equal expected.length, resource.send("#{action_method}_methods")[method].size, "#{resource.send("#{action_method}_methods")[method].inspect}"
       expected.each do |action|
-        assert resource.send("#{action_method}_methods")[method].include?(action),
+        assert_includes resource.send("#{action_method}_methods")[method], action,
           "#{method} not in #{action_method} methods: #{resource.send("#{action_method}_methods")[method].inspect}"
       end
     end

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -68,7 +68,7 @@ class CookieJarTest < ActiveSupport::TestCase
   def test_write_doesnt_set_a_nil_header
     headers = {}
     request.cookie_jar.write(headers)
-    assert !headers.include?("Set-Cookie")
+    assert_not_includes headers, "Set-Cookie"
   end
 end
 
@@ -1115,11 +1115,11 @@ class CookiesTest < ActionController::TestCase
     assert_equal "david", cookies[:user_name]
 
     get :noop
-    assert !@response.headers.include?("Set-Cookie")
+    assert_not_includes @response.headers, "Set-Cookie"
     assert_equal "david", cookies[:user_name]
 
     get :noop
-    assert !@response.headers.include?("Set-Cookie")
+    assert_not_includes @response.headers, "Set-Cookie"
     assert_equal "david", cookies[:user_name]
   end
 

--- a/actionpack/test/dispatch/header_test.rb
+++ b/actionpack/test/dispatch/header_test.rb
@@ -76,9 +76,9 @@ class HeaderTest < ActiveSupport::TestCase
 
   test "key?" do
     assert @headers.key?("CONTENT_TYPE")
-    assert @headers.include?("CONTENT_TYPE")
+    assert_includes @headers, "CONTENT_TYPE"
     assert @headers.key?("Content-Type")
-    assert @headers.include?("Content-Type")
+    assert_includes @headers, "Content-Type"
   end
 
   test "fetch with block" do

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -3120,7 +3120,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_builder_does_not_have_form_for_method
-    assert !ActionView::Helpers::FormBuilder.instance_methods.include?(:form_for)
+    assert_not_includes ActionView::Helpers::FormBuilder.instance_methods, :form_for
   end
 
   def test_form_for_and_fields_for

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -120,8 +120,8 @@ class LookupContextTest < ActiveSupport::TestCase
 
     @lookup_context.with_fallbacks do
       assert_equal 3, @lookup_context.view_paths.size
-      assert @lookup_context.view_paths.include?(ActionView::FallbackFileSystemResolver.new(""))
-      assert @lookup_context.view_paths.include?(ActionView::FallbackFileSystemResolver.new("/"))
+      assert_includes @lookup_context.view_paths, ActionView::FallbackFileSystemResolver.new("")
+      assert_includes @lookup_context.view_paths, ActionView::FallbackFileSystemResolver.new("/")
     end
   end
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -460,7 +460,7 @@ module RenderTestCases
   def test_render_knows_about_types_registered_when_extensions_are_checked_earlier_in_initialization
     ActionView::Template::Handlers.extensions
     ActionView::Template.register_template_handler :foo, CustomHandler
-    assert ActionView::Template::Handlers.extensions.include?(:foo)
+    assert_includes ActionView::Template::Handlers.extensions, :foo
   ensure
     ActionView::Template.unregister_template_handler :foo
   end

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -25,7 +25,7 @@ module ActionView
       def self.included(test_case)
         test_case.class_eval do
           test "helpers defined on ActionView::TestCase are available" do
-            assert test_case.ancestors.include?(ASharedTestHelper)
+            assert_includes test_case.ancestors, ASharedTestHelper
             assert_equal "Holla!", from_shared_helper
           end
         end
@@ -64,7 +64,7 @@ module ActionView
 
     helper AnotherTestHelper
     test "additional helper classes can be specified as in a controller" do
-      assert test_case.ancestors.include?(AnotherTestHelper)
+      assert_includes test_case.ancestors, AnotherTestHelper
       assert_equal "Howdy!", from_another_helper
     end
 
@@ -96,12 +96,12 @@ module ActionView
     tests ATestHelper
     test "tests the specified helper module" do
       assert_equal ATestHelper, test_case.helper_class
-      assert test_case.ancestors.include?(ATestHelper)
+      assert_includes test_case.ancestors, ATestHelper
     end
 
     helper AnotherTestHelper
     test "additional helper classes can be specified as in a controller" do
-      assert test_case.ancestors.include?(AnotherTestHelper)
+      assert_includes test_case.ancestors, AnotherTestHelper
       assert_equal "Howdy!", from_another_helper
 
       test_case.helper_class.module_eval do
@@ -161,7 +161,7 @@ module ActionView
     test "view_assigns excludes internal ivars" do
       INTERNAL_IVARS.each do |ivar|
         assert defined?(ivar), "expected #{ivar} to be defined"
-        assert !view_assigns.keys.include?(ivar.to_s.tr("@", "").to_sym), "expected #{ivar} to be excluded from view_assigns"
+        assert_not_includes view_assigns.keys, ivar.to_s.tr("@", "").to_sym, "expected #{ivar} to be excluded from view_assigns"
       end
     end
   end
@@ -200,7 +200,7 @@ module ActionView
 
     test "inflects the name of the helper module to test from the test case class" do
       assert_equal ATestHelper, test_case.helper_class
-      assert test_case.ancestors.include?(ATestHelper)
+      assert_includes test_case.ancestors, ATestHelper
     end
 
     test "a configured test controller is available" do
@@ -209,7 +209,7 @@ module ActionView
     end
 
     test "no additional helpers should shared across test cases" do
-      assert !test_case.ancestors.include?(AnotherTestHelper)
+      assert_not_includes test_case.ancestors, AnotherTestHelper
       assert_raise(NoMethodError) { send :from_another_helper }
     end
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -37,7 +37,7 @@ class ErrorsTest < ActiveModel::TestCase
   def test_include?
     errors = ActiveModel::Errors.new(self)
     errors[:foo] << "omg"
-    assert errors.include?(:foo), "errors should include :foo"
+    assert_includes errors, :foo, "errors should include :foo"
   end
 
   def test_dup
@@ -125,7 +125,7 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors[:foo]
     assert person.errors.empty?
     assert person.errors.blank?
-    assert !person.errors.include?(:foo)
+    assert_not_includes person.errors, :foo
   end
 
   test "include? does not add a key to messages hash" do

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -18,7 +18,7 @@ class JsonSerializationTest < ActiveModel::TestCase
     assert_no_match %r{^\{"contact":\{}, json
     assert_match %r{"name":"Konata Izumi"}, json
     assert_match %r{"age":16}, json
-    assert json.include?(%("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}))
+    assert_includes json, %("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))})
     assert_match %r{"awesome":true}, json
     assert_match %r{"preferences":\{"shows":"anime"\}}, json
   end
@@ -32,7 +32,7 @@ class JsonSerializationTest < ActiveModel::TestCase
       assert_match %r{^\{"contact":\{}, json
       assert_match %r{"name":"Konata Izumi"}, json
       assert_match %r{"age":16}, json
-      assert json.include?(%("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}))
+      assert_includes json, %("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))})
       assert_match %r{"awesome":true}, json
       assert_match %r{"preferences":\{"shows":"anime"\}}, json
     ensure
@@ -58,7 +58,7 @@ class JsonSerializationTest < ActiveModel::TestCase
     assert_match %r{^\{"json_contact":\{}, json
     assert_match %r{"name":"Konata Izumi"}, json
     assert_match %r{"age":16}, json
-    assert json.include?(%("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}))
+    assert_includes json, %("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))})
     assert_match %r{"awesome":true}, json
     assert_match %r{"preferences":\{"shows":"anime"\}}, json
   end
@@ -68,7 +68,7 @@ class JsonSerializationTest < ActiveModel::TestCase
 
     assert_match %r{"name":"Konata Izumi"}, json
     assert_match %r{"age":16}, json
-    assert json.include?(%("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}))
+    assert_includes json, %("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))})
     assert_match %r{"awesome":true}, json
     assert_match %r{"preferences":\{"shows":"anime"\}}, json
   end
@@ -79,7 +79,7 @@ class JsonSerializationTest < ActiveModel::TestCase
     assert_match %r{"name":"Konata Izumi"}, json
     assert_match %r{"age":16}, json
     assert_no_match %r{"awesome":true}, json
-    assert !json.include?(%("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}))
+    assert_not_includes json, %("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))})
     assert_no_match %r{"preferences":\{"shows":"anime"\}}, json
   end
 
@@ -89,7 +89,7 @@ class JsonSerializationTest < ActiveModel::TestCase
     assert_no_match %r{"name":"Konata Izumi"}, json
     assert_no_match %r{"age":16}, json
     assert_match %r{"awesome":true}, json
-    assert json.include?(%("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}))
+    assert_includes json, %("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))})
     assert_match %r{"preferences":\{"shows":"anime"\}}, json
   end
 

--- a/activemodel/test/cases/validations/validations_context_test.rb
+++ b/activemodel/test/cases/validations/validations_context_test.rb
@@ -38,7 +38,7 @@ class ValidationsContextTest < ActiveModel::TestCase
     Topic.validates_with(ValidatorThatAddsErrors, on: :create)
     topic = Topic.new
     assert topic.invalid?(:create), "Validation does run on create if 'on' is set to create"
-    assert topic.errors[:base].include?(ERROR_MESSAGE)
+    assert_includes topic.errors[:base], ERROR_MESSAGE
   end
 
   test "with a class that adds errors on multiple contexts and validating a new model" do
@@ -48,10 +48,10 @@ class ValidationsContextTest < ActiveModel::TestCase
     assert topic.valid?, "Validation ran with no context given when 'on' is set to context1 and context2"
 
     assert topic.invalid?(:context1), "Validation did not run on context1 when 'on' is set to context1 and context2"
-    assert topic.errors[:base].include?(ERROR_MESSAGE)
+    assert_includes topic.errors[:base], ERROR_MESSAGE
 
     assert topic.invalid?(:context2), "Validation did not run on context2 when 'on' is set to context1 and context2"
-    assert topic.errors[:base].include?(ERROR_MESSAGE)
+    assert_includes topic.errors[:base], ERROR_MESSAGE
   end
 
   test "with a class that validating a model for a multiple contexts" do
@@ -62,7 +62,7 @@ class ValidationsContextTest < ActiveModel::TestCase
     assert topic.valid?, "Validation ran with no context given when 'on' is set to context1 and context2"
 
     assert topic.invalid?([:context1, :context2]), "Validation did not run on context1 when 'on' is set to context1 and context2"
-    assert topic.errors[:base].include?(ERROR_MESSAGE)
-    assert topic.errors[:base].include?(ANOTHER_ERROR_MESSAGE)
+    assert_includes topic.errors[:base], ERROR_MESSAGE
+    assert_includes topic.errors[:base], ANOTHER_ERROR_MESSAGE
   end
 end

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -51,7 +51,7 @@ class ValidatesWithTest < ActiveModel::TestCase
     Topic.validates_with(ValidatorThatAddsErrors)
     topic = Topic.new
     assert topic.invalid?, "A class that adds errors causes the record to be invalid"
-    assert topic.errors[:base].include?(ERROR_MESSAGE)
+    assert_includes topic.errors[:base], ERROR_MESSAGE
   end
 
   test "with a class that returns valid" do
@@ -64,8 +64,8 @@ class ValidatesWithTest < ActiveModel::TestCase
     Topic.validates_with(ValidatorThatAddsErrors, OtherValidatorThatAddsErrors)
     topic = Topic.new
     assert topic.invalid?
-    assert topic.errors[:base].include?(ERROR_MESSAGE)
-    assert topic.errors[:base].include?(OTHER_ERROR_MESSAGE)
+    assert_includes topic.errors[:base], ERROR_MESSAGE
+    assert_includes topic.errors[:base], OTHER_ERROR_MESSAGE
   end
 
   test "with if statements that return false" do
@@ -78,7 +78,7 @@ class ValidatesWithTest < ActiveModel::TestCase
     Topic.validates_with(ValidatorThatAddsErrors, if: "1 == 1")
     topic = Topic.new
     assert topic.invalid?
-    assert topic.errors[:base].include?(ERROR_MESSAGE)
+    assert_includes topic.errors[:base], ERROR_MESSAGE
   end
 
   test "with unless statements that return true" do
@@ -91,7 +91,7 @@ class ValidatesWithTest < ActiveModel::TestCase
     Topic.validates_with(ValidatorThatAddsErrors, unless: "1 == 2")
     topic = Topic.new
     assert topic.invalid?
-    assert topic.errors[:base].include?(ERROR_MESSAGE)
+    assert_includes topic.errors[:base], ERROR_MESSAGE
   end
 
   test "passes all configuration options to the validator class" do
@@ -111,7 +111,7 @@ class ValidatesWithTest < ActiveModel::TestCase
     Topic.validates_with(ValidatorThatValidatesOptions, field: :first_name)
     topic = Topic.new
     assert topic.invalid?
-    assert topic.errors[:base].include?(ERROR_MESSAGE)
+    assert_includes topic.errors[:base], ERROR_MESSAGE
   end
 
   test "validates_with each validator" do

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -53,8 +53,8 @@ class ValidationsTest < ActiveModel::TestCase
 
     errors = r.errors.collect { |attr, messages| [attr.to_s, messages] }
 
-    assert errors.include?(["title", "is Empty"])
-    assert errors.include?(["content", "is Empty"])
+    assert_includes errors, ["title", "is Empty"]
+    assert_includes errors, ["content", "is Empty"]
   end
 
   def test_multiple_errors_per_attr_iteration_with_full_error_composition
@@ -86,8 +86,8 @@ class ValidationsTest < ActiveModel::TestCase
 
     assert_equal ["Reply is not dignifying"], r.errors[:base]
 
-    assert errors.include?("Title is Empty")
-    assert errors.include?("Reply is not dignifying")
+    assert_includes errors, "Title is Empty"
+    assert_includes errors, "Reply is not dignifying"
     assert_equal 2, r.errors.count
   end
 
@@ -101,8 +101,8 @@ class ValidationsTest < ActiveModel::TestCase
 
     assert_equal ["is invalid"], r.errors[:base]
 
-    assert errors.include?("Title is Empty")
-    assert errors.include?("is invalid")
+    assert_includes errors, "Title is Empty"
+    assert_includes errors, "is invalid"
 
     assert_equal 2, r.errors.count
   end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -33,10 +33,10 @@ module ActiveRecord
     def test_tables
       tables = nil
       ActiveSupport::Deprecation.silence { tables = @connection.tables }
-      assert tables.include?("accounts")
-      assert tables.include?("authors")
-      assert tables.include?("tasks")
-      assert tables.include?("topics")
+      assert_includes tables, "accounts"
+      assert_includes tables, "authors"
+      assert_includes tables, "tasks"
+      assert_includes tables, "topics"
     end
 
     def test_table_exists?
@@ -53,10 +53,10 @@ module ActiveRecord
 
     def test_data_sources
       data_sources = @connection.data_sources
-      assert data_sources.include?("accounts")
-      assert data_sources.include?("authors")
-      assert data_sources.include?("tasks")
-      assert data_sources.include?("topics")
+      assert_includes data_sources, "accounts"
+      assert_includes data_sources, "authors"
+      assert_includes data_sources, "tasks"
+      assert_includes data_sources, "topics"
     end
 
     def test_data_source_exists?

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -38,7 +38,7 @@ if ActiveRecord::Base.connection.supports_extensions?
 
     def test_hstore_included_in_extensions
       assert @connection.respond_to?(:extensions), "connection should have a list of extensions"
-      assert @connection.extensions.include?("hstore"), "extension list should include hstore"
+      assert_includes @connection.extensions, "hstore", "extension list should include hstore"
     end
 
     def test_disable_enable_hstore

--- a/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
@@ -100,10 +100,10 @@ class SchemaAuthorizationTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_tables_in_current_schemas
-    assert !@connection.tables.include?(TABLE_NAME)
+    assert_not_includes @connection.tables, TABLE_NAME
     USERS.each do |u|
       set_session_auth u
-      assert @connection.tables.include?(TABLE_NAME)
+      assert_includes @connection.tables, TABLE_NAME
       set_session_auth
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -130,7 +130,7 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     ensure
       @connection.drop_schema "test_schema3"
     end
-    assert !@connection.schema_names.include?("test_schema3")
+    assert_not_includes @connection.schema_names, "test_schema3"
   end
 
   def test_drop_schema_if_exists

--- a/activerecord/test/cases/associations/callbacks_test.rb
+++ b/activerecord/test/cases/associations/callbacks_test.rb
@@ -176,14 +176,14 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
   end
 
   def test_dont_add_if_before_callback_raises_exception
-    assert !@david.unchangeable_posts.include?(@authorless)
+    assert_not_includes @david.unchangeable_posts, @authorless
     begin
       @david.unchangeable_posts << @authorless
     rescue Exception
     end
     assert @david.post_log.empty?
-    assert !@david.unchangeable_posts.include?(@authorless)
+    assert_not_includes @david.unchangeable_posts, @authorless
     @david.reload
-    assert !@david.unchangeable_posts.include?(@authorless)
+    assert_not_includes @david.unchangeable_posts, @authorless
   end
 end

--- a/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
+++ b/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
@@ -134,8 +134,8 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
 
   def test_eager_association_loading_with_belongs_to_sti
     replies = Reply.all.merge!(includes: :topic, order: "topics.id").to_a
-    assert replies.include?(topics(:second))
-    assert !replies.include?(topics(:first))
+    assert_includes replies, topics(:second)
+    assert_not_includes replies, topics(:first)
     assert_equal topics(:first), assert_no_queries { replies.first.topic }
   end
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -42,11 +42,11 @@ class EagerAssociationTest < ActiveRecord::TestCase
     posts = Post.all.merge!(includes: :comments).to_a
     post = posts.find { |p| p.id == 1 }
     assert_equal 2, post.comments.size
-    assert post.comments.include?(comments(:greetings))
+    assert_includes post.comments, comments(:greetings)
 
     post = Post.all.merge!(includes: :comments, where: "posts.title = 'Welcome to the weblog'").first
     assert_equal 2, post.comments.size
-    assert post.comments.include?(comments(:greetings))
+    assert_includes post.comments, comments(:greetings)
 
     posts = Post.all.merge!(includes: :last_comment).to_a
     post = posts.find { |p| p.id == 1 }
@@ -103,7 +103,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
     posts = Post.all.merge!(includes: [ :comments, :author, :categories ], order: "posts.id").to_a
     assert_equal 2, posts.first.comments.size
     assert_equal 2, posts.first.categories.size
-    assert posts.first.comments.include?(comments(:greetings))
+    assert_includes posts.first.comments, comments(:greetings)
   end
 
   def test_duplicate_middle_objects
@@ -349,8 +349,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
     comments = Comment.all.merge!(includes: :post).to_a
     assert_equal 11, comments.length
     titles = comments.map { |c| c.post.title }
-    assert titles.include?(posts(:welcome).title)
-    assert titles.include?(posts(:sti_post_and_comments).title)
+    assert_includes titles, posts(:welcome).title
+    assert_includes titles, posts(:sti_post_and_comments).title
   end
 
   def test_eager_association_loading_with_belongs_to_and_limit
@@ -630,8 +630,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal 2, posts[0].categories.size
     assert_equal 1, posts[1].categories.size
     assert_equal 0, posts[2].categories.size
-    assert posts[0].categories.include?(categories(:technology))
-    assert posts[1].categories.include?(categories(:general))
+    assert_includes posts[0].categories, categories(:technology)
+    assert_includes posts[1].categories, categories(:general)
   end
 
   # Since the preloader for habtm gets raw row hashes from the database and then
@@ -695,8 +695,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal 2, posts[0].categories.size
     assert_equal 1, posts[1].categories.size
     assert_equal 0, posts[2].categories.size
-    assert posts[0].categories.include?(categories(:technology))
-    assert posts[1].categories.include?(categories(:general))
+    assert_includes posts[0].categories, categories(:technology)
+    assert_includes posts[1].categories, categories(:general)
   end
 
   def test_eager_with_inheritance
@@ -895,9 +895,9 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_polymorphic_type_condition
     post = Post.all.merge!(includes: :taggings).find(posts(:thinking).id)
-    assert post.taggings.include?(taggings(:thinking_general))
+    assert_includes post.taggings, taggings(:thinking_general)
     post = SpecialPost.all.merge!(includes: :taggings).find(posts(:thinking).id)
-    assert post.taggings.include?(taggings(:thinking_general))
+    assert_includes post.taggings, taggings(:thinking_general)
   end
 
   def test_eager_with_multiple_associations_with_same_table_has_many_and_habtm

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -169,7 +169,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     active_record = Project.find(1)
     assert !active_record.developers.empty?
     assert_equal 3, active_record.developers.size
-    assert active_record.developers.include?(david)
+    assert_includes active_record.developers, david
   end
 
   def test_adding_single
@@ -544,7 +544,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
     assert_no_queries(ignore_none: false) do
       assert project.developers.loaded?
-      assert project.developers.include?(developer)
+      assert_includes project.developers, developer
     end
   end
 
@@ -555,7 +555,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     project.reload
     assert ! project.developers.loaded?
     assert_queries(1) do
-      assert project.developers.include?(developer)
+      assert_includes project.developers, developer
     end
     assert ! project.developers.loaded?
   end
@@ -600,8 +600,8 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     project.save!
     project.reload
 
-    assert project.developers.include?(jamis)
-    assert project.developers.include?(david)
+    assert_includes project.developers, jamis
+    assert_includes project.developers, david
   end
 
   def test_find_in_association_with_options
@@ -628,7 +628,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     david.projects = [projects(:action_controller), Project.new("name" => "ActionWebSearch")]
     david.save
     assert_equal 2, david.projects.length
-    assert !david.projects.include?(projects(:active_record))
+    assert_not_includes david.projects, projects(:active_record)
   end
 
   def test_replace_on_new_object
@@ -646,9 +646,9 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     developer.special_projects << special_project
     developer.reload
 
-    assert developer.projects.include?(special_project)
-    assert developer.special_projects.include?(special_project)
-    assert !developer.special_projects.include?(other_project)
+    assert_includes developer.projects, special_project
+    assert_includes developer.special_projects, special_project
+    assert_not_includes developer.special_projects, other_project
   end
 
   def test_symbol_join_table
@@ -854,7 +854,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   def test_include_method_in_has_and_belongs_to_many_association_should_return_true_for_instance_added_with_build
     project = Project.new
     developer = project.developers.build
-    assert project.developers.include?(developer)
+    assert_includes project.developers, developer
   end
 
   def test_destruction_does_not_error_without_primary_key

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -870,7 +870,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     rescue Client::RaisedOnSave
     end
 
-    assert !companies(:first_firm).clients_of_firm.reload.include?(good)
+    assert_not_includes companies(:first_firm).clients_of_firm.reload, good
   end
 
   def test_transactions_when_adding_to_new_record

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -175,7 +175,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     person = Person.new
     post = Post.new
     person.posts << post
-    assert person.posts.include?(post)
+    assert_includes person.posts, post
   end
 
   def test_associate_existing
@@ -187,10 +187,10 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_queries(1) do
-      assert post.people.include?(person)
+      assert_includes post.people, person
     end
 
-    assert post.reload.people.reload.include?(person)
+    assert_includes post.reload.people.reload, person
   end
 
   def test_delete_all_for_with_dependent_option_destroy
@@ -266,7 +266,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       post.people.delete(person)
     end
 
-    assert !post.people.reload.include?(person)
+    assert_not_includes post.people.reload, person
   end
 
   def test_associating_new
@@ -284,10 +284,10 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_queries(1) do
-      assert posts(:thinking).people.include?(new_person)
+      assert_includes posts(:thinking).people, new_person
     end
 
-    assert posts(:thinking).reload.people.reload.include?(new_person)
+    assert_includes posts(:thinking).reload.people.reload, new_person
   end
 
   def test_associate_new_by_building
@@ -300,8 +300,8 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
     # Should only need to load the association once
     assert_queries(1) do
-      assert posts(:thinking).people.collect(&:first_name).include?("Bob")
-      assert posts(:thinking).people.collect(&:first_name).include?("Ted")
+      assert_includes posts(:thinking).people.collect(&:first_name), "Bob"
+      assert_includes posts(:thinking).people.collect(&:first_name), "Ted"
     end
 
     # 2 queries for each new record (1 to save the record itself, 1 for the join model)
@@ -312,8 +312,8 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       posts(:thinking).save
     end
 
-    assert posts(:thinking).reload.people.reload.collect(&:first_name).include?("Bob")
-    assert posts(:thinking).reload.people.reload.collect(&:first_name).include?("Ted")
+    assert_includes posts(:thinking).reload.people.reload.collect(&:first_name), "Bob"
+    assert_includes posts(:thinking).reload.people.reload.collect(&:first_name), "Ted"
   end
 
   def test_build_then_save_with_has_many_inverse
@@ -322,7 +322,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     person.save
     post.reload
 
-    assert post.people.include?(person)
+    assert_includes post.people, person
   end
 
   def test_build_then_save_with_has_one_inverse
@@ -331,7 +331,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     person.save
     post.reload
 
-    assert post.single_people.include?(person)
+    assert_includes post.single_people, person
   end
 
   def test_both_parent_ids_set_when_saving_new
@@ -550,12 +550,12 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_queries(0) {
-      assert posts(:welcome).people.include?(people(:david))
-      assert !posts(:welcome).people.include?(people(:michael))
+      assert_includes posts(:welcome).people, people(:david)
+      assert_not_includes posts(:welcome).people, people(:michael)
     }
 
-    assert posts(:welcome).reload.people.reload.include?(people(:david))
-    assert !posts(:welcome).reload.people.reload.include?(people(:michael))
+    assert_includes posts(:welcome).reload.people.reload, people(:david)
+    assert_not_includes posts(:welcome).reload.people.reload, people(:michael)
   end
 
   def test_replace_order_is_preserved
@@ -591,10 +591,10 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
     # *Now* we actually need the collection so it's loaded
     assert_queries(1) do
-      assert posts(:thinking).people.collect(&:first_name).include?("Jeb")
+      assert_includes posts(:thinking).people.collect(&:first_name), "Jeb"
     end
 
-    assert posts(:thinking).reload.people.reload.collect(&:first_name).include?("Jeb")
+    assert_includes posts(:thinking).reload.people.reload.collect(&:first_name), "Jeb"
   end
 
   def test_through_record_is_built_when_created_with_where
@@ -832,14 +832,14 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     category = author.named_categories.build(name: "Primary")
     author.save
     assert Categorization.exists?(author_id: author.id, named_category_name: category.name)
-    assert author.named_categories.reload.include?(category)
+    assert_includes author.named_categories.reload, category
   end
 
   def test_collection_create_with_nonstandard_primary_key_on_belongs_to
     author   = authors(:mary)
     category = author.named_categories.create(name: "Primary")
     assert Categorization.exists?(author_id: author.id, named_category_name: category.name)
-    assert author.named_categories.reload.include?(category)
+    assert_includes author.named_categories.reload, category
   end
 
   def test_collection_exists
@@ -908,14 +908,14 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     person = Person.new
     reference = person.references.build
     job = reference.build_job
-    assert person.jobs.include?(job)
+    assert_includes person.jobs, job
   end
 
   def test_include_method_in_association_through_should_return_true_for_instance_added_with_nested_builds
     author = Author.new
     post = author.posts.build
     comment = post.comments.build
-    assert author.comments.include?(comment)
+    assert_includes author.comments, comment
   end
 
   def test_through_association_readonly_should_be_false
@@ -1022,7 +1022,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     post    = posts(:welcome)
     address = author_addresses(:david_address)
 
-    assert post.author_addresses.include?(address)
+    assert_includes post.author_addresses, address
     post.author_addresses.delete(address)
     assert post[:author_count].nil?
   end
@@ -1107,7 +1107,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_many_through_obeys_order_on_through_association
     owner = owners(:blackbeard)
-    assert owner.toys.to_sql.include?("pets.name desc")
+    assert_includes owner.toys.to_sql, "pets.name desc"
     assert_equal ["parrot", "bulbul"], owner.toys.map { |r| r.pet.name }
   end
 

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -182,7 +182,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
       @member.organization = @organization
     end
     assert_equal @organization, @member.organization
-    assert @organization.members.include?(@member)
+    assert_includes @organization.members, @member
     assert_equal "Extra", @member.member_detail.extra_data
   end
 
@@ -197,16 +197,16 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     end
     assert_equal @organization, @member.organization
     assert_equal "Extra", @member.member_detail.extra_data
-    assert @organization.members.include?(@member)
-    assert !@new_organization.members.include?(@member)
+    assert_includes @organization.members, @member
+    assert_not_includes @new_organization.members, @member
 
     assert_no_difference "MemberDetail.count" do
       @member.organization = @new_organization
     end
     assert_equal @new_organization, @member.organization
     assert_equal "Extra", @member.member_detail.extra_data
-    assert !@organization.members.include?(@member)
-    assert @new_organization.members.include?(@member)
+    assert_not_includes @organization.members, @member
+    assert_includes @new_organization.members, @member
   end
 
   def test_preloading_has_one_through_on_belongs_to

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -24,15 +24,15 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     :edges
 
   def test_has_many
-    assert authors(:david).categories.include?(categories(:general))
+    assert_includes authors(:david).categories, categories(:general)
   end
 
   def test_has_many_inherited
-    assert authors(:mary).categories.include?(categories(:sti_test))
+    assert_includes authors(:mary).categories, categories(:sti_test)
   end
 
   def test_inherited_has_many
-    assert categories(:sti_test).authors.include?(authors(:mary))
+    assert_includes categories(:sti_test).authors, authors(:mary)
   end
 
   def test_has_many_distinct_through_join_model
@@ -467,10 +467,10 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     saved_post.tags << new_tag
     assert new_tag.persisted? #consistent with habtm!
     assert saved_post.persisted?
-    assert saved_post.tags.include?(new_tag)
+    assert_includes saved_post.tags, new_tag
 
     assert new_tag.persisted?
-    assert saved_post.reload.tags.reload.include?(new_tag)
+    assert_includes saved_post.reload.tags.reload, new_tag
 
     new_post = Post.new(title: "Association replacement works!", body: "You best believe it.")
     saved_tag = tags(:general)
@@ -478,11 +478,11 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     new_post.tags << saved_tag
     assert !new_post.persisted?
     assert saved_tag.persisted?
-    assert new_post.tags.include?(saved_tag)
+    assert_includes new_post.tags, saved_tag
 
     new_post.save!
     assert new_post.persisted?
-    assert new_post.reload.tags.reload.include?(saved_tag)
+    assert_includes new_post.reload.tags.reload, saved_tag
 
     assert !posts(:thinking).tags.build.persisted?
     assert !posts(:thinking).tags.new.persisted?
@@ -642,8 +642,8 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   def test_polymorphic_has_many
     expected = taggings(:welcome_general)
     p = Post.all.merge!(includes: :taggings).find(posts(:welcome).id)
-    assert_no_queries { assert p.taggings.include?(expected) }
-    assert posts(:welcome).taggings.include?(taggings(:welcome_general))
+    assert_no_queries { assert_includes p.taggings, expected }
+    assert_includes posts(:welcome).taggings, taggings(:welcome_general)
   end
 
   def test_polymorphic_has_one
@@ -675,8 +675,8 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     end
 
     taggables = taggings.map(&:taggable)
-    assert taggables.include?(items(:dvd))
-    assert taggables.include?(posts(:welcome))
+    assert_includes taggables, items(:dvd)
+    assert_includes taggables, posts(:welcome)
   end
 
   def test_preload_nil_polymorphic_belongs_to
@@ -709,7 +709,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
 
     assert_no_queries do
       assert david.categories.loaded?
-      assert david.categories.include?(category)
+      assert_includes david.categories, category
     end
   end
 
@@ -720,7 +720,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     david.reload
     assert ! david.categories.loaded?
     assert_queries(1) do
-      assert david.categories.include?(category)
+      assert_includes david.categories, category
     end
     assert ! david.categories.loaded?
   end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -131,7 +131,7 @@ class AssociationProxyTest < ActiveRecord::TestCase
 
     david.posts << (post = Post.new(title: "New on Edge", body: "More cool stuff!"))
     assert !david.posts.loaded?
-    assert david.posts.include?(post)
+    assert_includes david.posts, post
   end
 
   def test_push_has_many_through_does_not_load_target
@@ -139,7 +139,7 @@ class AssociationProxyTest < ActiveRecord::TestCase
 
     david.categories << categories(:technology)
     assert !david.categories.loaded?
-    assert david.categories.include?(categories(:technology))
+    assert_includes david.categories, categories(:technology)
   end
 
   def test_push_followed_by_save_does_not_load_target
@@ -149,7 +149,7 @@ class AssociationProxyTest < ActiveRecord::TestCase
     assert !david.posts.loaded?
     david.save
     assert !david.posts.loaded?
-    assert david.posts.include?(post)
+    assert_includes david.posts, post
   end
 
   def test_push_does_not_lose_additions_to_new_record

--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -39,13 +39,13 @@ module ActiveRecord
         instance = @klass.new
 
         @klass.attribute_names.each do |name|
-          assert !instance.methods.map(&:to_s).include?(name)
+          assert_not_includes instance.methods.map(&:to_s), name
         end
 
         @klass.define_attribute_methods
 
         @klass.attribute_names.each do |name|
-          assert instance.methods.map(&:to_s).include?(name), "#{name} is not defined"
+          assert_includes instance.methods.map(&:to_s), name, "#{name} is not defined"
         end
       end
 

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -755,7 +755,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     topic = @target.new(title: "The pros and cons of programming naked.")
     assert !topic.respond_to?(:title)
     exception = assert_raise(NoMethodError) { topic.title }
-    assert exception.message.include?("private method")
+    assert_includes exception.message, "private method"
     assert_equal "I'm private", topic.send(:title)
   end
 
@@ -765,7 +765,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     topic = @target.new
     assert !topic.respond_to?(:title=)
     exception = assert_raise(NoMethodError) { topic.title = "Pants" }
-    assert exception.message.include?("private method")
+    assert_includes exception.message, "private method"
     topic.send(:title=, "Very large pants")
   end
 
@@ -775,7 +775,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     topic = @target.new(title: "Isaac Newton's pants")
     assert !topic.respond_to?(:title?)
     exception = assert_raise(NoMethodError) { topic.title? }
-    assert exception.message.include?("private method")
+    assert_includes exception.message, "private method"
     assert topic.send(:title?)
   end
 

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -112,7 +112,7 @@ module ActiveRecord
 
       assert_equal 7, klass.attribute_types.length
       assert_equal 7, klass.column_defaults.length
-      assert klass.attribute_types.include?("wibble")
+      assert_includes klass.attribute_types, "wibble"
     end
 
     test "the given default value is cast from user" do
@@ -253,7 +253,7 @@ module ActiveRecord
     test "attributes not backed by database columns appear in inspect" do
       inspection = OverloadedType.new.inspect
 
-      assert inspection.include?("non_existent_decimal")
+      assert_includes inspection, "non_existent_decimal"
     end
   end
 end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -585,7 +585,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     firm.save
     firm.reload
     assert_equal 2, firm.clients.length
-    assert firm.clients.include?(companies(:second_client))
+    assert_includes firm.clients, companies(:second_client)
   end
 
   def test_assign_ids_for_through_a_belongs_to
@@ -594,7 +594,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     post.save
     post.reload
     assert_equal 2, post.people.length
-    assert post.people.include?(people(:david))
+    assert_includes post.people, people(:david)
   end
 
   def test_build_before_save
@@ -647,7 +647,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     assert firm.save
     firm.reload
     assert_equal 2, firm.clients.length
-    assert firm.clients.include?(Client.find_by_name("New Client"))
+    assert_includes firm.clients, Client.find_by_name("New Client")
   end
 end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1519,7 +1519,7 @@ class BasicsTest < ActiveRecord::TestCase
   test "ignored columns are not present in columns_hash" do
     cache_columns = Developer.connection.schema_cache.columns_hash(Developer.table_name)
     assert_includes cache_columns.keys, "first_name"
-    refute_includes Developer.columns_hash.keys, "first_name"
+    assert_not_includes Developer.columns_hash.keys, "first_name"
   end
 
   test "ignored columns have no attribute methods" do

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -93,20 +93,20 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_should_group_by_field
     c = Account.group(:firm_id).sum(:credit_limit)
     [1,6,2].each do |firm_id|
-      assert c.keys.include?(firm_id), "Group #{c.inspect} does not contain firm_id #{firm_id}"
+      assert_includes c.keys, firm_id, "Group #{c.inspect} does not contain firm_id #{firm_id}"
     end
   end
 
   def test_should_group_by_arel_attribute
     c = Account.group(Account.arel_table[:firm_id]).sum(:credit_limit)
     [1,6,2].each do |firm_id|
-      assert c.keys.include?(firm_id), "Group #{c.inspect} does not contain firm_id #{firm_id}"
+      assert_includes c.keys, firm_id, "Group #{c.inspect} does not contain firm_id #{firm_id}"
     end
   end
 
   def test_should_group_by_multiple_fields
     c = Account.group("firm_id", :credit_limit).count(:all)
-    [ [nil, 50], [1, 50], [6, 50], [6, 55], [9, 53], [2, 60] ].each { |firm_and_limit| assert c.keys.include?(firm_and_limit) }
+    [ [nil, 50], [1, 50], [6, 50], [6, 55], [9, 53], [2, 60] ].each { |firm_and_limit| assert_includes c.keys, firm_and_limit }
   end
 
   def test_should_group_by_multiple_fields_having_functions
@@ -453,7 +453,7 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_should_count_field_in_joined_table_with_group_by
     c = Account.group("accounts.firm_id").joins(:firm).count("companies.id")
 
-    [1,6,2,9].each { |firm_id| assert c.keys.include?(firm_id) }
+    [1,6,2,9].each { |firm_id| assert_includes c.keys, firm_id }
   end
 
   def test_should_count_field_of_root_table_with_conflicting_group_by_column

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -495,8 +495,8 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal 4, pirate.previous_changes.size
     assert_equal [nil, "arrr"], pirate.previous_changes["catchphrase"]
     assert_equal [nil, pirate.id], pirate.previous_changes["id"]
-    assert pirate.previous_changes.include?("updated_on")
-    assert pirate.previous_changes.include?("created_on")
+    assert_includes pirate.previous_changes, "updated_on"
+    assert_includes pirate.previous_changes, "created_on"
     assert !pirate.previous_changes.key?("parrot_id")
 
     pirate.catchphrase = "Yar!!"
@@ -631,7 +631,7 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal("arrrr", pirate.catchphrase_was)
     assert pirate.catchphrase_changed?(from: "arrrr")
     assert_not pirate.catchphrase_changed?(from: "anything else")
-    assert pirate.changed_attributes.include?(:catchphrase)
+    assert_includes pirate.changed_attributes, :catchphrase
 
     pirate.save!
     pirate.reload

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1008,8 +1008,8 @@ class FinderTest < ActiveRecord::TestCase
       where("project_id=1").to_a
     assert_equal 3, developers_on_project_one.length
     developer_names = developers_on_project_one.map(&:name)
-    assert developer_names.include?("David")
-    assert developer_names.include?("Jamis")
+    assert_includes developer_names, "David"
+    assert_includes developer_names, "Jamis"
   end
 
   def test_joins_dont_clobber_id
@@ -1092,7 +1092,7 @@ class FinderTest < ActiveRecord::TestCase
       order("client_of DESC").
       map(&:client_of)
 
-    assert client_of.include?(nil)
+    assert_includes client_of, nil
     assert_equal [2, 1].sort, client_of.compact.sort
   end
 

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -923,7 +923,7 @@ class FoxyFixturesTest < ActiveRecord::TestCase
   end
 
   def test_namespaced_models
-    assert admin_accounts(:signals37).users.include?(admin_users(:david))
+    assert_includes admin_accounts(:signals37).users, admin_users(:david)
     assert_equal 2, admin_accounts(:signals37).users.size
   end
 

--- a/activerecord/test/cases/json_serialization_test.rb
+++ b/activerecord/test/cases/json_serialization_test.rb
@@ -51,7 +51,7 @@ class JsonSerializationTest < ActiveRecord::TestCase
       assert_match %r{^\{"contact":\{}, json
       assert_match %r{"name":"Konata Izumi"}, json
       assert_match %r{"age":16}, json
-      assert json.include?(%("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}))
+      assert_includes json, %("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))})
       assert_match %r{"awesome":true}, json
       assert_match %r{"preferences":\{"shows":"anime"\}}, json
     end
@@ -62,7 +62,7 @@ class JsonSerializationTest < ActiveRecord::TestCase
 
     assert_match %r{"name":"Konata Izumi"}, json
     assert_match %r{"age":16}, json
-    assert json.include?(%("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}))
+    assert_includes json, %("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))})
     assert_match %r{"awesome":true}, json
     assert_match %r{"preferences":\{"shows":"anime"\}}, json
   end
@@ -73,7 +73,7 @@ class JsonSerializationTest < ActiveRecord::TestCase
     assert_match %r{"name":"Konata Izumi"}, json
     assert_match %r{"age":16}, json
     assert_no_match %r{"awesome":true}, json
-    assert !json.include?(%("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}))
+    assert_not_includes json, %("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))})
     assert_no_match %r{"preferences":\{"shows":"anime"\}}, json
   end
 
@@ -83,7 +83,7 @@ class JsonSerializationTest < ActiveRecord::TestCase
     assert_no_match %r{"name":"Konata Izumi"}, json
     assert_no_match %r{"age":16}, json
     assert_match %r{"awesome":true}, json
-    assert json.include?(%("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))}))
+    assert_includes json, %("created_at":#{ActiveSupport::JSON.encode(Time.utc(2006, 8, 1))})
     assert_match %r{"preferences":\{"shows":"anime"\}}, json
   end
 
@@ -275,7 +275,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
 
     ['"name":"David"', '"posts":[', '{"id":1}', '{"id":2}', '{"id":4}',
      '{"id":5}', '{"id":6}', '"name":"Mary"', '"posts":[', '{"id":7}', '{"id":9}'].each do |fragment|
-       assert json.include?(fragment), json
+       assert_includes json, fragment, json
      end
   end
 

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -32,7 +32,7 @@ module ActiveRecord
 
         rename_column :test_models, :first_name, :nick_name
         TestModel.reset_column_information
-        assert TestModel.column_names.include?("nick_name")
+        assert_includes TestModel.column_names, "nick_name"
         assert_equal ["foo"], TestModel.all.map(&:nick_name)
       end
 
@@ -45,7 +45,7 @@ module ActiveRecord
 
         rename_column "test_models", "first_name", "nick_name"
         TestModel.reset_column_information
-        assert TestModel.column_names.include?("nick_name")
+        assert_includes TestModel.column_names, "nick_name"
         assert_equal ["foo"], TestModel.all.map(&:nick_name)
       end
 
@@ -57,7 +57,7 @@ module ActiveRecord
 
         rename_column "test_models", "salary", "annual_salary"
 
-        assert TestModel.column_names.include?("annual_salary")
+        assert_includes TestModel.column_names, "annual_salary"
         default_after = connection.columns("test_models").find { |c| c.name == "annual_salary" }.default
         assert_equal "70000", default_after
       end
@@ -88,7 +88,7 @@ module ActiveRecord
         add_column "test_models", "first_name", :string
         rename_column "test_models", "first_name", "group"
 
-        assert TestModel.column_names.include?("group")
+        assert_includes TestModel.column_names, "group"
       end
 
       def test_rename_column_with_an_index

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -57,7 +57,7 @@ module ActiveRecord
 
           assert_equal "http://www.foreverflying.com/octopus-black7.jpg", connection.select_value("SELECT url FROM octopi WHERE id=1")
           index = connection.indexes(:octopi).first
-          assert index.columns.include?("url")
+          assert_includes index.columns, "url"
           assert_equal "index_octopi_on_url", index.name
         end
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -127,9 +127,9 @@ class ReflectionTest < ActiveRecord::TestCase
       :gps_location, nil, {}, Customer
     )
 
-    assert Customer.reflect_on_all_aggregations.include?(reflection_for_gps_location)
-    assert Customer.reflect_on_all_aggregations.include?(reflection_for_balance)
-    assert Customer.reflect_on_all_aggregations.include?(reflection_for_address)
+    assert_includes Customer.reflect_on_all_aggregations, reflection_for_gps_location
+    assert_includes Customer.reflect_on_all_aggregations, reflection_for_balance
+    assert_includes Customer.reflect_on_all_aggregations, reflection_for_address
 
     assert_equal reflection_for_address, Customer.reflect_on_aggregation(:address)
 

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -86,9 +86,9 @@ class RelationMergingTest < ActiveRecord::TestCase
     merged   = left.merge(right)
 
     assert_equal expected, merged.bound_attributes
-    assert !merged.to_sql.include?("omg")
-    assert merged.to_sql.include?("wtf")
-    assert merged.to_sql.include?("bbq")
+    assert_not_includes merged.to_sql, "omg"
+    assert_includes merged.to_sql, "wtf"
+    assert_includes merged.to_sql, "bbq"
   end
 
   def test_merging_reorders_bind_params

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -71,7 +71,7 @@ module ActiveRecord
 
     test "#references!" do
       assert relation.references!(:foo).equal?(relation)
-      assert relation.references_values.include?("foo")
+      assert_includes relation.references_values, "foo"
     end
 
     test "extending!" do

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -530,8 +530,8 @@ class RelationTest < ActiveRecord::TestCase
 
     assert_equal 3, developers_on_project_one.length
     developer_names = developers_on_project_one.map(&:name)
-    assert developer_names.include?("David")
-    assert developer_names.include?("Jamis")
+    assert_includes developer_names, "David"
+    assert_includes developer_names, "Jamis"
   end
 
   def test_find_on_hash_conditions
@@ -748,11 +748,11 @@ class RelationTest < ActiveRecord::TestCase
     posts = Post.preload(:comments)
     post = posts.find { |p| p.id == 1 }
     assert_equal 2, post.comments.size
-    assert post.comments.include?(comments(:greetings))
+    assert_includes post.comments, comments(:greetings)
 
     post = Post.where("posts.title = 'Welcome to the weblog'").preload(:comments).first
     assert_equal 2, post.comments.size
-    assert post.comments.include?(comments(:greetings))
+    assert_includes post.comments, comments(:greetings)
 
     posts = Post.preload(:last_comment)
     post = posts.find { |p| p.id == 1 }

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -63,7 +63,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
     def test_default_scoping_with_threads
       2.times do
         Thread.new {
-          assert DeveloperOrderedBySalary.all.to_sql.include?("salary DESC")
+          assert_includes DeveloperOrderedBySalary.all.to_sql, "salary DESC"
           DeveloperOrderedBySalary.connection.close
         }.join
       end
@@ -368,7 +368,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
   def test_unscoped_with_named_scope_should_not_have_default_scope
     assert_equal [DeveloperCalledJamis.find(developers(:poor_jamis).id)], DeveloperCalledJamis.poor
 
-    assert DeveloperCalledJamis.unscoped.poor.include?(developers(:david).becomes(DeveloperCalledJamis))
+    assert_includes DeveloperCalledJamis.unscoped.poor, developers(:david).becomes(DeveloperCalledJamis)
 
     assert_equal 11, DeveloperCalledJamis.unscoped.length
     assert_equal 1,  DeveloperCalledJamis.poor.length

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -33,8 +33,8 @@ class NamedScopingTest < ActiveRecord::TestCase
     all_posts.to_a
 
     new_post = Topic.create!
-    assert !all_posts.include?(new_post)
-    assert all_posts.reload.include?(new_post)
+    assert_not_includes all_posts, new_post
+    assert_includes all_posts.reload, new_post
   end
 
   def test_delegates_finds_and_calculations_to_the_base_class

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -133,8 +133,8 @@ class RelationScopingTest < ActiveRecord::TestCase
     scoped_developers = Developer.includes(:projects).scoping do
       Developer.where("projects.id" => 2).to_a
     end
-    assert scoped_developers.include?(developers(:david))
-    assert !scoped_developers.include?(developers(:jamis))
+    assert_includes scoped_developers, developers(:david)
+    assert_not_includes scoped_developers, developers(:jamis)
     assert_equal 1, scoped_developers.size
   end
 
@@ -143,8 +143,8 @@ class RelationScopingTest < ActiveRecord::TestCase
       Developer.where("developers_projects.project_id = 2").to_a
     end
 
-    assert scoped_developers.include?(developers(:david))
-    assert !scoped_developers.include?(developers(:jamis))
+    assert_includes scoped_developers, developers(:david)
+    assert_not_includes scoped_developers, developers(:jamis)
     assert_equal 1, scoped_developers.size
     assert_equal developers(:david).attributes, scoped_developers.first.attributes
   end
@@ -155,7 +155,7 @@ class RelationScopingTest < ActiveRecord::TestCase
     end
 
     assert_equal 1, new_comment.post_id
-    assert Post.find(1).comments.include?(new_comment)
+    assert_includes Post.find(1).comments, new_comment
   end
 
   def test_scoped_create_with_create_with
@@ -164,7 +164,7 @@ class RelationScopingTest < ActiveRecord::TestCase
     end
 
     assert_equal 1, new_comment.post_id
-    assert Post.find(1).comments.include?(new_comment)
+    assert_includes Post.find(1).comments, new_comment
   end
 
   def test_scoped_create_with_create_with_has_higher_priority
@@ -173,7 +173,7 @@ class RelationScopingTest < ActiveRecord::TestCase
     end
 
     assert_equal 1, new_comment.post_id
-    assert Post.find(1).comments.include?(new_comment)
+    assert_includes Post.find(1).comments, new_comment
   end
 
   def test_ensure_that_method_scoping_is_correctly_restored

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -30,7 +30,7 @@ module ActiveRecord
 
       protected_environments = ActiveRecord::Base.protected_environments.dup
       current_env            = ActiveRecord::Migrator.current_environment
-      assert !protected_environments.include?(current_env)
+      assert_not_includes protected_environments, current_env
       # Assert no error
       ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
 

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -631,11 +631,11 @@ class TransactionTest < ActiveRecord::TestCase
     assert_nothing_raised do
       Topic.reset_column_information
       Topic.connection.add_column("topics", "stuff", :string)
-      assert Topic.column_names.include?("stuff")
+      assert_includes Topic.column_names, "stuff"
 
       Topic.reset_column_information
       Topic.connection.remove_column("topics", "stuff")
-      assert !Topic.column_names.include?("stuff")
+      assert_not_includes Topic.column_names, "stuff"
     end
 
     if Topic.connection.supports_ddl_transactions?

--- a/activesupport/test/autoload_test.rb
+++ b/activesupport/test/autoload_test.rb
@@ -31,7 +31,7 @@ class TestAutoloadModule < ActiveSupport::TestCase
       end
     end
 
-    assert !$LOADED_FEATURES.include?(@some_class_path)
+    assert_not_includes $LOADED_FEATURES, @some_class_path
     assert_nothing_raised { ::Fixtures::Autoload::SomeClass }
   end
 
@@ -40,7 +40,7 @@ class TestAutoloadModule < ActiveSupport::TestCase
       autoload :SomeClass
     end
 
-    assert !$LOADED_FEATURES.include?(@some_class_path)
+    assert_not_includes $LOADED_FEATURES, @some_class_path
     assert_nothing_raised { ::Fixtures::Autoload::SomeClass }
   end
 
@@ -51,9 +51,9 @@ class TestAutoloadModule < ActiveSupport::TestCase
       end
     end
 
-    assert !$LOADED_FEATURES.include?(@some_class_path)
+    assert_not_includes $LOADED_FEATURES, @some_class_path
     ::Fixtures::Autoload.eager_load!
-    assert $LOADED_FEATURES.include?(@some_class_path)
+    assert_includes $LOADED_FEATURES, @some_class_path
     assert_nothing_raised { ::Fixtures::Autoload::SomeClass }
   end
 
@@ -64,7 +64,7 @@ class TestAutoloadModule < ActiveSupport::TestCase
       end
     end
 
-    assert !$LOADED_FEATURES.include?(@another_class_path)
+    assert_not_includes $LOADED_FEATURES, @another_class_path
     assert_nothing_raised { ::Fixtures::AnotherClass }
   end
 
@@ -75,7 +75,7 @@ class TestAutoloadModule < ActiveSupport::TestCase
       end
     end
 
-    assert !$LOADED_FEATURES.include?(@another_class_path)
+    assert_not_includes $LOADED_FEATURES, @another_class_path
     assert_nothing_raised { ::Fixtures::AnotherClass }
   end
 end

--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -66,7 +66,7 @@ class ConcernTest < ActiveSupport::TestCase
   def test_module_is_included_normally
     @klass.include(Baz)
     assert_equal "baz", @klass.new.baz
-    assert @klass.included_modules.include?(ConcernTest::Baz)
+    assert_includes @klass.included_modules, ConcernTest::Baz
   end
 
   def test_class_methods_are_extended
@@ -105,7 +105,7 @@ class ConcernTest < ActiveSupport::TestCase
     assert_equal "bar", @klass.new.bar
     assert_equal "bar+baz", @klass.new.baz
     assert_equal "bar's baz + baz", @klass.baz
-    assert @klass.included_modules.include?(ConcernTest::Bar)
+    assert_includes @klass.included_modules, ConcernTest::Bar
   end
 
   def test_dependencies_with_multiple_modules

--- a/activesupport/test/configurable_test.rb
+++ b/activesupport/test/configurable_test.rb
@@ -121,11 +121,11 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
 
   def assert_method_defined(object, method)
     methods = object.public_methods.map(&:to_s)
-    assert methods.include?(method.to_s), "Expected #{methods.inspect} to include #{method.to_s.inspect}"
+    assert_includes methods, method.to_s, "Expected #{methods.inspect} to include #{method.to_s.inspect}"
   end
 
   def assert_method_not_defined(object, method)
     methods = object.public_methods.map(&:to_s)
-    assert !methods.include?(method.to_s), "Expected #{methods.inspect} to not include #{method.to_s.inspect}"
+    assert_not_includes methods, method.to_s, "Expected #{methods.inspect} to not include #{method.to_s.inspect}"
   end
 end

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -97,28 +97,28 @@ class ToXmlTest < ActiveSupport::TestCase
     ].to_xml(skip_instruct: true, indent: 0)
 
     assert_equal '<objects type="array"><object>', xml.first(30)
-    assert xml.include?(%(<age type="integer">26</age>)), xml
-    assert xml.include?(%(<age-in-millis type="integer">820497600000</age-in-millis>)), xml
-    assert xml.include?(%(<name>David</name>)), xml
-    assert xml.include?(%(<age type="integer">31</age>)), xml
-    assert xml.include?(%(<age-in-millis type="decimal">1.0</age-in-millis>)), xml
-    assert xml.include?(%(<name>Jason</name>)), xml
+    assert_includes xml, %(<age type="integer">26</age>), xml
+    assert_includes xml, %(<age-in-millis type="integer">820497600000</age-in-millis>), xml
+    assert_includes xml, %(<name>David</name>), xml
+    assert_includes xml, %(<age type="integer">31</age>), xml
+    assert_includes xml, %(<age-in-millis type="decimal">1.0</age-in-millis>), xml
+    assert_includes xml, %(<name>Jason</name>), xml
   end
 
   def test_to_xml_with_non_hash_elements
     xml = %w[1 2 3].to_xml(skip_instruct: true, indent: 0)
 
     assert_equal '<strings type="array"><string', xml.first(29)
-    assert xml.include?(%(<string>2</string>)), xml
+    assert_includes xml, %(<string>2</string>), xml
   end
 
   def test_to_xml_with_non_hash_different_type_elements
     xml = [1, 2.0, "3"].to_xml(skip_instruct: true, indent: 0)
 
     assert_equal '<objects type="array"><object', xml.first(29)
-    assert xml.include?(%(<object type="integer">1</object>)), xml
-    assert xml.include?(%(<object type="float">2.0</object>)), xml
-    assert xml.include?(%(object>3</object>)), xml
+    assert_includes xml, %(<object type="integer">1</object>), xml
+    assert_includes xml, %(<object type="float">2.0</object>), xml
+    assert_includes xml, %(object>3</object>), xml
   end
 
   def test_to_xml_with_dedicated_name
@@ -135,10 +135,10 @@ class ToXmlTest < ActiveSupport::TestCase
     ].to_xml(skip_instruct: true, skip_types: true, indent: 0)
 
     assert_equal "<objects><object>", xml.first(17)
-    assert xml.include?(%(<street-address>Paulina</street-address>))
-    assert xml.include?(%(<name>David</name>))
-    assert xml.include?(%(<street-address>Evergreen</street-address>))
-    assert xml.include?(%(<name>Jason</name>))
+    assert_includes xml, %(<street-address>Paulina</street-address>)
+    assert_includes xml, %(<name>David</name>)
+    assert_includes xml, %(<street-address>Evergreen</street-address>)
+    assert_includes xml, %(<name>Jason</name>)
   end
 
   def test_to_xml_with_indent_set
@@ -147,10 +147,10 @@ class ToXmlTest < ActiveSupport::TestCase
     ].to_xml(skip_instruct: true, skip_types: true, indent: 4)
 
     assert_equal "<objects>\n    <object>", xml.first(22)
-    assert xml.include?(%(\n        <street-address>Paulina</street-address>))
-    assert xml.include?(%(\n        <name>David</name>))
-    assert xml.include?(%(\n        <street-address>Evergreen</street-address>))
-    assert xml.include?(%(\n        <name>Jason</name>))
+    assert_includes xml, %(\n        <street-address>Paulina</street-address>)
+    assert_includes xml, %(\n        <name>David</name>)
+    assert_includes xml, %(\n        <street-address>Evergreen</street-address>)
+    assert_includes xml, %(\n        <name>Jason</name>)
   end
 
   def test_to_xml_with_dasherize_false
@@ -159,8 +159,8 @@ class ToXmlTest < ActiveSupport::TestCase
     ].to_xml(skip_instruct: true, skip_types: true, indent: 0, dasherize: false)
 
     assert_equal "<objects><object>", xml.first(17)
-    assert xml.include?(%(<street_address>Paulina</street_address>))
-    assert xml.include?(%(<street_address>Evergreen</street_address>))
+    assert_includes xml, %(<street_address>Paulina</street_address>)
+    assert_includes xml, %(<street_address>Evergreen</street_address>)
   end
 
   def test_to_xml_with_dasherize_true
@@ -169,8 +169,8 @@ class ToXmlTest < ActiveSupport::TestCase
     ].to_xml(skip_instruct: true, skip_types: true, indent: 0, dasherize: true)
 
     assert_equal "<objects><object>", xml.first(17)
-    assert xml.include?(%(<street-address>Paulina</street-address>))
-    assert xml.include?(%(<street-address>Evergreen</street-address>))
+    assert_includes xml, %(<street-address>Paulina</street-address>)
+    assert_includes xml, %(<street-address>Evergreen</street-address>)
   end
 
   def test_to_xml_with_instruct
@@ -191,7 +191,7 @@ class ToXmlTest < ActiveSupport::TestCase
       builder.count 2
     end
 
-    assert xml.include?(%(<count>2</count>)), xml
+    assert_includes xml, %(<count>2</count>), xml
   end
 
   def test_to_xml_with_empty

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1127,63 +1127,63 @@ class HashToXmlTest < ActiveSupport::TestCase
   def test_one_level
     xml = { name: "David", street: "Paulina" }.to_xml(@xml_options)
     assert_equal "<person>", xml.first(8)
-    assert xml.include?(%(<street>Paulina</street>))
-    assert xml.include?(%(<name>David</name>))
+    assert_includes xml, %(<street>Paulina</street>)
+    assert_includes xml, %(<name>David</name>)
   end
 
   def test_one_level_dasherize_false
     xml = { name: "David", street_name: "Paulina" }.to_xml(@xml_options.merge(dasherize: false))
     assert_equal "<person>", xml.first(8)
-    assert xml.include?(%(<street_name>Paulina</street_name>))
-    assert xml.include?(%(<name>David</name>))
+    assert_includes xml, %(<street_name>Paulina</street_name>)
+    assert_includes xml, %(<name>David</name>)
   end
 
   def test_one_level_dasherize_true
     xml = { name: "David", street_name: "Paulina" }.to_xml(@xml_options.merge(dasherize: true))
     assert_equal "<person>", xml.first(8)
-    assert xml.include?(%(<street-name>Paulina</street-name>))
-    assert xml.include?(%(<name>David</name>))
+    assert_includes xml, %(<street-name>Paulina</street-name>)
+    assert_includes xml, %(<name>David</name>)
   end
 
   def test_one_level_camelize_true
     xml = { name: "David", street_name: "Paulina" }.to_xml(@xml_options.merge(camelize: true))
     assert_equal "<Person>", xml.first(8)
-    assert xml.include?(%(<StreetName>Paulina</StreetName>))
-    assert xml.include?(%(<Name>David</Name>))
+    assert_includes xml, %(<StreetName>Paulina</StreetName>)
+    assert_includes xml, %(<Name>David</Name>)
   end
 
   def test_one_level_camelize_lower
     xml = { name: "David", street_name: "Paulina" }.to_xml(@xml_options.merge(camelize: :lower))
     assert_equal "<person>", xml.first(8)
-    assert xml.include?(%(<streetName>Paulina</streetName>))
-    assert xml.include?(%(<name>David</name>))
+    assert_includes xml, %(<streetName>Paulina</streetName>)
+    assert_includes xml, %(<name>David</name>)
   end
 
   def test_one_level_with_types
     xml = { name: "David", street: "Paulina", age: 26, age_in_millis: 820497600000, moved_on: Date.new(2005, 11, 15), resident: :yes }.to_xml(@xml_options)
     assert_equal "<person>", xml.first(8)
-    assert xml.include?(%(<street>Paulina</street>))
-    assert xml.include?(%(<name>David</name>))
-    assert xml.include?(%(<age type="integer">26</age>))
-    assert xml.include?(%(<age-in-millis type="integer">820497600000</age-in-millis>))
-    assert xml.include?(%(<moved-on type="date">2005-11-15</moved-on>))
-    assert xml.include?(%(<resident type="symbol">yes</resident>))
+    assert_includes xml, %(<street>Paulina</street>)
+    assert_includes xml, %(<name>David</name>)
+    assert_includes xml, %(<age type="integer">26</age>)
+    assert_includes xml, %(<age-in-millis type="integer">820497600000</age-in-millis>)
+    assert_includes xml, %(<moved-on type="date">2005-11-15</moved-on>)
+    assert_includes xml, %(<resident type="symbol">yes</resident>)
   end
 
   def test_one_level_with_nils
     xml = { name: "David", street: "Paulina", age: nil }.to_xml(@xml_options)
     assert_equal "<person>", xml.first(8)
-    assert xml.include?(%(<street>Paulina</street>))
-    assert xml.include?(%(<name>David</name>))
-    assert xml.include?(%(<age nil="true"/>))
+    assert_includes xml, %(<street>Paulina</street>)
+    assert_includes xml, %(<name>David</name>)
+    assert_includes xml, %(<age nil="true"/>)
   end
 
   def test_one_level_with_skipping_types
     xml = { name: "David", street: "Paulina", age: nil }.to_xml(@xml_options.merge(skip_types: true))
     assert_equal "<person>", xml.first(8)
-    assert xml.include?(%(<street>Paulina</street>))
-    assert xml.include?(%(<name>David</name>))
-    assert xml.include?(%(<age nil="true"/>))
+    assert_includes xml, %(<street>Paulina</street>)
+    assert_includes xml, %(<name>David</name>)
+    assert_includes xml, %(<age nil="true"/>)
   end
 
   def test_one_level_with_yielding
@@ -1192,37 +1192,37 @@ class HashToXmlTest < ActiveSupport::TestCase
     end
 
     assert_equal "<person>", xml.first(8)
-    assert xml.include?(%(<street>Paulina</street>))
-    assert xml.include?(%(<name>David</name>))
-    assert xml.include?(%(<creator>Rails</creator>))
+    assert_includes xml, %(<street>Paulina</street>)
+    assert_includes xml, %(<name>David</name>)
+    assert_includes xml, %(<creator>Rails</creator>)
   end
 
   def test_two_levels
     xml = { name: "David", address: { street: "Paulina" } }.to_xml(@xml_options)
     assert_equal "<person>", xml.first(8)
-    assert xml.include?(%(<address><street>Paulina</street></address>))
-    assert xml.include?(%(<name>David</name>))
+    assert_includes xml, %(<address><street>Paulina</street></address>)
+    assert_includes xml, %(<name>David</name>)
   end
 
   def test_two_levels_with_second_level_overriding_to_xml
     xml = { name: "David", address: { street: "Paulina" }, child: IWriteMyOwnXML.new }.to_xml(@xml_options)
     assert_equal "<person>", xml.first(8)
-    assert xml.include?(%(<address><street>Paulina</street></address>))
-    assert xml.include?(%(<level_one><second_level>content</second_level></level_one>))
+    assert_includes xml, %(<address><street>Paulina</street></address>)
+    assert_includes xml, %(<level_one><second_level>content</second_level></level_one>)
   end
 
   def test_two_levels_with_array
     xml = { name: "David", addresses: [{ street: "Paulina" }, { street: "Evergreen" }] }.to_xml(@xml_options)
     assert_equal "<person>", xml.first(8)
-    assert xml.include?(%(<addresses type="array"><address>))
-    assert xml.include?(%(<address><street>Paulina</street></address>))
-    assert xml.include?(%(<address><street>Evergreen</street></address>))
-    assert xml.include?(%(<name>David</name>))
+    assert_includes xml, %(<addresses type="array"><address>)
+    assert_includes xml, %(<address><street>Paulina</street></address>)
+    assert_includes xml, %(<address><street>Evergreen</street></address>)
+    assert_includes xml, %(<name>David</name>)
   end
 
   def test_three_levels_with_array
     xml = { name: "David", addresses: [{ streets: [ { name: "Paulina" }, { name: "Paulina" } ] } ] }.to_xml(@xml_options)
-    assert xml.include?(%(<addresses type="array"><address><streets type="array"><street><name>))
+    assert_includes xml, %(<addresses type="array"><address><streets type="array"><street><name>)
   end
 
   def test_timezoned_attributes

--- a/activesupport/test/core_ext/module/concerning_test.rb
+++ b/activesupport/test/core_ext/module/concerning_test.rb
@@ -4,7 +4,7 @@ require "active_support/core_ext/module/concerning"
 class ModuleConcerningTest < ActiveSupport::TestCase
   def test_concerning_declares_a_concern_and_includes_it_immediately
     klass = Class.new { concerning(:Foo) {} }
-    assert klass.ancestors.include?(klass::Foo), klass.ancestors.inspect
+    assert_includes klass.ancestors, klass::Foo, klass.ancestors.inspect
   end
 end
 
@@ -21,10 +21,10 @@ class ModuleConcernTest < ActiveSupport::TestCase
     assert klass.const_defined?(:Baz, false)
     assert !ModuleConcernTest.const_defined?(:Baz)
     assert_kind_of ActiveSupport::Concern, klass::Baz
-    assert !klass.ancestors.include?(klass::Baz), klass.ancestors.inspect
+    assert_not_includes klass.ancestors, klass::Baz, klass.ancestors.inspect
 
     # Public method visibility by default
-    assert klass::Baz.public_instance_methods.map(&:to_s).include?("should_be_public")
+    assert_includes klass::Baz.public_instance_methods.map(&:to_s), "should_be_public"
 
     # Calls included hook
     assert_equal 1, Class.new { include klass::Baz }.instance_variable_get("@foo")

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -66,15 +66,15 @@ class RangeTest < ActiveSupport::TestCase
   end
 
   def test_exclusive_end_should_not_include_identical_with_inclusive_end
-    assert !(1...10).include?(1..10)
+    assert_not_includes (1...10), 1..10
   end
 
   def test_should_not_include_overlapping_first
-    assert !(2..8).include?(1..3)
+    assert_not_includes (2..8), 1..3
   end
 
   def test_should_not_include_overlapping_last
-    assert !(2..8).include?(5..9)
+    assert_not_includes (2..8), 5..9
   end
 
   def test_should_include_identical_exclusive_with_floats

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -114,25 +114,25 @@ class DependenciesTest < ActiveSupport::TestCase
       assert_equal 1, $check_warnings_load_count
       assert_equal true, $checked_verbose, "On first load warnings should be enabled."
 
-      assert ActiveSupport::Dependencies.loaded.include?(expanded)
+      assert_includes ActiveSupport::Dependencies.loaded, expanded
       ActiveSupport::Dependencies.clear
       assert_not ActiveSupport::Dependencies.loaded.include?(expanded)
-      assert ActiveSupport::Dependencies.history.include?(expanded)
+      assert_includes ActiveSupport::Dependencies.history, expanded
 
       silence_warnings { require_dependency filename }
       assert_equal 2, $check_warnings_load_count
       assert_equal nil, $checked_verbose, "After first load warnings should be left alone."
 
-      assert ActiveSupport::Dependencies.loaded.include?(expanded)
+      assert_includes ActiveSupport::Dependencies.loaded, expanded
       ActiveSupport::Dependencies.clear
       assert_not ActiveSupport::Dependencies.loaded.include?(expanded)
-      assert ActiveSupport::Dependencies.history.include?(expanded)
+      assert_includes ActiveSupport::Dependencies.history, expanded
 
       enable_warnings { require_dependency filename }
       assert_equal 3, $check_warnings_load_count
       assert_equal true, $checked_verbose, "After first load warnings should be left alone."
 
-      assert ActiveSupport::Dependencies.loaded.include?(expanded)
+      assert_includes ActiveSupport::Dependencies.loaded, expanded
       ActiveSupport::Dependencies.warnings_on_first_load = old_warnings
     end
   end
@@ -1059,13 +1059,13 @@ class DependenciesTest < ActiveSupport::TestCase
   end
 
   def test_load_and_require_stay_private
-    assert Object.private_methods.include?(:load)
-    assert Object.private_methods.include?(:require)
+    assert_includes Object.private_methods, :load
+    assert_includes Object.private_methods, :require
 
     ActiveSupport::Dependencies.unhook!
 
-    assert Object.private_methods.include?(:load)
-    assert Object.private_methods.include?(:require)
+    assert_includes Object.private_methods, :load
+    assert_includes Object.private_methods, :require
   ensure
     ActiveSupport::Dependencies.hook!
   end

--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -67,7 +67,7 @@ class LoggerTest < ActiveSupport::TestCase
   def test_should_log_debugging_message_when_debugging
     @logger.level = Logger::DEBUG
     @logger.add(Logger::DEBUG, @message)
-    assert @output.string.include?(@message)
+    assert_includes @output.string, @message
   end
 
   def test_should_not_log_debug_messages_when_log_level_is_info
@@ -79,25 +79,25 @@ class LoggerTest < ActiveSupport::TestCase
   def test_should_add_message_passed_as_block_when_using_add
     @logger.level = Logger::INFO
     @logger.add(Logger::INFO) { @message }
-    assert @output.string.include?(@message)
+    assert_includes @output.string, @message
   end
 
   def test_should_add_message_passed_as_block_when_using_shortcut
     @logger.level = Logger::INFO
     @logger.info { @message }
-    assert @output.string.include?(@message)
+    assert_includes @output.string, @message
   end
 
   def test_should_convert_message_to_string
     @logger.level = Logger::INFO
     @logger.info @integer_message
-    assert @output.string.include?(@integer_message.to_s)
+    assert_includes @output.string, @integer_message.to_s
   end
 
   def test_should_convert_message_to_string_when_passed_in_block
     @logger.level = Logger::INFO
     @logger.info { @integer_message }
-    assert @output.string.include?(@integer_message.to_s)
+    assert_includes @output.string, @integer_message.to_s
   end
 
   def test_should_not_evaluate_block_if_message_wont_be_logged
@@ -125,10 +125,10 @@ class LoggerTest < ActiveSupport::TestCase
     @logger.level = Logger::INFO
     @logger.info(UNICODE_STRING)
     @logger.info(BYTE_STRING)
-    assert @output.string.include?(UNICODE_STRING)
+    assert_includes @output.string, UNICODE_STRING
     byte_string = @output.string.dup
     byte_string.force_encoding("ASCII-8BIT")
-    assert byte_string.include?(BYTE_STRING)
+    assert_includes byte_string, BYTE_STRING
   end
 
   def test_silencing_everything_but_errors
@@ -138,7 +138,7 @@ class LoggerTest < ActiveSupport::TestCase
     end
 
     assert_not @output.string.include?("NOT THERE")
-    assert @output.string.include?("THIS IS HERE")
+    assert_includes @output.string, "THIS IS HERE"
   end
 
   def test_logger_silencing_works_for_broadcast
@@ -154,12 +154,12 @@ class LoggerTest < ActiveSupport::TestCase
       @logger.error "CORRECT ERROR"
     end
 
-    assert @output.string.include?("CORRECT DEBUG")
-    assert @output.string.include?("CORRECT ERROR")
+    assert_includes @output.string, "CORRECT DEBUG"
+    assert_includes @output.string, "CORRECT ERROR"
     assert_not @output.string.include?("FAILURE")
 
-    assert another_output.string.include?("CORRECT DEBUG")
-    assert another_output.string.include?("CORRECT ERROR")
+    assert_includes another_output.string, "CORRECT DEBUG"
+    assert_includes another_output.string, "CORRECT ERROR"
     assert_not another_output.string.include?("FAILURE")
   end
 
@@ -176,13 +176,13 @@ class LoggerTest < ActiveSupport::TestCase
       @logger.error "CORRECT ERROR"
     end
 
-    assert @output.string.include?("CORRECT DEBUG")
-    assert @output.string.include?("CORRECT ERROR")
+    assert_includes @output.string, "CORRECT DEBUG"
+    assert_includes @output.string, "CORRECT ERROR"
     assert_not @output.string.include?("FAILURE")
 
-    assert another_output.string.include?("CORRECT DEBUG")
-    assert another_output.string.include?("CORRECT ERROR")
-    assert another_output.string.include?("FAILURE")
+    assert_includes another_output.string, "CORRECT DEBUG"
+    assert_includes another_output.string, "CORRECT ERROR"
+    assert_includes another_output.string, "FAILURE"
     # We can't silence plain ruby Logger cause with thread safety
     # but at least we don't break it
   end

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -213,11 +213,11 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
   end
 
   def test_should_know_if_one_includes_the_other
-    assert @chars.include?("")
-    assert @chars.include?("ち")
-    assert @chars.include?("わ")
-    assert !@chars.include?("こちわ")
-    assert !@chars.include?("a")
+    assert_includes @chars, ""
+    assert_includes @chars, "ち"
+    assert_includes @chars, "わ"
+    assert_not_includes @chars, "こちわ"
+    assert_not_includes @chars, "a"
   end
 
   def test_include_raises_when_nil_is_passed

--- a/activesupport/test/ordered_hash_test.rb
+++ b/activesupport/test/ordered_hash_test.rb
@@ -129,22 +129,22 @@ class OrderedHashTest < ActiveSupport::TestCase
     copy = @ordered_hash.dup
     copy.delete("pink")
     assert_equal copy, @ordered_hash.delete_if { |k, _| k == "pink" }
-    assert !@ordered_hash.keys.include?("pink")
+    assert_not_includes @ordered_hash.keys, "pink"
   end
 
   def test_reject!
     (copy = @ordered_hash.dup).delete("pink")
     @ordered_hash.reject! { |k, _| k == "pink" }
     assert_equal copy, @ordered_hash
-    assert !@ordered_hash.keys.include?("pink")
+    assert_not_includes @ordered_hash.keys, "pink"
   end
 
   def test_reject
     copy = @ordered_hash.dup
     new_ordered_hash = @ordered_hash.reject { |k, _| k == "pink" }
     assert_equal copy, @ordered_hash
-    assert !new_ordered_hash.keys.include?("pink")
-    assert @ordered_hash.keys.include?("pink")
+    assert_not_includes new_ordered_hash.keys, "pink"
+    assert_includes @ordered_hash.keys, "pink"
     assert_instance_of ActiveSupport::OrderedHash, new_ordered_hash
   end
 
@@ -191,7 +191,7 @@ class OrderedHashTest < ActiveSupport::TestCase
   def test_shift
     pair = @ordered_hash.shift
     assert_equal [@keys.first, @values.first], pair
-    assert !@ordered_hash.keys.include?(pair.first)
+    assert_not_includes @ordered_hash.keys, pair.first
   end
 
   def test_keys
@@ -201,7 +201,7 @@ class OrderedHashTest < ActiveSupport::TestCase
   end
 
   def test_inspect
-    assert @ordered_hash.inspect.include?(@hash.inspect)
+    assert_includes @ordered_hash.inspect, @hash.inspect
   end
 
   def test_json

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -505,13 +505,13 @@ class TimeZoneTest < ActiveSupport::TestCase
   end
 
   def test_us_zones
-    assert ActiveSupport::TimeZone.us_zones.include?(ActiveSupport::TimeZone["Hawaii"])
-    assert !ActiveSupport::TimeZone.us_zones.include?(ActiveSupport::TimeZone["Kuala Lumpur"])
+    assert_includes ActiveSupport::TimeZone.us_zones, ActiveSupport::TimeZone["Hawaii"]
+    assert_not_includes ActiveSupport::TimeZone.us_zones, ActiveSupport::TimeZone["Kuala Lumpur"]
   end
 
   def test_country_zones
-    assert ActiveSupport::TimeZone.country_zones("ru").include?(ActiveSupport::TimeZone["Moscow"])
-    assert !ActiveSupport::TimeZone.country_zones(:ru).include?(ActiveSupport::TimeZone["Kuala Lumpur"])
+    assert_includes ActiveSupport::TimeZone.country_zones("ru"), ActiveSupport::TimeZone["Moscow"]
+    assert_not_includes ActiveSupport::TimeZone.country_zones(:ru), ActiveSupport::TimeZone["Kuala Lumpur"]
   end
 
   def test_to_yaml

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -126,7 +126,7 @@ class FullStackConsoleTest < ActiveSupport::TestCase
       end
     end
 
-    assert output.include?(expected), "#{expected.inspect} expected, but got:\n\n#{output}"
+    assert_includes output, expected, "#{expected.inspect} expected, but got:\n\n#{output}"
   end
 
   def write_prompt(command, expected_output = nil)

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -134,10 +134,10 @@ module ApplicationTests
       require "#{app_path}/config/environment"
       Rails.application.load_generators
 
-      assert Rails::Generators.hidden_namespaces.include?("assets")
-      assert Rails::Generators.hidden_namespaces.include?("helper")
-      assert Rails::Generators.hidden_namespaces.include?("js")
-      assert Rails::Generators.hidden_namespaces.include?("css")
+      assert_includes Rails::Generators.hidden_namespaces, "assets"
+      assert_includes Rails::Generators.hidden_namespaces, "helper"
+      assert_includes Rails::Generators.hidden_namespaces, "js"
+      assert_includes Rails::Generators.hidden_namespaces, "css"
       assert Rails::Generators.options[:rails][:api]
       assert_equal false, Rails::Generators.options[:rails][:assets]
       assert_equal false, Rails::Generators.options[:rails][:helper]

--- a/railties/test/application/initializers/i18n_test.rb
+++ b/railties/test/application/initializers/i18n_test.rb
@@ -30,7 +30,7 @@ module ApplicationTests
     end
 
     def assert_no_fallbacks
-      assert !I18n.backend.class.included_modules.include?(I18n::Backend::Fallbacks)
+      assert_not_includes I18n.backend.class.included_modules, I18n::Backend::Fallbacks
     end
 
     # Locales
@@ -62,8 +62,8 @@ module ApplicationTests
         "#{app_path}/config/locales/en.yml", "#{app_path}/config/another_locale.yml"
       ], Rails.application.config.i18n.load_path
 
-      assert I18n.load_path.include?("#{app_path}/config/locales/en.yml")
-      assert I18n.load_path.include?("#{app_path}/config/another_locale.yml")
+      assert_includes I18n.load_path, "#{app_path}/config/locales/en.yml"
+      assert_includes I18n.load_path, "#{app_path}/config/another_locale.yml"
     end
 
     test "load_path is populated before eager loaded models" do
@@ -214,7 +214,7 @@ fr:
     test "config.i18n.fallbacks = true initializes I18n.fallbacks with default settings" do
       I18n::Railtie.config.i18n.fallbacks = true
       load_app
-      assert I18n.backend.class.included_modules.include?(I18n::Backend::Fallbacks)
+      assert_includes I18n.backend.class.included_modules, I18n::Backend::Fallbacks
       assert_fallbacks de: [:de, :en]
     end
 
@@ -222,7 +222,7 @@ fr:
       I18n::Railtie.config.i18n.fallbacks = true
       I18n::Railtie.config.i18n.backend = Class.new(I18n::Backend::Simple).new
       load_app
-      assert I18n.backend.class.included_modules.include?(I18n::Backend::Fallbacks)
+      assert_includes I18n.backend.class.included_modules, I18n::Backend::Fallbacks
       assert_fallbacks de: [:de, :en]
     end
 

--- a/railties/test/application/initializers/load_path_test.rb
+++ b/railties/test/application/initializers/load_path_test.rb
@@ -19,7 +19,7 @@ module ApplicationTests
       RUBY
 
       require "#{app_path}/config/environment"
-      assert $:.include?("#{app_path}/app/models")
+      assert_includes $:, "#{app_path}/app/models"
     end
 
     test "initializing an application allows to load code on lib path inside application class definition" do
@@ -36,7 +36,7 @@ module ApplicationTests
         require "#{app_path}/config/environment"
       end
 
-      assert $:.include?("#{app_path}/lib")
+      assert_includes $:, "#{app_path}/lib"
     end
 
     test "initializing an application eager load any path under app" do

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -370,7 +370,7 @@ module ApplicationTests
       assert_equal 200, last_response.status
       assert_equal "It worked!", last_response.body
 
-      refute Rails.application.middleware.include?(ActionDispatch::Flash)
+      assert_not_includes Rails.application.middleware, ActionDispatch::Flash
     end
 
     test "cookie_only is set to true even if user tries to overwrite it" do

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -73,7 +73,7 @@ module ApplicationTests
     test "Rack::Cache is not included by default" do
       boot!
 
-      assert !middleware.include?("Rack::Cache"), "Rack::Cache is not included in the default stack unless you set config.action_dispatch.rack_cache"
+      assert_not_includes middleware, "Rack::Cache", "Rack::Cache is not included in the default stack unless you set config.action_dispatch.rack_cache"
     end
 
     test "Rack::Cache is present when action_dispatch.rack_cache is set" do
@@ -81,7 +81,7 @@ module ApplicationTests
 
       boot!
 
-      assert middleware.include?("Rack::Cache")
+      assert_includes middleware, "Rack::Cache"
     end
 
     test "ActiveRecord::Migration::CheckPending is present when active_record.migration_error is set to :page_load" do
@@ -89,13 +89,13 @@ module ApplicationTests
 
       boot!
 
-      assert middleware.include?("ActiveRecord::Migration::CheckPending")
+      assert_includes middleware, "ActiveRecord::Migration::CheckPending"
     end
 
     test "ActionDispatch::SSL is present when force_ssl is set" do
       add_to_config "config.force_ssl = true"
       boot!
-      assert middleware.include?("ActionDispatch::SSL")
+      assert_includes middleware, "ActionDispatch::SSL"
     end
 
     test "ActionDispatch::SSL is configured with options when given" do
@@ -109,7 +109,7 @@ module ApplicationTests
     test "removing Active Record omits its middleware" do
       use_frameworks []
       boot!
-      assert !middleware.include?("ActiveRecord::Migration::CheckPending")
+      assert_not_includes middleware, "ActiveRecord::Migration::CheckPending"
     end
 
     test "includes executor" do
@@ -139,20 +139,20 @@ module ApplicationTests
     test "removes static asset server if public_file_server.enabled is disabled" do
       add_to_config "config.public_file_server.enabled = false"
       boot!
-      assert !middleware.include?("ActionDispatch::Static")
+      assert_not_includes middleware, "ActionDispatch::Static"
     end
 
     test "can delete a middleware from the stack" do
       add_to_config "config.middleware.delete ActionDispatch::Static"
       boot!
-      assert !middleware.include?("ActionDispatch::Static")
+      assert_not_includes middleware, "ActionDispatch::Static"
     end
 
     test "can delete a middleware from the stack even if insert_before is added after delete" do
       add_to_config "config.middleware.delete Rack::Runtime"
       add_to_config "config.middleware.insert_before(Rack::Runtime, Rack::Config)"
       boot!
-      assert middleware.include?("Rack::Config")
+      assert_includes middleware, "Rack::Config"
       assert_not middleware.include?("Rack::Runtime")
     end
 
@@ -160,21 +160,21 @@ module ApplicationTests
       add_to_config "config.middleware.delete Rack::Runtime"
       add_to_config "config.middleware.insert_after(Rack::Runtime, Rack::Config)"
       boot!
-      assert middleware.include?("Rack::Config")
+      assert_includes middleware, "Rack::Config"
       assert_not middleware.include?("Rack::Runtime")
     end
 
     test "includes exceptions middlewares even if action_dispatch.show_exceptions is disabled" do
       add_to_config "config.action_dispatch.show_exceptions = false"
       boot!
-      assert middleware.include?("ActionDispatch::ShowExceptions")
-      assert middleware.include?("ActionDispatch::DebugExceptions")
+      assert_includes middleware, "ActionDispatch::ShowExceptions"
+      assert_includes middleware, "ActionDispatch::DebugExceptions"
     end
 
     test "removes ActionDispatch::Reloader if cache_classes is true" do
       add_to_config "config.cache_classes = true"
       boot!
-      assert !middleware.include?("ActionDispatch::Reloader")
+      assert_not_includes middleware, "ActionDispatch::Reloader"
     end
 
     test "use middleware" do

--- a/railties/test/application/paths_test.rb
+++ b/railties/test/application/paths_test.rb
@@ -55,9 +55,9 @@ module ApplicationTests
 
     test "booting up Rails yields a list of paths that are eager" do
       eager_load = @paths.eager_load
-      assert eager_load.include?(root("app/controllers"))
-      assert eager_load.include?(root("app/helpers"))
-      assert eager_load.include?(root("app/models"))
+      assert_includes eager_load, root("app/controllers")
+      assert_includes eager_load, root("app/helpers")
+      assert_includes eager_load, root("app/models")
     end
 
     test "environments has a glob equal to the current environment" do

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -101,7 +101,7 @@ module ApplicationTests
       File.delete "#{app_path}/config/initializers/disable_maintain_test_schema.rb"
 
       result = assert_successful_test_run("models/user_test.rb")
-      assert !result.include?("create_table(:users)")
+      assert_not_includes result, "create_table(:users)"
     end
 
     test "sql structure migrations" do
@@ -289,7 +289,7 @@ Expected: ["id", "name"]
       def assert_unsuccessful_run(name, message)
         result = run_test_file(name)
         assert_not_equal 0, $?.to_i
-        assert result.include?(message)
+        assert_includes result, message
         result
       end
 

--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -106,9 +106,9 @@ class NamedBaseTest < Rails::Generators::TestCase
   def test_hide_namespace
     g = generator ["Hidden"]
     g.class.stub(:namespace, "hidden") do
-      assert !Rails::Generators.hidden_namespaces.include?("hidden")
+      assert_not_includes Rails::Generators.hidden_namespaces, "hidden"
       g.class.hide!
-      assert Rails::Generators.hidden_namespaces.include?("hidden")
+      assert_includes Rails::Generators.hidden_namespaces, "hidden"
     end
   end
 

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -229,7 +229,7 @@ class GeneratorsTest < Rails::Generators::TestCase
 
   def test_source_paths_for_not_namespaced_generators
     mspec = Rails::Generators.find_by_namespace :fixjour
-    assert mspec.source_paths.include?(File.join(Rails.root, "lib", "templates", "fixjour"))
+    assert_includes mspec.source_paths, File.join(Rails.root, "lib", "templates", "fixjour")
   end
 
   def test_usage_with_embedded_ruby
@@ -239,8 +239,8 @@ class GeneratorsTest < Rails::Generators::TestCase
   end
 
   def test_hide_namespace
-    assert !Rails::Generators.hidden_namespaces.include?("special:namespace")
+    assert_not_includes Rails::Generators.hidden_namespaces, "special:namespace"
     Rails::Generators.hide_namespace("special:namespace")
-    assert Rails::Generators.hidden_namespaces.include?("special:namespace")
+    assert_includes Rails::Generators.hidden_namespaces, "special:namespace"
   end
 end

--- a/railties/test/paths_test.rb
+++ b/railties/test/paths_test.rb
@@ -103,7 +103,7 @@ class PathsTest < ActiveSupport::TestCase
       @root.add "app", with: "/app"
       @root["app"].autoload_once!
       assert @root["app"].autoload_once?
-      assert @root.autoload_once.include?(@root["app"].expanded.first)
+      assert_includes @root.autoload_once, @root["app"].expanded.first
     end
   end
 
@@ -114,14 +114,14 @@ class PathsTest < ActiveSupport::TestCase
 
     @root["app"].skip_autoload_once!
     assert !@root["app"].autoload_once?
-    assert !@root.autoload_once.include?(@root["app"].expanded.first)
+    assert_not_includes @root.autoload_once, @root["app"].expanded.first
   end
 
   test "it is possible to add a path without assignment and specify it should be loaded only once" do
     File.stub(:exist?, true) do
       @root.add "app", with: "/app", autoload_once: true
       assert @root["app"].autoload_once?
-      assert @root.autoload_once.include?("/app")
+      assert_includes @root.autoload_once, "/app"
     end
   end
 
@@ -129,8 +129,8 @@ class PathsTest < ActiveSupport::TestCase
     File.stub(:exist?, true) do
       @root.add "app", with: ["/app", "/app2"], autoload_once: true
       assert @root["app"].autoload_once?
-      assert @root.autoload_once.include?("/app")
-      assert @root.autoload_once.include?("/app2")
+      assert_includes @root.autoload_once, "/app"
+      assert_includes @root.autoload_once, "/app2"
     end
   end
 
@@ -157,7 +157,7 @@ class PathsTest < ActiveSupport::TestCase
       @root["app"] = "/app"
       @root["app"].eager_load!
       assert @root["app"].eager_load?
-      assert @root.eager_load.include?(@root["app"].to_a.first)
+      assert_includes @root.eager_load, @root["app"].to_a.first
     end
   end
 
@@ -168,14 +168,14 @@ class PathsTest < ActiveSupport::TestCase
 
     @root["app"].skip_eager_load!
     assert !@root["app"].eager_load?
-    assert !@root.eager_load.include?(@root["app"].to_a.first)
+    assert_not_includes @root.eager_load, @root["app"].to_a.first
   end
 
   test "it is possible to add a path without assignment and mark it as eager" do
     File.stub(:exist?, true) do
       @root.add "app", with: "/app", eager_load: true
       assert @root["app"].eager_load?
-      assert @root.eager_load.include?("/app")
+      assert_includes @root.eager_load, "/app"
     end
   end
 
@@ -183,8 +183,8 @@ class PathsTest < ActiveSupport::TestCase
     File.stub(:exist?, true) do
       @root.add "app", with: ["/app", "/app2"], eager_load: true
       assert @root["app"].eager_load?
-      assert @root.eager_load.include?("/app")
-      assert @root.eager_load.include?("/app2")
+      assert_includes @root.eager_load, "/app"
+      assert_includes @root.eager_load, "/app2"
     end
   end
 
@@ -193,8 +193,8 @@ class PathsTest < ActiveSupport::TestCase
       @root.add "app", with: "/app", eager_load: true, autoload_once: true
       assert @root["app"].eager_load?
       assert @root["app"].autoload_once?
-      assert @root.eager_load.include?("/app")
-      assert @root.autoload_once.include?("/app")
+      assert_includes @root.eager_load, "/app"
+      assert_includes @root.autoload_once, "/app"
     end
   end
 

--- a/railties/test/rails_info_test.rb
+++ b/railties/test/rails_info_test.rb
@@ -48,9 +48,9 @@ class InfoTest < ActiveSupport::TestCase
     end
 
     html = Rails::Info.to_html
-    assert html.include?('<tr><td class="name">Middleware</td>')
+    assert_includes html, '<tr><td class="name">Middleware</td>'
     properties.value_for("Middleware").each do |value|
-      assert html.include?("<li>#{CGI.escapeHTML(value)}</li>")
+      assert_includes html, "<li>#{CGI.escapeHTML(value)}</li>"
     end
   end
 

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -135,7 +135,7 @@ module RailtiesTest
       require "rdoc/task"
 
       Rails.application.load_tasks
-      assert $ran_block.include?("my_tie")
+      assert_includes $ran_block, "my_tie"
     end
 
     test "generators block is executed when MyApp.load_generators is called" do


### PR DESCRIPTION
`assert [1, 3].includes?(2)` fails with unhelpful "Asserting failed" message

`assert_includes [1, 3], 2` fails with "Expected [1, 3] to include 2" which makes it easier to debug and more obvious what went wrong
