### PR TITLE
initialize errors with name of class and other params

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -353,7 +353,7 @@ module ActiveRecord
       if ids.nil?
         error = "Couldn't find #{name}"
         error << " with#{conditions}" if conditions
-        raise RecordNotFound, error
+        raise RecordNotFound.new(error, name)
       elsif Array(ids).size == 1
         error = "Couldn't find #{name} with '#{primary_key}'=#{ids}#{conditions}"
         raise RecordNotFound.new(error, name, primary_key, ids)
@@ -361,7 +361,7 @@ module ActiveRecord
         error = "Couldn't find all #{name.pluralize} with '#{primary_key}': "
         error << "(#{ids.join(", ")})#{conditions} (found #{result_size} results, but was looking for #{expected_size})"
 
-        raise RecordNotFound, error
+        raise RecordNotFound.new(error, name, primary_key, ids)
       end
     end
 


### PR DESCRIPTION
When .find used with wrong ids we have name of model in ActiveRecord::RecordNotFound, but if it used in relations(like this: some_user.posts.find(42)) exception does not contain model's name. It happen because exception raised only with error message. 
I added other parameters. 
