### PR TITLE
Add missing require for zlib in ActiveRecord::Migrator

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1,4 +1,5 @@
 require "set"
+require "zlib"
 require "active_support/core_ext/module/attribute_accessors"
 require "active_support/core_ext/regexp"
 


### PR DESCRIPTION
Zlib is used to generate the advisory lock since commit 2c2a8755460 .

Using the Migrator fails since then, when it is called without the rails context:

```
NameError: uninitialized constant ActiveRecord::Migrator::Zlib
```

This patch fixes the above error.
