### PR TITLE
Removed ActiveRecord::Type::Value

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecated ActiveRecord::Type::Value in favor of ActiveModel::Type::Value
+
+    *Iain Beeston*
+
 *   Fixed support for case insensitive comparisons of `text` columns in
     PostgreSQL.
 

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -3,7 +3,7 @@ require "active_support/core_ext/string/strip"
 module ActiveRecord
   module AttributeMethods
     module TimeZoneConversion
-      class TimeZoneConverter < DelegateClass(Type::Value) # :nodoc:
+      class TimeZoneConverter < DelegateClass(ActiveModel::Type::Value) # :nodoc:
         def deserialize(value)
           convert_time_to_time_zone(super)
         end

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -116,9 +116,9 @@ module ActiveRecord
       # Users may also define their own custom types, as long as they respond
       # to the methods defined on the value type. The method +deserialize+ or
       # +cast+ will be called on your type object, with raw input from the
-      # database or from your controllers. See ActiveRecord::Type::Value for the
+      # database or from your controllers. See ActiveModel::Type::Value for the
       # expected API. It is recommended that your type objects inherit from an
-      # existing type, or from ActiveRecord::Type::Value
+      # existing type, or from ActiveModel::Type::Value
       #
       #   class MoneyType < ActiveRecord::Type::Integer
       #     def cast(value)
@@ -143,7 +143,7 @@ module ActiveRecord
       #   store_listing.price_in_cents # => 1000
       #
       # For more details on creating custom types, see the documentation for
-      # ActiveRecord::Type::Value. For more details on registering your types
+      # ActiveModel::Type::Value. For more details on registering your types
       # to be referenced by a symbol, see ActiveRecord::Type.register. You can
       # also pass a type object directly, in place of a symbol.
       #
@@ -190,7 +190,7 @@ module ActiveRecord
       # The type of an attribute is given the opportunity to change how dirty
       # tracking is performed. The methods +changed?+ and +changed_in_place?+
       # will be called from ActiveModel::Dirty. See the documentation for those
-      # methods in ActiveRecord::Type::Value for more details.
+      # methods in ActiveModel::Type::Value for more details.
       def attribute(name, cast_type, **options)
         name = name.to_s
         reload_schema_from_cache

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module OID # :nodoc:
-        class Array < Type::Value # :nodoc:
+        class Array < ActiveModel::Type::Value # :nodoc:
           include Type::Helpers::Mutable
 
           attr_reader :subtype, :delimiter

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/bit.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/bit.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module OID # :nodoc:
-        class Bit < Type::Value # :nodoc:
+        class Bit < ActiveModel::Type::Value # :nodoc:
           def type
             :bit
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/cidr.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/cidr.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module OID # :nodoc:
-        class Cidr < Type::Value # :nodoc:
+        class Cidr < ActiveModel::Type::Value # :nodoc:
           def type
             :cidr
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/enum.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/enum.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module OID # :nodoc:
-        class Enum < Type::Value # :nodoc:
+        class Enum < ActiveModel::Type::Value # :nodoc:
           def type
             :enum
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/hstore.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/hstore.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module OID # :nodoc:
-        class Hstore < Type::Value # :nodoc:
+        class Hstore < ActiveModel::Type::Value # :nodoc:
           include Type::Helpers::Mutable
 
           def type

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/legacy_point.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/legacy_point.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module OID # :nodoc:
-        class LegacyPoint < Type::Value # :nodoc:
+        class LegacyPoint < ActiveModel::Type::Value # :nodoc:
           include Type::Helpers::Mutable
 
           def type

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/point.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/point.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module OID # :nodoc:
-        class Point < Type::Value # :nodoc:
+        class Point < ActiveModel::Type::Value # :nodoc:
           include Type::Helpers::Mutable
 
           def type

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module OID # :nodoc:
-        class Range < Type::Value # :nodoc:
+        class Range < ActiveModel::Type::Value # :nodoc:
           attr_reader :subtype, :type
           delegate :user_input_in_time_zone, to: :subtype
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module OID # :nodoc:
-        class Uuid < Type::Value # :nodoc:
+        class Uuid < ActiveModel::Type::Value # :nodoc:
           ACCEPTABLE_UUID = %r{\A\{?([a-fA-F0-9]{4}-?){8}\}?\z}x
 
           alias_method :serialize, :deserialize

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/vector.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/vector.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module OID # :nodoc:
-        class Vector < Type::Value # :nodoc:
+        class Vector < ActiveModel::Type::Value # :nodoc:
           attr_reader :delim, :subtype
 
           # +delim+ corresponds to the `typdelim` column in the pg_types

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -104,7 +104,7 @@ module ActiveRecord
       super
     end
 
-    class EnumType < Type::Value # :nodoc:
+    class EnumType < ActiveModel::Type::Value # :nodoc:
       delegate :type, to: :subtype
 
       def initialize(name, mapping, subtype)

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -187,7 +187,7 @@ module ActiveRecord
     # In de/serialize we change `nil` to 0, so that we can allow passing
     # `nil` values to `lock_version`, and not result in `ActiveRecord::StaleObjectError`
     # during update record.
-    class LockingType < DelegateClass(Type::Value) # :nodoc:
+    class LockingType < DelegateClass(ActiveModel::Type::Value) # :nodoc:
       def deserialize(value)
         super.to_i
       end

--- a/activerecord/lib/active_record/type/internal/abstract_json.rb
+++ b/activerecord/lib/active_record/type/internal/abstract_json.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module Type
     module Internal # :nodoc:
-      class AbstractJson < Type::Value # :nodoc:
+      class AbstractJson < ActiveModel::Type::Value # :nodoc:
         include Type::Helpers::Mutable
 
         def type

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -1,6 +1,6 @@
 module ActiveRecord
   module Type
-    class Serialized < DelegateClass(Type::Value) # :nodoc:
+    class Serialized < DelegateClass(ActiveModel::Type::Value) # :nodoc:
       include Type::Helpers::Mutable
 
       attr_reader :subtype, :coder

--- a/activerecord/lib/active_record/type/value.rb
+++ b/activerecord/lib/active_record/type/value.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module Type
-    class Value < ActiveModel::Type::Value; end
+    Value = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("ActiveRecord::Type::Value", "ActiveModel::Type::Value")
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/composite_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/composite_test.rb
@@ -80,7 +80,7 @@ end
 class PostgresqlCompositeWithCustomOIDTest < ActiveRecord::PostgreSQLTestCase
   include PostgresqlCompositeBehavior
 
-  class FullAddressType < ActiveRecord::Type::Value
+  class FullAddressType < ActiveModel::Type::Value
     def type; :full_address end
 
     def deserialize(value)

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -127,7 +127,7 @@ module ActiveRecord
 
     if ActiveRecord::Base.connection.prepared_statements
       def test_statement_key_is_logged
-        bind = Relation::QueryAttribute.new(nil, 1, Type::Value.new)
+        bind = Relation::QueryAttribute.new(nil, 1, ActiveModel::Type::Value.new)
         @connection.exec_query("SELECT $1::integer", "SQL", [bind], prepare: true)
         name = @subscriber.payloads.last[:statement_name]
         assert name

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -219,7 +219,7 @@ module ActiveRecord
             string = @connection.quote("foo")
             @connection.exec_query("INSERT INTO ex (id, data) VALUES (1, #{string})")
 
-            bind = Relation::QueryAttribute.new("id", 1, Type::Value.new)
+            bind = Relation::QueryAttribute.new("id", 1, ActiveModel::Type::Value.new)
             result = @connection.exec_query("SELECT id, data FROM ex WHERE id = $1", nil, [bind])
 
             assert_equal 1, result.rows.length

--- a/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
@@ -114,6 +114,6 @@ class SchemaAuthorizationTest < ActiveRecord::PostgreSQLTestCase
     end
 
     def bind_param(value)
-      ActiveRecord::Relation::QueryAttribute.new(nil, value, ActiveRecord::Type::Value.new)
+      ActiveRecord::Relation::QueryAttribute.new(nil, value, ActiveModel::Type::Value.new)
     end
 end

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -476,7 +476,7 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     end
 
     def bind_param(value)
-      ActiveRecord::Relation::QueryAttribute.new(nil, value, ActiveRecord::Type::Value.new)
+      ActiveRecord::Relation::QueryAttribute.new(nil, value, ActiveModel::Type::Value.new)
     end
 end
 

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -82,7 +82,7 @@ module ActiveRecord
 
       def test_exec_insert
         with_example_table do
-          vals = [Relation::QueryAttribute.new("number", 10, Type::Value.new)]
+          vals = [Relation::QueryAttribute.new("number", 10, ActiveModel::Type::Value.new)]
           @conn.exec_insert("insert into ex (number) VALUES (?)", "SQL", vals)
 
           result = @conn.exec_query(
@@ -150,7 +150,7 @@ module ActiveRecord
         with_example_table "id int, data string" do
           @conn.exec_query('INSERT INTO ex (id, data) VALUES (1, "foo")')
           result = @conn.exec_query(
-            "SELECT id, data FROM ex WHERE id = ?", nil, [Relation::QueryAttribute.new(nil, 1, Type::Value.new)])
+            "SELECT id, data FROM ex WHERE id = ?", nil, [Relation::QueryAttribute.new(nil, 1, ActiveModel::Type::Value.new)])
 
           assert_equal 1, result.rows.length
           assert_equal 2, result.columns.length

--- a/activerecord/test/cases/attribute_set_test.rb
+++ b/activerecord/test/cases/attribute_set_test.rb
@@ -141,7 +141,7 @@ module ActiveRecord
     end
 
     test "fetch_value returns nil for unknown attributes when types has a default" do
-      types = Hash.new(Type::Value.new)
+      types = Hash.new(ActiveModel::Type::Value.new)
       builder = AttributeSet::Builder.new(types)
       attributes = builder.build_from_database
 
@@ -219,7 +219,7 @@ module ActiveRecord
     end
 
     test "#accessed_attributes returns only attributes which have been read" do
-      builder = AttributeSet::Builder.new(foo: Type::Value.new, bar: Type::Value.new)
+      builder = AttributeSet::Builder.new(foo: ActiveModel::Type::Value.new, bar: ActiveModel::Type::Value.new)
       attributes = builder.build_from_database(foo: "1", bar: "2")
 
       assert_equal [], attributes.accessed

--- a/activerecord/test/cases/attribute_test.rb
+++ b/activerecord/test/cases/attribute_test.rb
@@ -172,31 +172,31 @@ module ActiveRecord
     end
 
     test "an attribute has not been read by default" do
-      attribute = Attribute.from_database(:foo, 1, Type::Value.new)
+      attribute = Attribute.from_database(:foo, 1, ActiveModel::Type::Value.new)
       assert_not attribute.has_been_read?
     end
 
     test "an attribute has been read when its value is calculated" do
-      attribute = Attribute.from_database(:foo, 1, Type::Value.new)
+      attribute = Attribute.from_database(:foo, 1, ActiveModel::Type::Value.new)
       attribute.value
       assert attribute.has_been_read?
     end
 
     test "an attribute is not changed if it hasn't been assigned or mutated" do
-      attribute = Attribute.from_database(:foo, 1, Type::Value.new)
+      attribute = Attribute.from_database(:foo, 1, ActiveModel::Type::Value.new)
 
       refute attribute.changed?
     end
 
     test "an attribute is changed if it's been assigned a new value" do
-      attribute = Attribute.from_database(:foo, 1, Type::Value.new)
+      attribute = Attribute.from_database(:foo, 1, ActiveModel::Type::Value.new)
       changed = attribute.with_value_from_user(2)
 
       assert changed.changed?
     end
 
     test "an attribute is not changed if it's assigned the same value" do
-      attribute = Attribute.from_database(:foo, 1, Type::Value.new)
+      attribute = Attribute.from_database(:foo, 1, ActiveModel::Type::Value.new)
       unchanged = attribute.with_value_from_user(1)
 
       refute unchanged.changed?
@@ -228,7 +228,7 @@ module ActiveRecord
     end
 
     test "with_value_from_user validates the value" do
-      type = Type::Value.new
+      type = ActiveModel::Type::Value.new
       type.define_singleton_method(:assert_valid_value) do |value|
         if value == 1
           raise ArgumentError
@@ -244,7 +244,7 @@ module ActiveRecord
     end
 
     test "with_type preserves mutations" do
-      attribute = Attribute.from_database(:foo, "", Type::Value.new)
+      attribute = Attribute.from_database(:foo, "", ActiveModel::Type::Value.new)
       attribute.value << "1"
 
       assert_equal 1, attribute.with_type(Type::Integer.new).value

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -108,7 +108,7 @@ module ActiveRecord
       assert_equal 6, klass.column_defaults.length
       assert_not klass.attribute_types.include?("wibble")
 
-      klass.attribute :wibble, Type::Value.new
+      klass.attribute :wibble, ActiveModel::Type::Value.new
 
       assert_equal 7, klass.attribute_types.length
       assert_equal 7, klass.column_defaults.length
@@ -116,7 +116,7 @@ module ActiveRecord
     end
 
     test "the given default value is cast from user" do
-      custom_type = Class.new(Type::Value) do
+      custom_type = Class.new(ActiveModel::Type::Value) do
         def cast(*)
           "from user"
         end
@@ -201,7 +201,7 @@ module ActiveRecord
       child = Class.new(parent)
       child.new # => force a schema load
 
-      parent.attribute(:foo, Type::Value.new)
+      parent.attribute(:foo, ActiveModel::Type::Value.new)
 
       assert_equal(:bar, child.new(foo: :bar).foo)
     end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1400,7 +1400,7 @@ class BasicsTest < ActiveRecord::TestCase
     attrs = topic.attributes.dup
     attrs.delete "id"
 
-    typecast = Class.new(ActiveRecord::Type::Value) {
+    typecast = Class.new(ActiveModel::Type::Value) {
       def cast(value)
         "t.lo"
       end

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -41,7 +41,7 @@ module ActiveRecord
 
       def test_binds_are_logged
         sub   = Arel::Nodes::BindParam.new
-        binds = [Relation::QueryAttribute.new("id", 1, Type::Value.new)]
+        binds = [Relation::QueryAttribute.new("id", 1, ActiveModel::Type::Value.new)]
         sql   = "select * from topics where id = #{sub.to_sql}"
 
         @connection.exec_query(sql, "SQL", binds)

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -664,7 +664,7 @@ class DirtyTest < ActiveRecord::TestCase
   end
 
   test "attribute_changed? doesn't compute in-place changes for unrelated attributes" do
-    test_type_class = Class.new(ActiveRecord::Type::Value) do
+    test_type_class = Class.new(ActiveModel::Type::Value) do
       define_method(:changed_in_place?) do |*|
         raise
       end

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -81,7 +81,7 @@ if ActiveRecord::Base.connection.supports_explain?
       end
 
       def bind_param(name, value)
-        ActiveRecord::Relation::QueryAttribute.new(name, value, ActiveRecord::Type::Value.new)
+        ActiveRecord::Relation::QueryAttribute.new(name, value, ActiveModel::Type::Value.new)
       end
   end
 end

--- a/activerecord/test/cases/relation/where_clause_test.rb
+++ b/activerecord/test/cases/relation/where_clause_test.rb
@@ -176,7 +176,7 @@ class ActiveRecord::Relation
       end
 
       def attribute(name, value)
-        ActiveRecord::Attribute.with_cast_value(name, value, ActiveRecord::Type::Value.new)
+        ActiveRecord::Attribute.with_cast_value(name, value, ActiveModel::Type::Value.new)
       end
   end
 end

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -277,7 +277,7 @@ module ActiveRecord
       assert_equal({ 2=>1, 4=>3, 5=>1 }, authors(:david).posts.merge(posts_with_special_comments_with_ratings).count)
     end
 
-    class EnsureRoundTripTypeCasting < ActiveRecord::Type::Value
+    class EnsureRoundTripTypeCasting < ActiveModel::Type::Value
       def type
         :string
       end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -313,7 +313,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
       return if value.nil?
       value.gsub(" encoded", "")
     end
-    type = Class.new(ActiveRecord::Type::Value) do
+    type = Class.new(ActiveModel::Type::Value) do
       include ActiveRecord::Type::Helpers::Mutable
 
       def serialize(value)

--- a/activerecord/test/cases/type/type_map_test.rb
+++ b/activerecord/test/cases/type/type_map_test.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       def test_default_type
         mapping = TypeMap.new
 
-        assert_kind_of Value, mapping.lookup(:undefined)
+        assert_kind_of ActiveModel::Type::Value, mapping.lookup(:undefined)
       end
 
       def test_registering_types
@@ -122,7 +122,7 @@ module ActiveRecord
         assert_equal mapping.lookup(1), "string"
         assert_equal mapping.lookup(2), "int"
         assert_equal mapping.lookup(3), "string"
-        assert_kind_of Type::Value, mapping.lookup(4)
+        assert_kind_of ActiveModel::Type::Value, mapping.lookup(4)
       end
 
       def test_fetch

--- a/activerecord/test/cases/types_test.rb
+++ b/activerecord/test/cases/types_test.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     class TypesTest < ActiveRecord::TestCase
       def test_attributes_which_are_invalid_for_database_can_still_be_reassigned
-        type_which_cannot_go_to_the_database = Type::Value.new
+        type_which_cannot_go_to_the_database = ActiveModel::Type::Value.new
         def type_which_cannot_go_to_the_database.serialize(*)
           raise
         end


### PR DESCRIPTION
### Summary

The base class in the ActiveModel type API is `ActiveModel::Type::Value`, from which other types are subclassed (eg. `ActiveModel::Type::ImmutableString < ActiveModel::Type::Value`). ActiveRecord subclasses `ActiveModel::Type::Value` with it's own `Value` class. However, most of the ActiveRecord type classes don't use this base class, but instead are subclassed from ActiveModel's `Value` class. Other ActiveRecord type classes do sublass the ActiveRecord `Value` class.

For example,

| Subclasses `ActiveModel::Type::Value` | Subclasses `ActiveRecord::Type::Value` |
| --- | --- |
| `Decimal`, `Integer`, `String`... | `Time`, `Date`, `Array`... |

I believe there's a risk here, which is that if`ActiveRecord::Type::Value` is modified, the changes would be reflected inconsistently and could cause subtle bugs, because only the types that subclass `ActiveRecord::Type::Value` would pick up the changes.

My suggestion is that `ActiveRecord::Type::Value` should be removed entirely, which would mean that there is only one `Value` class, and everything is subclassed from that, in a single class hierarchy.
