### PR TITLE
Fix memoization bug on ActionDispatch::TestRequest#request_method=

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_request.rb
+++ b/actionpack/lib/action_dispatch/testing/test_request.rb
@@ -22,7 +22,7 @@ module ActionDispatch
     private_class_method :default_env
 
     def request_method=(method)
-      set_header("REQUEST_METHOD", method.to_s.upcase)
+      super(method.to_s.upcase)
     end
 
     def host=(host)

--- a/actionpack/test/dispatch/test_request_test.rb
+++ b/actionpack/test/dispatch/test_request_test.rb
@@ -88,6 +88,13 @@ class TestRequestTest < ActiveSupport::TestCase
     assert_equal "GoogleBot", req.user_agent
   end
 
+  test "request_method getter and setter" do
+    req = ActionDispatch::TestRequest.create
+    req.request_method # to reproduce bug caused by memoization
+    req.request_method = "POST"
+    assert_equal "POST", req.request_method
+  end
+
   test "setter methods" do
     req = ActionDispatch::TestRequest.create({})
     get = "GET"


### PR DESCRIPTION
`TestRequest` have been overrriding `request_method` setter since 2009,
but the actual implementation in `Request` (not `TestRequest`) has been
changed since that. Now it's also using `@request_method` instance
variable to keep the state.

The override in `TestRequest` have not been calling `super`, which caused
a bug that after accessing `#requst_method` the value was memoized and
then we've never been able to change it anymore:

``` ruby
req = ActionDispatch::TestRequest.create
puts "was: #{req.request_method}" # memoized here
req.request_method = "POST"
puts "became: #{req.request_method}"
```

output:

```
was: GET
became: GET
```

Since the only purpose of overriding the setter in TestRequest is to
upcase it, I'm changing it to `super(method.to_s.upcase)`

review @rafaelfranca 
cc @xldenis
