### PR TITLE
Ensure `#transform_values` of HWIDA to return HWIDA

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -273,6 +273,11 @@ module ActiveSupport
       dup.tap { |hash| hash.reject!(*args, &block) }
     end
 
+    def transform_values(*args, &block)
+      return to_enum(:transform_values) unless block_given?
+      dup.tap { |hash| hash.transform_values!(*args, &block) }
+    end
+
     # Convert to a regular hash with string keys.
     def to_hash
       _new_hash = Hash.new


### PR DESCRIPTION
On Ruby 2.4, naitive `Hash#transform_values` is implemented.
`Hash#transform_values` uses an instance of Hash (`rb_hash_new`) to
collect returned values of a block.
For ensuring `#transform_values` of HWIDA to return HWIDA, we should
define `#transform_values` on HWIDA.
