### PR TITLE
Use a regular hash for holding inflections

### DIFF
--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -339,27 +339,20 @@ class IrregularInflectionParamsWrapperTest < ActionController::TestCase
 
   tests ParamswrappernewsController
 
-  def test_uses_model_attribute_names_with_irregular_inflection
-    with_dup do
-      ActiveSupport::Inflector.inflections do |inflect|
-        inflect.irregular "paramswrappernews_item", "paramswrappernews"
-      end
-
-      with_default_wrapper_options do
-        @request.env["CONTENT_TYPE"] = "application/json"
-        post :parse, params: { "username" => "sikachu", "test_attr" => "test_value" }
-        assert_parameters("username" => "sikachu", "test_attr" => "test_value", "paramswrappernews_item" => { "test_attr" => "test_value" })
-      end
-    end
+  def teardown
+    ActiveSupport::Inflector::Inflections.clear!
+    load "active_support/inflections.rb"
   end
 
-  private
-
-    def with_dup
-      original = ActiveSupport::Inflector::Inflections.instance_variable_get(:@__instance__)[:en]
-      ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, en: original.dup)
-      yield
-    ensure
-      ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, en: original)
+  def test_uses_model_attribute_names_with_irregular_inflection
+    ActiveSupport::Inflector.inflections do |inflect|
+      inflect.irregular "paramswrappernews_item", "paramswrappernews"
     end
+
+    with_default_wrapper_options do
+      @request.env["CONTENT_TYPE"] = "application/json"
+      post :parse, params: { "username" => "sikachu", "test_attr" => "test_value" }
+      assert_parameters("username" => "sikachu", "test_attr" => "test_value", "paramswrappernews_item" => { "test_attr" => "test_value" })
+    end
+  end
 end

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -24,7 +24,7 @@ module ActiveSupport
     # singularization rules that is runs. This guarantees that your rules run
     # before any of the rules that may already have been loaded.
     class Inflections
-      @__instance__ = {}
+      @instances = {}
 
       class Uncountables < Array
         def initialize
@@ -58,20 +58,17 @@ module ActiveSupport
       end
 
       def self.instance(locale = :en)
-        @__instance__[locale] ||= new
+        @instances[locale] ||= new
+      end
+
+      def self.clear! # :nodoc:
+        @instances = {}
       end
 
       attr_reader :plurals, :singulars, :uncountables, :humans, :acronyms, :acronym_regex
 
       def initialize
         @plurals, @singulars, @uncountables, @humans, @acronyms, @acronym_regex = [], [], Uncountables.new, [], {}, /(?=a)b/
-      end
-
-      # Private, for the test suite.
-      def initialize_dup(orig) # :nodoc:
-        %w(plurals singulars uncountables humans acronyms acronym_regex).each do |scope|
-          instance_variable_set("@#{scope}", orig.send(scope).dup)
-        end
       end
 
       # Specifies a new acronym. An acronym must be specified as it will appear

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -1,4 +1,3 @@
-require "concurrent/map"
 require "active_support/core_ext/array/prepend_and_append"
 require "active_support/i18n"
 
@@ -25,7 +24,7 @@ module ActiveSupport
     # singularization rules that is runs. This guarantees that your rules run
     # before any of the rules that may already have been loaded.
     class Inflections
-      @__instance__ = Concurrent::Map.new
+      @__instance__ = {}
 
       class Uncountables < Array
         def initialize

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -8,18 +8,10 @@ class InflectorTest < ActiveSupport::TestCase
   include InflectorTestCases
   include ConstantizeTestCases
 
-  def setup
-    # Dups the singleton before each test, restoring the original inflections later.
-    #
-    # This helper is implemented by setting @__instance__ because in some tests
-    # there are module functions that access ActiveSupport::Inflector.inflections,
-    # so we need to replace the singleton itself.
-    @original_inflections = ActiveSupport::Inflector::Inflections.instance_variable_get(:@__instance__)[:en]
-    ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, en: @original_inflections.dup)
-  end
-
   def teardown
-    ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, en: @original_inflections)
+    # Restore the default rules
+    ActiveSupport::Inflector::Inflections.clear!
+    load "active_support/inflections.rb"
   end
 
   def test_pluralize_plurals


### PR DESCRIPTION
This does not actually make anything threadsafe:
1. `@__instance__[locale] ||= new` is not atomic
2. The `Inflections` instance itself is clearly not threadsafe

For those reasons, protecting the hash access is rather pointless. So lets just be honest and not create an illusion of threadsafety here.

I could totally be missing something though – so I would love a review.

/cc @tenderlove @matthewd @fxn
