### PR TITLE
Fix disable_text_with to refer to value option

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -894,7 +894,7 @@ module ActionView
           unless tag_options["data-disable-with"] == false || (data && data["disable_with"] == false)
             disable_with_text = tag_options["data-disable-with"]
             disable_with_text ||= data["disable_with"] if data
-            disable_with_text ||= value.to_s.clone
+            disable_with_text ||= tag_options["value"].to_s.clone
             tag_options.deep_merge!("data" => { "disable_with" => disable_with_text })
           else
             data.delete("disable_with") if data

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -517,6 +517,13 @@ class FormTagHelperTest < ActionView::TestCase
     )
   end
 
+  def test_submit_tag_with_value_option
+    assert_dom_equal(
+      %(<input type="submit" name="commit" value="Like" data-disable-with="Like" />),
+      submit_tag("Save", "value" => "Like")
+    )
+  end
+
   def test_submit_tag_with_symbol_value
     assert_dom_equal(
       %(<input data-disable-with="Save" name='commit' type="submit" value="Save" />),


### PR DESCRIPTION
### Summary

`submit_tag` is to override the value that is specified in the option, disable_with_text are not.

``` erb
<%= form_for User.new do |f| %>
  <!-- <input type="submit" name="commit" value="Like!" data-disable-with="Like!"> -->
  <%= f.submit 'Like!' %>

  <!-- <input type="submit" name="commit" value="Like!" data-disable-with="Create User"> -->
  <!-- I expect that `data-disable-with` will also be "Like!" -->
  <%= f.submit nil, { value: 'Like!' } %>
<% end %>
```
