### PR TITLE
Clarify comment for config.action_dispatch.show_exceptions

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -22,7 +22,8 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Raise exceptions instead of rendering exception templates.
+  # This flag will render exception templates when true.
+  # If you want to raise exceptions, set to false.
   config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment.


### PR DESCRIPTION
### Summary

The comment for `config.action_dispatch.show_exceptions = false` is ambiguous. It sounds like show exceptions will raise exceptions, but the opposite is true. Show exceptions will suppress them.
### Other Information

It took me 10 min. to figure this out. 
