### PR TITLE
Method 'out?' for object. Logic of code like pair include?/exclude? for object

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -13,6 +13,12 @@ class Object
     raise ArgumentError.new("The parameter passed to #in? must respond to #include?")
   end
 
+  # Returns true if this object is excluded out from argument. Argument must be
+  # any object which responds to +#exclude?+. Usage:
+  def out?(another_object)
+    another_object.exclude?(self)
+  end
+
   # Returns the receiver if it's included in the argument otherwise returns +nil+.
   # Argument must be any object which responds to +#include?+. Usage:
   #


### PR DESCRIPTION
Method `out?` can be used to find exclusion of object from some another object. It will help us to understand code more faster and will make it clever. In Rails we have amazing methods `include?` / `exclude?` and now we have ability to have the same pair with `in?`/`out?`