### PR TITLE
Fix an issue with JSON encoding of "Infinity" and "NaN" values

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -84,7 +84,7 @@ module ActiveSupport
             when String
               EscapedString.new(value)
             when Numeric, NilClass, TrueClass, FalseClass
-              value
+              value.as_json
             when Hash
               Hash[value.map { |k, v| [jsonify(k), jsonify(v)] }]
             when Array

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -432,6 +432,28 @@ EXPECTED
     assert_equal '"foo"', ActiveSupport::JSON.encode(exception)
   end
 
+  class InfiniteNumber
+    def as_json(options = nil)
+      { "number" => 1.0 / 0 }
+    end
+  end
+
+  def test_to_json_works_when_as_json_returns_infinite_number
+    expected = { number: nil }.to_json
+    assert_equal expected, InfiniteNumber.new.to_json
+  end
+
+  class NaNNumber
+    def as_json(options = nil)
+      { "number" => 0.0 / 0 }
+    end
+  end
+
+  def test_to_json_works_when_as_json_returns_NaN_number
+    expected = { number: nil }.to_json
+    assert_equal expected, NaNNumber.new.to_json
+  end
+
   protected
 
     def object_keys(json_object)


### PR DESCRIPTION
### Summary
- When `as_json` returns `Infinity` or `NaN` as the value of any of the key,
  we don't used to call `as_json` on it as it was treated as primitive.
- This used to pass `Infinity` or `NaN` to `JSON.generate` and Ruby used
  to throw an error for `Infinity/NaN not allowed in JSON.`
- This patch changes the code to call `as_json` on these primitives so
  that they are converted to proper values before being passed to
  `JSON.generate`.
- Fixes #26877.

r? @chancancode 
