### PR TITLE
Remove "Current version: " from rake db:version task

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -171,7 +171,7 @@ db_namespace = namespace :db do
 
   desc "Retrieves the current schema version number"
   task version: [:environment, :load_config] do
-    puts "Current version: #{ActiveRecord::Migrator.current_version}"
+    puts ActiveRecord::Migrator.current_version
   end
 
   # desc "Raises an error if there are pending migrations"


### PR DESCRIPTION
### Summary

Remove the "Current version: " prefix from the output for the `rake db:version` task, so it can be used in bash scripts more easily (You generally need the version only so you can pass it to `rake db:rollback` or similar). The task name already describes the expected output.
