### PR TITLE
WIP: Support channel_prefix configuration for ActionCable.

### DIFF
--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -72,7 +72,7 @@ module ActionCable
       # Pass <tt>coder: ActiveSupport::JSON</tt> to decode messages as JSON before passing to the callback.
       # Defaults to <tt>coder: nil</tt> which does no decoding, passes raw messages.
       def stream_from(broadcasting, callback = nil, coder: nil, &block)
-        broadcasting = String(broadcasting)
+        broadcasting = [connection.server.config.channel_prefix, String(broadcasting)].compact.join(':')
 
         # Don't send the confirmation until pubsub#subscribe is successful
         defer_subscription_confirmation!

--- a/actioncable/lib/action_cable/server/broadcasting.rb
+++ b/actioncable/lib/action_cable/server/broadcasting.rb
@@ -34,7 +34,8 @@ module ActionCable
           attr_reader :server, :broadcasting, :coder
 
           def initialize(server, broadcasting, coder:)
-            @server, @broadcasting, @coder = server, broadcasting, coder
+            @server, @coder = server, coder
+            @broadcasting = [@server.config.channel_prefix, broadcasting].compact.join(':')
           end
 
           def broadcast(message)

--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -6,6 +6,7 @@ module ActionCable
       attr_accessor :logger, :log_tags
       attr_accessor :connection_class, :worker_pool_size
       attr_accessor :disable_request_forgery_protection, :allowed_request_origins, :allow_same_origin_as_host
+      attr_accessor :channel_prefix
       attr_accessor :cable, :url, :mount_path
 
       def initialize


### PR DESCRIPTION
### Summary

Adds support for config.action_cable.channel_prefix for #27224

TODO:

- [ ] Tests (Suite passes, but need to test this change).
- [ ] Default to app_name:env in new_framework_defaults?
- [ ] Documentation
- [ ] ??? I'm sure there's more...
