### PR TITLE
fix link to `resque` [ci skip]

### DIFF
--- a/activejob/lib/active_job/queue_adapters.rb
+++ b/activejob/lib/active_job/queue_adapters.rb
@@ -8,7 +8,7 @@ module ActiveJob
   # * {Qu}[https://github.com/bkeepers/qu]
   # * {Que}[https://github.com/chanks/que]
   # * {queue_classic}[https://github.com/QueueClassic/queue_classic]
-  # * {Resque 1.x}[https://github.com/resque/resque/tree/1-x-stable]
+  # * {Resque}[https://github.com/resque/resque]
   # * {Sidekiq}[http://sidekiq.org]
   # * {Sneakers}[https://github.com/jondot/sneakers]
   # * {Sucker Punch}[https://github.com/brandonhilkert/sucker_punch]


### PR DESCRIPTION
`1-x-stable` branch does not exist, `master` is 1.x branch.
Ref: http://words.steveklabnik.com/rescuing-resque-again
