### PR TITLE
Explicitly require shellwords

### DIFF
--- a/railties/lib/rails/test_unit/sub_test_task.rb
+++ b/railties/lib/rails/test_unit/sub_test_task.rb
@@ -1,4 +1,5 @@
 require 'rake/testtask'
+require 'shellwords'
 
 module Rails
   class TestTask < Rake::TestTask # :nodoc: all


### PR DESCRIPTION
### Summary

Add require statement to ensure `Shellwords` is available when referenced, instead of expecting it to have been required by a 3rd party.
### Other Information

Apparently it has been assumed that shellwords were already required elsewhere when the test tasks are loaded.

But Rake v11 has removed its dependency on shellwords, so if you upgrade Rake you're no longer able to run Rails tests.
