### PR TITLE
deep symbolize keys on secrets.yml

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   The config file `secrets.yml` is now loaded in with all keys as symbols.
+    This allows secrets files to contain more complex information without all
+    child keys being strings while parent keys are symbols.
+
+    *Isaac Sloan*
+
 *   Add `:skip_sprockets` to `Rails::PluginBuilder::PASSTHROUGH_OPTIONS`
 
     *Tsukuru Tanimichi*

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -394,8 +394,8 @@ module Rails
           shared_secrets = all_secrets["shared"]
           env_secrets    = all_secrets[Rails.env]
 
-          secrets.merge!(shared_secrets.symbolize_keys) if shared_secrets
-          secrets.merge!(env_secrets.symbolize_keys) if env_secrets
+          secrets.merge!(shared_secrets.deep_symbolize_keys) if shared_secrets
+          secrets.merge!(env_secrets.deep_symbolize_keys) if env_secrets
         end
 
         # Fallback to config.secret_key_base if secrets.secret_key_base isn't set

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -636,6 +636,20 @@ module ApplicationTests
       end
     end
 
+    test "that nested keys are symbolized the same as parents for hashes more than one level deep" do
+      app_file "config/secrets.yml", <<-YAML
+        development:
+          smtp_settings:
+            address: "smtp.example.com"
+            user_name: "postmaster@example.com"
+            password: "697361616320736c6f616e2028656c6f7265737429"
+      YAML
+
+      app "development"
+
+      assert_equal "697361616320736c6f616e2028656c6f7265737429", app.secrets.smtp_settings[:password]
+    end
+
     test "protect from forgery is the default in a new app" do
       make_basic_app
 


### PR DESCRIPTION
### Summary

Changed symbolize_keys to deep_symbolize_keys where secrets.yml is loaded in. This allows secret files to contain more complex information without all child keys being strings while parent keys are symbols.

``` ruby
{:smtp_settings=>{"address"=>"smtp.mailgun.org", "port"=>587, "domain"=>"example.com", "authentication"=>"plain", "enable_starttls_auto"=>true, "user_name"=>"postmaster@mailgun.example.com", "password"=>"12d3f673e0a83c97045eb4e2d10ebc8a4"}}
```

becomes this

``` ruby
{:smtp_settings=>{:address=>"smtp.mailgun.org", :port=>587, :domain=>"example.com", :authentication=>"plain", :enable_starttls_auto=>true, :user_name=>"postmaster@mailgun.example.com", :password=>"12d3f673e0a83c97045eb4e2d10ebc8a4"}}
```

Source yaml.

``` yaml
development:
  smtp_settings:
    address: "smtp.mailgun.org"
    port: 587
    domain: "example.com"
    authentication: "plain"
    enable_starttls_auto: true
    user_name: "postmaster@mailgun.example.com"
    password: "12d3f673e0a83c97045eb4e2d10ebc8a4"
```
### Benchmarks

To do benchmarks I wrote a rake task which loaded the environment, printed the secrets and exited.

With `symbolize_keys`:
`2.36 real         1.94 user         0.55 sys`
`2.38 real         1.93 user         0.51 sys`

With `deep_symbolize_keys`:
`2.37 real         1.91 user         0.51 sys`
`2.31 real         1.89 user         0.49 sys`

As you can see there doesn't seem to be a negative effect in load time for this change. I wasn't able to find where the secrets.yml loading was being tested, but if someone could point that out to me I'll add tests as well.
