### PR TITLE
Mask forking filesystem event on JRuby.

### DIFF
--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -36,6 +36,8 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
   end
 
   test 'notifies forked processes' do
+    skip if defined?(JRUBY_VERSION)
+
     FileUtils.touch(tmpfiles)
 
     checker = new_checker(tmpfiles) { }


### PR DESCRIPTION
### Summary

JRuby does not support forking, but this test blindly forked. This patch omits that test when running on JRuby.
### Other Information

It was not clear to me the best way to mask this, but I did see other parts of the codebase use `defined?(JRUBY_VERSION)` so I went with that.
