### PR TITLE
Clarify default adapter in ActionCable guide  [ci skip]

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -240,9 +240,9 @@ WebNotificationsChannel.broadcast_to(
 ```
 
 The `WebNotificationsChannel.broadcast_to` call places a message in the current
-subscription adapter (by default `redis` for production and `async` for development & test)'s 
-pubsub queue under a separate broadcasting name for each user. For a user with an ID of 1, 
-the broadcasting name would be `web_notifications:1`.
+subscription adapter (by default `redis` for production and `async` for development and 
+test environments)'s pubsub queue under a separate broadcasting name for each user. 
+For a user with an ID of 1, the broadcasting name would be `web_notifications:1`.
 
 The channel has been instructed to stream everything that arrives at
 `web_notifications:1` directly to the client by invoking the `received`

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -240,9 +240,9 @@ WebNotificationsChannel.broadcast_to(
 ```
 
 The `WebNotificationsChannel.broadcast_to` call places a message in the current
-subscription adapter (Redis by default)'s pubsub queue under a separate
-broadcasting name for each user. For a user with an ID of 1, the broadcasting
-name would be `web_notifications:1`.
+subscription adapter (by default `redis` for production and `async` for development & test)'s 
+pubsub queue under a separate broadcasting name for each user. For a user with an ID of 1, 
+the broadcasting name would be `web_notifications:1`.
 
 The channel has been instructed to stream everything that arrives at
 `web_notifications:1` directly to the client by invoking the `received`


### PR DESCRIPTION
The current guide states that the default adapter for ActionCable is Redis. However Redis 
is only the default adapter for the production environment (as defined in `cable.yml`).

If by _default_ we understand the development environment that most people are running when following the guides, this may be confusing.
