### PR TITLE
make UrlGenerationError message more generic (fixes #26470).

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -45,7 +45,7 @@ module ActionDispatch
         end
 
         message = "No route matches #{Hash[constraints.sort_by { |k,v| k.to_s }].inspect}"
-        message << " missing required keys: #{missing_keys.sort.inspect}" if missing_keys && !missing_keys.empty?
+        message << " one or more required keys is missing or does not match the constraint: #{missing_keys.sort.inspect}" if missing_keys && !missing_keys.empty?
 
         raise ActionController::UrlGenerationError, message
       end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -210,7 +210,7 @@ module ActionDispatch
                 }
                 constraints = Hash[@route.requirements.merge(params).sort_by { |k,v| k.to_s }]
                 message = "No route matches #{constraints.inspect}"
-                message << " missing required keys: #{missing_keys.sort.inspect}"
+                message << " one or more required keys is missing or does not match the constraint: #{missing_keys.sort.inspect}"
 
                 raise ActionController::UrlGenerationError, message
               end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4686,7 +4686,7 @@ class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
 
   test "url helpers raise a helpful error message when generation fails" do
     url, missing = { action: "show", controller: "products", id: nil }, [:id]
-    message = "No route matches #{url.inspect} missing required keys: #{missing.inspect}"
+    message = "No route matches #{url.inspect} one or more required keys is missing or does not match the constraint: #{missing.inspect}"
 
     # Optimized url helper
     error = assert_raises(ActionController::UrlGenerationError) { product_path(nil) }
@@ -4699,7 +4699,7 @@ class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
 
   test "url helpers raise message with mixed parameters when generation fails " do
     url, missing = { action: "show", controller: "products", id: nil, "id"=>"url-tested" }, [:id]
-    message = "No route matches #{url.inspect} missing required keys: #{missing.inspect}"
+    message = "No route matches #{url.inspect} one or more required keys is missing or does not match the constraint: #{missing.inspect}"
 
     # Optimized url helper
     error = assert_raises(ActionController::UrlGenerationError) { product_path(nil, "id"=>"url-tested") }

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -102,7 +102,7 @@ module ActionDispatch
         get "/foo/:id", as: route_name, id: /\d+/, to: "foo#bar"
 
         error = assert_raises(ActionController::UrlGenerationError) do
-          @formatter.generate(route_name, {}, {id: 'aa'})
+          @formatter.generate(route_name, {}, id: 'aa')
         end
 
         assert_match(/one or more required keys is missing or does not match the constraint: \[:id\]/, error.message)

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -102,7 +102,7 @@ module ActionDispatch
         get "/foo/:id", as: route_name, id: /\d+/, to: "foo#bar"
 
         error = assert_raises(ActionController::UrlGenerationError) do
-          @formatter.generate(route_name, {}, id: 'aa')
+          @formatter.generate(route_name, {}, id: "aa")
         end
 
         assert_match(/one or more required keys is missing or does not match the constraint: \[:id\]/, error.message)

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -94,7 +94,18 @@ module ActionDispatch
           @formatter.generate(route_name, {}, {})
         end
 
-        assert_match(/missing required keys: \[:id\]/, error.message)
+        assert_match(/one or more required keys is missing or does not match the constraint: \[:id\]/, error.message)
+      end
+
+      def test_knows_what_parts_do_not_match_constraint
+        route_name = "gorby_thunderhorse"
+        get "/foo/:id", as: route_name, id: /\d+/, to: "foo#bar"
+
+        error = assert_raises(ActionController::UrlGenerationError) do
+          @formatter.generate(route_name, {}, {id: 'aa'})
+        end
+
+        assert_match(/one or more required keys is missing or does not match the constraint: \[:id\]/, error.message)
       end
 
       def test_does_not_include_missing_keys_message
@@ -104,7 +115,7 @@ module ActionDispatch
           @formatter.generate(route_name, {}, {})
         end
 
-        assert_no_match(/missing required keys: \[\]/, error.message)
+        assert_no_match(/one or more required keys is missing or does not match the constraint: \[\]/, error.message)
       end
 
       def test_X_Cascade
@@ -297,7 +308,7 @@ module ActionDispatch
         }
         request_parameters = primarty_parameters.merge(redirection_parameters).merge(missing_parameters)
 
-        message = "No route matches #{Hash[request_parameters.sort_by { |k,v|k.to_s }].inspect} missing required keys: #{[missing_key.to_sym].inspect}"
+        message = "No route matches #{Hash[request_parameters.sort_by { |k,v|k.to_s }].inspect} one or more required keys is missing or does not match the constraint: #{[missing_key.to_sym].inspect}"
 
         error = assert_raises(ActionController::UrlGenerationError) do
           @formatter.generate(


### PR DESCRIPTION
This is the minimal solution. Would be nice to distinguish between missing keys and values that do not match constraints some day.
