### PR TITLE
Deprecate the behavior of returning `nil` on `Float::INFINITY.as_json`, `Float::NAN.as_json` and `BigDecimal::INFINITY.as_json`, `BigDecimal::NAN.as_json`.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Deprecate the behavior of returning `nil` on `Float::INFINITY.as_json`,
+    `Float::NAN.as_json` and `BigDecimal::INFINITY.as_json`,
+    `BigDecimal::NAN.as_json`.
+
+    This change matches `#as_json` behavior from Active Support to that
+    JSON gem and Ruby rather than silently converting `INFINITY` or `NAN`
+    to `nil`.
+
+    *Prathamesh Sopatki*
+
 *   Remove deprecated class `ActiveSupport::Concurrency::Latch`
 
     *Andrew White*

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -99,10 +99,18 @@ class Numeric
 end
 
 class Float
-  # Encoding Infinity or NaN to JSON should return "null". The default returns
-  # "Infinity" or "NaN" which are not valid JSON.
   def as_json(options = nil) #:nodoc:
-    finite? ? self : nil
+    if finite?
+      self
+    else
+      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        The behavior of `Float::INFINITY.as_json` and `Float::NAN.as_json`
+        returning `nil` has been deprecated, and will be removed in Rails 5.2.
+        Users are expected to handle this conversion on the application level.
+      MSG
+
+      nil
+    end
   end
 end
 
@@ -117,7 +125,18 @@ class BigDecimal
   # BigDecimal, it still has the chance to post-process the string and get the
   # real value.
   def as_json(options = nil) #:nodoc:
-    finite? ? to_s : nil
+    if
+      finite?
+      to_s
+    else
+      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        The behavior of `BigDecimal::INFINITY.as_json` and `BigDecimal::NAN.as_json`
+        returning `nil` has been deprecated, and will be removed in Rails 5.2.
+        Users are expected to handle this conversion on the application level.
+      MSG
+
+      nil
+    end
   end
 end
 

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -432,24 +432,52 @@ EXPECTED
     assert_equal '"foo"', ActiveSupport::JSON.encode(exception)
   end
 
-  class InfiniteNumber
+  class FloatInfiniteNumber
     def as_json(options = nil)
       { "number" => Float::INFINITY }
     end
   end
 
   def test_to_json_works_when_as_json_returns_infinite_number
-    assert_equal '{"number":null}', InfiniteNumber.new.to_json
+    assert_deprecated do
+      assert_equal '{"number":null}', FloatInfiniteNumber.new.to_json
+    end
   end
 
-  class NaNNumber
+  class FloatNaNNumber
     def as_json(options = nil)
       { "number" => Float::NAN }
     end
   end
 
   def test_to_json_works_when_as_json_returns_NaN_number
-    assert_equal '{"number":null}', NaNNumber.new.to_json
+    assert_deprecated do
+      assert_equal '{"number":null}', FloatNaNNumber.new.to_json
+    end
+  end
+
+  class BigDecimalInfiniteNumber
+    def as_json(options = nil)
+      { "number" => BigDecimal::INFINITY }
+    end
+  end
+
+  def test_to_json_works_when_as_json_returns_infinite_number
+    assert_deprecated do
+      assert_equal '{"number":null}', BigDecimalInfiniteNumber.new.to_json
+    end
+  end
+
+  class BigDecimalNaNNumber
+    def as_json(options = nil)
+      { "number" => BigDecimal::NAN }
+    end
+  end
+
+  def test_to_json_works_when_as_json_returns_NaN_number
+    assert_deprecated do
+      assert_equal '{"number":null}', BigDecimalNaNNumber.new.to_json
+    end
   end
 
   protected

--- a/activesupport/test/json/encoding_test_cases.rb
+++ b/activesupport/test/json/encoding_test_cases.rb
@@ -36,10 +36,6 @@ module JSONTest
     NilTests      = [[ nil,   %(null)  ]]
     NumericTests  = [[ 1,     %(1)     ],
                      [ 2.5,   %(2.5)   ],
-                     [ 0.0 / 0.0,   %(null) ],
-                     [ 1.0 / 0.0,   %(null) ],
-                     [ -1.0 / 0.0,  %(null) ],
-                     [ BigDecimal("0.0") / BigDecimal("0.0"),  %(null) ],
                      [ BigDecimal("2.5"), %("#{BigDecimal('2.5')}") ]]
 
     StringTests   = [[ "this is the <string>",     %("this is the \\u003cstring\\u003e")],


### PR DESCRIPTION
### Summary

- This change matches `#as_json` behavior from Active Support to that
  JSON gem and Ruby rather than silently converting `INFINITY` or `NAN`
  to `nil`.
- Users are expected to handle this conversion at the application
  level as per their needs.

r? @pixeltrix 