### PR TITLE
fix AC warning method redefined.

### DIFF
--- a/actioncable/lib/action_cable/remote_connections.rb
+++ b/actioncable/lib/action_cable/remote_connections.rb
@@ -44,12 +44,6 @@ module ActionCable
           server.broadcast internal_channel, type: "disconnect"
         end
 
-        # Returns all the identifiers that were applied to this connection.
-        remove_method :identifiers
-        def identifiers
-          server.connection_identifiers
-        end
-
         private
           attr_reader :server
 

--- a/actioncable/lib/action_cable/remote_connections.rb
+++ b/actioncable/lib/action_cable/remote_connections.rb
@@ -45,6 +45,7 @@ module ActionCable
         end
 
         # Returns all the identifiers that were applied to this connection.
+        remove_method :identifiers
         def identifiers
           server.connection_identifiers
         end


### PR DESCRIPTION
### Fixes the following warning

```
[oz@localhost actioncable]$ bundle exec rake test
/home/oz/.rbenv/versions/2.3.3/bin/ruby -w -I"lib:test" -I"/home/oz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.3.0/lib" "/home/oz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb" "/home/oz/code/rails/actioncable/test/subscription_adapter/inline_test.rb" "/home/oz/code/rails/actioncable/test/subscription_adapter/async_test.rb" "/home/oz/code/rails/actioncable/test/subscription_adapter/base_test.rb" "/home/oz/code/rails/actioncable/test/subscription_adapter/postgresql_test.rb" "/home/oz/code/rails/actioncable/test/subscription_adapter/evented_redis_test.rb" "/home/oz/code/rails/actioncable/test/subscription_adapter/redis_test.rb" "/home/oz/code/rails/actioncable/test/subscription_adapter/subscriber_map_test.rb" "/home/oz/code/rails/actioncable/test/worker_test.rb" "/home/oz/code/rails/actioncable/test/connection/identifier_test.rb" "/home/oz/code/rails/actioncable/test/connection/stream_test.rb" "/home/oz/code/rails/actioncable/test/connection/subscriptions_test.rb" "/home/oz/code/rails/actioncable/test/connection/base_test.rb" "/home/oz/code/rails/actioncable/test/connection/client_socket_test.rb" "/home/oz/code/rails/actioncable/test/connection/multiple_identifiers_test.rb" "/home/oz/code/rails/actioncable/test/connection/cross_site_forgery_test.rb" "/home/oz/code/rails/actioncable/test/connection/string_identifier_test.rb" "/home/oz/code/rails/actioncable/test/connection/authorization_test.rb" "/home/oz/code/rails/actioncable/test/client_test.rb" "/home/oz/code/rails/actioncable/test/channel/rejection_test.rb" "/home/oz/code/rails/actioncable/test/channel/stream_test.rb" "/home/oz/code/rails/actioncable/test/channel/base_test.rb" "/home/oz/code/rails/actioncable/test/channel/broadcasting_test.rb" "/home/oz/code/rails/actioncable/test/channel/naming_test.rb" "/home/oz/code/rails/actioncable/test/channel/periodic_timers_test.rb" "/home/oz/code/rails/actioncable/test/server/base_test.rb" "/home/oz/code/rails/actioncable/test/server/broadcasting_test.rb" 
Run options: --seed 41014

# Running:

....................................................................................../home/oz/code/rails/actioncable/lib/action_cable/remote_connections.rb:48: warning: method redefined; discarding old identifiers
/home/oz/code/rails/activesupport/lib/active_support/core_ext/class/attribute.rb:110: warning: previous definition of identifiers was here
..................................................

```

ruby 2.3.3p222 (2016-11-21 revision 56859) [x86_64-linux]
Rails master