### PR TITLE
Add configuration hook for fetching Action Cable database connections

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -31,7 +31,7 @@ module ActionCable
       def with_connection(&block) # :nodoc:
         fetch_connection do |conn|
           unless conn.is_a?(PG::Connection)
-            raise "The Active Record database must be PostgreSQL in order to use the PostgreSQL Action Cable storage adapter"
+            raise "Action Cable's PostgreSQL adapter only supports the use of PG::Connection objects for interacting with the database."
           end
 
           yield conn

--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -29,14 +29,22 @@ module ActionCable
       end
 
       def with_connection(&block) # :nodoc:
-        ActiveRecord::Base.connection_pool.with_connection do |ar_conn|
-          pg_conn = ar_conn.raw_connection
-
-          unless pg_conn.is_a?(PG::Connection)
+        fetch_connection do |conn|
+          unless conn.is_a?(PG::Connection)
             raise "The Active Record database must be PostgreSQL in order to use the PostgreSQL Action Cable storage adapter"
           end
 
-          yield pg_conn
+          yield conn
+        end
+      end
+
+      # This method provides the database connection (an instance of PG::Connection)
+      # which is used for the adapter. By default, a connection is taken from
+      # Active Record's connection pool. Override this method if you wish to
+      # use a different ORM.
+      def fetch_connection
+        ActiveRecord::Base.connection_pool.with_connection do |ar_conn|
+          yield ar_conn.raw_connection
         end
       end
 

--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -34,6 +34,20 @@ class PostgresqlAdapterTest < ActionCable::TestCase
     ActiveRecord::Base.clear_all_connections!
   end
 
+  def test_raises_if_connection_is_not_pg_connection
+    bad_adapter = Class.new(ActionCable::SubscriptionAdapter::PostgreSQL) do
+      def fetch_connection
+        yield Object.new
+      end
+    end
+
+    e = assert_raises(RuntimeError) do
+      bad_adapter.new(ActionCable::Server::Base.new).with_connection
+    end
+
+    assert_match(/PostgreSQL adapter only supports the use of PG::Connection/, e.message)
+  end
+
   def cable_config
     { adapter: "postgresql" }
   end


### PR DESCRIPTION
### Summary

Method simply needs to return a `PG::Connection` object. Will by default
use Active Record, but can be overridden to support other ORMs.