### PR TITLE
Add rubocop to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ gem "rb-inotify", github: "matthewd/rb-inotify", branch: "close-handling", requi
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
 gem "json", ">= 2.0.0"
 
+gem "rubocop", require: false
+
 group :doc do
   gem "sdoc", "1.0.0.beta2"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
     addressable (2.4.0)
     amq-protocol (2.0.1)
     arel (7.1.2)
+    ast (2.3.0)
     backburner (1.3.1)
       beaneater (~> 1.0)
       concurrent-ruby (~> 1.0.1)
@@ -246,9 +247,12 @@ GEM
       mini_portile2 (~> 2.1.0)
     nokogiri (1.6.8.1-x86-mingw32)
       mini_portile2 (~> 2.1.0)
+    parser (2.3.2.0)
+      ast (~> 2.2)
     pg (0.19.0)
     pg (0.19.0-x64-mingw32)
     pg (0.19.0-x86-mingw32)
+    powerpack (0.1.1)
     psych (2.1.1)
     puma (3.6.0)
     qu (0.2.0)
@@ -271,6 +275,7 @@ GEM
       nokogiri (~> 1.6.0)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rainbow (2.1.0)
     rake (11.3.0)
     rb-fsevent (0.9.7)
     rdoc (5.0.0.beta2)
@@ -283,6 +288,13 @@ GEM
       redis (~> 3.3)
       resque (~> 1.26)
       rufus-scheduler (~> 3.2)
+    rubocop (0.45.0)
+      parser (>= 2.3.1.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     ruby_dep (1.4.0)
     rubyzip (1.2.0)
     rufus-scheduler (3.2.2)
@@ -346,6 +358,7 @@ GEM
       tzinfo (>= 1.0.0)
     uglifier (3.0.2)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.1.1)
     useragent (0.16.8)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -403,6 +416,7 @@ DEPENDENCIES
   redis
   resque!
   resque-scheduler
+  rubocop
   sass!
   sass-rails
   sdoc (= 1.0.0.beta2)


### PR DESCRIPTION
Since we have `.rubocop` and ask new PRs to satisfy Rubocop rules, I think it's worth having rubocop in the Gemfile.

@rafaelfranca 