### PR TITLE
Fix NameError: undefined local variable or method `result`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -86,8 +86,8 @@ module ActiveRecord
               end
 
               begin
-                ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-                  result = stmt.execute(*type_casted_binds)
+                result = ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+                  stmt.execute(*type_casted_binds)
                 end
               rescue Mysql2::Error => e
                 if cache_stmt


### PR DESCRIPTION
Caused by 007e50d8e5a900547471b6c4ec79d9d217682c5d.

#26925 was closed in favor of dcb364e.
But dcb364e is only fixed sqlite3 adapter and still broken mysql2
adapter with `prepared_statements: true` (`exec_stmt_and_free`).

``` diff
diff --git a/activerecord/test/config.example.yml b/activerecord/test/config.example.yml
index 58e2d45..7b3c1a6 100644
--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -56,9 +56,11 @@ connections:
       username: rails
       encoding: utf8
       collation: utf8_unicode_ci
+      prepared_statements: true
     arunit2:
       username: rails
       encoding: utf8
+      prepared_statements: true

   oracle:
      arunit:
```

```
% be rake test_mysql2 --verbose
...
Using mysql2
/Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb:90: warning: assigned but unused variable - result
/Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb:101:in `block in exec_stmt_and_free': NameError: undefined local variable or method `result' for #<ActiveRecord::ConnectionAdapters::Mysql2Adapter:0x007fe2c50eb140>: SELECT  `ar_internal_metadata`.* FROM `ar_internal_metadata` WHERE `ar_internal_metadata`.`key` = ? LIMIT ? (ActiveRecord::StatementInvalid)
        from /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:586:in `block in log'
...
```
