### PR TITLE
Make :as option also set request format (AC::TestCase)

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -498,10 +498,6 @@ module ActionController
 
         parameters ||= {}
 
-        if format
-          parameters[:format] = format
-        end
-
         @html_document = nil
 
         cookies.update(@request.cookies)
@@ -519,6 +515,10 @@ module ActionController
         if as
           @request.content_type = Mime[as].to_s
           format ||= as
+        end
+
+        if format
+          parameters[:format] = format
         end
 
         parameters = parameters.symbolize_keys

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -646,6 +646,11 @@ XML
     assert_equal 2, @request.request_parameters[:num_value]
   end
 
+  def test_using_as_json_sets_format_json
+    post :render_body, params: { bool_value: true, str_value: "string", num_value: 2 }, as: :json
+    assert_equal "json", @request.format
+  end
+
   def test_mutating_content_type_headers_for_plain_text_files_sets_the_header
     @request.headers["Content-Type"] = "text/plain"
     post :render_body, params: { name: "foo.txt" }


### PR DESCRIPTION
We introduced `as:` option in #26212 and it's supposed to also set `format` when it's blank:

``` ruby
if as
  @request.content_type = Mime[as].to_s
  format ||= as
end
```

But right now we assign `format` _before_ this block of code so `format ||= as` will always be ignored.

Counting that, now you'd always have to specify both `:as` and `:format`:

``` ruby
post :create, params: { foo: "bar" } as: :json, format: :json
```

But with my patch, `:format` will also be set to `json` when `as` is supplied.

``` ruby
post :create, params: { foo: "bar" } as: :json
```

review @rafaelfranca 
