### PR TITLE
Make [association, aggregation] cache clearing public again

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Re-publicize useful cache clearing methods
+    `clear_association_cache` and `clear_aggregation_cache`
+
+    *Chris Arcand*
+
 *   Made ActiveRecord consistently use `ActiveRecord::Type` (not `ActiveModel::Type`)
 
     *Iain Beeston*

--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -13,11 +13,11 @@ module ActiveRecord
       super
     end
 
-    private
+    def clear_aggregation_cache # :nodoc:
+      @aggregation_cache.clear if persisted?
+    end
 
-      def clear_aggregation_cache # :nodoc:
-        @aggregation_cache.clear if persisted?
-      end
+    private
 
       def init_internals # :nodoc:
         @aggregation_cache = {}

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -253,11 +253,11 @@ module ActiveRecord
       super
     end
 
+    def clear_association_cache # :nodoc:
+      @association_cache.clear if persisted?
+    end
+
     private
-      # Clears out the association cache.
-      def clear_association_cache # :nodoc:
-        @association_cache.clear if persisted?
-      end
 
       def init_internals # :nodoc:
         @association_cache = {}

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -41,6 +41,28 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_equal favs, fav2
   end
 
+  def test_clear_association_cache_stored
+    firm = Firm.find(1)
+    assert_kind_of Firm, firm
+
+    firm.clear_association_cache
+    assert_equal Firm.find(1).clients.collect(&:name).sort, firm.clients.collect(&:name).sort
+  end
+
+  def test_clear_association_cache_new_record
+    firm            = Firm.new
+    client_stored   = Client.find(3)
+    client_new      = Client.new
+    client_new.name = "The Joneses"
+    clients         = [ client_stored, client_new ]
+
+    firm.clients    << clients
+    assert_equal clients.map(&:name).to_set, firm.clients.map(&:name).to_set
+
+    firm.clear_association_cache
+    assert_equal clients.map(&:name).to_set, firm.clients.map(&:name).to_set
+  end
+
   def test_loading_the_association_target_should_keep_child_records_marked_for_destruction
     ship = Ship.create!(name: "The good ship Dollypop")
     part = ship.parts.create!(name: "Mast")


### PR DESCRIPTION
### Summary

This PR re-publicizes `Associations#clear_association_cache` and `Aggregations#clear_aggregation_cache`, which were privatized in https://github.com/rails/rails/pull/16989

From that PR:

> It also means that the currently undocumented clear_association_cache and clear_aggregation_cache methods are not used outside their modules and could be made private. I've done this but am ambivalent about that part, so let me know what you think.

While the preceding PR has good changes (responsibilities moved to their respective modules, limited access to the caches themselves) the privatization of the cache clearing methods serves no purpose. Clearing AR caches is a very useful thing and it seems very innocuous to have a method in the concerning module to clear out the very simple cache implemented within them.
### Other Information
- https://github.com/ManageIQ/manageiq/issues/6723
- https://github.com/ManageIQ/manageiq/pull/8668
- This partially reverts 17e0878, just bringing back the applicable tests. I did not add the API documentation mentioning this method back as it's not incredibly useful.

r? @rafaelfranca or @matthewd
