### PR TITLE
Add `:skip_sprockets` to `Rails::PluginBuilder::PASSTHROUGH_OPTIONS`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `:skip_sprockets` to `Rails::PluginBuilder::PASSTHROUGH_OPTIONS`
+
+    *Tsukuru Tanimichi*
+
 *   Allow the use of listen's 3.1.x branch
 
     *Esteban Santana Santana*

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -81,7 +81,7 @@ task default: :test
     end
 
     PASSTHROUGH_OPTIONS = [
-      :skip_active_record, :skip_action_mailer, :skip_javascript, :database,
+      :skip_active_record, :skip_action_mailer, :skip_javascript, :skip_sprockets, :database,
       :javascript, :quiet, :pretend, :force, :skip
     ]
 

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -100,6 +100,14 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_generating_adds_dummy_app_in_full_mode_without_sprockets
+    run_generator [destination_root, "-S", "--full"]
+
+    assert_file "test/dummy/config/environments/production.rb" do |contents|
+      assert_no_match(/config\.assets/, contents)
+    end
+  end
+
   def test_generating_adds_dummy_app_rake_tasks_without_unit_test_files
     run_generator [destination_root, "-T", "--mountable", "--dummy-path", "my_dummy_app"]
     assert_file "Rakefile", /APP_RAKEFILE/


### PR DESCRIPTION
`rails plugin new` with `--full` and `--skip-sprockets` options generates a dummy application that throws `NoMethodError`.

```
% rails plugin new my_engine -S --full --skip-gemspec
% cd my_engine
% bin/rails test
rails aborted!
NoMethodError: undefined method `assets' for #<Rails::Application::Configuration:0x007f83aa1e6100>
```