### PR TITLE
Set default precision for `ActiveModel::Type::Decimal` to 18

### DIFF
--- a/activemodel/lib/active_model/type/decimal.rb
+++ b/activemodel/lib/active_model/type/decimal.rb
@@ -5,6 +5,14 @@ module ActiveModel
     class Decimal < Value # :nodoc:
       include Helpers::Numeric
 
+      def initialize(**args)
+        super(**args)
+
+        unless @precision
+          @precision = 18
+        end
+      end
+
       def type
         :decimal
       end


### PR DESCRIPTION
### Summary

Active Model expects the default precision to be 18. If `precision` is 0
(which it is by default), MRI will autocorrect this to be 18, but JRuby
does not. In order to prevent an error being raised, we have to manually
default the precision to be 18.

There is no need for a regression test, the test suite already [has one](https://github.com/rails/rails/blob/master/activemodel/test/cases/type/decimal_test.rb#L34-L37).