### PR TITLE
Define Hash#transform_values and #transform_values! on only Ruby 2.2 and Ruby 2.3

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/transform_values.rb
+++ b/activesupport/lib/active_support/core_ext/hash/transform_values.rb
@@ -1,3 +1,4 @@
+unless {}.respond_to?(:transform_values) # TODO: Remove this file when we drop support to ruby < 2.4
 class Hash
   # Returns a new hash with the results of running +block+ once for every value.
   # The keys are unchanged.
@@ -26,4 +27,5 @@ class Hash
       self[key] = yield(value)
     end
   end
+end
 end


### PR DESCRIPTION
### Summary

`Hash#transform_values` and `Hash#transform_values` is implemented on ruby 2.4 (https://github.com/ruby/ruby/blob/trunk/hash.c#L1801-L1829), so it should define these methods only on ruby 2.2 and 2.3.
