### PR TITLE
Fix Fixnum deprecated warning in Ruby 2.4+

### DIFF
--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -21,7 +21,7 @@ class DurationTest < ActiveSupport::TestCase
   end
 
   def test_instance_of
-    assert 1.minute.instance_of?(Fixnum)
+    assert 1.minute.instance_of?(1.class)
     assert 2.days.instance_of?(ActiveSupport::Duration)
     assert !3.second.instance_of?(Numeric)
   end


### PR DESCRIPTION
This is the single one of near more than a thousand Fixnum/Bignum deprecation warnings that comes from Rails itself.

```[oz@localhost rails]$ ruby --version
ruby 2.4.0rc1 (2016-12-12 trunk 57064) [x86_64-linux]
[oz@localhost rails]$ bundle exec rake test 2>&1 | grep 'num is deprecated' | wc
   1516    9096  248967
[oz@localhost rails]$ bundle exec rake test 2>&1 | grep -v '/gems/2.4.0/gems/' | grep 'num is deprecated'
.........................................................................................................................................................................................................................................................................................................................................................../home/oz/code/rails/activesupport/test/core_ext/duration_test.rb:24: warning: constant ::Fixnum is deprecated
```