### PR TITLE
Explicitly document 'false' as value for 'action_on_unpermitted_parameters'

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -71,8 +71,8 @@ module ActionController
   # * +permit_all_parameters+ - If it's +true+, all the parameters will be
   #   permitted by default. The default is +false+.
   # * +action_on_unpermitted_parameters+ - Allow to control the behavior when parameters
-  #   that are not explicitly permitted are found. The values can be <tt>:log</tt> to
-  #   write a message on the logger or <tt>:raise</tt> to raise
+  #   that are not explicitly permitted are found. The values can be +false+ to just filter them
+  #   out, <tt>:log</tt> to additionally write a message on the logger, or <tt>:raise</tt> to raise
   #   ActionController::UnpermittedParameters exception. The default value is <tt>:log</tt>
   #   in test and development environments, +false+ otherwise.
   #


### PR DESCRIPTION
### Summary

These changes:

- Explicitly document `false` as one of the possible values for the `action_on_unpermitted_parameters` option. It was confusing to see it mentioned as default value without previously including it among the possible options.
- Add a missing Oxford comma, honoring the API Documentation Guidelines.

Note: While I've used 'filter them out' as explanation for the behavior, I'm not sure it's the best wording. Feel free to directly improve it if needed ;)