### PR TITLE
Test on Ruby 2.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ env:
 
 rvm:
   - 2.2.6
-  - 2.3.2
+  - 2.3.3
   - ruby-head
 
 matrix:


### PR DESCRIPTION
### Summary

- Ruby 2.3.3 is a bug fix release so let's test on that.
- https://www.ruby-lang.org/en/news/2016/11/21/ruby-2-3-3-released/