### PR TITLE
Wrong variable name in action mailer 

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -819,7 +819,7 @@ module ActionMailer
       create_parts_from_responses(message, responses)
 
       # Setup content type, reapply charset and handle parts order
-      message.content_type = set_content_type(message, content_type, headers[:content_type])
+      message.content_type = set_content_type(message, content_type, self.class.default[:content_type])
       message.charset      = charset
 
       if message.multipart?


### PR DESCRIPTION
### Summary

Currently, we use `headers[:content_type]` but I think it should be from class default variable `self.class.default[:content_type]`. Because in `set_content_type`, we named the third variable as `class_default`

