### PR TITLE
Fixed CONTENT_LENGTH header in ActionController::TestRequest

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -112,8 +112,9 @@ module ActionController
           end
         end
 
-        set_header "CONTENT_LENGTH", data.length.to_s
-        set_header "rack.input", StringIO.new(data)
+        data_stream = StringIO.new(data)
+        set_header "CONTENT_LENGTH", data_stream.length.to_s
+        set_header "rack.input", data_stream
       end
 
       fetch_header("PATH_INFO") do |k|

--- a/actionpack/test/controller/request/test_request_test.rb
+++ b/actionpack/test/controller/request/test_request_test.rb
@@ -11,6 +11,16 @@ class ActionController::TestRequestTest < ActionController::TestCase
     assert_equal nil, ActionController::TestSession::DEFAULT_OPTIONS[:myparam]
   end
 
+  def test_content_length_has_bytes_count_value
+    non_ascii_parameters = { data: { content: "Latin + Кириллица" } }
+    @request.set_header "REQUEST_METHOD", "POST"
+    @request.set_header "CONTENT_TYPE", "application/json"
+    @request.assign_parameters(@routes, "test", "create", non_ascii_parameters,
+                               "/test", [:data, :controller, :action])
+    assert_equal(@request.get_header("CONTENT_LENGTH"),
+                 StringIO.new(non_ascii_parameters.to_json).length.to_s)
+  end
+
   ActionDispatch::Session::AbstractStore::DEFAULT_OPTIONS.each_key do |option|
     test "rack default session options #{option} exists in session options and is default" do
       assert_equal(ActionDispatch::Session::AbstractStore::DEFAULT_OPTIONS[option],


### PR DESCRIPTION
CONENT_LENGTH setted by string length, which is equal to number of
characters in string  `set_header "CONTENT_LENGTH", data.length.to_s`

But StringIO.length is bytes count and when payload contains non-ASCII characters, stream's length will be different.

For example this spec with Cyrillic symbols will produce an error:

``` ruby
RSpec.describe PostsController, type: :controller do
  describe "POST #create" do
    before do
      request.headers['Content-Type'] = 'application/json'
      process :create, method: :post, params: { post: { content: 'Русские символы' } }
    end

    it { is_expected.to respond_with(200) }
  end
end
```

Error output is:

> Failure/Error: process :create, method: :post, params: { post: { content: 'Русские символы' } }
> 
> ```
>  ActionDispatch::ParamsParser::ParseError:
>    822: unexpected token at '{"post":{"content":"Русские с?'
>  # /Users/mgpnd/.rvm/gems/ruby-2.3.0/gems/rack-2.0.1/lib/rack/request.rb:57:in `fetch'
>  # /Users/mgpnd/.rvm/gems/ruby-2.3.0/gems/rack-2.0.1/lib/rack/request.rb:57:in `fetch_header'
>  # ./spec/controllers/posts_controller_spec.rb:25:in `block (3 levels) in <top (required)>'
>  # ------------------
>  # --- Caused by: ---
>  # JSON::ParserError:
>  #   822: unexpected token at '{"post":{"content":"Русские с?'
>  #   /Users/mgpnd/.rvm/gems/ruby-2.3.0/gems/rack-2.0.1/lib/rack/request.rb:57:in `fetch'
> ```

That happens because in `action_dispatch/http/request.rb`, line 299, request reads _n_ bytes form body stream where _n_ is Content-Length header value. It reads not the whole string and JSON parsing fails then.

``` ruby
def raw_post
  unless has_header? 'RAW_POST_DATA'
    raw_post_body = body
    # this line
    set_header('RAW_POST_DATA', raw_post_body.read(content_length))
    raw_post_body.rewind if raw_post_body.respond_to?(:rewind)
  end
  get_header 'RAW_POST_DATA'
end
```

So, that's why I've changed `CONTENT_LENGTH` setting.

You can reproduce the issue with [content-reproduce](https://github.com/mgpnd/content-reproduce) repository by running `rspec spec/controllers/posts_controller_spec.rb`
