### PR TITLE
Do not leak the Errors default proc when calling to_hash or as_json

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -280,7 +280,7 @@ module ActiveModel
           messages[attribute] = array.map { |message| full_message(attribute, message) }
         end
       else
-        messages.dup
+        without_default_proc(messages)
       end
     end
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -250,6 +250,16 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal({ name: ["cannot be blank"] }, person.errors.to_hash)
   end
 
+  test "to_hash returns a hash without default proc" do
+    person = Person.new
+    assert_nil person.errors.to_hash.default_proc
+  end
+
+  test "as_json returns a hash without default proc" do
+    person = Person.new
+    assert_nil person.errors.as_json.default_proc
+  end
+
   test "full_messages creates a list of error messages with the attribute name included" do
     person = Person.new
     person.errors.add(:name, "cannot be blank")


### PR DESCRIPTION
Since https://github.com/rails/rails/commit/b3dfd7d16cc37dcaf4298fe42e69a56ab3c6b00e the Hash returned by `ActiveModel::Errors#as_json` or `ActiveModel::Errors#to_hash` is coming with the original hash default proc.

It's a regression from 4.2, and I don't see how it could be useful / expected.

@sgrif @rafaelfranca for review please.
