### PR TITLE
Lazy-load blade for actioncable tests; no blade on JRuby.

### DIFF
--- a/actioncable/Rakefile
+++ b/actioncable/Rakefile
@@ -1,7 +1,6 @@
 require "rake/testtask"
 require "pathname"
 require "action_cable"
-require "blade"
 
 dir = File.dirname(__FILE__)
 
@@ -25,6 +24,7 @@ namespace :test do
   end
 
   task :integration do
+    require "blade"
     if ENV["CI"]
       Blade.start(interface: :ci)
     else
@@ -36,6 +36,7 @@ end
 namespace :assets do
   desc "Compile Action Cable assets"
   task :compile do
+    require "blade"
     Blade.build
   end
 end


### PR DESCRIPTION
### Summary

In ca0b6d0d416776655ed7516ac18f126fbde5315a, @sgrif masked out the `blade` libraries to only `:ruby` platform (yay!) However, the actioncable Rakefile still requires it blindly.

I've moved the requires to the rake tasks where Blade is actually used. An alternative would be to `rescue LoadError` but that would then produce a confusing error about the Blade constant being missing. I think mine is better.
### Other Information

I do need to wonder...shouldn't actioncable's tests all be runnable on implementations that don't support `blade` (or really, its transitive dependency `curses`).
