### PR TITLE
Support index.length for MySQL 8.0.0-dmr

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -388,7 +388,7 @@ module ActiveRecord
             end
 
             indexes.last.columns << row[:Column_name]
-            indexes.last.lengths.merge!(row[:Column_name] => row[:Sub_part]) if row[:Sub_part]
+            indexes.last.lengths.merge!(row[:Column_name] => row[:Sub_part].to_i) if row[:Sub_part]
           end
         end
 


### PR DESCRIPTION
### Summary

This pull request addresses #26774 since MySQL 8.0.0-dmr `SUB_PART` column of `information_schema.statistics` changed to varbinary(12), which is bigint(3) in MySQL 5.6.

This pull request has been tested with both versions of MySQL.

```
Server version: 8.0.0-dmr MySQL Community Server (GPL)
Server version: 5.6.33 MySQL Community Server (GPL)
```
