### PR TITLE
Should except `:distinct` rather than `:order` for `exists?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -7,7 +7,8 @@
 
     *Pavel Evstigneev*
 
-*   Avoid `unscope(:order)` when `limit_value` is presented for `count`.
+*   Avoid `unscope(:order)` when `limit_value` is presented for `count`
+    and `exists?`.
 
     If `limit_value` is presented, records fetching order is very important
     for performance. Should not unscope the order in the case.

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -321,7 +321,7 @@ module ActiveRecord
       relation = apply_join_dependency(self, construct_join_dependency(eager_loading: false))
       return false if ActiveRecord::NullRelation === relation
 
-      relation = relation.except(:select, :order).select(ONE_AS_ONE).limit(1)
+      relation = relation.except(:select, :distinct).select(ONE_AS_ONE).limit(1)
 
       case conditions
       when Array, Hash


### PR DESCRIPTION
Records fetching order is very important for performance if `limit` is
presented. Should not except the order in the case.

And `exists?` replaces select list to `1 AS one` therefore `:distinct`
is useless (`DISTINCT 1 AS one`). And PostgreSQL raises the following
error if `:distinct` and `:order` are used in the same time.

```
ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
```