### PR TITLE
Improve linking inside guides

### DIFF
--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -33,7 +33,9 @@ HTML
       end
 
       def paragraph(text)
-        if text =~ /^(TIP|IMPORTANT|CAUTION|WARNING|NOTE|INFO|TODO)[.:]/
+        if text =~ %r{^NOTE:\s+Defined\s+in\s+<code>(.*?)</code>\.?$}
+          %(<div class="note"><p>Defined in <code><a href="#{github_file_url($1)}">#{$1}</a></code>.</p></div>)
+        elsif text =~ /^(TIP|IMPORTANT|CAUTION|WARNING|NOTE|INFO|TODO)[.:]/
           convert_notes(text)
         elsif text.include?("DO NOT READ THIS FILE ON GITHUB")
         elsif text =~ /^\[<sup>(\d+)\]:<\/sup> (.+)$/
@@ -88,6 +90,22 @@ HTML
               end
             %(<div class="#{css_class}"><p>#{$2.strip}</p></div>)
           end
+        end
+
+        def github_file_url(file_path)
+          root, rest = file_path.split('/', 2)
+
+          case root
+          when 'abstract_controller', 'action_controller', 'action_dispatch'
+            path = ['actionpack', 'lib', root, rest].join('/')
+          when 'active_support', 'active_record', 'active_model', 'action_view',
+               'action_cable', 'action_mailer', 'action_pack', 'active_job'
+            path = [root.sub('_', ''), 'lib', root, rest].join('/')
+          else
+            path = file_path
+          end
+
+          ["https://github.com/rails/rails/tree", version || 'master', path].join('/')
         end
 
         def version

--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -15,6 +15,16 @@ module RailsGuides
 HTML
       end
 
+      def link(url, title, content)
+        if url.start_with?('http://api.rubyonrails.org')
+          %(<a href="#{api_link(url)}">#{content}</a>)
+        elsif title
+          %(<a href="#{url}" title="#{title}">#{content}</a>)
+        else
+          %(<a href="#{url}">#{content}</a>)
+        end
+      end
+
       def header(text, header_level)
         # Always increase the heading level by 1, so we can use h1, h2 heading in the document
         header_level += 1
@@ -78,6 +88,19 @@ HTML
               end
             %(<div class="#{css_class}"><p>#{$2.strip}</p></div>)
           end
+        end
+
+        def version
+          ENV['RAILS_VERSION']
+        end
+
+        def api_link(url)
+          if version && !url.match(/v\d\.\d\.\d/)
+            url.insert(url.index('.org')+4, "/#{version}")
+            url.sub('http://edgeapi', 'http://api') if url.include?('edgeapi')
+          end
+
+          url
         end
     end
   end

--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -150,7 +150,7 @@ The type of an attribute is given the opportunity to change how dirty
 tracking is performed.
 
 See its
-[documentation](http://api.rubyonrails.org/classes/ActiveRecord/Attributes/ClassMethods.html)
+[documentation](http://api.rubyonrails.org/v5.0.1/classes/ActiveRecord/Attributes/ClassMethods.html)
 for a detailed write up.
 
 


### PR DESCRIPTION
> Original proposal : https://gist.github.com/robin850/56848c86793ed7d5f0cafdf2b11d931a

Hi,

This pull request improves a bit linking to the API site or GitHub in the guides.

Actually, if `RAILS_VERSION` is specified generating the guides, it's automatically injected in `http://api.rubyonrails.org` URLs if there isn't a version already.

Also, now notes like "Defined in `path/to/file.rb`" are automatically expanded to a link so people can see the file on GitHub, tied to the version the guides were released against.

There's already an opened pull request to address this last point. The author has been properly credited inside the commit but here's the PR for future references: https://github.com/rails/rails/pull/20036.

Have a nice day ! :-)