### PR TITLE
Add missing test for singular resource output in rake routes

### DIFF
--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -174,6 +174,26 @@ module ApplicationTests
       assert_equal expected_output, output
     end
 
+    def test_singular_resource_output_in_rake_routes
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          resource :post
+        end
+      RUBY
+
+      expected_output = ["   Prefix Verb   URI Pattern          Controller#Action",
+                         " new_post GET    /post/new(.:format)  posts#new",
+                         "edit_post GET    /post/edit(.:format) posts#edit",
+                         "     post GET    /post(.:format)      posts#show",
+                         "          PATCH  /post(.:format)      posts#update",
+                         "          PUT    /post(.:format)      posts#update",
+                         "          DELETE /post(.:format)      posts#destroy",
+                         "          POST   /post(.:format)      posts#create\n"].join("\n")
+
+      output = Dir.chdir(app_path) { `bin/rails routes -c PostController` }
+      assert_equal expected_output, output
+    end
+
     def test_rails_routes_with_global_search_key
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do


### PR DESCRIPTION
### Summary

- This test was present in https://github.com/rails/rails/pull/27089
  but not present on master, may be removed in merge commit?
- There was discussion about moving this to `application/rake_test` so
  may be this happened in merge commit.
- https://github.com/rails/rails/pull/27089#discussion_r88731157

r? @rafaelfranca 