### PR TITLE
Remove reference to outdated blog post.

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -301,9 +301,7 @@ Deeply-nested resources quickly become cumbersome. In this case, for example, th
 /publishers/1/magazines/2/photos/3
 ```
 
-The corresponding route helper would be `publisher_magazine_photo_url`, requiring you to specify objects at all three levels. Indeed, this situation is confusing enough that a popular [article](http://weblog.jamisbuck.org/2007/2/5/nesting-resources) by Jamis Buck proposes a rule of thumb for good Rails design:
-
-TIP: _Resources should never be nested more than 1 level deep._
+The corresponding route helper would be `publisher_magazine_photo_url`, requiring you to specify objects at all three levels, which is not recommended since resources should never be nested more than 1 level deep.
 
 #### Shallow Nesting
 


### PR DESCRIPTION
Remove mention of outdated [blog post](http://weblog.jamisbuck.org/2007/2/5/nesting-resources) from routing docs, [next section](http://guides.rubyonrails.org/routing.html#shallow-nesting) already speaks about how to avoid deep nesting.

The paragraph was updated including:

> TIP: Resources should never be nested more than 1 level deep.