### PR TITLE
Adding Inch-CI badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Everyone interacting in Rails and its sub-projects' codebases, issue trackers, c
 ## Code Status
 
 [![Build Status](https://travis-ci.org/rails/rails.svg?branch=master)](https://travis-ci.org/rails/rails)
+[![Documentation Status](http://inch-ci.org/github/rails/rails.svg?branch=master)](http://inch-ci.org/github/rails/rails)
 
 ## License
 


### PR DESCRIPTION
With this PR I would like to add [Inch-CI](http://inch-ci.org/) to Rails. 

You can find the detailed page for Rails on Inch-CI [here](http://inch-ci.org/github/rails/rails/branch/master)

In case we decide to use this, we would just need to add a webhook to the project, like described here:
http://inch-ci.org/help/webhook

What do you guys think of continuous checking for good inline documentation, as well?
We already put it into ActiveResource. 😸 
