### PR TITLE
remove `mongrel` once again

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -21,7 +21,7 @@ module Rails
 
       def option_parser(options) # :nodoc:
         OptionParser.new do |opts|
-          opts.banner = "Usage: rails server [mongrel, thin etc] [options]"
+          opts.banner = "Usage: rails server [puma, thin etc] [options]"
 
           opts.separator ""
           opts.separator "Options:"


### PR DESCRIPTION
`mongrel` was removed in #26408. But have back accidentally in #26414.
