### PR TITLE
In PostgreSQL, allow spaces in table names without schema

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
@@ -64,12 +64,16 @@ module ActiveRecord
         # * <tt>"schema_name".table_name</tt>
         # * <tt>"schema.name"."table name"</tt>
         def extract_schema_qualified_name(string)
-          schema, table = string.scan(/[^".\s]+|"[^"]*"/)
-          if table.nil?
-            table = schema
-            schema = nil
+          if string.include?(".")
+            schema, table = string.scan(/[^".\s]+|"[^"]*"/)
+            if table.nil?
+              table = schema
+              schema = nil
+            end
+            PostgreSQL::Name.new(schema, table)
+          else
+            PostgreSQL::Name.new(nil, string)
           end
-          PostgreSQL::Name.new(schema, table)
         end
       end
     end

--- a/activerecord/test/cases/adapters/postgresql/utils_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/utils_test.rb
@@ -8,6 +8,7 @@ class PostgreSQLUtilsTest < ActiveRecord::PostgreSQLTestCase
   def test_extract_schema_qualified_name
     {
       %(table_name)            => [nil,"table_name"],
+      %("table_name")            => [nil,"table_name"],
       %("table.name")          => [nil,"table.name"],
       %(schema.table_name)     => %w{schema table_name},
       %("schema".table_name)   => %w{schema table_name},

--- a/activerecord/test/cases/adapters/postgresql/utils_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/utils_test.rb
@@ -14,6 +14,8 @@ class PostgreSQLUtilsTest < ActiveRecord::PostgreSQLTestCase
       %(schema."table_name")   => %w{schema table_name},
       %("schema"."table_name") => %w{schema table_name},
       %("even spaces".table)   => ["even spaces","table"],
+      %(spaces table only)     => [nil,"spaces table only"],
+      %("spaces table only")   => [nil,"spaces table only"],
       %(schema."table.name")   => ["schema", "table.name"]
     }.each do |given, expect|
       assert_equal Name.new(*expect), extract_schema_qualified_name(given)


### PR DESCRIPTION
### Summary

Fix for #26721 by checking for a dot before parsing out schema. Test case added.
### Other Information

If your table name has spaces  (e.g. ‘work orders’) and you don’t
specify schema or use quotes, the postgresql adapter would use the
first word as schema. This fix interprets as table name unless it
contains a dot.

This function has previously been the source of performance issues. This change should cause a slight performance penalty when the schema is included, and improve performance when it's not.

I benchmarked this patch in rails 4.2.7 by running the test cases for 20s:

```
require 'test_helper'

class PgPerformanceTest < ActiveSupport::TestCase
  TIME    = (ENV['BENCHMARK_TIME'] || 20).to_i
  RECORDS = (ENV['BENCHMARK_RECORDS'] || TIME*1000).to_i

  test 'pg performance' do
    Benchmark.ips(TIME) do |x|
      test_cases = [
        %(table_name),
        %("table.name"),
        %(schema.table_name),
        %("schema".table_name),
        %(schema."table_name"),
        %("schema"."table_name"),
        %("even spaces".table),
        %(spaces table only),
        %("spaces table only"),
        %(schema."table.name"),
      ]

      x.report("without dot check") do
        test_cases.each do |given|
          ActiveRecord::ConnectionAdapters::PostgreSQL::Utils.extract_schema_qualified_name(given)
        end
      end

      x.report("with dot check") do
        test_cases.each do |given|
          ActiveRecord::ConnectionAdapters::PostgreSQL::Utils.my_extract_schema_qualified_name(given)
        end
      end
    end
  end
end
```

```
Warming up --------------------------------------
   without dot check     2.776k i/100ms
      with dot check     3.445k i/100ms
Calculating -------------------------------------
   without dot check     28.045k (± 5.0%) i/s -    560.752k in  20.055669s
      with dot check     35.182k (± 4.6%) i/s -    702.780k in  20.020912s
Finished in 44.31501s
```

First time contributor here! Hope I can get this to PR a usable state.
