### PR TITLE
Support plain loggers in DebugExceptions

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -38,7 +38,9 @@ module ActionDispatch
       end
 
       def render(*)
-        if logger = ActionView::Base.logger
+        logger = ActionView::Base.logger
+
+        if logger && logger.respond_to?(:silence)
           logger.silence { super }
         else
           super

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -384,6 +384,23 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "logs with non active support loggers" do
+    @app = DevelopmentApp
+    io = StringIO.new
+    logger = Logger.new(io)
+
+    _old, ActionView::Base.logger = ActionView::Base.logger, logger
+    begin
+      assert_nothing_raised do
+        get "/", headers: { "action_dispatch.show_exceptions" => true, "action_dispatch.logger" => logger }
+      end
+    ensure
+      ActionView::Base.logger = _old
+    end
+
+    assert_match(/puke/, io.rewind && io.read)
+  end
+
   test "uses backtrace cleaner from env" do
     @app = DevelopmentApp
     backtrace_cleaner = ActiveSupport::BacktraceCleaner.new


### PR DESCRIPTION
I have been seeing people setting `Logger` instances for `config.logger`
and it blowing up on `rails/web-console` usage.

Now, I doubt many folks are manually setting `ActionView::Base.logger`,
but given that `DebugExceptions` is running in a pretty fragile
environment already, having it crash (and being silent) in those cases
can be pretty tricky to trace down.

I'm proposing we verify whether the `ActionView::Base.logger` supports
silencing before we try to do it, to save us the headache of tracing it
down.
