### PR TITLE
Use #sort_by instead of #sort

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -903,8 +903,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_eager_with_multiple_associations_with_same_table_has_many_and_habtm
     # Eager includes of has many and habtm associations aren't necessarily sorted in the same way
     def assert_equal_after_sort(item1, item2, item3 = nil)
-      assert_equal(item1.sort { |a, b| a.id <=> b.id }, item2.sort { |a, b| a.id <=> b.id })
-      assert_equal(item3.sort { |a, b| a.id <=> b.id }, item2.sort { |a, b| a.id <=> b.id }) if item3
+      assert_equal(item1.sort_by(&:id), item2.sort_by(&:id))
+      assert_equal(item3.sort_by(&:id), item2.sort_by(&:id)) if item3
     end
     # Test regular association, association with conditions, association with
     # STI, and association with conditions assured not to be true

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -57,7 +57,7 @@ module ActiveSupport
           start_time = Time.now
           cleanup
           instrument(:prune, target_size, from: @cache_size) do
-            keys = synchronize { @key_access.keys.sort { |a, b| @key_access[a].to_f <=> @key_access[b].to_f } }
+            keys = synchronize { @key_access.keys.sort_by { |v| @key_access[v].to_f } }
             keys.each do |key|
               delete_entry(key, options)
               return if @cache_size <= target_size || (max_time && Time.now - start_time > max_time)


### PR DESCRIPTION
### Summary

`#sort_by` is faster than `#sort`, so speed improves.

### Benchmark

```rb
require "benchmark"

hash = {}
10_000_000.times { |i| hash[i] = rand(100_000) } 

puts RUBY_VERSION
puts "sort: #{Benchmark.realtime { hash.keys.sort { |a, b| hash[a].to_f <=> hash[b].to_f } }}"
puts "sort_by: #{Benchmark.realtime { hash.keys.sort_by { |v| hash[v].to_f } }}"

# => 2.3.3
# => sort: 80.61629199999152
# => sort_by: 11.888424000004306
```