### PR TITLE
Refactor column initialization into `new_column_from_field`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -161,6 +161,14 @@ module ActiveRecord
         SchemaCreation.new self
       end
 
+      # Returns an array of +Column+ objects for the table specified by +table_name+.
+      def columns(table_name) # :nodoc:
+        table_name = table_name.to_s
+        column_definitions(table_name).map do |field|
+          new_column_from_field(table_name, field)
+        end
+      end
+
       # this method must only be called while holding connection pool's mutex
       def lease
         if in_use?

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -398,18 +398,14 @@ module ActiveRecord
         indexes
       end
 
-      # Returns an array of +Column+ objects for the table specified by +table_name+.
-      def columns(table_name) # :nodoc:
-        table_name = table_name.to_s
-        column_definitions(table_name).map do |field|
-          type_metadata = fetch_type_metadata(field[:Type], field[:Extra])
-          if type_metadata.type == :datetime && field[:Default] == "CURRENT_TIMESTAMP"
-            default, default_function = nil, field[:Default]
-          else
-            default, default_function = field[:Default], nil
-          end
-          new_column(field[:Field], default, type_metadata, field[:Null] == "YES", table_name, default_function, field[:Collation], comment: field[:Comment].presence)
+      def new_column_from_field(table_name, field) # :nodoc:
+        type_metadata = fetch_type_metadata(field[:Type], field[:Extra])
+        if type_metadata.type == :datetime && field[:Default] == "CURRENT_TIMESTAMP"
+          default, default_function = nil, field[:Default]
+        else
+          default, default_function = field[:Default], nil
         end
+        new_column(field[:Field], default, type_metadata, field[:Null] == "YES", table_name, default_function, field[:Collation], comment: field[:Comment].presence)
       end
 
       def table_comment(table_name) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -221,21 +221,23 @@ module ActiveRecord
           end.compact
         end
 
-        # Returns the list of all column definitions for a table.
-        def columns(table_name) # :nodoc:
-          table_name = table_name.to_s
-          column_definitions(table_name).map do |column_name, type, default, notnull, oid, fmod, collation, comment|
-            oid = oid.to_i
-            fmod = fmod.to_i
-            type_metadata = fetch_type_metadata(column_name, type, oid, fmod)
-            default_value = extract_value_from_default(default)
-            default_function = extract_default_function(default_value, default)
-            new_column(column_name, default_value, type_metadata, !notnull, table_name, default_function, collation, comment: comment.presence)
-          end
-        end
-
-        def new_column(*args) # :nodoc:
-          PostgreSQLColumn.new(*args)
+        def new_column_from_field(table_name, field) # :nondoc:
+          column_name, type, default, notnull, oid, fmod, collation, comment = field
+          oid = oid.to_i
+          fmod = fmod.to_i
+          type_metadata = fetch_type_metadata(column_name, type, oid, fmod)
+          default_value = extract_value_from_default(default)
+          default_function = extract_default_function(default_value, default)
+          PostgreSQLColumn.new(
+            column_name,
+            default_value,
+            type_metadata,
+            !notnull,
+            table_name,
+            default_function,
+            collation,
+            comment: comment.presence
+          )
         end
 
         def table_options(table_name) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -308,20 +308,24 @@ module ActiveRecord
       def columns(table_name) # :nodoc:
         table_name = table_name.to_s
         table_structure(table_name).map do |field|
-          case field["dflt_value"]
-          when /^null$/i
-            field["dflt_value"] = nil
-          when /^'(.*)'$/m
-            field["dflt_value"] = $1.gsub("''", "'")
-          when /^"(.*)"$/m
-            field["dflt_value"] = $1.gsub('""', '"')
-          end
-
-          collation = field["collation"]
-          sql_type = field["type"]
-          type_metadata = fetch_type_metadata(sql_type)
-          new_column(field["name"], field["dflt_value"], type_metadata, field["notnull"].to_i == 0, table_name, nil, collation)
+          new_column_from_field(table_name, field)
         end
+      end
+
+      def new_column_from_field(table_name, field) # :nondoc:
+        case field["dflt_value"]
+        when /^null$/i
+          field["dflt_value"] = nil
+        when /^'(.*)'$/m
+          field["dflt_value"] = $1.gsub("''", "'")
+        when /^"(.*)"$/m
+          field["dflt_value"] = $1.gsub('""', '"')
+        end
+
+        collation = field["collation"]
+        sql_type = field["type"]
+        type_metadata = fetch_type_metadata(sql_type)
+        new_column(field["name"], field["dflt_value"], type_metadata, field["notnull"].to_i == 0, table_name, nil, collation)
       end
 
       # Returns an array of indexes for the given table.


### PR DESCRIPTION
This refactoring would allow us to reduce the identical repeating code in adapters (`column_definitions(table_name).map do |field|`) and to manually create columns based on the result of `SHOW FULL FIELDS` (which we will use later to store schema cache in YAML)

?r @rafaelfranca 