### PR TITLE
use correct variable in BacktraceCleaner test

### DIFF
--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -15,7 +15,7 @@ class BacktraceCleanerTest < ActiveSupport::TestCase
   test "should format installed gems not in Gem.default_dir correctly" do
     target_dir = Gem.path.detect { |p| p != Gem.default_dir }
     # skip this test if default_dir is the only directory on Gem.path
-    if @target_dir
+    if target_dir
       backtrace = [ "#{target_dir}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
       result = @cleaner.clean(backtrace, :all)
       assert_equal "nosuchgem (1.2.3) lib/foo.rb", result[0]


### PR DESCRIPTION
`@target_dir` variable was changed to local variable in 8e1714b.