### PR TITLE
use `Gem.win_platform?` to check windows Ruby platforms

### DIFF
--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -204,7 +204,7 @@ module StaticTests
   end
 
   # Windows doesn't allow \ / : * ? " < > | in filenames
-  unless RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
+  unless Gem.win_platform?
     def test_serves_static_file_with_colon
       with_static_file "/foo/foo:bar.html" do |file|
         assert_html file, get("/foo/foo%3Abar.html")

--- a/actionview/test/actionpack/controller/layout_test.rb
+++ b/actionview/test/actionpack/controller/layout_test.rb
@@ -252,7 +252,7 @@ class LayoutStatusIsRenderedTest < ActionController::TestCase
   end
 end
 
-unless /mswin|mingw/.match?(RbConfig::CONFIG["host_os"])
+unless Gem.win_platform?
   class LayoutSymlinkedTest < LayoutTest
     layout "symlinked/symlinked_layout"
   end

--- a/railties/lib/rails/commands/runner/USAGE
+++ b/railties/lib/rails/commands/runner/USAGE
@@ -8,7 +8,7 @@ Run the Ruby file located at `path/to/filename.rb` after loading the app:
 
   <%= executable %> path/to/filename.rb
 
-<% if RbConfig::CONFIG['host_os'] !~ /mswin|mingw/ %>
+<% unless Gem.win_platform? %>
 You can also use the runner command as a shebang line for your executables:
 
   #!/usr/bin/env <%= File.expand_path(executable) %>

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -279,13 +279,13 @@ module Rails
         def execute_command(executor, command, options = {})
           log executor, command
           env  = options[:env] || ENV["RAILS_ENV"] || "development"
-          sudo = options[:sudo] && RbConfig::CONFIG["host_os"] !~ /mswin|mingw/ ? "sudo " : ""
+          sudo = options[:sudo] && !Gem.win_platform? ? "sudo " : ""
           in_root { run("#{sudo}#{extify(executor)} #{command} RAILS_ENV=#{env}", verbose: false) }
         end
 
         # Add an extension to the given name based on the platform.
         def extify(name)
-          if RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
+          if Gem.win_platform?
             "#{name}.bat"
           else
             name

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -433,7 +433,7 @@ module Rails
       def yarn_path
         commands = ["yarn"]
 
-        if RbConfig::CONFIG["host_os"] =~ /mswin|cygwin/
+        if Gem.win_platform?
           ENV["PATHEXT"].split(File::PATH_SEPARATOR).each do |ext|
             commands << commands[0] + ext
           end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -428,7 +428,7 @@ module Rails
           "/opt/local/var/run/mysql4/mysqld.sock",  # mac + darwinports + mysql4
           "/opt/local/var/run/mysql5/mysqld.sock",  # mac + darwinports + mysql5
           "/opt/lampp/var/mysql/mysql.sock"         # xampp for linux
-        ].find { |f| File.exist?(f) } unless RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
+        ].find { |f| File.exist?(f) } unless Gem.win_platform?
       end
 
       def get_builder_class


### PR DESCRIPTION
`Gem.win_platform?` check if it is Windows more accurately.
Ref: https://github.com/ruby/ruby/blob/ruby_2_2/lib/rubygems.rb#L945..L952