### PR TITLE
Allow attribute_changed? method to receive to and from arrays

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Added support for array arguments to name_changed? method.
+    
+    `object.name_changed? from: [nil, "Pete"], to: "John"`
+
+    *Valentín Sanjuan*
+
 *   Removed deprecated `:tokenizer` in the length validator.
 
     *Rafael Mendonça França*

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -67,6 +67,9 @@ module ActiveModel
   #   person.changed?       # => true
   #   person.name_changed?  # => true
   #   person.name_changed?(from: nil, to: "Bob") # => true
+  #   person.name_changed?(from: [nil, "Pete"], to: "Bob") # => true
+  #   person.name_changed?(from: [nil, "Pete"], to: ["Bob", "John") # => true
+  #   person.name_changed?(from: nil, to: ["Bob", "John") # => true
   #   person.name_was       # => nil
   #   person.name_change    # => [nil, "Bob"]
   #   person.name = 'Bill'
@@ -179,8 +182,8 @@ module ActiveModel
     # Handles <tt>*_changed?</tt> for +method_missing+.
     def attribute_changed?(attr, from: OPTION_NOT_GIVEN, to: OPTION_NOT_GIVEN) # :nodoc:
       !!changes_include?(attr) &&
-        (to == OPTION_NOT_GIVEN || to == __send__(attr)) &&
-        (from == OPTION_NOT_GIVEN || from == changed_attributes[attr])
+        (to == OPTION_NOT_GIVEN || [to].flatten.include?(__send__(attr))) &&
+        (from == OPTION_NOT_GIVEN || [from].flatten.include?(changed_attributes[attr]))
     end
 
     # Handles <tt>*_was</tt> for +method_missing+.

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -79,6 +79,15 @@ class DirtyTest < ActiveModel::TestCase
     assert_not @model.name_changed?(to: "Pete")
     assert @model.name_changed?(from: nil)
     assert_not @model.name_changed?(from: "Pete")
+
+    assert @model.name_changed?(from: [nil, "Pete"])
+    assert_not @model.name_changed?(from: ["Ringo", "Pete"])
+    assert @model.name_changed?(to: [nil, "Ringo"])
+    assert_not @model.name_changed?(to: [nil, "Pete"])
+    assert @model.name_changed?(from: nil, to: ["Pete", "Ringo"])
+    assert_not @model.name_changed?(from: "Pete", to: ["Ringo", "John"])
+    assert @model.name_changed?(from: [nil, "Pete"], to: "Ringo")
+    assert_not @model.name_changed?(from: ["Pete"], to: ["Ringo", "John"])
   end
 
   test "changes accessible through both strings and symbols" do


### PR DESCRIPTION
### Summary

Added support for attribute_changed? method of dirty attributes to receive array params as to or from. This is more expressive and useful way for look at attribute changes avoiding the excessive use of conditionals. 
 
