### PR TITLE
Allow any key in Renderer environment hash

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Allow keys not found in RACK_KEY_TRANSLATION for setting the environment when rendering
+    arbitrary templates.
+
+    *Sammy Larbi*
+
 *   Remove deprecated support to non-keyword arguments in `ActionDispatch::IntegrationTest#process`,
     `#get`, `#post`, `#patch`, `#put`, `#delete`, and `#head`.
 

--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -102,7 +102,9 @@ module ActionController
         method: ->(v) { v.upcase },
       }
 
-      def rack_key_for(key); RACK_KEY_TRANSLATION[key]; end
+      def rack_key_for(key)
+        RACK_KEY_TRANSLATION.fetch(key, key.to_s)
+      end
 
       def rack_value_for(key, value)
         RACK_VALUE_TRANSLATION.fetch(key, IDENTITY).call value

--- a/actionpack/test/controller/renderer_test.rb
+++ b/actionpack/test/controller/renderer_test.rb
@@ -60,6 +60,14 @@ class RendererTest < ActiveSupport::TestCase
     assert_equal "true", content
   end
 
+  test "rendering with custom env using a key that is not in RACK_KEY_TRANSLATION" do
+    value    = "warden is here"
+    renderer = ApplicationController.renderer.new warden: value
+    content  = renderer.render inline: "<%= request.env['warden'] %>"
+
+    assert_equal value, content
+  end
+
   test "rendering with defaults" do
     renderer = ApplicationController.renderer.new https: true
     content = renderer.render inline: "<%= request.ssl? %>"


### PR DESCRIPTION
When rendering arbitrary templates, it would be helpful to not overwrite `env` keys with `nil` if they don't match any found in the `RACK_KEY_TRANSLATION` hash.

Is there any interest in this?
