### PR TITLE
No blade on jruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ group :cable do
   gem 'redis', require: false
 
   gem 'faye-websocket', require: false
-  gem 'blade', '~> 0.5.5', require: false
+  gem 'blade', '~> 0.5.5', require: false, platforms: :ruby
 end
 
 # Add your own local bundler stuff.


### PR DESCRIPTION
### Summary

The `blade` library has a transitive dependency on `curses` which is not installable on JRuby. This patch masks it out.
