### PR TITLE
Support IO

### DIFF
--- a/activesupport/lib/active_support/io.rb
+++ b/activesupport/lib/active_support/io.rb
@@ -1,0 +1,5 @@
+class IO
+  def self.puts(*args)
+    $stdout.puts(args)
+  end
+end


### PR DESCRIPTION
There are more and more people who switching to more modern web framework called Phoenix. And lots of services is being rewritten to it. But still there are lots of services left with Rails and switching back and forth while developing and debugging with "puts-method" leads to annoying moments when there is no `IO.puts` method. This PR should fix it!
