### PR TITLE
[ci skip] Update PG adapter documentation

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -90,7 +90,7 @@ module ActiveRecord
         end
 
         # Executes an SQL statement, returning a PG::Result object on success
-        # or raising a PG exception otherwise.
+        # or raising a PG::Error exception otherwise.
         # Note: the PG::Result object is manually memory managed; if you don't
         # need it specifically, you may want consider the <tt>exec_query</tt> wrapper.
         def execute(sql, name = nil)


### PR DESCRIPTION
Per discussion in pull request #26622:

> "Let's change it to PG::Error. The more specific classes mentioned are subclasses, and the fact the raised exception is a PG::UndefinedColumn doesn't change the fact that it's also a PG::Error." - @matthewd
