### PR TITLE
Fix typo in Rails 5.0 release notes – “when when”

### DIFF
--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -585,7 +585,7 @@ Please refer to the [Changelog][active-record] for detailed changes.
     gem. ([Pull Request](https://github.com/rails/rails/pull/21161))
 
 *   Removed support for the legacy `mysql` database adapter from core. Most users should
-    be able to use `mysql2`. It will be converted to a separate gem when when we find someone
+    be able to use `mysql2`. It will be converted to a separate gem when we find someone
     to maintain it. ([Pull Request 1](https://github.com/rails/rails/pull/22642),
     [Pull Request 2](https://github.com/rails/rails/pull/22715))
 


### PR DESCRIPTION
[ci skip]