### PR TITLE
Add note on defaults block option

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -603,6 +603,14 @@ get 'photos/:id', to: 'photos#show', defaults: { format: 'jpg' }
 
 Rails would match `photos/12` to the `show` action of `PhotosController`, and set `params[:format]` to `"jpg"`.
 
+You can also use `defaults` in a block format to define the defaults for multiple items:
+
+```ruby
+defaults format: :json do
+  resources :photos
+end
+```
+
 NOTE: You cannot override defaults via query parameters - this is for security reasons. The only defaults that can be overridden are dynamic segments via substitution in the URL path.
 
 ### Naming Routes


### PR DESCRIPTION
### Summary

When I was looking for how to default the entire routes file to JSON I could only find the postfix option. It was mentioned on IRC that you could do this with a block as well and I had not found it in the documentation.