### PR TITLE
Remove `Rack::Runtime from console log [ci skip]

### DIFF
--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -181,7 +181,6 @@ $ bin/rails middleware
 (in /Users/lifo/Rails/blog)
 use ActionDispatch::Static
 use #<ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x00000001c304c8>
-use Rack::Runtime
 ...
 run Rails.application.routes
 ```


### PR DESCRIPTION
according to its explanation, "`Rack::Runtime` is not a part of it."