### PR TITLE
test, don't connect to mysql when running sqlite3 tests.

### DIFF
--- a/activerecord/test/cases/invalid_connection_test.rb
+++ b/activerecord/test/cases/invalid_connection_test.rb
@@ -1,22 +1,24 @@
 require "cases/helper"
 
-class TestAdapterWithInvalidConnection < ActiveRecord::TestCase
-  self.use_transactional_fixtures = false
-
-  class Bird < ActiveRecord::Base
-  end
-
-  def setup
-    # Can't just use current adapter; sqlite3 will create a database
-    # file on the fly.
-    Bird.establish_connection adapter: 'mysql', database: 'i_do_not_exist'
-  end
-
-  teardown do
-    Bird.remove_connection
-  end
-
-  test "inspect on Model class does not raise" do
-    assert_equal "#{Bird.name} (call '#{Bird.name}.connection' to establish a connection)", Bird.inspect
+if current_adapter?(:MysqlAdapter)
+  class TestAdapterWithInvalidConnection < ActiveRecord::TestCase
+    self.use_transactional_fixtures = false
+  
+    class Bird < ActiveRecord::Base
+    end
+  
+    def setup
+      # Can't just use current adapter; sqlite3 will create a database
+      # file on the fly.
+      Bird.establish_connection adapter: 'mysql', database: 'i_do_not_exist'
+    end
+  
+    teardown do
+      Bird.remove_connection
+    end
+  
+    test "inspect on Model class does not raise" do
+      assert_equal "#{Bird.name} (call '#{Bird.name}.connection' to establish a connection)", Bird.inspect
+    end
   end
 end


### PR DESCRIPTION
### test, don't connect to mysql when running sqlite3 tests.

Resolves the following:

```
Error:
TestAdapterWithInvalidConnection#test_inspect_on_Model_class_does_not_raise:
Gem::LoadError: Specified 'mysql' for database adapter, but the gem is not loaded. Add `gem 'mysql'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord).
    /home/oz/code/rails/activerecord/lib/active_record/connection_adapters/connection_specification.rb:177:in `rescue in spec'
    /home/oz/code/rails/activerecord/lib/active_record/connection_adapters/connection_specification.rb:174:in `spec'
    /home/oz/code/rails/activerecord/lib/active_record/connection_handling.rb:50:in `establish_connection'
    /home/oz/code/rails/activerecord/test/cases/invalid_connection_test.rb:12:in `setup'
```

Ports 4b1f67a11a6fd5680a7ce37b695a4d86e6a2c302