### PR TITLE
Models inherit from ApplicationRecord [skip ci]

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -7,7 +7,7 @@ module ActiveRecord
   # default is named "type" (can be changed by overwriting <tt>Base.inheritance_column</tt>).
   # This means that an inheritance looking like this:
   #
-  #   class Company < ActiveRecord::Base; end
+  #   class Company < ApplicationRecord; end
   #   class Firm < Company; end
   #   class Client < Company; end
   #   class PriorityClient < Client; end


### PR DESCRIPTION
ActiveRecord models used to inherit from ActiveRecord::Base.
With Rails 5.0 models should inherit from ApplicationRecord instead.