### PR TITLE
Wrap lines in initializers to 80 chars

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/backtrace_silencers.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/backtrace_silencers.rb
@@ -1,7 +1,9 @@
 # Be sure to restart your server when you modify this file.
 
-# You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
+# You can add backtrace silencers for libraries that you're using
+# but don't wish to see in your backtraces.
 # Rails.backtrace_cleaner.add_silencer { |line| line =~ /my_noisy_library/ }
 
-# You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
+# You can also remove all the silencers if you're trying to debug a problem
+# that might stem from framework code.
 # Rails.backtrace_cleaner.remove_silencers!

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb
@@ -1,8 +1,9 @@
 # Be sure to restart your server when you modify this file.
 
 # Avoid CORS issues when API is called from the frontend app.
-# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
-
+# Handle Cross-Origin Resource Sharing (CORS) in order to accept
+# cross-origin AJAX requests.
+#
 # Read more: https://github.com/cyu/rack-cors
 
 # Rails.application.config.middleware.insert_before 0, Rack::Cors do

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
@@ -7,34 +7,38 @@
 #
 <%- end -%>
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
-<%- unless options[:api] -%>
+Rails.application.configure do
+  <%- unless options[:api] -%>
 
-# Enable per-form CSRF tokens. Previous versions had false.
-Rails.application.config.action_controller.per_form_csrf_tokens = <%= options[:update] ? false : true %>
+  # Enable per-form CSRF tokens. Previous versions had false.
+  config.action_controller.per_form_csrf_tokens = <%= options[:update] ? false : true %>
 
-# Enable origin-checking CSRF mitigation. Previous versions had false.
-Rails.application.config.action_controller.forgery_protection_origin_check = <%= options[:update] ? false : true %>
-<%- end -%>
+  # Enable origin-checking CSRF mitigation. Previous versions had false.
+  config.action_controller.forgery_protection_origin_check = <%= options[:update] ? false : true %>
+  <%- end -%>
 
-# Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
-# Previous versions had false.
-ActiveSupport.to_time_preserves_timezone = <%= options[:update] ? false : true %>
-<%- unless options[:skip_active_record] -%>
+  # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
+  # Previous versions had false.
+  ActiveSupport.to_time_preserves_timezone = <%= options[:update] ? false : true %>
+  <%- unless options[:skip_active_record] -%>
 
-# Require `belongs_to` associations by default. Previous versions had false.
-Rails.application.config.active_record.belongs_to_required_by_default = <%= options[:update] ? false : true %>
-<%- end -%>
+  # Require `belongs_to` associations by default. Previous versions had false.
+  config.active_record.belongs_to_required_by_default = <%= options[:update] ? false : true %>
+  <%- end -%>
 
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = <%= options[:update] ? true : false %>
-<%- unless options[:update] -%>
+  # Do not halt callback chains when a callback returns false.
+  # Previous versions had true.
+  ActiveSupport.halt_callback_chains_on_return_false = <%= options[:update] ? true : false %>
+  <%- unless options[:update] -%>
 
-# Configure SSL options to enable HSTS with subdomains. Previous versions had false.
-Rails.application.config.ssl_options = { hsts: { subdomains: true } }
-<%- end -%>
-<%- unless options[:skip_sprockets] -%>
+  # Configure SSL options to enable HSTS with subdomains.
+  # Previous versions had false.
+  config.ssl_options = { hsts: { subdomains: true } }
+  <%- end -%>
+  <%- unless options[:skip_sprockets] -%>
 
-# Unknown asset fallback will return the path passed in when the given
-# asset is not present in the asset pipeline.
-Rails.application.config.assets.unknown_asset_fallback = <%= options[:update] ? true : false %>
-<%- end -%>
+  # Unknown asset fallback will return the path passed in when the given
+  # asset is not present in the asset pipeline.
+  config.assets.unknown_asset_fallback = <%= options[:update] ? true : false %>
+  <%- end -%>
+end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/wrap_parameters.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/wrap_parameters.rb.tt
@@ -3,7 +3,8 @@
 # This file contains settings for ActionController::ParamsWrapper which
 # is enabled by default.
 
-# Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
+# Enable parameter wrapping for JSON. You can disable this by setting :format
+# to an empty array.
 ActiveSupport.on_load(:action_controller) do
   wrap_parameters format: [:json]
 end

--- a/railties/lib/rails/generators/rails/app/templates/db/seeds.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/db/seeds.rb.tt
@@ -1,5 +1,7 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
+# This file should contain all the record creation needed to seed the
+# database with its default values.
+# The data can then be loaded with the rails db:seed command
+# (or created alongside the database with db:setup).
 #
 # Examples:
 #


### PR DESCRIPTION
Hi!

I hope many of teams use linters like rubocop. They usually check for maximum line length.

Just created rails application generates several files with very long comments (over 100 chars) which trigger linter warnings. I've wrapped such lines in this PR.

I've also wrapped all the code in `new_framework_defaults.rb.tt` into `Rails.application.configure` to avoid duplications of `Rails.application.config...`.

