### PR TITLE
Work around read/close race (x2)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ group :cable do
   gem "hiredis", require: false
   gem "redis", require: false
 
-  gem "websocket-client-simple", require: false
+  gem "websocket-client-simple", github: "matthewd/websocket-client-simple", branch: "close-race", require: false
 
   gem "blade", require: false, platforms: [:ruby]
   gem "blade-sauce_labs_plugin", require: false, platforms: [:ruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,15 @@ GIT
       ffi (>= 0.5.0)
 
 GIT
+  remote: https://github.com/matthewd/websocket-client-simple.git
+  revision: e161305f1a466b9398d86df3b1731b03362da91b
+  branch: close-race
+  specs:
+    websocket-client-simple (0.3.0)
+      event_emitter
+      websocket
+
+GIT
   remote: https://github.com/resque/resque.git
   revision: 20d885065ac19e7f7d7a982f4ed1296083db0300
   specs:
@@ -350,9 +359,6 @@ GEM
       nokogiri
     wdm (0.1.1)
     websocket (1.2.3)
-    websocket-client-simple (0.3.0)
-      event_emitter
-      websocket
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -414,7 +420,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   w3c_validators
   wdm (>= 0.1.0)
-  websocket-client-simple
+  websocket-client-simple!
 
 BUNDLED WITH
    1.13.2

--- a/actioncable/lib/action_cable/connection/stream.rb
+++ b/actioncable/lib/action_cable/connection/stream.rb
@@ -106,7 +106,6 @@ module ActionCable
         def clean_rack_hijack
           return unless @rack_hijack_io
           @event_loop.detach(@rack_hijack_io, self)
-          @rack_hijack_io.close
           @rack_hijack_io = nil
         end
     end

--- a/actioncable/lib/action_cable/connection/stream_event_loop.rb
+++ b/actioncable/lib/action_cable/connection/stream_event_loop.rb
@@ -36,6 +36,7 @@ module ActionCable
         @todo << lambda do
           @nio.deregister io
           @map.delete io
+          io.close
         end
         wakeup
       end

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -21,13 +21,6 @@ WebSocket::Frame::Data.prepend Module.new {
     super
   end
 }
-
-WebSocket::Client::Simple::Client.prepend Module.new {
-  def initialize(*)
-    @socket = nil
-    super
-  end
-}
 #
 ####
 


### PR DESCRIPTION
It is very very not-good if one thread calls `close` on an IO at the same time that another calls `read`.

The segfaults we've recently seen on Travis appear to be attributable to websocket-client-simple, but our real `close` method seems subject to the race too.

Branch is PRed here: https://github.com/shokai/websocket-client-simple/pull/25

```
*** glibc detected *** /home/travis/.rvm/rubies/ruby-2.3.1/bin/ruby: corrupted double-linked list: 0x00007fdd500155d0 ***
```

`valgrind --tool=memcheck --max-stackframe=8382448 --track-origins=yes ruby …` output: https://gist.github.com/matthewd/0d584378aa3c083fa3581c72f15e292a

Huge thanks to @tenderlove, who spent a lot of time on this with me -- and without whom I'd still just be staring blankly at Valgrind documentation 🍻

---

I suspect the upstream fix is to wait [inside `rb_thread_fd_close`](https://github.com/ruby/ruby/blob/dd3b3d716e8da28f0717537a37be62207dfbf7d2/thread.c#L2180) until there are no threads where `th->waiting_fd == fd`. But I'll defer to @ko1 and @nobu on that 😅
