### PR TITLE
Followup of UUID default extension in the docs

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -12,11 +12,21 @@ module ActiveRecord
         #   end
         #
         # By default, this will use the +gen_random_uuid()+ function from the
-        # +pgcrypto+ extension (only PostgreSQL >= 9.4), or +uuid_generate_v4()+
-        # function from the +uuid-ossp+ extension. To enable the appropriate
-        # extension, which is a requirement, you can use the +enable_extension+
-        # method in your migrations. To use a UUID primary key without any of
-        # of extensions, you can set the +:default+ option to +nil+:
+        # +pgcrypto+ extension. As that extension is only available in
+        # PostgreSQL 9.4+, for earlier versions an explicit default can be set
+        # to use +uuid_generate_v4()+ from the +uuid-ossp+ extension instead:
+        #
+        #   create_table :stuffs, id: false do |t|
+        #     t.primary_key :id, :uuid, default: "uuid_generate_v4()"
+        #     t.uuid :foo_id
+        #     t.timestamps
+        #   end
+        #
+        # To enable the appropriate extension, which is a requirement, use
+        # the +enable_extension+ method in your migrations.
+        #
+        # To use a UUID primary key without any of the extensions, set the
+        # +:default+ option to +nil+:
         #
         #   create_table :stuffs, id: false do |t|
         #     t.primary_key :id, :uuid, default: nil

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -422,7 +422,7 @@ device = Device.create
 device.id # => "814865cd-5a1d-4771-9306-4268f188fe9e"
 ```
 
-NOTE: `uuid_generate_v4()` (from `uuid-ossp`) is assumed if no `:default` option was
+NOTE: `gen_random_uuid()` (from `pgcrypto`) is assumed if no `:default` option was
 passed to `create_table`.
 
 Full Text Search


### PR DESCRIPTION
### Summary

- Mentioned that for PostgreSQL < 9.4, you need to pass the
  default option with "uuid_generate_v4()"
- Also updated PostgreSQL Active Record guide with this change.
- https://github.com/rails/rails/pull/25395#r66877078

r? @rafaelfranca 