### PR TITLE
use `force_encoding` instread of `encode!` to avoid `UndefinedConversionError`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -35,7 +35,7 @@ module ActiveRecord
             if value.is_a?(::Array)
               result = @pg_encoder.encode(type_cast_array(value, :serialize))
               if encoding = determine_encoding_of_strings(value)
-                result.encode!(encoding)
+                result.force_encoding(encoding)
               end
               result
             else

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -312,9 +312,9 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_encoding_arrays_of_utf8_strings
-    string_with_utf8 = "nový"
-    assert_equal [string_with_utf8], @type.deserialize(@type.serialize([string_with_utf8]))
-    assert_equal [[string_with_utf8]], @type.deserialize(@type.serialize([[string_with_utf8]]))
+    arrays_of_utf8_strings = %w(nový ファイル)
+    assert_equal arrays_of_utf8_strings, @type.deserialize(@type.serialize(arrays_of_utf8_strings))
+    assert_equal [arrays_of_utf8_strings], @type.deserialize(@type.serialize([arrays_of_utf8_strings]))
   end
 
   private


### PR DESCRIPTION
### Summary

`PG::TextEncoder::Array#encode` returns the encoded value with `ASCII-8BIT`.
But in some cases, trying to convert `ASCII-8BIT` to `UTF-8` cause an error.

```ruby
"{\xE3\x83\x95\xE3\x82\xA1\xE3\x82\xA4\xE3\x83\xAB}".encode!(Encoding::UTF_8)
# => Encoding::UndefinedConversionError: "\xE3" from ASCII-8BIT to UTF-8
```
Should use `force_encoding` to avoid this error.

Follow up to 7ba3a48df5bfdc5e98506bb829f937e03b55a5b3

Ref: https://github.com/rails/rails/pull/23619#issuecomment-189924036