### PR TITLE
prevent `TypeError` for `LogSubscriber#sql`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -80,6 +80,7 @@ module ActiveRecord
                 "sql.active_record",
                 sql: sql,
                 binds: binds,
+                type_casted_binds: type_casted_binds(binds),
                 name: name,
                 connection_id: object_id,
                 cached: true,

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -188,6 +188,17 @@ class LogSubscriberTest < ActiveRecord::TestCase
     assert_match(/SELECT .*?FROM .?developers.?/i, @logger.logged(:debug).last)
   end
 
+  def test_cached_queries_with_binds
+    ActiveRecord::Base.cache do
+      Developer.first
+      Developer.first
+    end
+    wait
+
+    assert_equal 2, @logger.logged(:debug).size
+    assert_match(/CACHE Developer Load.*"LIMIT", 1/i, @logger.logged(:debug).last)
+  end
+
   def test_basic_query_doesnt_log_when_level_is_not_debug
     @logger.level = INFO
     Developer.all.load


### PR DESCRIPTION
### Summary

The #26584 changed to preserve cached queries name and output cached
queries to log. But `QueryCache#cache_sql` don't set `type_casted_binds` payload.
Therefore, following errors occur when output the log.

``` ruby
Could not log "sql.active_record" event. TypeError: wrong argument type NilClass (must respond to :each) ["rails/activerecord/lib/active_record/log_subscriber.rb:42"]
```

This fixes the above error.
