### PR TITLE
Bump bundler version in the before_install hook of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
 bundler_args: --without test --jobs 3 --retry 3
 before_install:
   - "rm ${BUNDLE_GEMFILE}.lock"
+  - "gem update bundler"
   - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
   - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"
 


### PR DESCRIPTION
- We were running into issues with old bundler versions on 4.2
  builds. So we bumped the bundler version on 4-2-stable branch in
  https://github.com/rails/rails/pull/26592.
- This commit applies same change to master as per discussion in
  https://github.com/rails/rails/pull/26592#issuecomment-254026755.

r? @matthewd 
