### PR TITLE
Fix brittle tests which were relying on the error message text from mysql2 gem

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -65,18 +65,18 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
 
   def test_execute_after_disconnect
     @connection.disconnect!
-    error = assert_raise(ActiveRecord::StatementInvalid) do
+
+    assert_raise(ActiveRecord::StatementInvalid) do
       @connection.execute("SELECT 1")
     end
-    assert_match(/MySQL client is not connected/, error.message)
   end
 
   def test_quote_after_disconnect
     @connection.disconnect!
-    error = assert_raise(Mysql2::Error) do
+
+    assert_raise(Mysql2::Error) do
       @connection.quote("string")
     end
-    assert_match(/MySQL client is not connected/, error.message)
   end
 
   def test_active_after_disconnect


### PR DESCRIPTION
### Summary
- These tests were fixed earlier on master in https://github.com/rails/rails/commit/f13ec72664fd13d33d617103ca964a7592295854.
- They started failing in first place due to change in https://github.com/brianmario/mysql2/commit/f14023fcfee9e85e6fc1b0e568048811518f8c23.
- They will fail again when the message is changed in mysql2 so let's
  not rely on the error message.
