### PR TITLE
Disable sorting of params in to_query

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -77,7 +77,7 @@ class Hash
       unless (value.is_a?(Hash) || value.is_a?(Array)) && value.empty?
         value.to_query(namespace ? "#{namespace}[#{key}]" : key)
       end
-    end.compact.sort! * "&"
+    end.compact * "&"
   end
 
   alias_method :to_param, :to_query


### PR DESCRIPTION
### Summary

The order of query params can be significant. For example in the rails_pjax gem, where the `_pjax` param is stripped from the url using a regex. Because of the sorting the `_pjax` param is always the first, which causes the test not to be representable for a real-world request where query parameters aren't necessarily sorted. 

### Other Information

See rails/pjax_rails#85 for a local fix in the testcase.