### PR TITLE
fix fixtures loading for models with same table names in different databases

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -536,16 +536,16 @@ module ActiveRecord
           update_all_loaded_fixtures fixtures_map
 
           connection.transaction(requires_new: true) do
-            deleted_tables = Set.new
+            deleted_tables = Hash.new { |h, k| h[k] = Set.new }
             fixture_sets.each do |fs|
               conn = fs.model_class.respond_to?(:connection) ? fs.model_class.connection : connection
               table_rows = fs.table_rows
 
               table_rows.each_key do |table|
-                unless deleted_tables.include? table
+                unless deleted_tables[conn].include? table
                   conn.delete "DELETE FROM #{conn.quote_table_name(table)}", "Fixture Delete"
                 end
-                deleted_tables << table
+                deleted_tables[conn] << table
               end
 
               table_rows.each do |fixture_set_name, rows|

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -12,9 +12,11 @@ require "models/company"
 require "models/computer"
 require "models/course"
 require "models/developer"
+require "models/dog"
 require "models/doubloon"
 require "models/joke"
 require "models/matey"
+require "models/other_dog"
 require "models/parrot"
 require "models/pirate"
 require "models/post"
@@ -1019,5 +1021,18 @@ class FixtureClassNamesTest < ActiveRecord::TestCase
 
   test "fixture_class_names returns nil for unregistered identifier" do
     assert_nil fixture_class_names["unregistered_identifier"]
+  end
+end
+
+class SameNameDifferentDatabaseFixturesTest < ActiveRecord::TestCase
+  fixtures :dogs, :other_dogs
+
+  test "fixtures are properly loaded" do
+    # Force loading the fixtures again to reproduce issue
+    ActiveRecord::FixtureSet.reset_cache
+    create_fixtures("dogs", "other_dogs")
+
+    assert_kind_of Dog, dogs(:sophie)
+    assert_kind_of OtherDog, other_dogs(:lassie)
   end
 end

--- a/activerecord/test/fixtures/other_dogs.yml
+++ b/activerecord/test/fixtures/other_dogs.yml
@@ -1,0 +1,2 @@
+lassie:
+  id: 1

--- a/activerecord/test/models/other_dog.rb
+++ b/activerecord/test/models/other_dog.rb
@@ -1,0 +1,5 @@
+require_dependency "models/arunit2_model"
+
+class OtherDog < ARUnit2Model
+  self.table_name = "dogs"
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1050,3 +1050,5 @@ Professor.connection.create_table :courses_professors, id: false, force: true do
   t.references :course
   t.references :professor
 end
+
+OtherDog.connection.create_table :dogs, force: true

--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -2,6 +2,7 @@ require "active_support/logger"
 require "models/college"
 require "models/course"
 require "models/professor"
+require "models/other_dog"
 
 module ARTest
   def self.connection_name


### PR DESCRIPTION
Hello ❤️

Updating an app to Rails 5 I found a regression introduced by this commit https://github.com/vipulnsward/rails/commit/5578b141fca04ba44a1377d309d35169bcf98f87

The app I'm working on has different models that connect to different databases and some of them use the same table names. In this case is not enough just to save the table name to know that we have already run `DELETE FROM` prior inserting the fixtures, that causes problems loading the fixtures of my app because some tables are not properly cleaned up. I could solve the problem by appending the database name in the key that we use in order to know if we have to clean the table.

I hope you like the fix! Cheers 👋 