### PR TITLE
Fix CI failure due to missing `Regexp#match?`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -692,7 +692,7 @@ module ActiveRecord
 
       def register_integer_type(mapping, key, options) # :nodoc:
         mapping.register_type(key) do |sql_type|
-          if /\bunsigned\b/.match?(sql_type)
+          if /\bunsigned\b/ === sql_type
             Type::UnsignedInteger.new(options)
           else
             Type::Integer.new(options)

--- a/activerecord/lib/active_record/connection_adapters/mysql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/column.rb
@@ -20,7 +20,7 @@ module ActiveRecord
         end
 
         def unsigned?
-          !/\A(?:enum|set)\b/.match?(sql_type) && /\bunsigned\b/.match?(sql_type)
+          /\A(?:enum|set)\b/ !~ sql_type && /\bunsigned\b/ === sql_type
         end
 
         def case_sensitive?


### PR DESCRIPTION
Follow up to f39779fb8e40bf88ea842116e4bddcd7280a9a94.

CI failure is due to missing `Regexp#match?` in 5-0-stable.
