### PR TITLE
Skip test that depends on RubyVM when it is not available (JRuby).

### DIFF
--- a/activesupport/test/executor_test.rb
+++ b/activesupport/test/executor_test.rb
@@ -192,6 +192,8 @@ class ExecutorTest < ActiveSupport::TestCase
   end
 
   def test_class_serial_is_unaffected
+    skip if !defined?(RubyVM)
+
     hook = Class.new do
       define_method(:run) do
         nil


### PR DESCRIPTION
### Summary

Only MRI defines `RubyVM`, so mask out this test if it's not available.
