### PR TITLE
add `ActionController::Parameters#merge!`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ActionController::Parameters#merge!`, which behaves the same as `Hash#merge!`.
+
+    *Yuji Yaginuma*
+
 *   Allow keys not found in RACK_KEY_TRANSLATION for setting the environment when rendering
     arbitrary templates.
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -573,6 +573,13 @@ module ActionController
       )
     end
 
+    # Returns current <tt>ActionController::Parameters</tt> instance which
+    # +other_hash+ merges into current hash.
+    def merge!(other_hash)
+      @parameters.merge!(other_hash.to_h)
+      self
+    end
+
     # This is required by ActiveModel attribute assignment, so that user can
     # pass +Parameters+ to a mass assignment methods in a model. It should not
     # matter as we are using +HashWithIndifferentAccess+ internally.

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -244,6 +244,23 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert merged_params[:id]
   end
 
+  test "not permitted is sticky beyond merge!" do
+    assert_not @params.merge!(a: "b").permitted?
+  end
+
+  test "permitted is sticky beyond merge!" do
+    @params.permit!
+    assert @params.merge!(a: "b").permitted?
+  end
+
+  test "merge! with parameters" do
+    other_params = ActionController::Parameters.new(id: "1234").permit!
+    @params.merge!(other_params)
+
+    assert_equal "1234", @params[:id]
+    assert_equal "32", @params[:person][:age]
+  end
+
   test "modifying the parameters" do
     @params[:person][:hometown] = "Chicago"
     @params[:person][:family] = { brother: "Jonas" }


### PR DESCRIPTION
### Summary

Currenty, `ActionController::Parameters` has `#merge` but not has `#merge!`.
However, in such case want to set the default parameter to params, there is a matter that would like to update the params itself, I think that `#merge!` is useful.  

Like this. 

``` ruby
permitted_organization_params.tap do |pr|
  password = generate_random_pasword
  pr['users_attributes'].each do |index, attributes|
    attributes.merge!(
      'password'              => password,
      'password_confirmation' => password
    )
  end
end
```
