### PR TITLE
Allow the use of custom Javascript engines in new apps.

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -33,6 +33,9 @@ module Rails
         class_option :javascript,         type: :string, aliases: "-j", default: "jquery",
                                           desc: "Preconfigure for selected JavaScript library"
 
+        class_option :transpiler,         type: :string, aliases: "-t", default: "coffee",
+                                          desc: "Preconfigure for selected JavaScript transpiler"
+
         class_option :skip_gemfile,       type: :boolean, default: false,
                                           desc: "Don't create a Gemfile"
 
@@ -314,15 +317,15 @@ module Rails
         GemfileEntry.new "jbuilder", "~> 2.5", comment, {}, options[:api]
       end
 
-      def coffee_gemfile_entry
-        GemfileEntry.version "coffee-rails", "~> 4.2", "Use CoffeeScript for .coffee assets and views"
+      def transpiler_gemfile_entry
+        GemfileEntry.version "#{options[:transpiler]}-rails", nil, "Use #{options[:transpiler]} as JavaScript Transpiler"
       end
 
       def javascript_gemfile_entry
         if options[:skip_javascript] || options[:skip_sprockets]
           []
         else
-          gems = [coffee_gemfile_entry, javascript_runtime_gemfile_entry]
+          gems = [transpiler_gemfile_entry, javascript_runtime_gemfile_entry]
           gems << GemfileEntry.version("#{options[:javascript]}-rails", nil,
                                        "Use #{options[:javascript]} as the JavaScript library")
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -33,8 +33,8 @@ module Rails
         class_option :javascript,         type: :string, aliases: "-j", default: "jquery",
                                           desc: "Preconfigure for selected JavaScript library"
 
-        class_option :transpiler,         type: :string, aliases: "-t", default: "coffee",
-                                          desc: "Preconfigure for selected JavaScript transpiler"
+        class_option :javascript_engine,  type: :string, aliases: "-je", default: "coffee",
+                                          desc: "Preconfigure for selected JavaScript engine"
 
         class_option :skip_gemfile,       type: :boolean, default: false,
                                           desc: "Don't create a Gemfile"
@@ -317,15 +317,15 @@ module Rails
         GemfileEntry.new "jbuilder", "~> 2.5", comment, {}, options[:api]
       end
 
-      def transpiler_gemfile_entry
-        GemfileEntry.version "#{options[:transpiler]}-rails", nil, "Use #{options[:transpiler]} as JavaScript Transpiler"
+      def javascript_engine_gemfile_entry
+        GemfileEntry.version "#{options[:javascript_engine]}-rails", nil, "Use #{options[:javascript_engine]} as JavaScript engine"
       end
 
       def javascript_gemfile_entry
         if options[:skip_javascript] || options[:skip_sprockets]
           []
         else
-          gems = [transpiler_gemfile_entry, javascript_runtime_gemfile_entry]
+          gems = [javascript_engine_gemfile_entry, javascript_runtime_gemfile_entry]
           gems << GemfileEntry.version("#{options[:javascript]}-rails", nil,
                                        "Use #{options[:javascript]} as the JavaScript library")
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -457,13 +457,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "prototype-rails"
   end
 
-  def test_coffee_is_the_default_transpiler
+  def test_coffee_is_the_default_javascript_engine
     run_generator
     assert_gem "coffee-rails"
   end
 
-  def test_other_transpilers
-    run_generator [destination_root, "-t", "babel"]
+  def test_other_javascript_engines
+    run_generator [destination_root, "-je", "babel"]
     assert_gem "babel-rails"
   end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -457,6 +457,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "prototype-rails"
   end
 
+  def test_coffee_is_the_default_transpiler
+    run_generator
+    assert_gem "coffee-rails"
+  end
+
+  def test_other_transpilers
+    run_generator [destination_root, "-t", "babel"]
+    assert_gem "babel-rails"
+  end
+
   def test_javascript_is_skipped_if_required
     run_generator [destination_root, "--skip-javascript"]
 


### PR DESCRIPTION
### Summary

This will allow the use of custom Javascript engines in new apps using the --javascript-engine option.

There are others Javascript engines plugins beyond coffee-rails like [babel-rails](https://github.com/Liceth/babel-rails), [typescript-rails](https://github.com/typescript-ruby/typescript-rails), [elm-rails](https://github.com/fbonetti/elm-rails), etc.
