### PR TITLE
remove deprecated pg_dump flag

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -51,7 +51,7 @@ module ActiveRecord
           search_path = search_path.split(",").map{|search_path_part| "--schema=#{Shellwords.escape(search_path_part.strip)}" }.join(" ")
         end
 
-        command = "pg_dump -i -s -x -O -f #{Shellwords.escape(filename)} #{search_path} #{Shellwords.escape(configuration['database'])}"
+        command = "pg_dump -s -x -O -f #{Shellwords.escape(filename)} #{search_path} #{Shellwords.escape(configuration['database'])}"
         raise 'Error dumping database' unless Kernel.system(command)
 
         File.open(filename, "a") { |f| f << "SET search_path TO #{ActiveRecord::Base.connection.schema_search_path};\n\n" }


### PR DESCRIPTION
Hi,

I had a issue to migrate the tables using `rails 4.0.3` with `postgres 9.5.4` 

``` sh
pg_dump: invalid option -- i
Try "pg_dump --help" for more information.
rake aborted!
Error dumping database
```

I removed the deprecated pg_dump flag
