### PR TITLE
Check whether the current attribute being read is aliased or not before reading

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `write_attribute` method to check whether an attribute is aliased or not, and
+    use the aliased attribute name if needed.
+
+    *Prathamesh Sonpatki*
+
 *   Fix `read_attribute` method to check whether an attribute is aliased or not, and
     use the aliased attribute name if needed.
 
@@ -65,7 +70,7 @@
 
     *Jon Moss*
 
-*   Add `stat` method to `ActiveRecord::ConnectionAdapters::ConnectionPool`.
+*   Added `stat` method to `ActiveRecord::ConnectionAdapters::ConnectionPool`.
 
     Example:
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix `read_attribute` method to check whether an attribute is aliased or not, and
+    use the aliased attribute name if needed.
+
+    Fixes #26417.
+
+    *Prathamesh Sonpatki*
+
 *   PostgreSQL & MySQL: Use big integer as primary key type for new tables
 
     *Jon McCartie*, *Pavel Pravosud*
@@ -58,7 +65,7 @@
 
     *Jon Moss*
 
-*   Added `stat` method to `ActiveRecord::ConnectionAdapters::ConnectionPool`
+*   Add `stat` method to `ActiveRecord::ConnectionAdapters::ConnectionPool`.
 
     Example:
 

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -48,7 +48,12 @@ module ActiveRecord
       # it has been typecast (for example, "2004-12-12" in a date column is cast
       # to a date object, like Date.new(2004, 12, 12)).
       def read_attribute(attr_name, &block)
-        name = attr_name.to_s
+        name = if self.class.attribute_alias?(attr_name)
+          self.class.attribute_alias(attr_name).to_s
+        else
+          attr_name.to_s
+        end
+
         name = self.class.primary_key if name == "id".freeze
         _read_attribute(name, &block)
       end

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -29,7 +29,13 @@ module ActiveRecord
       # specified +value+. Empty strings for Integer and Float columns are
       # turned into +nil+.
       def write_attribute(attr_name, value)
-        write_attribute_with_type_cast(attr_name, value, true)
+        name = if self.class.attribute_alias?(attr_name)
+          self.class.attribute_alias(attr_name).to_s
+        else
+          attr_name.to_s
+        end
+
+        write_attribute_with_type_cast(name, value, true)
       end
 
       def raw_write_attribute(attr_name, value) # :nodoc:

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -329,6 +329,16 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal "Don't change the topic", topic[:title]
   end
 
+  test "read_attribute can read aliased attributes as well" do
+    topic = Topic.new(title: "Don't change the topic")
+
+    assert_equal "Don't change the topic", topic.read_attribute("heading")
+    assert_equal "Don't change the topic", topic["heading"]
+
+    assert_equal "Don't change the topic", topic.read_attribute(:heading)
+    assert_equal "Don't change the topic", topic[:heading]
+  end
+
   test "read_attribute raises ActiveModel::MissingAttributeError when the attribute does not exist" do
     computer = Computer.select("id").first
     assert_raises(ActiveModel::MissingAttributeError) { computer[:developer] }

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -319,6 +319,13 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal "Still another topic: part 4", topic.title
   end
 
+  test "write_attribute can write aliased attributes as well" do
+    topic = Topic.new(title: "Don't change the topic")
+    topic.write_attribute :heading, "New topic"
+
+    assert_equal "New topic", topic.title
+  end
+
   test "read_attribute" do
     topic = Topic.new
     topic.title = "Don't change the topic"


### PR DESCRIPTION
### Summary
- If aliased, then use the aliased attribute name.
- Fixes #26417.
