### PR TITLE
Improve clarity of AJ tests output

### DIFF
--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -5,6 +5,7 @@ ActiveSupport.halt_callback_chains_on_return_false = false
 GlobalID.app = "aj"
 
 @adapter = ENV["AJ_ADAPTER"] || "inline"
+puts "Using #{@adapter}"
 
 if ENV["AJ_INTEGRATION_TESTS"]
   require "support/integration/helper"


### PR DESCRIPTION
### Output adapter name before running AJ tests for it

We do [something similar](https://github.com/rails/rails/blob/master/activerecord/test/support/connection.rb#L16) in AR tests, it gives a context to the chunks as they rush up the screen.