### PR TITLE
change `MemCacheStore#increment` and `MemCacheStore#decrement` to public API [ci skip]

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -110,7 +110,7 @@ module ActiveSupport
       # operator and can only be used on values written with the :raw option.
       # Calling it on a value not stored with :raw will initialize that value
       # to zero.
-      def increment(name, amount = 1, options = nil) # :nodoc:
+      def increment(name, amount = 1, options = nil)
         options = merged_options(options)
         instrument(:increment, name, amount: amount) do
           rescue_error_with nil do
@@ -123,7 +123,7 @@ module ActiveSupport
       # operator and can only be used on values written with the :raw option.
       # Calling it on a value not stored with :raw will initialize that value
       # to zero.
-      def decrement(name, amount = 1, options = nil) # :nodoc:
+      def decrement(name, amount = 1, options = nil)
         options = merged_options(options)
         instrument(:decrement, name, amount: amount) do
           rescue_error_with nil do


### PR DESCRIPTION
I'm not sure why these methods not public. But these methods are public in
other cache stores, I think that may be in public.

Ref:
http://edgeapi.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-increment
http://edgeapi.rubyonrails.org/classes/ActiveSupport/Cache/FileStore.html#method-i-increment
http://edgeapi.rubyonrails.org/classes/ActiveSupport/Cache/MemoryStore.html#method-i-increment
http://edgeapi.rubyonrails.org/classes/ActiveSupport/Cache/NullStore.html#method-i-increment
