### PR TITLE
Wait for file events to propagated for slower Listen backends.

### DIFF
--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -49,6 +49,7 @@ module FileUpdateCheckerSharedTests
     checker = new_checker(tmpfiles) { i += 1 }
 
     touch(tmpfiles)
+    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -62,6 +63,7 @@ module FileUpdateCheckerSharedTests
     checker = new_checker(tmpfiles) { i += 1 }
 
     touch(tmpfiles)
+    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -75,6 +77,7 @@ module FileUpdateCheckerSharedTests
     checker = new_checker(tmpfiles) { i += 1 }
 
     rm_f(tmpfiles)
+    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -88,6 +91,7 @@ module FileUpdateCheckerSharedTests
     assert !checker.updated?
 
     touch(tmpfiles)
+    wait
 
     assert checker.updated?
   end
@@ -102,6 +106,7 @@ module FileUpdateCheckerSharedTests
     assert !checker.updated?
 
     touch(tmpfiles)
+    wait
 
     assert checker.updated?
   end
@@ -115,6 +120,7 @@ module FileUpdateCheckerSharedTests
     assert !checker.updated?
 
     rm_f(tmpfiles)
+    wait
 
     assert checker.updated?
   end
@@ -131,6 +137,7 @@ module FileUpdateCheckerSharedTests
     checker = new_checker(tmpfiles) { i += 1 }
 
     touch(tmpfiles[1..-1])
+    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -147,6 +154,7 @@ module FileUpdateCheckerSharedTests
     checker = new_checker(tmpfiles) { i += 1 }
 
     touch(tmpfiles[1..-1])
+    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -159,6 +167,7 @@ module FileUpdateCheckerSharedTests
     assert !checker.updated?
 
     touch(tmpfiles)
+    wait
 
     assert checker.updated?
     checker.execute
@@ -171,6 +180,7 @@ module FileUpdateCheckerSharedTests
     checker = new_checker([], tmpdir => :rb) { i += 1 }
 
     touch(tmpfile('foo.rb'))
+    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -182,11 +192,13 @@ module FileUpdateCheckerSharedTests
     checker = new_checker([], tmpdir => [:rb, :txt]) { i += 1 }
 
     touch(tmpfile('foo.rb'))
+    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
 
     touch(tmpfile('foo.txt'))
+    wait
 
     assert checker.execute_if_updated
     assert_equal 2, i
@@ -198,6 +210,7 @@ module FileUpdateCheckerSharedTests
     checker = new_checker([], tmpdir => :txt) { i += 1 }
 
     touch(tmpfile('foo.rb'))
+    wait
 
     assert !checker.execute_if_updated
     assert_equal 0, i
@@ -210,6 +223,7 @@ module FileUpdateCheckerSharedTests
     checker = new_checker([non_existing]) { i += 1 }
 
     touch(non_existing)
+    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -228,6 +242,7 @@ module FileUpdateCheckerSharedTests
     assert_equal 0, i
 
     touch(File.join(subdir, "nested.rb"))
+    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
@@ -242,17 +257,20 @@ module FileUpdateCheckerSharedTests
     checker = new_checker([], tmpdir => :rb, subdir => :txt) { i += 1 }
 
     touch(tmpfile('new.txt'))
+    wait
 
     assert !checker.execute_if_updated
     assert_equal 0, i
 
     # subdir does not look for Ruby files, but its parent tmpdir does.
     touch(File.join(subdir, "nested.rb"))
+    wait
 
     assert checker.execute_if_updated
     assert_equal 1, i
 
     touch(File.join(subdir, "nested.txt"))
+    wait
 
     assert checker.execute_if_updated
     assert_equal 2, i


### PR DESCRIPTION
### Summary

The tests for filesystem events ("checker" or "listen") do not wait for the `Listen` event loop to catch up with changes. This patch adds the waits, so they'll run green on platforms where `Listen` has some delay.
### Other Information

On JRuby, the `listen` library does not have access to synchronous filesystem events, a la `rb_fsevent` and similar libraries. Instead, it uses a listen loop that may introduce some delay after filesystem changes before an event is fired. Other tests here used `wait` to wait for those changes to propagate, so I added the same wait to the remaining tests. With this change, these tests are green on JRuby.
