### PR TITLE
Fix jbuilder <> ActionController::API testing issues

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -636,6 +636,8 @@ module ActionDispatch
         def register_encoder(*args)
           RequestEncoder.register_encoder(*args)
         end
+
+        delegate :fallback_encoder, :fallback_encoder=, to: RequestEncoder
       end
 
       def app

--- a/actionpack/lib/action_dispatch/testing/request_encoder.rb
+++ b/actionpack/lib/action_dispatch/testing/request_encoder.rb
@@ -40,8 +40,12 @@ module ActionDispatch
       encoder(mime ? mime.ref : nil).response_parser
     end
 
+    class << self
+      attr_accessor :fallback_encoder
+    end
+
     def self.encoder(name)
-      @encoders[name] || @encoders[:identity]
+      @encoders[name] || @encoders[fallback_encoder || :identity]
     end
 
     def self.register_encoder(mime_name, param_encoder: nil, response_parser: nil)

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/api_functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/api_functional_test.rb
@@ -11,31 +11,31 @@ class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTe
   end
 
   test "should get index" do
-    get <%= index_helper %>_url, as: :json
+    get <%= index_helper %>_url
     assert_response :success
   end
 
   test "should create <%= singular_table_name %>" do
     assert_difference('<%= class_name %>.count') do
-      post <%= index_helper %>_url, params: { <%= "#{singular_table_name}: { #{attributes_hash} }" %> }, as: :json
+      post <%= index_helper %>_url, params: { <%= "#{singular_table_name}: { #{attributes_hash} }" %> }
     end
 
     assert_response 201
   end
 
   test "should show <%= singular_table_name %>" do
-    get <%= show_helper %>, as: :json
+    get <%= show_helper %>
     assert_response :success
   end
 
   test "should update <%= singular_table_name %>" do
-    patch <%= show_helper %>, params: { <%= "#{singular_table_name}: { #{attributes_hash} }" %> }, as: :json
+    patch <%= show_helper %>, params: { <%= "#{singular_table_name}: { #{attributes_hash} }" %> }
     assert_response 200
   end
 
   test "should destroy <%= singular_table_name %>" do
     assert_difference('<%= class_name %>.count', -1) do
-      delete <%= show_helper %>, as: :json
+      delete <%= show_helper %>
     end
 
     assert_response 204

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -238,8 +238,8 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     assert_file "test/controllers/users_controller_test.rb" do |content|
       assert_match(/class UsersControllerTest < ActionDispatch::IntegrationTest/, content)
       assert_match(/test "should get index"/, content)
-      assert_match(/post users_url, params: \{ user: \{ age: @user\.age, name: @user\.name, organization_id: @user\.organization_id, organization_type: @user\.organization_type \} \}, as: :json/, content)
-      assert_match(/patch user_url\(@user\), params: \{ user: \{ age: @user\.age, name: @user\.name, organization_id: @user\.organization_id, organization_type: @user\.organization_type \} \}, as: :json/, content)
+      assert_match(/post users_url, params: \{ user: \{ age: @user\.age, name: @user\.name, organization_id: @user\.organization_id, organization_type: @user\.organization_type \} \}/, content)
+      assert_match(/patch user_url\(@user\), params: \{ user: \{ age: @user\.age, name: @user\.name, organization_id: @user\.organization_id, organization_type: @user\.organization_type \} \}/, content)
       assert_no_match(/assert_redirected_to/, content)
     end
   end


### PR DESCRIPTION
### Summary

- Add fallback encoder support to `ActionDispatch::IntegrationTest`
  - Now gems like jbuilder can set fallback encoders (in that case, a
`:json` fallback encoder for `ActionController::API` controllers).
- Revert changes made in d68562e

### Other Information

- Should this be backported to `5-0-stable` (I think so...?)
- Write patch for jbuilder that will utilize this new functionality

Patch for jbuilder would look something like this:

``` diff
--- a/lib/jbuilder/railtie.rb
+++ b/lib/jbuilder/railtie.rb
@@ -20,6 +20,10 @@ class Jbuilder
           if self == ActionController::API
             include ActionController::Helpers
             include ActionController::ImplicitRender
+
+            if ActionDispatch::IntegrationTest.respond_to?(:fallback_encoder=)
+              ActionDispatch::IntegrationTest.fallback_encoder = :json
+            end
           end
         end
       end
```

ref #25183