### PR TITLE
Limited ids for with group by

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -425,8 +425,9 @@ module ActiveRecord
       end
 
       def limited_ids_for(relation)
-        values = @klass.connection.columns_for_distinct(
-          "#{quoted_table_name}.#{quoted_primary_key}", relation.order_values)
+        col = "#{quoted_table_name}.#{quoted_primary_key}"
+        col = "MIN(#{col}) AS #{primary_key}" if group_values.any?
+        values = @klass.connection.columns_for_distinct(col, relation.order_values)
 
         relation = relation.except(:select).select(values).distinct!
         arel = relation.arel

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1221,6 +1221,15 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal tyre2, zyke.tyres.custom_find_by(id: tyre2.id)
   end
 
+  test "limitable relation with group by" do
+    types = nil
+    assert_nothing_raised do
+      #it use distict select, !but for primary key, wich is not present in GROUP BY obviously
+      scope = Post.includes(:comments).where(Comment.arel_table[:body].matches('Special')).group(:type).limit(15)
+      types = scope.pluck(:type)
+    end
+  end
+
   protected
     def table_with_custom_primary_key
       yield(Class.new(Toy) do


### PR DESCRIPTION
fix bug in method `limited_ids_for`, presented with group by.
I hope test is obvious. If not, please let me know, I will try to explain.
Not sure this is the best solution. MIN() is not exactly what we want, but in general case it should work.