### PR TITLE
Add missing require in active_support/hash_with_indifferent_access.rb 

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -1,5 +1,6 @@
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/hash/reverse_merge"
+require "active_support/core_ext/hash/indifferent_access"
 
 module ActiveSupport
   # Implements a hash where keys <tt>:foo</tt> and <tt>"foo"</tt> are considered


### PR DESCRIPTION
See https://gist.github.com/claudiob/43cc7fe77ff95951538af2825a71e5ec

In short, nesting a `Hash` inside a `HashWithIndifferentAccess` raises an error because `nested_under_indifferent_access` is not defined on `Hash` unless "active_support/core_ext/hash/indifferent_access" is explicitly required
