### PR TITLE
Introduce `reload_<association>` reader for singular associations.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Introduce `Model#reload_<association>` to bring back the behavior
+    of `Article.category(true)` where `category` is a singular
+    association.
+
+    The force reloading of the association reader was deprecated in
+    #20888. Unfortunately the suggested alternative of
+    `article.reload.category` does not expose the same behavior.
+
+    This patch adds a reader method with the prefix `reload_` for
+    singular associations. This method has the same semantics as
+    passing true to the association reader used to have.
+
+    *Yves Senn*
+
 *   Make sure eager loading `ActiveRecord::Associations` also loads
     constants defined in `ActiveRecord::Associations::Preloader`.
 

--- a/activerecord/lib/active_record/associations/builder/singular_association.rb
+++ b/activerecord/lib/active_record/associations/builder/singular_association.rb
@@ -8,7 +8,16 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
     def self.define_accessors(model, reflection)
       super
-      define_constructors(model.generated_association_methods, reflection.name) if reflection.constructable?
+      mixin = model.generated_association_methods
+      name = reflection.name
+
+      define_constructors(mixin, name) if reflection.constructable?
+
+      mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
+        def reload_#{name}
+          association(:#{name}).force_reload_reader
+        end
+      CODE
     end
 
     # Defines the (build|create)_association methods for belongs_to or has_one association

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -30,6 +30,13 @@ module ActiveRecord
         record
       end
 
+      # Implements the reload reader method, e.g. foo.reload_bar for
+      # Foo.has_one :bar
+      def force_reload_reader
+        klass.uncached { reload }
+        target
+      end
+
       private
 
         def create_scope

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -291,6 +291,16 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert client.account.new_record?
   end
 
+  def test_reloading_the_belonging_object
+    odegy_account = accounts(:odegy_account)
+
+    assert_equal "Odegy", odegy_account.firm.name
+    Company.where(id: odegy_account.firm_id).update_all(name: "ODEGY")
+    assert_equal "Odegy", odegy_account.firm.name
+
+    assert_equal "ODEGY", odegy_account.reload_firm.name
+  end
+
   def test_natural_assignment_to_nil
     client = Client.find(3)
     client.firm = nil

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -326,6 +326,16 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_reload_association
+    odegy = companies(:odegy)
+
+    assert_equal 53, odegy.account.credit_limit
+    Account.where(id: odegy.account.id).update_all(credit_limit: 80)
+    assert_equal 53, odegy.account.credit_limit
+
+    assert_equal 80, odegy.reload_account.credit_limit
+  end
+
   def test_build
     firm = Firm.new("name" => "GlobalMegaCorp")
     firm.save


### PR DESCRIPTION
### Summary

This patch brings back the functionality of passing true to the
association proxy. The behavior was deprecated with #20888 and scheduled
for removal in Rails 5.1.

The deprecation mentioned that instead of `Article.category(true)` one
should use `article#reload.category`. Unfortunately the alternative does
not expose the same behavior as passing true to the reader
did. Specifically reloading the parent record throws unsaved changes and
other caches away. Passing true only affected the association.

This is problematic and there is no easy workaround. I propose to bring
back the old functionality by introducing this new reader method for
singular associations.

### Implications

We started to issue deprecation warnings for this since 5.0.0. If this is merged, I think we should backport the patch to `5-0-stable` and update the deprecation warning accordingly.