### PR TITLE
Removing deprecation of `use_transactional_fixtures`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -325,5 +325,9 @@
 
     *Ralin Chimev*
 
+*   Removing deprecation of `use_transactional_fixtures`
+
+    *Brandon Weiss
+
 
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -862,29 +862,17 @@ module ActiveRecord
       class_attribute :fixture_table_names
       class_attribute :fixture_class_names
       class_attribute :use_transactional_tests
-      class_attribute :use_transactional_fixtures
       class_attribute :use_instantiated_fixtures # true, false, or :no_instances
       class_attribute :pre_loaded_fixtures
       class_attribute :config
 
-      singleton_class.deprecate "use_transactional_fixtures=" => "use use_transactional_tests= instead"
-
       self.fixture_table_names = []
+      self.use_transactional_tests = true
       self.use_instantiated_fixtures = false
       self.pre_loaded_fixtures = false
       self.config = ActiveRecord::Base
 
       self.fixture_class_names = {}
-
-      silence_warnings do
-        define_singleton_method :use_transactional_tests do
-          if use_transactional_fixtures.nil?
-            true
-          else
-            use_transactional_fixtures
-          end
-        end
-      end
     end
 
     module ClassMethods

--- a/activerecord/test/cases/test_fixtures_test.rb
+++ b/activerecord/test/cases/test_fixtures_test.rb
@@ -6,31 +6,13 @@ class TestFixturesTest < ActiveRecord::TestCase
     @klass.send(:include, ActiveRecord::TestFixtures)
   end
 
-  def test_deprecated_use_transactional_fixtures=
-    assert_deprecated "use use_transactional_tests= instead" do
-      @klass.use_transactional_fixtures = true
-    end
-  end
-
-  def test_use_transactional_tests_prefers_use_transactional_fixtures
-    ActiveSupport::Deprecation.silence do
-      @klass.use_transactional_fixtures = false
-    end
-
-    assert_equal false, @klass.use_transactional_tests
-  end
-
   def test_use_transactional_tests_defaults_to_true
-    ActiveSupport::Deprecation.silence do
-      @klass.use_transactional_fixtures = nil
-    end
-
     assert_equal true, @klass.use_transactional_tests
   end
 
   def test_use_transactional_tests_can_be_overridden
-    @klass.use_transactional_tests = "foobar"
+    @klass.use_transactional_tests = false
 
-    assert_equal "foobar", @klass.use_transactional_tests
+    assert_equal false, @klass.use_transactional_tests
   end
 end


### PR DESCRIPTION
It was introduced in #19282 and has existed for one major version.
It looks like other deprecations from 5.0 are being removed so I
think it’s time to remove this.