### PR TITLE
[ci skip] Removes broken performance testing link from the 2.2 release notes

### DIFF
--- a/guides/source/2_2_release_notes.md
+++ b/guides/source/2_2_release_notes.md
@@ -45,7 +45,6 @@ The internal documentation of Rails, in the form of code comments, has been impr
 * [A Guide to Testing Rails Applications](testing.html)
 * [Securing Rails Applications](security.html)
 * [Debugging Rails Applications](debugging_rails_applications.html)
-* [Performance Testing Rails Applications](performance_testing.html)
 * [The Basics of Creating Rails Plugins](plugins.html)
 
 All told, the Guides provide tens of thousands of words of guidance for beginning and intermediate Rails developers.


### PR DESCRIPTION
### Summary

There is currently a broken link to a page about performance testing in the rails 2.2 release notes. It would appear that this file was removed in a previous release of the guides and as such the page that it used to lead to does not exist.
### Other Information

As an immediate solution I have just removed the link from the page but I'd wonder what the actual best way to handle this is and whether instead we should instead do the following:

The old version of the performance testing guide is still available at [http://guides.rubyonrails.org/v2.3.11/performance_testing.html](http://guides.rubyonrails.org/v2.3.11/performance_testing.html), should the link lead there instead of edgeguides.rubyonrails.org? 

If so should all the links to guides in the 2.2 release notes lead to 2.3.11 versions of their guides instead of the current ones available on edgeguides.rubyonrails.org (which are relevant for rails 5, unlikely to be what someone looking at very old release notes is after)?
### Edit

Following feedback from @prathamesh-sonpatki I have completely removed the line from the file and modified the commit.
