### PR TITLE
Allow the use of listen's 3.1.x branch.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ end
 
 # Active Support.
 gem 'dalli', '>= 2.2.1'
-gem 'listen', '~> 3.0.5', require: false
+gem 'listen', '>= 3.0.5', '< 3.2', require: false
 
 # Active Job.
 group :job do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,9 +174,10 @@ GEM
     kindlerb (0.1.1)
       mustache
       nokogiri
-    listen (3.0.8)
+    listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -251,6 +252,7 @@ GEM
       redis (~> 3.0)
       resque (~> 1.25)
       rufus-scheduler (~> 3.2)
+    ruby_dep (1.4.0)
     rufus-scheduler (3.2.2)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -343,7 +345,7 @@ DEPENDENCIES
   hiredis
   jquery-rails
   kindlerb (= 0.1.1)
-  listen (~> 3.0.5)
+  listen (>= 3.0.5, < 3.2)
   minitest (< 5.3.4)
   mocha (~> 0.14)
   mysql2 (>= 0.4.4)
@@ -379,4 +381,4 @@ DEPENDENCIES
   wdm (>= 0.1.0)
 
 BUNDLED WITH
-   1.13.1
+   1.13.2

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1237,7 +1237,7 @@ false:
 
 ```ruby
 group :development do
-  gem 'listen', '~> 3.0.4'
+  gem 'listen', '>= 3.0.5', '< 3.2'
 end
 ```
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow the use of listen's 3.1.x branch
+
+    *Esteban Santana Santana*
+
 *   Run `Minitest.after_run` hooks when running `rails test`.
 
     *Michael Grosser*

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -39,7 +39,7 @@ group :development do
   <%- end -%>
 <%- end -%>
 <% if depend_on_listen? -%>
-  gem 'listen', '~> 3.0.5'
+  gem 'listen', '>= 3.0.5', '< 3.2'
 <% end -%>
 <% if spring_install? -%>
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring


### PR DESCRIPTION
### Summary

We have a need to use the newer versions of the `listen` gem and the version pinning in `rails` & specifically `railties` is preventing this. When the initial [evented monitor](https://github.com/rails/rails/commit/de6ad5665d2679944a9ee9407826ba88395a1003) feature was written, the latest version of `listen` was the 3.0.x series. Since then the `listen` project has moved on to the 3.1.x series. This patch corrects that version pinning by expanding its range to include the 3.1.x branch.
### Other Information

The `bundle exec rake test` command was run for `railties` & `activesupport` to make sure that there was no regression. `CHANGELOG`, `Gemfile.lock` and documentation were also updated.

This is the 5.0 branch version of #26695.
