### PR TITLE
4-2-backport: activerecord/mysql2: Avoid setting @connection to nil, just close it

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Using a mysql2 connection after it fails to reconnect will now have an error message
+    saying the connection is closed rather than an undefined method error message.
+
+    *Dylan Thacker-Smith*
+
 *   Bust Model.attribute_names cache when resetting column information
     
     *James Coleman*

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -87,7 +87,6 @@ module ActiveRecord
       #++
 
       def active?
-        return false unless @connection
         @connection.ping
       end
 
@@ -102,10 +101,7 @@ module ActiveRecord
       # Otherwise, this method does nothing.
       def disconnect!
         super
-        unless @connection.nil?
-          @connection.close
-          @connection = nil
-        end
+        @connection.close
       end
 
       #--
@@ -222,11 +218,9 @@ module ActiveRecord
 
       # Executes the SQL statement in the context of this connection.
       def execute(sql, name = nil)
-        if @connection
-          # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been
-          # made since we established the connection
-          @connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
-        end
+        # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been
+        # made since we established the connection
+        @connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
 
         super
       end

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -65,6 +65,26 @@ class MysqlConnectionTest < ActiveRecord::TestCase
     assert @connection.active?
   end
 
+  def test_execute_after_disconnect
+    @connection.disconnect!
+    error = assert_raise(ActiveRecord::StatementInvalid) do
+      @connection.execute("SELECT 1")
+    end
+    assert_equal Mysql2::Error, error.original_exception.class
+  end
+
+  def test_quote_after_disconnect
+    @connection.disconnect!
+    assert_raise(Mysql2::Error) do
+      @connection.quote("string")
+    end
+  end
+
+  def test_active_after_disconnect
+    @connection.disconnect!
+    assert_equal false, @connection.active?
+  end
+
   def test_mysql_connection_collation_is_configured
     assert_equal 'utf8_unicode_ci', @connection.show_variable('collation_connection')
     assert_equal 'utf8_general_ci', ARUnit2Model.connection.show_variable('collation_connection')


### PR DESCRIPTION
@rafaelfranca, @arthurnn please review
cc @Sirupsen

Backport #26434 for the 4-2-stable branch
