### PR TITLE
Fix ActionCable client test when server restarts

### DIFF
--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -10,6 +10,8 @@ class ClientTest < ActionCable::TestCase
   WAIT_WHEN_EXPECTING_EVENT = 8
   WAIT_WHEN_NOT_EXPECTING_EVENT = 0.5
 
+  @@event_machine_thr = nil
+
   class EchoChannel < ActionCable::Channel::Base
     def subscribed
       stream_from "global"
@@ -44,7 +46,7 @@ class ClientTest < ActionCable::TestCase
     # and now the "real" setup for our test:
     server.config.disable_request_forgery_protection = true
 
-    Thread.new { EventMachine.run } unless EventMachine.reactor_running?
+    @@event_machine_thr = Thread.new { EventMachine.run } unless EventMachine.reactor_running?
     Thread.pass until EventMachine.reactor_running?
 
     # faye-websocket is warning-rich
@@ -266,6 +268,7 @@ class ClientTest < ActionCable::TestCase
       c.send_message command: "subscribe", identifier: JSON.generate(channel: "ClientTest::EchoChannel")
       assert_equal({ "identifier"=>"{\"channel\":\"ClientTest::EchoChannel\"}", "type"=>"confirm_subscription" }, c.read_message)
 
+      @@event_machine_thr.kill unless @@event_machine_thr.nil?
       ActionCable.server.restart
       c.wait_for_close
       assert c.closed?


### PR DESCRIPTION
### Summary

Running the follwing test fails for both Arch Linux and Ubuntu 16.04:

`env FAYE=1 bundle exec ruby -Itest test/client_test.rb -n test_server_restart`

But it passes on Travis (Ubuntu 12.04).
### Other Information

It looks like an instance of the following issue:
https://github.com/eventmachine/eventmachine/issues/670

Where one user suggested killing the EM thread before server shutdown
might be a workaround. The user never gave the feedback if that worked,
but seems to fix for this case.

More information at: https://github.com/rails/rails/issues/26538
