### PR TITLE
Fix 4.2-stable build - Cherry pick "use correct Gemfile in `bin/setup` test"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ script: 'ci/travis.rb'
 before_install:
   - "rvm current | grep 'jruby' && export AR_JDBC=true || echo"
   - "rm ${BUNDLE_GEMFILE}.lock"
+  - "ruby -v | grep '1.9.3' && gem update bundler || true"
 before_script:
   - bundle update
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ script: 'ci/travis.rb'
 before_install:
   - "rvm current | grep 'jruby' && export AR_JDBC=true || echo"
   - "rm ${BUNDLE_GEMFILE}.lock"
-  - "ruby -v | grep '1.9.3' && gem update bundler || true"
+  - "ruby -v | egrep '^ruby 1.9' && gem update bundler || true"
+  - "ruby -v | egrep '^ruby 2.0' && gem update bundler || true"
+  - "ruby -v | egrep '^ruby 2.1' && gem update bundler || true"
 before_script:
   - bundle update
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ script: 'ci/travis.rb'
 before_install:
   - "rvm current | grep 'jruby' && export AR_JDBC=true || echo"
   - "rm ${BUNDLE_GEMFILE}.lock"
-  - "ruby -v | egrep '^ruby 1.9' && gem update bundler || true"
-  - "ruby -v | egrep '^ruby 2.0' && gem update bundler || true"
-  - "ruby -v | egrep '^ruby 2.1' && gem update bundler || true"
+  - "gem update bundler"
 before_script:
   - bundle update
 cache: bundler

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -6,10 +6,17 @@ module ApplicationTests
 
     def setup
       build_app
+
+      create_gemfile
+      update_boot_file_to_use_bundler
+      @old_gemfile_env = ENV["BUNDLE_GEMFILE"]
+      ENV["BUNDLE_GEMFILE"] = app_path + "/Gemfile"
     end
 
     def teardown
       teardown_app
+
+      ENV["BUNDLE_GEMFILE"] = @old_gemfile_env
     end
 
     def test_bin_setup
@@ -50,5 +57,16 @@ The Gemfile's dependencies are satisfied
         OUTPUT
       end
     end
+
+    private
+      def create_gemfile
+        app_file("Gemfile", "source 'https://rubygems.org'")
+        app_file("Gemfile", "gem 'rails', path: '#{RAILS_FRAMEWORK_ROOT}'", "a")
+        app_file("Gemfile", "gem 'sqlite3'", "a")
+      end
+
+      def update_boot_file_to_use_bundler
+        app_file("config/boot.rb", "require 'bundler/setup'")
+      end
   end
 end


### PR DESCRIPTION
### Summary

Currently, `bin/setup` test uses Gemfile of Rails. But this Gemfile is not a
file to be used in Rails application.
Add a Gemfile to Rails application that is created for test, it has been
modified to use the Gemfile.
