### PR TITLE
5-0-stable: Avoid `unscope(:order)` when `limit_value` is presented for `count`and `exists?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,5 @@
-*   Avoid `unscope(:order)` when `limit_value` is presented for `count`.
+*   Avoid `unscope(:order)` when `limit_value` is presented for `count`
+    and `exists?`.
 
     If `limit_value` is presented, records fetching order is very important
     for performance. We should not unscope the order in the case.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Avoid `unscope(:order)` when `limit_value` is presented for `count`.
+
+    If `limit_value` is presented, records fetching order is very important
+    for performance. We should not unscope the order in the case.
+
+    *Ryuta Kamizono*
+
 *   Check whether `Rails.application` defined before calling it
 
     In #27674 we changed the migration generator to generate migrations at the

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -223,17 +223,17 @@ module ActiveRecord
     end
 
     def execute_simple_calculation(operation, column_name, distinct) #:nodoc:
-      # PostgreSQL doesn't like ORDER BY when there are no GROUP BY
-      relation = unscope(:order)
-
       column_alias = column_name
 
-      if operation == "count" && (relation.limit_value || relation.offset_value)
+      if operation == "count" && (limit_value || offset_value)
         # Shortcut when limit is zero.
-        return 0 if relation.limit_value == 0
+        return 0 if limit_value == 0
 
-        query_builder = build_count_subquery(relation, column_name, distinct)
+        query_builder = build_count_subquery(spawn, column_name, distinct)
       else
+        # PostgreSQL doesn't like ORDER BY when there are no GROUP BY
+        relation = unscope(:order)
+
         column = aggregate_column(column_name)
 
         select_value = operation_over_aggregate_column(column, operation, distinct)

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -321,7 +321,7 @@ module ActiveRecord
       relation = apply_join_dependency(self, construct_join_dependency)
       return false if ActiveRecord::NullRelation === relation
 
-      relation = relation.except(:select, :order).select(ONE_AS_ONE).limit(1)
+      relation = relation.except(:select, :distinct).select(ONE_AS_ONE).limit(1)
 
       case conditions
       when Array, Hash

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -386,7 +386,7 @@ module ActiveRecord
     end
 
     def construct_relation_for_exists(relation, conditions)
-      relation = relation.except(:select, :distinct)._select!(ONE_AS_ONE).limit!(1)
+      relation = relation.except(:select, :distinct, :order)._select!(ONE_AS_ONE).limit!(1)
 
       case conditions
       when Array, Hash

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -321,16 +321,7 @@ module ActiveRecord
       relation = apply_join_dependency(self, construct_join_dependency)
       return false if ActiveRecord::NullRelation === relation
 
-      relation = relation.except(:select, :distinct).select(ONE_AS_ONE).limit(1)
-
-      case conditions
-      when Array, Hash
-        relation = relation.where(conditions)
-      else
-        unless conditions == :none
-          relation = relation.where(primary_key => conditions)
-        end
-      end
+      relation = construct_relation_for_exists(relation, conditions)
 
       connection.select_value(relation, "#{name} Exists", relation.bound_attributes) ? true : false
     end
@@ -394,6 +385,19 @@ module ActiveRecord
       end
     end
 
+    def construct_relation_for_exists(relation, conditions)
+      relation = relation.except(:select, :distinct)._select!(ONE_AS_ONE).limit!(1)
+
+      case conditions
+      when Array, Hash
+        relation.where!(conditions)
+      else
+        relation.where!(primary_key => conditions) unless conditions == :none
+      end
+
+      relation
+    end
+
     def construct_join_dependency(joins = [])
       including = eager_load_values + includes_values
       ActiveRecord::Associations::JoinDependency.new(@klass, including, joins)
@@ -412,8 +416,7 @@ module ActiveRecord
     end
 
     def apply_join_dependency(relation, join_dependency)
-      relation = relation.except(:includes, :eager_load, :preload)
-      relation = relation.joins join_dependency
+      relation = relation.except(:includes, :eager_load, :preload).joins!(join_dependency)
 
       if using_limitable_reflections?(join_dependency.reflections)
         relation

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -209,6 +209,11 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal true, Topic.order(:id).distinct.exists?
   end
 
+  # Ensure +exists?+ runs without an error by excluding order value.
+  def test_exists_with_order
+    assert_equal true, Topic.order("invalid sql here").exists?
+  end
+
   def test_exists_with_includes_limit_and_empty_result
     assert_equal false, Topic.includes(:replies).limit(0).exists?
     assert_equal false, Topic.includes(:replies).limit(1).where('0 = 1').exists?


### PR DESCRIPTION
Backport #26972 and #26981.

Our Rails app encountered lots of slow queries due to except `:order` in production.
Currently I'm using `relation.load.size` instead as a workaround to keep `:order`.

I'd like to backport these fixes to latest stable branch.