### PR TITLE
Fix `apply_seconds_precision` not to be affected by `mathn`

### DIFF
--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -34,7 +34,7 @@ module ActiveModel
           return value unless precision && value.respond_to?(:usec)
           number_of_insignificant_digits = 6 - precision
           round_power = 10**number_of_insignificant_digits
-          value.change(usec: value.usec / round_power * round_power)
+          value.change(usec: value.usec - value.usec % round_power)
         end
 
         def type_cast_for_schema(value)


### PR DESCRIPTION
Currently `apply_seconds_precision` cannnot round usec
when after `require 'mathn'`.

```
irb(main):001:0> 1234 / 1000 * 1000
=> 1000
irb(main):002:0> 1234 - 1234 % 1000
=> 1000
irb(main):003:0> require 'mathn'
=> true
irb(main):004:0> 1234 / 1000 * 1000
=> 1234
irb(main):005:0> 1234 - 1234 % 1000
=> 1000
```