### PR TITLE
Create secure tokens that are stored as a digest

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Using `has_secure_token_digest` on a model will now allow generating a
+    secure random token and store the encrypted token as a `_digest` of that attribute.
+    This will also include a method `#authenticated?` to test whether an
+    unencrypted token matches the encrypted digest.
+
+    *Unathi Chonco*
+
 *   Fixed support for case insensitive comparisons of `text` columns in
     PostgreSQL.
 

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -73,6 +73,7 @@ module ActiveRecord
   autoload :Translation
   autoload :Validations
   autoload :SecureToken
+  autoload :SecureTokenDigest
 
   eager_autoload do
     autoload :ActiveRecordError, "active_record/errors"

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -319,6 +319,7 @@ module ActiveRecord #:nodoc:
     include Store
     include SecureToken
     include Suppressor
+    include SecureTokenDigest
   end
 
   ActiveSupport.run_load_hooks(:active_record, Base)

--- a/activerecord/lib/active_record/secure_token_digest.rb
+++ b/activerecord/lib/active_record/secure_token_digest.rb
@@ -88,8 +88,8 @@ module ActiveRecord
       #
       #   user = User.new(name: 'david', token: 'mUc3m00RsqyRe')
       #   user.save
-      #   user.authenticate(:token, 'notright')         # => false
-      #   user.authenticate(:token, 'mUc3m00RsqyRe')    # => true
+      #   user.authenticated?(:token, 'notright')         # => false
+      #   user.authenticated?(:token, 'mUc3m00RsqyRe')    # => true
       def authenticated?(attribute, unencrypted_token)
         BCrypt::Password.new(self.send("#{attribute}_digest")).is_password?(unencrypted_token)
       end

--- a/activerecord/lib/active_record/secure_token_digest.rb
+++ b/activerecord/lib/active_record/secure_token_digest.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       #
       # Example using #has_secure_token_digest
       #
-      #   # Schema: User(name:string, password_digest:string)
+      #   # Schema: User(name:string, token_digest:string, activation_token_digest:string)
       #   class User < ActiveRecord::Base
       #     has_secure_token_digest
       #     has_secure_token_digest :activation_token

--- a/activerecord/lib/active_record/secure_token_digest.rb
+++ b/activerecord/lib/active_record/secure_token_digest.rb
@@ -7,16 +7,16 @@ module ActiveRecord
       # This mechanism requires you to have a +XXX_digest+ attribute.
       # Where +XXX+ is the name of your desired token
       #
-      # Add bcrypt (~> 3.1.7) to Gemfile to use #has_secure_digest:
+      # Add bcrypt (~> 3.1.7) to Gemfile to use #has_secure_token_digest:
       #
       #   gem 'bcrypt', '~> 3.1.7'
       #
-      # Example using #has_secure_digest
+      # Example using #has_secure_token_digest
       #
       #   # Schema: User(name:string, password_digest:string)
       #   class User < ActiveRecord::Base
-      #     has_secure_digest
-      #     has_secure_digest :activation_token
+      #     has_secure_token_digest
+      #     has_secure_token_digest :activation_token
       #   end
       #
       #   user = User.new(name: 'david', token: 'custom_token')

--- a/activerecord/lib/active_record/secure_token_digest.rb
+++ b/activerecord/lib/active_record/secure_token_digest.rb
@@ -1,0 +1,98 @@
+module ActiveRecord
+  module SecureTokenDigest
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Adds methods to set and authenticate against a BCrypt token.
+      # This mechanism requires you to have a +XXX_digest+ attribute.
+      # Where +XXX+ is the name of your desired token
+      #
+      # Add bcrypt (~> 3.1.7) to Gemfile to use #has_secure_digest:
+      #
+      #   gem 'bcrypt', '~> 3.1.7'
+      #
+      # Example using #has_secure_digest
+      #
+      #   # Schema: User(name:string, password_digest:string)
+      #   class User < ActiveRecord::Base
+      #     has_secure_digest
+      #     has_secure_digest :activation_token
+      #   end
+      #
+      #   user = User.new(name: 'david', token: 'custom_token')
+      #   user.save                                               # => true
+      #   user.token                                              # => 'custom_token'
+      #   user.token_digest                                       # => '...$2a$10$WwyBciEDPyZ8T0NNSJoZrObu6KxFnQDdzZoC0gMR6X.ylW03JL2V2'
+      #   user.activation_token                                   # => nil
+      #   user.activation_token_digest                            # => nil
+      #
+      #   user.regenerate_activation_token                        # => true
+      #   user.activation_token                                   # => 'mUc3m00RsqyRe'
+      #   user.activation_token_digest                            # => '$2a$10$4LEA7r4YmNHtvlAvHhsYAeZmk/xeUVtMTYqwIvYY76EW5GUqDiP4.'
+      #   user.authenticated?(:activation_token,'notright')       # => false
+      #   user.authenticated?(:activation_token,'mUc3m00RsqyRe')  # => true
+      def has_secure_token_digest(attribute = :token)
+        # Load bcrypt gem only when has_secure_token_digest is used.
+        begin
+          require "bcrypt"
+        rescue LoadError
+          $stderr.puts "You don't have bcrypt installed in your application. Please add it to your Gemfile and run bundle install"
+          raise
+        end
+
+        attr_reader attribute
+
+        include InstanceMethodsOnActivation
+
+        # Encrypts the token into the +_digest+ attribute, only if the
+        # new token is not empty.
+        #
+        #   class User < ActiveRecord::Base
+        #     has_secure_token_digest
+        #   end
+        #
+        #   user = User.new
+        #   user.token = nil
+        #   user.token_digest # => nil
+        #   user.token = 'mUc3m00RsqyRe'
+        #   user.token_digest # => "$2a$10$4LEA7r4YmNHtvlAvHhsYAeZmk/xeUVtMTYqwIvYY76EW5GUqDiP4."
+        define_method("#{attribute}=") do |unencrypted_token|
+          if unencrypted_token.nil?
+            self.send("#{attribute}_digest=", nil)
+          elsif !unencrypted_token.empty?
+            instance_variable_set("@#{attribute}", unencrypted_token)
+            cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
+            self.send("#{attribute}_digest=", BCrypt::Password.create(unencrypted_token, cost: cost))
+          end
+        end
+
+        define_method("regenerate_#{attribute}") do
+          self.send("#{attribute}=", self.class.generate_unique_secure_token)
+          self.send("save!")
+        end
+      end
+
+      def generate_unique_secure_token
+        SecureRandom.base58(24)
+      end
+    end
+
+    module InstanceMethodsOnActivation
+      require "active_support/core_ext/securerandom"
+
+      # Returns +true+ if the token is correct, otherwise +false+.
+      #
+      #   class User < ActiveRecord::Base
+      #     has_secure_token_digest
+      #   end
+      #
+      #   user = User.new(name: 'david', token: 'mUc3m00RsqyRe')
+      #   user.save
+      #   user.authenticate(:token, 'notright')         # => false
+      #   user.authenticate(:token, 'mUc3m00RsqyRe')    # => true
+      def authenticated?(attribute, unencrypted_token)
+        BCrypt::Password.new(self.send("#{attribute}_digest")).is_password?(unencrypted_token)
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/secure_token_digest_test.rb
+++ b/activerecord/test/cases/secure_token_digest_test.rb
@@ -1,0 +1,49 @@
+require "cases/helper"
+require "models/user"
+
+class SecureTokenDigestTest < ActiveRecord::TestCase
+  setup do
+    @user = User.new
+  end
+
+  def test_token_values_are_not_automatically_generated_on_create
+    @user.save
+
+    assert_nil @user.activation_token
+    assert_nil @user.activation_token_digest
+  end
+
+  def test_regenerating_the_secure_digest
+    @user.regenerate_activation_token
+
+    assert_not_nil @user.activation_token
+    assert_not_nil @user.activation_token_digest
+  end
+
+  def test_token_value_not_overwritten_when_present
+    @user.activation_token = "custom-secure-token"
+    @user.save
+
+    assert_equal @user.activation_token, "custom-secure-token"
+  end
+
+  def test_token_and_digest_replaced_on_regeneration
+    @user.activation_token = "custom-secure-token"
+    @user.save
+
+    old_token = @user.activation_token
+    old_digest = @user.activation_token_digest
+    @user.regenerate_activation_token
+
+    assert_not_equal @user.activation_token, old_token
+    assert_not_equal @user.activation_token_digest, old_digest
+  end
+
+  def test_authenticated_returns_correct_result
+    @user.regenerate_activation_token
+    correct_token = @user.activation_token
+
+    assert @user.authenticated?(:activation_token, correct_token)
+    assert_not @user.authenticated?(:activation_token, 'notright')
+  end
+end

--- a/activerecord/test/models/user.rb
+++ b/activerecord/test/models/user.rb
@@ -3,6 +3,7 @@ require "models/job"
 class User < ActiveRecord::Base
   has_secure_token
   has_secure_token :auth_token
+  has_secure_token_digest :activation_token
 
   has_and_belongs_to_many :jobs_pool,
     class_name: Job,

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1022,6 +1022,7 @@ ActiveRecord::Schema.define do
   create_table :users, force: true do |t|
     t.string :token
     t.string :auth_token
+    t.string :activation_token_digest
   end
 
   create_table :test_with_keyword_column_name, force: true do |t|


### PR DESCRIPTION
### Summary

Using `has_secure_token_digest` on a model will now allow generating a
secure random token and store the encrypted token as a `_digest` of that attribute.
This also includes a method `#authenticated?` to test whether an
unencrypted token matches the encrypted digest.
### Other Information

This serves as a dynamic version of `has_secure_password` and also can be used
as a more secure variant to `has_secure_token`
