### PR TITLE
Change page:change to turbolinks:load in README.md [ci skip]

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -167,7 +167,7 @@ App.cable.subscriptions.create "AppearanceChannel",
   buttonSelector = "[data-behavior~=appear_away]"
 
   install: ->
-    $(document).on "page:change.appearance", =>
+    $(document).on "turbolinks:load.appearance", =>
       @appear()
 
     $(document).on "click.appearance", buttonSelector, =>

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -422,7 +422,7 @@ App.cable.subscriptions.create "AppearanceChannel",
   buttonSelector = "[data-behavior~=appear_away]"
 
   install: ->
-    $(document).on "page:change.appearance", =>
+    $(document).on "turbolinks:load.appearance", =>
       @appear()
 
     $(document).on "click.appearance", buttonSelector, =>


### PR DESCRIPTION
With Turbolinks5, `page:change` does not work any more. It has to be replaced with `turbolinks:load`
