### PR TITLE
fix `ActiveModel::Translation#human_attribute_name`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   fix `ActiveModel::Translation#human_attribute_name`
+
+    *Ryotaro Goto*
+
 *   Execute `ConfirmationValidator` validation when `_confirmation`'s value is `false`.
 
     *bogdanvlviv*

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -44,7 +44,7 @@ module ActiveModel
     def human_attribute_name(attribute, options = {})
       options   = { count: 1 }.merge!(options)
       parts     = attribute.to_s.split(".")
-      attribute = parts.pop
+      attribute = parts.pop || ""
       namespace = parts.join("/") unless parts.empty?
       attributes_scope = "#{i18n_scope}.attributes"
 
@@ -55,7 +55,9 @@ module ActiveModel
         defaults << :"#{attributes_scope}.#{namespace}.#{attribute}"
       else
         defaults = lookup_ancestors.map do |klass|
-          :"#{attributes_scope}.#{klass.model_name.i18n_key}.#{attribute}"
+          attribute.empty? ?
+            :"#{attributes_scope}.#{klass.model_name.i18n_key}" :
+            :"#{attributes_scope}.#{klass.model_name.i18n_key}.#{attribute}"
         end
       end
 

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -39,6 +39,14 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     assert_equal "Name", Person.human_attribute_name("name", default: :default_name)
   end
 
+  def test_human_attribute_name_empty_arg
+    assert_equal "", Person.human_attribute_name("")
+  end
+
+  def test_human_attribute_name_empty_arg_using_default_option
+    assert_equal "name default attribute", Person.human_attribute_name("", default: "name default attribute")
+  end
+
   def test_translated_model_attributes_with_symbols
     I18n.backend.store_translations "en", activemodel: { attributes: { person: { name: "person name attribute" } } }
     assert_equal "person name attribute", Person.human_attribute_name(:name)


### PR DESCRIPTION
### Summary

ActiveModel::Translation#human_attribute_name occurs an error
when first argument is "" and :"".

```
NoMethodError: undefined method `humanize' for nil:NilClass
```

Now

```
Person.human_attribute_name("") #=> NoMethodError
Person.human_attribute_name("", default: "name default")
#=> NoMethodError
```

After fixed

```
Person.human_attribute_name("") #=> ""

Person.human_attribute_name("", default: "name default")
#=> "name default"
```
### Other Information

benchmarked a region that seems to affect speed in this change

Warming up --------------------------------------
                   A   155.962k i/100ms
                   B   152.921k i/100ms
Calculating -------------------------------------
                   A      2.661M (± 3.1%) i/s -     13.413M in   5.044699s
                   B      2.559M (± 4.0%) i/s -     12.845M in   5.028342s

Comparison:
                   A:  2661421.7 i/s
                   B:  2558689.0 i/s - same-ish: difference falls within error

the code is

```
require 'benchmark/ips'
Benchmark.ips do |x|
  x.report('A') {
    klass_name = 'Person'
    attribute = 'name'
    :"#{klass_name}.#{attribute}"
  }
  x.report('B') {
    klass_name = 'Person'
    attribute = 'name'
    attribute.empty? ?
      :"#{klass_name}" :
      :"#{klass_name}.#{attribute}"
  }

  x.compare!
end
```
