### PR TITLE
Add missing `+` around a some literals.

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -215,7 +215,7 @@ module AbstractController
       # ==== Returns
       # * <tt>string</tt> - The name of the method that handles the action
       # * false           - No valid method name could be found.
-      # Raise AbstractController::ActionNotFound.
+      # Raise +AbstractController::ActionNotFound+.
       def _find_action_name(action_name)
         _valid_action_name?(action_name) && method_for_action(action_name)
       end
@@ -231,11 +231,11 @@ module AbstractController
       # with a template matching the action name is considered to exist.
       #
       # If you override this method to handle additional cases, you may
-      # also provide a method (like _handle_method_missing) to handle
+      # also provide a method (like +_handle_method_missing+) to handle
       # the case.
       #
-      # If none of these conditions are true, and method_for_action
-      # returns nil, an AbstractController::ActionNotFound exception will be raised.
+      # If none of these conditions are true, and +method_for_action+
+      # returns +nil+, an +AbstractController::ActionNotFound+ exception will be raised.
       #
       # ==== Parameters
       # * <tt>action_name</tt> - An action name to find a method name for

--- a/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
+++ b/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
@@ -40,7 +40,7 @@ module ActionController
       end
 
       # Pick the template digest to include in the ETag. If the +:template+ option
-      # is present, use the named template. If +:template+ is nil or absent, use
+      # is present, use the named template. If +:template+ is +nil+ or absent, use
       # the default controller/action template. If +:template+ is false, omit the
       # template digest from the ETag.
       def pick_template_for_etag(options)

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -539,7 +539,7 @@ module ActionController
       new_instance_with_inherited_permitted_status(@parameters.select(&block))
     end
 
-    # Equivalent to Hash#keep_if, but returns nil if no changes were made.
+    # Equivalent to Hash#keep_if, but returns +nil+ if no changes were made.
     def select!(&block)
       @parameters.select!(&block)
       self

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -249,7 +249,7 @@ module ActionDispatch # :nodoc:
       end
     end
 
-    # Sets the HTTP character set. In case of nil parameter
+    # Sets the HTTP character set. In case of +nil+ parameter
     # it sets the charset to utf-8.
     #
     #   response.charset = 'utf-16' # => 'utf-16'

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -179,7 +179,7 @@ module ActionDispatch
 
       # Returns a jar that'll automatically generate a signed representation of cookie value and verify it when reading from
       # the cookie again. This is useful for creating cookies with values that the user is not supposed to change. If a signed
-      # cookie was tampered with by the user (or a 3rd party), nil will be returned.
+      # cookie was tampered with by the user (or a 3rd party), +nil+ will be returned.
       #
       # If +secrets.secret_key_base+ and +secrets.secret_token+ (deprecated) are both set,
       # legacy cookies signed with the old key generator will be transparently upgraded.
@@ -202,7 +202,7 @@ module ActionDispatch
       end
 
       # Returns a jar that'll automatically encrypt cookie values before sending them to the client and will decrypt them for read.
-      # If the cookie was tampered with by the user (or a 3rd party), nil will be returned.
+      # If the cookie was tampered with by the user (or a 3rd party), +nil+ will be returned.
       #
       # If +secrets.secret_key_base+ and +secrets.secret_token+ (deprecated) are both set,
       # legacy cookies signed with the old key generator will be transparently upgraded.

--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -129,7 +129,7 @@ module ActionDispatch
       end
 
       # Builds a hash containing the flashes to keep for the next request.
-      # If there are none to keep, returns nil.
+      # If there are none to keep, returns +nil+.
       def to_session_value #:nodoc:
         flashes_to_keep = @flashes.except(*@discard)
         return nil if flashes_to_keep.empty?

--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -85,7 +85,7 @@ module ActionDispatch
       end
 
       # Returns value of the key stored in the session or
-      # nil if the given key is not found in the session.
+      # +nil+ if the given key is not found in the session.
       def [](key)
         load_for_read!
         @delegate[key.to_s]

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -98,7 +98,7 @@ module ActionView
     # to avoid warnings in the client about mixed media.
     # Note that the request parameter might not be supplied, e.g. when the assets
     # are precompiled via a Rake task. Make sure to use a Proc instead of a lambda,
-    # since a Proc allows missing parameters and sets them to nil.
+    # since a +Proc+ allows missing parameters and sets them to +nil+.
     #
     #   config.action_controller.asset_host = Proc.new { |source, request|
     #     if request && request.ssl?
@@ -233,7 +233,7 @@ module ActionView
         stylesheet: ".css"
       }
 
-      # Compute extname to append to asset path. Returns nil if
+      # Compute extname to append to asset path. Returns +nil+ if
       # nothing should be added.
       def compute_asset_extname(source, options = {})
         return if options[:extname] == false

--- a/actionview/lib/action_view/helpers/atom_feed_helper.rb
+++ b/actionview/lib/action_view/helpers/atom_feed_helper.rb
@@ -163,7 +163,7 @@ module ActionView
           @xml, @view, @feed_options = xml, view, feed_options
         end
 
-        # Accepts a Date or Time object and inserts it in the proper format. If nil is passed, current time in UTC is used.
+        # Accepts a Date or Time object and inserts it in the proper format. If +nil+ is passed, current time in UTC is used.
         def updated(date_or_time = nil)
           @xml.updated((date_or_time || Time.now.utc).xmlschema)
         end
@@ -174,7 +174,7 @@ module ActionView
         #
         # * <tt>:published</tt>: Time first published. Defaults to the created_at attribute on the record if one such exists.
         # * <tt>:updated</tt>: Time of update. Defaults to the updated_at attribute on the record if one such exists.
-        # * <tt>:url</tt>: The URL for this entry or false or nil for not having a link tag. Defaults to the polymorphic_url for the record.
+        # * <tt>:url</tt>: The URL for this entry or +false+ or +nil+ for not having a link tag. Defaults to the +polymorphic_url+ for the record.
         # * <tt>:id</tt>: The ID for this entry. Defaults to "tag:#{@view.request.host},#{@feed_options[:schema_date]}:#{record.class}/#{record.id}"
         # * <tt>:type</tt>: The TYPE for this entry. Defaults to "text/html".
         def entry(record, options = {})

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -220,7 +220,7 @@ module ActionView
       #   the respective locale (e.g. [:year, :month, :day] in the en locale that ships with Rails).
       # * <tt>:include_blank</tt>     - Include a blank option in every select field so it's possible to set empty
       #   dates.
-      # * <tt>:default</tt>           - Set a default date if the affected date isn't set or is nil.
+      # * <tt>:default</tt>           - Set a default date if the affected date isn't set or is +nil+.
       # * <tt>:selected</tt>          - Set a date that overrides the actual value.
       # * <tt>:disabled</tt>          - Set to true if you want show the select fields as disabled.
       # * <tt>:prompt</tt>            - Set to true (for a generic prompt), a prompt string or a hash of prompt strings
@@ -866,7 +866,7 @@ module ActionView
         end
 
         # Returns translated month names, but also ensures that a custom month
-        # name array has a leading nil element.
+        # name array has a leading +nil+ element.
         def month_names
           @month_names ||= begin
             month_names = @options[:use_month_names] || translated_month_names

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -151,7 +151,7 @@ module ActionView
       # defined in <tt>:radius</tt> (which defaults to 100). If the excerpt radius overflows the beginning or end of the +text+,
       # then the <tt>:omission</tt> option (which defaults to "...") will be prepended/appended accordingly. Use the
       # <tt>:separator</tt> option to choose the delimitation. The resulting string will be stripped in any case. If the +phrase+
-      # isn't found, nil is returned.
+      # isn't found, +nil+ is returned.
       #
       #   excerpt('This is an example', 'an', radius: 5)
       #   # => ...s is an exam...

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -92,16 +92,16 @@ module ActionView
   #     layout false
   #
   # In these examples, we have three implicit lookup scenarios:
-  # * The BankController uses the "bank" layout.
-  # * The ExchangeController uses the "exchange" layout.
-  # * The CurrencyController inherits the layout from BankController.
+  # * The +BankController+ uses the "bank" layout.
+  # * The +ExchangeController+ uses the "exchange" layout.
+  # * The +CurrencyController+ inherits the layout from BankController.
   #
   # However, when a layout is explicitly set, the explicitly set layout wins:
-  # * The InformationController uses the "information" layout, explicitly set.
-  # * The TellerController also uses the "information" layout, because the parent explicitly set it.
-  # * The EmployeeController uses the "employee" layout, because it set the layout to nil, resetting the parent configuration.
-  # * The VaultController chooses a layout dynamically by calling the <tt>access_level_layout</tt> method.
-  # * The TillController does not use a layout at all.
+  # * The +InformationController+ uses the "information" layout, explicitly set.
+  # * The +TellerController+ also uses the "information" layout, because the parent explicitly set it.
+  # * The +EmployeeController+ uses the "employee" layout, because it set the layout to +nil+, resetting the parent configuration.
+  # * The +VaultController+ chooses a layout dynamically by calling the <tt>access_level_layout</tt> method.
+  # * The +TillController+ does not use a layout at all.
   #
   # == Types of layouts
   #
@@ -149,8 +149,8 @@ module ActionView
   # The template will be looked always in <tt>app/views/layouts/</tt> folder. But you can point
   # <tt>layouts</tt> folder direct also. <tt>layout "layouts/demo"</tt> is the same as <tt>layout "demo"</tt>.
   #
-  # Setting the layout to nil forces it to be looked up in the filesystem and fallbacks to the parent behavior if none exists.
-  # Setting it to nil is useful to re-enable template lookup overriding a previous configuration set in the parent:
+  # Setting the layout to +nil+ forces it to be looked up in the filesystem and fallbacks to the parent behavior if none exists.
+  # Setting it to +nil+ is useful to re-enable template lookup overriding a previous configuration set in the parent:
   #
   #     class ApplicationController < ActionController::Base
   #       layout "application"
@@ -255,7 +255,7 @@ module ActionView
       # true::   raise an ArgumentError
       # nil::    Force default layout behavior with inheritance
       #
-      # Return value of Proc & Symbol arguments should be String, false, true or nil
+      # Return value of +Proc & Symbol+ arguments should be +String+, +false+, +true+ or +nil+
       # with the same meaning as described above.
       # ==== Parameters
       # * <tt>layout</tt> - The layout to use.
@@ -405,11 +405,11 @@ module ActionView
     #
     # ==== Parameters
     # * <tt>formats</tt> - The formats accepted to this layout
-    # * <tt>require_layout</tt> - If set to true and layout is not found,
-    #   an +ArgumentError+ exception is raised (defaults to false)
+    # * <tt>require_layout</tt> - If set to +true+ and layout is not found,
+    #   an +ArgumentError+ exception is raised (defaults to +false+)
     #
     # ==== Returns
-    # * <tt>template</tt> - The template object for the default layout (or nil)
+    # * <tt>template</tt> - The template object for the default layout (or +nil+)
     def _default_layout(formats, require_layout = false)
       begin
         value = _layout(formats) if action_has_layout?

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -99,7 +99,7 @@ module ActionView
   #
   #   <%= render partial: "ad", collection: @advertisements, spacer_template: "ad_divider" %>
   #
-  # If the given <tt>:collection</tt> is nil or empty, <tt>render</tt> will return nil. This will allow you
+  # If the given <tt>:collection</tt> is +nil+ or empty, <tt>render</tt> will return nil. This will allow you
   # to specify a text which will displayed instead by using this form:
   #
   #   <%= render(partial: "ad", collection: @advertisements) || "There's no ad to be displayed" %>

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -68,7 +68,7 @@ module ActiveModel
       #
       # Options:
       # * <tt>:on</tt> - Specifies the contexts where this validation is active.
-      #   Runs in all validation contexts by default (nil). You can pass a symbol
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)
@@ -134,7 +134,7 @@ module ActiveModel
       #
       # Options:
       # * <tt>:on</tt> - Specifies the contexts where this validation is active.
-      #   Runs in all validation contexts by default (nil). You can pass a symbol
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -72,7 +72,7 @@ module ActiveModel
       # There is also a list of options that could be used along with validators:
       #
       # * <tt>:on</tt> - Specifies the contexts where this validation is active.
-      #   Runs in all validation contexts by default (nil). You can pass a symbol
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)

--- a/activemodel/lib/active_model/validations/with.rb
+++ b/activemodel/lib/active_model/validations/with.rb
@@ -45,7 +45,7 @@ module ActiveModel
       #
       # Configuration options:
       # * <tt>:on</tt> - Specifies the contexts where this validation is active.
-      #   Runs in all validation contexts by default (nil). You can pass a symbol
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)

--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -206,7 +206,7 @@ module ActiveRecord
         #   or a Proc that is called when a new value is assigned to the value object. The converter is
         #   passed the single value that is used in the assignment and is only called if the new value is
         #   not an instance of <tt>:class_name</tt>. If <tt>:allow_nil</tt> is set to true, the converter
-        #   can return nil to skip the assignment.
+        #   can return +nil+ to skip the assignment.
         #
         # Option examples:
         #   composed_of :temperature, mapping: %w(reading celsius)

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -264,7 +264,7 @@ module ActiveRecord
         super
       end
 
-      # Returns the specified association instance if it exists, nil otherwise.
+      # Returns the specified association instance if it exists, +nil+ otherwise.
       def association_instance_get(name)
         @association_cache[name]
       end

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -254,7 +254,7 @@ module ActiveRecord
         # so that when stale_state is different from the value stored on the last find_target,
         # the target is stale.
         #
-        # This is only relevant to certain associations, which is why it returns nil by default.
+        # This is only relevant to certain associations, which is why it returns +nil+ by default.
         def stale_state
         end
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -435,8 +435,9 @@ module ActiveRecord
           records.each { |record| callback(:after_remove, record) }
         end
 
-        # Delete the given records from the association, using one of the methods :destroy,
-        # :delete_all or :nullify (or nil, in which case a default is used).
+        # Delete the given records from the association,
+        # using one of the methods +:destroy+, +:delete_all+
+        # or +:nullify+ (or +nil+, in which case a default is used).
         def delete_records(records, method)
           raise NotImplementedError
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -69,7 +69,7 @@ module ActiveRecord
     #   threads, which can occur if a programmer forgets to close a
     #   connection at the end of a thread or a thread dies unexpectedly.
     #   Regardless of this setting, the Reaper will be invoked before every
-    #   blocking wait. (Default nil, which means don't schedule the Reaper).
+    #   blocking wait. (Default +nil+, which means don't schedule the Reaper).
     #
     #--
     # Synchronization policy:
@@ -116,7 +116,7 @@ module ActiveRecord
           end
         end
 
-        # If +element+ is in the queue, remove and return it, or nil.
+        # If +element+ is in the queue, remove and return it, or +nil+.
         def delete(element)
           synchronize do
             @queue.delete(element)
@@ -135,7 +135,7 @@ module ActiveRecord
         # If +timeout+ is not given, remove and return the head the
         # queue if the number of available elements is strictly
         # greater than the number of threads currently waiting (that
-        # is, don't jump ahead in line).  Otherwise, return nil.
+        # is, don't jump ahead in line).  Otherwise, return +nil+.
         #
         # If +timeout+ is given, block if there is no element
         # available, waiting up to +timeout+ seconds for an element to
@@ -171,14 +171,14 @@ module ActiveRecord
             @queue.size > @num_waiting
           end
 
-          # Removes and returns the head of the queue if possible, or nil.
+          # Removes and returns the head of the queue if possible, or +nil+.
           def remove
             @queue.shift
           end
 
           # Remove and return the head the queue if the number of
           # available elements is strictly greater than the number of
-          # threads currently waiting.  Otherwise, return nil.
+          # threads currently waiting.  Otherwise, return +nil+.
           def no_wait_poll
             remove if can_remove_no_wait?
           end
@@ -282,7 +282,7 @@ module ActiveRecord
       end
 
       # Every +frequency+ seconds, the reaper will call +reap+ on +pool+.
-      # A reaper instantiated with a nil frequency will never reap the
+      # A reaper instantiated with a +nil+ frequency will never reap the
       # connection pool.
       #
       # Configure the frequency by setting "reaping_frequency" in your

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_limits.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_limits.rb
@@ -46,7 +46,7 @@ module ActiveRecord
       end
 
       # Returns the maximum number of elements in an IN (x,y,z) clause.
-      # nil means no limit.
+      # +nil+ means no limit.
       def in_clause_length
         nil
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -115,7 +115,7 @@ module ActiveRecord
 
       # Executes an INSERT query and returns the new record's ID
       #
-      # +id_value+ will be returned unless the value is nil, in
+      # +id_value+ will be returned unless the value is +nil+, in
       # which case the database will attempt to calculate the last inserted
       # id and return that value.
       #

--- a/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
@@ -53,7 +53,7 @@ module ActiveRecord
 
         # Returns an instance of <tt>ActiveRecord::ConnectionAdapters::PostgreSQL::Name</tt>
         # extracted from +string+.
-        # +schema+ is nil if not specified in +string+.
+        # +schema+ is +nil+ if not specified in +string+.
         # +schema+ and +identifier+ exclude surrounding quotes (regardless of whether provided in +string+)
         # +string+ supports the range of schema/table references understood by PostgreSQL, for example:
         #

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -43,7 +43,7 @@ module ActiveRecord
 
   # Raised when connection to the database could not been established (for example when
   # {ActiveRecord::Base.connection=}[rdoc-ref:ConnectionHandling#connection]
-  # is given a nil object).
+  # is given a +nil+ object).
   class ConnectionNotEstablished < ActiveRecordError
   end
 

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -15,9 +15,9 @@ module ActiveRecord
       self.cache_timestamp_format = :usec
     end
 
-    # Returns a String, which Action Pack uses for constructing a URL to this
-    # object. The default implementation returns this record's id as a String,
-    # or nil if this record's unsaved.
+    # Returns a +String+, which Action Pack uses for constructing a URL to this
+    # object. The default implementation returns this record's id as a +String+,
+    # or +nil+ if this record's unsaved.
     #
     # For example, suppose that you have a User model, and that you have a
     # <tt>resources :users</tt> route. Normally, +user_path+ will

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -292,7 +292,7 @@ module ActiveRecord
       end
 
       # Sets the name of the sequence to use when generating ids to the given
-      # value, or (if the value is nil or false) to the value returned by the
+      # value, or (if the value is +nil+ or +false+) to the value returned by the
       # given block. This is required for Oracle and is useful for any
       # database which relies on sequences for primary key generation.
       #

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -541,7 +541,7 @@ module ActiveRecord
 
         # Attempts to find the inverse association name automatically.
         # If it cannot find a suitable inverse association name, it returns
-        # nil.
+        # +nil+.
         def inverse_name
           options.fetch(:inverse_of) do
             if @automatic_inverse_of == false

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -42,7 +42,7 @@ module ActiveRecord
         # Adds a class method for retrieving and querying objects.
         # The method is intended to return an ActiveRecord::Relation
         # object, which is composable with other scopes.
-        # If it returns nil or false, an
+        # If it returns +nil+ or +false+, an
         # {all}[rdoc-ref:Scoping::Named::ClassMethods#all] scope is returned instead.
         #
         # A \scope represents a narrowing of a database query, such as

--- a/activerecord/lib/active_record/validations/associated.rb
+++ b/activerecord/lib/active_record/validations/associated.rb
@@ -37,7 +37,7 @@ module ActiveRecord
       #
       # * <tt>:message</tt> - A custom error message (default is: "is invalid").
       # * <tt>:on</tt> - Specifies the contexts where this validation is active.
-      #   Runs in all validation contexts by default (nil). You can pass a symbol
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)

--- a/activerecord/lib/active_record/validations/presence.rb
+++ b/activerecord/lib/active_record/validations/presence.rb
@@ -44,7 +44,7 @@ module ActiveRecord
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "can't be blank").
       # * <tt>:on</tt> - Specifies the contexts where this validation is active.
-      #   Runs in all validation contexts by default (nil). You can pass a symbol
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)

--- a/activesupport/lib/active_support/core_ext/hash/compact.rb
+++ b/activesupport/lib/active_support/core_ext/hash/compact.rb
@@ -14,7 +14,7 @@ class Hash
 
   unless Hash.instance_methods(false).include?(:compact!)
     # Replaces current hash with non +nil+ values.
-    # Returns nil if no changes were made, otherwise returns the hash.
+    # Returns +nil+ if no changes were made, otherwise returns the hash.
     #
     #   hash = { a: true, b: false, c: nil }
     #   hash.compact!        # => { a: true, b: false }

--- a/activesupport/lib/active_support/core_ext/kernel/reporting.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/reporting.rb
@@ -1,7 +1,7 @@
 module Kernel
   module_function
 
-  # Sets $VERBOSE to nil for the duration of the block and back to its original
+  # Sets $VERBOSE to +nil+ for the duration of the block and back to its original
   # value afterwards.
   #
   #   silence_warnings do

--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -6,7 +6,7 @@ module SecureRandom
   #
   # The argument _n_ specifies the length, of the random string to be generated.
   #
-  # If _n_ is not specified or is nil, 16 is assumed. It may be larger in the future.
+  # If _n_ is not specified or is +nil+, 16 is assumed. It may be larger in the future.
   #
   # The result may contain alphanumeric characters except 0, O, I and l
   #

--- a/activesupport/lib/active_support/core_ext/string/access.rb
+++ b/activesupport/lib/active_support/core_ext/string/access.rb
@@ -3,7 +3,7 @@ class String
   # position. The first character of the string is at position 0, the next at
   # position 1, and so on. If a range is supplied, a substring containing
   # characters at offsets given by the range is returned. In both cases, if an
-  # offset is negative, it is counted from the end of the string. Returns nil
+  # offset is negative, it is counted from the end of the string. Returns +nil+
   # if the initial offset falls outside the string. Returns an empty string if
   # the beginning of the range is greater than the end of the string.
   #
@@ -17,7 +17,7 @@ class String
   #
   # If a Regexp is given, the matching portion of the string is returned.
   # If a String is given, that given string is returned if it occurs in
-  # the string. In both cases, nil is returned if there is no match.
+  # the string. In both cases, +nil+ is returned if there is no match.
   #
   #   str = "hello"
   #   str.at(/lo/) # => "lo"

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -67,7 +67,7 @@ class String
   end
 
   # +safe_constantize+ tries to find a declared constant with the name specified
-  # in the string. It returns nil when the name is not in CamelCase
+  # in the string. It returns +nil+ when the name is not in CamelCase
   # or is not initialized.  See ActiveSupport::Inflector.safe_constantize
   #
   #   'Module'.safe_constantize  # => Module

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -68,7 +68,8 @@ module ActiveSupport
             :ESCAPE_REGEX_WITHOUT_HTML_ENTITIES, :EscapedString
 
           # Convert an object into a "JSON-ready" representation composed of
-          # primitives like Hash, Array, String, Numeric, and true/false/nil.
+          # primitives like Hash, Array, String, Numeric,
+          # and +true+/+false+/+nil+.
           # Recursively calls #as_json to the object to recursively build a
           # fully JSON-ready object.
           #

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -87,7 +87,7 @@ module ActiveSupport #:nodoc:
       end
 
       # Works like <tt>String#slice!</tt>, but returns an instance of
-      # Chars, or nil if the string was not modified. The string will not be
+      # Chars, or +nil+ if the string was not modified. The string will not be
       # modified if the range given is out of bounds
       #
       #   string = 'Welcome'

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -109,7 +109,7 @@ module ActiveSupport
     # * <tt>:locale</tt> - Sets the locale to be used for formatting
     #   (defaults to current locale).
     # * <tt>:precision</tt> - Sets the precision of the number
-    #   (defaults to 3). Keeps the number's precision if nil.
+    #   (defaults to 3). Keeps the number's precision if +nil+.
     # * <tt>:significant</tt> - If +true+, precision will be the number
     #   of significant_digits. If +false+, the number of fractional
     #   digits (defaults to +false+).
@@ -183,7 +183,7 @@ module ActiveSupport
     # * <tt>:locale</tt> - Sets the locale to be used for formatting
     #   (defaults to current locale).
     # * <tt>:precision</tt> - Sets the precision of the number
-    #   (defaults to 3). Keeps the number's precision if nil.
+    #   (defaults to 3). Keeps the number's precision if +nil+.
     # * <tt>:significant</tt> - If +true+, precision will be the number
     #   of significant_digits. If +false+, the number of fractional
     #   digits (defaults to +false+).

--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -74,7 +74,7 @@ module ActiveSupport
       #
       # If no handler matches the exception, check for a handler matching the
       # (optional) exception.cause. If no handler matches the exception or its
-      # cause, this returns nil so you can deal with unhandled exceptions.
+      # cause, this returns +nil+, so you can deal with unhandled exceptions.
       # Be sure to re-raise unhandled exceptions if this is what you expect.
       #
       #     begin
@@ -83,7 +83,7 @@ module ActiveSupport
       #       rescue_with_handler(exception) || raise
       #     end
       #
-      # Returns the exception if it was handled and nil if it was not.
+      # Returns the exception if it was handled and +nil+ if it was not.
       def rescue_with_handler(exception, object: self)
         if handler = handler_for_rescue(exception, object: object)
           handler.call exception

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -166,7 +166,7 @@ def set_locale
   I18n.locale = extract_locale_from_tld || I18n.default_locale
 end
 
-# Get locale from top-level domain or return nil if such locale is not available
+# Get locale from top-level domain or return +nil+ if such locale is not available
 # You have to put something like:
 #   127.0.0.1 application.com
 #   127.0.0.1 application.it

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -53,7 +53,7 @@ module Rails
     end
 
     # Returns a Pathname object of the current Rails project,
-    # otherwise it returns nil if there is no project:
+    # otherwise it returns +nil+ if there is no project:
     #
     #   Rails.root
     #     # => #<Pathname:/Users/someuser/some/path/project>
@@ -100,7 +100,7 @@ module Rails
     end
 
     # Returns a Pathname object of the public folder of the current
-    # Rails project, otherwise it returns nil if there is no project:
+    # Rails project, otherwise it returns +nil+ if there is no project:
     #
     #   Rails.public_path
     #     # => #<Pathname:/Users/someuser/some/path/project/public>


### PR DESCRIPTION
Hi! :smile:  Today was inspired to improve our docs!

I added missing `+` around a some literals, mainly around `nil`.

[ci skip]
