### PR TITLE
Should be sync the `primary_key` definition with actually created

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -39,7 +39,7 @@ module ActiveRecord
       self.emulate_booleans = true
 
       NATIVE_DATABASE_TYPES = {
-        primary_key: "BIGINT(8) UNSIGNED auto_increment PRIMARY KEY",
+        primary_key: "bigint auto_increment PRIMARY KEY",
         string:      { name: "varchar", limit: 255 },
         text:        { name: "text", limit: 65535 },
         integer:     { name: "int", limit: 4 },


### PR DESCRIPTION
Actually the `primary_key` definition is not used but the inconsistency
is confusing. Actual definition is `bigint auto_increment PRIMARY KEY`
so `UNSIGNED` and `(8)` is unnecessary.

See also #21607.