### PR TITLE
Fix a force ssl redirection bug that occur when session store disabled.

### DIFF
--- a/actionpack/lib/action_controller/metal/force_ssl.rb
+++ b/actionpack/lib/action_controller/metal/force_ssl.rb
@@ -89,7 +89,7 @@ module ActionController
         end
 
         secure_url = ActionDispatch::Http::URL.url_for(options.slice(*URL_OPTIONS))
-        flash.keep if respond_to?(:flash)
+        flash.keep if respond_to?(:flash) && request.respond_to?(:flash)
         redirect_to secure_url, options.slice(*REDIRECT_OPTIONS)
       end
     end

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -92,22 +92,6 @@ class RedirectToSSL < ForceSSLController
   end
 end
 
-class RedirectToSSLIfSessionStoreDisabled < ForceSSLController
-  def banana
-    request.class_eval do
-      alias_method :flash_origin, :flash
-      undef_method :flash
-    end
-
-    force_ssl_redirect || render(plain: "monkey")
-  ensure
-    request.class_eval do
-      alias_method :flash, :flash_origin
-      undef_method :flash_origin
-    end
-  end
-end
-
 class ForceSSLControllerLevelTest < ActionController::TestCase
   def test_banana_redirects_to_https
     get :banana
@@ -334,14 +318,6 @@ class RedirectToSSLTest < ActionController::TestCase
     get :cheeseburger
     assert_response 200
     assert_equal "ihaz", response.body
-  end
-end
-
-class RedirectToSSLIfSessionStoreDisabledTest < ActionController::TestCase
-  def test_banana_redirects_to_https_if_not_https_and_session_store_disabled
-    get :banana
-    assert_response 301
-    assert_equal "https://test.host/redirect_to_ssl_if_session_store_disabled/banana", redirect_to_url
   end
 end
 

--- a/actionpack/test/controller/force_ssl_test.rb
+++ b/actionpack/test/controller/force_ssl_test.rb
@@ -92,6 +92,22 @@ class RedirectToSSL < ForceSSLController
   end
 end
 
+class RedirectToSSLIfSessionStoreDisabled < ForceSSLController
+  def banana
+    request.class_eval do
+      alias_method :flash_origin, :flash
+      undef_method :flash
+    end
+
+    force_ssl_redirect || render(plain: "monkey")
+  ensure
+    request.class_eval do
+      alias_method :flash, :flash_origin
+      undef_method :flash_origin
+    end
+  end
+end
+
 class ForceSSLControllerLevelTest < ActionController::TestCase
   def test_banana_redirects_to_https
     get :banana
@@ -318,6 +334,14 @@ class RedirectToSSLTest < ActionController::TestCase
     get :cheeseburger
     assert_response 200
     assert_equal "ihaz", response.body
+  end
+end
+
+class RedirectToSSLIfSessionStoreDisabledTest < ActionController::TestCase
+  def test_banana_redirects_to_https_if_not_https_and_session_store_disabled
+    get :banana
+    assert_response 301
+    assert_equal "https://test.host/redirect_to_ssl_if_session_store_disabled/banana", redirect_to_url
   end
 end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1532,5 +1532,24 @@ module ApplicationTests
 
       assert_equal :default, Rails.configuration.debug_exception_response_format
     end
+
+    test "controller force_ssl declaration can be used even if session_store is disabled" do
+      make_basic_app do |application|
+        application.config.session_store :disabled
+      end
+
+      class ::OmgController < ActionController::Base
+        force_ssl
+
+        def index
+          render plain: "Yay! You're on Rails!"
+        end
+      end
+
+      get "/"
+
+      assert_equal 301, last_response.status
+      assert_equal "https://example.org/", last_response.location
+    end
   end
 end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -162,7 +162,6 @@ module TestHelpers
       require "rails"
       require "action_controller/railtie"
       require "action_view/railtie"
-      require "action_dispatch/middleware/flash"
 
       @app = Class.new(Rails::Application)
       @app.config.eager_load = false


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/pull/19682#issuecomment-261835411

I couldn't request [the same modification](https://github.com/rails/rails/pull/19682/files) as the last time. Because it was degraded at API mode.

@spastorino @prathamesh-sonpatki @rafaelfranca 

### Related Issues
* https://github.com/rails/rails/issues/19679
* https://github.com/rails/rails/issues/27009

### Reproduced apps
* https://github.com/supercaracal/session_store_less_sample
* https://github.com/bronson/force-ssl-repro-app