### PR TITLE
Add next and previous day of week api to ActiveSupport

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `Date#prev_occurring` and `Date#next_occurring` to return specified next/previous occurring day of week.
+
+    *Shota Iguchi*
+
 *   Add default option to class_attribute. Before:
 
       class_attribute :settings

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -320,6 +320,22 @@ module DateAndTime
       beginning_of_year..end_of_year
     end
 
+    # Returns specific next occurring day of week
+    def next_occurring(day_of_week)
+      current_day_number = wday != 0 ? wday - 1 : 6
+      from_now = DAYS_INTO_WEEK.fetch(day_of_week) - current_day_number
+      from_now += 7 unless from_now > 0
+      since(from_now.days)
+    end
+
+    # Returns specific previous occurring day of week
+    def prev_occurring(day_of_week)
+      current_day_number = wday != 0 ? wday - 1 : 6
+      ago = current_day_number - DAYS_INTO_WEEK.fetch(day_of_week)
+      ago += 7 unless ago > 0
+      ago(ago.days)
+    end
+
     private
       def first_hour(date_or_time)
         date_or_time.acts_like?(:time) ? date_or_time.beginning_of_day : date_or_time

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -28,6 +28,28 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_next_occur
+    datetime = DateTime.new(2016, 9, 24, 0, 0) # saturday
+    assert_equal datetime.next_occurring(:monday), datetime.since(2.days)
+    assert_equal datetime.next_occurring(:tuesday), datetime.since(3.days)
+    assert_equal datetime.next_occurring(:wednesday), datetime.since(4.days)
+    assert_equal datetime.next_occurring(:thursday), datetime.since(5.days)
+    assert_equal datetime.next_occurring(:friday), datetime.since(6.days)
+    assert_equal datetime.next_occurring(:saturday), datetime.since(1.week)
+    assert_equal datetime.next_occurring(:sunday), datetime.since(1.day)
+  end
+
+  def test_prev_occur
+    datetime = DateTime.new(2016, 9, 24, 0, 0) # saturday
+    assert_equal datetime.prev_occurring(:monday), datetime.ago(5.days)
+    assert_equal datetime.prev_occurring(:tuesday), datetime.ago(4.days)
+    assert_equal datetime.prev_occurring(:wednesday), datetime.ago(3.days)
+    assert_equal datetime.prev_occurring(:thursday), datetime.ago(2.days)
+    assert_equal datetime.prev_occurring(:friday), datetime.ago(1.day)
+    assert_equal datetime.prev_occurring(:saturday), datetime.ago(1.week)
+    assert_equal datetime.prev_occurring(:sunday), datetime.ago(6.days)
+  end
+
   def test_readable_inspect
     datetime = DateTime.new(2005, 2, 21, 14, 30, 0)
     assert_equal "Mon, 21 Feb 2005 14:30:00 +0000", datetime.readable_inspect


### PR DESCRIPTION
### Summary

I want a next day of week api on ActiveSupport datetime extentions. 

So, I implemented next day of week api.

For example,

``` rb
date = Date.new(2016, 9, 26)

date.monday? # => true
date.next_monday # => date + 1.week
date.next_tuesday # =>  date + 1.day
```

WDYT?
## 

P.S.

The difference between `next_week(:tuesday)` and `next_tuesday` .

``` rb
date = Date.today.monday
date.next_week(:tuesday) # == date + 8.days
date.next_tuesday # == date + 1.day
```
