### PR TITLE
Updated test expression to unless because is more expressive

### DIFF
--- a/activemodel/lib/active_model/forbidden_attributes_protection.rb
+++ b/activemodel/lib/active_model/forbidden_attributes_protection.rb
@@ -18,7 +18,7 @@ module ActiveModel
     protected
       def sanitize_for_mass_assignment(attributes)
         if attributes.respond_to?(:permitted?)
-          raise ActiveModel::ForbiddenAttributesError if !attributes.permitted?
+          raise ActiveModel::ForbiddenAttributesError unless attributes.permitted?
           attributes.to_h
         else
           attributes


### PR DESCRIPTION
I found a test expression that not compatible with rubocop and I decided fixe it. This PR doens't fix a bug and doesn't change the documentation.

=)

Thanks!