### PR TITLE
remove warning from big integer test

### DIFF
--- a/activemodel/test/cases/type/big_integer_test.rb
+++ b/activemodel/test/cases/type/big_integer_test.rb
@@ -12,7 +12,7 @@ module ActiveModel
 
       def test_small_values
         type = Type::BigInteger.new
-        assert_equal -9999999999999999999999999999999, type.serialize(-9999999999999999999999999999999)
+        assert_equal(-9999999999999999999999999999999, type.serialize(-9999999999999999999999999999999))
       end
 
       def test_large_values


### PR DESCRIPTION
This removes the following warnings.

```
activemodel/test/cases/type/big_integer_test.rb:15: warning: ambiguous first argument; put parentheses or a space even after `-' operator
```
