### PR TITLE
Support stop listening to individual broadcasts

### DIFF
--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -72,7 +72,9 @@ module ActionCable
       # Pass <tt>coder: ActiveSupport::JSON</tt> to decode messages as JSON before passing to the callback.
       # Defaults to <tt>coder: nil</tt> which does no decoding, passes raw messages.
       def stream_from(broadcasting, callback = nil, coder: nil, &block)
-        broadcasting = String(broadcasting)
+        broadcasting = to_broadcasting(broadcasting)
+        # nothing to do if stream exists
+        return if streams.key?(broadcasting)
 
         # Don't send the confirmation until pubsub#subscribe is successful
         defer_subscription_confirmation!
@@ -80,7 +82,7 @@ module ActionCable
         # Build a stream handler by wrapping the user-provided callback with
         # a decoder or defaulting to a JSON-decoding retransmitter.
         handler = worker_pool_stream_handler(broadcasting, callback || block, coder: coder)
-        streams << [ broadcasting, handler ]
+        streams[broadcasting] = handler
 
         connection.server.event_loop.post do
           pubsub.subscribe(broadcasting, handler, lambda do
@@ -100,6 +102,18 @@ module ActionCable
         stream_from(broadcasting_for([ channel_name, model ]), callback || block, coder: coder)
       end
 
+      # Unsubscribe from the pubsub queue for a single stream
+      def stop_stream_from(broadcasting)
+        broadcasting = to_broadcasting(broadcasting)
+        pubsub.unsubscribe broadcasting, streams[broadcasting]
+        logger.info "#{self.class.name} stopped streaming from #{broadcasting}"
+      end
+
+      # Stop streaming from the pubsub queue for the <tt>model</tt> in this channel.
+      def stop_stream_for(model)
+        stop_stream_from(broadcasting_for([ channel_name, model ]))
+      end
+
       # Unsubscribes all streams associated with this channel from the pubsub queue.
       def stop_all_streams
         streams.each do |broadcasting, callback|
@@ -112,7 +126,7 @@ module ActionCable
         delegate :pubsub, to: :connection
 
         def streams
-          @_streams ||= []
+          @_streams ||= {}
         end
 
         # Always wrap the outermost handler to invoke the user handler on the
@@ -156,6 +170,10 @@ module ActionCable
           else
             handler
           end
+        end
+
+        def to_broadcasting(broadcasting)
+          String(broadcasting)
         end
 
         def stream_transmitter(handler = identity_handler, broadcasting:)

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -74,8 +74,10 @@ module ActionCable
       def stream_from(broadcasting, callback = nil, coder: nil, &block)
         broadcasting = to_broadcasting(broadcasting)
         # nothing to do if stream exists
-        return if streams.key?(broadcasting)
-
+        if streams.key?(broadcasting)
+          logger.warn "attempted to listen to stream broadcast '#{broadcasting}' more than once"
+          return
+        end
         # Don't send the confirmation until pubsub#subscribe is successful
         defer_subscription_confirmation!
 

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -106,6 +106,7 @@ module ActionCable
       def stop_stream_from(broadcasting)
         broadcasting = to_broadcasting(broadcasting)
         pubsub.unsubscribe broadcasting, streams[broadcasting]
+        streams.delete(broadcasting)
         logger.info "#{self.class.name} stopped streaming from #{broadcasting}"
       end
 

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -83,6 +83,40 @@ module ActionCable::StreamTests
       end
     end
 
+    test "stop_stream_from" do
+      run_in_eventmachine do
+        channel_name = "test-stream-channel"
+        connection = TestConnection.new
+        connection.expects(:pubsub).twice.returns mock().tap { |m|
+          m.expects(:subscribe).with(channel_name, kind_of(Proc), kind_of(Proc))
+            .returns stub_everything(:pubsub)
+          m.expects(:unsubscribe).with(channel_name, kind_of(Proc))
+            .returns stub_everything(:pubsub)
+        }
+        channel = ChatChannel.new connection, ""
+        channel.stream_from channel_name
+        channel.stop_stream_from channel_name
+      end
+    end
+
+
+    test "stop_stream_for" do
+      run_in_eventmachine do
+        model = Room.new(1)
+        channel_name = 'action_cable:stream_tests:chat:Room#1-Campfire'
+        connection = TestConnection.new
+        connection.expects(:pubsub).twice.returns mock().tap { |m|
+          m.expects(:subscribe).with(channel_name, kind_of(Proc), kind_of(Proc))
+            .returns stub_everything(:pubsub)
+          m.expects(:unsubscribe).with(channel_name, kind_of(Proc))
+            .returns stub_everything(:pubsub)
+        }
+        channel = ChatChannel.new connection, ""
+        channel.stream_for model
+        channel.stop_stream_for model
+      end
+    end
+
     test "stream_from subscription confirmation" do
       run_in_eventmachine do
         connection = TestConnection.new

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -87,7 +87,7 @@ module ActionCable::StreamTests
       end
     end
 
-    test 'stop_stream_from' do
+    test "stop_stream_from" do
       run_in_eventmachine do
         channel_name = "test-stream-channel"
         connection = TestConnection.new
@@ -103,7 +103,7 @@ module ActionCable::StreamTests
       end
     end
 
-    test 'restarting a stream after stoping it' do
+    test "restarting a stream after stoping it" do
       run_in_eventmachine do
         channel_name = "test-stream-channel"
         connection = TestConnection.new
@@ -117,10 +117,10 @@ module ActionCable::StreamTests
       end
     end
 
-    test 'stop_stream_for' do
+    test "stop_stream_for" do
       run_in_eventmachine do
         model = Room.new(1)
-        channel_name = 'action_cable:stream_tests:chat:Room#1-Campfire'
+        channel_name = "action_cable:stream_tests:chat:Room#1-Campfire"
         connection = TestConnection.new
         connection.expects(:pubsub).twice.returns mock().tap { |m|
           m.expects(:subscribe).with(channel_name, kind_of(Proc), kind_of(Proc))
@@ -169,11 +169,11 @@ module ActionCable::StreamTests
       end
     end
 
-    test 'duplicate stream warning' do
+    test "duplicate stream warning" do
       run_in_eventmachine do
         connection = TestConnection.new
         channel_name = "duplicate-test-stream-channel"
-        channel = ChatChannel.new connection, ''
+        channel = ChatChannel.new connection, ""
         channel.stream_from channel_name
         channel.expects(:logger).returns mock().tap { |m|
           m.expects(:warn).with(regexp_matches(/more than once/))

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -168,6 +168,19 @@ module ActionCable::StreamTests
         assert_equal 1, connection.transmissions.size
       end
     end
+
+    test 'duplicate stream warning' do
+      run_in_eventmachine do
+        connection = TestConnection.new
+        channel_name = "duplicate-test-stream-channel"
+        channel = ChatChannel.new connection, ''
+        channel.stream_from channel_name
+        channel.expects(:logger).returns mock().tap { |m|
+          m.expects(:warn).with(regexp_matches(/more than once/))
+        }
+        channel.stream_from channel_name
+      end
+    end
   end
 
   require "action_cable/subscription_adapter/async"

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -23,6 +23,10 @@ module ActionCable::StreamTests
       transmit_subscription_confirmation
     end
 
+    def current_stream_broadcasts
+      streams
+    end
+
     private def pick_coder(coder)
       case coder
       when nil, "json"
@@ -83,7 +87,7 @@ module ActionCable::StreamTests
       end
     end
 
-    test "stop_stream_from" do
+    test 'stop_stream_from' do
       run_in_eventmachine do
         channel_name = "test-stream-channel"
         connection = TestConnection.new
@@ -99,8 +103,21 @@ module ActionCable::StreamTests
       end
     end
 
+    test 'restarting a stream after stoping it' do
+      run_in_eventmachine do
+        channel_name = "test-stream-channel"
+        connection = TestConnection.new
+        channel = ChatChannel.new connection, ""
+        channel.stream_from channel_name
+        assert channel.current_stream_broadcasts[channel_name]
+        channel.stop_stream_from channel_name
+        assert_empty channel.current_stream_broadcasts
+        channel.stream_from channel_name
+        assert channel.current_stream_broadcasts[channel_name]
+      end
+    end
 
-    test "stop_stream_for" do
+    test 'stop_stream_for' do
       run_in_eventmachine do
         model = Room.new(1)
         channel_name = 'action_cable:stream_tests:chat:Room#1-Campfire'


### PR DESCRIPTION
Adds  `ActionCable::Channel#stop_stream_for` and `ActionCable::Channel#stop_stream_from` methods.

Broadcasts can be listened to using stream_for and stream_from but there isn't anyway to stop listening to individual broadcasts. All broadcasts can be silenced by using `stop_all_streams`, but that doesn't help the use case of a client that wants to stop listening to a single broadcast
channel.

This switches `@streams` from an array of [stream_name, listening proc] to a Hash with the stream name as the key.  By doing so we can obtain a reference to the listening proc and use that when unsubscribing from a named broadcast stream.

Note: I also added a check in `stream_from` for an existing subscription and am returning early if it exists.  Not sure if that's desired but it seemed like a good idea to me.  Maybe it should have a `log.warn "broadcast is already being listened for"` warning though
