### PR TITLE
fix QueryCache nil dup

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Notifications see frozen SQL string.
+
+    Fixes #23774
+
+    *Richard Monette*
+
+*   RuntimeErrors are no longer translated to ActiveRecord::StatementInvalid.
+
+    *Richard Monette*
+
 *   Change the schema cache format to use YAML instead of Marshal.
 
     *Kir Shatrov*

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -10,9 +10,9 @@ module ActiveRecord
       def to_sql(arel, binds = [])
         if arel.respond_to?(:ast)
           collected = visitor.accept(arel.ast, collector)
-          collected.compile(binds, self)
+          collected.compile(binds, self).freeze
         else
-          arel
+          arel.dup.freeze
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -598,7 +598,12 @@ module ActiveRecord
 
         def translate_exception(exception, message)
           # override in derived class
-          ActiveRecord::StatementInvalid.new(message)
+          case exception
+          when RuntimeError
+            exception
+          else
+            ActiveRecord::StatementInvalid.new(message)
+          end
         end
 
         def without_prepared_statement?(binds)

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -285,13 +285,13 @@ module ActiveRecord
 
     unless current_adapter?(:PostgreSQLAdapter)
       def test_log_invalid_encoding
-        error = assert_raise ActiveRecord::StatementInvalid do
+        error = assert_raises RuntimeError do
           @connection.send :log, "SELECT 'ы' FROM DUAL" do
             raise "ы".force_encoding(Encoding::ASCII_8BIT)
           end
         end
 
-        assert_not_nil error.cause
+        assert_not_nil error.message
       end
     end
 


### PR DESCRIPTION
Because the sql component of the payload to the subscriber can be mutated, it is possible the validity of the check for the presence of the key may actually changed. Using dup ensures that the check remains valid when the cache is eventually queried. 

Fixes https://github.com/rails/rails/issues/23774