### PR TITLE
Extract `quoted_binary` and use it rather than override `_quote`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -150,6 +150,10 @@ module ActiveRecord
         quoted_date(value).sub(/\A2000-01-01 /, "")
       end
 
+      def quoted_binary(value) # :nodoc:
+        "'#{quote_string(value.to_s)}'"
+      end
+
       private
 
         def type_casted_binds(binds)
@@ -162,7 +166,7 @@ module ActiveRecord
 
         def _quote(value)
           case value
-          when String, ActiveSupport::Multibyte::Chars, Type::Binary::Data
+          when String, ActiveSupport::Multibyte::Chars
             "'#{quote_string(value.to_s)}'"
           when true       then quoted_true
           when false      then quoted_false
@@ -170,6 +174,7 @@ module ActiveRecord
           # BigDecimals need to be put in a non-normalized form and quoted.
           when BigDecimal then value.to_s("F")
           when Numeric, ActiveSupport::Duration then value.to_s
+          when Type::Binary::Data then quoted_binary(value)
           when Type::Time::Value then "'#{quoted_time(value)}'"
           when Date, Time then "'#{quoted_date(value)}'"
           when Symbol     then "'#{quote_string(value.to_s)}'"

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -36,15 +36,9 @@ module ActiveRecord
           end
         end
 
-        private
-
-          def _quote(value)
-            if value.is_a?(Type::Binary::Data)
-              "x'#{value.hex}'"
-            else
-              super
-            end
-          end
+        def quoted_binary(value)
+          "x'#{value.hex}'"
+        end
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -55,6 +55,10 @@ module ActiveRecord
           end
         end
 
+        def quoted_binary(value) # :nodoc:
+          "'#{escape_bytea(value.to_s)}'"
+        end
+
         def quote_default_expression(value, column) # :nodoc:
           if value.is_a?(Proc)
             value.call
@@ -76,8 +80,6 @@ module ActiveRecord
 
           def _quote(value)
             case value
-            when Type::Binary::Data
-              "'#{escape_bytea(value.to_s)}'"
             when OID::Xml::Data
               "xml '#{quote_string(value.to_s)}'"
             when OID::Bit::Data

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -18,15 +18,11 @@ module ActiveRecord
           quoted_date(value)
         end
 
-        private
+        def quoted_binary(value)
+          "x'#{value.hex}'"
+        end
 
-          def _quote(value)
-            if value.is_a?(Type::Binary::Data)
-              "x'#{value.hex}'"
-            else
-              super
-            end
-          end
+        private
 
           def _type_cast(value)
             case value


### PR DESCRIPTION
Each databases have different binary representation. Therefore all
adapters overrides `_quote` for quoting binary.
Extract `quoted_binary` for quoting binary and use it rather than
override `_quote`.
