### PR TITLE
Set target ruby version for rubocop to 2.2 instead 2.3.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.2
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
   DisabledByDefault: true


### PR DESCRIPTION
### Summary

This change will help to catch ruby 2.3+ syntax in code base. Right now, minimal ruby version set to 2.2.2 in gemspecs.
