### PR TITLE
Use secure source for gems referencing "github" in the generated apps

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -1,5 +1,10 @@
 source 'https://rubygems.org'
 
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
 <% gemfile_entries.each do |gem| -%>
 <% if gem.comment -%>
 


### PR DESCRIPTION
### Summary

- New apps generated on master and latest bundler give warning about
  "github" source being insecure.
- Use the same solution used for Rails master in the generated app's
  Gemfile to fix this issue.

r? @rafaelfranca 