### PR TITLE
Fix table comment dumping

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -239,7 +239,9 @@ module ActiveRecord
         end
 
         def table_options(table_name) # :nodoc:
-          { comment: table_comment(table_name) }
+          if comment = table_comment(table_name)
+            { comment: comment }
+          end
         end
 
         # Returns a comment stored in database for given table

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -229,7 +229,7 @@ HEADER
       end
 
       def format_options(options)
-        options.map { |key, value| "#{key}: #{value.inspect}" if value }.compact.join(", ")
+        options.map { |key, value| "#{key}: #{value.inspect}" }.join(", ")
       end
 
       def remove_prefix_and_suffix(table)

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -51,6 +51,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     output = standard_dump
     assert_match %r{create_table "accounts"}, output
     assert_match %r{create_table "authors"}, output
+    assert_no_match %r{(?<=, ) do \|t\|}, output
     assert_no_match %r{create_table "schema_migrations"}, output
     assert_no_match %r{create_table "ar_internal_metadata"}, output
   end


### PR DESCRIPTION
Follow up to #26735.

If `table_options` returns `{ comment: nil }`, `create_table` line is
broken.

Example:

``` ruby
  create_table "accounts", force: :cascade,  do |t|
```
