### PR TITLE
Support index.length for MySQL 8.0.0-dmr at 5-0-stable

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -387,7 +387,7 @@ module ActiveRecord
             end
 
             indexes.last.columns << row[:Column_name]
-            indexes.last.lengths << row[:Sub_part].to_i
+            indexes.last.lengths << row[:Sub_part].to_i unless row[:Sub_part].nil?
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -387,7 +387,7 @@ module ActiveRecord
             end
 
             indexes.last.columns << row[:Column_name]
-            indexes.last.lengths << row[:Sub_part]
+            indexes.last.lengths << row[:Sub_part].to_i
           end
         end
 


### PR DESCRIPTION
### Summary

This pull request reverts 6df853b6f19297f89961dfeb5b002093d5e5db51 and addresses these 3 failures at `5-0-stable` branch caused by 4cf4c863c30f445aca908bf79afe8cde2520b038
Since `row[:Sub_part].to_i` is 0 when `row[:Sub_part]` is nil, which adds unnecessary `length: {\"column_name\"=>0}` to schema dump.

``` ruby
$ ARCONN=mysql2 bundle exec ruby -W -w -I"lib:test" test/cases/schema_dumper_test.rb -n test_schema_dumps_index_columns_in_right_order
Using mysql2
Run options: -n test_schema_dumps_index_columns_in_right_order --seed 44594

# Running:

F

Finished in 16.292066s, 0.0614 runs/s, 0.0614 assertions/s.

  1) Failure:
SchemaDumperTest#test_schema_dumps_index_columns_in_right_order [test/cases/schema_dumper_test.rb:191]:
--- expected
+++ actual
@@ -1 +1 @@
-"t.index [\"firm_id\", \"type\", \"rating\"], name: \"company_index\", using: :btree"
+"t.index [\"firm_id\", \"type\", \"rating\"], name: \"company_index\", length: {\"firm_id\"=>0, \"type\"=>0, \"rating\"=>0}, using: :btree"


1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

``` ruby
$ ARCONN=mysql2 bundle exec ruby -W -w -I"lib:test" test/cases/schema_dumper_test.rb -n test_schema_dumps_index_type
Using mysql2
Run options: -n test_schema_dumps_index_type --seed 65490

# Running:

F

Finished in 15.691604s, 0.0637 runs/s, 0.1275 assertions/s.

  1) Failure:
SchemaDumperTest#test_schema_dumps_index_type [test/cases/schema_dumper_test.rb:253]:
Expected /t\.index \["awesome"\], name: "index_key_tests_on_awesome", type: :fulltext/ to match "# This file is auto-generated from the current state of the database. Instead
# of editing this file, please use the migrations feature of Active Record to
# incrementally modify your database, and then regenerate this schema definition.
#
# Note that this schema.rb definition is the authoritative source for your
# database schema. If you need to create the application database on another
# system, you should be using db:schema:load, not running all the migrations
# from scratch. The latter is a flawed and unsustainable approach (the more migrations
# you'll amass, the slower it'll run and the greater likelihood for issues).
#
# It's strongly recommended that you check this file into your version control system.

ActiveRecord::Schema.define(version: 0) do
... snip ...
  create_table \"key_tests\", force: :cascade, options: \"ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci\" do |t|
    t.string \"awesome\"
    t.string \"pizza\"
    t.string \"snacks\"
    t.index [\"awesome\"], name: \"index_key_tests_on_awesome\", length: {\"awesome\"=>0}, type: :fulltext
    t.index [\"pizza\"], name: \"index_key_tests_on_pizza\", length: {\"pizza\"=>0}, using: :btree
    t.index [\"snacks\"], name: \"index_key_tests_on_snack\", length: {\"snacks\"=>0}, using: :btree
  end
end
".

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

``` ruby
$ ARCONN=mysql2 bundle exec ruby -W -w -I"lib:test" test/cases/schema_dumper_test.rb -n test_schema_dumps_partial_indices
Using mysql2
Run options: -n test_schema_dumps_partial_indices --seed 15102

# Running:

F

Finished in 15.587157s, 0.0642 runs/s, 0.0642 assertions/s.

  1) Failure:
SchemaDumperTest#test_schema_dumps_partial_indices [test/cases/schema_dumper_test.rb:202]:
--- expected
+++ actual
@@ -1 +1 @@
-"t.index [\"firm_id\", \"type\"], name: \"company_partial_index\", using: :btree"
+"t.index [\"firm_id\", \"type\"], name: \"company_partial_index\", length: {\"firm_id\"=>0, \"type\"=>0}, using: :btree"


1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```
### Other Information

This pull request is intentionally created for `5-0-stable` branch as discussed in #26785.
