### PR TITLE
Deprecate passing `name` to `indexes` like `tables`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,9 @@
+*   Deprecate passing `name` to `indexes`.
+
+    *Ryuta Kamizono*
+
 *   Compare deserialized values for `PostgreSQL::OID::Hstore` types when
-    calling `ActiveRecord::Dirty#changed_in_place?`
+    calling `ActiveRecord::Dirty#changed_in_place?`.
 
     Fixes #27502.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -69,7 +69,9 @@ module ActiveRecord
       end
 
       # Returns an array of indexes for the given table.
-      # def indexes(table_name, name = nil) end
+      def indexes(table_name, name = nil)
+        raise NotImplementedError, "#indexes is not implemented"
+      end
 
       # Checks to see if an index exists on a table for a given index definition.
       #

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -367,6 +367,12 @@ module ActiveRecord
 
       # Returns an array of indexes for the given table.
       def indexes(table_name, name = nil) #:nodoc:
+        if name
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Passing name to #indexes is deprecated without replacement.
+          MSG
+        end
+
         indexes = []
         current_index = nil
         execute_and_free("SHOW KEYS FROM #{quote_table_name(table_name)}", "SCHEMA") do |result|

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -166,7 +166,13 @@ module ActiveRecord
         end
 
         # Returns an array of indexes for the given table.
-        def indexes(table_name, name = nil)
+        def indexes(table_name, name = nil) # :nodoc:
+          if name
+            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+              Passing name to #indexes is deprecated without replacement.
+            MSG
+          end
+
           table = Utils.extract_schema_qualified_name(table_name.to_s)
 
           result = query(<<-SQL, "SCHEMA")

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -316,6 +316,12 @@ module ActiveRecord
 
       # Returns an array of indexes for the given table.
       def indexes(table_name, name = nil) #:nodoc:
+        if name
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Passing name to #indexes is deprecated without replacement.
+          MSG
+        end
+
         exec_query("PRAGMA index_list(#{quote_table_name(table_name)})", "SCHEMA").map do |row|
           sql = <<-SQL
             SELECT sql

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -95,7 +95,7 @@ module ActiveRecord
     end
 
     def test_indexes_logs_name
-      @connection.indexes("items", "hello")
+      assert_deprecated { @connection.indexes("items", "hello") }
       assert_equal "SCHEMA", @subscriber.logged[0][1]
     end
 

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -287,7 +287,7 @@ module ActiveRecord
       def test_indexes_logs_name
         with_example_table do
           assert_logged [["PRAGMA index_list(\"ex\")", "SCHEMA", []]] do
-            @conn.indexes("ex", "hello")
+            assert_deprecated { @conn.indexes("ex", "hello") }
           end
         end
       end


### PR DESCRIPTION
Passing `name` to `tables` is already deprecated at #21601.
Passing `name` to `indexes` is also unused.
