### PR TITLE
fix new warning in ruby 2.4

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/reserved_word_test.rb
@@ -143,7 +143,7 @@ class Mysql2ReservedWordTest < ActiveRecord::Mysql2TestCase
     end
 
     # custom create table, uses execute on connection to create a table, note: escapes table_name, does NOT escape columns
-    def create_tables_directly (tables, connection = @connection)
+    def create_tables_directly(tables, connection = @connection)
       tables.each do |table_name, column_properties|
         connection.execute("CREATE TABLE `#{table_name}` ( #{column_properties} )")
       end

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -983,7 +983,7 @@ class MemoryStoreTest < ActiveSupport::TestCase
   end
 
   def test_pruning_is_capped_at_a_max_time
-    def @cache.delete_entry (*args)
+    def @cache.delete_entry(*args)
       sleep(0.01)
       super
     end


### PR DESCRIPTION
This fixes the following warning.

```
test/caching_test.rb:986: warning: parentheses after method name is interpreted as
test/caching_test.rb:986: warning: an argument list, not a decomposed argument

test/cases/adapters/mysql2/reserved_word_test.rb:146: warning: parentheses after method name is interpreted as
test/cases/adapters/mysql2/reserved_word_test.rb:146: warning: an argument list, not a decomposed argument
```

Ref: https://github.com/ruby/ruby/commit/65e27c8b138d6959608658ffce2fa761842b8d24