### PR TITLE
Eager load distinct default scopes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   An eager loaded default scope containing distinct will now issue a distinct
+    query against the database.
+
+    Fixes #26545.
+
+    *Stephen Bussey*
+
 *   Serialize JSON attribute value `nil` as SQL `NULL`, not JSON `null`
 
     *Trung Duc Tran*

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -161,6 +161,10 @@ module ActiveRecord
               scope.where!(klass.table_name => { reflection.type => model.base_class.sti_name })
             end
 
+            if preload_values[:distinct] || values[:distinct]
+              scope.distinct!
+            end
+
             scope.unscope_values = Array(values[:unscope]) + Array(preload_values[:unscope])
             klass.default_scoped.merge(scope)
           end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -982,8 +982,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
     preloaded_category = category.clubs.includes(club_category_ratings: { category: [:clubs_with_joins] }).to_a
 
     assert_no_queries do
-      ids = preloaded_category.first.club_category_ratings.first.category.clubs_with_joins.map(&:id).sort
-      assert_equal([club.id, club.id, moustache_club.id], ids)
+      ids = preloaded_category.first.club_category_ratings.first.category.clubs_with_joins.map(&:id)
+      assert_equal([club.id, club.id, moustache_club.id].sort, ids.sort)
     end
   end
 
@@ -1000,8 +1000,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
     preloaded_category = category.clubs.includes(club_category_ratings: { category: [:clubs_distinct_joins] }).to_a
 
     assert_no_queries do
-      ids = preloaded_category.first.club_category_ratings.first.category.clubs_distinct_joins.map(&:id).sort
-      assert_equal([club.id, moustache_club.id], ids)
+      ids = preloaded_category.first.club_category_ratings.first.category.clubs_distinct_joins.map(&:id)
+      assert_equal([club.id, moustache_club.id].sort, ids.sort)
     end
   end
 

--- a/activerecord/test/fixtures/club_category_ratings.yml
+++ b/activerecord/test/fixtures/club_category_ratings.yml
@@ -1,0 +1,14 @@
+boring_club_general_rating1:
+  category_id: 1
+  club_id: 1
+  value: 1
+
+boring_club_general_rating2:
+  category_id: 1
+  club_id: 1
+  value: 2
+
+moustache_club_general_rating:
+  category_id: 1
+  club_id: 2
+  value: 11

--- a/activerecord/test/fixtures/club_category_ratings.yml
+++ b/activerecord/test/fixtures/club_category_ratings.yml
@@ -1,14 +1,14 @@
 boring_club_general_rating1:
   category_id: 1
-  club_id: 1
+  club: boring_club
   value: 1
 
 boring_club_general_rating2:
   category_id: 1
-  club_id: 1
+  club: boring_club
   value: 2
 
 moustache_club_general_rating:
   category_id: 1
-  club_id: 2
+  club: moustache_club
   value: 11

--- a/activerecord/test/fixtures/clubs.yml
+++ b/activerecord/test/fixtures/clubs.yml
@@ -1,14 +1,11 @@
 boring_club:
-  id: 1
   name: Banana appreciation society
   category_id: 1
 
 moustache_club:
-  id: 2
   name: Moustache and Eyebrow Fancier Club
   category_id: 1
 
 crazy_club:
-  id: 3
   name: Skull and bones
   category_id: 2

--- a/activerecord/test/fixtures/clubs.yml
+++ b/activerecord/test/fixtures/clubs.yml
@@ -1,8 +1,14 @@
 boring_club:
+  id: 1
   name: Banana appreciation society
   category_id: 1
+
 moustache_club:
+  id: 2
   name: Moustache and Eyebrow Fancier Club
+  category_id: 1
+
 crazy_club:
+  id: 3
   name: Skull and bones
   category_id: 2

--- a/activerecord/test/models/category.rb
+++ b/activerecord/test/models/category.rb
@@ -29,6 +29,8 @@ class Category < ActiveRecord::Base
   has_many :authors_with_select, -> { select "authors.*, categorizations.post_id" }, through: :categorizations, source: :author
 
   has_many :clubs
+  has_many :clubs_with_joins, -> { with_ratings }, class_name: "Club"
+  has_many :clubs_distinct_joins, -> { with_distinct_joins }, class_name: "Club"
 
   scope :general, -> { where(name: "General") }
 end

--- a/activerecord/test/models/category.rb
+++ b/activerecord/test/models/category.rb
@@ -28,6 +28,8 @@ class Category < ActiveRecord::Base
   has_many :authors, through: :categorizations
   has_many :authors_with_select, -> { select "authors.*, categorizations.post_id" }, through: :categorizations, source: :author
 
+  has_many :clubs
+
   scope :general, -> { where(name: "General") }
 end
 

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -5,6 +5,7 @@ class Club < ActiveRecord::Base
   has_one :sponsor
   has_one :sponsored_member, through: :sponsor, source: :sponsorable, source_type: "Member"
   belongs_to :category
+  has_many :club_category_ratings
 
   has_many :favourites, -> { where(memberships: { favourite: true }) }, through: :memberships, source: :member
 

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -9,6 +9,14 @@ class Club < ActiveRecord::Base
 
   has_many :favourites, -> { where(memberships: { favourite: true }) }, through: :memberships, source: :member
 
+  def self.with_ratings
+    joins(:club_category_ratings)
+  end
+
+  def self.with_distinct_joins
+    joins(:club_category_ratings).distinct
+  end
+
   private
 
     def private_method

--- a/activerecord/test/models/club_category_rating.rb
+++ b/activerecord/test/models/club_category_rating.rb
@@ -1,0 +1,4 @@
+class ClubCategoryRating < ActiveRecord::Base
+  belongs_to :club
+  belongs_to :category
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -157,6 +157,12 @@ ActiveRecord::Schema.define do
     t.integer :category_id
   end
 
+  create_table :club_category_ratings, force: true do |t|
+    t.integer :category_id
+    t.integer :club_id
+    t.integer :value, null: false
+  end
+
   create_table :collections, force: true do |t|
     t.string :name
   end


### PR DESCRIPTION
### Summary

Adds distinct capabilities in eager loaded default scope relationships. This became a bug when `joins` was supported without distinct. It is possible to produce duplicates not otherwise possible.

Fixes #26545 with @maclover7 
### Other Information
- Ensured that the eager loading works properly with `assert_no_queries`
- Had to add a new model to get a relationship representative of https://gist.github.com/maclover7/ee54dacea920a2580335ffe3d09356b8
