### PR TITLE
Add note about step needed to get tests to pass if you implemented basic auth [ci skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -800,6 +800,13 @@ end
 
 Now you can try running all the tests and they should pass.
 
+NOTE: If you followed the steps in the Basic Authentication section, you'll need to add the following to the `setup` block to get all the tests passing:
+
+```ruby
+request.headers['Authorization'] = ActionController::HttpAuthentication::Basic.
+  encode_credentials('dhh', 'secret')
+```
+
 ### Available Request Types for Functional Tests
 
 If you're familiar with the HTTP protocol, you'll know that `get` is a type of request. There are 6 request types supported in Rails functional tests:


### PR DESCRIPTION
Addresses #22862

Added note about needing to add additional code to the setup block to get the tests to pass if you've implemented basic authorization.

[ci skip]

cc @cllns 