### PR TITLE
add check of argument

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -361,6 +361,9 @@ module ActiveSupport
       # the cache with the given keys, then that data is returned. Otherwise,
       # the supplied block is called for each key for which there was no data,
       # and the result will be written to the cache and returned.
+      # Therefore, you need to pass a block that returns the data to be written
+      # to the cache. If you do not want to write the cache when the cache is
+      # not found, use #read_multi.
       #
       # Options are passed to the underlying cache implementation.
       #
@@ -374,6 +377,8 @@ module ActiveSupport
       #   #      "unknown_key" => "Fallback value for key: unknown_key" }
       #
       def fetch_multi(*names)
+        raise ArgumentError, "Missing block: `Cache#fetch_multi` requires a block." unless block_given?
+
         options = names.extract_options!
         options = merged_options(options)
         results = read_multi(*names, options)

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -363,6 +363,12 @@ module CacheStoreBehavior
     assert_equal({ foo => "FOO!", bar => "BAM!" }, values)
   end
 
+  def test_fetch_multi_without_block
+    assert_raises(ArgumentError) do
+      @cache.fetch_multi("foo")
+    end
+  end
+
   def test_read_and_write_compressed_small_data
     @cache.write("foo", "bar", compress: true)
     assert_equal "bar", @cache.read("foo")


### PR DESCRIPTION
### Summary

`#fetch_multi` in case did not cache hit, to write a cache using the block value.
https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache.rb#L383..L384

Therefore, block is a need to pass always, I think should check first.
