### PR TITLE
Add ability to access the AV helpers in the AC bug report templates

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -53,4 +53,8 @@ class BugTest < Minitest::Test
     def app
       Rails.application
     end
+
+    def helper
+      TestController.helpers
+    end
 end

--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -48,4 +48,8 @@ class BugTest < Minitest::Test
     def app
       Rails.application
     end
+
+    def helper
+      TestController.helpers
+    end
 end


### PR DESCRIPTION
- So that people can use these templates for bugs related to AV bugs as
  well.
- Originated from https://github.com/rails/rails/issues/26816.

Open to create a new AV template for bug reporting as well, but don't feel the need as of now for my experience. Anyone has seen any such cases for AV bug report template?
