### PR TITLE
Prevent issue number in documentation from becoming markdown header [ci skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -32,8 +32,8 @@
     of `Article.category(true)` where `category` is a singular
     association.
 
-    The force reloading of the association reader was deprecated in
-    #20888. Unfortunately the suggested alternative of
+    The force reloading of the association reader was deprecated
+    in #20888. Unfortunately the suggested alternative of
     `article.reload.category` does not expose the same behavior.
 
     This patch adds a reader method with the prefix `reload_` for


### PR DESCRIPTION
### Summary

[Problematic file](https://github.com/rails/rails/blob/00797f14a4882942560c8a0945ab5c2f085c4625/activerecord/CHANGELOG.md).

I took a quick look at open issues/pull requests but no fix in sight.

### Other Information

The alternative is escaping it but moving around the text seems a bit simpler.