### PR TITLE
Init result to nil, to avoid warning

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -85,6 +85,7 @@ module ActiveRecord
                 stmt = @connection.prepare(sql)
               end
 
+              result = nil
               begin
                 ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
                   result = stmt.execute(*type_casted_binds)


### PR DESCRIPTION
cc @matthewd 