### PR TITLE
support callable in `routes.default_url_options`

### DIFF
--- a/actionmailer/test/url_test.rb
+++ b/actionmailer/test/url_test.rb
@@ -79,10 +79,14 @@ class ActionMailerUrlTest < ActionMailer::TestCase
     UrlTestMailer.delivery_method = :test
 
     AppRoutes.draw do
-      ActiveSupport::Deprecation.silence do
-        get ":controller(/:action(/:id))"
-        get "/welcome" => "foo#bar", as: "welcome"
-        get "/dummy_model" => "foo#baz", as: "dummy_model"
+      default_url_options -> { { locale: I18n.locale == :en ? nil : I18n.locale } }
+
+      scope "(:locale)", locale: /en|id/ do
+        ActiveSupport::Deprecation.silence do
+          get ":controller(/:action(/:id))"
+          get "/welcome" => "foo#bar", as: "welcome"
+          get "/dummy_model" => "foo#baz", as: "dummy_model"
+        end
       end
     end
 
@@ -104,6 +108,15 @@ class ActionMailerUrlTest < ActionMailer::TestCase
 
     # array
     assert_url_for "/dummy_model" , [DummyModel]
+
+    # dynamic segment
+    I18n.with_locale :en do
+      assert_url_for "/a/b/c", controller: "a", action: "b", id: "c"
+    end
+
+    I18n.with_locale :id do
+      assert_url_for "/id/a/b/c", controller: "a", action: "b", id: "c"
+    end
   end
 
   def test_signed_up_with_url

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -226,6 +226,8 @@ module ActionDispatch
           def call(t, args, inner_options)
             controller_options = t.url_options
             options = controller_options.merge @options
+            options = t._routes.default_url_options.merge options
+
             hash = handle_positional_args(controller_options,
                                           inner_options || {},
                                           args,
@@ -304,7 +306,7 @@ module ActionDispatch
 
       attr_accessor :formatter, :set, :named_routes, :default_scope, :router
       attr_accessor :disable_clear_and_finalize, :resources_path_names
-      attr_accessor :default_url_options
+      attr_writer :default_url_options
       attr_reader :env_key
 
       alias :routes :set
@@ -666,7 +668,15 @@ module ActionDispatch
                           :original_script_name, :relative_url_root]
 
       def optimize_routes_generation?
-        default_url_options.empty?
+        !@default_url_options.respond_to?(:call) && @default_url_options.empty?
+      end
+
+      def default_url_options
+        if @default_url_options.respond_to?(:call)
+          @default_url_options.call
+        else
+          @default_url_options
+        end
       end
 
       def find_script_name(options)

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -818,6 +818,19 @@ class UrlOptionsIntegrationTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal "/foo/1/edit", url_for(action: "edit", only_path: true)
   end
+
+  def test_can_haz_callable_default_url_options_in_routes
+    original_default_url_options = self.class.routes.default_url_options.dup
+    self.class.routes.default_url_options = -> { { host: "foobar.com" } }
+
+    assert_equal "http://foobar.com/foo", foos_url
+
+    get "/bar"
+    assert_response :success
+    assert_equal "http://bar.com/foo", foos_url
+  ensure
+    self.class.routes.default_url_options = original_default_url_options
+  end
 end
 
 class HeadWithStatusActionIntegrationTest < ActionDispatch::IntegrationTest

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -115,6 +115,16 @@ module ActionDispatch
         assert_equal "http://example.com/foo", url_helpers.foo_url(only_path: false)
       end
 
+      test "only_path: false with *_url and callable global :host option" do
+        @set.default_url_options = -> { { host: "example.com" } }
+
+        draw do
+          get "foo", to: SimpleApp.new("foo#index")
+        end
+
+        assert_equal "http://example.com/foo", url_helpers.foo_url(only_path: false)
+      end
+
       test "explicit keys win over implicit keys" do
         draw do
           resources :foo do


### PR DESCRIPTION
to be used when we want to have defaults that are lazily evaluated.

for example, when we want to have `I18n.locale` as part as the path, and we want it to reflect the locale that currently is active when the url is generated

`#default_url_options` in controller solve cases when we're generating the url in controller and views, but it doesn't handle cases when `Rails.application.routes.url_helpers` are included in other classes, which this commit address