### PR TITLE
Backport #25192 to 4-2-stable

### DIFF
--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -15,9 +15,8 @@ module ActiveSupport
     end
 
     # Returns a derived key suitable for use.  The default key_size is chosen
-    # to be compatible with the default settings of ActiveSupport::MessageVerifier.
-    # i.e. OpenSSL::Digest::SHA1#block_length
-    def generate_key(salt, key_size=64)
+    # to be compatible with the acceptable key length of aes-256-cbc, the default cipher.
+    def generate_key(salt, key_size=32)
       OpenSSL::PKCS5.pbkdf2_hmac_sha1(@secret, salt, @iterations, key_size)
     end
   end
@@ -32,9 +31,8 @@ module ActiveSupport
     end
 
     # Returns a derived key suitable for use.  The default key_size is chosen
-    # to be compatible with the default settings of ActiveSupport::MessageVerifier.
-    # i.e. OpenSSL::Digest::SHA1#block_length
-    def generate_key(salt, key_size=64)
+    # to be compatible with the acceptable key length of aes-256-cbc, the default cipher.
+    def generate_key(salt, key_size=32)
       @cache_keys["#{salt}#{key_size}"] ||= @key_generator.generate_key(salt, key_size)
     end
   end

--- a/activesupport/test/key_generator_test.rb
+++ b/activesupport/test/key_generator_test.rb
@@ -19,7 +19,7 @@ class KeyGeneratorTest < ActiveSupport::TestCase
   test "Generating a key of the default length" do
     derived_key = @generator.generate_key("some_salt")
     assert_kind_of String, derived_key
-    assert_equal OpenSSL::Digest::SHA1.new.block_length, derived_key.length, "Should have generated a key of the default size"
+    assert_equal OpenSSL::Cipher.new('aes-256-cbc').key_len, derived_key.length, "Should have generated a key of the default size"
   end
 
   test "Generating a key of an alternative length" do

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -22,7 +22,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
   end
 
   def setup
-    @secret    = SecureRandom.hex(64)
+    @secret    = SecureRandom.random_bytes(32)
     @verifier  = ActiveSupport::MessageVerifier.new(@secret, :serializer => ActiveSupport::MessageEncryptor::NullSerializer)
     @encryptor = ActiveSupport::MessageEncryptor.new(@secret)
     @data = { :some => "data", :now => Time.local(2010) }
@@ -58,7 +58,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
   def test_alternative_serialization_method
     prev = ActiveSupport.use_standard_json_time_format
     ActiveSupport.use_standard_json_time_format = true
-    encryptor = ActiveSupport::MessageEncryptor.new(SecureRandom.hex(64), SecureRandom.hex(64), :serializer => JSONSerializer.new)
+    encryptor = ActiveSupport::MessageEncryptor.new(SecureRandom.random_bytes(32), SecureRandom.random_bytes(128), :serializer => JSONSerializer.new)
     message = encryptor.encrypt_and_sign({ :foo => 123, 'bar' => Time.utc(2010) })
     exp = { "foo" => 123, "bar" => "2010-01-01T00:00:00.000Z" }
     assert_equal exp, encryptor.decrypt_and_verify(message)


### PR DESCRIPTION
### Summary

Fixes #25185

Backport of #25192

### Steps to reproduce

1. Run `rails new` and change Gemfile

```diff
diff --git a/Gemfile b/Gemfile
index e186de1..5e698bc 100644
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source 'https://rubygems.org'
 
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '4.2.7.1'
+gem 'rails', git: 'https://github.com/rails/rails', branch: '4-2-stable'
+# cf. https://github.com/flori/json/issues/303
+gem 'json', '2.0.2'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
 # Use SCSS for stylesheets
@@ -21,7 +22,7 @@ gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
-gem 'sdoc', '~> 0.4.0', group: :doc
+# gem 'sdoc', '~> 0.4.0', group: :doc
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
```

2. Execute commands in RAILS_ROOT

```shell
$ bundle install
$ bin/rails g scaffold Book title 
$ bin/rake db:migrate
$ bin/rails s
```

3. Open `localhost:3000/books` in browser

<img width="500" alt="evidence" src="https://cloud.githubusercontent.com/assets/409323/20138353/44675ac0-a6c3-11e6-9b71-bf8b805cbb59.png">



### System configuration
**Rails version**: 4-2-stable

**Ruby version**: ruby 2.4.0dev (2016-11-09 trunk 56682) [x86_64-darwin16]