### PR TITLE
Fixnum and Bignum are deprecated in Ruby trunk

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -34,8 +34,8 @@ module ActiveJob
   module Arguments
     extend self
     # :nodoc:
-    # Calls #uniq since Integer, Fixnum, and Bignum are all the same class on Ruby 2.4+
-    TYPE_WHITELIST = [ NilClass, String, Integer, Fixnum, Bignum, Float, BigDecimal, TrueClass, FalseClass ].uniq
+    TYPE_WHITELIST = [ NilClass, String, Integer, Float, BigDecimal, TrueClass, FalseClass ]
+    TYPE_WHITELIST.push(Fixnum, Bignum) unless 1.class == Integer
 
     # Serializes a set of arguments. Whitelisted types are returned
     # as-is. Arrays/Hashes are serialized element by element.

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -138,7 +138,7 @@ class QueryCacheTest < ActiveRecord::TestCase
         assert_kind_of Numeric, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
       elsif current_adapter?(:SQLite3Adapter, :Mysql2Adapter, :PostgreSQLAdapter)
         # Future versions of the sqlite3 adapter will return numeric
-        assert_instance_of Fixnum, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
+        assert_instance_of 0.class, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
       else
         assert_instance_of String, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
       end

--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -134,7 +134,7 @@ module ActiveSupport::NumericWithFormat
 end
 
 # Ruby 2.4+ unifies Fixnum & Bignum into Integer.
-if Integer == Fixnum
+if 0.class == Integer
   Integer.prepend ActiveSupport::NumericWithFormat
 else
   Fixnum.prepend ActiveSupport::NumericWithFormat

--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -48,8 +48,8 @@ module ActiveSupport
       }
 
       # No need to map these on Ruby 2.4+
-      TYPE_NAMES["Fixnum"] = "integer" unless Fixnum == Integer
-      TYPE_NAMES["Bignum"] = "integer" unless Bignum == Integer
+      TYPE_NAMES["Fixnum"] = "integer" unless 0.class == Integer
+      TYPE_NAMES["Bignum"] = "integer" unless 0.class == Integer
     end
 
     FORMATTING = {

--- a/activesupport/test/core_ext/array/grouping_test.rb
+++ b/activesupport/test/core_ext/array/grouping_test.rb
@@ -4,11 +4,11 @@ require "active_support/core_ext/array"
 class GroupingTest < ActiveSupport::TestCase
   def setup
     # In Ruby < 2.4, test we avoid Integer#/ (redefined by mathn)
-    Fixnum.send :private, :/ unless Fixnum == Integer
+    Fixnum.send :private, :/ unless 0.class == Integer
   end
 
   def teardown
-    Fixnum.send :public, :/ unless Fixnum == Integer
+    Fixnum.send :public, :/ unless 0.class == Integer
   end
 
   def test_in_groups_of_with_perfect_fit


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/12739

Previously: #25056 (which left these because the deprecation was undecided)

/cc @jeremy 
