### PR TITLE
Explicitly unpack the expanded args to avoid execution order diff.

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -410,8 +410,8 @@ module ActiveSupport
         # values.
         def make_lambda
           lambda do |target, value, &block|
-            c = expand(target, value, block)
-            c.shift.send(*c, &c.shift)
+            target, block, method, *arguments = expand(target, value, block)
+            target.send(method, *arguments, &block)
           end
         end
 
@@ -419,8 +419,8 @@ module ActiveSupport
         # values, but then return the boolean inverse of that result.
         def inverted_lambda
           lambda do |target, value, &block|
-            c = expand(target, value, block)
-            ! c.shift.send(*c, &c.shift)
+            target, block, method, *arguments = expand(target, value, block)
+            ! target.send(method, *arguments, &block)
           end
         end
 


### PR DESCRIPTION
### Summary

In https://bugs.ruby-lang.org/issues/12860 I argue that MRI's
execution order here is incorrect. The splatting of the 'c' args
should happen before the shift, but it happens after. On JRuby, it
behaves the way you would expect, leading to the 'c' args splat
still containing the block and producing an error like "cannot
convert proc to symbol" when the send attempts to coerce
it.

This patch makes the unpacking order explicit with a multi-assign,
which behaves properly on all implementations I tested.
### Additional Information

This code appears to have been introduced after the most recent Rails release so I don't _think_ it needs to be backported. I started running into the "proc to symbol" errors only after switching to master for JRuby testing.
