### PR TITLE
Fixing remove index bug

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fixing bug at index removal
+   
+    When an index was created with condition like `lower(name)` 
+    it is returned as string from the database, and is not returned 
+    as an expected array.
+     
+    Fix #26635 
+     
+    *Hebert Coelho* 
+
 *   Serialize JSON attribute value `nil` as SQL `NULL`, not JSON `null`
 
     *Trung Duc Tran*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1215,7 +1215,7 @@ module ActiveRecord
           if column_names.any?
             checks << lambda do |i|
               columns = i.columns.is_a?(String) ? [i.columns] : i.columns
-              columns.join('_and_') == column_names.join('_and_')
+              columns.join("_and_") == column_names.join("_and_")
             end
           end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1213,7 +1213,10 @@ module ActiveRecord
           end
 
           if column_names.any?
-            checks << lambda { |i| i.columns.join("_and_") == column_names.join("_and_") }
+            checks << lambda do |i|
+              columns = i.columns.is_a?(String) ? [i.columns] : i.columns
+              columns.join('_and_') == column_names.join('_and_')
+            end
           end
 
           raise ArgumentError, "No name or columns specified" if checks.none?

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -126,6 +126,19 @@ module ActiveRecord
         assert connection.index_exists?(:testings, :foo, unique: true)
       end
 
+      if current_adapter?(:PostgreSQLAdapter)
+        # when an index is created with a function, indexes are not located by column name
+        # the index name recovered from the database in this case could be lower(bar)
+        def test_delete_index_when_column_has_no_formal_name
+          connection.execute('CREATE UNIQUE INDEX index_users_on_lower_email ON testings (lower(bar))')
+          connection.add_index :testings, :foo, unique: true
+
+          connection.remove_index :testings, :foo
+
+          assert_not connection.index_exists?(:testings, :foo)
+        end
+      end
+
       def test_named_index_exists
         connection.add_index :testings, :foo, name: "custom_index_name"
 

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -130,7 +130,7 @@ module ActiveRecord
         # when an index is created with a function, indexes are not located by column name
         # the index name recovered from the database in this case could be lower(bar)
         def test_delete_index_when_column_has_no_formal_name
-          connection.execute('CREATE UNIQUE INDEX index_users_on_lower_email ON testings (lower(bar))')
+          connection.execute("CREATE UNIQUE INDEX index_users_on_lower_email ON testings (lower(bar))")
           connection.add_index :testings, :foo, unique: true
 
           connection.remove_index :testings, :foo


### PR DESCRIPTION
### Summary

There was a bug that for index that was using special functions in its condition:

```
CREATE UNIQUE INDEX index_users_on_lower_email ON testings (lower(bar))
```

The solution what to update the 'check' that was made to support string.

Based on Issue: https://github.com/rails/rails/issues/26635
