### PR TITLE
Optimize many? and one? using exists?-like query.

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -261,14 +261,24 @@ module ActiveRecord
 
     # Returns true if there is exactly one record.
     def one?
-      return super if block_given?
-      limit_value ? records.one? : size == 1
+      if block_given?
+        super
+      elsif limit_value || loaded?
+        records.one?
+      else
+        exists_some?(:none, max: 1)
+      end
     end
 
     # Returns true if there is more than one record.
     def many?
-      return super if block_given?
-      limit_value ? records.many? : size > 1
+      if block_given?
+        super
+      elsif limit_value || loaded?
+        records.many?
+      else
+        exists_some?(:none, min: 2)
+      end
     end
 
     # Returns a cache key that can be used to identify the records fetched by


### PR DESCRIPTION
02da8aea made it possible to express `empty?` (and thus `any?`) in terms of `exists?`.
And now I see the potential of `exists?` algorithm to be extended to serve `many?` and `one?` methods too.

The idea is the following:

- `any?` runs `SELECT 1 ... LIMIT 1` and checks that result set is of size 1 (already implemented as `exists?`)
- `many?` runs `SELECT 1 ... LIMIT 2` and checks that result set is of size 2.
- `one?` runs `SELECT 1 ... LIMIT 2` and checks that result set is of size 1.