### PR TITLE
Remove broken Renderer#with_defaults method

### DIFF
--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -54,11 +54,6 @@ module ActionController
       self.class.new controller, env, defaults
     end
 
-    # Create a new renderer for the same controller but with new defaults.
-    def with_defaults(defaults)
-      self.class.new controller, env, self.defaults.merge(defaults)
-    end
-
     # Accepts a custom Rack environment to render templates in.
     # It will be merged with ActionController::Renderer.defaults
     def initialize(controller, env, defaults)


### PR DESCRIPTION
### Summary

The `Renderer#with_defaults` method was introduced in
https://github.com/rails/rails/commit/2db7304c2c338711b265e92a51d29121cbd702e6
with the intent of enabling a new renderer to be created with new
defaults passed in. However, the method is broken as it references
`env`, which is not available, thus throwing an error.

While throwing the error can be fixed either by referencing the
`@env` instance variable (or creating an `attr_reader` for it), the
method will still not perform as expected since `env` already has the
defaults merged in (via the initializer). The only way for it to work
would be to call `normalize_keys(env.merge(defaults))`, ie:

```
def with_defaults(defaults)
  self.class.new controller, normalize_keys(env.merge(defaults)), self.defaults.merge(defaults)
end
```

It feels like that would be a much more confusing API, though.

This PR opts to remove the method, without entering a deprecation cycle
since it is already broken.