### PR TITLE
Do not clear HTTP_COOKIES header after request

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -514,8 +514,6 @@ module ActionController
           @request = @controller.request
           @response = @controller.response
 
-          @request.delete_header "HTTP_COOKIE"
-
           if @request.have_cookie_jar?
             unless @request.cookie_jar.committed?
               @request.cookie_jar.write(@response)

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -272,6 +272,10 @@ class CookiesTest < ActionController::TestCase
     def noop
       head :ok
     end
+
+    def encrypted_cookie
+      cookies.encrypted["foo"]
+    end
   end
 
   tests TestController
@@ -1187,6 +1191,12 @@ class CookiesTest < ActionController::TestCase
     get :noop
     assert_equal "david", cookies["user_name"]
     assert_equal "david", cookies[:user_name]
+  end
+
+  def test_cookies_are_not_cleared
+    cookies.encrypted["foo"] = "bar"
+    get :noop
+    assert_equal "bar", @controller.encrypted_cookie
   end
 
   private


### PR DESCRIPTION
### Summary

We now depend on this request environment variable in order to power cookies for controllers. This commit restores behavior lost in the transition from 4.2 to 5.0.

ref #27145 