### PR TITLE
Drop jQuery as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "jquery-rails"
 gem "coffee-rails"
 gem "sass-rails"
 gem "turbolinks", "~> 5"
+gem "rails-ujs", github: "rails/rails-ujs"
 
 # require: false so bcrypt is loaded only when has_secure_password is used.
 # This is to avoid Active Model (and by extension the entire framework)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,13 @@ GIT
       websocket
 
 GIT
+  remote: https://github.com/rails/rails-ujs.git
+  revision: 767692f53dec79d42928029a55fdfcced35681e8
+  specs:
+    rails-ujs (0.0.1)
+      railties (>= 3.1)
+
+GIT
   remote: https://github.com/resque/resque.git
   revision: 20d885065ac19e7f7d7a982f4ed1296083db0300
   specs:
@@ -399,6 +406,7 @@ DEPENDENCIES
   racc (>= 1.4.6)
   rack-cache (~> 1.2)
   rails!
+  rails-ujs!
   rake (>= 11.1)
   rb-inotify!
   redcarpet (~> 3.2.3)

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Removed jquery-rails from default stack, instead rails-ujs is
+    included as default UJS adapter.
+
+    *Guillermo Iguaran*
+
 *   The config file `secrets.yml` is now loaded in with all keys as symbols.
     This allows secrets files to contain more complex information without all
     child keys being strings while parent keys are symbols.

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -30,7 +30,7 @@ module Rails
         class_option :database,           type: :string, aliases: "-d", default: "sqlite3",
                                           desc: "Preconfigure for selected database (options: #{DATABASES.join('/')})"
 
-        class_option :javascript,         type: :string, aliases: "-j", default: "jquery",
+        class_option :javascript,         type: :string, aliases: "-j",
                                           desc: "Preconfigure for selected JavaScript library"
 
         class_option :skip_gemfile,       type: :boolean, default: false,
@@ -328,8 +328,13 @@ module Rails
           gems = [javascript_runtime_gemfile_entry]
           gems << coffee_gemfile_entry unless options[:skip_coffee]
 
-          gems << GemfileEntry.version("#{options[:javascript]}-rails", nil,
-                                       "Use #{options[:javascript]} as the JavaScript library")
+          if options[:javascript]
+            gems << GemfileEntry.version("#{options[:javascript]}-rails", nil,
+              "Use #{options[:javascript]} as the JavaScript library")
+          end
+
+          gems << GemfileEntry.github("rails-ujs", "rails/rails-ujs", nil,
+                                      "Unobstrusive JavaScript adapter for Rails")
 
           unless options[:skip_turbolinks]
             gems << GemfileEntry.version("turbolinks", "~> 5",

--- a/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/application.js.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/javascripts/application.js.tt
@@ -11,8 +11,10 @@
 // about supported directives.
 //
 <% unless options[:skip_javascript] -%>
+<% if options[:javascript] -%>
 //= require <%= options[:javascript] %>
-//= require <%= options[:javascript] %>_ujs
+<% end -%>
+//= require rails-ujs
 <% unless options[:skip_turbolinks] -%>
 //= require turbolinks
 <% end -%>

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -35,7 +35,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_no_match(/gem 'coffee-rails'/, content)
-      assert_no_match(/gem 'jquery-rails'/, content)
+      assert_no_match(/gem 'rails-ujs'/, content)
       assert_no_match(/gem 'sass-rails'/, content)
       assert_no_match(/gem 'web-console'/, content)
       assert_match(/# gem 'jbuilder'/, content)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -405,7 +405,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match(/#\s+require\s+["']sprockets\/railtie["']/, content)
     end
     assert_file "Gemfile" do |content|
-      assert_no_match(/jquery-rails/, content)
       assert_no_match(/sass-rails/, content)
       assert_no_match(/uglifier/, content)
       assert_no_match(/coffee-rails/, content)
@@ -448,22 +447,20 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_jquery_is_the_default_javascript_library
+  def test_rails_ujs_is_the_default_ujs_library
     run_generator
     assert_file "app/assets/javascripts/application.js" do |contents|
-      assert_match %r{^//= require jquery}, contents
-      assert_match %r{^//= require jquery_ujs}, contents
+      assert_match %r{^//= require rails-ujs}, contents
     end
-    assert_gem "jquery-rails"
+    assert_gem "rails-ujs"
   end
 
-  def test_other_javascript_libraries
-    run_generator [destination_root, "-j", "prototype"]
+  def test_inclusion_of_javascript_libraries_if_required
+    run_generator [destination_root, "-j", "jquery"]
     assert_file "app/assets/javascripts/application.js" do |contents|
-      assert_match %r{^//= require prototype}, contents
-      assert_match %r{^//= require prototype_ujs}, contents
+      assert_match %r{^//= require jquery}, contents
     end
-    assert_gem "prototype-rails"
+    assert_gem "jquery-rails"
   end
 
   def test_javascript_is_skipped_if_required
@@ -479,8 +476,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_no_match(/coffee-rails/, content)
-      assert_no_match(/jquery-rails/, content)
       assert_no_match(/uglifier/, content)
+      assert_no_match(/rails-ujs/, content)
     end
 
     assert_file "config/environments/production.rb" do |content|
@@ -493,7 +490,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_no_match(/coffee-rails/, content)
-      assert_match(/jquery-rails/, content)
       assert_match(/uglifier/, content)
     end
   end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -507,7 +507,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
       assert_no_match("gemspec", contents)
       assert_match(/gem 'rails'/, contents)
       assert_match_sqlite3(contents)
-      assert_no_match(/# gem "jquery-rails"/, contents)
     end
   end
 


### PR DESCRIPTION
As discussed in #25208 we have decided to remove jQuery from default stack and use a vanilla version of the ujs driver named [rails-ujs](https://github.com/rails/rails-ujs) instead.

This Pull Request remove `jquery-rails` from new applications and provides `rails-ujs` through `Action View` (to do this I had to convert `ActionView::Railtie` into an `Engine`).

The new rails-ujs was developed by @liudangyi as part of Google Summer of Code, all credits for this goes to him and to his mentor @pixeltrix  👏 👏 👏 👏 👏 