### PR TITLE
gemfile entry method need to return an empty array rather than nil

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -320,10 +320,10 @@ module Rails
       end
 
       def webpacker_gemfile_entry
-        if options[:webpack]
-          comment = "Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker"
-          GemfileEntry.github "webpacker", "rails/webpacker", nil, comment
-        end
+        return [] unless options[:webpack]
+
+        comment = "Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker"
+        GemfileEntry.github "webpacker", "rails/webpacker", nil, comment
       end
 
       def jbuilder_gemfile_entry


### PR DESCRIPTION
This fixes the following error when executing rails new command.

```
(erb):9:in `block in template': undefined method `comment' for nil:NilClass (NoMethodError)
```

Follow up to #27288