### PR TITLE
ActionCable::Connection::Base doc code sample syntax error

### DIFF
--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -24,11 +24,8 @@ module ActionCable
     #
     #       protected
     #         def find_verified_user
-    #           if current_user = User.find_by_identity cookies.signed[:identity_id]
-    #             current_user
-    #           else
+    #           User.find_by_identity(cookies.signed[:identity_id]) ||
     #             reject_unauthorized_connection
-    #           end
     #         end
     #     end
     #   end


### PR DESCRIPTION
### Summary

Doc code sample generates syntax error, needs parenthesis around .find_by_identity parameter.

Seemed clearer to remove local variable (named after method/attribute, bad) and if/else/end statement, then replace with '||' operator

FYI, came across this working on a YARD based doc system, it uses Ripper for code highlighting, and I noticed this section wasn't highlighted...