### PR TITLE
Soften this test since YAML.dump may produce keys in other orders.

### DIFF
--- a/actionpack/test/controller/parameters/serialization_test.rb
+++ b/actionpack/test/controller/parameters/serialization_test.rb
@@ -14,12 +14,10 @@ class ParametersSerializationTest < ActiveSupport::TestCase
 
   test "yaml serialization" do
     params = ActionController::Parameters.new(key: :value)
-    assert_equal <<-end_of_yaml.strip_heredoc, YAML.dump(params)
-      --- !ruby/object:ActionController::Parameters
-      parameters: !ruby/hash:ActiveSupport::HashWithIndifferentAccess
-        key: :value
-      permitted: false
-    end_of_yaml
+    yaml_dump = YAML.dump(params)
+    assert_match("--- !ruby/object:ActionController::Parameters", yaml_dump)
+    assert_match(/parameters: !ruby\/hash:ActiveSupport::HashWithIndifferentAccess\n\s+key: :value/, yaml_dump)
+    assert_match("permitted: false", yaml_dump)
   end
 
   test "yaml deserialization" do


### PR DESCRIPTION
### Summary

JRuby's YAML engine is not libyaml, and may produce keys in a different order. That led to this failure (the SOLE failure) in actionpack:

```
  1) Failure:
ParametersSerializationTest#test_yaml_serialization [/Users/headius/projects/rails/actionpack/test/controller/parameters/serialization_test.rb:17]:
--- expected
+++ actual
@@ -1,5 +1,5 @@
 "--- !ruby/object:ActionController::Parameters
+permitted: false
 parameters: !ruby/hash:ActiveSupport::HashWithIndifferentAccess
   key: :value
-permitted: false
 "
```

This patch modifies the test to use regexp matching for key lines rather than a string comparison.
