### PR TITLE
Fix #26518

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -41,7 +41,12 @@ module ActionView
           @view_context = view_context
         end
 
-        def tag_string(name, content = nil, escape_attributes: true, **options, &block)
+        def tag_string(*args, escape_attributes: true, **options, &block)
+
+          content_options = args.extract_options!
+          name, content = args
+          options = content_options.merge options
+
           content = @view_context.capture(self, &block) if block_given?
           if VOID_ELEMENTS.include?(name) && content.nil?
             "<#{name.to_s.dasherize}#{tag_options(options, escape_attributes)}>".html_safe

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -42,7 +42,6 @@ module ActionView
         end
 
         def tag_string(*args, escape_attributes: true, **options, &block)
-
           content_options = args.extract_options!
           name, content = args
           options = content_options.merge options

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -29,10 +29,11 @@ class TagHelperTest < ActionView::TestCase
     assert_equal tag, tag
   end
 
-  def test_tag_options
-    str = tag("p", "class" => "show", :class => "elsewhere")
-    assert_match(/class="show"/, str)
-    assert_match(/class="elsewhere"/, str)
+  def test_tag_builder_options
+    str = tag.p("class" => "show", :class => "elsewhere")
+    assert_match /class="show"/, str
+    assert_match /class="elsewhere"/, str
+    assert_equal "<p class=\"show\" class=\"elsewhere\"></p>", str
   end
 
   def test_tag_options_rejects_nil_option

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -29,11 +29,16 @@ class TagHelperTest < ActionView::TestCase
     assert_equal tag, tag
   end
 
+  def test_tag_options
+    str = tag("p", "class" => "show", :class => "elsewhere")
+    assert_match(/class="show"/, str)
+    assert_match(/class="elsewhere"/, str)
+  end
+
   def test_tag_builder_options
     str = tag.p("class" => "show", :class => "elsewhere")
-    assert_match /class="show"/, str
-    assert_match /class="elsewhere"/, str
-    assert_equal "<p class=\"show\" class=\"elsewhere\"></p>", str
+    assert_match(/class="show"/, str)
+    assert_match(/class="elsewhere"/, str)
   end
 
   def test_tag_options_rejects_nil_option


### PR DESCRIPTION
### Summary

The edge case:

```
tag.p("class" => "show", :class => "elsewhere")
```

Before:

```
"<p class=\"elsewhere\">{&quot;class&quot;=&gt;&quot;show&quot;}</p>"
```

After:

```
"<p class=\"show\" class=\"elsewhere\"></p>"
```
