### PR TITLE
Allowing multiple columns to be passed to calculations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Allow all ActiveRecord Calculations to accecpt mutliple columns for 
+    aggregation. When requesting mutltiple columns with an aggregation a
+    hash is returned where the keys are the requested column names and the
+    values are the caluclated values
+
+        scope.sum(:foo, :bar)
+        # => {foo: 123, bar: 456}
+
+    When requesting a grouped aggregation, the same structure is provided
+    one layer deepr.
+
+        scope.group(:id).sum(:foo, :bar)
+        # => { 1: {foo: 123, bar: 456}, 2: {foo: 987, bar: 765}}
+
+    *Brian Malinconico*
+
 *   Make sure eager loading `ActiveRecord::Associations` also loads
     constants defined in `ActiveRecord::Associations::Preloader`.
 

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -750,8 +750,8 @@ module ActiveRecord
         load_target.uniq
       end
 
-      def calculate(operation, column_name)
-        null_scope? ? scope.calculate(operation, column_name) : super
+      def calculate(operation, *column_name)
+        null_scope? ? scope.calculate(operation, *column_name) : super
       end
 
       def pluck(*column_names)

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -40,7 +40,7 @@ module ActiveRecord
       ""
     end
 
-    def calculate(operation, _column_name)
+    def calculate(operation, *_column_names)
       case operation
       when :count, :sum
         group_values.any? ? Hash.new : 0


### PR DESCRIPTION
### Summary

This PR allows users to pass multiple columns to all of the AR calculation methods.

When requesting an aggregation of a single value, current behavior is preserved and the single value is returned. When multiple columns are requested a hash is returned.

```ruby
scope.sum(:foo, :bar)
# => {foo: 123, bar: 456}
```

When requesting a grouped aggregation, the same values are provided in place of the existing single values:


```ruby
scope.group(:id).sum(:foo, :bar)
# => { 1: {foo: 123, bar: 456}, 2: {foo: 987, bar: 765}}
```

### Arel Tables

When passed an arel_table for instead of a symbol/string the arel_table object is returned as a key. This decision was made so the end user doesn't have to do a translation, however I'm open to suggestions for a more appropriate key.

### Invalid Arguments

Previous implementations required the arguments be set. `scope.maximum` would have thrown a runtime error requesting an argument. The current implementation use the splat will not error like this, as such guards were placed at `calculate`. I'm not thrilled with this, and would appreciate some feedback, since the error that will be thrown without it will be a bit cryptic.

### Attribute Aliasing

If you alias a attribute and request a calculation based on both of the alias and the original attribute, two calculation columns will be requested. I don't think this will have a negative impact on performance.

### Further Tests

I'd like to spend some time adding more tests, but due to the size of the test file I wanted to get some feedback before I fully went down that rabbit hole. Currently my plan is to continue adding a multi-attribute test for all of the existing tests cases. Any feedback regarding potential gaps would be greatly appreciated.