### PR TITLE
Undeprecate plural positional argument

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -225,14 +225,7 @@ module ActionView
       #
       #   pluralize(2, 'Person', locale: :de)
       #   # => 2 Personen
-      def pluralize(count, singular, deprecated_plural = nil, plural: nil, locale: I18n.locale)
-        if deprecated_plural
-          ActiveSupport::Deprecation.warn("Passing plural as a positional argument " \
-            "is deprecated and will be removed in Rails 5.1. Use e.g. " \
-            "pluralize(1, 'person', plural: 'people') instead.")
-          plural ||= deprecated_plural
-        end
-
+      def pluralize(count, singular, plural_arg = nil, plural: plural_arg, locale: I18n.locale)
         word = if (count == 1 || count =~ /^1(\.0+)?$/)
           singular
         else

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -379,6 +379,8 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("1.25 counts", pluralize("1.25", "count"))
     assert_equal("1.0 count", pluralize("1.0", "count"))
     assert_equal("1.00 count", pluralize("1.00", "count"))
+    assert_equal("2 counters", pluralize(2, "count", "counters"))
+    assert_equal("0 counters", pluralize(nil, "count", "counters"))
     assert_equal("2 counters", pluralize(2, "count", plural: "counters"))
     assert_equal("0 counters", pluralize(nil, "count", plural: "counters"))
     assert_equal("2 people", pluralize(2, "person"))
@@ -402,12 +404,6 @@ class TextHelperTest < ActionView::TestCase
       assert_equal("2 regions",  pluralize(2, "region", locale: :en))
     ensure
       I18n.locale = old_locale
-    end
-  end
-
-  def test_deprecated_plural_as_positional_argument
-    assert_deprecated do
-      pluralize(2, "count", "counters")
     end
   end
 


### PR DESCRIPTION
> DEPRECATION WARNING: Passing plural as a positional argument is deprecated and will be removed in Rails 5.1. Use e.g. pluralize(1, 'person', plural: 'people') instead.

This is a rough deprecation warning. Unclear why it's removed, and it turns out it's just for calling consistency with other helpers. I don't think that flies in this case. Passing one as an unlabeled positional argument and the other as a keyword arg over-emphasizes that one is required (the singular form) and the other is not (since we use the inflector to generate a plural if it's not provided).

Concise and natural to read and write:

``` ruby
pluralize people.count, 'person', 'people'
```

Surprise that one of the nouns needs labeling:

``` ruby
pluralize people.count, 'person', plural: 'people'
```

So let's just not deprecate the positional arg. (The `plural:` kwarg shipped in 5.0.0, so we're keeping it.)

We could _optionally_ label both nouns, but that's a mega mouthful:

``` ruby
pluralize people.count, singular: 'person', plural: 'people'
```

Partially reverts #20638.
