### PR TITLE
Update minimum version of `mail` gem to 2.6.0

### DIFF
--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('actionpack',  version)
-  s.add_dependency('mail',        '~> 2.5.4')
+  s.add_dependency('mail',        '~> 2.6.0')
 end


### PR DESCRIPTION
Updates the version of the `mail` gem shipped with actionmailer to be
in the 2.6.x release in order to mitigate SMTP injection outlined in the
[MBSD whitepaper](http://www.mbsd.jp/Whitepaper/smtpi.pdf).