### PR TITLE
Make 'to_date' able to handle incomplete strings

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -40,9 +40,11 @@ class String
   #   "1-1-2012".to_date   # => Sun, 01 Jan 2012
   #   "01/01/2012".to_date # => Sun, 01 Jan 2012
   #   "2012-12-13".to_date # => Thu, 13 Dec 2012
+  #   "2012/12".to_date    # => Sat, 01 Dec 2012
+  #   "2012-12".to_date    # => Sat, 01 Dec 2012
   #   "12/13/2012".to_date # => ArgumentError: invalid date
   def to_date
-    ::Date.parse(self, false) unless blank?
+    ::Date.parse(complement_date_string(self), false) unless blank?
   end
 
   # Converts a string to a DateTime value.
@@ -54,4 +56,11 @@ class String
   def to_datetime
     ::DateTime.parse(self, false) unless blank?
   end
+
+  private
+
+    def complement_date_string(str)
+      return str unless str.count("-") == 1
+      str + "-01"
+    end
 end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -629,6 +629,11 @@ class StringConversionsTest < ActiveSupport::TestCase
     assert_nil "".to_date
     assert_equal Date.new(Date.today.year, 2, 3), "Feb 3rd".to_date
   end
+
+  def test_incomplete_string_to_date
+    assert_equal Date.new(2016, 11, 1), "2016/11".to_date
+    assert_equal Date.new(2016, 11, 1), "2016-11".to_date
+  end
 end
 
 class StringBehaviourTest < ActiveSupport::TestCase


### PR DESCRIPTION
```
"2016/11/01".to_date
=> Tue, 01 Nov 2016

"2016-11-01".to_date
=> Tue, 01 Nov 2016
```

OK, This is exactly what I expected. However, the case below sounds a bit strange to me.

```
"2016/11".to_date   
=> Tue, 01 Nov 2016

"2016-11".to_date
ArgumentError: invalid date
```

I don't think this makes sense.  
The latter should also return a Date instance. 