### PR TITLE
Refactor ActionView::Context#_layout_for

### DIFF
--- a/actionview/lib/action_view/context.rb
+++ b/actionview/lib/action_view/context.rb
@@ -28,8 +28,7 @@ module ActionView
     # returns the correct buffer on +yield+. This is usually
     # overwritten by helpers to add more behavior.
     # :api: plugin
-    def _layout_for(name=nil)
-      name ||= :layout
+    def _layout_for(name = :layout)
       view_flow.get(name).html_safe
     end
   end


### PR DESCRIPTION
### Summary

Just use Ruby's default argument feature to refactor the old `ActionView::Context#_layout_for` method.
