### PR TITLE
Catch invalid UTF-8 JSON documents and respond with BadRequest

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -7,7 +7,12 @@ module ActionDispatch
 
       DEFAULT_PARSERS = {
         Mime[:json].symbol => -> (raw_post) {
-          data = ActiveSupport::JSON.decode(raw_post)
+          encoded = raw_post.force_encoding(Encoding::UTF_8)
+          unless encoded.valid_encoding?
+            raise Rack::Utils::InvalidParameterError, "Invalid UTF-8 sequence"
+          end
+
+          data = ActiveSupport::JSON.decode(encoded)
           data.is_a?(Hash) ? data : { _json: data }
         }
       }

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1042,6 +1042,21 @@ class RequestParameters < BaseRequestTest
     assert_raises(ActionController::BadRequest) { request.parameters }
   end
 
+  test "JSON parameter containing an invalid UTF8 sequence" do
+    invalid = "{ \"bad\": \"\xBE\" }"
+
+    request = stub_request(
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_LENGTH" => invalid.length,
+        "CONTENT_TYPE" => "application/json",
+        "rack.input" => StringIO.new(invalid)
+    )
+
+    assert_raises(ActionDispatch::Http::Parameters::ParseError) do
+      request.parameters
+    end
+  end
+
   test "parameters not accessible after rack parse error 1" do
     request = stub_request(
       "REQUEST_METHOD" => "POST",


### PR DESCRIPTION
It's currently possible to send a malformed JSON document on POST that includes invalid UTF-8 byte sequences. Unfortunately the JSON decoder will not perform any checks on the validity of the input string and will include the invalid byte sequence in the deserialized object. This generally leads to hideous errors further down the stack, since the sequences are not valid in UTF-8.

The current change will serve a 400 for any invalid JSON; we do something similar already for GET requests (see #21990).