### PR TITLE
Stop testing MRI implementation details

### DIFF
--- a/activemodel/test/cases/type/decimal_test.rb
+++ b/activemodel/test/cases/type/decimal_test.rb
@@ -31,9 +31,10 @@ module ActiveModel
         assert_equal BigDecimal("0.33"), type.cast(Rational(1, 3))
       end
 
-      def test_type_cast_decimal_from_rational_without_precision_defaults_to_18_36
+      def test_type_cast_decimal_from_rational_without_precision_returns_at_least_16_precision
         type = Decimal.new
-        assert_equal BigDecimal("0.333333333333333333E0"), type.cast(Rational(1, 3))
+        expected = BigDecimal("0.3333333333333333E0")
+        assert_equal expected, type.cast(Rational(1, 3)).round(16)
       end
 
       def test_type_cast_decimal_from_object_responding_to_d


### PR DESCRIPTION
Right now this test fails on JRuby:

```
--- expected
+++ actual
@@ -1 +1 @@
-#<BigDecimal:5f3c866c,'0.333333333333333333',18(20)>
+#<BigDecimal:16e0afab,'0.3333333333333333',16(20)>
```

We should not describe MRI implementation details in tests because it's
valid only for MRI. We can't guarantee that `Rational(1, 3)` will
always be '0.3333333333333333',16(20) on other platforms.

This is the same issue as in #27117

@guilleiguaran @maclover