### PR TITLE
Only move fixture_file_upload to IntegrationTest

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -69,7 +69,7 @@ module ActionDispatch
       DEFAULT_HOST = "www.example.com"
 
       include Minitest::Assertions
-      include RequestHelpers, Assertions
+      include TestProcess, RequestHelpers, Assertions
 
       %w( status status_message headers body redirect? ).each do |method|
         delegate method, to: :response, allow_nil: true
@@ -598,7 +598,7 @@ module ActionDispatch
   # Consult the Rails Testing Guide for more.
 
   class IntegrationTest < ActiveSupport::TestCase
-    include TestProcess
+    include TestProcess::FixtureFile
 
     module UrlOptions
       extend ActiveSupport::Concern

--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -3,6 +3,26 @@ require "action_dispatch/middleware/flash"
 
 module ActionDispatch
   module TestProcess
+    module FixtureFile
+      # Shortcut for <tt>Rack::Test::UploadedFile.new(File.join(ActionDispatch::IntegrationTest.fixture_path, path), type)</tt>:
+      #
+      #   post :change_avatar, avatar: fixture_file_upload('files/spongebob.png', 'image/png')
+      #
+      # To upload binary files on Windows, pass <tt>:binary</tt> as the last parameter.
+      # This will not affect other platforms:
+      #
+      #   post :change_avatar, avatar: fixture_file_upload('files/spongebob.png', 'image/png', :binary)
+      def fixture_file_upload(path, mime_type = nil, binary = false)
+        if self.class.respond_to?(:fixture_path) && self.class.fixture_path &&
+            !File.exist?(path)
+          path = File.join(self.class.fixture_path, path)
+        end
+        Rack::Test::UploadedFile.new(path, mime_type, binary)
+      end
+    end
+
+    include FixtureFile
+
     def assigns(key = nil)
       raise NoMethodError,
         "assigns has been extracted to a gem. To continue using it,
@@ -23,22 +43,6 @@ module ActionDispatch
 
     def redirect_to_url
       @response.redirect_url
-    end
-
-    # Shortcut for <tt>Rack::Test::UploadedFile.new(File.join(ActionDispatch::IntegrationTest.fixture_path, path), type)</tt>:
-    #
-    #   post :change_avatar, avatar: fixture_file_upload('files/spongebob.png', 'image/png')
-    #
-    # To upload binary files on Windows, pass <tt>:binary</tt> as the last parameter.
-    # This will not affect other platforms:
-    #
-    #   post :change_avatar, avatar: fixture_file_upload('files/spongebob.png', 'image/png', :binary)
-    def fixture_file_upload(path, mime_type = nil, binary = false)
-      if self.class.respond_to?(:fixture_path) && self.class.fixture_path &&
-          !File.exist?(path)
-        path = File.join(self.class.fixture_path, path)
-      end
-      Rack::Test::UploadedFile.new(path, mime_type, binary)
     end
   end
 end


### PR DESCRIPTION
The rest of the helpers are better placed on Session -- and this is the only one that cares which class it is defined on.

Revises #26384. The new test added there is still passing, but I haven't come up with a test that proves this change is necessary. :confused:

cc @senny 