### PR TITLE
Make `:auto_increment` to internal primary key option

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -42,7 +42,12 @@ module ActiveRecord
         # a record (as primary keys cannot be +nil+). This might be done via the
         # +SecureRandom.uuid+ method and a +before_save+ callback, for instance.
         def primary_key(name, type = :primary_key, **options)
-          options[:default] = options.fetch(:default, "gen_random_uuid()") if type == :uuid
+          if type == :uuid
+            options[:default] = options.fetch(:default, "gen_random_uuid()")
+          elsif options.delete(:auto_increment) == true && type == :integer
+            type = :serial
+          end
+
           super
         end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_definitions.rb
@@ -1,0 +1,23 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      module ColumnMethods
+        def primary_key(name, type = :primary_key, **options)
+          if options.delete(:auto_increment) == true && type == :integer
+            type = :primary_key
+          end
+
+          super
+        end
+      end
+
+      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+        include ColumnMethods
+      end
+
+      class Table < ActiveRecord::ConnectionAdapters::Table
+        include ColumnMethods
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -3,6 +3,7 @@ require "active_record/connection_adapters/statement_pool"
 require "active_record/connection_adapters/sqlite3/explain_pretty_printer"
 require "active_record/connection_adapters/sqlite3/quoting"
 require "active_record/connection_adapters/sqlite3/schema_creation"
+require "active_record/connection_adapters/sqlite3/schema_definitions"
 
 gem "sqlite3", "~> 1.3.6"
 require "sqlite3"
@@ -73,6 +74,10 @@ module ActiveRecord
           def dealloc(stmt)
             stmt[:stmt].close unless stmt[:stmt].closed?
           end
+      end
+
+      def update_table_definition(table_name, base) # :nodoc:
+        SQLite3::Table.new(table_name, base)
       end
 
       def schema_creation # :nodoc:
@@ -568,6 +573,10 @@ module ActiveRecord
           else
             basic_structure.to_hash
           end
+        end
+
+        def create_table_definition(*args)
+          SQLite3::TableDefinition.new(*args)
         end
     end
   end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -216,6 +216,33 @@ class PrimaryKeyWithNoConnectionTest < ActiveRecord::TestCase
   end
 end
 
+class PrimaryKeyWithAutoIncrementTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  class AutoIncrement < ActiveRecord::Base
+  end
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table(:auto_increments, id: :integer, auto_increment: true, force: true)
+  end
+
+  def teardown
+    @connection.drop_table(:auto_increments, if_exists: true)
+  end
+
+  def test_primary_key_with_auto_increment
+    record1 = AutoIncrement.create!
+    assert_not_nil record1.id
+
+    record1.destroy
+
+    record2 = AutoIncrement.create!
+    assert_not_nil record2.id
+    assert_operator record2.id, :>, record1.id
+  end
+end
+
 class PrimaryKeyAnyTypeTest < ActiveRecord::TestCase
   include SchemaDumpingHelper
 


### PR DESCRIPTION
Using `:auto_increment` option for abstracting the DB-specific auto
incremental types. It is worth to ease to implement the compatibility
layer.

I think that this will help to implement #26266.