### PR TITLE
Don't put db:migrate and db:setup in binfiles if activerecord is excluded

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -10,15 +10,22 @@ def system!(*args)
 end
 
 chdir APP_ROOT do
-  # This script is a way to update your development environment automatically.
-  # Add necessary update steps to this file.
+  # This script is a starting point to setup your application.
+  # Add necessary setup steps to this file.
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
+<% unless options.skip_active_record -%>
 
-  puts "\n== Updating database =="
-  system! 'bin/rails db:migrate'
+  # puts "\n== Copying sample files =="
+  # unless File.exist?('config/database.yml')
+  #   cp 'config/database.yml.sample', 'config/database.yml'
+  # end
+
+  puts "\n== Preparing database =="
+  system! 'bin/rails db:setup'
+<% end -%>
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'

--- a/railties/lib/rails/generators/rails/app/templates/bin/update.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/update.tt
@@ -10,20 +10,17 @@ def system!(*args)
 end
 
 chdir APP_ROOT do
-  # This script is a starting point to setup your application.
-  # Add necessary setup steps to this file.
+  # This script is a way to update your development environment automatically.
+  # Add necessary update steps to this file.
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
+<% unless options.skip_active_record -%>
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   cp 'config/database.yml.sample', 'config/database.yml'
-  # end
-
-  puts "\n== Preparing database =="
-  system! 'bin/rails db:setup'
+  puts "\n== Updating database =="
+  system! 'bin/rails db:migrate'
+<% end -%>
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -363,6 +363,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "test/test_helper.rb" do |helper_content|
       assert_no_match(/fixtures :all/, helper_content)
     end
+    assert_file "bin/setup" do |setup_content|
+      assert_no_match(/db:setup/, setup_content)
+    end
+    assert_file "bin/update" do |update_content|
+      assert_no_match(/db:migrate/, update_content)
+    end
 
     assert_file "config/initializers/new_framework_defaults.rb" do |initializer_content|
       assert_no_match(/belongs_to_required_by_default/, initializer_content)


### PR DESCRIPTION
### Summary

Currently `bin/setup` and `bin/update` always include `db:setup` and `db:migrate`, which makes them fail if active record is skipped. This PR excludes those lines if active record is skipped.
