### PR TITLE
Add #25546 and #25817 to changelog [ci skip]

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix adding implicitly rendered template digests to ETags.
+
+    Fixes a case when modifying an implicitly rendered template for a
+    controller action using `fresh_when` or `stale?` would not result in a new
+    `ETag` value.
+
+    *Javan Makhmali*
+
 *   Make `fixture_file_upload` work in integration tests.
 
     *Yuji Yaginuma*


### PR DESCRIPTION
@javan's fix for ETag templates in #25546, and later extended in #25817 should be in the changelog.
