### PR TITLE
Made ActiveRecord consistently use ActiveRecord::Type (not ActiveModel::Type)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Made ActiveRecord consistently use `ActiveRecord::Type` (not `ActiveModel::Type`)
+
+    *Iain Beeston*
+
 *   Serialize JSON attribute value `nil` as SQL `NULL`, not JSON `null`
 
     *Trung Duc Tran*

--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -19,7 +19,7 @@ module ActiveRecord
             if Numeric === value || value !~ /[^0-9]/
               !value.to_i.zero?
             else
-              return false if ActiveModel::Type::Boolean::FALSE_VALUES.include?(value)
+              return false if ActiveRecord::Type::Boolean::FALSE_VALUES.include?(value)
               !value.blank?
             end
           elsif value.respond_to?(:zero?)

--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -1,4 +1,6 @@
 require "active_model/type"
+require "active_record/type/helpers"
+require "active_record/type/value"
 
 require "active_record/type/internal/abstract_json"
 require "active_record/type/internal/timezone"
@@ -48,7 +50,6 @@ module ActiveRecord
       end
     end
 
-    Helpers = ActiveModel::Type::Helpers
     BigInteger = ActiveModel::Type::BigInteger
     Binary = ActiveModel::Type::Binary
     Boolean = ActiveModel::Type::Boolean
@@ -59,7 +60,6 @@ module ActiveRecord
     String = ActiveModel::Type::String
     Text = ActiveModel::Type::Text
     UnsignedInteger = ActiveModel::Type::UnsignedInteger
-    Value = ActiveModel::Type::Value
 
     register(:big_integer, Type::BigInteger, override: false)
     register(:binary, Type::Binary, override: false)

--- a/activerecord/lib/active_record/type/helpers.rb
+++ b/activerecord/lib/active_record/type/helpers.rb
@@ -1,0 +1,5 @@
+module ActiveRecord
+  module Type
+    Helpers = ActiveModel::Type::Helpers
+  end
+end

--- a/activerecord/lib/active_record/type/internal/abstract_json.rb
+++ b/activerecord/lib/active_record/type/internal/abstract_json.rb
@@ -1,8 +1,8 @@
 module ActiveRecord
   module Type
     module Internal # :nodoc:
-      class AbstractJson < ActiveModel::Type::Value # :nodoc:
-        include ActiveModel::Type::Helpers::Mutable
+      class AbstractJson < Type::Value # :nodoc:
+        include Type::Helpers::Mutable
 
         def type
           :json

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module Type
-    class Serialized < DelegateClass(ActiveModel::Type::Value) # :nodoc:
-      include ActiveModel::Type::Helpers::Mutable
+    class Serialized < DelegateClass(Type::Value) # :nodoc:
+      include Type::Helpers::Mutable
 
       attr_reader :subtype, :coder
 

--- a/activerecord/lib/active_record/type/value.rb
+++ b/activerecord/lib/active_record/type/value.rb
@@ -1,0 +1,5 @@
+module ActiveRecord
+  module Type
+    class Value < ActiveModel::Type::Value; end
+  end
+end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -313,8 +313,8 @@ class SerializedAttributeTest < ActiveRecord::TestCase
       return if value.nil?
       value.gsub(" encoded", "")
     end
-    type = Class.new(ActiveModel::Type::Value) do
-      include ActiveModel::Type::Helpers::Mutable
+    type = Class.new(ActiveRecord::Type::Value) do
+      include ActiveRecord::Type::Helpers::Mutable
 
       def serialize(value)
         return if value.nil?


### PR DESCRIPTION
### Summary

Right now most of the `ActiveModel::Type` types are aliased in the `ActiveRecord::Type` module (eg. `ActiveRecord::Type::String` is just a constant assigned to `ActiveModel::Type::String`), making the two versions exactly equivalent. Throughout ActiveRecord, the two namespaces used interchangeably. However, if a rails app (or rails itself) ever overrode the definition of an `ActiveRecord::Type` class, any code that refers to the `ActiveModel::Type` class would not pick up the change, and this could introduce bugs.

I've updated the code so that throughout ActiveRecord, we always refer to the ActiveRecord version of a type.
