### PR TITLE
Fixes TypeError Exception when cache counter value equals nil 

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -72,7 +72,7 @@ module ActiveRecord
         # the loaded flag is set to true as well.
         def count_records
           count = if reflection.has_cached_counter?
-            owner._read_attribute reflection.counter_cache_column
+            owner._read_attribute(reflection.counter_cache_column).to_i
           else
             scope.count
           end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1742,6 +1742,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert !company.clients.loaded?
   end
 
+  def test_counter_cache_on_unloaded_association
+    car = Car.create(name: "My AppliCar")
+    assert_equal car.engines.size, 0
+  end
+
   def test_get_ids_ignores_include_option
     assert_equal [readers(:michael_welcome).id], posts(:welcome).readers_with_person_ids
   end


### PR DESCRIPTION
When defining a cache counter attribute in a model but not defining its default value nor disallowing `null` then when calling `#size` on the respective `has_many` association we are hit by:

     `TypeError: nil can't be coerced into Fixnum`

I ~~assume~~ really hope this change doesn't break any other use case I might not be considering.