### PR TITLE
Return true if attribute is not changed for update_attribute

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Return `true` from `update_attribute` when the value of the attribute
+    to be updated is unchanged.
+
+    Fixes #26593.
+
+    *Prathamesh Sonpatki*
+
 *   Always store errors details information with symbols.
 
     When the association is autosaved we were storing the details with

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -252,7 +252,8 @@ module ActiveRecord
       name = name.to_s
       verify_readonly_attribute(name)
       public_send("#{name}=", value)
-      save(validate: false) if changed?
+
+      changed? ? save(validate: false) : true
     end
 
     # Updates the attributes of the model from the passed-in hash and saves the

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -391,14 +391,14 @@ class PersistenceTest < ActiveRecord::TestCase
     end
     topic = klass.create(title: "Another New Topic")
     assert_queries(0) do
-      topic.update_attribute(:title, "Another New Topic")
+      assert topic.update_attribute(:title, "Another New Topic")
     end
   end
 
   def test_update_does_not_run_sql_if_record_has_not_changed
     topic = Topic.create(title: "Another New Topic")
-    assert_queries(0) { topic.update(title: "Another New Topic") }
-    assert_queries(0) { topic.update_attributes(title: "Another New Topic") }
+    assert_queries(0) { assert topic.update(title: "Another New Topic") }
+    assert_queries(0) { assert topic.update_attributes(title: "Another New Topic") }
   end
 
   def test_delete


### PR DESCRIPTION
### Summary
- If the attribute is not changed, then update_attribute does not run
  SQL query, this effectively means that no change was made to the
  attribute.
- This change was made in https://github.com/rails/rails/commit/0fcd4cf5
  to avoid a SQL call.
- But the change resulted into `nil` being returned when there was no
  change in the attribute value.
- This commit corrects the behavior to return true if there is no change
  in attribute value. This is same as previous behavior of Rails 4.2
  plus benefit of no additional SQL call.
- Fixes #26593.

r? @rafaelfranca 
