### PR TITLE
form_helper typo fix [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -520,7 +520,7 @@ module ActionView
       #
       # By default +form_with+ attaches the <tt>data-remote</tt> attribute
       # submitting the form via an XMLHTTPRequest in the background if an
-      # an Unobtrusive JavaScript driver, like rails-ujs, is used. See the
+      # Unobtrusive JavaScript driver, like rails-ujs, is used. See the
       # <tt>:remote</tt> option for more.
       #
       # For ease of comparison the examples above left out the submit button,


### PR DESCRIPTION
### Summary
delete duplicated `an`
(~ in the background if an `an` Unobtrusive ~)