### PR TITLE
Run tests by Ruby 2.2.6 and 2.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,14 +47,14 @@ env:
     - "GEM=guides"
 
 rvm:
-  - 2.2.5
-  - 2.3.1
+  - 2.2.6
+  - 2.3.2
   - ruby-head
 
 matrix:
   include:
     # Latest compiled version in http://rubies.travis-ci.org
-    - rvm: 2.3.1
+    - rvm: 2.3.2
       env:
         - "GEM=ar:mysql2"
       addons:


### PR DESCRIPTION
Ruby [2.2.6](https://www.ruby-lang.org/en/news/2016/11/15/ruby-2-2-6-released) and [2.3.2](https://www.ruby-lang.org/en/news/2016/11/15/ruby-2-3-2-released) has been released. Then these Ruby versions are available on Travis CI.

http://rubies.travis-ci.org