### PR TITLE
don't create db directory when skip active_record

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -241,6 +241,7 @@ module Rails
       end
 
       def create_db_files
+        return if options[:skip_active_record]
         build(:db)
       end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -356,6 +356,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_generator_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
+    assert_no_directory "db/"
     assert_no_file "config/database.yml"
     assert_no_file "app/models/application_record.rb"
     assert_file "config/application.rb", /#\s+require\s+["']active_record\/railtie["']/


### PR DESCRIPTION
Hey all, 
### Actual behavior/Motivation

when using rails new my-app --skip-active-record

The db directory is created with seeds.rb file inside it.

and also because,  the `rails db:seed` command doesn't work

```
$ rails db:seed
rails aborted!
Don't know how to build task 'db:seed' (see --tasks)
```
### Expected behavior

I would not expect the db directory to exist
#### System configuration

Rails version: 5.0.0.1

Ruby version: 2.3.1
