### PR TITLE
Add test validating that Model.attribute_names cache is busted

### DIFF
--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -106,12 +106,14 @@ module ActiveRecord
 
       assert_equal 6, klass.attribute_types.length
       assert_equal 6, klass.column_defaults.length
+      assert_equal 6, klass.attribute_names.length
       assert_not klass.attribute_types.include?("wibble")
 
       klass.attribute :wibble, Type::Value.new
 
       assert_equal 7, klass.attribute_types.length
       assert_equal 7, klass.column_defaults.length
+      assert_equal 7, klass.attribute_names.length
       assert_includes klass.attribute_types, "wibble"
     end
 


### PR DESCRIPTION
### Summary

`Model.attribute_names` is cached and relies on Model.columns. The cache is not busted properly in 4.2 (see https://github.com/rails/rails/pull/26705) and was fixed in master, but there still is no test coverage.
