### PR TITLE
allow ActiveRecord::Core#slice to use array arg

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow `slice` to take an array of methods (without need for splatting).
+
+    *Cohen Carlisle*
+
 *   Improved partial writes with HABTM and has many through associations
     to fire database query only if relation has been changed.
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -538,7 +538,7 @@ module ActiveRecord
 
     # Returns a hash of the given methods with their names as keys and returned values as values.
     def slice(*methods)
-      Hash[methods.map! { |method| [method, public_send(method)] }].with_indifferent_access
+      Hash[methods.flatten.map! { |method| [method, public_send(method)] }].with_indifferent_access
     end
 
     private

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1428,6 +1428,16 @@ class BasicsTest < ActiveRecord::TestCase
     assert_nil hash["firm_name"]
   end
 
+  def test_slice_accepts_array_argument
+    attrs = {
+      title: "slice",
+      author_name: "@Cohen-Carlisle",
+      content: "accept arrays so I don't have to splat"
+    }.with_indifferent_access
+    topic = Topic.new(attrs)
+    assert_equal attrs, topic.slice(attrs.keys)
+  end
+
   def test_default_values_are_deeply_dupped
     company = Company.new
     company.description << "foo"


### PR DESCRIPTION
### Summary

This allows `ActiveRecord::Core#slice` to take an array of attributes to retain in addition to a splat of arguments, making it behave like like `ActiveRecord::QueryMethods#select`.
### Other Information

Imagine you have some code as follows:

``` ruby
class User < ApplicationRecord
  PUBLIC_FIELDS = %i(foo bar baz).freeze

  scope :public_fooed, -> { select(PUBLIC_FIELDS).where(foo: true) }

  def publicize
   slice(*PUBLIC_FIELDS)
  end
end
```

It annoys me that to filter attributes at the model class level (while doing a `::select`), you don't need to splat `PUBLIC_FIELDS`, but you do when doing it at the model object level (with `#slice`).

Since ActiveRecord::Core#slice will never have attributes (or methods) that are arrays, we can safely flatten its arguments to make it behave like `::select` with regard to array arguments.
