### PR TITLE
Extract `NumericData` model for tests

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -15,6 +15,7 @@ require "models/boolean"
 require "models/column_name"
 require "models/subscriber"
 require "models/comment"
+require "models/numeric_data"
 require "models/minimalistic"
 require "models/warehouse_thing"
 require "models/parrot"
@@ -906,13 +907,6 @@ class BasicsTest < ActiveRecord::TestCase
         assert_equal "a text field", default.char3
       end
     end
-  end
-
-  class NumericData < ActiveRecord::Base
-    self.table_name = "numeric_data"
-
-    attribute :my_house_population, :integer
-    attribute :atoms_in_universe, :integer
   end
 
   def test_big_decimal_conditions

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -15,7 +15,6 @@ require "models/boolean"
 require "models/column_name"
 require "models/subscriber"
 require "models/comment"
-require "models/numeric_data"
 require "models/minimalistic"
 require "models/warehouse_thing"
 require "models/parrot"
@@ -907,73 +906,6 @@ class BasicsTest < ActiveRecord::TestCase
         assert_equal "a text field", default.char3
       end
     end
-  end
-
-  def test_big_decimal_conditions
-    m = NumericData.new(
-      bank_balance: 1586.43,
-      big_bank_balance: BigDecimal("1000234000567.95"),
-      world_population: 6000000000,
-      my_house_population: 3
-    )
-    assert m.save
-    assert_equal 0, NumericData.where("bank_balance > ?", 2000.0).count
-  end
-
-  def test_numeric_fields
-    m = NumericData.new(
-      bank_balance: 1586.43,
-      big_bank_balance: BigDecimal("1000234000567.95"),
-      world_population: 6000000000,
-      my_house_population: 3
-    )
-    assert m.save
-
-    m1 = NumericData.find(m.id)
-    assert_not_nil m1
-
-    # As with migration_test.rb, we should make world_population >= 2**62
-    # to cover 64-bit platforms and test it is a Bignum, but the main thing
-    # is that it's an Integer.
-    assert_kind_of Integer, m1.world_population
-    assert_equal 6000000000, m1.world_population
-
-    assert_kind_of Integer, m1.my_house_population
-    assert_equal 3, m1.my_house_population
-
-    assert_kind_of BigDecimal, m1.bank_balance
-    assert_equal BigDecimal("1586.43"), m1.bank_balance
-
-    assert_kind_of BigDecimal, m1.big_bank_balance
-    assert_equal BigDecimal("1000234000567.95"), m1.big_bank_balance
-  end
-
-  def test_numeric_fields_with_scale
-    m = NumericData.new(
-      bank_balance: 1586.43122334,
-      big_bank_balance: BigDecimal("234000567.952344"),
-      world_population: 6000000000,
-      my_house_population: 3
-    )
-    assert m.save
-
-    m1 = NumericData.find(m.id)
-    assert_not_nil m1
-
-    # As with migration_test.rb, we should make world_population >= 2**62
-    # to cover 64-bit platforms and test it is a Bignum, but the main thing
-    # is that it's an Integer.
-    assert_kind_of Integer, m1.world_population
-    assert_equal 6000000000, m1.world_population
-
-    assert_kind_of Integer, m1.my_house_population
-    assert_equal 3, m1.my_house_population
-
-    assert_kind_of BigDecimal, m1.bank_balance
-    assert_equal BigDecimal("1586.43"), m1.bank_balance
-
-    assert_kind_of BigDecimal, m1.big_bank_balance
-    assert_equal BigDecimal("234000567.95"), m1.big_bank_balance
   end
 
   def test_auto_id

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -8,6 +8,7 @@ require "models/organization"
 require "models/possession"
 require "models/topic"
 require "models/reply"
+require "models/numeric_data"
 require "models/minivan"
 require "models/speedometer"
 require "models/ship_part"
@@ -16,14 +17,6 @@ require "models/developer"
 require "models/comment"
 require "models/rating"
 require "models/post"
-
-class NumericData < ActiveRecord::Base
-  self.table_name = "numeric_data"
-
-  attribute :world_population, :integer
-  attribute :my_house_population, :integer
-  attribute :atoms_in_universe, :integer
-end
 
 class CalculationsTest < ActiveRecord::TestCase
   fixtures :companies, :accounts, :topics, :speedometers, :minivans, :books

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -4,10 +4,7 @@ require "models/pirate"   # For timestamps
 require "models/parrot"
 require "models/person"   # For optimistic locking
 require "models/aircraft"
-
-class NumericData < ActiveRecord::Base
-  self.table_name = "numeric_data"
-end
+require "models/numeric_data"
 
 class DirtyTest < ActiveRecord::TestCase
   include InTimeZone

--- a/activerecord/test/cases/numeric_data_test.rb
+++ b/activerecord/test/cases/numeric_data_test.rb
@@ -1,0 +1,71 @@
+require "cases/helper"
+require "models/numeric_data"
+
+class NumericDataTest < ActiveRecord::TestCase
+  def test_big_decimal_conditions
+    m = NumericData.new(
+      bank_balance: 1586.43,
+      big_bank_balance: BigDecimal("1000234000567.95"),
+      world_population: 6000000000,
+      my_house_population: 3
+    )
+    assert m.save
+    assert_equal 0, NumericData.where("bank_balance > ?", 2000.0).count
+  end
+
+  def test_numeric_fields
+    m = NumericData.new(
+      bank_balance: 1586.43,
+      big_bank_balance: BigDecimal("1000234000567.95"),
+      world_population: 6000000000,
+      my_house_population: 3
+    )
+    assert m.save
+
+    m1 = NumericData.find(m.id)
+    assert_not_nil m1
+
+    # As with migration_test.rb, we should make world_population >= 2**62
+    # to cover 64-bit platforms and test it is a Bignum, but the main thing
+    # is that it's an Integer.
+    assert_kind_of Integer, m1.world_population
+    assert_equal 6000000000, m1.world_population
+
+    assert_kind_of Integer, m1.my_house_population
+    assert_equal 3, m1.my_house_population
+
+    assert_kind_of BigDecimal, m1.bank_balance
+    assert_equal BigDecimal("1586.43"), m1.bank_balance
+
+    assert_kind_of BigDecimal, m1.big_bank_balance
+    assert_equal BigDecimal("1000234000567.95"), m1.big_bank_balance
+  end
+
+  def test_numeric_fields_with_scale
+    m = NumericData.new(
+      bank_balance: 1586.43122334,
+      big_bank_balance: BigDecimal("234000567.952344"),
+      world_population: 6000000000,
+      my_house_population: 3
+    )
+    assert m.save
+
+    m1 = NumericData.find(m.id)
+    assert_not_nil m1
+
+    # As with migration_test.rb, we should make world_population >= 2**62
+    # to cover 64-bit platforms and test it is a Bignum, but the main thing
+    # is that it's an Integer.
+    assert_kind_of Integer, m1.world_population
+    assert_equal 6000000000, m1.world_population
+
+    assert_kind_of Integer, m1.my_house_population
+    assert_equal 3, m1.my_house_population
+
+    assert_kind_of BigDecimal, m1.bank_balance
+    assert_equal BigDecimal("1586.43"), m1.bank_balance
+
+    assert_kind_of BigDecimal, m1.big_bank_balance
+    assert_equal BigDecimal("234000567.95"), m1.big_bank_balance
+  end
+end

--- a/activerecord/test/models/numeric_data.rb
+++ b/activerecord/test/models/numeric_data.rb
@@ -1,0 +1,3 @@
+class NumericData < ActiveRecord::Base
+  self.table_name = "numeric_data"
+end

--- a/activerecord/test/models/numeric_data.rb
+++ b/activerecord/test/models/numeric_data.rb
@@ -1,3 +1,8 @@
 class NumericData < ActiveRecord::Base
   self.table_name = "numeric_data"
+  # Decimal columns with 0 scale being automatically treated as integers
+  # is deprecated, and will be removed in a future version of Rails.
+  attribute :world_population, :big_integer
+  attribute :my_house_population, :big_integer
+  attribute :atoms_in_universe, :big_integer
 end


### PR DESCRIPTION
Currently `NumericData` model is defined some places.
