### PR TITLE
Fix testing isolation

### DIFF
--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -2,6 +2,7 @@ module ActiveSupport
   module Testing
     module Isolation
       require "thread"
+      require "shellwords"
 
       def self.included(klass) #:nodoc:
         klass.class_eval do
@@ -80,7 +81,7 @@ module ActiveSupport
 
               load_paths = $-I.map { |p| "-I\"#{File.expand_path(p)}\"" }.join(" ")
               orig_args = ORIG_ARGV.join(" ")
-              test_opts = "-n#{self.class.name}##{self.name}"
+              test_opts = "-n#{self.class.name}##{Shellwords.escape(self.name)}"
               command = "#{Gem.ruby} #{load_paths} #{$0} '#{orig_args}' #{test_opts}"
 
               # IO.popen lets us pass env in a cross-platform way


### PR DESCRIPTION
`AS::Testing::Isolation` has two ways to isolate the process:
forking and subprocessing. The second way is used on JRuby and other
platforms that don't support forking. There's also a way to use subprocessing on MRI by setting `NO_FORK=1`

The way how subprocessing works is that we prepare a command to run a
new process. Example:

```
/opt/rubies/2.3.0/bin/ruby -I{skipped_load_path} test/initializable_test.rb '' -nInitializableTests::Basic#test_Initializer_provides_context's_class_name
```

As you see, there's unescaped quote at the end of the line.
It leads to:

```
sh: -c: line 0: unexpected EOF while looking for matching `''
sh: -c: line 1: syntax error: unexpected end of file
```

We have to escape the test name in the command that we prepare.

This fixes tests on MRI + NO_FORK variable and on JRuby :tada:

Fixes https://github.com/rails/rails/issues/27050

cc @rafaelfranca 