### PR TITLE
[ci skip] Clarify Postgresql Documentation

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -89,10 +89,10 @@ module ActiveRecord
           end
         end
 
-        # Executes an SQL statement, returning a PGresult object on success
-        # or raising a PGError exception otherwise.
-        # Note: the PGresult object is manually memory managed; if you don't
-        # need it specifically, you many want consider the exec_query wrapper.
+        # Executes an SQL statement, returning a PG::Result object on success
+        # or raising a PG exception otherwise.
+        # Note: the PG::Result object is manually memory managed; if you don't
+        # need it specifically, you may want consider the <tt>exec_query</tt> wrapper.
         def execute(sql, name = nil)
           log(sql, name) do
             @connection.async_exec(sql)


### PR DESCRIPTION
### Summary

This clarifies the object that **ActiveRecord::Base.connection.execute** will return when using Postgresql.

I did make the PGError statement more ambiguous because it does not return a specific exception each time:
- Undefined column returns **PG::UndefinedColumn**
- A syntax error returns **PG::SyntaxError**
- etc.
