### PR TITLE
ActiveJob::Core#serialize stores provider_job_id (fixes #26581).

### DIFF
--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -80,6 +80,7 @@ module ActiveJob
       {
         "job_class"  => self.class.name,
         "job_id"     => job_id,
+        "provider_job_id" => provider_job_id,
         "queue_name" => queue_name,
         "priority"   => priority,
         "arguments"  => serialize_arguments(arguments),

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -44,4 +44,12 @@ class JobSerializationTest < ActiveSupport::TestCase
     job.deserialize({})
     assert_equal "en", job.locale
   end
+
+  test "serialize stores provider_job_id" do
+    job = HelloJob.new
+    assert_nil job.serialize["provider_job_id"]
+
+    job.provider_job_id = "some value set by adapter"
+    assert_equal job.provider_job_id, job.serialize["provider_job_id"]
+  end
 end


### PR DESCRIPTION
### Summary

Fixes #26581, adds provider_job_id to the hash returned by ActiveJob::Core#serialize, and a test.
