### PR TITLE
Prevent circular require of proxy_wrappers.rb, Fixes #26430

### DIFF
--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -1,3 +1,4 @@
+require "active_support/deprecation"
 require "active_support/deprecation/proxy_wrappers"
 
 class LoadError


### PR DESCRIPTION
### Summary

Adding `require "active_support/deprecation"` before requiring `active_support/deprecation/proxy_wrappers` prevents autoloading of `ActiveSupport::Deprecation` which causes circular require of proxy_wrappers.rb.
#### Before

```
➜  core_ext git:(fix_issue_26430) ruby -w -e "require 'active_support'; require 'active_support/core_ext'"
/Users/wolfgangteuber/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:71: warning: loading in progress, circular require considered harmful - /Users/wolfgangteuber/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.1/lib/active_support/deprecation/proxy_wrappers.rb
        from -e:1:in  `<main>'
        from /Users/wolfgangteuber/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:71:in  `require'
        from /Users/wolfgangteuber/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:71:in  `require'
        from /Users/wolfgangteuber/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.1/lib/active_support/core_ext.rb:4:in  `<top (required)>'
        from /Users/wolfgangteuber/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.1/lib/active_support/core_ext.rb:4:in  `each'
        from /Users/wolfgangteuber/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.1/lib/active_support/core_ext.rb:6:in  `block in <top (required)>'
        from /Users/wolfgangteuber/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:123:in  `require'
        from /Users/wolfgangteuber/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:123:in  `require'
        from /Users/wolfgangteuber/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.1/lib/active_support/core_ext/load_error.rb:2:in  `<top (required)>'
        from /Users/wolfgangteuber/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:71:in  `require'
        from /Users/wolfgangteuber/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:71:in  `require'
        from /Users/wolfgangteuber/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.1/lib/active_support/deprecation/proxy_wrappers.rb:3:in  `<top (required)>'
        from /Users/wolfgangteuber/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.1/lib/active_support/deprecation/proxy_wrappers.rb:4:in  `<module:ActiveSupport>'
        from /Users/wolfgangteuber/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:71:in  `require'
        from /Users/wolfgangteuber/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:71:in  `require'
        from /Users/wolfgangteuber/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.1/lib/active_support/deprecation.rb:3:in  `<top (required)>'
        from /Users/wolfgangteuber/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.1/lib/active_support/deprecation.rb:6:in  `<module:ActiveSupport>'
        from /Users/wolfgangteuber/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.0.1/lib/active_support/deprecation.rb:19:in  `<class:Deprecation>'
        from /Users/wolfgangteuber/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:71:in  `require'
        from /Users/wolfgangteuber/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:71:in  `require'
➜  core_ext git:(fix_issue_26430)
```
#### After

```
➜  core_ext git:(fix_issue_26430) ruby -w -e "require 'active_support'; require 'active_support/core_ext'"
➜  core_ext git:(fix_issue_26430)
```
### Other Information

Fixes #26430
CHANGELOG or guide updates are not needed.
