### PR TITLE
Call `spawn` and bang method for `none`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -763,7 +763,7 @@ module ActiveRecord
     #   end
     #
     def none
-      where("1=0").extending!(NullRelation)
+      spawn.none!
     end
 
     def none! # :nodoc:


### PR DESCRIPTION
All query methods calls `spawn` and bang method, but only `none` is not.