### PR TITLE
Added  touch option to ActiveRecord::CounterCache methods.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add option to update specified timestamp columns when incrementing,
+    decrementing, resetting, or updating counter caches.
+
+    Fixes #26724.
+
+    *Jarred Trost*
+
 *   Remove deprecated `#uniq`, `#uniq!`, and `#uniq_value`.
 
     *Ryuta Kamizono*

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -211,4 +211,145 @@ class CounterCacheTest < ActiveRecord::TestCase
       aircraft.wheels.first.destroy
     end
   end
+
+  test "does not update counters with touch: false" do
+    previous_updated_at = @topic.updated_at
+    Topic.update_counters(@topic.id, replies_count: -1, touch: false)
+    assert_equal previous_updated_at, @topic.reload.updated_at
+  end
+
+  test "update counters with touch: true" do
+    previous_updated_at = @topic.updated_at
+    Topic.update_counters(@topic.id, replies_count: -1, touch: true)
+    assert_not_equal previous_updated_at, @topic.reload.updated_at
+  end
+
+  test "update multiple counters with touch: true" do
+    previous_updated_at = @topic.updated_at
+    Topic.update_counters(@topic.id, replies_count: 2, unique_replies_count: 2, touch: true)
+    assert_not_equal previous_updated_at, @topic.reload.updated_at
+  end
+
+  test "reset counters with touch: true" do
+    previous_updated_at = @topic.updated_at
+    Topic.reset_counters(@topic.id, :replies, touch: true)
+    assert_not_equal previous_updated_at, @topic.reload.updated_at
+  end
+
+  test "reset multiple counters with touch: true" do
+    previous_updated_at = @topic.updated_at
+    Topic.update_counters(@topic.id, replies_count: 1, unique_replies_count: 1)
+    Topic.reset_counters(@topic.id, :replies, :unique_replies, touch: true)
+    assert_not_equal previous_updated_at, @topic.reload.updated_at
+  end
+
+  test "increment counters with touch: true" do
+    previous_updated_at = @topic.updated_at
+    Topic.increment_counter(:replies_count, @topic.id, touch: true)
+    assert_not_equal previous_updated_at, @topic.reload.updated_at
+  end
+
+  test "decrement counters with touch: true" do
+    previous_updated_at = @topic.updated_at
+    Topic.decrement_counter(:replies_count, @topic.id, touch: true)
+    assert_not_equal previous_updated_at, @topic.reload.updated_at
+  end
+
+  test "update counters with touch: :written_on" do
+    previous_written_on = @topic.written_on
+    Topic.update_counters(@topic.id, replies_count: -1, touch: :written_on)
+    assert_not_equal previous_written_on, @topic.reload.written_on
+  end
+
+  test "update multiple counters with touch: :written_on" do
+    previous_written_on = @topic.written_on
+    Topic.update_counters(@topic.id, replies_count: 2, unique_replies_count: 2, touch: :written_on)
+    assert_not_equal previous_written_on, @topic.reload.written_on
+  end
+
+  test "reset counters with touch: :written_on" do
+    previous_written_on = @topic.written_on
+    Topic.reset_counters(@topic.id, :replies, touch: :written_on)
+    assert_not_equal previous_written_on, @topic.reload.written_on
+  end
+
+  test "reset multiple counters with touch: :written_on" do
+    previous_written_on = @topic.written_on
+    Topic.update_counters(@topic.id, replies_count: 1, unique_replies_count: 1)
+    Topic.reset_counters(@topic.id, :replies, :unique_replies, touch: :written_on)
+    assert_not_equal previous_written_on, @topic.reload.written_on
+  end
+
+  test "increment counters with touch: :written_on" do
+    previous_written_on = @topic.written_on
+    Topic.increment_counter(:replies_count, @topic.id, touch: :written_on)
+    assert_not_equal previous_written_on, @topic.reload.written_on
+  end
+
+  test "decrement counters with touch: :written_on" do
+    previous_written_on = @topic.written_on
+    Topic.decrement_counter(:replies_count, @topic.id, touch: :written_on)
+    assert_not_equal previous_written_on, @topic.reload.written_on
+  end
+
+  test "update counters with touch: %i( updated_at written_on )" do
+    previous_updated_at = @topic.updated_at
+    previous_written_on = @topic.written_on
+
+    Topic.update_counters(@topic.id, replies_count: -1, touch: %i( updated_at written_on ))
+
+    assert_not_equal previous_updated_at, @topic.reload.updated_at
+    assert_not_equal previous_written_on, @topic.reload.written_on
+  end
+
+  test "update multiple counters with touch: %i( updated_at written_on )" do
+    previous_updated_at = @topic.updated_at
+    previous_written_on = @topic.written_on
+
+    Topic.update_counters(@topic.id, replies_count: 2, unique_replies_count: 2, touch: %i( updated_at written_on ))
+
+    assert_not_equal previous_updated_at, @topic.reload.updated_at
+    assert_not_equal previous_written_on, @topic.reload.written_on
+  end
+
+  test "reset counters with touch: %i( updated_at written_on )" do
+    previous_updated_at = @topic.updated_at
+    previous_written_on = @topic.written_on
+
+    Topic.reset_counters(@topic.id, :replies, touch: %i( updated_at written_on ))
+
+    assert_not_equal previous_updated_at, @topic.reload.updated_at
+    assert_not_equal previous_written_on, @topic.reload.written_on
+  end
+
+  test "reset multiple counters with touch: %i( updated_at written_on )" do
+    previous_updated_at = @topic.updated_at
+    previous_written_on = @topic.written_on
+
+    Topic.update_counters(@topic.id, replies_count: 1, unique_replies_count: 1)
+    Topic.reset_counters(@topic.id, :replies, :unique_replies, touch: %i( updated_at written_on ))
+
+    assert_not_equal previous_updated_at, @topic.reload.updated_at
+    assert_not_equal previous_written_on, @topic.reload.written_on
+  end
+
+  test "increment counters with touch: %i( updated_at written_on )" do
+    previous_updated_at = @topic.updated_at
+    previous_written_on = @topic.written_on
+
+    Topic.increment_counter(:replies_count, @topic.id, touch: %i( updated_at written_on ))
+
+    assert_not_equal previous_updated_at, @topic.reload.updated_at
+    assert_not_equal previous_written_on, @topic.reload.written_on
+  end
+
+  test "decrement counters with touch: %i( updated_at written_on )" do
+    previous_updated_at = @topic.updated_at
+    previous_written_on = @topic.written_on
+
+    Topic.decrement_counter(:replies_count, @topic.id, touch: %i( updated_at written_on ))
+
+    assert_not_equal previous_updated_at, @topic.reload.updated_at
+    assert_not_equal previous_written_on, @topic.reload.written_on
+  end
 end

--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -28,9 +28,7 @@ module Rails
 
             return @rake_tasks if defined?(@rake_tasks)
 
-            ActiveSupport::Deprecation.silence do
-              require_application_and_environment!
-            end
+            require_application_and_environment!
 
             Rake::TaskManager.record_task_metadata = true
             Rake.application.instance_variable_set(:@name, "rails")


### PR DESCRIPTION
After messing something up with the [original PR](https://github.com/rails/rails/pull/26781) I decided to close that one and start anew.

### Summary

This fixes #26724. There are cases in which calling the methods in `ActiveRecord::CounterCache` should update the `updated_at` value of the affected records. For example, if a counter cache is included in a view that is fragment cached, it would be convenient if the fragment cache was expired when the counter cache was updated by changing the updated_at value.

@kaspth suggested this public API, which is implemented in this pull request:

````ruby
# Uses `timestamp_attributes_for_update_in_model`:
Message.reset_counters [ 2, 18 ], comments_count: 5, touch: true

# Touch just one timestamp:
Message.reset_counters [ 2, 18 ], comments_count: 5, touch: :last_discussed_at

# The assumed rare case where you want to touch `updated_at` plus `last_discussed_at`:
Message.reset_counters [ 2, 18 ], comments_count: 5, touch: %i( updated_at last_discussed_at )
````

Working with the API was a bit difficult here because each method in this module has a slightly different signature. This pull request ensures compatibility with the current implementation of these methods while providing this new option. I'll go through each method to explain the changes:

**.reset_counters** accepts any number of counters as a splat argument, so the `{touch: true}` option is added as a double splat argument to separate it from the `counters` argument.

**.update_counters** accepts any number of counters as a hash. There is no way to add another argument at the end of this method signature since the current implementation looks like this:

```
Topic.update_counters(@topic.id, replies_count: 2, unique_replies_count: 2)
```

Therefore, I tacked `touch: true` onto the end of the `counters` argument, and it's removed from the hash before iterating through the counters.

**.increment_counter** and **.decrement_counter** accept a separate options hash much like `.reset_counters` does. These methods call `.update_counters`, so the options hash is merged into the `counters` hash.

cc @eileencodes 
