### PR TITLE
round before calculating exponent in number_to_human_converter

### DIFF
--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -4,6 +4,7 @@ module ActiveSupport
 
     eager_autoload do
       autoload :NumberConverter
+      autoload :RoundingHelper
       autoload :NumberToRoundedConverter
       autoload :NumberToDelimitedConverter
       autoload :NumberToHumanConverter

--- a/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
@@ -9,6 +9,7 @@ module ActiveSupport
       self.validate_float = true
 
       def convert # :nodoc:
+        @number = RoundingHelper.new(options).round(number)
         @number = Float(number)
 
         # for backwards compatibility with those that didn't add strip_insignificant_zeros to their locale files
@@ -20,10 +21,7 @@ module ActiveSupport
         exponent = calculate_exponent(units)
         @number = number / (10**exponent)
 
-        until (rounded_number = NumberToRoundedConverter.convert(number, options)) != NumberToRoundedConverter.convert(1000, options)
-          @number = number / 1000.0
-          exponent += 3
-        end
+        rounded_number = NumberToRoundedConverter.convert(number, options)
         unit = determine_unit(units, exponent)
         format.gsub("%n".freeze, rounded_number).gsub("%u".freeze, unit).strip
       end

--- a/activesupport/lib/active_support/number_helper/rounding_helper.rb
+++ b/activesupport/lib/active_support/number_helper/rounding_helper.rb
@@ -1,0 +1,64 @@
+module ActiveSupport
+  module NumberHelper
+    class RoundingHelper # :nodoc:
+      attr_reader :options
+
+      def initialize(options)
+        @options = options
+      end
+
+      def round(number)
+        return number unless precision
+        number = convert_to_decimal(number)
+        if significant && precision > 0
+          round_significant(number)
+        else
+          round_without_significant(number)
+        end
+      end
+
+      def digit_count(number)
+        return 1 if number.zero?
+        (Math.log10(absolute_number(number)) + 1).floor
+      end
+
+      private
+        def round_without_significant(number)
+          number = number.round(precision)
+          number = number.to_i if precision == 0 && number.finite?
+          number = number.abs if number.zero? # prevent showing negative zeros
+          number
+        end
+
+        def round_significant(number)
+          return 0 if number.zero?
+          digits = digit_count(number)
+          multiplier = 10**(digits - precision)
+          (number / BigDecimal.new(multiplier.to_f.to_s)).round * multiplier
+        end
+
+        def convert_to_decimal(number)
+          case number
+          when Float, String
+            number = BigDecimal(number.to_s)
+          when Rational
+            number = BigDecimal(number, digit_count(number.to_i) + precision)
+          else
+            number = number.to_d
+          end
+        end
+
+        def precision
+          options[:precision]
+        end
+
+        def significant
+          options[:significant]
+        end
+
+        def absolute_number(number)
+          number.respond_to?(:abs) ? number.abs : number.to_d.abs
+        end
+    end
+  end
+end

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -321,12 +321,18 @@ module ActiveSupport
           gangster = { hundred: "hundred bucks", million: "thousand quids" }
           assert_equal "1 hundred bucks", number_helper.number_to_human(100, units: gangster)
           assert_equal "25 hundred bucks", number_helper.number_to_human(2500, units: gangster)
+          assert_equal "1000 hundred bucks", number_helper.number_to_human(100_000, units: gangster)
+          assert_equal "1 thousand quids", number_helper.number_to_human(999_999, units: gangster)
+          assert_equal "1 thousand quids", number_helper.number_to_human(1_000_000, units: gangster)
           assert_equal "25 thousand quids", number_helper.number_to_human(25000000, units: gangster)
           assert_equal "12300 thousand quids", number_helper.number_to_human(12345000000, units: gangster)
 
           #Spaces are stripped from the resulting string
           assert_equal "4", number_helper.number_to_human(4, units: { unit: "", ten: "tens " })
           assert_equal "4.5  tens", number_helper.number_to_human(45, units: { unit: "", ten: " tens   " })
+
+          #Uses only the provided units and does not try to use larger ones
+          assert_equal "1000 kilometers", number_helper.number_to_human(1_000_000, units: { unit: "meter", thousand: "kilometers" })
         end
       end
 


### PR DESCRIPTION
### Summary

Fixes #25664

Introduced in: https://github.com/rails/rails/commit/597a9276671f5d7884a0ee1a617656dd5ee4b0ea

Other PRs:
- 1: https://github.com/rails/rails/pull/25742
- 2: https://github.com/rails/rails/pull/26433

I think the real problem is that `NumberToHumanConverter` does not round before calling `calculate_exponent`, which led to the confusing [workaround](https://github.com/rails/rails/commit/597a9276671f5d7884a0ee1a617656dd5ee4b0ea) that introduced #25664 in the first place.

Unfortunately the code to round in `NumberToRoundedConverter` (with options for precision and significant digits) is tied to formatting it as a string. The motivation for adding a new class `RoundingHelper` is to extract this part of the code so it can reused in `NumberToHumanConverter`.

I am fairly new to the Rails codebase, so I'm unsure of where to put the helper class. Should it go in its own file? Should it be a module?

There is also the messy fact that `NumberToHumanConverter` is rounding twice. I suppose the formatting code could be extracted as well.
