### PR TITLE
Raise helpful error when running test database rake tasks and test da…

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -52,6 +52,13 @@ module ActiveRecord
         @@configurations
       end
 
+      # Returns configuration for given env or raises error if the configuration does not exist
+      def self.configuration(env)
+        configurations.fetch(env) do
+          raise ActiveRecord::AdapterNotSpecified, "No #{env.inspect} database configured. Available database configurations: #{configurations.keys.inspect}"
+        end
+      end
+
       ##
       # :singleton-method:
       # Determines whether to use Time.utc (using :utc) or Time.local (using :local) when pulling

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -332,7 +332,7 @@ db_namespace = namespace :db do
       begin
         should_reconnect = ActiveRecord::Base.connection_pool.active_connection?
         ActiveRecord::Schema.verbose = false
-        ActiveRecord::Tasks::DatabaseTasks.load_schema ActiveRecord::Base.configurations["test"], :ruby, ENV["SCHEMA"]
+        ActiveRecord::Tasks::DatabaseTasks.load_schema ActiveRecord::Base.configurations("test"), :ruby, ENV["SCHEMA"]
       ensure
         if should_reconnect
           ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[ActiveRecord::Tasks::DatabaseTasks.env])
@@ -342,7 +342,7 @@ db_namespace = namespace :db do
 
     # desc "Recreate the test database from an existent structure.sql file"
     task load_structure: %w(db:test:purge) do
-      ActiveRecord::Tasks::DatabaseTasks.load_schema ActiveRecord::Base.configurations["test"], :sql, ENV["SCHEMA"]
+      ActiveRecord::Tasks::DatabaseTasks.load_schema ActiveRecord::Base.configurations("test"), :sql, ENV["SCHEMA"]
     end
 
     # desc "Recreate the test database from a fresh schema"
@@ -363,7 +363,7 @@ db_namespace = namespace :db do
 
     # desc "Empty the test database"
     task purge: %w(environment load_config check_protected_environments) do
-      ActiveRecord::Tasks::DatabaseTasks.purge ActiveRecord::Base.configurations["test"]
+      ActiveRecord::Tasks::DatabaseTasks.purge ActiveRecord::Base.configurations("test")
     end
 
     # desc 'Load the test schema'


### PR DESCRIPTION
### Summary

- Inspiration for this change comes from https://github.com/rails/rails/issues/24294
  where `db:test:purge` fails when used with DATABASE_URL.
- This is because the database rake tasks don't depend on RAILS_ENV
  and that's why DATABASE_URL gets applied to development environment
  by default when running these tasks.
- This means that the "test" database configuration is not present but
  while running test database rake tasks we expect it to be present.
- This commit will raise a helpful error when "test" database
  configuration is not present, gently reminding users that they need
  to add it before running the test database rake tasks.

cc @schneems @matthewd 