### PR TITLE
Fix to use define_singleton_method method

### DIFF
--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -27,9 +27,7 @@ module ActiveRecord
       end.join("\n")
 
       # Overriding inspect to be more human readable, especially in the console.
-      def str.inspect
-        self
-      end
+      str.define_singleton_method(:inspect) { self }
 
       str
     end


### PR DESCRIPTION
### Summary

Fix to use `define_singleton_method` to defining singleton method.

Rails5 works with more than ruby 2.2.2.
