### PR TITLE
Allow to custom content type when setting mailer body

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -3,4 +3,16 @@
 
     *Jeremy Daer*
 
+*   Mime type: allow to custom content type when setting body in headers
+    and attachments.
+
+    Example:
+
+        def test_emails
+          attachments["invoice.pdf"] = "This is test File content"
+          mail(body: "Hello there", content_type: "text/html")
+        end
+
+    *Minh Quy*
+
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/actionmailer/CHANGELOG.md) for previous changes.

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -208,6 +208,19 @@ module ActionMailer
   #       end
   #     end
   #
+  # You can also send attachments with html template, in this case you need to add body, attachments,
+  # and custom content type like this:
+  #
+  #     class NotifierMailer < ApplicationMailer
+  #       def welcome(recipient)
+  #         attachments['free_book.pdf'] = File.read('path/to/file.pdf')
+  #         mail(to: recipient,
+  #              subject: "New account information",
+  #              content_type: "text/html",
+  #              body: "<html><body>Hello there</body></html>")
+  #       end
+  #     end
+  #
   # = Inline Attachments
   #
   # You can also specify that a file should be displayed inline with other HTML. This is useful

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -900,13 +900,17 @@ module ActionMailer
           yield(collector)
           collector.responses
         elsif headers[:body]
-          [{
-            body: headers.delete(:body),
-            content_type: self.class.default[:content_type] || "text/plain"
-          }]
+          collect_responses_from_text(headers)
         else
           collect_responses_from_templates(headers)
         end
+      end
+
+      def collect_responses_from_text(headers)
+        [{
+          body: headers.delete(:body),
+          content_type: headers[:content_type] || self.class.default[:content_type] || "text/plain"
+        }]
       end
 
       def collect_responses_from_templates(headers)

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -922,7 +922,7 @@ module ActionMailer
       def collect_responses_from_text(headers)
         [{
           body: headers.delete(:body),
-          content_type: headers[:content_type] || self.class.default[:content_type] || "text/plain"
+          content_type: headers[:content_type] || "text/plain"
         }]
       end
 

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -140,7 +140,7 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("multipart/mixed", email.mime_type)
   end
 
-  test "set mime type to text/html when attachment is inclued and body is set" do
+  test "set mime type to text/html when attachment is included and body is set" do
     email = BaseMailer.attachment_with_content(body: "Hello there", content_type: "text/html")
     assert_equal("text/html", email.mime_type)
   end

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -140,6 +140,11 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("multipart/mixed", email.mime_type)
   end
 
+  test "set mime type to text/html when attachment is inclued and body is set" do
+    email = BaseMailer.attachment_with_content(body: "Hello there", content_type: "text/html")
+    assert_equal("text/html", email.mime_type)
+  end
+
   test "adds the rendered template as part" do
     email = BaseMailer.attachment_with_content
     assert_equal(2, email.parts.length)

--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -533,6 +533,10 @@ Please refer to the [Changelog][action-mailer] for detailed changes.
     whether your templates should perform caching or not.
     ([Pull Request](https://github.com/rails/rails/pull/22825))
 
+*   Added support for custom `content_type` when setting body in
+    headers and attachments.
+    ([Pull Request](https://github.com/rails/rails/pull/27227))
+
 
 Active Record
 -------------


### PR DESCRIPTION
### Summary

Allow to custom `content-type` in case of setting `headers[:body]` and `attachments`

```
attachments[:rails] = xxx
mail(
  body: "<html><body>Hello rails</body></html>",
  content_type: "text/html"
)
# => content_type is now text/hml
```