### PR TITLE
Remove dup distinct from AR query list doc [ci skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -81,7 +81,6 @@ The methods are:
 * `reorder`
 * `reverse_order`
 * `select`
-* `distinct`
 * `where`
 
 Finder methods that return a collection, such as `where` and `group`, return an instance of `ActiveRecord::Relation`.  Methods that find a single entity, such as `find` and `first`, return a single instance of the model.


### PR DESCRIPTION
The distinct method is mentioned twice in the active_record_querying.md file. I've removed the latter entry, which appears out of sort order from the other methods.
