### PR TITLE
Add PhantomJS runner for UJS integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
   directories:
     - /tmp/cache/unicode_conformance
     - /tmp/beanstalkd-1.10
+    - node_modules
+    - $HOME/.nvm
 
 services:
   - memcached
@@ -21,6 +23,8 @@ before_install:
   - "gem update bundler"
   - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
   - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"
+  - "nvm install node"
+  - "[[ $(phantomjs --version) > '2' ]] || npm install -g phantomjs-prebuilt"
 
 before_script:
   - bundle update

--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,7 @@ group :test do
   end
 
   gem "benchmark-ips"
+  gem "childprocess"
 end
 
 platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,6 +382,7 @@ DEPENDENCIES
   blade
   blade-sauce_labs_plugin
   byebug
+  childprocess
   coffee-rails
   dalli (>= 2.2.1)
   delayed_job!

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -8,7 +8,7 @@ task :package
 # Run the unit tests
 
 desc "Run all unit tests"
-task test: ["test:template", "test:integration:action_pack", "test:integration:active_record"]
+task test: ["test:template", "test:integration:action_pack", "test:integration:active_record", "test:integration:ujs"]
 
 namespace :test do
   task :isolated do
@@ -43,13 +43,29 @@ namespace :test do
       t.verbose = true
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
+
+    desc "UJS Integration Tests"
+    task :ujs do
+      if phantomjs = which("phantomjs")
+        process = start_process
+        puts "Web server process started..."
+        fail "Failed due to timeout running server process" unless wait_for_process(4567)
+        puts "Running tests with phantomjs..."
+        output = `#{phantomjs} test/ujs/runner.js http://localhost:4567`
+        puts output.lines.grep(/passed/)
+        fail "UJS tests failed" unless $?.success?
+        stop_process(process)
+      else
+        puts "Skipping UJS tests because PhantomJS was not detected in PATH"
+      end
+    end
   end
 end
 
 namespace :ujs do
   desc "Starts the test server"
   task :server do
-    system 'bundle exec rackup test/ujs/config.ru -p 4567 -s puma'
+    system "bundle exec rackup test/ujs/config.ru -p 4567 -s puma"
   end
 end
 
@@ -57,4 +73,53 @@ task :lines do
   load File.expand_path("..", File.dirname(__FILE__)) + "/tools/line_statistics"
   files = FileList["lib/**/*.rb"]
   CodeTools::LineStatistics.new(files).print_loc
+end
+
+def which(cmd)
+  exts = ENV["PATHEXT"] ? ENV["PATHEXT"].split(";") : [""]
+  ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
+    exts.each { |ext|
+      exe = "#{path}/#{cmd}#{ext}"
+      return exe if File.executable? exe
+    }
+  end
+  return nil
+end
+
+def start_process
+  require "childprocess"
+  FileUtils.mkdir_p("test/ujs/log")
+  args = %w(ruby -S bundle exec rackup test/ujs/config.ru -p 4567 -s puma)
+  process = ChildProcess.build(*args)
+  process.start
+  process
+end
+
+def stop_process(process)
+  begin
+    process.poll_for_exit(5)
+  rescue ChildProcess::TimeoutError
+    process.stop
+  end
+end
+
+def wait_for_process(port, timeout = 5)
+  timestamp = Time.now.to_i + timeout
+  while true
+    if port_busy?(port)
+      return true
+    elsif Time.now.to_i > timestamp
+      puts "timed out after #{timeout} seconds"
+      return false
+    end
+  end
+end
+
+# TODO: Test this in a Windows machine.
+def port_busy?(port)
+  if RbConfig::CONFIG["host_os"] =~ /msdos|mswin|djgpp|mingw|windows/
+    `netstat -an | findstr ":#{port}.*:[^:]*$"` != ""
+  else
+    `lsof -i :#{port}` != ""
+  end
 end

--- a/actionview/test/ujs/runner.js
+++ b/actionview/test/ujs/runner.js
@@ -1,0 +1,148 @@
+/*
+ * PhantomJS Runner QUnit Plugin 1.2.0
+ *
+ * PhantomJS binaries: http://phantomjs.org/download.html
+ * Requires PhantomJS 1.6+ (1.7+ recommended)
+ *
+ * Run with:
+ *   phantomjs runner.js [url-of-your-qunit-testsuite]
+ *
+ * e.g.
+ *   phantomjs runner.js http://localhost/qunit/test/index.html
+ */
+
+/*global phantom:false, require:false, console:false, window:false, QUnit:false */
+
+(function() {
+	'use strict';
+
+	var url, page, timeout,
+		args = require('system').args;
+
+	// arg[0]: scriptName, args[1...]: arguments
+	if (args.length < 2 || args.length > 3) {
+		console.error('Usage:\n  phantomjs runner.js [url-of-your-qunit-testsuite] [timeout-in-seconds]');
+		phantom.exit(1);
+	}
+
+	url = args[1];
+	page = require('webpage').create();
+	if (args[2] !== undefined) {
+		timeout = parseInt(args[2], 10);
+	}
+
+	// Route `console.log()` calls from within the Page context to the main Phantom context (i.e. current `this`)
+	page.onConsoleMessage = function(msg) {
+		console.log(msg);
+	};
+
+	page.onInitialized = function() {
+		page.evaluate(addLogging);
+	};
+
+	page.onCallback = function(message) {
+		var result,
+			failed;
+
+		if (message) {
+			if (message.name === 'QUnit.done') {
+				result = message.data;
+				failed = !result || !result.total || result.failed;
+
+				if (!result.total) {
+					console.error('No tests were executed. Are you loading tests asynchronously?');
+				}
+
+				phantom.exit(failed ? 1 : 0);
+			}
+		}
+	};
+
+	page.open(url, function(status) {
+		if (status !== 'success') {
+			console.error('Unable to access network: ' + status);
+			phantom.exit(1);
+		} else {
+			// Cannot do this verification with the 'DOMContentLoaded' handler because it
+			// will be too late to attach it if a page does not have any script tags.
+			var qunitMissing = page.evaluate(function() { return (typeof QUnit === 'undefined' || !QUnit); });
+			if (qunitMissing) {
+				console.error('The `QUnit` object is not present on this page.');
+				phantom.exit(1);
+			}
+
+			// Set a timeout on the test running, otherwise tests with async problems will hang forever
+			if (typeof timeout === 'number') {
+				setTimeout(function() {
+					console.error('The specified timeout of ' + timeout + ' seconds has expired. Aborting...');
+					phantom.exit(1);
+				}, timeout * 1000);
+			}
+
+			// Do nothing... the callback mechanism will handle everything!
+		}
+	});
+
+	function addLogging() {
+		window.document.addEventListener('DOMContentLoaded', function() {
+			var currentTestAssertions = [];
+
+			QUnit.log(function(details) {
+				var response;
+
+				// Ignore passing assertions
+				if (details.result) {
+					return;
+				}
+
+				response = details.message || '';
+
+				if (typeof details.expected !== 'undefined') {
+					if (response) {
+						response += ', ';
+					}
+
+					response += 'expected: ' + details.expected + ', but was: ' + details.actual;
+				}
+
+				if (details.source) {
+					response += "\n" + details.source;
+				}
+
+				currentTestAssertions.push('Failed assertion: ' + response);
+			});
+
+			QUnit.testDone(function(result) {
+				var i,
+					len,
+					name = '';
+
+				if (result.module) {
+					name += result.module + ': ';
+				}
+				name += result.name;
+
+				if (result.failed) {
+					console.log('\n' + 'Test failed: ' + name);
+
+					for (i = 0, len = currentTestAssertions.length; i < len; i++) {
+						console.log('    ' + currentTestAssertions[i]);
+					}
+				}
+
+				currentTestAssertions.length = 0;
+			});
+
+			QUnit.done(function(result) {
+				console.log('\n' + 'Took ' + result.runtime +  'ms to run ' + result.total + ' tests. ' + result.passed + ' passed, ' + result.failed + ' failed.');
+
+				if (typeof window.callPhantom === 'function') {
+					window.callPhantom({
+						'name': 'QUnit.done',
+						'data': result
+					});
+				}
+			});
+		}, false);
+	}
+})();


### PR DESCRIPTION
This add `test:integration:ujs` rake task for running of UJS tests in CI.