### PR TITLE
DRYing duplicate methods

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -97,12 +97,7 @@ module ActiveSupport
           value
         end
 
-        def decrement(name, amount = 1, options = nil) # :nodoc:
-          return super unless local_cache
-          value = bypass_local_cache { super }
-          write_cache_value(name, value, options)
-          value
-        end
+        alias_method :decrement, :increment
 
         protected
           def read_entry(key, options) # :nodoc:


### PR DESCRIPTION
Use `alias_method` to prevent using duplicate method
