### PR TITLE
Add types to ActiveRecord::Store accessors

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   ActiveRecord::Store accessors can now have types defined to
+    automatically cast values on read and write.
+
+    *Chris Oliver*
+
 *   Deprecate passing arguments and block at the same time to
     `ActiveRecord::QueryMethods#select`.
 

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -66,6 +66,16 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal false, @john.remember_login
   end
 
+  test "casting attribute types" do
+    @john.birth_date = Date.today
+    assert_equal Date, @john.birth_date.class
+  end
+
+  test "retrieving casted attributes" do
+    @john.update(birth_date: Date.today)
+    assert_equal Date, @john.reload.birth_date.class
+  end
+
   test "overriding a write accessor" do
     @john.phone_number = "(123) 456-7890"
 

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -17,7 +17,7 @@ class Admin::User < ActiveRecord::Base
   store :params, accessors: [ :token ], coder: YAML
   store :settings, accessors: [ :color, :homepage ]
   store_accessor :settings, :favorite_food
-  store :preferences, accessors: [ :remember_login ]
+  store :preferences, accessors: [ :remember_login, birth_date: :date ]
   store :json_data, accessors: [ :height, :weight ], coder: Coder.new
   store :json_data_empty, accessors: [ :is_a_good_guy ], coder: Coder.new
 


### PR DESCRIPTION
### Summary

ActiveRecord::Store is awesome, but it doesn't have any support for casting types. The documentation recommends overriding the setters for casting values to their appropriate types.

Now that we have the `attributes` api in Rails 5, we can use that to simplify this and add type support to AR::Store.

As an example, we can go from this:

``` ruby
class Song < ActiveRecord::Base
  # Uses a stored integer to hold the volume adjustment of the song
  store :settings, accessors: [:volume_adjustment]

  def volume_adjustment=(decibels)
    super(decibels.to_i)
  end

  def volume_adjustment
    super.to_i
  end
end
```

To this:

``` ruby
class Song < ActiveRecord::Base
  store :settings, accessors: [volume_adjustment: :integer]
end
```

Since this uses ActiveRecord::Types for the lookup, you can use any registered type and it will work just like standard attributes.
