### PR TITLE
Fix test breaking error uninitialized constant ActiveRecord::Type::Value

### DIFF
--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -59,6 +59,7 @@ module ActiveRecord
     Float = ActiveModel::Type::Float
     Integer = ActiveModel::Type::Integer
     String = ActiveModel::Type::String
+    Value = ActiveModel::Type::Value
 
     register(:big_integer, Type::BigInteger, override: false)
     register(:binary, Type::Binary, override: false)


### PR DESCRIPTION
### Fixes the following error when launching AR tests:

```/home/oz/code/rails/activerecord/lib/active_record/enum.rb:107:in `<module:Enum>': uninitialized constant ActiveRecord::Type::Value (NameError)
	from /home/oz/code/rails/activerecord/lib/active_record/enum.rb:96:in `<module:ActiveRecord>'
	from /home/oz/code/rails/activerecord/lib/active_record/enum.rb:3:in `<top (required)>'
	from /home/oz/code/rails/activerecord/lib/active_record/base.rb:287:in `<class:Base>'
	from /home/oz/code/rails/activerecord/lib/active_record/base.rb:275:in `<module:ActiveRecord>'
	from /home/oz/code/rails/activerecord/lib/active_record/base.rb:25:in `<top (required)>'
	from /home/oz/code/rails/activerecord/lib/active_record/fixtures.rb:875:in `block in <module:TestFixtures>'
	from /home/oz/code/rails/activesupport/lib/active_support/concern.rb:120:in `class_eval'
	from /home/oz/code/rails/activesupport/lib/active_support/concern.rb:120:in `append_features'
	from /home/oz/code/rails/activerecord/test/cases/test_case.rb:16:in `include'
	from /home/oz/code/rails/activerecord/test/cases/test_case.rb:16:in `<class:TestCase>'
	from /home/oz/code/rails/activerecord/test/cases/test_case.rb:13:in `<module:ActiveRecord>'
	from /home/oz/code/rails/activerecord/test/cases/test_case.rb:9:in `<top (required)>'
	from /home/oz/code/rails/activerecord/test/cases/helper.rb:6:in `require'
	from /home/oz/code/rails/activerecord/test/cases/helper.rb:6:in `<top (required)>'
	from /home/oz/code/rails/activerecord/test/cases/mixin_test.rb:1:in `require'
	from /home/oz/code/rails/activerecord/test/cases/mixin_test.rb:1:in `<top (required)>'
	from /home/oz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:15:in `require'
	from /home/oz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:15:in `block in <main>'
	from /home/oz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:4:in `select'
	from /home/oz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!```

Reverts a line from ef76f83f4cf0f27e84c0c5f4a3ff426d7ad84d9d, merged in #26696.

ruby 2.3.3p222 (2016-11-21 revision 56859) [x86_64-linux]
Rails master
And you can see the same error in the CI.