### PR TITLE
Remove outdated comment [ci skip]

### DIFF
--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -4,7 +4,6 @@ require "active_record/relation/merger"
 
 module ActiveRecord
   module SpawnMethods
-    # This is overridden by Associations::CollectionProxy
     def spawn #:nodoc:
       clone
     end


### PR DESCRIPTION
### Summary

- No longer valid after https://github.com/rails/rails/commit/0e1cafcbc4d67

Found out while going through related code.