### PR TITLE
Optionally allow ActionCable requests from the same host as origin

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -340,6 +340,11 @@ To disable and allow requests from any origin:
 Rails.application.config.action_cable.disable_request_forgery_protection = true
 ```
 
+It is also possible to allow origins that are starting with the actual HTTP HOST header:
+```ruby
+Rails.application.config.action_cable.allow_same_origin_as_host = true
+```
+
 ### Consumer Configuration
 
 Once you have decided how to run your cable server (see below), you must provide the server URL (or path) to your client-side setup.

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -195,7 +195,10 @@ module ActionCable
         def allow_request_origin?
           return true if server.config.disable_request_forgery_protection
 
+          proto = Rack::Request.new(env).ssl? ? "https" : "http"
           if Array(server.config.allowed_request_origins).any? { |allowed_origin|  allowed_origin === env["HTTP_ORIGIN"] }
+            true
+          elsif server.config.allow_same_origin_as_host && env["HTTP_ORIGIN"] == "#{proto}://#{env['HTTP_HOST']}"
             true
           else
             logger.error("Request origin not allowed: #{env['HTTP_ORIGIN']}")

--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -5,7 +5,7 @@ module ActionCable
     class Configuration
       attr_accessor :logger, :log_tags
       attr_accessor :use_faye, :connection_class, :worker_pool_size
-      attr_accessor :disable_request_forgery_protection, :allowed_request_origins
+      attr_accessor :disable_request_forgery_protection, :allowed_request_origins, :allow_same_origin_as_host
       attr_accessor :cable, :url, :mount_path
 
       def initialize
@@ -15,6 +15,7 @@ module ActionCable
         @worker_pool_size = 4
 
         @disable_request_forgery_protection = false
+        @allow_same_origin_as_host = false
       end
 
       # Returns constant of subscription adapter specified in config/cable.yml.

--- a/actioncable/test/connection/cross_site_forgery_test.rb
+++ b/actioncable/test/connection/cross_site_forgery_test.rb
@@ -18,6 +18,7 @@ class ActionCable::Connection::CrossSiteForgeryTest < ActionCable::TestCase
   teardown do
     @server.config.disable_request_forgery_protection = false
     @server.config.allowed_request_origins = []
+    @server.config.allow_same_origin_as_host = false
   end
 
   test "disable forgery protection" do
@@ -49,6 +50,13 @@ class ActionCable::Connection::CrossSiteForgeryTest < ActionCable::TestCase
     @server.config.allowed_request_origins = [/http:\/\/ruby.*/, /.*rai.s.*com/, "string" ]
     assert_origin_allowed "http://rubyonrails.com"
     assert_origin_allowed "http://www.rubyonrails.com"
+    assert_origin_not_allowed "http://hax.com"
+    assert_origin_not_allowed "http://rails.co.uk"
+  end
+
+  test "allow same origin as host" do
+    @server.config.allow_same_origin_as_host = true
+    assert_origin_allowed "http://#{HOST}"
     assert_origin_not_allowed "http://hax.com"
     assert_origin_not_allowed "http://rails.co.uk"
   end


### PR DESCRIPTION
### Summary

When the `allow_same_origin_as_host` is set to `true`, the request
forgery protection permits `HTTP_ORIGIN` values starting with the
corresponding `proto://` prefix followed by `HTTP_HOST`. This way
it is not required to specify the list of allowed URLs.
### Other Information

https://groups.google.com/forum/?fromgroups#!topic/rubyonrails-core/4U5pKIgtJFU
