### PR TITLE
Configure query caching (per thread) on the connection pool

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -307,6 +307,7 @@ module ActiveRecord
       end
 
       include MonitorMixin
+      include QueryCache::ConnectionPoolConfiguration
 
       attr_accessor :automatic_reconnect, :checkout_timeout, :schema_cache
       attr_reader :spec, :connections, :size, :reaper

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -24,10 +24,17 @@ module ActiveRecord
     end
 
     def self.run
-      ActiveRecord::Base.connection.enable_query_cache!
+      caching_pool = ActiveRecord::Base.connection_pool
+      caching_was_enabled = caching_pool.query_cache_enabled
+
+      caching_pool.enable_query_cache!
+
+      [caching_pool, caching_was_enabled]
     end
 
-    def self.complete(_)
+    def self.complete((caching_pool, caching_was_enabled))
+      caching_pool.disable_query_cache! unless caching_was_enabled
+
       ActiveRecord::Base.connection_handler.connection_pool_list.each do |pool|
         pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?
       end

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -28,8 +28,8 @@ module ActiveRecord
     end
 
     def self.complete(_)
-      unless ActiveRecord::Base.connected? && ActiveRecord::Base.connection.transaction_open?
-        ActiveRecord::Base.clear_active_connections!
+      ActiveRecord::Base.connection_handler.connection_pool_list.each do |pool|
+        pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?
       end
     end
 


### PR DESCRIPTION
Fixes #25573

cc @sgrif 

On reflection, I believe this makes #26909 backportable (which isn't too surprising: it almost reverses that PR's changes to the querycache middleware).