### PR TITLE
[ci skip] `MiniTest` -> `Minitest`

### DIFF
--- a/railties/test/code_statistics_calculator_test.rb
+++ b/railties/test/code_statistics_calculator_test.rb
@@ -24,7 +24,7 @@ class CodeStatisticsCalculatorTest < ActiveSupport::TestCase
     end
   end
 
-  test "count number of methods in MiniTest file" do
+  test "count number of methods in Minitest file" do
     code = <<-RUBY
       class FooTest < ActionController::TestCase
         test 'expectation' do


### PR DESCRIPTION
### Summary

MiniTest was renamed to Minitest.
Already renamed on https://github.com/rails/rails/pull/13366
But slipped into on https://github.com/rails/rails/pull/18413/files#diff-6bb90a693835b0e92910b796c8b0ef59R27