### PR TITLE
Remove warning from Bignum constant access

### DIFF
--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -423,7 +423,6 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
 
   # TODO: Remove positive and negative tests when we drop support to ruby < 2.3
   b = 2**64
-  b *= b until Bignum === b
 
   T_ZERO = b.coerce(0).first
   T_ONE  = b.coerce(1).first


### PR DESCRIPTION
Remove warning from access to Bignum class, 2**64 is already a known bignum value. 
See also http://patshaughnessy.net/2014/1/9/how-big-is-a-bignum for smallest bignum value