### PR TITLE
use `active_support/testing/autorun` in `bin/test` script

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/bin/test.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/test.tt
@@ -5,4 +5,6 @@ require 'rails/test_unit/minitest_plugin'
 
 Rails::TestUnitReporter.executable = 'bin/test'
 
-exit Minitest.run(ARGV)
+Minitest.run_via[:rails] = true
+
+require "active_support/testing/autorun"

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -86,6 +86,12 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
     assert_match(%r{cannot load such file.+test/not_exists\.rb}, error)
   end
 
+  def test_executed_only_once
+    create_test_file "foo"
+    result =  run_test_command("test/foo_test.rb")
+    assert_equal 1, result.scan(/1 runs, 1 assertions, 0 failures/).length
+  end
+
   private
     def plugin_path
       "#{@destination_root}/bukkits"


### PR DESCRIPTION
29f0fbd5db643b885665e4a14c7de3bf6c0d9c96 has changed that always call
`Minitest.autorun` in `active_support/testing/autorun`.

Therefore, when used directly `Minitest.run`, tests are performed twice.
