### PR TITLE
Do not rely on Ruby implementation in AM test

### DIFF
--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -82,7 +82,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
     Topic.validates_numericality_of :approved, greater_than: BigDecimal.new("97.18")
 
     invalid!([-97.18, BigDecimal.new("97.18"), BigDecimal("-97.18")], "must be greater than 97.18")
-    valid!([97.18, 98, BigDecimal.new("98")]) # Notice the 97.18 as a float is greater than 97.18 as a BigDecimal due to floating point precision
+    valid!([97.19, 98, BigDecimal.new("98"), BigDecimal.new("97.19")])
   end
 
   def test_validates_numericality_with_greater_than_using_string_value
@@ -123,7 +123,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
   def test_validates_numericality_with_equal_to_using_differing_numeric_types
     Topic.validates_numericality_of :approved, equal_to: BigDecimal.new("97.18")
 
-    invalid!([-97.18, 97.18], "must be equal to 97.18")
+    invalid!([-97.18], "must be equal to 97.18")
     valid!([BigDecimal.new("97.18")])
   end
 
@@ -165,7 +165,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
   def test_validates_numericality_with_less_than_or_equal_to_using_differing_numeric_types
     Topic.validates_numericality_of :approved, less_than_or_equal_to: BigDecimal.new("97.18")
 
-    invalid!([97.18, 98], "must be less than or equal to 97.18")
+    invalid!([97.19, 98], "must be less than or equal to 97.18")
     valid!([-97.18, BigDecimal.new("-97.18"), BigDecimal.new("97.18")])
   end
 


### PR DESCRIPTION
Now a few tests in ActiveModel rely on Ruby implementation and the fact
that in MRI `97.18` as a float is greater than `97.18` as a BigDecimal.

This is only relevant for MRI. On JRuby, comparing float to BigDecimal
would be conversion of them to the same type and they will be equal.

I'd like the ActiveModel test suite to be Ruby implementation-agnostic.
We want to test ActiveModel, not the the Ruby internals.

This PR fixes a couple more JRuby tests.

@guilleiguaran @headius 