### PR TITLE
Fix `require_dependency` message format

### DIFF
--- a/actionview/test/actionpack/abstract/helper_test.rb
+++ b/actionview/test/actionpack/abstract/helper_test.rb
@@ -109,7 +109,7 @@ module AbstractController
     class InvalidHelpersTest < ActiveSupport::TestCase
       def test_controller_raise_error_about_real_require_problem
         e = assert_raise(LoadError) { AbstractInvalidHelpers.helper(:invalid_require) }
-        assert_equal "No such file to load -- very_invalid_file_name", e.message
+        assert_equal "No such file to load -- very_invalid_file_name.rb", e.message
       end
 
       def test_controller_raise_error_about_missing_helper

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -242,7 +242,7 @@ module ActiveSupport #:nodoc:
       # resolution deterministic for constants with the same relative name in
       # different namespaces whose evaluation would depend on load order
       # otherwise.
-      def require_dependency(file_name, message = "No such file to load -- %s")
+      def require_dependency(file_name, message = "No such file to load -- %s.rb")
         file_name = file_name.to_path if file_name.respond_to?(:to_path)
         unless file_name.is_a?(String)
           raise ArgumentError, "the file name must either be a String or implement #to_path -- you passed #{file_name.inspect}"


### PR DESCRIPTION
`depend_on` message format is `"No such file to load -- %s.rb"`.
But `require_dependency` message is missing `.rb` suffix.

```
% git grep -n 'No such file to load'
actionview/test/actionpack/abstract/helper_test.rb:112:        assert_equal "No such file to load -- very_invalid_file_name.rb", e.message
activesupport/lib/active_support/dependencies.rb:245:      def require_dependency(file_name, message = "No such file to load -- %s.rb")
activesupport/lib/active_support/dependencies.rb:333:    def depend_on(file_name, message = "No such file to load -- %s.rb")
```