### PR TITLE
Removes 'raw: true' from MemCacheStore#read_multi

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -97,7 +97,7 @@ module ActiveSupport
         options = merged_options(options)
 
         keys_to_names = Hash[names.map { |name| [normalize_key(name, options), name] }]
-        raw_values = @data.get_multi(keys_to_names.keys, raw: true)
+        raw_values = @data.get_multi(keys_to_names.keys)
         values = {}
         raw_values.each do |key, value|
           entry = deserialize_entry(value)


### PR DESCRIPTION
### Summary

Addresses the bug in https://github.com/rails/rails/issues/27066

Some graphs to back up the problem:

Network packets per second per box:
![image](https://cloud.githubusercontent.com/assets/832655/20365046/745d676a-ac13-11e6-827a-1b12d016b140.png)

the purple line is the memcached box where the key `"{:raw=>true}"` lives.

Misses per second per box. The key `"{:raw=>true}"` is causing ~20x miss rate.
![image](https://cloud.githubusercontent.com/assets/832655/20365101/ab645cdc-ac13-11e6-9bc5-e9f7107381ae.png)

This machine I'm on doesn't have a ruby version high enough to bundle and meet the ruby_dep for Rails 5, so I could not verify the tests.

---

Copied from the issue:

The definition of `get_multi` in Dalli at https://github.com/petergoldstein/dalli/blob/master/lib/dalli/client.rb#L65 is:

```ruby
def get_multi(*keys)
```

the implementation of `read_multi` in `ActiveSupport::MemCacheStore` at https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache/mem_cache_store.rb#L100 is:

```ruby
raw_values = @data.get_multi(keys_to_names.keys, raw: true)
```

what's happening is that every call to `read_multi` is also adding a key called `"{:raw=>true}"`. We discovered this because this issue has been causing an incredible cache miss rate for us on one of our memcached servers. We run with 9 memcached servers and 8 of the 9 get about 1.5k misses per second. The server that `"{:raw => true}"` is supposed to reside on is getting about 40k misses per second and the incoming packets per second is now starting to overload the box.

I think the `raw: true` should be removed, unless other drives require it, in which case it should only be removed for Dalli.

---

As far as I can tell, this affects Rails 4 and 5. Dalli's signature of `get_multi` has been the same since at least 2010.