### PR TITLE
Allow running migration from error screen, instead of asking to run from console

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
@@ -9,7 +9,11 @@
 
 <div id="container">
   <h2><%= h @exception.message %></h2>
-
+  <%- if h @exception.message.to_s.match(/^Migrations are pending.*RAILS_ENV=development$/) %>
+      <form method="post" action="/rails/migrate">
+        <h2> <input value="Attempt Migrating from here" type="submit"/> </h2>
+      </form>
+  <%- end %>
   <%= render template: "rescues/_source" %>
   <%= render template: "rescues/_trace" %>
   <%= render template: "rescues/_request_and_response" %>

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -545,7 +545,7 @@ module ActiveRecord
       def call(env)
         if connection.supports_migrations?
           mtime = ActiveRecord::Migrator.last_migration.mtime.to_i
-          if @last_check < mtime
+          if !rails_migration_path?(env) && @last_check < mtime
             ActiveRecord::Migration.check_pending!(connection)
             @last_check = mtime
           end
@@ -554,6 +554,10 @@ module ActiveRecord
       end
 
       private
+
+        def rails_migration_path?(env)
+          Rails.env.development? && env["ORIGINAL_FULLPATH"] == '/rails/migrate'
+        end
 
         def connection
           ActiveRecord::Base.connection

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -25,6 +25,7 @@ module Rails
 
   autoload :Info
   autoload :InfoController
+  autoload :MigrationController
   autoload :MailersController
   autoload :WelcomeController
 

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -25,6 +25,7 @@ module Rails
             get "/rails/info/properties" => "rails/info#properties", internal: true
             get "/rails/info/routes"     => "rails/info#routes", internal: true
             get "/rails/info"            => "rails/info#index", internal: true
+            post "/rails/migrate"        => "rails/migration#migrate", internal: true
           end
 
           app.routes.append do

--- a/railties/lib/rails/migration_controller.rb
+++ b/railties/lib/rails/migration_controller.rb
@@ -1,0 +1,15 @@
+require "rails/application_controller"
+
+class Rails::MigrationController < Rails::ApplicationController # :nodoc:
+  before_action :require_local!
+
+  def migrate
+    require 'rake'
+    Rake::Task.clear
+    Rails.application.load_tasks
+    Rake::Task['db:migrate'].invoke
+    redirect_to "/"
+  ensure
+    Rake::Task.clear
+  end
+end


### PR DESCRIPTION
In Development mode:
Every time someone checks out a new branch with migrations, they are presented with this error prompt from pending migrations. 
Instead of asking to run migrations from console, allow to run migrations from browser.

Note: This is just a WIP PoC, to get feedback if we want to go in such a direction.

What this looks like:

![action controller- exception caught 2016-09-18 22-32-42](https://cloud.githubusercontent.com/assets/567626/18617606/ee220e44-7df0-11e6-8486-cd95df19f0d1.jpg)
