### PR TITLE
[ci skip] fix typo in Actionpack Changelog

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -11,7 +11,7 @@
 
     *Rafael Mendonça França*
 
-*   Remove deprecated support for passing `:path` and route path as stings in `ActionDispatch::Routing::Mapper#match`.
+*   Remove deprecated support for passing `:path` and route path as strings in `ActionDispatch::Routing::Mapper#match`.
 
     *Rafael Mendonça França*
 


### PR DESCRIPTION
Change `stings` to `strings` in recent Changelog update.
