### PR TITLE
Be able to use String#blank? with invalid encoding

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `String#blank?` no longer raises `ArgumentError` by invalid encoding strings.
+
+    *Yuuki Inoue*
+
 *   Use `Hash#compact` and `Hash#compact!` from Ruby 2.4. Old Ruby versions
     will continue to get these methods from Active Support as before.
 

--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -117,7 +117,7 @@ class String
     # The regexp that matches blank strings is expensive. For the case of empty
     # strings we can speed up this method (~3.5x) with an empty? call. The
     # penalty for the rest of strings is marginal.
-    empty? || BLANK_RE.match?(self)
+    empty? || valid_encoding? && BLANK_RE.match?(self)
   end
 end
 

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -15,7 +15,7 @@ class BlankTest < ActiveSupport::TestCase
   end
 
   BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", [], {} ]
-  NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 } ]
+  NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", "\xAE", [nil], { nil => 0 } ]
 
   def test_blank
     BLANK.each { |v| assert_equal true, v.blank?,  "#{v.inspect} should be blank" }


### PR DESCRIPTION
### Summary

Should be able to call `String#blank?` against invalid encoding String object.

`Regexp.match` will raise `ArgumentError` if passed invalid encoding strings.
I thought if the string including invalid encoding characters, it is not blank.

This change to be effective in the below case.

``` ruby

row = {
  "name"  => "Cardinal Slant-D\xAE Ring Binder",
  "price" => "2930",
  "include_tax" => "",
  "ship-weight" => "420.80",
  "category-name" => "Office Furnishings",
  "manufacturer" => "",
}

params = Hash[row.map{|k, v| [k.tr('-', '_'), v.presence&.scrub]}].compact
Product.create(params)
```
