### PR TITLE
Idempotent option for after_commit :destroy callback

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Emulate db trigger behaviour for after_commit :destroy, :update
+
+    Race conditions can occur when an ActiveRecord is destroyed
+    twice or destroyed and updated. The callbacks should only be
+    triggered once, similar to a SQL database trigger.
+
+    *Stefan Budeanu*
+
 *   Moved DecimalWithoutScale, Text, and UnsignedInteger from Active Model to Active Record
 
     *Iain Beeston*

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -461,9 +461,10 @@ module ActiveRecord
           when :create
             transaction_record_state(:new_record)
           when :destroy
-            destroyed?
+            defined?(@_trigger_destroy_callback) && @_trigger_destroy_callback
           when :update
-            !(transaction_record_state(:new_record) || destroyed?)
+            !(transaction_record_state(:new_record) || destroyed?) &&
+              (defined?(@_trigger_update_callback) && @_trigger_update_callback)
           end
         end
       end


### PR DESCRIPTION
### Summary

In SQL a `DELETE` statement is always idempotent (will always succeed even if the underlying table is only modified once). Consequently the `after_commit` callbacks on `:destroy`will be invoked multiple times for a given model, even if a single deletion occurred. This means that user handlers must also be idempotent, which is not always the case (for example, if counting resources).

The issue addressed in this PR is related to https://github.com/rails/rails/pull/14735 and is fixed in a similar fashion:

- Introduce an optional `:idempotent` flag for the `after_commit` callback.
- Default to `true` to preserve existing behaviour.
- Cache whether the operation affected any rows and provide an `actually_destroyed?` getter.
- Demonstrate problem and solution with new unit tests.

We (Shopify) have been running a monkey patched version of this PR since October in production with no ill-effects.

r: @byroot @sgrif
cc: @tenderlove

P.S. This is my first Rails PR, so if there are any silly issues or violated conventions please let me know and I will resolve them as soon as possible. Thank you!
