### PR TITLE
Upgrade JRuby to satisfy gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,14 +59,14 @@ matrix:
         - "GEM=ar:mysql2"
       addons:
         mariadb: 10.0
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.5.0
       jdk: oraclejdk8
       env:
         - "JRUBY_OPTS='--dev -J-Xmx1024M'"
         - "GEM='ap'"
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.5.0
   fast_finish: true
 
 notifications:


### PR DESCRIPTION
https://travis-ci.org/rails/rails/jobs/173621075#L271


    Resolving dependencies.....................................................
    ruby_dep-1.5.0 requires ruby version >= 2.2.5, which is incompatible with the
    current version, ruby 2.2.3p0 (jruby 9.0.5.0)
    The command "eval bundle install --without test --jobs 3 --retry 3 --path=${BUNDLE_PATH:-vendor/bundle}" failed. Retrying, 2 of 3.

`ruby_dep 1.5.0` requires ruby >=2.2.5. This is something that jruby-9.0.5.0 doesn't provide.

This PR upgrades the `.travis.yml` to `jruby-9.1.5.0`.