### PR TITLE
Remove delete deprecations in AR::Relation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove ability to pass conditions in `destroy_all` and `delete_all` methods
+
+    *Dino Maric*
+
 *   Fixed support for case insensitive comparisons of `text` columns in
     PostgreSQL.
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -443,16 +443,8 @@ module ActiveRecord
     # ==== Examples
     #
     #   Person.where(age: 0..18).destroy_all
-    def destroy_all(conditions = nil)
-      if conditions
-        ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)
-          Passing conditions to destroy_all is deprecated and will be removed in Rails 5.1.
-          To achieve the same use where(conditions).destroy_all.
-        MESSAGE
-        where(conditions).destroy_all
-      else
-        records.each(&:destroy).tap { reset }
-      end
+    def destroy_all
+      records.each(&:destroy).tap { reset }
     end
 
     # Destroy an object (or multiple objects) that has the given id. The object is instantiated first,
@@ -500,7 +492,7 @@ module ActiveRecord
     #
     #   Post.limit(100).delete_all
     #   # => ActiveRecord::ActiveRecordError: delete_all doesn't support limit
-    def delete_all(conditions = nil)
+    def delete_all
       invalid_methods = INVALID_METHODS_FOR_DELETE_ALL.select do |method|
         value = get_value(method)
         SINGLE_VALUE_METHODS.include?(method) ? value : value.any?
@@ -509,27 +501,19 @@ module ActiveRecord
         raise ActiveRecordError.new("delete_all doesn't support #{invalid_methods.join(', ')}")
       end
 
-      if conditions
-        ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)
-          Passing conditions to delete_all is deprecated and will be removed in Rails 5.1.
-          To achieve the same use where(conditions).delete_all.
-        MESSAGE
-        where(conditions).delete_all
+      stmt = Arel::DeleteManager.new
+      stmt.from(table)
+
+      if joins_values.any?
+        @klass.connection.join_to_delete(stmt, arel, arel_attribute(primary_key))
       else
-        stmt = Arel::DeleteManager.new
-        stmt.from(table)
-
-        if joins_values.any?
-          @klass.connection.join_to_delete(stmt, arel, arel_attribute(primary_key))
-        else
-          stmt.wheres = arel.constraints
-        end
-
-        affected = @klass.connection.delete(stmt, "SQL", bound_attributes)
-
-        reset
-        affected
+        stmt.wheres = arel.constraints
       end
+
+      affected = @klass.connection.delete(stmt, "SQL", bound_attributes)
+
+      reset
+      affected
     end
 
     # Deletes the row with a primary key matching the +id+ argument, using a

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1014,23 +1014,11 @@ class RelationTest < ActiveRecord::TestCase
     assert davids.loaded?
   end
 
-  def test_destroy_all_with_conditions_is_deprecated
-    assert_deprecated do
-      assert_difference("Author.count", -1) { Author.destroy_all(name: "David") }
-    end
-  end
-
   def test_delete_all
     davids = Author.where(name: "David")
 
     assert_difference("Author.count", -1) { davids.delete_all }
     assert ! davids.loaded?
-  end
-
-  def test_delete_all_with_conditions_is_deprecated
-    assert_deprecated do
-      assert_difference("Author.count", -1) { Author.delete_all(name: "David") }
-    end
   end
 
   def test_delete_all_loaded


### PR DESCRIPTION
Remove ability to pass conditions to `destroy_all` and `delete_all`methods in `ActiveRecord::Relation`
