### PR TITLE
Add Yarn support in new apps using --yarn option

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -33,6 +33,9 @@ module Rails
         class_option :javascript,         type: :string, aliases: "-j",
                                           desc: "Preconfigure for selected JavaScript library"
 
+        class_option :yarn,               type: :boolean, default: false,
+                                          desc: "Preconfigure for assets management with Yarn"
+
         class_option :skip_gemfile,       type: :boolean, default: false,
                                           desc: "Don't create a Gemfile"
 
@@ -412,6 +415,55 @@ module Rails
 
       def run_bundle
         bundle_command("install") if bundle_install?
+      end
+
+      def run_yarn
+        if package_json_exist?
+          if yarn_path
+            say_status :run, "yarn install"
+            yarn_command("install")
+          else
+            say_status :warning, "yarn option passed but Yarn executable was not detected in the system.", :yellow
+            say_status :warning, "Download Yarn at https://yarnpkg.com/en/docs/install", :yellow
+          end
+        end
+      end
+
+      def package_json_exist?
+        File.exist?("package.json")
+      end
+
+      def yarn_path
+        commands = ["yarn"]
+
+        if RbConfig::CONFIG["host_os"] =~ /mswin|cygwin/
+          ENV["PATHEXT"].split(File::PATH_SEPARATOR).each do |ext|
+            commands << commands[0] + ext
+          end
+        end
+
+        yarn_path = commands.find do |cmd|
+          paths = ENV["PATH"].split(File::PATH_SEPARATOR)
+
+          path = paths.find do |p|
+            full_path = File.expand_path(cmd, p)
+            File.executable?(full_path) && File.file?(full_path)
+          end
+
+          path && File.expand_path(cmd, path)
+        end
+
+        yarn_path
+      end
+
+      def yarn_command(command)
+        full_command = "#{yarn_path} #{command}"
+
+        if options[:quiet]
+          system(full_command, out: File::NULL)
+        else
+          system(full_command)
+        end
       end
 
       def generate_spring_binstubs

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -53,6 +53,10 @@ module Rails
       template "gitignore", ".gitignore"
     end
 
+    def packagejson
+      template "package.json"
+    end
+
     def app
       directory "app"
 
@@ -205,6 +209,7 @@ module Rails
         build(:readme)
         build(:rakefile)
         build(:configru)
+        build(:packagejson) if options[:yarn]
         build(:gitignore) unless options[:skip_git]
         build(:gemfile)   unless options[:skip_gemfile]
       end
@@ -355,7 +360,7 @@ module Rails
       end
 
       public_task :apply_rails_template, :run_bundle
-      public_task :generate_spring_binstubs
+      public_task :run_yarn, :generate_spring_binstubs
 
       def run_after_bundle_callbacks
         @after_bundle_callbacks.each(&:call)

--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -16,8 +16,11 @@ chdir APP_ROOT do
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
-<% unless options.skip_active_record -%>
+<% if options[:yarn] %>
+  system! 'yarn'
 
+<% end %>
+<% unless options.skip_active_record -%>
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')
   #   cp 'config/database.yml.sample', 'config/database.yml'

--- a/railties/lib/rails/generators/rails/app/templates/bin/update.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/update.tt
@@ -16,8 +16,11 @@ chdir APP_ROOT do
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
-<% unless options.skip_active_record -%>
+<% if options[:yarn] %>
+  system! 'yarn'
 
+<% end %>
+<% unless options.skip_active_record -%>
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'
 <% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
@@ -5,6 +5,10 @@ Rails.application.config.assets.version = '1.0'
 
 # Add additional assets to the asset load path
 # Rails.application.config.assets.paths << Emoji.images_path
+<%- if options[:yarn] -%>
+# Add Yarn node_modules folder to the asset load path.
+Rails.application.config.assets.paths << Rails.root.join('node_modules')
+<%- end -%>
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -21,5 +21,10 @@
 !/tmp/.keep
 <% end -%>
 
+<% if options[:yarn] -%>
+# Ignore node modules.
+/node_modules/*
+
+<% end -%>
 # Ignore Byebug command history file.
 .byebug_history

--- a/railties/lib/rails/generators/rails/app/templates/package.json
+++ b/railties/lib/rails/generators/rails/app/templates/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "<%= app_name %>",
+  "private": true,
+  "dependencies": {
+    "rails-ujs": "rails/rails-ujs"
+  }
+}

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -497,6 +497,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_generator_if_yarn_option_is_given
     run_generator([destination_root, "--yarn"])
     assert_file "package.json", /dependencies/
+    assert_file "config/initializers/assets.rb", /node_modules/
   end
 
   def test_inclusion_of_jbuilder

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -494,6 +494,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_generator_if_yarn_option_is_given
+    run_generator([destination_root, "--yarn"])
+    assert_file "package.json", /dependencies/
+  end
+
   def test_inclusion_of_jbuilder
     run_generator
     assert_gem "jbuilder"
@@ -612,6 +617,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_generation_runs_bundle_install
     assert_generates_with_bundler
+  end
+
+  def test_generation_runs_yarn_install_with_yarn_option
+    assert_generates_with_yarn yarn: true
   end
 
   def test_dev_option
@@ -836,6 +845,20 @@ class AppGeneratorTest < Rails::Generators::TestCase
       end
 
       generator.stub :bundle_command, command_check do
+        quietly { generator.invoke_all }
+      end
+    end
+
+    def assert_generates_with_yarn(options = {})
+      generator([destination_root], options)
+
+      command_check = -> command do
+        @install_called ||= 0
+        @install_called += 1
+        assert_equal 1, @install_called, "install expected to be called once, but was called #{@install_called} times"
+      end
+
+      generator.stub :yarn_command, command_check do
         quietly { generator.invoke_all }
       end
     end


### PR DESCRIPTION
This add a package.json and the settings needed to get npm nodules integrated in new apps when the --yarn option is used (e.g `rails new blog --yarn`).

The next changes should be done to finish this:
- [x] Add `package.json` in new apps when `--yarn` option is passed
- [x] Run `yarn install` after `bundle install` in new apps
- [x] Add rails-ujs dependency to `package.json`
- [x] Add `node_modules` folder to asset paths
- [x] Fix existing broken tests
- [x] Add new tests
- [x] Changelog
