### PR TITLE
removed `@current` as it is not used

### DIFF
--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -45,7 +45,6 @@ module Rails
       attr_accessor :path
 
       def initialize(path)
-        @current = nil
         @path = path
         @root = {}
       end


### PR DESCRIPTION
### Summary

Was trying to answer a question on stackoverflow and looking into the logic of how folders end up in the `autoloadpath`. Trying to understand the logic it looked to me that `@current` is used nowhere in `Root` itself and most likely a reminiscent from a refactoring.

Unit-Tests are still 🍏 

```
 |2.3.0| workify in ~/Documents/rails/rails/railties
± |current_is_not_used ✓| → ruby -I"lib:test" test/paths_test.rb
Run options: --seed 61508

# Running:

....................................

Finished in 0.004794s, 7508.9356 runs/s, 13766.3820 assertions/s.

36 runs, 66 assertions, 0 failures, 0 errors, 0 skips
```
