### PR TITLE
id composite support

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -558,7 +558,11 @@ module ActiveRecord
       attributes_values = arel_attributes_with_values_for_create(attribute_names)
 
       new_id = self.class.unscoped.insert attributes_values
-      self.id ||= new_id if self.class.primary_key
+      if self.class.primary_key.kind_of?(Array)
+        self.id = new_id
+      else
+        self.id ||= new_id if self.class.primary_key
+      end
 
       @new_record = false
       id


### PR DESCRIPTION
### Summary

Validates if id is composite. In this case, self.id need receive id from db because operator ||= is not null in some cases.
### Other Information

Ex: 
t.integer :id
t.boolean :active

self.primary_key = :id, :active

in this case, after save the record, id not receives the return from db, then your value remains nil
