### PR TITLE
SQL Literals should not be type casted

### DIFF
--- a/activerecord/lib/active_record/type_caster/map.rb
+++ b/activerecord/lib/active_record/type_caster/map.rb
@@ -7,6 +7,7 @@ module ActiveRecord
 
       def type_cast_for_database(attr_name, value)
         return value if value.is_a?(Arel::Nodes::BindParam)
+        return value if value.is_a?(Arel::Nodes::SqlLiteral)
         type = types.type_for_attribute(attr_name.to_s)
         type.serialize(value)
       end

--- a/activerecord/test/cases/type_caster/map_test.rb
+++ b/activerecord/test/cases/type_caster/map_test.rb
@@ -1,0 +1,29 @@
+require "cases/helper"
+require "models/topic"
+
+module ActiveRecord
+  module TypeCaster
+    class MapTest < ActiveRecord::TestCase
+      setup do
+        @map = Map.new(Topic)
+      end
+
+      test "type casts based on column type" do
+        casted = @map.type_cast_for_database("id", "100")
+        assert_equal casted, 100
+      end
+
+      test "does not type cast BindParam" do
+        bind_param = Arel::Nodes::BindParam.new
+        casted = @map.type_cast_for_database("id", bind_param)
+        assert_equal bind_param, casted
+      end
+
+      test "does not type cast SqlLiteral" do
+        sql_literal = Arel::Nodes::SqlLiteral.new("foo")
+        casted = @map.type_cast_for_database("id", sql_literal)
+        assert_equal sql_literal, casted
+      end
+    end
+  end
+end


### PR DESCRIPTION
The issue makes itself apparent when querying integer colums, which will call `#to_i`:

```ruby
Post.arel_table[:id].eq(Arel.sql('coalesce(1, 0)')).to_sql
#=> "posts"."id" = 0
```

The above Arel works as expected in 4.2.7, but breaks in 5.0.