### PR TITLE
Add test case to boolean attribute predicate

### DIFF
--- a/activemodel/lib/active_model/type/boolean.rb
+++ b/activemodel/lib/active_model/type/boolean.rb
@@ -23,6 +23,8 @@ module ActiveModel
         def cast_value(value)
           if value == ""
             nil
+          elsif value.blank?
+            false
           else
             !FALSE_VALUES.include?(value)
           end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -425,7 +425,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   end
 
   test "boolean attribute predicate" do
-    [nil, "", false, "false", "f", 0].each do |value|
+    [nil, "", " ", [], false, "false", "f", 0].each do |value|
       assert_equal false, Topic.new(approved: value).approved?
     end
 


### PR DESCRIPTION
### Summary

I've added a test case to handle type casting a blank string to a boolean. A boolean attribute currently returns `true` for a blank string.

It's also being tested on string attributes here: https://github.com/rails/rails/blob/0fc115724b87f7b4c990dc26d8b42f48ae72dfeb/activerecord/test/cases/attribute_methods_test.rb#L411

Thanks for reviewing my PR!
