### PR TITLE
Fix memory leak in action view

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix memory leak when ActionView::Resolver.caching? is false.
+
+    *Max Melentiev*
+
 *   Fix issue with `button_to`'s `to_form_params`
 
     `button_to` was throwing exception when invoked with `params` hash that

--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -3,7 +3,7 @@
 require "action_view/dependency_tracker"
 
 module ActionView
-  class Digestor
+  module Digestor
     @@digest_mutex = Mutex.new
 
     module PerExecutionDigestCacheExpiry

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -112,22 +112,17 @@ module ActionView
         @view_paths = ActionView::PathSet.new(Array(paths))
       end
 
-      def find(name, prefixes = [], partial = false, keys = [], options = {})
-        @view_paths.find(*args_for_lookup(name, prefixes, partial, keys, options))
+      %i(
+        find
+        find_file
+        find_all
+        exists?
+      ).each do |method|
+        define_method method do |name, prefixes = [], partial = false, keys = [], **options|
+          @view_paths.public_send(method, *args_for_lookup(name, prefixes, partial, keys, options))
+        end
       end
       alias :find_template :find
-
-      def find_file(name, prefixes = [], partial = false, keys = [], options = {})
-        @view_paths.find_file(*args_for_lookup(name, prefixes, partial, keys, options))
-      end
-
-      def find_all(name, prefixes = [], partial = false, keys = [], options = {})
-        @view_paths.find_all(*args_for_lookup(name, prefixes, partial, keys, options))
-      end
-
-      def exists?(name, prefixes = [], partial = false, keys = [], **options)
-        @view_paths.exists?(*args_for_lookup(name, prefixes, partial, keys, options))
-      end
       alias :template_exists? :exists?
 
       def any?(name, prefixes = [], partial = false)

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -53,25 +53,18 @@ module ActionView
     register_detail(:variants) { [] }
     register_detail(:handlers) { Template::Handlers.extensions }
 
-    module DetailsKey #:nodoc:
-      module_function
+    class DetailsKey #:nodoc:
+      @store = Concurrent::Map.new
 
-      @details_keys = Concurrent::Map.new
+      # Make hash uniq.
+      alias_method :hash, :object_id
 
-      def get(details)
+      def self.get(details)
         if details[:formats]
           details = details.dup
           details[:formats] &= Template::Types.symbols
         end
-        @details_keys[details] ||= Concurrent::Map.new
-      end
-
-      def clear
-        @details_keys.clear
-      end
-
-      def digest_caches
-        @details_keys.values
+        @store[details] ||= new
       end
     end
 

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -53,12 +53,12 @@ module ActionView
     register_detail(:variants) { [] }
     register_detail(:handlers) { Template::Handlers.extensions }
 
-    class DetailsKey #:nodoc:
-      alias :eql? :equal?
+    module DetailsKey #:nodoc:
+      module_function
 
       @details_keys = Concurrent::Map.new
 
-      def self.get(details)
+      def get(details)
         if details[:formats]
           details = details.dup
           details[:formats] &= Template::Types.symbols
@@ -66,11 +66,11 @@ module ActionView
         @details_keys[details] ||= Concurrent::Map.new
       end
 
-      def self.clear
+      def clear
         @details_keys.clear
       end
 
-      def self.digest_caches
+      def digest_caches
         @details_keys.values
       end
     end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -76,7 +76,7 @@ module ActionView
     initializer "action_view.per_request_digest_cache" do |app|
       ActiveSupport.on_load(:action_view) do
         unless ActionView::Resolver.caching?
-          app.executor.to_run ActionView::Digestor::PerExecutionDigestCacheExpiry
+          app.executor.to_run Digestor::PerExecutionCacheExpiry
         end
       end
     end

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -179,11 +179,10 @@ module ActionView
     # it always hits the resolver but if the key is present, check if the
     # resolver is fresher before returning it.
     def cached(key, path_info, details, locals)
-      name, prefix, partial = path_info
       locals = locals.map(&:to_s).sort!
 
       if key
-        @cache.cache(key, name, prefix, partial, locals) do
+        @cache.cache(key, *path_info, locals) do
           decorate(yield, path_info, details, locals)
         end
       else

--- a/actionview/test/template/compiled_templates_test.rb
+++ b/actionview/test/template/compiled_templates_test.rb
@@ -3,10 +3,6 @@
 require "abstract_unit"
 
 class CompiledTemplatesTest < ActiveSupport::TestCase
-  teardown do
-    ActionView::LookupContext::DetailsKey.clear
-  end
-
   def test_template_with_nil_erb_return
     assert_equal "This is nil: \n", render(template: "test/nil_return")
   end

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -24,7 +24,7 @@ class TemplateDigestorTest < ActionView::TestCase
     @cwd     = Dir.pwd
     @tmp_dir = Dir.mktmpdir
 
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::Digestor.clear_cache
     FileUtils.cp_r FixtureFinder::FIXTURES_DIR, @tmp_dir
     Dir.chdir @tmp_dir
   end
@@ -330,12 +330,12 @@ class TemplateDigestorTest < ActionView::TestCase
 
     def assert_digest_difference(template_name, options = {})
       previous_digest = digest(template_name, options)
-      finder.digest_cache.clear
+      ActionView::Digestor.clear_cache
 
       yield
 
       assert_not_equal previous_digest, digest(template_name, options), "digest didn't change"
-      finder.digest_cache.clear
+      ActionView::Digestor.clear_cache
     end
 
     def digest(template_name, options = {})

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -6,7 +6,6 @@ require "abstract_controller/rendering"
 class LookupContextTest < ActiveSupport::TestCase
   def setup
     @lookup_context = ActionView::LookupContext.new(FIXTURE_LOAD_PATH, {})
-    ActionView::LookupContext::DetailsKey.clear
   end
 
   def teardown


### PR DESCRIPTION
https://github.com/rails/rails/issues/27273 for details.

Here I moved digest cache back to Digestor. In this way, it's possible not to clear DetailsKey cache, and keys for cached templates will be permanent.

~I need to add testcase for not leaking memory.~
~I'm fixing action pack tests.~