### PR TITLE
Introduce `...SQLite3Adapter.execute_batch()` method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Introduce ActiveRecord::ConnectionAdapters::SQLite3Adapter.execute_batch() to allow batch
+    statements to be passed to SQLite.
+
+    Fixes #26948.
+
+    *Joe Nyland*
+
 *   Change the type argument of `ActiveRecord::Base#attribute` to be optional.
     The default is now `ActiveRecord::Type::Value.new`, which provides no type
     casting behavior.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1042,7 +1042,7 @@ module ActiveRecord
           if (duplicate = inserting.detect { |v| inserting.count(v) > 1 })
             raise "Duplicate migration #{duplicate}. Please renumber your migrations to resolve the conflict."
           end
-          execute insert_versions_sql(inserting)
+          execute_batch insert_versions_sql(inserting)
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -238,6 +238,14 @@ module ActiveRecord
         end
       end
 
+      def execute_batch(sql, name = nil) #:nodoc:
+        log(sql, name) do
+          ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+            @connection.execute_batch(sql)
+          end
+        end
+      end
+
       def begin_db_transaction #:nodoc:
         log("begin transaction", nil) { @connection.transaction }
       end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -209,6 +209,22 @@ module ActiveRecord
         end
       end
 
+      def test_execute_batch
+        with_example_table do
+          @conn.execute_batch "INSERT INTO ex (number) VALUES (10); INSERT INTO ex (number) VALUES (20)"
+          records = @conn.execute "SELECT * FROM ex"
+          assert_equal 2, records.length
+
+          record = records.first
+          assert_equal 10, record["number"]
+          assert_equal 1, record["id"]
+
+          record = records.last
+          assert_equal 20, record["number"]
+          assert_equal 2, record["id"]
+        end
+      end
+
       def test_quote_string
         assert_equal "''", @conn.quote_string("'")
       end


### PR DESCRIPTION
### Summary

When using a version of SQLite3 that does not support multi-insert statements, we build a string containing multiple statements. This string is then passed to `SQLite3::Database.execute()` but `.execute()` will only execute the first statement in a string and return any necessary results.

This change introduces a new method which uses `SQLite3::Database.execute_batch()` to execute all of the statements in the string. The caveat with `SQLite3::Database.execute_batch()` is that it cannot return a result set and instead returns nil. See http://www.rubydoc.info/gems/sqlite3/1.3.12/SQLite3%2FDatabase%3Aexecute_batch.

This new method is used to insert multiple versions into the `schema_migrations` table when migrations have been executed successfully, but only when normal multi-insert statements aren't supported by the SQLite3 version installed on the system.

Fixes #26948.

### Other Information
N/A