### PR TITLE
Prevent circular require of proxy_wrappers.rb, Fixes #26430

### DIFF
--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -1,4 +1,5 @@
-require 'active_support/deprecation/proxy_wrappers'
+require "active_support/deprecation"
+require "active_support/deprecation/proxy_wrappers"
 
 class LoadError
   REGEXPS = [


### PR DESCRIPTION
Backport of #26563 to `5-0-stable`.

This fixes #26430.
