### PR TITLE
Use bulk SQL INSERT when bootstraping fixtures

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -422,6 +422,12 @@ module ActiveRecord
         rename_column_indexes(table_name, column.name, new_column_name)
       end
 
+      def insert_fixtures(rows, table_name)
+        rows.each do |row|
+          insert_fixture(row, table_name)
+        end
+      end
+
       protected
 
         def table_structure(table_name)

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -549,9 +549,7 @@ module ActiveRecord
               end
 
               table_rows.each do |fixture_set_name, rows|
-                rows.each do |row|
-                  conn.insert_fixture(row, fixture_set_name)
-                end
+                conn.insert_fixtures(rows, fixture_set_name)
               end
 
               # Cap primary key sequences to max(pk).

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -188,6 +188,12 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
     assert_equal(PgArray.last.tags, tag_values)
   end
 
+  def test_insert_fixtures
+    tag_values = ["val1", "val2", "val3_with_'_multiple_quote_'_chars"]
+    @connection.insert_fixtures([{ "tags" => tag_values }], "pg_arrays" )
+    assert_equal(PgArray.last.tags, tag_values)
+  end
+
   def test_attribute_for_inspect_for_array_field
     record = PgArray.new { |a| a.ratings = (1..10).to_a }
     assert_equal("[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]", record.attribute_for_inspect(:ratings))

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -52,6 +52,31 @@ class FixturesTest < ActiveRecord::TestCase
     end
   end
 
+  class InsertQueriesSubscriber
+    attr_reader :events
+
+    def initialize
+      @events = []
+    end
+
+    def call(_, _, _, _, values)
+      @events << values[:sql] if values[:sql] =~ /INSERT/
+    end
+  end
+
+  if current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter)
+    def test_bulk_insert
+      begin
+        insert_subscriber = InsertQueriesSubscriber.new
+        subscription = ActiveSupport::Notifications.subscribe("sql.active_record", insert_subscriber)
+        create_fixtures("bulbs")
+        assert_equal 1, insert_subscriber.events.size, "It takes one INSERT query to insert two fixtures"
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscription)
+      end
+    end
+  end
+
   def test_broken_yaml_exception
     badyaml = Tempfile.new ["foo", ".yml"]
     badyaml.write "a: : "
@@ -220,7 +245,12 @@ class FixturesTest < ActiveRecord::TestCase
     e = assert_raise(ActiveRecord::Fixture::FixtureError) do
       ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT + "/naked/yml", "parrots")
     end
-    assert_equal(%(table "parrots" has no column named "arrr".), e.message)
+
+    if current_adapter?(:SQLite3Adapter)
+      assert_equal(%(table "parrots" has no column named "arrr".), e.message)
+    else
+      assert_equal(%(table "parrots" has no columns named "arrr", "foobar".), e.message)
+    end
   end
 
   def test_yaml_file_with_symbol_columns

--- a/activerecord/test/fixtures/naked/yml/parrots.yml
+++ b/activerecord/test/fixtures/naked/yml/parrots.yml
@@ -1,2 +1,3 @@
 george:
   arrr: "Curious George"
+  foobar: Foobar


### PR DESCRIPTION
We've been using this patch at Shopify and it makes fixtures insert way faster because we can leverage bulk INSERT. I think this patch is worth sharing with the rest of the community.

It won't work when fixture fields are different, for example:

``` yml
bob:
  id: 1
  name: Bob
david:
  id: 2
```

In this case we will fallback to single insert that we have been using all the time.
### Concerns
- It introduces a new API method (`insert_fixtures`) that other adapters have to support.
- We could always use bulk insert even in case with the fixture I demonstrated above. That would make us insert `name = NULL` for `david`. That works fine in most of the cases except when `name` it's auto-increment column.

cc @rafaelfranca @sgrif 
