### PR TITLE
Fix model schema doc strings

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -2,71 +2,130 @@ module ActiveRecord
   module ModelSchema
     extend ActiveSupport::Concern
 
+    ##
+    # :singleton-method: primary_key_prefix_type
+    # :call-seq: primary_key_prefix_type
+    # Accessor for the name of the prefix string to prepend to every table name. So if set
+    # to "basecamp_", all table names will be named like "basecamp_projects", "basecamp_people",
+    # etc. This is a convenient way of creating a namespace for tables in a shared database.
+    # By default, the prefix is the empty string.
+    #
+    # If you are organising your models within modules you can add a prefix to the models within
+    # a namespace by defining a singleton method in the parent module called table_name_prefix which
+    # returns your chosen prefix.
+
+    ##
+    # :singleton-method: primary_key_prefix_type=
+    # :call-seq: primary_key_prefix_type=(prefix)
+    # Accessor for the name of the prefix string to prepend to every table name. So if set
+    # to "basecamp_", all table names will be named like "basecamp_projects", "basecamp_people",
+    # etc. This is a convenient way of creating a namespace for tables in a shared database.
+    # By default, the prefix is the empty string.
+    #
+    # If you are organising your models within modules you can add a prefix to the models within
+    # a namespace by defining a singleton method in the parent module called table_name_prefix which
+    # returns your chosen prefix.
+
+    ##
+    # :singleton-method: table_name_suffix
+    # :call-seq: table_name_suffix
+    # Works like +table_name_prefix+, but appends instead of prepends (set to "_basecamp" gives "projects_basecamp",
+    # "people_basecamp"). By default, the suffix is the empty string.
+    #
+    # If you are organising your models within modules, you can add a suffix to the models within
+    # a namespace by defining a singleton method in the parent module called table_name_suffix which
+    # returns your chosen suffix.
+
+    ##
+    # :singleton-method: table_name_suffix=
+    # :call-seq: table_name_suffix=(suffix)
+    # Works like +table_name_prefix+, but appends instead of prepends (set to "_basecamp" gives "projects_basecamp",
+    # "people_basecamp"). By default, the suffix is the empty string.
+    #
+    # If you are organising your models within modules, you can add a suffix to the models within
+    # a namespace by defining a singleton method in the parent module called table_name_suffix which
+    # returns your chosen suffix.
+
+    ##
+    # :singleton-method: schema_migrations_table_name
+    # :call-seq: schema_migrations_table_name
+    # Accessor for the name of the schema migrations table. By default, the value is "schema_migrations"
+
+    ##
+    # :singleton-method: schema_migrations_table_name=
+    # :call-seq: schema_migrations_table_name=(table_name)
+    # Sets the name of the schema migrations table. By default, the value is "schema_migrations"
+
+    ##
+    # :singleton-method: internal_metadata_table_name
+    # :call-seq: internal_metadata_table_name
+    # Accessor for the name of the internal metadata table. By default, the value is "ar_internal_metadata"
+
+    ##
+    # :singleton-method: internal_metadata_table_name=
+    # :call-seq: internal_metadata_table_name=(table_name)
+    # Sets the name of the internal metadata table. By default, the value is "ar_internal_metadata"
+
+    ##
+    # :singleton-method: protected_environments
+    # :call-seq: protected_environments
+    # Accessor for an array of names of environments where destructive actions should be prohibited. By default,
+    # the value is ["production"]
+
+    ##
+    # :singleton-method: protected_environments=
+    # :call-seq: protected_environments=(environments)
+    # Sets an array of names of environments where destructive actions should be prohibited. By default,
+    # the value is ["production"]
+
+    ##
+    # :singleton-method: pluralize_table_names
+    # :call-seq: pluralize_table_names
+    # Indicates whether table names should be the pluralized versions of the corresponding class names.
+    # If true, the default table name for a Product class will be +products+. If false, it would just be +product+.
+    # See table_name for the full rules on table/class naming. This is true, by default.
+
+    ##
+    # :singleton-method: pluralize_table_names=
+    # :call-seq: pluralize_table_names=(value)
+    # Set whether table names should be the pluralized versions of the corresponding class names.
+    # If true, the default table name for a Product class will be +products+. If false, it would just be +product+.
+    # See table_name for the full rules on table/class naming. This is true, by default.
+
+    ##
+    # :singleton-method: ignored_columns
+    # :call-seq: ignored_columns
+    # Sets list of columns names the model should ignore. Ignored columns won't have attribute
+    # accessors defined, and won't be referenced in SQL queries.
+
+    ##
+    # :singleton-method: ignored_columns=
+    # :call-seq: ignored_columns=(columns)
+    # Lists the columns names the model should ignore. Ignored columns won't have attribute accessors defined, and
+    # won't be referenced in SQL queries.
+
     included do
-      ##
-      # :singleton-method:
-      # Accessor for the prefix type that will be prepended to every primary key column name.
-      # The options are :table_name and :table_name_with_underscore. If the first is specified,
-      # the Product class will look for "productid" instead of "id" as the primary column. If the
-      # latter is specified, the Product class will look for "product_id" instead of "id". Remember
-      # that this is a global setting for all Active Records.
+
       mattr_accessor :primary_key_prefix_type, instance_writer: false
 
-      ##
-      # :singleton-method:
-      # Accessor for the name of the prefix string to prepend to every table name. So if set
-      # to "basecamp_", all table names will be named like "basecamp_projects", "basecamp_people",
-      # etc. This is a convenient way of creating a namespace for tables in a shared database.
-      # By default, the prefix is the empty string.
-      #
-      # If you are organising your models within modules you can add a prefix to the models within
-      # a namespace by defining a singleton method in the parent module called table_name_prefix which
-      # returns your chosen prefix.
       class_attribute :table_name_prefix, instance_writer: false
       self.table_name_prefix = ""
 
-      ##
-      # :singleton-method:
-      # Works like +table_name_prefix+, but appends instead of prepends (set to "_basecamp" gives "projects_basecamp",
-      # "people_basecamp"). By default, the suffix is the empty string.
-      #
-      # If you are organising your models within modules, you can add a suffix to the models within
-      # a namespace by defining a singleton method in the parent module called table_name_suffix which
-      # returns your chosen suffix.
       class_attribute :table_name_suffix, instance_writer: false
       self.table_name_suffix = ""
 
-      ##
-      # :singleton-method:
-      # Accessor for the name of the schema migrations table. By default, the value is "schema_migrations"
       class_attribute :schema_migrations_table_name, instance_accessor: false
       self.schema_migrations_table_name = "schema_migrations"
 
-      ##
-      # :singleton-method:
-      # Accessor for the name of the internal metadata table. By default, the value is "ar_internal_metadata"
       class_attribute :internal_metadata_table_name, instance_accessor: false
       self.internal_metadata_table_name = "ar_internal_metadata"
 
-      ##
-      # :singleton-method:
-      # Accessor for an array of names of environments where destructive actions should be prohibited. By default,
-      # the value is ["production"]
       class_attribute :protected_environments, instance_accessor: false
       self.protected_environments = ["production"]
 
-      ##
-      # :singleton-method:
-      # Indicates whether table names should be the pluralized versions of the corresponding class names.
-      # If true, the default table name for a Product class will be +products+. If false, it would just be +product+.
-      # See table_name for the full rules on table/class naming. This is true, by default.
       class_attribute :pluralize_table_names, instance_writer: false
       self.pluralize_table_names = true
 
-      ##
-      # :singleton-method:
-      # Accessor for the list of columns names the model should ignore. Ignored columns won't have attribute
-      # accessors defined, and won't be referenced in SQL queries.
       class_attribute :ignored_columns, instance_accessor: false
       self.ignored_columns = [].freeze
 


### PR DESCRIPTION
### Summary

Model Schema's singleton methods were not producing documentation from their doc strings because these were in an include block. Moved them out and fixed them to have the getter and setter documented.
### Other Information

Blame Rafael. He made me do this.

Thanks for contributing to Rails!

**Review**
@rafaelfranca 
