### PR TITLE
Fix `add_index` to normalize column names and options

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1171,6 +1171,7 @@ module ActiveRecord
           if order = options[:order]
             case order
             when Hash
+              order = order.symbolize_keys
               quoted_columns.each { |name, column| column << " #{order[name].upcase}" if order[name].present? }
             when String
               quoted_columns.each { |name, column| column << " #{order.upcase}" if order.present? }
@@ -1192,7 +1193,7 @@ module ActiveRecord
         def quoted_columns_for_index(column_names, **options)
           return [column_names] if column_names.is_a?(String)
 
-          quoted_columns = Hash[column_names.map { |name| [name, quote_column_name(name).dup] }]
+          quoted_columns = Hash[column_names.map { |name| [name.to_sym, quote_column_name(name).dup] }]
           add_options_for_index_columns(quoted_columns, options).values
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -718,6 +718,7 @@ module ActiveRecord
           if length = options[:length]
             case length
             when Hash
+              length = length.symbolize_keys
               quoted_columns.each { |name, column| column << "(#{length[name]})" if length[name].present? }
             when Integer
               quoted_columns.each { |name, column| column << "(#{length})" }

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -28,12 +28,15 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
 
     expected = "CREATE  INDEX `index_people_on_last_name_and_first_name`  ON `people` (`last_name`(15), `first_name`(15)) "
     assert_equal expected, add_index(:people, [:last_name, :first_name], length: 15)
+    assert_equal expected, add_index(:people, ["last_name", "first_name"], length: 15)
 
     expected = "CREATE  INDEX `index_people_on_last_name_and_first_name`  ON `people` (`last_name`(15), `first_name`) "
     assert_equal expected, add_index(:people, [:last_name, :first_name], length: { last_name: 15 })
+    assert_equal expected, add_index(:people, ["last_name", "first_name"], length: { last_name: 15 })
 
     expected = "CREATE  INDEX `index_people_on_last_name_and_first_name`  ON `people` (`last_name`(15), `first_name`(10)) "
     assert_equal expected, add_index(:people, [:last_name, :first_name], length: { last_name: 15, first_name: 10 })
+    assert_equal expected, add_index(:people, ["last_name", :first_name], length: { last_name: 15, "first_name" => 10 })
 
     %w(SPATIAL FULLTEXT UNIQUE).each do |type|
       expected = "CREATE #{type} INDEX `index_people_on_last_name`  ON `people` (`last_name`) "

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -39,6 +39,10 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
     expected = %(CREATE  INDEX CONCURRENTLY "index_people_on_last_name" ON "people"  ("last_name"))
     assert_equal expected, add_index(:people, :last_name, algorithm: :concurrently)
 
+    expected = %(CREATE  INDEX  "index_people_on_last_name_and_first_name" ON "people"  ("last_name" DESC, "first_name" ASC))
+    assert_equal expected, add_index(:people, [:last_name, :first_name], order: { last_name: :desc, first_name: :asc })
+    assert_equal expected, add_index(:people, ["last_name", :first_name], order: { last_name: :desc, "first_name" => :asc })
+
     %w(gin gist hash btree).each do |type|
       expected = %(CREATE  INDEX  "index_people_on_last_name" ON "people" USING #{type} ("last_name"))
       assert_equal expected, add_index(:people, :last_name, using: type)


### PR DESCRIPTION
Currently does not work the following code.

``` ruby
  add_index(:people, ["last_name", "first_name"], order: { last_name: :desc, first_name: :asc })
```

Normalize column names and options to fix the issue.
