### PR TITLE
change return value of `duplicable?` with Ruby 2.4+

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Change return value of `NilClass#duplicable?`, `FalseClass#duplicable?`,
+    `TrueClass#duplicable?`, `Symbol#duplicable?` and `Numeric#duplicable?`
+    to true with Ruby 2.4+. These classes can dup with Ruby 2.4+.
+
+    *Yuji Yaginuma*
+
 *   Remove deprecated class `ActiveSupport::Concurrency::Latch`
 
     *Andrew White*

--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -1,7 +1,7 @@
 #--
-# Most objects are cloneable, but not all. For example you can't dup +nil+:
+# Most objects are cloneable, but not all. For example you can't dup methods:
 #
-#   nil.dup # => TypeError: can't dup NilClass
+#   method(:puts).dup # => TypeError: allocator undefined for Method
 #
 # Classes may signal their instances are not duplicable removing +dup+/+clone+
 # or raising exceptions from them. So, to dup an arbitrary object you normally
@@ -19,7 +19,7 @@
 class Object
   # Can you safely dup this object?
   #
-  # False for +nil+, +false+, +true+, symbol, number, method objects;
+  # False for method objects;
   # true otherwise.
   def duplicable?
     true
@@ -27,52 +27,77 @@ class Object
 end
 
 class NilClass
-  # +nil+ is not duplicable:
-  #
-  #   nil.duplicable? # => false
-  #   nil.dup         # => TypeError: can't dup NilClass
-  def duplicable?
-    false
+  begin
+    nil.dup
+  rescue TypeError
+
+    # +nil+ is not duplicable:
+    #
+    #   nil.duplicable? # => false
+    #   nil.dup         # => TypeError: can't dup NilClass
+    def duplicable?
+      false
+    end
   end
 end
 
 class FalseClass
-  # +false+ is not duplicable:
-  #
-  #   false.duplicable? # => false
-  #   false.dup         # => TypeError: can't dup FalseClass
-  def duplicable?
-    false
+  begin
+    false.dup
+  rescue TypeError
+
+    # +false+ is not duplicable:
+    #
+    #   false.duplicable? # => false
+    #   false.dup         # => TypeError: can't dup FalseClass
+    def duplicable?
+      false
+    end
   end
 end
 
 class TrueClass
-  # +true+ is not duplicable:
-  #
-  #   true.duplicable? # => false
-  #   true.dup         # => TypeError: can't dup TrueClass
-  def duplicable?
-    false
+  begin
+    true.dup
+  rescue TypeError
+
+    # +true+ is not duplicable:
+    #
+    #   true.duplicable? # => false
+    #   true.dup         # => TypeError: can't dup TrueClass
+    def duplicable?
+      false
+    end
   end
 end
 
 class Symbol
-  # Symbols are not duplicable:
-  #
-  #   :my_symbol.duplicable? # => false
-  #   :my_symbol.dup         # => TypeError: can't dup Symbol
-  def duplicable?
-    false
+  begin
+    :symbol.dup
+  rescue TypeError
+
+    # Symbols are not duplicable:
+    #
+    #   :my_symbol.duplicable? # => false
+    #   :my_symbol.dup         # => TypeError: can't dup Symbol
+    def duplicable?
+      false
+    end
   end
 end
 
 class Numeric
-  # Numbers are not duplicable:
-  #
-  #  3.duplicable? # => false
-  #  3.dup         # => TypeError: can't dup Integer
-  def duplicable?
-    false
+  begin
+    1.dup
+  rescue TypeError
+
+    # Numbers are not duplicable:
+    #
+    #  3.duplicable? # => false
+    #  3.dup         # => TypeError: can't dup Integer
+    def duplicable?
+      false
+    end
   end
 end
 

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -4,8 +4,13 @@ require "active_support/core_ext/object/duplicable"
 require "active_support/core_ext/numeric/time"
 
 class DuplicableTest < ActiveSupport::TestCase
-  RAISE_DUP = [method(:puts)]
-  ALLOW_DUP = ["1", Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal.new("4.56")]
+  if RUBY_VERSION >= "2.4.0"
+    RAISE_DUP = [method(:puts)]
+    ALLOW_DUP = ["1", Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal.new("4.56"), nil, false, true, :symbol, 1, 2.3]
+  else
+    RAISE_DUP = [nil, false, true, :symbol, 1, 2.3, method(:puts)]
+    ALLOW_DUP = ["1", Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal.new("4.56")]
+  end
 
   def test_duplicable
     rubinius_skip "* Method#dup is allowed at the moment on Rubinius\n" \


### PR DESCRIPTION
### Summary

`NilClass`, `FalseClass`, `TrueClass`, `Symbol` and `Numeric` can dup
with Ruby 2.4+. Therefore, the result of `duplicable?` should also be adapted to result of `dup`.

Ref: https://bugs.ruby-lang.org/issues/12979