### PR TITLE
Fix tests for prepared_statements: false and queries hitting `#select_all`

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/prepared_statements_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/prepared_statements_test.rb
@@ -6,17 +6,17 @@ class PreparedStatementsTest < ActiveRecord::PostgreSQLTestCase
   fixtures :developers
 
   def setup
-    @default_prepared_statements = ActiveRecord::Base.connection.instance_variable_get("@prepared_statements")
-    ActiveRecord::Base.connection.instance_variable_set("@prepared_statements", false)
+    @conn = ActiveRecord::Base.establish_connection :arunit_with_prepared_statements
   end
 
   def teardown
-    ActiveRecord::Base.connection.instance_variable_set("@prepared_statements", @default_prepared_statements)
+    @conn.release_connection
+    ActiveRecord::Base.establish_connection :arunit
   end
 
   def test_nothing_raised_with_falsy_prepared_statements
     assert_nothing_raised do
-      Developer.where(id: 1)
+      Developer.where(id: 1).to_a
     end
   end
 end

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -77,6 +77,9 @@ connections:
   postgresql:
     arunit:
       min_messages: warning
+    arunit_without_prepared_statements:
+      min_messages: warning
+      prepared_statements: false
     arunit2:
       min_messages: warning
 

--- a/activerecord/test/support/config.rb
+++ b/activerecord/test/support/config.rb
@@ -26,7 +26,8 @@ module ARTest
 
     def expand_config(config)
       config["connections"].each do |adapter, connection|
-        dbs = [["arunit", "activerecord_unittest"], ["arunit2", "activerecord_unittest2"]]
+        dbs = [["arunit", "activerecord_unittest"], ["arunit2", "activerecord_unittest2"],
+               ["arunit_with_prepared_statements", "activerecord_unittest"]]
         dbs.each do |name, dbname|
           unless connection[name].is_a?(Hash)
             connection[name] = { "database" => connection[name] }


### PR DESCRIPTION
### Summary

- The query needs to be executed for hitting `select_all` so made sure
  that query gets executed.
- Also instead of changing instance variable, just add new
  configuration for prepared_statements: false and use it for this
  test.
- This way we don't have to touch the internals of AR code and still
  disable prepared statements config for this test.

r? @kaspth 