### PR TITLE
Fix attributes names caching

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Bust Model.attribute_names cache when resetting column information
+    
+    *James Coleman*
+
 *   Fix query caching when type information is reset
 
     Backports ancillary fix in 5.0.

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -136,6 +136,7 @@ module ActiveRecord
         @content_columns = nil
         @default_attributes = nil
         @persistable_attribute_names = nil
+        @attribute_names = nil
       end
 
       def raw_default_values

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -102,6 +102,7 @@ module ActiveRecord
       assert_not klass.column_names.include?('wibble')
       assert_equal 5, klass.content_columns.length
       assert_equal 6, klass.column_names.length
+      assert_equal 6, klass.attribute_names.length
 
       klass.attribute :wibble, Type::Value.new
       assert_equal 7, klass.columns.length
@@ -111,6 +112,7 @@ module ActiveRecord
       assert klass.column_names.include?('wibble')
       assert_equal 6, klass.content_columns.length
       assert_equal 7, klass.column_names.length
+      assert_equal 7, klass.attribute_names.length
     end
 
     test "non string/integers use custom types for queries" do

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -101,15 +101,16 @@ module ActiveRecord
       assert_equal 6, klass.column_defaults.length
       assert_not klass.column_names.include?('wibble')
       assert_equal 5, klass.content_columns.length
+      assert_equal 6, klass.column_names.length
 
       klass.attribute :wibble, Type::Value.new
-
       assert_equal 7, klass.columns.length
       assert klass.columns_hash.key?('wibble')
       assert_equal 7, klass.column_types.length
       assert_equal 7, klass.column_defaults.length
       assert klass.column_names.include?('wibble')
       assert_equal 6, klass.content_columns.length
+      assert_equal 7, klass.column_names.length
     end
 
     test "non string/integers use custom types for queries" do


### PR DESCRIPTION
### Summary

`Model.attribute_names` is cached and relies on `Model.columns`, but does not currently have its cache busted when `Model.reset_column_information` is called.
