### PR TITLE
Add `Style/EmptyElse` in `.rubocop.yml`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,10 @@ Style/CaseIndentation:
 Style/CommentIndentation:
   Enabled: true
 
+# No empty else.
+Style/EmptyElse:
+  Enabled: true
+
 # No extra empty lines.
 Style/EmptyLines:
   Enabled: true

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -814,8 +814,6 @@ module ActionController
               sanitized[key] = permit_any_in_array(value)
             when Parameters
               sanitized[key] = permit_any_in_parameters(value)
-            else
-              # Filter this one out.
             end
           end
           sanitized.permitted = true
@@ -830,8 +828,6 @@ module ActionController
               sanitized << element
             when Parameters
               sanitized << permit_any_in_parameters(element)
-            else
-              # Filter this one out.
             end
           end
         end

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -18,8 +18,6 @@ module ActionDispatch
         fetch_header("action_dispatch.request.content_type") do |k|
           v = if get_header("CONTENT_TYPE") =~ /^([^,\;]*)/
             Mime::Type.lookup($1.strip.downcase)
-          else
-            nil
           end
           set_header k, v
         end

--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -99,8 +99,6 @@ module ActionDispatch
                   "omg"
                 end
               when Nodes::Terminal then n.symbol
-              else
-                nil
               end
             }.compact.join
           end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1859,8 +1859,6 @@ module ActionDispatch
             path_without_format = path.sub(/\(\.:format\)$/, "")
             if using_match_shorthand?(path_without_format)
               path_without_format.gsub(%r{^/}, "").sub(%r{/([^/]*)$}, '#\1').tr("-", "_")
-            else
-              nil
             end
           end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -546,10 +546,8 @@ module ActiveRecord
             # Object identifier types
           when /\A-?\d+\z/
             $1
-          else
             # Anything else is blank, some user type, or some function
             # and we can't know the value of that, so return nil.
-            nil
           end
         end
 

--- a/railties/test/json_params_parsing_test.rb
+++ b/railties/test/json_params_parsing_test.rb
@@ -21,8 +21,6 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
       params = ActionController::Parameters.new request.parameters
       if params[:t]
         klass.find_by_title(params[:t])
-      else
-        nil
       end
     }
 


### PR DESCRIPTION
To avoid #26375 and #27170 in the future.