### PR TITLE
Fix copy_time_to: Copy nsec instead of usec

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `DateAndTime::Calculations#copy_time_to`. Copy `nsec` instead of `usec`.
+
+    Jumping forward or backward between weeks now preserves nanosecond digits.
+
+    *Josua Schmid*
+
 *   Fix `ActiveSupport::TimeWithZone#in` across DST boundaries.
 
     Previously calls to `in` were being sent to the non-DST aware

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -334,7 +334,7 @@ module DateAndTime
       end
 
       def copy_time_to(other)
-        other.change(hour: hour, min: min, sec: sec, usec: try(:usec))
+        other.change(hour: hour, min: min, sec: sec, nsec: try(:nsec))
       end
   end
 end

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -126,7 +126,9 @@ module DateAndTimeBehavior
   end
 
   def test_next_week_at_same_time
-    assert_equal date_time_init(2005,2,28,15,15,10),  date_time_init(2005,2,22,15,15,10).next_week(:monday, same_time: true)
+    assert_equal date_time_init(2005,2,28,15,15,10), date_time_init(2005,2,22,15,15,10).next_week(:monday, same_time: true)
+    assert_equal date_time_init(2005,2,28,15,15,10,999999), date_time_init(2005,2,22,15,15,10,999999).next_week(:monday, same_time: true)
+    assert_equal date_time_init(2005,2,28,15,15,10,Rational(999999999, 1000)), date_time_init(2005,2,22,15,15,10,Rational(999999999, 1000)).next_week(:monday, same_time: true)
     assert_equal date_time_init(2005,3,4,15,15,10),   date_time_init(2005,2,22,15,15,10).next_week(:friday, same_time: true)
     assert_equal date_time_init(2006,10,30,0,0,0), date_time_init(2006,10,23,0,0,0).next_week(:monday, same_time: true)
     assert_equal date_time_init(2006,11,1,0,0,0),  date_time_init(2006,10,23,0,0,0).next_week(:wednesday, same_time: true)


### PR DESCRIPTION
### Summary

`copy_time_to` has been introduced in https://github.com/rails/rails/commit/b6d0d0d106b5cd59f8da3f893b29a05bc85ac14e to enable time preservation when jumping between weeks with `next_week`, `prev_week`and `prev_weekday`.

Currently the precision of the method is limited to microseconds (`usec`). Because of that the following reproduction example unexpectedly evaluates to `false`:

``` ruby
t = Time.now.end_of_day

t.usec == t.next_week(same_time: true).usec
#=> true

t.nsec == t.next_week(same_time: true).nsec
#=> false
```

With this fix `copy_time_to` doesn't forget the `nsec` digits.
