### PR TITLE
[ci skip] Document regex change

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/column.rb
@@ -5,6 +5,7 @@ module ActiveRecord
         delegate :extra, to: :sql_type_metadata, allow_nil: true
 
         def unsigned?
+          # enum and set types do not allow being defined as unsigned.
           !/\A(?:enum|set)\b/.match?(sql_type) && /\bunsigned\b/.match?(sql_type)
         end
 


### PR DESCRIPTION
### Summary

In #27126, @kamipo updated the regex matcher for `unsigned?` to exclude enum and set types. There was a discussion on why the change was necessary, and I thought it might be worthwhile to include the reasoning in with the code for future readers.
