### PR TITLE
Use #sort_by instead of #sort

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -903,8 +903,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_eager_with_multiple_associations_with_same_table_has_many_and_habtm
     # Eager includes of has many and habtm associations aren't necessarily sorted in the same way
     def assert_equal_after_sort(item1, item2, item3 = nil)
-      assert_equal(item1.sort { |a, b| a.id <=> b.id }, item2.sort { |a, b| a.id <=> b.id })
-      assert_equal(item3.sort { |a, b| a.id <=> b.id }, item2.sort { |a, b| a.id <=> b.id }) if item3
+      assert_equal(item1.sort_by(&:id), item2.sort_by(&:id))
+      assert_equal(item3.sort_by(&:id), item2.sort_by(&:id)) if item3
     end
     # Test regular association, association with conditions, association with
     # STI, and association with conditions assured not to be true


### PR DESCRIPTION
I fixed it according to other test case.

ref. https://ruby-doc.org/core-2.3.3/Enumerable.html#method-i-sort_by