### PR TITLE
Convert Date/Time#advance and #change to keyword args

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,8 @@
-*   Update `#advance` methods to take keyword args
+*   Convert `Date/Time#change` methods to take keyword args
+
+    *Ben Woosley*
+
+*   Convert `Date/Time#advance` methods to take keyword args
 
     *Ben Woosley*
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Update `#advance` methods to take keyword args
+
+    *Ben Woosley*
+
 *   Fix `ActiveSupport::TimeWithZone#in` across DST boundaries.
 
     Previously calls to `in` were being sent to the non-DST aware
@@ -8,10 +12,10 @@
         Time.zone = "US/Eastern"
 
         t = Time.zone.local(2016,11,6,1)
-        # => Sun, 06 Nov 2016 01:00:00 EDT -05:00 
+        # => Sun, 06 Nov 2016 01:00:00 EDT -05:00
 
         t.in(1.hour)
-        # => Sun, 06 Nov 2016 01:00:00 EST -05:00 
+        # => Sun, 06 Nov 2016 01:00:00 EST -05:00
 
     Fixes #26580.
 

--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -105,15 +105,13 @@ class Date
   alias_method :minus_without_duration, :-
   alias_method :-, :minus_with_duration
 
-  # Provides precise Date calculations for years, months, and days. The +options+ parameter takes a hash with
-  # any of these keys: <tt>:years</tt>, <tt>:months</tt>, <tt>:weeks</tt>, <tt>:days</tt>.
-  def advance(options)
-    options = options.dup
+  # Provides precise Date calculations for years, months, and days.
+  def advance(years: nil, months: nil, weeks: nil, days: nil)
     d = self
-    d = d >> options.delete(:years) * 12 if options[:years]
-    d = d >> options.delete(:months)     if options[:months]
-    d = d +  options.delete(:weeks) * 7  if options[:weeks]
-    d = d +  options.delete(:days)       if options[:days]
+    d = d >> years * 12 if years
+    d = d >> months     if months
+    d = d +  weeks * 7  if weeks
+    d = d +  days       if days
     d
   end
 

--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -116,15 +116,14 @@ class Date
   end
 
   # Returns a new Date where one or more of the elements have been changed according to the +options+ parameter.
-  # The +options+ parameter is a hash with a combination of these keys: <tt>:year</tt>, <tt>:month</tt>, <tt>:day</tt>.
   #
   #   Date.new(2007, 5, 12).change(day: 1)               # => Date.new(2007, 5, 1)
   #   Date.new(2007, 5, 12).change(year: 2005, month: 1) # => Date.new(2005, 1, 12)
-  def change(options)
+  def change(year: nil, month: nil, day: nil)
     ::Date.new(
-      options.fetch(:year, year),
-      options.fetch(:month, month),
-      options.fetch(:day, day)
+      year || self.year,
+      month || self.month,
+      day || self.day
     )
   end
 

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -334,7 +334,13 @@ module DateAndTime
       end
 
       def copy_time_to(other)
-        other.change(hour: hour, min: min, sec: sec, usec: try(:usec))
+        if other.is_a?(Time)
+          other.change(hour: hour, min: min, sec: sec, usec: try(:usec))
+        elsif acts_like?(:time)
+          other.change(hour: hour, min: min, sec: sec)
+        else
+          other
+        end
       end
   end
 end

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -36,26 +36,24 @@ class DateTime
   end
 
   # Returns a new DateTime where one or more of the elements have been changed
-  # according to the +options+ parameter. The time options (<tt>:hour</tt>,
+  # according to the parameters. The time options (<tt>:hour</tt>,
   # <tt>:min</tt>, <tt>:sec</tt>) reset cascadingly, so if only the hour is
   # passed, then minute and sec is set to 0. If the hour and minute is passed,
-  # then sec is set to 0. The +options+ parameter takes a hash with any of these
-  # keys: <tt>:year</tt>, <tt>:month</tt>, <tt>:day</tt>, <tt>:hour</tt>,
-  # <tt>:min</tt>, <tt>:sec</tt>, <tt>:offset</tt>, <tt>:start</tt>.
+  # then sec is set to 0.
   #
   #   DateTime.new(2012, 8, 29, 22, 35, 0).change(day: 1)              # => DateTime.new(2012, 8, 1, 22, 35, 0)
   #   DateTime.new(2012, 8, 29, 22, 35, 0).change(year: 1981, day: 1)  # => DateTime.new(1981, 8, 1, 22, 35, 0)
   #   DateTime.new(2012, 8, 29, 22, 35, 0).change(year: 1981, hour: 0) # => DateTime.new(1981, 8, 29, 0, 0, 0)
-  def change(options)
+  def change(year: nil, month: nil, day: nil, hour: nil, min: nil, sec: nil, offset: nil, start: nil)
     ::DateTime.civil(
-      options.fetch(:year, year),
-      options.fetch(:month, month),
-      options.fetch(:day, day),
-      options.fetch(:hour, hour),
-      options.fetch(:min, options[:hour] ? 0 : min),
-      options.fetch(:sec, (options[:hour] || options[:min]) ? 0 : sec + sec_fraction),
-      options.fetch(:offset, offset),
-      options.fetch(:start, start)
+      year || self.year,
+      month || self.month,
+      day || self.day,
+      hour || self.hour,
+      min || (hour ? 0 : self.min),
+      sec || ((hour || min) ? 0 : self.sec + sec_fraction),
+      offset || self.offset,
+      start || self.start
     )
   end
 

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -60,26 +60,23 @@ class DateTime
   end
 
   # Uses Date to provide precise Time calculations for years, months, and days.
-  # The +options+ parameter takes a hash with any of these keys: <tt>:years</tt>,
-  # <tt>:months</tt>, <tt>:weeks</tt>, <tt>:days</tt>, <tt>:hours</tt>,
-  # <tt>:minutes</tt>, <tt>:seconds</tt>.
-  def advance(options)
-    unless options[:weeks].nil?
-      options[:weeks], partial_weeks = options[:weeks].divmod(1)
-      options[:days] = options.fetch(:days, 0) + 7 * partial_weeks
+  def advance(years: nil, months: nil, weeks: nil, days: nil, hours: nil, minutes: nil, seconds: nil)
+    unless weeks.nil?
+      weeks, partial_weeks = weeks.divmod(1)
+      days = (days || 0) + 7 * partial_weeks
     end
 
-    unless options[:days].nil?
-      options[:days], partial_days = options[:days].divmod(1)
-      options[:hours] = options.fetch(:hours, 0) + 24 * partial_days
+    unless days.nil?
+      days, partial_days = days.divmod(1)
+      hours = (hours || 0) + 24 * partial_days
     end
 
-    d = to_date.advance(options)
+    d = to_date.advance(years: years, months: months, weeks: weeks, days: days)
     datetime_advanced_by_date = change(year: d.year, month: d.month, day: d.day)
     seconds_to_advance = \
-      options.fetch(:seconds, 0) +
-      options.fetch(:minutes, 0) * 60 +
-      options.fetch(:hours, 0) * 3600
+      (seconds || 0) +
+      (minutes || 0) * 60 +
+      (hours || 0) * 3600
 
     if seconds_to_advance.zero?
       datetime_advanced_by_date

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -84,28 +84,27 @@ class Time
   # to the +options+ parameter. The time options (<tt>:hour</tt>, <tt>:min</tt>,
   # <tt>:sec</tt>, <tt>:usec</tt>, <tt>:nsec</tt>) reset cascadingly, so if only
   # the hour is passed, then minute, sec, usec and nsec is set to 0. If the hour
-  # and minute is passed, then sec, usec and nsec is set to 0. The +options+
-  # parameter takes a hash with any of these keys: <tt>:year</tt>, <tt>:month</tt>,
-  # <tt>:day</tt>, <tt>:hour</tt>, <tt>:min</tt>, <tt>:sec</tt>, <tt>:usec</tt>
-  # <tt>:nsec</tt>. Pass either <tt>:usec</tt> or <tt>:nsec</tt>, not both.
+  # and minute is passed, then sec, usec and nsec is set to 0.
+  # Pass either <tt>:usec</tt> or <tt>:nsec</tt>, not both.
   #
   #   Time.new(2012, 8, 29, 22, 35, 0).change(day: 1)              # => Time.new(2012, 8, 1, 22, 35, 0)
   #   Time.new(2012, 8, 29, 22, 35, 0).change(year: 1981, day: 1)  # => Time.new(1981, 8, 1, 22, 35, 0)
   #   Time.new(2012, 8, 29, 22, 35, 0).change(year: 1981, hour: 0) # => Time.new(1981, 8, 29, 0, 0, 0)
-  def change(options)
-    new_year  = options.fetch(:year, year)
-    new_month = options.fetch(:month, month)
-    new_day   = options.fetch(:day, day)
-    new_hour  = options.fetch(:hour, hour)
-    new_min   = options.fetch(:min, options[:hour] ? 0 : min)
-    new_sec   = options.fetch(:sec, (options[:hour] || options[:min]) ? 0 : sec)
+  def change(year: nil, month: nil, day: nil, hour: nil, min: nil, sec: nil, nsec: nil, usec: nil)
+    new_year  = year || self.year
+    new_month = month || self.month
+    new_day   = day || self.day
+    new_hour  = hour || self.hour
+    new_min   = min || (hour ? 0 : self.min)
+    new_sec   = sec || ((hour || min) ? 0 : self.sec)
 
-    if new_nsec = options[:nsec]
-      raise ArgumentError, "Can't change both :nsec and :usec at the same time: #{options.inspect}" if options[:usec]
-      new_usec = Rational(new_nsec, 1000)
-    else
-      new_usec  = options.fetch(:usec, (options[:hour] || options[:min] || options[:sec]) ? 0 : Rational(nsec, 1000))
-    end
+    new_usec =
+      if nsec
+        raise ArgumentError, "Can't change both :nsec and :usec at the same time" if usec
+        Rational(nsec, 1000)
+      else
+        usec || ((hour || min || sec) ? 0 : Rational(self.nsec, 1000))
+      end
 
     if utc?
       ::Time.utc(new_year, new_month, new_day, new_hour, new_min, new_sec, new_usec)

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -118,34 +118,31 @@ class Time
   end
 
   # Uses Date to provide precise Time calculations for years, months, and days
-  # according to the proleptic Gregorian calendar. The +options+ parameter
-  # takes a hash with any of these keys: <tt>:years</tt>, <tt>:months</tt>,
-  # <tt>:weeks</tt>, <tt>:days</tt>, <tt>:hours</tt>, <tt>:minutes</tt>,
-  # <tt>:seconds</tt>.
+  # according to the proleptic Gregorian calendar.
   #
   #   Time.new(2015, 8, 1, 14, 35, 0).advance(seconds: 1) # => 2015-08-01 14:35:01 -0700
   #   Time.new(2015, 8, 1, 14, 35, 0).advance(minutes: 1) # => 2015-08-01 14:36:00 -0700
   #   Time.new(2015, 8, 1, 14, 35, 0).advance(hours: 1)   # => 2015-08-01 15:35:00 -0700
   #   Time.new(2015, 8, 1, 14, 35, 0).advance(days: 1)    # => 2015-08-02 14:35:00 -0700
   #   Time.new(2015, 8, 1, 14, 35, 0).advance(weeks: 1)   # => 2015-08-08 14:35:00 -0700
-  def advance(options)
-    unless options[:weeks].nil?
-      options[:weeks], partial_weeks = options[:weeks].divmod(1)
-      options[:days] = options.fetch(:days, 0) + 7 * partial_weeks
+  def advance(years: nil, months: nil, weeks: nil, days: nil, hours: nil, minutes: nil, seconds: nil)
+    unless weeks.nil?
+      weeks, partial_weeks = weeks.divmod(1)
+      days = (days || 0) + 7 * partial_weeks
     end
 
-    unless options[:days].nil?
-      options[:days], partial_days = options[:days].divmod(1)
-      options[:hours] = options.fetch(:hours, 0) + 24 * partial_days
+    unless days.nil?
+      days, partial_days = days.divmod(1)
+      hours = (hours || 0) + 24 * partial_days
     end
 
-    d = to_date.advance(options)
+    d = to_date.advance(years: years, months: months, weeks: weeks, days: days)
     d = d.gregorian if d.julian?
     time_advanced_by_date = change(year: d.year, month: d.month, day: d.day)
     seconds_to_advance = \
-      options.fetch(:seconds, 0) +
-      options.fetch(:minutes, 0) * 60 +
-      options.fetch(:hours, 0) * 3600
+      (seconds || 0) +
+      (minutes || 0) * 60 +
+      (hours || 0) * 3600
 
     if seconds_to_advance.zero?
       time_advanced_by_date

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -333,10 +333,6 @@ module ActiveSupport
     # according to the proleptic Gregorian calendar. The result is returned as a
     # new TimeWithZone object.
     #
-    # The +options+ parameter takes a hash with any of these keys:
-    # <tt>:years</tt>, <tt>:months</tt>, <tt>:weeks</tt>, <tt>:days</tt>,
-    # <tt>:hours</tt>, <tt>:minutes</tt>, <tt>:seconds</tt>.
-    #
     # If advancing by a value of variable length (i.e., years, weeks, months,
     # days), move forward from #time, otherwise move forward from #utc, for
     # accuracy when moving across DST boundaries.
@@ -350,13 +346,13 @@ module ActiveSupport
     #   now.advance(weeks: 1)   # => Sun, 09 Nov 2014 01:26:28 EST -05:00
     #   now.advance(months: 1)  # => Tue, 02 Dec 2014 01:26:28 EST -05:00
     #   now.advance(years: 1)   # => Mon, 02 Nov 2015 01:26:28 EST -05:00
-    def advance(options)
+    def advance(years: nil, months: nil, weeks: nil, days: nil, hours: nil, minutes: nil, seconds: nil)
       # If we're advancing a value of variable length (i.e., years, weeks, months, days), advance from #time,
       # otherwise advance from #utc, for accuracy when moving across DST boundaries
-      if options.values_at(:years, :weeks, :months, :days).any?
-        method_missing(:advance, options)
+      if (years || weeks || months || days)
+        method_missing(:advance, years: years, months: months, weeks: weeks, days: days, hours: hours, minutes: minutes, seconds: seconds)
       else
-        utc.advance(options).in_time_zone(time_zone)
+        utc.advance(hours: hours, minutes: minutes, seconds: seconds).in_time_zone(time_zone)
       end
     end
 


### PR DESCRIPTION
This results in a more limited interface and protects against certain
possible errors (e.g. passing arguments via string keys,
mis-spelling keys).

I was personally bit by this in passing a string-keyed options hash to the advance method.
