### PR TITLE
Add support for `belongs_to`'s `optional` option to handle data integrity

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -127,6 +127,20 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
       if reflection.options[:optional].nil?
         required = model.belongs_to_required_by_default
+      elsif reflection.options[:optional] == :with_integrity
+        callback = lambda do |record|
+          fk       = reflection.foreign_key
+          fk_value = record.public_send(fk)
+          association_klass = record.association(reflection.name).klass
+          association_pk    = association_klass.primary_key
+
+          if fk_value.present? && association_klass.find_by("#{association_pk}": fk_value).nil?
+            record.errors.add(fk, :invalid)
+          end
+        end
+
+        model.validate callback
+        required = false
       else
         required = !reflection.options[:optional]
       end


### PR DESCRIPTION
By adding this support, the model can able to save foreign_key to either `nil` (NULL) value or to the valid foreign key value which means foreign key value must present in the foreign table. (Ref #26557)

``` ruby
class Post < ActiveRecord::Base
  belongs_to :author, optional: :with_integrity
end

author = Author.create!
post = Post.create!(author_id: author.id)

post.author_id = 0 # Invalid id which is not present in the `authors` table
post.save! # Should raise 'ActiveRecord::RecordInvalid' error

post.author_id = nil
post.save! # No Error
```

Based on this issue's discussion #26557. Added this feature.

Feedbacks are welcome :)
