### PR TITLE
remove assets config from `new_framework_defaults` if `--skip-sprockets` is true

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
@@ -32,7 +32,9 @@ ActiveSupport.halt_callback_chains_on_return_false = <%= options[:update] ? true
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }
 <%- end -%>
+<%- unless options[:skip_sprockets] -%>
 
 # Unknown asset fallback will return the path passed in when the given
 # asset is not present in the asset pipeline.
 Rails.application.config.assets.unknown_asset_fallback = <%= options[:update] ? true : false %>
+<%- end -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -412,6 +412,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_no_match(/config\.assets\.js_compressor = :uglifier/, content)
       assert_no_match(/config\.assets\.css_compressor = :sass/, content)
     end
+    assert_file "config/initializers/new_framework_defaults.rb" do |content|
+      assert_no_match(/unknown_asset_fallback/, content)
+    end
   end
 
   def test_generator_if_skip_action_cable_is_given


### PR DESCRIPTION
If `sprockets` is not loaded, `Rails.application.config.assets` is not defined.
