### PR TITLE
Preserve cached queries name in AS notifications

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -65,7 +65,7 @@ module ActiveRecord
         if @query_cache_enabled && !locked?(arel)
           arel, binds = binds_from_relation arel, binds
           sql = to_sql(arel, binds)
-          cache_sql(sql, binds) { super(sql, name, binds, preparable: preparable) }
+          cache_sql(sql, name, binds) { super(sql, name, binds, preparable: preparable) }
         else
           super
         end
@@ -73,11 +73,17 @@ module ActiveRecord
 
       private
 
-        def cache_sql(sql, binds)
+        def cache_sql(sql, name, binds)
           result =
             if @query_cache[sql].key?(binds)
-              ActiveSupport::Notifications.instrument("sql.active_record",
-                sql: sql, binds: binds, name: "CACHE", connection_id: object_id)
+              ActiveSupport::Notifications.instrument(
+                "sql.active_record",
+                sql: sql,
+                binds: binds,
+                name: name,
+                connection_id: object_id,
+                cached: true,
+              )
               @query_cache[sql][binds]
             else
               @query_cache[sql][binds] = yield

--- a/activerecord/lib/active_record/explain_subscriber.rb
+++ b/activerecord/lib/active_record/explain_subscriber.rb
@@ -18,10 +18,13 @@ module ActiveRecord
     #
     # On the other hand, we want to monitor the performance of our real database
     # queries, not the performance of the access to the query cache.
-    IGNORED_PAYLOADS = %w(SCHEMA EXPLAIN CACHE)
+    IGNORED_PAYLOADS = %w(SCHEMA EXPLAIN)
     EXPLAINED_SQLS = /\A\s*(with|select|update|delete|insert)\b/i
     def ignore_payload?(payload)
-      payload[:exception] || IGNORED_PAYLOADS.include?(payload[:name]) || payload[:sql] !~ EXPLAINED_SQLS
+      payload[:exception] ||
+        payload[:cached] ||
+        IGNORED_PAYLOADS.include?(payload[:name]) ||
+        payload[:sql] !~ EXPLAINED_SQLS
     end
 
     ActiveSupport::Notifications.subscribe("sql.active_record", new)

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -35,6 +35,7 @@ module ActiveRecord
       return if IGNORE_PAYLOAD_NAMES.include?(payload[:name])
 
       name  = "#{payload[:name]} (#{event.duration.round(1)}ms)"
+      name  = "CACHE #{name}" if payload[:cached]
       sql   = payload[:sql]
       binds = nil
 

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -125,12 +125,9 @@ module ActiveRecord
     end
 
     def call(name, start, finish, message_id, values)
+      return if values[:cached]
+
       sql = values[:sql]
-
-      # FIXME: this seems bad. we should probably have a better way to indicate
-      # the query was cached
-      return if "CACHE" == values[:name]
-
       self.class.log_all << sql
       self.class.log << sql unless ignore.match?(sql)
     end


### PR DESCRIPTION
In 4.2, the payload name for `sql.active_record` events was always the same regardless of whether the cache was hit or not.

e.g. `"FooBar Load"`.

But since 5.0, when the request hit the cache the name is always `"CACHED"`. In our case it's problematic because we have a couple automated systems which subscribe to those, and the name being replaced mean we can only rely on the raw SQL query to distinguish them.

IMO a separate property in the payload is preferable.

cc @sgrif @rafaelfranca @kirs 
