### PR TITLE
Fixes an issue where time_zone_conversion that causes an exception in…

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -70,6 +70,7 @@ module ActiveRecord
         private
 
           def inherited(subclass)
+            super
             # We need to apply this decorator here, rather than on module inclusion. The closure
             # created by the matcher would otherwise evaluate for `ActiveRecord::Base`, not the
             # sub class being decorated. As such, changes to `time_zone_aware_attributes`, or
@@ -80,7 +81,6 @@ module ActiveRecord
                 TimeZoneConverter.new(type)
               end
             end
-            super
           end
 
           def create_time_zone_conversion_attribute?(name, cast_type)


### PR DESCRIPTION
### Summary

Following off of #15945, I realized that super
needs to be the first thing that is called in an AbstractModel's inherited method.
I was receiving errors within the inherited method of time_zone_conversion, so I tested
locally by moving super to the top of the method declaration. All exceptions went away.

While this stack trace is for AR 4.2.7.1, the bug remains in 5.0.
<details>

```
/Users/juliannadeau/.gem/ruby/2.2.3/gems/activerecord-4.2.7.1/lib/active_record/relation/delegation.rb:9:in `relation_delegate_class': undefined method `[]' for nil:NilClass (NoMethodError)
    from /Users/juliannadeau/.gem/ruby/2.2.3/gems/activerecord-4.2.7.1/lib/active_record/relation/delegation.rb:112:in `relation_class_for'
    from /Users/juliannadeau/.gem/ruby/2.2.3/gems/activerecord-4.2.7.1/lib/active_record/relation/delegation.rb:106:in `create'
    from /Users/juliannadeau/.gem/ruby/2.2.3/gems/activerecord-4.2.7.1/lib/active_record/model_schema.rb:150:in `table_name='
    from /Users/juliannadeau/.gem/ruby/2.2.3/gems/activerecord-4.2.7.1/lib/active_record/model_schema.rb:160:in `reset_table_name'
    from /Users/juliannadeau/.gem/ruby/2.2.3/gems/activerecord-4.2.7.1/lib/active_record/model_schema.rb:126:in `table_name'
    from /Users/juliannadeau/.gem/ruby/2.2.3/gems/activerecord-4.2.7.1/lib/active_record/model_schema.rb:230:in `table_exists?'
    from /Users/juliannadeau/.gem/ruby/2.2.3/gems/activerecord-4.2.7.1/lib/active_record/core.rb:219:in `inspect'
    from /Users/juliannadeau/src/github.com/Shopify/shopify/test/test_helper.rb:2:in `to_s'
    from /Users/juliannadeau/src/github.com/Shopify/shopify/test/test_helper.rb:2:in `block in <top (required)>'
    from /Users/juliannadeau/.gem/ruby/2.2.3/gems/activesupport-4.2.7.1/lib/active_support/core_ext/class/attribute.rb:86:in `block (4 levels) in class_attribute'
    from /Users/juliannadeau/.gem/ruby/2.2.3/gems/activerecord-4.2.7.1/lib/active_record/attribute_decorators.rb:22:in `decorate_matching_attribute_types'
    from /Users/juliannadeau/.gem/ruby/2.2.3/gems/activerecord-4.2.7.1/lib/active_record/locking/optimistic.rb:182:in `block in inherited'
    from /Users/juliannadeau/.gem/ruby/2.2.3/gems/activerecord-4.2.7.1/lib/active_record/locking/optimistic.rb:180:in `class_eval'
    from /Users/juliannadeau/.gem/ruby/2.2.3/gems/activerecord-4.2.7.1/lib/active_record/locking/optimistic.rb:180:in `inherited'
    from /Users/juliannadeau/.gem/ruby/2.2.3/gems/activerecord-4.2.7.1/lib/active_record/attribute_methods.rb:66:in `inherited'
    from /Users/juliannadeau/.gem/ruby/2.2.3/gems/activerecord-4.2.7.1/lib/active_record/attribute_methods/time_zone_conversion.rb:58:in `inherited'
    from /Users/juliannadeau/src/github.com/Shopify/shopify/app/models/shop.rb:4:in `<top (required)>'
```

</details>

I'm not sure how to add a test for this, or if its necessary.

cc @rafaelfranca 
