### PR TITLE
Add ActiveRecord::Base.connection_pool.stat

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `stat` method to `ActiveRecord::ConnectionAdapters::ConnectionPool`
+
+    Example:
+
+        ActiveRecord::Base.connection_pool.stat # =>
+        { size: 15, connections: 1, busy: 1, dead: 0, idle: 0, waiting: 0, checkout_timeout: 5 }
+
+    *Pavel Evstigneev*
+
 *   Avoid `unscope(:order)` when `limit_value` is presented for `count`.
 
     If `limit_value` is presented, records fetching order is very important

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -581,6 +581,24 @@ module ActiveRecord
         @available.num_waiting
       end
 
+      # Return connection pool's usage statistic
+      # Example:
+      #
+      #    ActiveRecord::Base.connection_pool.stat # => { size: 15, connections: 1, busy: 1, dead: 0, idle: 0, waiting: 0, checkout_timeout: 5 }
+      def stat
+        synchronize do
+          {
+            size: size,
+            connections: @connections.size,
+            busy: @connections.count { |c| c.in_use? && c.owner.alive? },
+            dead: @connections.count { |c| c.in_use? && !c.owner.alive? },
+            idle: @connections.count { |c| !c.in_use? },
+            waiting: num_waiting_in_queue,
+            checkout_timeout: checkout_timeout
+          }
+        end
+      end
+
       private
         #--
         # this is unfortunately not concurrent


### PR DESCRIPTION
Example:
```ruby
p ActiveRecord::Base.connection_pool.stat
{
  max: 25,
  total: 1,
  busy: 1,
  dead: 0,
  idle: 0,
  num_waiting: 0,
  checkout_timeout: 5
}
```

Related to #26898
