### PR TITLE
Simplify the regex for `unsigned?` method

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/column.rb
@@ -5,8 +5,7 @@ module ActiveRecord
         delegate :extra, to: :sql_type_metadata, allow_nil: true
 
         def unsigned?
-          # enum and set types do not allow being defined as unsigned.
-          !/\A(?:enum|set)\b/.match?(sql_type) && /\bunsigned\b/.match?(sql_type)
+          /\bunsigned(?: zerofill)?\z/.match?(sql_type)
         end
 
         def case_sensitive?

--- a/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/unsigned_type_test.rb
@@ -15,6 +15,7 @@ class Mysql2UnsignedTypeTest < ActiveRecord::Mysql2TestCase
       t.bigint  :unsigned_bigint,  unsigned: true
       t.float   :unsigned_float,   unsigned: true
       t.decimal :unsigned_decimal, unsigned: true, precision: 10, scale: 2
+      t.column  :unsigned_zerofill, "int unsigned zerofill"
     end
   end
 
@@ -48,7 +49,6 @@ class Mysql2UnsignedTypeTest < ActiveRecord::Mysql2TestCase
       t.unsigned_bigint  :unsigned_bigint_t
       t.unsigned_float   :unsigned_float_t
       t.unsigned_decimal :unsigned_decimal_t, precision: 10, scale: 2
-      t.column :unsigned_zerofill, "int unsigned zerofill"
     end
 
     @connection.columns("unsigned_types").select { |c| /^unsigned_/.match?(c.name) }.each do |column|


### PR DESCRIPTION
It is enough to distinguish only the trailing `unsigned` and `unsigned zerofill`.