### PR TITLE
make path helper work with `ActionController::Parameters`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix support to `ActionController::Parameters` in path helper method.
+
+    Fixes #26958.
+
+    *Yuji Yaginuma*
+
 *   Commit flash changes when using a redirect route.
 
     Fixes #27992.

--- a/actionpack/test/dispatch/url_generation_test.rb
+++ b/actionpack/test/dispatch/url_generation_test.rb
@@ -135,5 +135,16 @@ module TestUrlGeneration
         format: "json"
       )
     end
+
+    test "generating URLS with permitted strong params" do
+      params = ActionController::Parameters.new(test: { truthy: "1" })
+      params.permit!
+      assert_equal "/bars?test%5Btruthy%5D=1", bars_path(params: { test: params[:test] })
+    end
+
+    test "generating URLS with unpermited strong params" do
+      params = ActionController::Parameters.new(test: { truthy: "1" })
+      assert_raise(ArgumentError) { bars_path(params: { test: params[:test] }) }
+    end
   end
 end


### PR DESCRIPTION
### Summary

The path helper calls `#to_param` inside. But `ActionController::Parameters`
does not have `#to_param`, so `NoMethodError` error will raise.
To avoid this, convert to hash if argument is `ActionController::Parameters`

Fixes #26958.