### PR TITLE
Fix a test on 4-2-stable

### DIFF
--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -433,7 +433,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     a = open_session
     b = open_session
 
-    refute_same(a.integration_session, b.integration_session)
+    refute_same(a.send(:integration_session), b.send(:integration_session))
   end
 
   def test_get_with_query_string


### PR DESCRIPTION
`ActionDispatch::Integration::Runner#integration_session` is private in
Rails 4.2. So we should call it via `send`.