### PR TITLE
Fix `change_column` to drop default with `null: false`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -777,11 +777,11 @@ module ActiveRecord
         def change_column_sql(table_name, column_name, type, options = {})
           column = column_for(table_name, column_name)
 
-          unless options_include_default?(options)
+          unless options.key?(:default)
             options[:default] = column.default
           end
 
-          unless options.has_key?(:null)
+          unless options.key?(:null)
             options[:null] = column.null
           end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -499,7 +499,7 @@ module ActiveRecord
           end
           execute sql
 
-          change_column_default(table_name, column_name, options[:default]) if options_include_default?(options)
+          change_column_default(table_name, column_name, options[:default]) if options.key?(:default)
           change_column_null(table_name, column_name, options[:null], options[:default]) if options.key?(:null)
           change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -405,11 +405,10 @@ module ActiveRecord
 
       def change_column(table_name, column_name, type, options = {}) #:nodoc:
         alter_table(table_name) do |definition|
-          include_default = options_include_default?(options)
           definition[column_name].instance_eval do
             self.type    = type
             self.limit   = options[:limit] if options.include?(:limit)
-            self.default = options[:default] if include_default
+            self.default = options[:default] if options.include?(:default)
             self.null    = options[:null] if options.include?(:null)
             self.precision = options[:precision] if options.include?(:precision)
             self.scale = options[:scale] if options.include?(:scale)

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -225,6 +225,16 @@ module ActiveRecord
         assert_nil TestModel.new.contributor
       end
 
+      def test_change_column_to_drop_default_with_null_false
+        add_column "test_models", "contributor", :boolean, default: true, null: false
+        assert TestModel.new.contributor?
+
+        change_column "test_models", "contributor", :boolean, default: nil, null: false
+        TestModel.reset_column_information
+        assert_not TestModel.new.contributor?
+        assert_nil TestModel.new.contributor
+      end
+
       def test_change_column_with_new_default
         add_column "test_models", "administrator", :boolean, default: true
         assert TestModel.new.administrator?


### PR DESCRIPTION
Currently `change_column` cannot drop default if `null: false` is
specified at the same time. This change fixes the issue.

``` ruby
  # cannot drop default
  change_column "tests", "contributor", :boolean, default: nil, null: false

  # we need the following workaround currently
  change_column "tests", "contributor", :boolean, null: false
  change_column "tests", "contributor", :boolean, default: nil
```
