### PR TITLE
Prevent to create blank comment

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -284,10 +284,10 @@ module ActiveRecord
         end
 
         if supports_comments? && !supports_comments_in_create?
-          change_table_comment(table_name, comment) if comment
+          change_table_comment(table_name, comment) if comment.present?
 
           td.columns.each do |column|
-            change_column_comment(table_name, column.name, column.comment) if column.comment
+            change_column_comment(table_name, column.name, column.comment) if column.comment.present?
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -509,7 +509,7 @@ module ActiveRecord
       end
 
       def add_sql_comment!(sql, comment) # :nodoc:
-        sql << " COMMENT #{quote(comment)}" if comment
+        sql << " COMMENT #{quote(comment)}" if comment.present?
         sql
       end
 

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -128,9 +128,7 @@ HEADER
 
           table_options = @connection.table_options(table)
           if table_options.present?
-            table_options.each do |key, value|
-              tbl.print ", #{key}: #{value.inspect}" if value.present?
-            end
+            tbl.print ", #{format_options(table_options)}"
           end
 
           tbl.puts " do |t|"
@@ -235,6 +233,10 @@ HEADER
 
           stream.puts add_foreign_key_statements.sort.join("\n")
         end
+      end
+
+      def format_options(options)
+        options.map { |key, value| "#{key}: #{value.inspect}" if value }.compact.join(", ")
       end
 
       def remove_prefix_and_suffix(table)


### PR DESCRIPTION
Currently blank comment does not dump to `db/schema.rb`. But created it
even if specified blank.
