### PR TITLE
Use absolute module reference for LegacyYamlAdapter

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -357,7 +357,7 @@ module ActiveRecord
     #   post.init_with(coder)
     #   post.title # => 'hello world'
     def init_with(coder)
-      coder = LegacyYamlAdapter.convert(self.class, coder)
+      coder = ActiveRecord::LegacyYamlAdapter.convert(self.class, coder)
       @attributes = self.class.yaml_encoder.decode(coder)
 
       init_internals


### PR DESCRIPTION
### Summary

It seems everything in this file is referenced via the ActiveRecord module.  We've had some pretty weird issues (pretty much impossible to recreate in a small app, and very rare) dealing with loading LegacyYamlAdapter in production.  The app starts fine but it seems it looks for the file in the wrong place when attempting to call enums.  The enums then return nil.  We think that referencing this LegacyYamlAdapter via it's full module name will fix the issue.

```
NameError: uninitialized constant ActiveRecord::Core::LegacyYamlAdapter
Did you mean? ActiveRecord::LegacyYamlAdapter
```
