### PR TITLE
Remove unused method `namespaced_file_path`

### DIFF
--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -90,10 +90,6 @@ module Rails
           @class_path
         end
 
-        def namespaced_file_path
-          @namespaced_file_path ||= namespaced_class_path.join("/")
-        end
-
         def namespaced_class_path
           @namespaced_class_path ||= [namespaced_path] + @class_path
         end


### PR DESCRIPTION
```
$ git grep namespaced_file_path
railties/lib/rails/generators/named_base.rb:        def namespaced_file_path
railties/lib/rails/generators/named_base.rb:          @namespaced_file_path ||= namespaced_class_path.join("/")
```