### PR TITLE
Fix incorrect output from rails routes when using singular resources …

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,11 +1,17 @@
-*   Fixes multiple calls to `logger.fatal` instead of a single call, 
-    for every line in an exception backtrace, when printing trace 
+*   Fixes Incorrect output from rails routes when using singular resources.
+
+    Fixes #26606
+
+    *Erick Reyna*
+    
+*   Fixes multiple calls to `logger.fatal` instead of a single call,
+    for every line in an exception backtrace, when printing trace
     from `DebugExceptions` middleware.
-      
+
     Fixes #26134  
 
     *Vipul A M*
-   
+
 *   Add support for arbitrary hashes in strong parameters:
 
     ```ruby

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1244,11 +1244,11 @@ module ActionDispatch
         # the plural):
         #
         #   GET       /profile/new
-        #   POST      /profile
         #   GET       /profile
         #   GET       /profile/edit
         #   PATCH/PUT /profile
         #   DELETE    /profile
+        #   POST      /profile
         #
         # === Options
         # Takes same options as +resources+.
@@ -1266,15 +1266,15 @@ module ActionDispatch
 
               concerns(options[:concerns]) if options[:concerns]
 
-              collection do
-                post :create
-              end if parent_resource.actions.include?(:create)
-
               new do
                 get :new
               end if parent_resource.actions.include?(:new)
 
               set_member_mappings_for_resource
+
+              collection do
+                post :create
+              end if parent_resource.actions.include?(:create)
             end
           end
 

--- a/railties/test/application/rake/single_resource_test.rb
+++ b/railties/test/application/rake/single_resource_test.rb
@@ -1,0 +1,33 @@
+require "isolation/abstract_unit"
+require "active_support/core_ext/string/strip"
+
+class RakeTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  def setup
+    build_app
+  end
+
+  def teardown
+    teardown_app
+  end
+
+  def test_singular_resource_output_in_rake_routes
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        resource :post
+      end
+    RUBY
+    expected_output = ["   Prefix Verb   URI Pattern          Controller#Action",
+                       " new_post GET    /post/new(.:format)  posts#new",
+                       "edit_post GET    /post/edit(.:format) posts#edit",
+                       "     post GET    /post(.:format)      posts#show",
+                       "          PATCH  /post(.:format)      posts#update",
+                       "          PUT    /post(.:format)      posts#update",
+                       "          DELETE /post(.:format)      posts#destroy",
+                       "          POST   /post(.:format)      posts#create\n"].join("\n")
+
+    output = Dir.chdir(app_path) { `bin/rails routes -c PostController` }
+    assert_equal expected_output, output
+  end
+end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -159,13 +159,13 @@ module ApplicationTests
         end
       RUBY
       expected_output = ["         Prefix Verb   URI Pattern                Controller#Action",
-                         "     admin_post POST   /admin/post(.:format)      admin/posts#create",
                          " new_admin_post GET    /admin/post/new(.:format)  admin/posts#new",
                          "edit_admin_post GET    /admin/post/edit(.:format) admin/posts#edit",
-                         "                GET    /admin/post(.:format)      admin/posts#show",
+                         "     admin_post GET    /admin/post(.:format)      admin/posts#show",
                          "                PATCH  /admin/post(.:format)      admin/posts#update",
                          "                PUT    /admin/post(.:format)      admin/posts#update",
-                         "                DELETE /admin/post(.:format)      admin/posts#destroy\n"].join("\n")
+                         "                DELETE /admin/post(.:format)      admin/posts#destroy",
+                         "                POST   /admin/post(.:format)      admin/posts#create\n"].join("\n")
 
       output = Dir.chdir(app_path) { `bin/rails routes -c Admin::PostController` }
       assert_equal expected_output, output


### PR DESCRIPTION
Related Issue #26606 
Rails routes was giving an incorrect output when a single resources was defined in routes.rb An example output is the following:
```
     profile POST   /profile(.:format)                                 profiles#create
 new_profile GET    /profile/new(.:format)                             profiles#new
edit_profile GET    /profile/edit(.:format)                            profiles#edit
             GET    /profile(.:format)                                 profiles#show
             PATCH  /profile(.:format)                                 profiles#update
             PUT    /profile(.:format)                                 profiles#update
             DELETE /profile(.:format)                                 profiles#destroy
```
Now it gives the expected output:
```
      Prefix Verb   URI Pattern             Controller#Action
 new_profile GET    /profile/new(.:format)  profiles#new
edit_profile GET    /profile/edit(.:format) profiles#edit
     profile GET    /profile(.:format)      profiles#show
             PATCH  /profile(.:format)      profiles#update
             PUT    /profile(.:format)      profiles#update
             DELETE /profile(.:format)      profiles#destroy
             POST   /profile(.:format)      profiles#create
```