### PR TITLE
Remove wrong comment about PostgreSQL and UUIDs

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -91,9 +91,6 @@ class PostgresqlUUIDTest < ActiveRecord::PostgreSQLTestCase
      "a0eebc999c0b4ef8bb6d6bb9bd380a11",
      "a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11",
      "{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}",
-     # The following is not a valid RFC 4122 UUID, but PG doesn't seem to care,
-     # so we shouldn't block it either. (Pay attention to "fb6d" – the "f" here
-     # is invalid – it must be one of 8, 9, A, B, a, b according to the spec.)
      "{a0eebc99-9c0b-4ef8-fb6d-6bb9bd380a11}",
     ].each do |valid_uuid|
       uuid = UUIDType.new guid: valid_uuid


### PR DESCRIPTION
PostgreSQL cares about valid UUID, and `a0eebc99-9c0b-4ef8-fb6d-6bb9bd380a11`
is valid UUID. There's other versions other than the more popular
version 4, and so PostgreSQL's `uuid` type doesn't enforce a specific
version. It will accept any string that passes the general UUID validity
check.