### PR TITLE
ability to overwrite humanize method within human_attribute_name

### DIFF
--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -34,7 +34,7 @@ module ActiveModel
     end
 
     # Humanize method for the class. Could be overwriten f.e. with :titleize.
-    self.humanize_method = :humanize
+    self.humanize_attribute_name_method = :humanize
     
     # Transforms attribute names into a more human format, such as "First name"
     # instead of "first_name".
@@ -62,7 +62,7 @@ module ActiveModel
 
       defaults << :"attributes.#{attribute}"
       defaults << options.delete(:default) if options[:default]
-      defaults << attribute.send(self.humanize_method)
+      defaults << attribute.send(self.humanize_attribute_name_method)
 
       options[:default] = defaults
       I18n.translate(defaults.shift, options)

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -34,6 +34,7 @@ module ActiveModel
     end
 
     # Humanize method for the class. Could be overwriten f.e. with :titleize.
+    mattr_accessor :humanize_attribute_name_method
     self.humanize_attribute_name_method = :humanize
     
     # Transforms attribute names into a more human format, such as "First name"

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -33,6 +33,9 @@ module ActiveModel
       ancestors.select { |x| x.respond_to?(:model_name) }
     end
 
+    # Humanize method for the class. Could be overwriten f.e. with :titleize.
+    self.humanize_method = :humanize
+    
     # Transforms attribute names into a more human format, such as "First name"
     # instead of "first_name".
     #
@@ -59,7 +62,7 @@ module ActiveModel
 
       defaults << :"attributes.#{attribute}"
       defaults << options.delete(:default) if options[:default]
-      defaults << attribute.humanize
+      defaults << attribute.send(self.humanize_method)
 
       options[:default] = defaults
       I18n.translate(defaults.shift, options)

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -36,7 +36,7 @@ module ActiveModel
     # Humanize method for the class. Could be overwriten f.e. with :titleize.
     mattr_accessor :humanize_attribute_name_method
     self.humanize_attribute_name_method = :humanize
-    
+
     # Transforms attribute names into a more human format, such as "First name"
     # instead of "first_name".
     #


### PR DESCRIPTION
### Summary

Common case is to have titleized attribute names so with this patch one could easily do that with:
ActiveModel::Translation.humanize_attribute_name_method = :titleize
### Other Information

Benchmark.bm(4) do |b|
b.report("direct") { 1_000_000.times { "foo".humanize } }
b.report("send") { 1_000_000.times { "foo".send(:humanize) } }
end
direct: @real=8.701733449008316, @cstime=0.0, @cutime=0.0, @stime=0.0, @utime=8.596000000000004, @total=8.596000000000004
send: @real=10.015889608999714, @cstime=0.0, @cutime=0.0, @stime=0.0, @utime=9.687999999999995, @total=9.687999999999995
