### PR TITLE
Convert ActionController::Parameters to a hash in button_to

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -331,6 +331,12 @@ module ActionView
 
         inner_tags = method_tag.safe_concat(button).safe_concat(request_token_tag)
         if params
+          params = if params.respond_to?(:permitted?)
+                     params.to_h
+                   else
+                     params
+                   end
+
           to_form_params(params).each do |param|
             inner_tags.safe_concat tag(:input, type: "hidden", name: param[:name], value: param[:value])
           end

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -221,6 +221,22 @@ class UrlHelperTest < ActiveSupport::TestCase
     )
   end
 
+  class FakeParams
+    def permitted?
+    end
+
+    def to_h
+      { foo: :bar, baz: "quux" }
+    end
+  end
+
+  def test_button_to_with_strong_params
+    assert_dom_equal(
+      %{<form action="http://www.example.com" class="button_to" method="post"><input type="submit" value="Hello" /><input type="hidden" name="baz" value="quux" /><input type="hidden" name="foo" value="bar" /></form>},
+      button_to("Hello", "http://www.example.com", params: FakeParams.new)
+    )
+  end
+
   def test_button_to_with_nested_hash_params
     assert_dom_equal(
       %{<form action="http://www.example.com" class="button_to" method="post"><input type="submit" value="Hello" /><input type="hidden" name="foo[bar]" value="baz" /></form>},


### PR DESCRIPTION
### Summary

Before, an error would be raised saying that the method `to_param` was
undefined on the instance of `ActionController::Parameters`. Now, we are
checking to see if the `params` object being passed to `button_to`
responds to the `permitted?` method, and if so, we will call `to_h` on it. If it
does not respond to `permitted?`, then the `params` will remain
unchanged.
### Other Information

Addresses #26802.

r? @rafaelfranca 
