### PR TITLE
Show an "unmatched constraints" error when params fail to match constraints

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Show an "unmatched constraints" error when params fail to match constraints
+    on a matched route, rather than a "missing keys" error.
+
+    Fixes #26470.
+
+    *Chris Carter*
+
 *   Fix adding implicitly rendered template digests to ETags.
 
     Fixes a case when modifying an implicitly rendered template for a

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -44,8 +44,12 @@ module ActionDispatch
           return [route.format(parameterized_parts), params]
         end
 
+        unmatched_keys = (missing_keys || []) & constraints.keys
+        missing_keys = (missing_keys || []) - unmatched_keys
+
         message = "No route matches #{Hash[constraints.sort_by { |k,v| k.to_s }].inspect}"
-        message << " missing required keys: #{missing_keys.sort.inspect}" if missing_keys && !missing_keys.empty?
+        message << ", missing required keys: #{missing_keys.sort.inspect}" if missing_keys && !missing_keys.empty?
+        message << ", possible unmatched constraints: #{unmatched_keys.sort.inspect}" if unmatched_keys && !unmatched_keys.empty?
 
         raise ActionController::UrlGenerationError, message
       end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -210,7 +210,7 @@ module ActionDispatch
                 }
                 constraints = Hash[@route.requirements.merge(params).sort_by { |k,v| k.to_s }]
                 message = "No route matches #{constraints.inspect}"
-                message << " missing required keys: #{missing_keys.sort.inspect}"
+                message << ", missing required keys: #{missing_keys.sort.inspect}"
 
                 raise ActionController::UrlGenerationError, message
               end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4684,22 +4684,25 @@ class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
 
   include Routes.url_helpers
 
-  test "url helpers raise a helpful error message when generation fails" do
+  test "url helpers raise a 'missing keys' error for a nil param with optimized helpers" do
     url, missing = { action: "show", controller: "products", id: nil }, [:id]
-    message = "No route matches #{url.inspect} missing required keys: #{missing.inspect}"
+    message = "No route matches #{url.inspect}, missing required keys: #{missing.inspect}"
 
-    # Optimized url helper
     error = assert_raises(ActionController::UrlGenerationError) { product_path(nil) }
     assert_equal message, error.message
+  end
 
-    # Non-optimized url helper
+  test "url helpers raise a 'constraint failure' error for a nil param with non-optimized helpers" do
+    url, missing = { action: "show", controller: "products", id: nil }, [:id]
+    message = "No route matches #{url.inspect}, possible unmatched constraints: #{missing.inspect}"
+
     error = assert_raises(ActionController::UrlGenerationError, message) { product_path(id: nil) }
     assert_equal message, error.message
   end
 
-  test "url helpers raise message with mixed parameters when generation fails " do
+  test "url helpers raise message with mixed parameters when generation fails" do
     url, missing = { action: "show", controller: "products", id: nil, "id"=>"url-tested" }, [:id]
-    message = "No route matches #{url.inspect} missing required keys: #{missing.inspect}"
+    message = "No route matches #{url.inspect}, possible unmatched constraints: #{missing.inspect}"
 
     # Optimized url helper
     error = assert_raises(ActionController::UrlGenerationError) { product_path(nil, "id"=>"url-tested") }

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -297,7 +297,7 @@ module ActionDispatch
         }
         request_parameters = primarty_parameters.merge(redirection_parameters).merge(missing_parameters)
 
-        message = "No route matches #{Hash[request_parameters.sort_by { |k,v|k.to_s }].inspect} missing required keys: #{[missing_key.to_sym].inspect}"
+        message = "No route matches #{Hash[request_parameters.sort_by { |k,v|k.to_s }].inspect}, missing required keys: #{[missing_key.to_sym].inspect}"
 
         error = assert_raises(ActionController::UrlGenerationError) do
           @formatter.generate(


### PR DESCRIPTION
### Summary

Currently a misleading "missing required keys" error is thrown when a param
fails to match the constraints of a particular route. This PR ensures that
these params are recognised as unmatching rather than missing.

Fixes #26470.
### Other Information

Note: this means that a different error message will be provided between
optimized and non-optimized path helpers, due to the fact that the former does
not check constraints when matching routes.
