### PR TITLE
Adding protect_from_forgery into ActionController::Base

### DIFF
--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -250,7 +250,9 @@ module ActionController
       include mod
     end
     setup_renderer!
-
+    
+    protect_from_forgery with: :null_session
+    
     # Define some internal variables that should not be propagated to the view.
     PROTECTED_IVARS = AbstractController::Rendering::DEFAULT_PROTECTED_INSTANCE_VARIABLES + %i(
       @_params @_response @_request @_config @_url_options @_action_has_layout @_view_context_class


### PR DESCRIPTION
### Pre-history

Ever asked yourself why default `application_controller` looks like this?

```
class ApplicationController < ActionController::Base
  protect_from_forgery with: :exception
end
```

Like many things in Rails, it's just a tradition, not because it's the right thing to do. (Remember match ':controller/:action/:id' that left every single action vulnerable to CSRF?).

Let's figure out how exactly this innocent line is bad. First, <a href="http://homakov.blogspot.com/2014/12/blatant-csrf-in-doorkeeper-most-popular.html">we need to review a story with Doorkeeper</a> which left every Doorkeeper endpoint vulnerable to CSRF i.e. getting access token with any scope with unauthenticated POST request. Websites like Digital Ocean/Coinbase etc got a really bad bug because of 3rd party library.

The problem behind that was how Doorkeeper's ApplicationController inherited from Base w/o the protect_from_forgery part. Same thing happened to few other gems: it's very easy to forget to include that critical line of code. Many developers create new internal controllers (like AdminController) and also don't include that line. Long story short, I audited a lot of Rails code: **it's been a disaster.** 

It's clear to everyone, protect_from_forgery must be ON by default. But the right place for it is in `base.rb`, not in the generated template. Base has everything that works with the browser: cookies, sessions, redirects, and to work properly with the browser it also must *always* verify the authenticity_token. It's not like we can routinely switch it on or of.

## CSRF protection 101: 

If the request has authenticity_token equal one from the session = request was initiated from our domain, session and cookies can be used.

If it lacks authenticity_token or it's invalid = nullify cookies/session. Do not raise any error - explicit API tokens can be used. Just pretend you didn't receive any cookies plus show a console warning "Received cookies without valid authenticity_token".

There's no use in two other options:

1. As you can see `with: :exception` breaks APIs - those would be just fine w/o cookies (and there wouldn't be tons of reports on StackOverflow from people trying to make API work on Rails and eventually switching that annoying thing off with skip_before_filter...).

2. :reset_session option would be equivalent to Log Out CSRF - very annoying low severity bug, makes no sense to use this one.

Recap:

1. We must add `protect_from_forgery with: :null_session` directly to `base.rb`, to the controlling talking to the browser. That would prevent dozens of gems out there being vulnerable to CSRF like Doorkeeper because they forgot to add "protect_me_from_csrf" line at some point

2. We should deprecate two other options :reset_session/:exception because they are useless and even somewhat dangerous.