### PR TITLE
show correct usage in console / dbconsole / runner / version command

### DIFF
--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -130,6 +130,10 @@ module Rails
             end
           end
       end
+
+      def help
+        self.class.command_help(shell, self.class.command_name)
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

`Thor` recognizes the public method as a command. Therefore, if use the help
method that `Thor` is provided, it show command number of public methods.
If dealing with one of class as one of command, I think it is strange as usage.
In this case I think it is good to use `command_help`.

Before:

```
$ ./bin/rails c --help
Commands:
  bin/rails console [environment] [options]  # Describe available commands or one specific command
  bin/rails console [environment] [options]  #

Options:
  -s, [--sandbox], [--no-sandbox]  # Rollback database modifications on exit.
  -e, [--environment=ENVIRONMENT]  # Specifies the environment to run this console under (test/development/production).

```

After:

```
./bin/rails c --help
Usage:
  bin/rails console [environment] [options]

Options:
  -s, [--sandbox], [--no-sandbox]  # Rollback database modifications on exit.
  -e, [--environment=ENVIRONMENT]  # Specifies the environment to run this console under (test/development/production).

```

r? @kaspth 
