### PR TITLE
Ignore warnings caused by bundled gems

### DIFF
--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -385,7 +385,9 @@ XML
       $stderr = STDERR
     end
 
-    assert err.empty?, err.inspect
+    # Ignore warnings caused by bundled gems
+    err_without_bundled_gem = err.split("\n").reject { |msg| msg =~ /vendor\/bundle/ }
+    assert err_without_bundled_gem.empty?, err_without_bundled_gem.inspect
   end
 
   def test_assert_generates


### PR DESCRIPTION
Checking all warnings makes the test case fragile.
For example `test_should_not_impose_childless_html_tags_in_xml` failed
by these warnings.

```
"/home/travis/build/rails/rails/vendor/bundle/ruby/2.4.0/gems/\
nokogiri-1.6.8.1/lib/nokogiri/xml/document.rb:44: \
warning: constant ::Fixnum is deprecated\n"
```

This commit will suppress these noise.