### PR TITLE
Fix invalid command for precompiling the assets in guides.

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -701,7 +701,7 @@ information on compiling locally.
 The task is:
 
 ```bash
-$ RAILS_ENV=production bin/rails assets:precompile
+$ RAILS_ENV=production bin/rake assets:precompile
 ```
 
 Capistrano (v2.15.1 and above) includes a recipe to handle this in deployment.


### PR DESCRIPTION
### Summary

The command described for precompiling the assets in the asset pipeline guides is invalid.

`RAILS_ENV=production bin/rails assets:precompile`

should be

`RAILS_ENV=production bin/rake assets:precompile`

http://guides.rubyonrails.org/asset_pipeline.html#precompiling-assets
