### PR TITLE
Fix constantize edge case involving prepend, autoloading and name conflicts

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -274,7 +274,7 @@ module ActiveSupport
 
           # Go down the ancestors to check if it is owned directly. The check
           # stops when we reach Object or the end of ancestors tree.
-          constant = constant.ancestors.inject do |const, ancestor|
+          constant = constant.ancestors.inject(constant) do |const, ancestor|
             break const    if ancestor == Object
             break ancestor if ancestor.const_defined?(name, false)
             const

--- a/activesupport/test/autoloading_fixtures/prepend.rb
+++ b/activesupport/test/autoloading_fixtures/prepend.rb
@@ -1,0 +1,8 @@
+class SubClassConflict
+end
+
+class Prepend
+  module PrependedModule
+  end
+  prepend PrependedModule
+end

--- a/activesupport/test/autoloading_fixtures/prepend/sub_class_conflict.rb
+++ b/activesupport/test/autoloading_fixtures/prepend/sub_class_conflict.rb
@@ -1,0 +1,2 @@
+class Prepend::SubClassConflict
+end

--- a/activesupport/test/constantize_test_cases.rb
+++ b/activesupport/test/constantize_test_cases.rb
@@ -73,6 +73,11 @@ module ConstantizeTestCases
         yield("RaisesNoMethodError")
       end
     end
+
+    with_autoloading_fixtures do
+      yield("Prepend::SubClassConflict")
+      assert_equal "constant", defined?(Prepend::SubClassConflict)
+    end
   end
 
   def run_safe_constantize_tests_on


### PR DESCRIPTION
In the following situation:

```ruby
class Bar
end

module Baz
end

class Foo
  prepend Baz
end

class Foo::Bar
end
```

Running `Inflector.constantize('Foo::Bar')` would blow up with a `NameError: uninitialized constant Baz::Bar`.

What is happening is that `constatize` was written before the introduction
of `prepend`, and wrongly assume that `klass.ancestors.first == klass`.

So it uses `klass.ancestors.inject` without arguments, as a result
a prepended module is used in place of the actual class.

@rafaelfranca @sgrif for review please.

cc @ptolts because you stepped upon that bug.