### PR TITLE
Only search fixture_path for files that can't be found directly

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -34,7 +34,8 @@ module ActionDispatch
     #
     #   post :change_avatar, avatar: fixture_file_upload('files/spongebob.png', 'image/png', :binary)
     def fixture_file_upload(path, mime_type = nil, binary = false)
-      if self.class.respond_to?(:fixture_path) && self.class.fixture_path
+      if self.class.respond_to?(:fixture_path) && self.class.fixture_path &&
+          !File.exist?(path)
         path = File.join(self.class.fixture_path, path)
       end
       Rack::Test::UploadedFile.new(path, mime_type, binary)

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -962,6 +962,13 @@ XML
     end
   end
 
+  def test_fixture_file_upload_ignores_fixture_path_given_full_path
+    TestCaseTest.stub :fixture_path, File.dirname(__FILE__) do
+      uploaded_file = fixture_file_upload("#{FILES_DIR}/mona_lisa.jpg", "image/jpg")
+      assert_equal File.open("#{FILES_DIR}/mona_lisa.jpg", READ_PLAIN).read, uploaded_file.read
+    end
+  end
+
   def test_fixture_file_upload_ignores_nil_fixture_path
     uploaded_file = fixture_file_upload("#{FILES_DIR}/mona_lisa.jpg", "image/jpg")
     assert_equal File.open("#{FILES_DIR}/mona_lisa.jpg", READ_PLAIN).read, uploaded_file.read


### PR DESCRIPTION
When passed an already-valid file name, prepending the path is likely to create problems.

This is particularly relevant for #26384, which adds fixture_path handling to test classes that previously didn't have it: any existing caller must have been manually locating the file, and we don't want to break them.
