### PR TITLE
Fix typo in 5_0_release_notes.md doc [ci skip]

### DIFF
--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -583,7 +583,7 @@ Please refer to the [Changelog][active-record] for detailed changes.
 
 *   Removed support for the legacy `mysql` database adapter from core. Most users should
     be able to use `mysql2`. It will be converted to a separate gem when when we find someone
-    to maintain it. ([Pull Request 1](https://github.com/rails/rails/pull/22642)],
+    to maintain it. ([Pull Request 1](https://github.com/rails/rails/pull/22642),
     [Pull Request 2](https://github.com/rails/rails/pull/22715))
 
 *   Removed support for the `protected_attributes` gem.


### PR DESCRIPTION
<img width="636" alt="2016-09-29 22 00 39" src="https://cloud.githubusercontent.com/assets/4487291/18954970/49fe5e78-8690-11e6-870b-837781609ed3.png">
