### PR TITLE
Update sqlite3 gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,9 +286,9 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.11)
-    sqlite3 (1.3.11-x64-mingw32)
-    sqlite3 (1.3.11-x86-mingw32)
+    sqlite3 (1.3.12)
+    sqlite3 (1.3.12-x64-mingw32)
+    sqlite3 (1.3.12-x86-mingw32)
     stackprof (0.2.9)
     sucker_punch (2.0.2)
       concurrent-ruby (~> 1.0.0)
@@ -379,4 +379,4 @@ DEPENDENCIES
   wdm (>= 0.1.0)
 
 BUNDLED WITH
-   1.13.1
+   1.13.3


### PR DESCRIPTION
### Summary

Updated the sqlite3 gem to prevent segmentation faults on MacOS sierra.
