### PR TITLE
[WIP] Enable JRuby testing for Active Model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,11 @@ matrix:
       env:
         - "JRUBY_OPTS='--dev -J-Xmx1024M'"
         - "GEM='ap'"
+    - rvm: jruby-9.1.5.0
+      jdk: oraclejdk8
+      env:
+        - "JRUBY_OPTS='--dev -J-Xmx1024M'"
+        - "GEM='amo'"
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-9.1.5.0


### PR DESCRIPTION
### Summary

Seems like there is a general push to add builds for JRuby to our Travis CI test harness. Like with Action Pack, the Active Model JRuby build is in the allowed failures section.


cc @headius 