### PR TITLE
remove warning from railtie

### DIFF
--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -194,7 +194,7 @@ module Rails
         # `#each_registered_block(type, &block)`
         def register_block_for(type, &blk)
           var_name = "@#{type}"
-          blocks = instance_variable_get(var_name) || instance_variable_set(var_name, [])
+          blocks = instance_variable_defined?(var_name) ? instance_variable_get(var_name) : instance_variable_set(var_name, [])
           blocks << blk if blk
           blocks
         end


### PR DESCRIPTION
This removes the following warnings.

```ruby
rails/railties/lib/rails/railtie.rb:186: warning: instance variable @rake_tasks not initialized
rails/railties/lib/rails/railtie.rb:186: warning: instance variable @rake_tasks not initialized
rails/railties/lib/rails/railtie.rb:186: warning: instance variable @load_console not initialized
rails/railties/lib/rails/railtie.rb:186: warning: instance variable @rake_tasks not initialized
```

Ref: https://travis-ci.org/rails/rails/jobs/172343131