### PR TITLE
Added possibility to check on `:priority` in test helper methods

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Added possibility to check on `:priority` in test helper methods
+    `assert_enqueued_with` and `assert_performed_with`
+
+    *Wojciech Wnętrzak*
+
 *   Removed deprecated support to passing the adapter class to `.queue_adapter`.
 
     *Rafael Mendonça França*

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -40,7 +40,12 @@ module ActiveJob
       private
 
         def job_to_hash(job, extras = {})
-          { job: job.class, args: job.serialize.fetch("arguments"), queue: job.queue_name }.merge!(extras)
+          {
+            job: job.class,
+            args: job.serialize.fetch("arguments"),
+            queue: job.queue_name,
+            priority: job.priority
+          }.merge!(extras)
         end
 
         def enqueue_or_perform(perform, job, job_data)

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -232,9 +232,16 @@ module ActiveJob
     #       MyJob.set(wait_until: Date.tomorrow.noon).perform_later
     #     end
     #   end
-    def assert_enqueued_with(job: nil, args: nil, at: nil, queue: nil)
+    #
+    # Argument options:
+    # * <tt>:job</tt> - Job class name.
+    # * <tt>:args</tt> - Arguments passed to job when enqueueing.
+    # * <tt>:at</tt> - Time when job should perform.
+    # * <tt>:queue</tt> - Queue name.
+    # * <tt>:priority</tt> - Priority value.
+    def assert_enqueued_with(job: nil, args: nil, at: nil, queue: nil, priority: nil)
       original_enqueued_jobs_count = enqueued_jobs.count
-      expected = { job: job, args: args, at: at, queue: queue }.compact
+      expected = { job: job, args: args, at: at, queue: queue, priority: priority }.compact
       serialized_args = serialize_args_for_assertion(expected)
       yield
       in_block_jobs = enqueued_jobs.drop(original_enqueued_jobs_count)
@@ -256,9 +263,16 @@ module ActiveJob
     #       MyJob.set(wait_until: Date.tomorrow.noon).perform_later
     #     end
     #   end
-    def assert_performed_with(job: nil, args: nil, at: nil, queue: nil)
+    #
+    # Argument options:
+    # * <tt>:job</tt> - Job class name.
+    # * <tt>:args</tt> - Arguments passed to job when enqueueing.
+    # * <tt>:at</tt> - Time when job should perform.
+    # * <tt>:queue</tt> - Queue name.
+    # * <tt>:priority</tt> - Priority value.
+    def assert_performed_with(job: nil, args: nil, at: nil, queue: nil, priority: nil)
       original_performed_jobs_count = performed_jobs.count
-      expected = { job: job, args: args, at: at, queue: queue }.compact
+      expected = { job: job, args: args, at: at, queue: queue, priority: priority }.compact
       serialized_args = serialize_args_for_assertion(expected)
       perform_enqueued_jobs { yield }
       in_block_jobs = performed_jobs.drop(original_performed_jobs_count)

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -225,6 +225,18 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_enqueued_job_with_priority_option
+    assert_enqueued_with(job: HelloJob, priority: 10) do
+      HelloJob.set(priority: 10).perform_later
+    end
+
+    assert_raise ActiveSupport::TestCase::Assertion do
+      assert_enqueued_with(job: HelloJob, priority: 10) do
+        HelloJob.set(priority: 5).perform_later
+      end
+    end
+  end
+
   def test_assert_enqueued_job_with_global_id_args
     ricardo = Person.new(9)
     assert_enqueued_with(job: HelloJob, args: [ricardo]) do
@@ -475,6 +487,18 @@ class PerformedJobsTest < ActiveJob::TestCase
     assert_raise ActiveSupport::TestCase::Assertion do
       assert_performed_with(job: HelloJob, at: Date.today.noon) do
         HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
+      end
+    end
+  end
+
+  def test_assert_performed_job_with_priority_option
+    assert_performed_with(job: HelloJob, priority: 10) do
+      HelloJob.set(priority: 10).perform_later
+    end
+
+    assert_raise ActiveSupport::TestCase::Assertion do
+      assert_performed_with(job: HelloJob, priority: 10) do
+        HelloJob.set(priority: 5).perform_later
       end
     end
   end


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/19425

Also documents possible arguments passed to test methods.
