### PR TITLE
Remove unnecessary `respond_to?(:indexes)` checking

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1199,10 +1199,6 @@ module ActiveRecord
         def index_name_for_remove(table_name, options = {})
           return options[:name] if can_remove_index_by_name?(options)
 
-          # if the adapter doesn't support the indexes call the best we can do
-          # is return the default index name for the options provided
-          return index_name(table_name, options) unless respond_to?(:indexes)
-
           checks = []
 
           if options.is_a?(Hash)

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -69,20 +69,15 @@ module ActiveRecord
     def test_indexes
       idx_name = "accounts_idx"
 
-      if @connection.respond_to?(:indexes)
-        indexes = @connection.indexes("accounts")
-        assert indexes.empty?
+      indexes = @connection.indexes("accounts")
+      assert indexes.empty?
 
-        @connection.add_index :accounts, :firm_id, name: idx_name
-        indexes = @connection.indexes("accounts")
-        assert_equal "accounts", indexes.first.table
-        assert_equal idx_name, indexes.first.name
-        assert !indexes.first.unique
-        assert_equal ["firm_id"], indexes.first.columns
-      else
-        warn "#{@connection.class} does not respond to #indexes"
-      end
-
+      @connection.add_index :accounts, :firm_id, name: idx_name
+      indexes = @connection.indexes("accounts")
+      assert_equal "accounts", indexes.first.table
+      assert_equal idx_name, indexes.first.name
+      assert !indexes.first.unique
+      assert_equal ["firm_id"], indexes.first.columns
     ensure
       @connection.remove_index(:accounts, name: idx_name) rescue nil
     end


### PR DESCRIPTION
Currently all adapters (postgresql, mysql2, sqlite3, oracle-enhanced,
and sqlserver) implemented `indexes` and schema dumper expects
implemented `indexes`.

https://github.com/rails/rails/blob/v5.0.0/activerecord/lib/active_record/schema_dumper.rb#L208

Therefore `respond_to?(:indexes)` checking is unnecessary.
