### PR TITLE
Fix to use empty? method from DateTime#blank?

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/blank.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/blank.rb
@@ -3,10 +3,11 @@ require "date"
 class DateTime #:nodoc:
   # No DateTime is ever blank:
   #
+  #   DateTime.now.empty? # => false
   #   DateTime.now.blank? # => false
   #
   # @return [false]
-  def blank?
+  def empty?
     false
   end
 end


### PR DESCRIPTION
### Summary

I think DateTime#blank? should be use Object#blank? method.

WDYT?
## 

5.0.0.1/lib/active_support/core_ext/object/blank.rb @ line 14:
Owner: Object
Visibility: public
Number of lines: 3

``` rb
def blank?
  respond_to?(:empty?) ? !!empty? : !self
end
```
