### PR TITLE
Make ActiveSupport::Inflector use I18n.locale instead of :en

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -15,7 +15,7 @@ class String
   #
   # If the optional parameter +locale+ is specified,
   # the word will be pluralized as a word of that language.
-  # By default, this parameter is set to <tt>:en</tt>.
+  # By default, this parameter is set to the value of <tt>I18n.locale</tt>.
   # You must define your own inflection rules for languages other than English.
   #
   #   'post'.pluralize             # => "posts"
@@ -28,8 +28,9 @@ class String
   #   'apple'.pluralize(2)         # => "apples"
   #   'ley'.pluralize(:es)         # => "leyes"
   #   'ley'.pluralize(1, :es)      # => "ley"
-  def pluralize(count = nil, locale = :en)
+  def pluralize(count = nil, locale = I18n.locale)
     locale = count if count.is_a?(Symbol)
+
     if count == 1
       dup
     else
@@ -41,7 +42,7 @@ class String
   #
   # If the optional parameter +locale+ is specified,
   # the word will be singularized as a word of that language.
-  # By default, this parameter is set to <tt>:en</tt>.
+  # By default, this parameter is set to the value of <tt>I18n.locale</tt>.
   # You must define your own inflection rules for languages other than English.
   #
   #   'posts'.singularize            # => "post"
@@ -51,7 +52,7 @@ class String
   #   'the blue mailmen'.singularize # => "the blue mailman"
   #   'CamelOctopi'.singularize      # => "CamelOctopus"
   #   'leyes'.singularize(:es)       # => "ley"
-  def singularize(locale = :en)
+  def singularize(locale = I18n.locale)
     ActiveSupport::Inflector.singularize(self, locale)
   end
 

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -19,7 +19,7 @@ module ActiveSupport
     #
     # If passed an optional +locale+ parameter, the word will be
     # pluralized using rules defined for that language. By default,
-    # this parameter is set to <tt>:en</tt>.
+    # this parameter is set to the value of <tt>I18n.locale</tt>.
     #
     #   pluralize('post')             # => "posts"
     #   pluralize('octopus')          # => "octopi"
@@ -27,7 +27,7 @@ module ActiveSupport
     #   pluralize('words')            # => "words"
     #   pluralize('CamelOctopus')     # => "CamelOctopi"
     #   pluralize('ley', :es)         # => "leyes"
-    def pluralize(word, locale = :en)
+    def pluralize(word, locale = I18n.locale)
       apply_inflections(word, inflections(locale).plurals)
     end
 
@@ -36,7 +36,7 @@ module ActiveSupport
     #
     # If passed an optional +locale+ parameter, the word will be
     # singularized using rules defined for that language. By default,
-    # this parameter is set to <tt>:en</tt>.
+    # this parameter is set to the value of <tt>I18n.locale</tt>.
     #
     #   singularize('posts')            # => "post"
     #   singularize('octopi')           # => "octopus"
@@ -44,7 +44,7 @@ module ActiveSupport
     #   singularize('word')             # => "word"
     #   singularize('CamelOctopi')      # => "CamelOctopus"
     #   singularize('leyes', :es)       # => "ley"
-    def singularize(word, locale = :en)
+    def singularize(word, locale = I18n.locale)
       apply_inflections(word, inflections(locale).singulars)
     end
 

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -421,6 +421,10 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal("los", "el".pluralize(:es))
     assert_equal("els", "el".pluralize)
 
+    I18n.locale = :es
+    assert_equal("los", "el".pluralize)
+    I18n.locale = :en
+
     ActiveSupport::Inflector.inflections(:es) { |inflect| inflect.clear }
 
     assert ActiveSupport::Inflector.inflections(:es).plurals.empty?


### PR DESCRIPTION
The PR https://github.com/rails/rails/pull/7197 added an awesome flexibility in 
the Inflector class for us who don't have the english as native language or/and 
work in others idioms.

This patch try to keep this job and adds more flexibility for the methods 
`singularize` and `pluralize`, today when the user are in a language different 
of the English, we need send the current locale to this methods, see a example: 

``` ruby
(main:0) > I18n.locale
=> :"pt-BR"
(main:0) > "capital".pluralize 2
=> "capitals"
(main:0) > ActiveSupport::Inflector.inflections(:"pt-BR") do |inflect|
  inflect.plural(/al$/i,  'ais')
end  
=> [[/al$/i, "ais"]]
(main:0) >  "capital".pluralize 2
=> "capitals"
(main:0) > "capital".pluralize 2, I18n.locale
=> "capitais"
```

Even the locale as `:"pt-BR"`, the `pluralize` use `:en`.

So I thinking, why not use `I18n.locale` as fallback default instead of force 
`:en`? That's what makes this PR and like the default value of `I18n.locale` is 
`:en` we will not crash any app in the world because this change and 
the no-english apps now can be less verbose.

What do y'all think?
