### PR TITLE
Use built-in #transform_values when available.

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/transform_values.rb
+++ b/activesupport/lib/active_support/core_ext/hash/transform_values.rb
@@ -16,7 +16,7 @@ class Hash
       result[key] = yield(value)
     end
     result
-  end
+  end unless method_defined? :transform_values
 
   # Destructively converts all values using the +block+ operations.
   # Same as +transform_values+ but modifies +self+.
@@ -25,5 +25,5 @@ class Hash
     each do |key, value|
       self[key] = yield(value)
     end
-  end
+  end unless method_defined? :transform_values!
 end


### PR DESCRIPTION
The methods Hash#transform_values and Hash#transform_values! have been
implemented in Ruby and they'll be available as part of the standard
library.

Here's the link to the discussion in Ruby's issue tracker:
https://bugs.ruby-lang.org/issues/12512

These methods are implemented in C so they're expected to perform
better.
