### PR TITLE
Docs: `tag` only accept attribute names as symbols

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -139,6 +139,7 @@ module ActionView
       # ==== Options
       #
       # Any passed options become attributes on the generated tag.
+      # You can only use symbols (not strings) for the attribute names.
       #
       #   tag.section class: %w( kitties puppies )
       #   # => <section class="kitties puppies"></section>
@@ -200,7 +201,7 @@ module ActionView
       # hash to +options+. Set +escape+ to false to disable attribute value
       # escaping.
       #
-      # ==== Options
+      # ==== Options (Legacy syntax)
       #
       # You can use symbols or strings for the attribute names.
       #
@@ -210,7 +211,7 @@ module ActionView
       # HTML5 <tt>data-*</tt> attributes can be set with a single +data+ key
       # pointing to a hash of sub-attributes.
       #
-      # ==== Examples
+      # ==== Examples (Legacy syntax)
       #
       #   tag("br")
       #   # => <br />


### PR DESCRIPTION
[ci skip]

See https://github.com/rails/rails/issues/26518#issuecomment-252826489

@dhh:

> I'd support symbol-only keys going forward with these new APIs.
> We can break with the past here since the tag proxy is new and so is form_with.
