### PR TITLE
Avoid unneccessarily converting nil to string

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -64,7 +64,7 @@ module ActiveRecord
         #   sanitize_sql_for_order("id ASC")
         #   # => "id ASC"
         def sanitize_sql_for_order(condition)
-          if condition.is_a?(Array) && condition.first.to_s.include?("?")
+          if condition.is_a?(Array) && condition.any? && condition.first.to_s.include?("?".freeze)
             sanitize_sql_array(condition)
           else
             condition


### PR DESCRIPTION
Running the current ActiveRecord tests, I saw `#sanitize_sql_for_order` being called 20068 times with an empty array, and only 2805 times with a non-empty array.

When called with an empty array, the first line (`[].first.to_s.include("?")`) will unneccessarily allocate two strings, `""` and `"?"`. By freezing the `"?"` and checking against empty arrays, we can make the method more than twice as fast in the most common case. For other arguments, the runtime is comparable to the current implementation.

Performance script:

```
require 'benchmark/ips'

Benchmark.ips do |x|
  condition = ["name=? and group_id=?", "foo'bar", 4]
  x.report("original")    { condition.is_a?(Array) && condition.first.to_s.include?("?") }
  x.report("empty-check") { condition.is_a?(Array) && condition.any? && condition.first.to_s.include?("?".freeze) }
  x.compare!
end

Benchmark.ips do |x|
  condition = ["position"]
  x.report("original")    { condition.is_a?(Array) && condition.first.to_s.include?("?") }
  x.report("empty-check") { condition.is_a?(Array) && condition.any? && condition.first.to_s.include?("?".freeze) }
  x.compare!
end

Benchmark.ips do |x|
  condition = []
  x.report("original")    { condition.is_a?(Array) && condition.first.to_s.include?("?") }
  x.report("empty-check") { condition.is_a?(Array) && condition.any? && condition.first.to_s.include?("?".freeze) }
  x.compare!
end
```

Results:

```
Warming up --------------------------------------
            original   200.685k i/100ms
         empty-check   182.827k i/100ms
Calculating -------------------------------------
            original      4.169M (±10.3%) i/s -     20.671M in   5.040107s
         empty-check      4.223M (± 2.8%) i/s -     21.208M in   5.026017s

Comparison:
         empty-check:  4222988.3 i/s
            original:  4169126.2 i/s - same-ish: difference falls within error

Warming up --------------------------------------
            original   209.549k i/100ms
         empty-check   212.640k i/100ms
Calculating -------------------------------------
            original      4.304M (± 6.1%) i/s -     21.584M in   5.035971s
         empty-check      4.345M (± 2.7%) i/s -     21.902M in   5.044407s

Comparison:
         empty-check:  4345159.0 i/s
            original:  4303567.5 i/s - same-ish: difference falls within error

Warming up --------------------------------------
            original   191.417k i/100ms
         empty-check   278.279k i/100ms
Calculating -------------------------------------
            original      3.578M (± 6.9%) i/s -     17.802M in   5.009026s
         empty-check      7.684M (± 6.2%) i/s -     38.403M in   5.032166s

Comparison:
         empty-check:  7684342.8 i/s
            original:  3578112.8 i/s - 2.15x  slower
```

See also #22133.
cc/ @yui-knk
r? @pixeltrix 
