### PR TITLE
Improve experience for declaring Rack routes

### DIFF
--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -189,6 +189,12 @@ module ActionDispatch
         assert_raises ArgumentError do
           mapper.mount as: "exciting"
         end
+
+        assert_raises ArgumentError do
+          mapper.match 10, to: Object.new, via: [:all]
+          mapper.get 10, to: Object.new
+          mapper.post 10, to: Object.new
+        end
       end
 
       def test_scope_does_not_destructively_mutate_default_options


### PR DESCRIPTION
### Summary

This commit has two main benefits:

1. When trying to use the `match` (or really any other) helper to mount
a Rack application, it is possible that one could pass the wrong state
of the Rack application to the route definition. For example, let's say
you have `RackApp` which defines its `call` method as an instance
method (not on the class). If you do the following:

```ruby
get '/rack', to: RackApp
```

You would previously get this error mesage:

```
ArgumentError: Missing :controller key on routes definition, please check your routes.
	from /Users/jon/code/rails/rails/actionpack/lib/action_dispatch/routing/mapper.rb:327:in `check_part'
	from /Users/jon/code/rails/rails/actionpack/lib/action_dispatch/routing/mapper.rb:307:in `check_controller_and_action'
[...]
```

, which is not very helpful. You would now get this error message:

```
ArgumentError: A Rack application (responds to the #call method) must be specified
	from /Users/jon/code/rails/rails/actionpack/lib/action_dispatch/routing/mapper.rb:1860:in `raise_if_not_rack_app'
	from /Users/jon/code/rails/rails/actionpack/lib/action_dispatch/routing/mapper.rb:1880:in `decomposed_match'
[...]
```

2. Improves the error message and capitalizes Rack.

My apologies for having to call `raise_if_not_rack_app` from so many different
places... the routing code has many different branches, so it is
difficult to call the method from a single place. :(