### PR TITLE
Fix document of the output of javascript_include_tag.

### DIFF
--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -796,7 +796,7 @@ You can specify a full path relative to the document root, or a URL, if you pref
 Rails will then output a `script` tag such as this:
 
 ```html
-<script src='/assets/main.js'></script>
+<script src="/javascripts/main.js"></script>
 ```
 
 The request to this asset is then served by the Sprockets gem.


### PR DESCRIPTION
### Summary

The output of
```
<%= javascript_include_tag "main" %>
```
is 

```
<script src="/javascripts/main.js"></script>
```
while it is 
```
<script src='/assets/main.js'></script>
```
in the current guides.

