### PR TITLE
remove unused require `benchmark`

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -1,8 +1,6 @@
-require "benchmark"
 require "zlib"
 require "active_support/core_ext/array/extract_options"
 require "active_support/core_ext/array/wrap"
-require "active_support/core_ext/benchmark"
 require "active_support/core_ext/module/attribute_accessors"
 require "active_support/core_ext/numeric/bytes"
 require "active_support/core_ext/numeric/time"


### PR DESCRIPTION
`Benchmark` was removed at 4215e9a
