### PR TITLE
Fix docs for allowed params to `get` in controller tests  [ci skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -761,8 +761,8 @@ and also ensuring that the right response body has been generated.
 
 The `get` method kicks off the web request and populates the results into the `@response`. It can accept up to 6 arguments:
 
-* The action of the controller you are requesting.
-  This can be in the form of a string or a route (i.e. `articles_url`).
+* The URI of the controller action you are requesting.
+  This can be in the form of a string or a route helper (e.g. `articles_url`).
 * `params`: option with a hash of request parameters to pass into the action
   (e.g. query string parameters or article variables).
 * `headers`: for setting the headers that will be passed with the request.
@@ -775,13 +775,13 @@ All of these keyword arguments are optional.
 Example: Calling the `:show` action, passing an `id` of 12 as the `params` and setting `HTTP_REFERER` header:
 
 ```ruby
-get :show, params: { id: 12 }, headers: { "HTTP_REFERER" => "http://example.com/home" }
+get article_url, params: { id: 12 }, headers: { "HTTP_REFERER" => "http://example.com/home" }
 ```
 
 Another example: Calling the `:update` action, passing an `id` of 12 as the `params` as an Ajax request.
 
 ```ruby
-patch update_url, params: { id: 12 }, xhr: true
+patch article_url, params: { id: 12 }, xhr: true
 ```
 
 NOTE: If you try running `test_should_create_article` test from `articles_controller_test.rb` it will fail on account of the newly added model level validation and rightly so.


### PR DESCRIPTION
### Summary

Fixes #26602

Relevant method documentation for `ActionDispatch::Integration::RequestHelpers#get`:

https://github.com/rails/rails/blob/abe3da9f12710ea85be69b17172bef41220037fc/actionpack/lib/action_dispatch/testing/integration.rb#L14-L43
### Other Information

I'm not entirely happy with the documentation here, which still appears to be written with the old method in mind. For instance, in describing a test:

> Let's take a look at one such test, test_should_get_index from the file articles_controller_test.rb.

```
# articles_controller_test.rb
class ArticlesControllerTest < ActionDispatch::IntegrationTest
  test "should get index" do
    get articles_url
    assert_response :success
  end
end
```

> In the test_should_get_index test, Rails simulates a request on the action called index, making sure   the request was successful and also ensuring that the right response body has been generated.

`Rails simulates a request on the action called index` doesn't seem to be a precise description here. 

Perhaps instead, `Rails simulates a request to articles_url, triggering the index action`? I'm not sure what the most clear way to write this is.
