### PR TITLE
remove unnecessary `RAILS_ENV` setting

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
@@ -1,4 +1,3 @@
-ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 

--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
@@ -1,6 +1,3 @@
-# Configure Rails Environment
-ENV["RAILS_ENV"] = "test"
-
 require File.expand_path("../../<%= options[:dummy_path] -%>/config/environment.rb", __FILE__)
 <% unless options[:skip_active_record] -%>
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../<%= options[:dummy_path] -%>/db/migrate", __FILE__)]


### PR DESCRIPTION
### Summary

`RAILS_ENV` is always set in the initialization process of test runner.
https://github.com/rails/rails/blob/9fa07095a35be2d8cb5adcc992b988e73a6d9719/railties/lib/rails/test_unit/minitest_plugin.rb#L74

Therefore, it is not necessary to set in `test_helper`.
