### PR TITLE
Remove unnecessary attr_acessors in AV tests (and get rid of two method redefined warnings)

### DIFF
--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -499,8 +499,6 @@ class FormWithActsLikeFormForTest < FormWithTest
   end
 
   def test_form_with_with_file_field_generate_multipart
-    Post.send :attr_accessor, :file
-
     form_with(model: @post, id: "create-post") do |f|
       concat f.file_field(:file)
     end
@@ -513,8 +511,6 @@ class FormWithActsLikeFormForTest < FormWithTest
   end
 
   def test_fields_with_file_field_generate_multipart
-    Comment.send :attr_accessor, :file
-
     form_with(model: @post) do |f|
       concat f.fields(:comment, model: @post) { |c|
         concat c.file_field(:file)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1751,8 +1751,6 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_with_file_field_generate_multipart
-    Post.send :attr_accessor, :file
-
     form_for(@post, html: { id: "create-post" }) do |f|
       concat f.file_field(:file)
     end
@@ -1765,8 +1763,6 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_fields_for_with_file_field_generate_multipart
-    Comment.send :attr_accessor, :file
-
     form_for(@post) do |f|
       concat f.fields_for(:comment, @post) { |c|
         concat c.file_field(:file)


### PR DESCRIPTION
### Fixes the following warnings when launching AV tests:

```
[oz@localhost actionview]$ bundle exec rake test
/home/oz/.rbenv/versions/2.3.3/bin/ruby -w -I"lib:test" -I"/home/oz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.3.0/lib" "/home/oz/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb" "test/template/number_helper_test.rb" "test/template/form_helper/form_with_test.rb" "test/template/date_helper_i18n_test.rb" "test/template/form_helper_test.rb" "test/template/atom_feed_helper_test.rb" "test/template/output_safety_helper_test.rb" "test/template/controller_helper_test.rb" "test/template/digestor_test.rb" "test/template/dependency_tracker_test.rb" "test/template/sanitize_helper_test.rb" "test/template/lookup_context_test.rb" "test/template/text_test.rb" "test/template/text_helper_test.rb" "test/template/template_error_test.rb" "test/template/resolver_patterns_test.rb" "test/template/resolver_cache_test.rb" "test/template/streaming_render_test.rb" "test/template/html_test.rb" "test/template/record_identifier_test.rb" "test/template/render_test.rb" "test/template/active_model_helper_test.rb" "test/template/record_tag_helper_test.rb" "test/template/javascript_helper_test.rb" "test/template/url_helper_test.rb" "test/template/form_tag_helper_test.rb" "test/template/form_options_helper_i18n_test.rb" "test/template/translation_helper_test.rb" "test/template/test_test.rb" "test/template/template_test.rb" "test/template/tag_helper_test.rb" "test/template/test_case_test.rb" "test/template/erb_util_test.rb" "test/template/asset_tag_helper_test.rb" "test/template/form_options_helper_test.rb" "test/template/capture_helper_test.rb" "test/template/form_collections_helper_test.rb" "test/template/log_subscriber_test.rb" "test/template/erb/form_for_test.rb" "test/template/erb/tag_helper_test.rb" "test/template/partial_iteration_test.rb" "test/template/testing/fixture_resolver_test.rb" "test/template/testing/null_resolver_test.rb" "test/template/date_helper_test.rb" "test/template/compiled_templates_test.rb" 
Run options: --seed 28319

# Running:

....................S..................................................................................................................................................................................................................................................................................../home/oz/code/rails/actionview/test/template/form_helper_test.rb:1768: warning: method redefined; discarding old file
/home/oz/code/rails/actionview/test/template/form_helper_test.rb:1768: warning: method redefined; discarding old file=
..................................................................................../home/oz/code/rails/actionview/test/template/form_helper_test.rb:1754: warning: method redefined; discarding old file
/home/oz/code/rails/actionview/test/template/form_helper_test.rb:1754: warning: method redefined; discarding old file=
.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 13.763360s, 139.6461 runs/s, 311.9878 assertions/s.

1922 runs, 4294 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
```

Removes two unnecessary Post.send calls from their respective tests.