### PR TITLE
Correct caller tracking in delegated deprecation methods

### DIFF
--- a/activesupport/lib/active_support/deprecation/instance_delegator.rb
+++ b/activesupport/lib/active_support/deprecation/instance_delegator.rb
@@ -6,6 +6,7 @@ module ActiveSupport
     module InstanceDelegator # :nodoc:
       def self.included(base)
         base.extend(ClassMethods)
+        base.singleton_class.prepend(OverrideDelegators)
         base.public_class_method :new
       end
 
@@ -17,6 +18,18 @@ module ActiveSupport
 
         def method_added(method_name)
           singleton_class.delegate(method_name, to: :instance)
+        end
+      end
+
+      module OverrideDelegators # :nodoc:
+        def warn(message = nil, callstack = nil)
+          callstack ||= caller_locations(2)
+          super
+        end
+
+        def deprecation_warning(deprecated_method_name, message = nil, caller_backtrace = nil)
+          caller_backtrace ||= caller_locations(2)
+          super
         end
       end
     end


### PR DESCRIPTION
Without this, we're relying on the path-based caller stripping to skip over the extra level of in-framework caller... and that doesn't always work. Fixes #24858; closes #24861.

The filename-based caller filter makes this hard to test at the moment, but it basically changes:

```
irb(main):001:0> def retired_method; ActiveSupport::Deprecation.warn "use better_method instead"; nil; end
=> :retired_method
irb(main):002:0> retired_method
DEPRECATION WARNING: use better_method instead (called from retired_method at (irb):1)
=> nil
irb(main):003:0> retired_method
DEPRECATION WARNING: use better_method instead (called from retired_method at (irb):1)
=> nil
```

(incorrectly blaming `retired_method` as being the _caller_)

into:

```
irb(main):001:0> def retired_method; ActiveSupport::Deprecation.warn "use better_method instead"; nil; end
=> :retired_method
irb(main):002:0> retired_method
DEPRECATION WARNING: use better_method instead (called from irb_binding at (irb):2)
=> nil
irb(main):003:0> retired_method
DEPRECATION WARNING: use better_method instead (called from irb_binding at (irb):3)
=> nil
```
