### PR TITLE
Replace '-' with '/' before to_date calls Date.parse

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -42,7 +42,7 @@ class String
   #   "2012-12-13".to_date # => Thu, 13 Dec 2012
   #   "12/13/2012".to_date # => ArgumentError: invalid date
   def to_date
-    ::Date.parse(self, false) unless blank?
+    ::Date.parse(self.gsub("-", "/"), false) unless blank?
   end
 
   # Converts a string to a DateTime value.


### PR DESCRIPTION
This PR is similar to https://github.com/rails/rails/pull/27027
which was already rejected.

I understand the reason why it was rejected:
> the lack of a date component doesn't imply the first of that date

But I'm still unconvinced with this behavior:

```
"2016/11/01".to_date
=> Tue, 01 Nov 2016

"2016-11-01".to_date
=> Tue, 01 Nov 2016

"2016/11".to_date   
=> Tue, 01 Nov 2016

"2016-11".to_date
ArgumentError: invalid date
```

Currently hyphens and slashes in the string behave differently. This is an unpredictable behavior and looks like a bug for me.

if "-" are replaced with "/" before calling Date.parse method, The behaviors will be consistent.
