### PR TITLE
ActionCable: also pass data hash when argument is optional

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -253,10 +253,10 @@ module ActionCable
         def dispatch_action(action, data)
           logger.info action_signature(action, data)
 
-          if method(action).arity == 1
-            public_send action, data
-          else
+          if method(action).arity.zero?
             public_send action
+          else
+            public_send action, data
           end
         end
 


### PR DESCRIPTION
### Summary

Fix data hash not being passed if the method definition has a default value for the data argument (arity -1 instead of 1). I don't know if this was intended but this issue confused me and is in my opinion non-intuitive behaviour.
### Other Information

```
class RconConsoleChannel < ApplicationCable::Channel
  # default value
  def test data = {}
    puts data.inspect
    # => {}
  end

  # no default value
  def test data
    puts data.inspect
    # => {"arg"=>"foo", "action"=>"test"}
  end
end
```
