### PR TITLE
Use sh instead of Ruby script for yarn binstub

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,7 +1,7 @@
-*   Add Yarn support in new apps using --yarn option. This adds a yarn binstop, vendor/package.json,
+*   Add Yarn support in new apps using --yarn option. This adds a yarn binstub, vendor/package.json,
     and the settings needed to get npm modules integrated in new apps.
 
-    *Liceth Ovalles*, *Guillermo Iguaran*, *DHH*
+    *Liceth Ovalles*, *Guillermo Iguaran*, *DHH*, *ianks*
 
 *   Removed jquery-rails from default stack, instead rails-ujs that is shipped
     with Action View is included as default UJS adapter.

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -68,9 +68,12 @@ module Rails
     end
 
     def bin
-      directory "bin" do |content|
+      directory "bin" , exclude_pattern: /\/bin\/yarn$/ do |content|
         "#{shebang}\n" + content
       end
+
+      copy_file "bin/yarn", "bin/yarn"
+
       chmod "bin", 0755 & ~File.umask, verbose: false
     end
 

--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn
@@ -1,2 +1,11 @@
-VENDOR_PATH = File.expand_path('../vendor', __dir__)
-Dir.chdir(VENDOR_PATH) { exec "yarnpkg #{ARGV.join(" ")}" }
+#!/bin/sh
+
+case $(uname) in
+	*CYGWIN*) basedir=$(cygpath -w "$basedir")
+	;;
+	*)        basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+	;;
+esac
+
+cd "$basedir/../vendor" || exit
+yarn "$@"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -495,6 +495,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_generator_if_yarn_option_is_given
     run_generator([destination_root, "--yarn"])
     assert_file "vendor/package.json", /dependencies/
+    assert_file "bin/yarn", %r{\A#!/bin/sh\n}
     assert_file "config/initializers/assets.rb", /node_modules/
   end
 


### PR DESCRIPTION
Seeing as yarn already uses `sh` for their binstub (https://github.com/yarnpkg/yarn/blob/master/bin/yarn), we opt to use `sh` as well. The main reason for this being that boot times for some interpreters (i.e. jruby) are rather slow. This makes for a much better UX for these users.

See: https://github.com/rails/rails/pull/27245