### PR TITLE
ActiveSupport::TimeZone#tzinfo cannot be nil anymore

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -285,7 +285,7 @@ module ActiveSupport
       if @utc_offset
         @utc_offset
       else
-        tzinfo.current_period.utc_offset if tzinfo && tzinfo.current_period
+        tzinfo.current_period.utc_offset
       end
     end
 


### PR DESCRIPTION
I came around this after chasing bugs with `ActiveSupport::Timezone`
having `@tzinfo` as a string in Rails 5 stable. Seeing that this is no
longer possible to with the latest `ActiveSupport::Timezone.find_tzinfo`
changes, that made it always return a `TZInfo::Timezone instances`.
