### PR TITLE
Fix storing string "Null" as NULL in PostgeSQL database.

### DIFF
--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -433,7 +433,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     a = open_session
     b = open_session
 
-    refute_same(a.integration_session, b.integration_session)
+    refute_same(a.send(:integration_session), b.send(:integration_session))
   end
 
   def test_get_with_query_string

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix NULL quoting rule for arrays on PostgreSQL.
+
+    *Alexander Sergey*
+
 *   Bust Model.attribute_names cache when resetting column information
     
     *James Coleman*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -88,7 +88,7 @@ module ActiveRecord
           # for a list of all cases in which strings will be quoted.
           def string_requires_quoting?(string)
             string.empty? ||
-              string == "NULL" ||
+              string.upcase == "NULL" ||
               string =~ /[\{\}"\\\s]/ ||
               string.include?(delimiter)
           end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -201,7 +201,7 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
   end
 
   def test_string_quoting_rules_match_pg_behavior
-    tags = ["", "one{", "two}", %(three"), "four\\", "five ", "six\t", "seven\n", "eight,", "nine", "ten\r", "NULL"]
+    tags = ["", "one{", "two}", %(three"), "four\\", "five ", "six\t", "seven\n", "eight,", "nine", "ten\r", "NULL", "Null"]
     x = PgArray.create!(tags: tags)
     x.reload
 


### PR DESCRIPTION
### Summary

If array element is equal to `"Null"`, it is stored as `NULL` in PostgreSQL database.

#### Example

```ruby
p = Post.new
p.tags = ["ruby", "Null", "NULL"]
p.save
p.reload
```

Expected `p.tags`:
```ruby
["ruby", "Null", "NULL"]
```

Actual `p.tags`: 
```ruby
["ruby", nil, "NULL"]
```

The problem is in quoting rules for array elements in constructing SQL queries. When checked for `NULL`, array elements are only compared to string `"NULL"`, while this check has to be case insensitive.

Quote from [PostgreSQL documentation](http://www.postgresql.org/docs/9.2/static/arrays.html#ARRAYS-IO):

> If the value written for an element is NULL **(in any case variant)**, the element is taken to be NULL.

### Other information
There is no such problem with Rails 5.

