### PR TITLE
Spike which adds logging of unhandled exceptions to AsyncAdapter.

### DIFF
--- a/activejob/lib/active_job/queue_adapters/async_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/async_adapter.rb
@@ -66,6 +66,11 @@ module ActiveJob
 
         def perform
           Base.execute @job_data
+        rescue => ex
+          # Perform the magic incantations necessary to use ActiveJob tagged logging
+          # The format the output appropriately
+          ActiveJob::Base.logger.error ex
+          raise ex
         end
       end
 


### PR DESCRIPTION
### Summary

This PR is not ready to be merged. I've created it to seek feedback and guidance from the core team.

This PR updates the `AsyncAdapter::JobWrapper` class to add logging when unhandled exceptions are raised by the job. It simply rescues the exception, writes to the log, then re-raises the exception (re-raising may not actually be necessary).

This PR addresses #26848 ("ActiveJob AsyncAdapter swallows exceptions, doesn't log by default") by logging unhandled exceptions raised by jobs. It is incomplete. It is not using tagged logging or formatting the output. (I would greatly appreciate guidance on wiring up tagged logging into the `JobWrapper` class.) It does not include a changelog update nor does it have unit tests. The original implementation included `activejob/test/cases/async_job_test.rb` but those tests appear to have been removed. I have manually tested and verified that logging will occur.
