### PR TITLE
Remove duplicated `unless current_adapter?(:SQLite3Adapter)` condition

### DIFF
--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -72,9 +72,7 @@ module ActiveRecord
           assert_kind_of BigDecimal, row.wealth
 
           # If this assert fails, that means the SELECT is broken!
-          unless current_adapter?(:SQLite3Adapter)
-            assert_equal correct_value, row.wealth
-          end
+          assert_equal correct_value, row.wealth
 
           # Reset to old state
           TestModel.delete_all


### PR DESCRIPTION
`test_native_decimal_insert_manual_vs_automatic` exists inside
`unless current_adapter?(:SQLite3Adapter)`. This condition is
duplicated.
