### PR TITLE
Logs exception backtrace in `ActiveSupport::TaggedLogging`

### DIFF
--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -99,7 +99,20 @@ module ActiveSupport
     class SimpleFormatter < ::Logger::Formatter
       # This method is invoked when a log event occurs
       def call(severity, timestamp, progname, msg)
-        "#{String === msg ? msg : msg.inspect}\n"
+        "#{msg2str(msg)}\n"
+      end
+
+      private
+
+      def msg2str(msg)
+        case msg
+        when ::String
+          msg
+        when ::Exception
+          "#{ msg.message } (#{ msg.class })"
+        else
+          msg.inspect
+        end
       end
     end
   end

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -16,9 +16,8 @@ module ActiveSupport
   # to aid debugging of multi-user production applications.
   module TaggedLogging
     module Formatter # :nodoc:
-      # This method is invoked when a log event occurs.
       def call(severity, timestamp, progname, msg)
-        super(severity, timestamp, progname, "#{tags_text}#{msg}")
+        super(severity, timestamp, progname, "#{tags_text}#{msg2str(msg)}")
       end
 
       def tagged(*tags)


### PR DESCRIPTION
### Summary

Adds the exception backtrace to the TaggedLogging formatter, similar to what the base formatter class does. In addition, when a non `String` or `Exception` is handled, the formatter now outputs `msg.inspect`.