### PR TITLE
Don't clear digest cache in test environment

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Use `ActionView::Resolver.caching?` (`config.action_view.cache_template_loading`)
+    to enable template recompilation.
+
+    Before it was enabled by `consider_all_requests_local`, which caused
+    recompilation in tests.
+
+    *Max Melentiev*
+
 *   Add `form_with` to unify `form_tag` and `form_for` usage.
 
     Used like `form_tag` (where just the open tag is output):

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -39,7 +39,7 @@ module ActionView
 
     initializer "action_view.per_request_digest_cache" do |app|
       ActiveSupport.on_load(:action_view) do
-        if app.config.consider_all_requests_local
+        unless ActionView::Resolver.caching?
           app.executor.to_run ActionView::Digestor::PerExecutionDigestCacheExpiry
         end
       end


### PR DESCRIPTION
__TL/DR__ `rspec spec/integration`. Before: 35sec. After patch: 20sec. 

#20384 implemented template digest expiry for dev requests. It's enabled by default for test env, which is not required and degradates test performance.

I'm not sure if there should be testcase for this commit.

__UPD__ There is failing test on travis. But it's for actioncable, and passes locally for me.