### PR TITLE
Fix association scope inside autosaved association callbacks

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -383,6 +383,9 @@ module ActiveRecord
         if association = association_instance_get(reflection.name)
           autosave = reflection.options[:autosave]
 
+          # reconstruct the scope now that we know the owner's id
+          association.reset_scope if association.respond_to?(:reset_scope)
+
           if records = associated_records_to_validate_or_save(association, @new_record_before_save, autosave)
             if autosave
               records_to_destroy = records.select(&:marked_for_destruction?)
@@ -408,9 +411,6 @@ module ActiveRecord
               raise ActiveRecord::Rollback unless saved
             end
           end
-
-          # reconstruct the scope now that we know the owner's id
-          association.reset_scope if association.respond_to?(:reset_scope)
         end
       end
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -649,6 +649,33 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     assert_equal 2, firm.clients.length
     assert_includes firm.clients, Client.find_by_name("New Client")
   end
+
+  def test_inverse_association_within_autosave_after_save_callback
+    posts = Class.new(ActiveRecord::Base) do
+      self.table_name = "posts"
+    end
+    comments = Class.new(ActiveRecord::Base) do
+      self.table_name = "comments"
+    end
+    posts.class_eval do
+      has_many :comments, inverse_of: :post, foreign_key: :post_id, anonymous_class: comments
+    end
+    comments.class_eval do
+      belongs_to :post, inverse_of: :comments, anonymous_class: posts
+
+      attr_accessor :post_comments_count
+      after_save do
+        self.post_comments_count = post.comments.count
+      end
+    end
+
+    post = posts.new(title: "Test", body: "...")
+    comment = post.comments.build(body: "...")
+    post.save!
+
+    assert_equal 1, post.comments.count
+    assert_equal 1, comment.post_comments_count
+  end
 end
 
 class TestDefaultAutosaveAssociationOnNewRecord < ActiveRecord::TestCase


### PR DESCRIPTION
This pull request fixes has many scope in autosave after_save callbacks.
This problem is also present in 4.2.x.

```ruby
class Post < ActiveRecord::Base
  has_many :comments, inverse_of: :post
end

class Comment < ActiveRecord::Base
  belongs_to :post

  after_save do
    puts post.comments.count #=> expected 1, got: 0
    puts post.comments.reload.count #=> expected: 1, got: 1
  end
end

post = Post.new
post.comments.build
post.save!
```