### PR TITLE
add ActionController::Parameters#reverse_merge

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Add ActionController::Parameters#reverse_merge[!]` which behaves the same as `Hash#reverse_merge[!]`.
+*   Add `ActionController::Parameters#reverse_merge[!]` which behaves the same as `Hash#reverse_merge[!]`.
 
 	*Mitsutaka Mimura*
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add ActionController::Parameters#reverse_merge[!]` which behaves the same as `Hash#reverse_merge[!]`.
+
+	*Mitsutaka Mimura*
+
 *   Use accept header in integration tests with `as: :json`
 
     Instead of appending the `format` to the request path. Rails will figure

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -590,6 +590,21 @@ module ActionController
       self
     end
 
+    # Returns a new <tt>ActionController::Parameters</tt> with all keys from
+    # current hasth merges into +other_hash+.
+    def reverse_merge(other_hash)
+      new_instance_with_inherited_permitted_status(
+        other_hash.to_h.reverse_merge(@parameters)
+      )
+    end
+
+    # Returns current <tt>ActionController::Parameters</tt> instance which
+    # current hash merges into +other_hash+.
+    def reverse_merge!(other_hash)
+      @parameters = other_hash.to_h.merge!(@parameters)
+      self
+    end
+
     # This is required by ActiveModel attribute assignment, so that user can
     # pass +Parameters+ to a mass assignment methods in a model. It should not
     # matter as we are using +HashWithIndifferentAccess+ internally.

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -594,7 +594,7 @@ module ActionController
     # current hasth merges into +other_hash+.
     def reverse_merge(other_hash)
       new_instance_with_inherited_permitted_status(
-        other_hash.to_h.reverse_merge(@parameters)
+        other_hash.to_h.merge(@parameters)
       )
     end
 

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -309,7 +309,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "reverse_merge with parameters" do
-    other_params = ActionController::Parameters.new(id: "1234", person: {age: 30}).permit!
+    other_params = ActionController::Parameters.new(id: "1234", person: { age: 30 }).permit!
     merged_params = @params.reverse_merge(other_params)
 
     assert merged_params[:id]
@@ -326,7 +326,7 @@ class ParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "reverse_merge! with parameters" do
-    other_params = ActionController::Parameters.new(id: "1234", person: {age: 30}).permit!
+    other_params = ActionController::Parameters.new(id: "1234", person: { age: 30 }).permit!
     @params.reverse_merge!(other_params)
 
     assert_equal "1234", @params[:id]

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -299,6 +299,40 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert_equal "32", @params[:person][:age]
   end
 
+  test "not permitted is sticky beyond reverse_merges" do
+    assert !@params.reverse_merge(a: "b").permitted?
+  end
+
+  test "permitted is sticky beyond reverse_merges" do
+    @params.permit!
+    assert @params.reverse_merge(a: "b").permitted?
+  end
+
+  test "reverse_merge with parameters" do
+    other_params = ActionController::Parameters.new(id: "1234", person: {age: 30}).permit!
+    merged_params = @params.reverse_merge(other_params)
+
+    assert merged_params[:id]
+    assert_equal "32", @params[:person][:age]
+  end
+
+  test "not permitted is sticky beyond reverse_merge!" do
+    assert_not @params.reverse_merge!(a: "b").permitted?
+  end
+
+  test "permitted is sticky beyond reverse_merge!" do
+    @params.permit!
+    assert @params.reverse_merge!(a: "b").permitted?
+  end
+
+  test "reverse_merge! with parameters" do
+    other_params = ActionController::Parameters.new(id: "1234", person: {age: 30}).permit!
+    @params.reverse_merge!(other_params)
+
+    assert_equal "1234", @params[:id]
+    assert_equal "32", @params[:person][:age]
+  end
+
   test "modifying the parameters" do
     @params[:person][:hometown] = "Chicago"
     @params[:person][:family] = { brother: "Jonas" }


### PR DESCRIPTION
### Summary

Currenty, ActionController::Parameters dosen't have #reverse_merge and #reverse_merge!.

By using reverse_merge, you can write behaviors like default values.

```ruby
# before
params[:age] = 30 unless params[:age]

# after
params.reverse_merge(age: 30)
```

