### PR TITLE
Fix `ActiveSupport::TimeWithZone#localtime`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Fix `ActiveSupport::TimeWithZone#localtime` when called with different
+    `utc_offset` values.
+
+    Previously memoization in `localtime` wasn't taking the `utc_offset`
+    parameter into account when returning a cached value. It now caches the
+    computed value depending on the `utc_offset` parameter, e.g:
+
+      Time.zone = "US/Eastern"
+
+      t = Time.zone.local(2016,5,2,11)
+      # => Mon, 02 May 2016 11:00:00 EDT -04:00
+
+      t.localtime(-7200)
+      # => 2016-05-02 13:00:00 -0200
+
+      t.localtime(-3600)
+      # => 2016-05-02 14:00:00 -0100
+
+    Fixes #26644.
+
+    *Thomas Balthazar*
+
 *   Fix `ActiveSupport::TimeWithZone#in` across DST boundaries.
 
     Previously calls to `in` were being sent to the non-DST aware

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -80,7 +80,8 @@ module ActiveSupport
 
     # Returns a <tt>Time</tt> instance of the simultaneous time in the system timezone.
     def localtime(utc_offset = nil)
-      @localtime ||= utc.getlocal(utc_offset)
+      @localtime ||= {}
+      @localtime[utc_offset] ||= utc.getlocal(utc_offset)
     end
     alias_method :getlocal, :localtime
 

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -54,6 +54,12 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_instance_of Time, @dt_twz.localtime
   end
 
+  def test_localtime_with_offset
+    assert_equal 0, @twz.localtime.gmt_offset
+    assert_equal (-3600), @twz.localtime(-3600).gmt_offset
+    assert_equal (-7200), @twz.localtime(-7200).gmt_offset
+  end
+
   def test_utc?
     assert_equal false, @twz.utc?
 


### PR DESCRIPTION
### Summary

Fix `ActiveSupport::TimeWithZone#localtime` when called with different `utc_offset` values.

Previously memoization in `localtime` wasn't taking the `utc_offset` parameter into account when returning a cached value. It now caches the computed value depending on the `utc_offset` parameter, e.g:

``` ruby
Time.zone = "US/Eastern"

t = Time.zone.local(2016,5,2,11)
# => Mon, 02 May 2016 11:00:00 EDT -04:00

t.localtime(-7200)
# => 2016-05-02 13:00:00 -0200

t.localtime(-3600)
# => 2016-05-02 14:00:00 -0100
```

Fixes #26644.
