### PR TITLE
Revert "fix typo in `match` doc [ci skip]"

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -532,7 +532,7 @@ module ActionDispatch
         #      end
         #
         # [:constraints]
-        #   Constraints parameters with a hash of regular expressions
+        #   Constrains parameters with a hash of regular expressions
         #   or an object that responds to <tt>matches?</tt>. In addition, constraints
         #   other than path can also be specified with any object
         #   that responds to <tt>===</tt> (eg. String, Array, Range, etc.).


### PR DESCRIPTION
Reverts rails/rails#27114