### PR TITLE
Raise on invalid :as param in integration tests

### DIFF
--- a/actionpack/lib/action_dispatch/testing/request_encoder.rb
+++ b/actionpack/lib/action_dispatch/testing/request_encoder.rb
@@ -40,7 +40,7 @@ module ActionDispatch
     end
 
     def self.encoder(name)
-      @encoders[name] || WWWFormEncoder
+      @encoders[name] || raise(ArgumentError, "Can't respond with unregistered encoder: #{name}. Register encoders with ActionDispatch::IntegrationTest.register_encoder(:#{name})")
     end
 
     def self.register_encoder(mime_name, param_encoder: nil, response_parser: nil)

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -980,6 +980,12 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
     Mime::Type.unregister :wibble
   end
 
+  def test_encoding_with_unregistered_encoder
+    assert_raise ArgumentError do
+      post_to_foos as: :unregisterd_encoder
+    end
+  end
+
   def test_parsed_body_without_as_option
     with_routing do |routes|
       routes.draw do


### PR DESCRIPTION
see Rails/rails#27059