### PR TITLE
collection_cache_key now respects limit()

### DIFF
--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -14,7 +14,7 @@ module ActiveRecord
         column = "#{connection.quote_table_name("timestamps")}.#{connection.quote_column_name(timestamp_column)}"
 
         query = unscoped
-          .select("COUNT(*) AS #{connection.quote_column_name("size")}", "MAX(#{column}) AS timestamp")
+          .select("COUNT(*) AS #{connection.quote_column_name("size")}", "MAX(#{column}) AS #{connection.quote_column_name("timestamp")}")
           .from(collection.unscope(:select, :order), "timestamps")
         result = connection.select_one(query)
 

--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -13,8 +13,9 @@ module ActiveRecord
         column_type = type_for_attribute(timestamp_column.to_s)
         column = "#{connection.quote_table_name("timestamps")}.#{connection.quote_column_name(timestamp_column)}"
 
-        query = "SELECT COUNT(*) AS #{connection.quote_column_name("size")}, MAX(#{column}) AS timestamp" \
-          " FROM (#{collection.unscope(:select).to_sql}) AS #{connection.quote_column_name("timestamps")}"
+        query = unscoped
+          .select("COUNT(*) AS #{connection.quote_column_name("size")}", "MAX(#{column}) AS timestamp")
+          .from(collection.unscope(:select, :order), "timestamps")
         result = connection.select_one(query)
 
         if result.blank?

--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         column_type = type_for_attribute(timestamp_column.to_s)
         column = "#{connection.quote_table_name("timestamps")}.#{connection.quote_column_name(timestamp_column)}"
 
-        query = "SELECT COUNT(*) AS #{connection.quote_column_name("size")}, MAX(#{column}) AS timestamp" <<
+        query = "SELECT COUNT(*) AS #{connection.quote_column_name("size")}, MAX(#{column}) AS timestamp" \
           " FROM (#{collection.unscope(:select).to_sql}) AS #{connection.quote_column_name("timestamps")}"
         result = connection.select_one(query)
 

--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -11,12 +11,10 @@ module ActiveRecord
         end
       else
         column_type = type_for_attribute(timestamp_column.to_s)
-        column = "#{connection.quote_table_name(collection.table_name)}.#{connection.quote_column_name(timestamp_column)}"
+        column = "#{connection.quote_table_name("timestamps")}.#{connection.quote_column_name(timestamp_column)}"
 
-        query = collection
-          .unscope(:select)
-          .select("COUNT(*) AS #{connection.quote_column_name("size")}", "MAX(#{column}) AS timestamp")
-          .unscope(:order)
+        query = "SELECT COUNT(*) AS #{connection.quote_column_name("size")}, MAX(#{column}) AS timestamp" <<
+          " FROM (#{collection.unscope(:select).to_sql}) AS #{connection.quote_column_name("timestamps")}"
         result = connection.select_one(query)
 
         if result.blank?

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -91,5 +91,11 @@ module ActiveRecord
 
       assert_match(/\Adevelopers\/query-(\h+)-2-(\d+)\Z/, developers.cache_key)
     end
+
+    test "cache_key with a relation with limit and joins" do
+      developers = Developer.joins(:projects).limit(3)
+
+      assert_match(/\Adevelopers\/query-(\h+)-3-(\d+)\Z/, developers.cache_key)
+    end
   end
 end

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -85,7 +85,7 @@ module ActiveRecord
 
       assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/, developers.cache_key)
     end
-  
+
     test "cache_key with a relation with limit" do
       developers = Developer.limit(2)
 

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -85,5 +85,11 @@ module ActiveRecord
 
       assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/, developers.cache_key)
     end
+  
+    test "cache_key with a relation with limit" do
+      developers = Developer.limit(2)
+
+      assert_match(/\Adevelopers\/query-(\h+)-2-(\d+)\Z/, developers.cache_key)
+    end
   end
 end


### PR DESCRIPTION
As recently discussed in https://github.com/rails/rails/issues/27326 and previously discussed in https://github.com/rails/rails/pull/21503, the implementation of `collection_cache_key` that was merged with https://github.com/rails/rails/pull/20884 would ignore `limit()` relations.

This had the effect of many scenarios where the collection_cache_key query was _slower_ than the actual ActiveRecord query it was supposed to be avoiding.

For example, in a publishing CMS that has 100,000 `Articles`, the front page might say something like `Article.last(5)`, but the `collection_cache_key` would grind away to find the `COUNT` and `MAX` of _all_ 100,000 timestamps!

(In our company’s application, the SQL for the cache_key queries was about 8x slower than just loading the AR objects directly, even after making custom database indices to make the cache_key as fast as possible.)

This branch includes a failing test illustrating this issue, and a patch that fixes it.

(cc @sgrif)