### PR TITLE
Remove deprecated callback methods

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Removed deprecated *_filter callback methods from AbstractController
+
+    *Iain Beeston*
+
 *   Show an "unmatched constraints" error when params fail to match constraints
     on a matched route, rather than a "missing keys" error.
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Removed deprecated AbstractController#skip_action_callback
+
+    *Iain Beeston*
+
 *   Removed deprecated *_filter callback methods from AbstractController
 
     *Iain Beeston*

--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -54,20 +54,6 @@ module AbstractController
         end
       end
 
-      # Skip before, after, and around action callbacks matching any of the names.
-      #
-      # ==== Parameters
-      # * <tt>names</tt> - A list of valid names that could be used for
-      #   callbacks. Note that skipping uses Ruby equality, so it's
-      #   impossible to skip a callback defined using an anonymous proc
-      #   using #skip_action_callback.
-      def skip_action_callback(*names)
-        ActiveSupport::Deprecation.warn("`skip_action_callback` is deprecated and will be removed in Rails 5.1. Please use skip_before_action, skip_after_action or skip_around_action instead.")
-        skip_before_action(*names, raise: false)
-        skip_after_action(*names, raise: false)
-        skip_around_action(*names, raise: false)
-      end
-
       # Take callback names and an optional callback proc, normalize them,
       # then call the block with each callback. This allows us to abstract
       # the normalization across several methods that use it.

--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -68,11 +68,6 @@ module AbstractController
         skip_around_action(*names, raise: false)
       end
 
-      def skip_filter(*names)
-        ActiveSupport::Deprecation.warn("`skip_filter` is deprecated and will be removed in Rails 5.1. Use skip_before_action, skip_after_action or skip_around_action instead.")
-        skip_action_callback(*names)
-      end
-
       # Take callback names and an optional callback proc, normalize them,
       # then call the block with each callback. This allows us to abstract
       # the normalization across several methods that use it.
@@ -187,20 +182,10 @@ module AbstractController
           end
         end
 
-        define_method "#{callback}_filter" do |*names, &blk|
-          ActiveSupport::Deprecation.warn("#{callback}_filter is deprecated and will be removed in Rails 5.1. Use #{callback}_action instead.")
-          send("#{callback}_action", *names, &blk)
-        end
-
         define_method "prepend_#{callback}_action" do |*names, &blk|
           _insert_callbacks(names, blk) do |name, options|
             set_callback(:process_action, callback, name, options.merge(prepend: true))
           end
-        end
-
-        define_method "prepend_#{callback}_filter" do |*names, &blk|
-          ActiveSupport::Deprecation.warn("prepend_#{callback}_filter is deprecated and will be removed in Rails 5.1. Use prepend_#{callback}_action instead.")
-          send("prepend_#{callback}_action", *names, &blk)
         end
 
         # Skip a before, after or around callback. See _insert_callbacks
@@ -211,18 +196,8 @@ module AbstractController
           end
         end
 
-        define_method "skip_#{callback}_filter" do |*names, &blk|
-          ActiveSupport::Deprecation.warn("skip_#{callback}_filter is deprecated and will be removed in Rails 5.1. Use skip_#{callback}_action instead.")
-          send("skip_#{callback}_action", *names, &blk)
-        end
-
         # *_action is the same as append_*_action
         alias_method :"append_#{callback}_action", :"#{callback}_action"
-
-        define_method "append_#{callback}_filter" do |*names, &blk|
-          ActiveSupport::Deprecation.warn("append_#{callback}_filter is deprecated and will be removed in Rails 5.1. Use append_#{callback}_action instead.")
-          send("append_#{callback}_action", *names, &blk)
-        end
       end
     end
   end

--- a/actionpack/lib/action_controller/metal/testing.rb
+++ b/actionpack/lib/action_controller/metal/testing.rb
@@ -12,7 +12,7 @@ module ActionController
     end
 
     module ClassMethods
-      def before_filters
+      def before_actions
         _process_action_callbacks.find_all { |x| x.kind == :before }.map(&:name)
       end
     end

--- a/actionpack/test/abstract/callbacks_test.rb
+++ b/actionpack/test/abstract/callbacks_test.rb
@@ -264,53 +264,5 @@ module AbstractController
         assert_equal "Hello world Howdy!", controller.response_body
       end
     end
-
-    class AliasedCallbacks < ControllerWithCallbacks
-      ActiveSupport::Deprecation.silence do
-        before_filter :first
-        after_filter :second
-        around_filter :aroundz
-      end
-
-      def first
-        @text = "Hello world"
-      end
-
-      def second
-        @second = "Goodbye"
-      end
-
-      def aroundz
-        @aroundz = "FIRST"
-        yield
-        @aroundz << "SECOND"
-      end
-
-      def index
-        @text ||= nil
-        self.response_body = @text.to_s
-      end
-    end
-
-    class TestAliasedCallbacks < ActiveSupport::TestCase
-      def setup
-        @controller = AliasedCallbacks.new
-      end
-
-      test "before_filter works" do
-        @controller.process(:index)
-        assert_equal "Hello world", @controller.response_body
-      end
-
-      test "after_filter works" do
-        @controller.process(:index)
-        assert_equal "Goodbye", @controller.instance_variable_get("@second")
-      end
-
-      test "around_filter works" do
-        @controller.process(:index)
-        assert_equal "FIRSTSECOND", @controller.instance_variable_get("@aroundz")
-      end
-    end
   end
 end

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -2,7 +2,7 @@ require "abstract_unit"
 
 class ActionController::Base
   class << self
-    %w(append_around_action prepend_after_action prepend_around_action prepend_before_action skip_after_action skip_before_action skip_action_callback).each do |pending|
+    %w(append_around_action prepend_after_action prepend_around_action prepend_before_action skip_after_action skip_before_action).each do |pending|
       define_method(pending) do |*args|
         $stderr.puts "#{pending} unimplemented: #{args.inspect}"
       end unless method_defined?(pending)
@@ -956,13 +956,6 @@ class ControllerWithTwoLessFilters < ControllerWithAllTypesOfFilters
   skip_after_action :after
 end
 
-class SkipFilterUsingSkipActionCallback < ControllerWithAllTypesOfFilters
-  ActiveSupport::Deprecation.silence do
-    skip_action_callback :around_again
-    skip_action_callback :after
-  end
-end
-
 class YieldingAroundFiltersTest < ActionController::TestCase
   include PostsController::AroundExceptions
 
@@ -1045,19 +1038,6 @@ class YieldingAroundFiltersTest < ActionController::TestCase
     response = test_process(controller, "fail_3")
     assert_equal "", response.body
     assert_equal 3, controller.instance_variable_get(:@try)
-  end
-
-  def test_skipping_with_skip_action_callback
-    test_process(SkipFilterUsingSkipActionCallback,"no_raise")
-    assert_equal "before around (before yield) around (after yield)", @controller.instance_variable_get(:@ran_filter).join(" ")
-  end
-
-  def test_deprecated_skip_action_callback
-    assert_deprecated do
-      Class.new(PostsController) do
-        skip_action_callback :clean_up
-      end
-    end
   end
 
   protected

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -1060,14 +1060,6 @@ class YieldingAroundFiltersTest < ActionController::TestCase
     end
   end
 
-  def test_deprecated_skip_filter
-    assert_deprecated do
-      Class.new(PostsController) do
-        skip_filter :clean_up
-      end
-    end
-  end
-
   protected
     def test_process(controller, action = "show")
       @controller = controller.is_a?(Class) ? controller.new : controller

--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -1,7 +1,6 @@
 require "active_job"
 require "support/job_buffer"
 
-ActiveSupport.halt_callback_chains_on_return_false = false
 GlobalID.app = "aj"
 
 @adapter  = ENV["AJ_ADAPTER"] || "inline"

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Removed support for returning false to halt validation callbacks (deprecated).
+
+    *Iain Beeston*
 
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -103,7 +103,6 @@ module ActiveModel
     def define_model_callbacks(*callbacks)
       options = callbacks.extract_options!
       options = {
-        terminator: deprecated_false_terminator,
         skip_after_callbacks_if_terminated: true,
         scope: [:kind, :name],
         only: [:before, :around, :after]

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -23,7 +23,6 @@ module ActiveModel
       included do
         include ActiveSupport::Callbacks
         define_callbacks :validation,
-                         terminator: deprecated_false_terminator,
                          skip_after_callbacks_if_terminated: true,
                          scope: [:kind, :name]
       end

--- a/activemodel/test/cases/callbacks_test.rb
+++ b/activemodel/test/cases/callbacks_test.rb
@@ -27,7 +27,7 @@ class CallbacksTest < ActiveModel::TestCase
       false
     end
 
-    ActiveSupport::Deprecation.silence { after_create "@callbacks << :final_callback" }
+    after_create :final_callback
 
     def initialize(options = {})
       @callbacks = []
@@ -40,6 +40,10 @@ class CallbacksTest < ActiveModel::TestCase
       @callbacks << :before_create
       throw(@before_create_throws) if @before_create_throws
       @before_create_returns
+    end
+
+    def final_callback
+      @callbacks << :final_callback
     end
 
     def create
@@ -61,14 +65,6 @@ class CallbacksTest < ActiveModel::TestCase
     model = ModelCallbacks.new
     model.create
     assert_equal model.callbacks.last, :final_callback
-  end
-
-  test "the callback chain is halted when a before callback returns false (deprecated)" do
-    model = ModelCallbacks.new(before_create_returns: false)
-    assert_deprecated do
-      model.create
-      assert_equal model.callbacks.last, :before_create
-    end
   end
 
   test "the callback chain is halted when a callback throws :abort" do

--- a/activemodel/test/cases/validations/callbacks_test.rb
+++ b/activemodel/test/cases/validations/callbacks_test.rb
@@ -121,15 +121,6 @@ class CallbacksWithMethodNamesShouldBeCalled < ActiveModel::TestCase
     assert_equal false, output
   end
 
-  def test_deprecated_further_callbacks_should_not_be_called_if_before_validation_returns_false
-    d = DogDeprecatedBeforeValidatorReturningFalse.new
-    assert_deprecated do
-      output = d.valid?
-      assert_equal [], d.history
-      assert_equal false, output
-    end
-  end
-
   def test_further_callbacks_should_be_called_if_after_validation_returns_false
     d = DogAfterValidatorReturningFalse.new
     d.valid?

--- a/activemodel/test/cases/validations/conditional_validation_test.rb
+++ b/activemodel/test/cases/validations/conditional_validation_test.rb
@@ -41,40 +41,6 @@ class ConditionalValidationTest < ActiveModel::TestCase
     assert_equal ["hoo 5"], t.errors["title"]
   end
 
-  def test_if_validation_using_string_true
-    # When the evaluated string returns true
-    Topic.validates_length_of(:title, maximum: 5, too_long: "hoo %{count}", if: "a = 1; a == 1")
-    t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
-    assert t.invalid?
-    assert t.errors[:title].any?
-    assert_equal ["hoo 5"], t.errors["title"]
-  end
-
-  def test_unless_validation_using_string_true
-    # When the evaluated string returns true
-    Topic.validates_length_of(:title, maximum: 5, too_long: "hoo %{count}", unless: "a = 1; a == 1")
-    t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
-    assert t.valid?
-    assert_empty t.errors[:title]
-  end
-
-  def test_if_validation_using_string_false
-    # When the evaluated string returns false
-    Topic.validates_length_of(:title, maximum: 5, too_long: "hoo %{count}", if: "false")
-    t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
-    assert t.valid?
-    assert_empty t.errors[:title]
-  end
-
-  def test_unless_validation_using_string_false
-    # When the evaluated string returns false
-    Topic.validates_length_of(:title, maximum: 5, too_long: "hoo %{count}", unless: "false")
-    t = Topic.new("title" => "uhohuhoh", "content" => "whatever")
-    assert t.invalid?
-    assert t.errors[:title].any?
-    assert_equal ["hoo 5"], t.errors["title"]
-  end
-
   def test_if_validation_using_block_true
     # When the block returns true
     Topic.validates_length_of(:title, maximum: 5, too_long: "hoo %{count}",
@@ -111,27 +77,5 @@ class ConditionalValidationTest < ActiveModel::TestCase
     assert t.invalid?
     assert t.errors[:title].any?
     assert_equal ["hoo 5"], t.errors["title"]
-  end
-
-  # previous implementation of validates_presence_of eval'd the
-  # string with the wrong binding, this regression test is to
-  # ensure that it works correctly
-  def test_validation_with_if_as_string
-    Topic.validates_presence_of(:title)
-    Topic.validates_presence_of(:author_name, if: "title.to_s.match('important')")
-
-    t = Topic.new
-    assert t.invalid?, "A topic without a title should not be valid"
-    assert_empty t.errors[:author_name], "A topic without an 'important' title should not require an author"
-
-    t.title = "Just a title"
-    assert t.valid?, "A topic with a basic title should be valid"
-
-    t.title = "A very important title"
-    assert t.invalid?, "A topic with an important title, but without an author, should not be valid"
-    assert t.errors[:author_name].any?, "A topic with an 'important' title should require an author"
-
-    t.author_name = "Hubert J. Farnsworth"
-    assert t.valid?, "A topic with an important title and author should be valid"
   end
 end

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -96,7 +96,7 @@ class ValidatesWithTest < ActiveModel::TestCase
 
   test "passes all configuration options to the validator class" do
     topic = Topic.new
-    condition = -> { 1 == 1}
+    condition = -> { 1 == 1 }
     validator = Minitest::Mock.new
     validator.expect(:new, validator, [{ foo: :bar, if: condition, class: Topic }])
     validator.expect(:validate, nil, [topic])

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -69,26 +69,26 @@ class ValidatesWithTest < ActiveModel::TestCase
   end
 
   test "with if statements that return false" do
-    Topic.validates_with(ValidatorThatAddsErrors, if: "1 == 2")
+    Topic.validates_with(ValidatorThatAddsErrors, if: -> { 1 == 2 })
     topic = Topic.new
     assert topic.valid?
   end
 
   test "with if statements that return true" do
-    Topic.validates_with(ValidatorThatAddsErrors, if: "1 == 1")
+    Topic.validates_with(ValidatorThatAddsErrors, if: -> { 1 == 1 })
     topic = Topic.new
     assert topic.invalid?
     assert_includes topic.errors[:base], ERROR_MESSAGE
   end
 
   test "with unless statements that return true" do
-    Topic.validates_with(ValidatorThatAddsErrors, unless: "1 == 1")
+    Topic.validates_with(ValidatorThatAddsErrors, unless: -> { 1 == 1 })
     topic = Topic.new
     assert topic.valid?
   end
 
   test "with unless statements that returns false" do
-    Topic.validates_with(ValidatorThatAddsErrors, unless: "1 == 2")
+    Topic.validates_with(ValidatorThatAddsErrors, unless: -> { 1 == 2 })
     topic = Topic.new
     assert topic.invalid?
     assert_includes topic.errors[:base], ERROR_MESSAGE
@@ -96,13 +96,13 @@ class ValidatesWithTest < ActiveModel::TestCase
 
   test "passes all configuration options to the validator class" do
     topic = Topic.new
+    condition = -> { 1 == 1}
     validator = Minitest::Mock.new
-    validator.expect(:new, validator, [{ foo: :bar, if: "1 == 1", class: Topic }])
+    validator.expect(:new, validator, [{ foo: :bar, if: condition, class: Topic }])
     validator.expect(:validate, nil, [topic])
     validator.expect(:is_a?, false, [Symbol])
-    validator.expect(:is_a?, false, [String])
 
-    Topic.validates_with(validator, if: "1 == 1", foo: :bar)
+    Topic.validates_with(validator, if: condition, foo: :bar)
     assert topic.valid?
     validator.verify
   end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Removed support for returning false to halt ActiveRecord callbacks (deprecated).
+
+    *Iain Beeston*
+
 *   Made ActiveRecord consistently use `ActiveRecord::Type` (not `ActiveModel::Type`)
 
     *Iain Beeston*

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -95,10 +95,9 @@ module ActiveRecord
   #
   # == Types of callbacks
   #
-  # There are four types of callbacks accepted by the callback macros: Method references (symbol), callback objects,
-  # inline methods (using a proc), and inline eval methods (using a string). Method references and callback objects
-  # are the recommended approaches, inline methods using a proc are sometimes appropriate (such as for
-  # creating mix-ins), and inline eval methods are deprecated.
+  # There are three types of callbacks accepted by the callback macros: Method references (symbol), callback objects
+  # and inline methods (using a proc). Method references and callback objects are the recommended approaches, and
+  # inline methods using a proc are sometimes appropriate (such as for creating mix-ins).
   #
   # The method reference callbacks work by specifying a protected or private method available in the object, like this:
   #

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -11,7 +11,6 @@ module ActiveRecord
                        :before_commit_without_transaction_enrollment,
                        :commit_without_transaction_enrollment,
                        :rollback_without_transaction_enrollment,
-                       terminator: deprecated_false_terminator,
                        scope: [:kind, :name]
     end
 

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -294,7 +294,7 @@ module ActiveRecord
             fire_on = Array(options[:on])
             assert_valid_transaction_action(fire_on)
             options[:if] = Array(options[:if])
-            options[:if] << "transaction_include_any_action?(#{fire_on})"
+            options[:if] << lambda { transaction_include_any_action?(fire_on) }
           end
         end
 

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -404,70 +404,6 @@ class CallbacksTest < ActiveRecord::TestCase
     ], david.history
   end
 
-  def test_deprecated_before_save_returning_false
-    david = ImmutableDeveloper.find(1)
-    assert_deprecated do
-      assert david.valid?
-      assert !david.save
-      exc = assert_raise(ActiveRecord::RecordNotSaved) { david.save! }
-      assert_equal exc.record, david
-      assert_equal "Failed to save the record", exc.message
-    end
-
-    david = ImmutableDeveloper.find(1)
-    david.salary = 10_000_000
-    assert !david.valid?
-    assert !david.save
-    assert_raise(ActiveRecord::RecordInvalid) { david.save! }
-
-    someone = CallbackCancellationDeveloper.find(1)
-    someone.cancel_before_save = true
-    assert_deprecated do
-      assert someone.valid?
-      assert !someone.save
-    end
-    assert_save_callbacks_not_called(someone)
-  end
-
-  def test_deprecated_before_create_returning_false
-    someone = CallbackCancellationDeveloper.new
-    someone.cancel_before_create = true
-    assert_deprecated do
-      assert someone.valid?
-      assert !someone.save
-    end
-    assert_save_callbacks_not_called(someone)
-  end
-
-  def test_deprecated_before_update_returning_false
-    someone = CallbackCancellationDeveloper.find(1)
-    someone.cancel_before_update = true
-    assert_deprecated do
-      assert someone.valid?
-      assert !someone.save
-    end
-    assert_save_callbacks_not_called(someone)
-  end
-
-  def test_deprecated_before_destroy_returning_false
-    david = ImmutableDeveloper.find(1)
-    assert_deprecated do
-      assert !david.destroy
-      exc = assert_raise(ActiveRecord::RecordNotDestroyed) { david.destroy! }
-      assert_equal exc.record, david
-      assert_equal "Failed to destroy the record", exc.message
-    end
-    assert_not_nil ImmutableDeveloper.find_by_id(1)
-
-    someone = CallbackCancellationDeveloper.find(1)
-    someone.cancel_before_destroy = true
-    assert_deprecated do
-      assert !someone.destroy
-      assert_raise(ActiveRecord::RecordNotDestroyed) { someone.destroy! }
-    end
-    assert !someone.after_destroy_called
-  end
-
   def assert_save_callbacks_not_called(someone)
     assert !someone.after_save_called
     assert !someone.after_create_called
@@ -523,34 +459,6 @@ class CallbacksTest < ActiveRecord::TestCase
     assert !someone.destroy
     assert_raise(ActiveRecord::RecordNotDestroyed) { someone.destroy! }
     assert !someone.after_destroy_called
-  end
-
-  def test_callback_returning_false
-    david = CallbackDeveloperWithFalseValidation.find(1)
-    assert_deprecated { david.save }
-    assert_equal [
-      [ :after_find,            :method ],
-      [ :after_find,            :string ],
-      [ :after_find,            :proc   ],
-      [ :after_find,            :object ],
-      [ :after_find,            :block  ],
-      [ :after_initialize,            :method ],
-      [ :after_initialize,            :string ],
-      [ :after_initialize,            :proc   ],
-      [ :after_initialize,            :object ],
-      [ :after_initialize,            :block  ],
-      [ :before_validation,           :method ],
-      [ :before_validation,           :string ],
-      [ :before_validation,           :proc   ],
-      [ :before_validation,           :object ],
-      [ :before_validation,           :block  ],
-      [ :before_validation, :returning_false  ],
-      [ :after_rollback, :block  ],
-      [ :after_rollback, :object ],
-      [ :after_rollback, :proc   ],
-      [ :after_rollback, :string ],
-      [ :after_rollback, :method ],
-    ], david.history
   end
 
   def test_callback_throwing_abort

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -6,10 +6,6 @@ class CallbackDeveloper < ActiveRecord::Base
   self.table_name = "developers"
 
   class << self
-    def callback_string(callback_method)
-      "history << [#{callback_method.to_sym.inspect}, :string]"
-    end
-
     def callback_proc(callback_method)
       Proc.new { |model| model.history << [callback_method, :proc] }
     end
@@ -33,7 +29,6 @@ class CallbackDeveloper < ActiveRecord::Base
   ActiveRecord::Callbacks::CALLBACKS.each do |callback_method|
     next if callback_method.to_s.start_with?("around_")
     define_callback_method(callback_method)
-    ActiveSupport::Deprecation.silence { send(callback_method, callback_string(callback_method)) }
     send(callback_method, callback_proc(callback_method))
     send(callback_method, callback_object(callback_method))
     send(callback_method) { |model| model.history << [callback_method, :block] }
@@ -178,7 +173,6 @@ class CallbacksTest < ActiveRecord::TestCase
     david = CallbackDeveloper.new
     assert_equal [
       [ :after_initialize,            :method ],
-      [ :after_initialize,            :string ],
       [ :after_initialize,            :proc   ],
       [ :after_initialize,            :object ],
       [ :after_initialize,            :block  ],
@@ -189,12 +183,10 @@ class CallbacksTest < ActiveRecord::TestCase
     david = CallbackDeveloper.find(1)
     assert_equal [
       [ :after_find,            :method ],
-      [ :after_find,            :string ],
       [ :after_find,            :proc   ],
       [ :after_find,            :object ],
       [ :after_find,            :block  ],
       [ :after_initialize,            :method ],
-      [ :after_initialize,            :string ],
       [ :after_initialize,            :proc   ],
       [ :after_initialize,            :object ],
       [ :after_initialize,            :block  ],
@@ -206,17 +198,14 @@ class CallbacksTest < ActiveRecord::TestCase
     david.valid?
     assert_equal [
       [ :after_initialize,            :method ],
-      [ :after_initialize,            :string ],
       [ :after_initialize,            :proc   ],
       [ :after_initialize,            :object ],
       [ :after_initialize,            :block  ],
       [ :before_validation,           :method ],
-      [ :before_validation,           :string ],
       [ :before_validation,           :proc   ],
       [ :before_validation,           :object ],
       [ :before_validation,           :block  ],
       [ :after_validation,            :method ],
-      [ :after_validation,            :string ],
       [ :after_validation,            :proc   ],
       [ :after_validation,            :object ],
       [ :after_validation,            :block  ],
@@ -228,22 +217,18 @@ class CallbacksTest < ActiveRecord::TestCase
     david.valid?
     assert_equal [
       [ :after_find,            :method ],
-      [ :after_find,            :string ],
       [ :after_find,            :proc   ],
       [ :after_find,            :object ],
       [ :after_find,            :block  ],
       [ :after_initialize,            :method ],
-      [ :after_initialize,            :string ],
       [ :after_initialize,            :proc   ],
       [ :after_initialize,            :object ],
       [ :after_initialize,            :block  ],
       [ :before_validation,           :method ],
-      [ :before_validation,           :string ],
       [ :before_validation,           :proc   ],
       [ :before_validation,           :object ],
       [ :before_validation,           :block  ],
       [ :after_validation,            :method ],
-      [ :after_validation,            :string ],
       [ :after_validation,            :proc   ],
       [ :after_validation,            :object ],
       [ :after_validation,            :block  ],
@@ -254,44 +239,36 @@ class CallbacksTest < ActiveRecord::TestCase
     david = CallbackDeveloper.create("name" => "David", "salary" => 1000000)
     assert_equal [
       [ :after_initialize,            :method ],
-      [ :after_initialize,            :string ],
       [ :after_initialize,            :proc   ],
       [ :after_initialize,            :object ],
       [ :after_initialize,            :block  ],
       [ :before_validation,           :method ],
-      [ :before_validation,           :string ],
       [ :before_validation,           :proc   ],
       [ :before_validation,           :object ],
       [ :before_validation,           :block  ],
       [ :after_validation,            :method ],
-      [ :after_validation,            :string ],
       [ :after_validation,            :proc   ],
       [ :after_validation,            :object ],
       [ :after_validation,            :block  ],
       [ :before_save,                 :method ],
-      [ :before_save,                 :string ],
       [ :before_save,                 :proc   ],
       [ :before_save,                 :object ],
       [ :before_save,                 :block  ],
       [ :before_create,               :method ],
-      [ :before_create,               :string ],
       [ :before_create,               :proc   ],
       [ :before_create,               :object ],
       [ :before_create,               :block  ],
       [ :after_create,                :method ],
-      [ :after_create,                :string ],
       [ :after_create,                :proc   ],
       [ :after_create,                :object ],
       [ :after_create,                :block  ],
       [ :after_save,                  :method ],
-      [ :after_save,                  :string ],
       [ :after_save,                  :proc   ],
       [ :after_save,                  :object ],
       [ :after_save,                  :block  ],
       [ :after_commit,                :block  ],
       [ :after_commit,                :object ],
       [ :after_commit,                :proc   ],
-      [ :after_commit,                :string ],
       [ :after_commit,                :method ]
     ], david.history
   end
@@ -323,49 +300,40 @@ class CallbacksTest < ActiveRecord::TestCase
     david.save
     assert_equal [
       [ :after_find,            :method ],
-      [ :after_find,            :string ],
       [ :after_find,            :proc   ],
       [ :after_find,            :object ],
       [ :after_find,            :block  ],
       [ :after_initialize,            :method ],
-      [ :after_initialize,            :string ],
       [ :after_initialize,            :proc   ],
       [ :after_initialize,            :object ],
       [ :after_initialize,            :block  ],
       [ :before_validation,           :method ],
-      [ :before_validation,           :string ],
       [ :before_validation,           :proc   ],
       [ :before_validation,           :object ],
       [ :before_validation,           :block  ],
       [ :after_validation,            :method ],
-      [ :after_validation,            :string ],
       [ :after_validation,            :proc   ],
       [ :after_validation,            :object ],
       [ :after_validation,            :block  ],
       [ :before_save,                 :method ],
-      [ :before_save,                 :string ],
       [ :before_save,                 :proc   ],
       [ :before_save,                 :object ],
       [ :before_save,                 :block  ],
       [ :before_update,               :method ],
-      [ :before_update,               :string ],
       [ :before_update,               :proc   ],
       [ :before_update,               :object ],
       [ :before_update,               :block  ],
       [ :after_update,                :method ],
-      [ :after_update,                :string ],
       [ :after_update,                :proc   ],
       [ :after_update,                :object ],
       [ :after_update,                :block  ],
       [ :after_save,                  :method ],
-      [ :after_save,                  :string ],
       [ :after_save,                  :proc   ],
       [ :after_save,                  :object ],
       [ :after_save,                  :block  ],
       [ :after_commit,                :block  ],
       [ :after_commit,                :object ],
       [ :after_commit,                :proc   ],
-      [ :after_commit,                :string ],
       [ :after_commit,                :method ]
     ], david.history
   end
@@ -399,29 +367,24 @@ class CallbacksTest < ActiveRecord::TestCase
     david.destroy
     assert_equal [
       [ :after_find,            :method ],
-      [ :after_find,            :string ],
       [ :after_find,            :proc   ],
       [ :after_find,            :object ],
       [ :after_find,            :block  ],
       [ :after_initialize,            :method ],
-      [ :after_initialize,            :string ],
       [ :after_initialize,            :proc   ],
       [ :after_initialize,            :object ],
       [ :after_initialize,            :block  ],
       [ :before_destroy,              :method ],
-      [ :before_destroy,              :string ],
       [ :before_destroy,              :proc   ],
       [ :before_destroy,              :object ],
       [ :before_destroy,              :block  ],
       [ :after_destroy,               :method ],
-      [ :after_destroy,               :string ],
       [ :after_destroy,               :proc   ],
       [ :after_destroy,               :object ],
       [ :after_destroy,               :block  ],
       [ :after_commit,                :block  ],
       [ :after_commit,                :object ],
       [ :after_commit,                :proc   ],
-      [ :after_commit,                :string ],
       [ :after_commit,                :method ]
     ], david.history
   end
@@ -431,12 +394,10 @@ class CallbacksTest < ActiveRecord::TestCase
     CallbackDeveloper.delete(david.id)
     assert_equal [
       [ :after_find,            :method ],
-      [ :after_find,            :string ],
       [ :after_find,            :proc   ],
       [ :after_find,            :object ],
       [ :after_find,            :block  ],
       [ :after_initialize,            :method ],
-      [ :after_initialize,            :string ],
       [ :after_initialize,            :proc   ],
       [ :after_initialize,            :object ],
       [ :after_initialize,            :block  ],
@@ -597,17 +558,14 @@ class CallbacksTest < ActiveRecord::TestCase
     david.save
     assert_equal [
       [ :after_find,        :method ],
-      [ :after_find,        :string ],
       [ :after_find,        :proc   ],
       [ :after_find,        :object ],
       [ :after_find,        :block  ],
       [ :after_initialize,  :method ],
-      [ :after_initialize,  :string ],
       [ :after_initialize,  :proc   ],
       [ :after_initialize,  :object ],
       [ :after_initialize,  :block  ],
       [ :before_validation, :method ],
-      [ :before_validation, :string ],
       [ :before_validation, :proc   ],
       [ :before_validation, :object ],
       [ :before_validation, :block  ],
@@ -615,7 +573,6 @@ class CallbacksTest < ActiveRecord::TestCase
       [ :after_rollback,    :block  ],
       [ :after_rollback,    :object ],
       [ :after_rollback,    :proc   ],
-      [ :after_rollback,    :string ],
       [ :after_rollback,    :method ],
     ], david.history
   end

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -206,16 +206,6 @@ class TransactionTest < ActiveRecord::TestCase
     assert_equal posts_count, author.posts.reload.size
   end
 
-  def test_cancellation_from_returning_false_in_before_filter
-    def @first.before_save_for_transaction
-      false
-    end
-
-    assert_deprecated do
-      @first.save
-    end
-  end
-
   def test_cancellation_from_before_destroy_rollbacks_in_destroy
     add_cancelling_before_destroy_with_db_side_effect_to_topic @first
     nbooks_before_destroy = Book.count

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Removed support for returning false to halt a callback chain (deprecated).
+
+    Define a custom terminator to retain the old behavior.
+
+    *Iain Beeston*
+
 *   Removed support for callbacks defined as strings (deprecated).
 
     *Iain Beeston*

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Removed support for callbacks defined as strings (deprecated).
+
+    *Iain Beeston*
+
 *   Fix `ActiveSupport::TimeWithZone#in` across DST boundaries.
 
     Previously calls to `in` were being sent to the non-DST aware
@@ -8,10 +12,10 @@
         Time.zone = "US/Eastern"
 
         t = Time.zone.local(2016,11,6,1)
-        # => Sun, 06 Nov 2016 01:00:00 EDT -05:00 
+        # => Sun, 06 Nov 2016 01:00:00 EDT -05:00
 
         t.in(1.hour)
-        # => Sun, 06 Nov 2016 01:00:00 EST -05:00 
+        # => Sun, 06 Nov 2016 01:00:00 EST -05:00
 
     Fixes #26580.
 

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -79,14 +79,6 @@ module ActiveSupport
 
   cattr_accessor :test_order # :nodoc:
 
-  def self.halt_callback_chains_on_return_false
-    Callbacks.halt_and_display_warning_on_return_false
-  end
-
-  def self.halt_callback_chains_on_return_false=(value)
-    Callbacks.halt_and_display_warning_on_return_false = value
-  end
-
   def self.to_time_preserves_timezone
     DateAndTime::Compatibility.preserve_timezone
   end

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -279,13 +279,6 @@ module ActiveSupport
 
       class Callback #:nodoc:#
         def self.build(chain, filter, kind, options)
-          if filter.is_a?(String)
-            ActiveSupport::Deprecation.warn(<<-MSG.squish)
-              Passing string to define callback is deprecated and will be removed
-              in Rails 5.1 without replacement.
-            MSG
-          end
-
           new chain.name, filter, kind, options, chain.config
         end
 
@@ -427,7 +420,6 @@ module ActiveSupport
         # Filters support:
         #
         #   Symbols:: A method to call.
-        #   Strings:: Some content to evaluate.
         #   Procs::   A proc to call with the object.
         #   Objects:: An object with a <tt>before_foo</tt> method on it to call.
         #
@@ -437,8 +429,6 @@ module ActiveSupport
           case filter
           when Symbol
             new(nil, filter, [], nil)
-          when String
-            new(nil, :instance_exec, [:value], compile_lambda(filter))
           when Conditionals::Value
             new(filter, :call, [:target, :value], nil)
           when ::Proc
@@ -454,10 +444,6 @@ module ActiveSupport
 
             new(filter, method_to_call, [:target], nil)
           end
-        end
-
-        def self.compile_lambda(filter)
-          eval("lambda { |value| #{filter} }")
         end
       end
 
@@ -637,9 +623,8 @@ module ActiveSupport
         #   set_callback :save, :before_method
         #
         # The callback can be specified as a symbol naming an instance method; as a
-        # proc, lambda, or block; as a string to be instance evaluated(deprecated); or as an
-        # object that responds to a certain method determined by the <tt>:scope</tt>
-        # argument to +define_callbacks+.
+        # proc, lambda, or block; or as an object that responds to a certain method
+        # determined by the <tt>:scope</tt> argument to +define_callbacks+.
         #
         # If a proc, lambda, or block is given, its body is evaluated in the context
         # of the current object. It can also optionally accept the current object as

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -23,10 +23,6 @@ module CallbacksTest
         method_name
       end
 
-      def callback_string(callback_method)
-        "history << [#{callback_method.to_sym.inspect}, :string]"
-      end
-
       def callback_proc(callback_method)
         Proc.new { |model| model.history << [callback_method, :proc] }
       end
@@ -61,7 +57,6 @@ module CallbacksTest
     [:before_save, :after_save].each do |callback_method|
       callback_method_sym = callback_method.to_sym
       send(callback_method, callback_symbol(callback_method_sym))
-      ActiveSupport::Deprecation.silence { send(callback_method, callback_string(callback_method_sym)) }
       send(callback_method, callback_proc(callback_method_sym))
       send(callback_method, callback_object(callback_method_sym.to_s.gsub(/_save/, "")))
       send(callback_method, CallbackClass)
@@ -196,11 +191,6 @@ module CallbacksTest
     before_save Proc.new { |r| r.history << "b00m" }, if: :no
     before_save Proc.new { |r| r.history << [:before_save, :symbol] }, unless: :no
     before_save Proc.new { |r| r.history << "b00m" }, unless: :yes
-    # string
-    before_save Proc.new { |r| r.history << [:before_save, :string] }, if: "yes"
-    before_save Proc.new { |r| r.history << "b00m" }, if: "no"
-    before_save Proc.new { |r| r.history << [:before_save, :string] }, unless: "no"
-    before_save Proc.new { |r| r.history << "b00m" }, unless: "yes"
     # Combined if and unless
     before_save Proc.new { |r| r.history << [:before_save, :combined_symbol] }, if: :yes, unless: :no
     before_save Proc.new { |r| r.history << "b00m" }, if: :yes, unless: :yes
@@ -231,7 +221,6 @@ module CallbacksTest
     set_callback :save, :before, :nope,           if: :no
     set_callback :save, :before, :nope,           unless: :yes
     set_callback :save, :after,  :tweedle
-    ActiveSupport::Deprecation.silence { set_callback :save, :before, "tweedle_dee" }
     set_callback :save, :before, proc { |m| m.history << "yup" }
     set_callback :save, :before, :nope,           if: proc { false }
     set_callback :save, :before, :nope,           unless: proc { true }
@@ -262,10 +251,6 @@ module CallbacksTest
     def w0tno
       @history << "boom"
       yield
-    end
-
-    def tweedle_dee
-      @history << "tweedle dee"
     end
 
     def tweedle_dum
@@ -394,7 +379,6 @@ module CallbacksTest
       around = AroundPerson.new
       around.save
       assert_equal [
-        "tweedle dee",
         "yup", "yup",
         "tweedle dum pre",
         "w0tyes before",
@@ -487,7 +471,6 @@ module CallbacksTest
       assert_equal [], person.history
       person.save
       assert_equal [
-        [:before_save, :string],
         [:before_save, :proc],
         [:before_save, :object],
         [:before_save, :block],
@@ -495,7 +478,6 @@ module CallbacksTest
         [:after_save, :class],
         [:after_save, :object],
         [:after_save, :proc],
-        [:after_save, :string],
         [:after_save, :symbol]
       ], person.history
     end
@@ -514,7 +496,6 @@ module CallbacksTest
         [:after_save, :class],
         [:after_save, :object],
         [:after_save, :proc],
-        [:after_save, :string],
         [:after_save, :symbol]
       ], person.history
     end
@@ -527,7 +508,6 @@ module CallbacksTest
       person.save
       assert_equal [
         [:before_save, :symbol],
-        [:before_save, :string],
         [:before_save, :proc],
         [:before_save, :object],
         [:before_save, :class],
@@ -536,7 +516,6 @@ module CallbacksTest
         [:after_save, :class],
         [:after_save, :object],
         [:after_save, :proc],
-        [:after_save, :string],
         [:after_save, :symbol]
       ], person.history
     end
@@ -551,8 +530,6 @@ module CallbacksTest
         [:before_save, :proc],
         [:before_save, :symbol],
         [:before_save, :symbol],
-        [:before_save, :string],
-        [:before_save, :string],
         [:before_save, :combined_symbol],
       ], person.history
     end
@@ -886,7 +863,6 @@ module CallbacksTest
       writer.save
       assert_equal [
         [:before_save, :symbol],
-        [:before_save, :string],
         [:before_save, :proc],
         [:before_save, :object],
         [:before_save, :class],
@@ -895,7 +871,6 @@ module CallbacksTest
         [:after_save, :class],
         [:after_save, :object],
         [:after_save, :proc],
-        [:after_save, :string],
         [:after_save, :symbol]
       ], writer.history
     end
@@ -1109,14 +1084,6 @@ module CallbacksTest
       assert_equal 1, calls.length
     end
 
-    def test_add_eval
-      calls = []
-      klass = ActiveSupport::Deprecation.silence { build_class("bar") }
-      klass.class_eval { define_method(:bar) { calls << klass } }
-      klass.new.run
-      assert_equal 1, calls.length
-    end
-
     def test_skip_class # removes one at a time
       calls = []
       callback = Class.new {
@@ -1149,15 +1116,6 @@ module CallbacksTest
       assert_equal 0, calls.length
     end
 
-    def test_skip_string # raises error
-      calls = []
-      klass =  ActiveSupport::Deprecation.silence { build_class("bar") }
-      klass.class_eval { define_method(:bar) { calls << klass } }
-      assert_raises(ArgumentError) { klass.skip "bar" }
-      klass.new.run
-      assert_equal 1, calls.length
-    end
-
     def test_skip_undefined_callback # raises error
       calls = []
       klass = build_class(:bar)
@@ -1174,16 +1132,6 @@ module CallbacksTest
       klass.skip :qux, raise: false
       klass.new.run
       assert_equal 1, calls.length
-    end
-  end
-
-  class DeprecatedWarningTest < ActiveSupport::TestCase
-    def test_deprecate_string_callback
-      klass = Class.new(Record)
-
-      assert_deprecated do
-        klass.send :before_save, "tweedle_dee"
-      end
     end
   end
 end

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -807,34 +807,8 @@ module CallbacksTest
     end
   end
 
-  class CallbackFalseTerminatorWithoutConfigTest < ActiveSupport::TestCase
-    def test_returning_false_does_not_halt_callback_if_config_variable_is_not_set
-      obj = CallbackFalseTerminator.new
-      obj.save
-      assert_equal nil, obj.halted
-      assert obj.saved
-    end
-  end
-
-  class CallbackFalseTerminatorWithConfigTrueTest < ActiveSupport::TestCase
-    def setup
-      ActiveSupport::Callbacks.halt_and_display_warning_on_return_false = true
-    end
-
-    def test_returning_false_does_not_halt_callback_if_config_variable_is_true
-      obj = CallbackFalseTerminator.new
-      obj.save
-      assert_equal nil, obj.halted
-      assert obj.saved
-    end
-  end
-
-  class CallbackFalseTerminatorWithConfigFalseTest < ActiveSupport::TestCase
-    def setup
-      ActiveSupport::Callbacks.halt_and_display_warning_on_return_false = false
-    end
-
-    def test_returning_false_does_not_halt_callback_if_config_variable_is_false
+  class CallbackFalseTerminatorTest < ActiveSupport::TestCase
+    def test_returning_false_does_not_halt_callback
       obj = CallbackFalseTerminator.new
       obj.save
       assert_equal nil, obj.halted

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -624,8 +624,6 @@ There are a few configuration options available in Active Support:
 
 * `config.active_support.time_precision` sets the precision of JSON encoded time values. Defaults to `3`.
 
-* `ActiveSupport.halt_callback_chains_on_return_false` specifies whether Active Record and Active Model callback chains can be halted by returning `false` in a 'before' callback. When set to `false`, callback chains are halted only when explicitly done so with `throw(:abort)`. When set to `true`, callback chains are halted when a callback returns `false` (the previous behavior before Rails 5) and a deprecation warning is given. Defaults to `true` during the deprecation period. New Rails 5 apps generate an initializer file called `new_framework_defaults.rb` which sets the value to `false`. This file is *not* added when running `rails app:update`, so returning `false` will still work on older apps ported to Rails 5 and display a deprecation warning to prompt users to update their code.
-
 * `ActiveSupport::Logger.silencer` is set to `false` to disable the ability to silence logging in a block. The default is `true`.
 
 * `ActiveSupport::Cache::Store.logger` specifies the logger to use within cache store operations.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
@@ -25,8 +25,6 @@ ActiveSupport.to_time_preserves_timezone = <%= options[:update] ? false : true %
 Rails.application.config.active_record.belongs_to_required_by_default = <%= options[:update] ? false : true %>
 <%- end -%>
 
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = <%= options[:update] ? true : false %>
 <%- unless options[:update] -%>
 
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -211,7 +211,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
       quietly { generator.send(:update_config_files) }
 
       assert_file "#{app_root}/config/initializers/new_framework_defaults.rb" do |content|
-        assert_match(/ActiveSupport\.halt_callback_chains_on_return_false = true/, content)
         assert_match(/Rails\.application\.config.active_record\.belongs_to_required_by_default = false/, content)
         assert_no_match(/Rails\.application\.config\.ssl_options/, content)
       end


### PR DESCRIPTION
### Summary

There are a large number of deprecations related to callbacks that were due to be removed in Rails 5.1 (a few of these I put in, most I did not). I've taken the liberty to remove these.

The deprecated "features" are:
- `*_filter` callback hooks (e.g. `before_filter`)
- `skip_action_callback`
- Evaluating a string as the body of a callback hook
- Returning false from a callback to halt the callback chain

I've removed each in a separate commit (I hope that's ok?)

In each case I've removed the old code without adding any new warning to users if they use the deprecated forms, and I've removed the tests without adding any new tests to explicitly check that the deprecated forms _do not_ work.
