### PR TITLE
Output which file rake log:clear is truncating

### DIFF
--- a/railties/lib/rails/tasks/log.rake
+++ b/railties/lib/rails/tasks/log.rake
@@ -31,6 +31,7 @@ namespace :log do
 
   def clear_log_file(file)
     f = File.open(file, "w")
+    puts "Truncating #{file}"
     f.close
   end
 end

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -54,6 +54,7 @@ Created database 'db/development.sqlite3'
 Created database 'db/test.sqlite3'
 
 == Removing old logs and tempfiles ==
+Truncating log/development.log
 
 == Restarting application server ==
         OUTPUT


### PR DESCRIPTION
This is a simple change that outputs which file `rake log:clear` is truncating.
