### PR TITLE
Avoid bumping the class serial when invoking executor

### DIFF
--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -6,6 +6,12 @@ module ActionView
   class Digestor
     @@digest_mutex = Mutex.new
 
+    module PerExecutionDigestCacheExpiry
+      def self.before(target)
+        ActionView::LookupContext::DetailsKey.clear
+      end
+    end
+
     class << self
       # Supported options:
       #

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -40,7 +40,7 @@ module ActionView
     initializer "action_view.per_request_digest_cache" do |app|
       ActiveSupport.on_load(:action_view) do
         if app.config.consider_all_requests_local
-          app.executor.to_run { ActionView::LookupContext::DetailsKey.clear }
+          app.executor.to_run ActionView::Digestor::PerExecutionDigestCacheExpiry
         end
       end
     end

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -34,16 +34,14 @@ module ActiveRecord
     def self.complete(enabled)
       ActiveRecord::Base.connection.clear_query_cache
       ActiveRecord::Base.connection.disable_query_cache! unless enabled
+
+      unless ActiveRecord::Base.connected? && ActiveRecord::Base.connection.transaction_open?
+        ActiveRecord::Base.clear_active_connections!
+      end
     end
 
     def self.install_executor_hooks(executor = ActiveSupport::Executor)
       executor.register_hook(self)
-
-      executor.to_complete do
-        unless ActiveRecord::Base.connected? && ActiveRecord::Base.connection.transaction_open?
-          ActiveRecord::Base.clear_active_connections!
-        end
-      end
     end
   end
 end

--- a/activesupport/test/executor_test.rb
+++ b/activesupport/test/executor_test.rb
@@ -158,6 +158,61 @@ class ExecutorTest < ActiveSupport::TestCase
     assert_equal :some_state, supplied_state
   end
 
+  def test_hook_insertion_order
+    invoked = []
+    supplied_state = []
+
+    hook_class = Class.new do
+      attr_accessor :letter
+
+      define_method(:initialize) do |letter|
+        self.letter = letter
+      end
+
+      define_method(:run) do
+        invoked << :"run_#{letter}"
+        :"state_#{letter}"
+      end
+
+      define_method(:complete) do |state|
+        invoked << :"complete_#{letter}"
+        supplied_state << state
+      end
+    end
+
+    executor.register_hook(hook_class.new(:a))
+    executor.register_hook(hook_class.new(:b))
+    executor.register_hook(hook_class.new(:c), outer: true)
+    executor.register_hook(hook_class.new(:d))
+
+    executor.wrap {}
+
+    assert_equal [:run_c, :run_a, :run_b, :run_d, :complete_a, :complete_b, :complete_d, :complete_c], invoked
+    assert_equal [:state_a, :state_b, :state_d, :state_c], supplied_state
+  end
+
+  def test_class_serial_is_unaffected
+    hook = Class.new do
+      define_method(:run) do
+        nil
+      end
+
+      define_method(:complete) do |state|
+        nil
+      end
+    end.new
+
+    executor.register_hook(hook)
+
+    before = RubyVM.stat(:class_serial)
+    executor.wrap {}
+    executor.wrap {}
+    executor.wrap {}
+    after = RubyVM.stat(:class_serial)
+
+    assert_equal before, after
+  end
+
   def test_separate_classes_can_wrap
     other_executor = Class.new(ActiveSupport::Executor)
 


### PR DESCRIPTION
Fixes #25068.

The general conclusion here is that we should avoid using the block form of `set_callback` within the framework. Users can choose the convenience and brevity, but (unless/until @tenderlove can [prevent the serial increment](https://github.com/rspec/rspec-core/issues/2194#issuecomment-200597089) on instance_eval) it has a trade-off we shouldn't be making for them.
