### PR TITLE
Add :except_on option to validations

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added `:except_on` option to validators that does the exact opposite of `:on`.
+    
+    *Jochen Niebuhr*
+
 *   Removed deprecated `:tokenizer` in the length validator.
 
     *Rafael Mendonça França*

--- a/activemodel/lib/active_model/validations/absence.rb
+++ b/activemodel/lib/active_model/validations/absence.rb
@@ -21,7 +21,7 @@ module ActiveModel
       # * <tt>:message</tt> - A custom error message (default is: "must be blank").
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except_on+, +:allow_nil+, +:allow_blank+, and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_absence_of(*attr_names)
         validates_with AbsenceValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -92,7 +92,7 @@ module ActiveModel
       #   before validation.
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except_on+, +:allow_nil+, +:allow_blank+, and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information.
       def validates_acceptance_of(*attr_names)
         validates_with AcceptanceValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -54,12 +54,21 @@ module ActiveModel
         #   person.name   # => "bob"
         def before_validation(*args, &block)
           options = args.last
-          if options.is_a?(Hash) && options[:on]
-            options[:if] = Array(options[:if])
-            options[:on] = Array(options[:on])
-            options[:if].unshift ->(o) {
-              options[:on].include? o.validation_context
-            }
+          if options.is_a?(Hash)
+            if options[:on]
+              options[:if] = Array(options[:if])
+              options[:on] = Array(options[:on])
+              options[:if].unshift ->(o) {
+                options[:on].include? o.validation_context
+              }
+            end
+            if options[:except_on]
+              options[:unless] = Array(options[:unless])
+              options[:except_on] = Array(options[:except_on])
+              options[:unless].unshift ->(o) {
+                options[:except_on].include? o.validation_context
+              }
+            end
           end
           set_callback(:validation, :before, *args, &block)
         end
@@ -93,11 +102,18 @@ module ActiveModel
         def after_validation(*args, &block)
           options = args.extract_options!
           options[:prepend] = true
-          options[:if] = Array(options[:if])
           if options[:on]
+            options[:if] = Array(options[:if])
             options[:on] = Array(options[:on])
             options[:if].unshift ->(o) {
               options[:on].include? o.validation_context
+            }
+          end
+          if options[:except_on]
+            options[:unless] = Array(options[:unless])
+            options[:except_on] = Array(options[:except_on])
+            options[:unless].unshift ->(o) {
+              options[:except_on].include? o.validation_context
             }
           end
           set_callback(:validation, :after, *(args << options), &block)

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -68,7 +68,7 @@ module ActiveModel
       #   non-text columns (+true+ by default).
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except_on+, +:allow_nil+, +:allow_blank+, and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_confirmation_of(*attr_names)
         validates_with ConfirmationValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/exclusion.rb
+++ b/activemodel/lib/active_model/validations/exclusion.rb
@@ -37,7 +37,7 @@ module ActiveModel
       #   reserved").
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except_on+, +:allow_nil+, +:allow_blank+, and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_exclusion_of(*attr_names)
         validates_with ExclusionValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/format.rb
+++ b/activemodel/lib/active_model/validations/format.rb
@@ -104,7 +104,7 @@ module ActiveModel
       #   beginning or end of the string. These anchors are <tt>^</tt> and <tt>$</tt>.
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except_on+, +:allow_nil+, +:allow_blank+, and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_format_of(*attr_names)
         validates_with FormatValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/inclusion.rb
+++ b/activemodel/lib/active_model/validations/inclusion.rb
@@ -35,7 +35,7 @@ module ActiveModel
       #   not included in the list").
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except_on+, +:allow_nil+, +:allow_blank+, and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_inclusion_of(*attr_names)
         validates_with InclusionValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -111,7 +111,7 @@ module ActiveModel
       #   <tt>too_long</tt>/<tt>too_short</tt>/<tt>wrong_length</tt> message.
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+ and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except_on+ and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_length_of(*attr_names)
         validates_with LengthValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -135,7 +135,7 @@ module ActiveModel
       # * <tt>:even</tt> - Specifies the value must be an even number.
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+ .
+      # +:if+, +:unless+, +:on+, +:except_on+, +:allow_nil+, +:allow_blank+, and +:strict+ .
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       #
       # The following checks can also be supplied with a proc or a symbol which

--- a/activemodel/lib/active_model/validations/presence.rb
+++ b/activemodel/lib/active_model/validations/presence.rb
@@ -28,7 +28,7 @@ module ActiveModel
       # * <tt>:message</tt> - A custom error message (default is: "can't be blank").
       #
       # There is also a list of default options supported by every validator:
-      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # +:if+, +:unless+, +:on+, +:except_on+, +:allow_nil+, +:allow_blank+, and +:strict+.
       # See <tt>ActiveModel::Validation#validates</tt> for more information
       def validates_presence_of(*attr_names)
         validates_with PresenceValidator, _merge_attributes(attr_names)

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -76,6 +76,12 @@ module ActiveModel
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:except_on</tt> - Specifies the contexts where this validation is not active.
+      #   This works the opposite way of <tt>:on</tt>.
+      #   Runs in all validation contexts by default (unless specified otherwise using <tt>:on</tt>).
+      #   You can pass a symbol or an array of symbols. (e.g. <tt>except_on: :create</tt> or
+      #   <tt>except_on: :custom_validation_context</tt> or
+      #   <tt>except_on: [:create, :custom_validation_context]</tt>)
       # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,
@@ -97,7 +103,7 @@ module ActiveModel
       #   validates :token, uniqueness: true, strict: TokenGenerationException
       #
       #
-      # Finally, the options +:if+, +:unless+, +:on+, +:allow_blank+, +:allow_nil+, +:strict+
+      # Finally, the options +:if+, +:unless+, +:on+, +:except_on+, +:allow_blank+, +:allow_nil+, +:strict+
       # and +:message+ can be given to one specific validator, as a hash:
       #
       #   validates :password, presence: { if: :password_required?, message: 'is forgotten.' }, confirmation: true
@@ -153,7 +159,7 @@ module ActiveModel
       # When creating custom validators, it might be useful to be able to specify
       # additional default keys. This can be done by overwriting this method.
       def _validates_default_keys # :nodoc:
-        [:if, :unless, :on, :allow_blank, :allow_nil , :strict]
+        [:if, :unless, :on, :except_on, :allow_blank, :allow_nil , :strict]
       end
 
       def _parse_validates_options(options) # :nodoc:

--- a/activemodel/lib/active_model/validations/with.rb
+++ b/activemodel/lib/active_model/validations/with.rb
@@ -49,6 +49,12 @@ module ActiveModel
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:except_on</tt> - Specifies the contexts where this validation is not active.
+      #   This works the opposite way of <tt>:on</tt>.
+      #   Runs in all validation contexts by default (unless specified otherwise using <tt>:on</tt>).
+      #   You can pass a symbol or an array of symbols. (e.g. <tt>except_on: :create</tt> or
+      #   <tt>except_on: :custom_validation_context</tt> or
+      #   <tt>except_on: [:create, :custom_validation_context]</tt>)
       # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>).
@@ -124,7 +130,7 @@ module ActiveModel
     #     end
     #   end
     #
-    # Standard configuration options (<tt>:on</tt>, <tt>:if</tt> and
+    # Standard configuration options (<tt>:on</tt>, <tt>:except_on</tt>, <tt>:if</tt> and
     # <tt>:unless</tt>), which are available on the class version of
     # +validates_with+, should instead be placed on the +validates+ method
     # as these are applied and tested in the callback.

--- a/activemodel/test/cases/validations/callbacks_test.rb
+++ b/activemodel/test/cases/validations/callbacks_test.rb
@@ -57,6 +57,14 @@ class DogValidatorWithOnCondition < Dog
   def set_after_validation_marker;  history << "after_validation_marker" ; end
 end
 
+class DogValidatorWithExceptOnCondition < Dog
+  before_validation :set_before_validation_marker, except_on: :update
+  after_validation :set_after_validation_marker, except_on: :update
+
+  def set_before_validation_marker; history << "before_validation_marker"; end
+  def set_after_validation_marker;  history << "after_validation_marker" ; end
+end
+
 class DogValidatorWithIfCondition < Dog
   before_validation :set_before_validation_marker1, if: -> { true }
   before_validation :set_before_validation_marker2, if: -> { false }
@@ -94,6 +102,24 @@ class CallbacksWithMethodNamesShouldBeCalled < ActiveModel::TestCase
     d = DogValidatorWithOnCondition.new
     d.valid?
     assert_equal [], d.history
+  end
+
+  def test_except_on_condition_is_respected_for_validation_with_matching_context
+    d = DogValidatorWithExceptOnCondition.new
+    d.valid?(:update)
+    assert_equal [], d.history
+  end
+
+  def test_except_on_condition_is_respected_for_validation_without_matching_context
+    d = DogValidatorWithExceptOnCondition.new
+    d.valid?(:save)
+    assert_equal ["before_validation_marker", "after_validation_marker"], d.history
+  end
+
+  def test_except_on_condition_is_respected_for_validation_without_context
+    d = DogValidatorWithExceptOnCondition.new
+    d.valid?
+    assert_equal ["before_validation_marker", "after_validation_marker"], d.history
   end
 
   def test_before_validation_and_after_validation_callbacks_should_be_called

--- a/activemodel/test/cases/validations/validations_context_test.rb
+++ b/activemodel/test/cases/validations/validations_context_test.rb
@@ -65,4 +65,21 @@ class ValidationsContextTest < ActiveModel::TestCase
     assert_includes topic.errors[:base], ERROR_MESSAGE
     assert_includes topic.errors[:base], ANOTHER_ERROR_MESSAGE
   end
+
+  test "with a class that adds errors on all contexts but a custom context" do
+    Topic.validates_with(ValidatorThatAddsErrors, except_on: :context)
+    topic = Topic.new
+    assert topic.valid?(:context), "Validation doesn't run on valid?(:context) if 'except_on' is set to context"
+  end
+
+  test "with a class that adds errors except on multiple contexts and validating a new model and an excluded context" do
+    Topic.validates_with(ValidatorThatAddsErrors, except_on: [:context1, :context2])
+
+    topic = Topic.new
+    assert topic.invalid?, "Validation ran with no context given when 'except_on' is set to context1 and context2"
+    assert_includes topic.errors[:base], ERROR_MESSAGE
+
+    assert topic.valid?(:context1), "Validation did not run on context1 when 'except_on' is set to context1 and context2"
+    assert topic.valid?(:context2), "Validation did not run on context2 when 'except_on' is set to context1 and context2"
+  end
 end


### PR DESCRIPTION
### Summary

In some cases, you might need a validation to not run in a
specific context. To achieve this, the :except_on option was
added. It performs the same logic as the :on option but adds
the resulting lambda into the :unless option.
