### PR TITLE
Update list of `duplicable?` objects  in AS core_ext guide [ci skip]

### DIFF
--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -499,8 +499,6 @@ class FormWithActsLikeFormForTest < FormWithTest
   end
 
   def test_form_with_with_file_field_generate_multipart
-    Post.send :attr_accessor, :file
-
     form_with(model: @post, id: "create-post") do |f|
       concat f.file_field(:file)
     end
@@ -513,8 +511,6 @@ class FormWithActsLikeFormForTest < FormWithTest
   end
 
   def test_fields_with_file_field_generate_multipart
-    Comment.send :attr_accessor, :file
-
     form_with(model: @post) do |f|
       concat f.fields(:comment, model: @post) { |c|
         concat c.file_field(:file)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1751,8 +1751,6 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_with_file_field_generate_multipart
-    Post.send :attr_accessor, :file
-
     form_for(@post, html: { id: "create-post" }) do |f|
       concat f.file_field(:file)
     end
@@ -1765,8 +1763,6 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_fields_for_with_file_field_generate_multipart
-    Comment.send :attr_accessor, :file
-
     form_for(@post) do |f|
       concat f.fields_for(:comment, @post) { |c|
         concat c.file_field(:file)

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -164,7 +164,7 @@ Active Support provides `duplicable?` to programmatically query an object about 
 false.duplicable? # => false
 ```
 
-By definition all objects are `duplicable?` except `nil`, `false`, `true`, symbols, numbers, class, module, and method objects.
+By definition all objects are `duplicable?` including big decimals but excluding all other numbers, as well as `nil`, `false`, `true`, symbols, class, module, and method objects.
 
 WARNING: Any class can disallow duplication by removing `dup` and `clone` or raising exceptions from them. Thus only `rescue` can tell whether a given arbitrary object is duplicable. `duplicable?` depends on the hard-coded list above, but it is much faster than `rescue`. Use it only if you know the hard-coded list is enough in your use case.
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -33,7 +33,7 @@ module Rails
         class_option :javascript,         type: :string, aliases: "-j",
                                           desc: "Preconfigure for selected JavaScript library"
 
-        class_option :webpack,            type: :string, default: "base",
+        class_option :webpack,            type: :string, default: nil,
                                           desc: "Preconfigure for app-like JavaScript with Webpack"
 
         class_option :skip_yarn,          type: :boolean, default: false,
@@ -428,7 +428,7 @@ module Rails
       def run_webpack
         if !(webpack = options[:webpack]).nil?
           rails_command "webpacker:install"
-          rails_command "webpacker:install:#{webpack}" unless webpack == "base"
+          rails_command "webpacker:install:#{webpack}" unless webpack == "webpack"
         end
       end
 


### PR DESCRIPTION
BigDecimal has been `duplicable?` since 440559f.