### PR TITLE
Shutdown pubsub connection before classes are reloaded

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -70,6 +70,7 @@ module ActionCable
 
         app.reloader.before_class_unload do
           ActionCable.server.restart
+          ActionCable.server.pubsub.shutdown
         end
       end
     end

--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -70,7 +70,6 @@ module ActionCable
 
         app.reloader.before_class_unload do
           ActionCable.server.restart
-          ActionCable.server.pubsub.shutdown
         end
       end
     end

--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -37,9 +37,13 @@ module ActionCable
         connections.each(&:close)
 
         @mutex.synchronize do
-          worker_pool.halt if @worker_pool
-
+          # Shutdown the worker pool
+          @worker_pool.halt if @worker_pool
           @worker_pool = nil
+
+          # Shutdown the pub/sub adapter
+          @pubsub.shutdown if @pubsub
+          @pubsub = nil
         end
       end
 

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+require "stubs/test_server"
+require "active_support/core_ext/hash/indifferent_access"
+
+class BaseTest < ActiveSupport::TestCase
+  def setup
+    @server = ActionCable::Server::Base.new
+    @server.config.cable = { adapter: "async" }.with_indifferent_access
+  end
+
+  class FakeConnection
+    def close
+    end
+  end
+
+  test "#restart closes all open connections" do
+    conn = FakeConnection.new
+    @server.add_connection(conn)
+
+    conn.expects(:close)
+    @server.restart
+  end
+
+  test "#restart shuts down worker pool" do
+    @server.worker_pool.expects(:halt)
+    @server.restart
+  end
+
+  test "#restart shuts down pub/sub adapter" do
+    @server.pubsub.expects(:shutdown)
+    @server.restart
+  end
+end


### PR DESCRIPTION
### Summary

Before this patch, if you were to make a file edit in your Rails
application and you tried to load up the page, it would hang
indefinitely. The issue is that Active Record is trying to cleanup after
itself and clear all active connection, but Action Cable is still
holding onto a connection from the pool. To resolve this, we are now
shutting down the pubsub adapter before classes are reloaded, to avoid
this altogether (connection is being returned to the pool).

Credits to @skateman for discovering this bug. :)
