### PR TITLE
Refining Array#sum monkey-patch using Refinements

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -115,9 +115,14 @@ end
 # and fall back to the compatible implementation, but that's much slower than
 # just calling the compat method in the first place.
 if Array.instance_methods(false).include?(:sum) && !(%w[a].sum rescue false)
-  class Array
-    alias :orig_sum :sum
+  # Using Refinements here in order not to expose our internal method
+  using Module.new {
+    refine Array do
+      alias :orig_sum :sum
+    end
+  }
 
+  class Array
     def sum(init = nil, &block) #:nodoc:
       if init.is_a?(Numeric) || first.is_a?(Numeric)
         init ||= 0


### PR DESCRIPTION
Here's an alternative implementation of `Array#sum`.

Current `Array#sum` unwantedly exposes our own internal `orig_sum` method to the outside world.
Ruby 2's probably most unused but useful new feature "Refinements" is provided exactly for this use case to define a perfectly private method that can be accessed only inside this file.

I'd like to ask the core members' opinion about this approach, since AFAIK we've never used Refinements in our code base before.
If you like it, I'd love to rewrite some other monkey-patches to this style.
And I guess #25202 can also be more elegantly solved using this technique.

/cc @jeremy 