### PR TITLE
Avoid invalid attribute on local forms generated by `form_with`

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2293,10 +2293,6 @@ module ActionView
           if options.key?(:skip_id)
             options[:include_id] = !options.delete(:skip_id)
           end
-
-          if options.key?(:local)
-            options[:remote] = !options.delete(:local)
-          end
         end
     end
   end

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -116,6 +116,16 @@ class FormWithActsLikeFormTagTest < FormWithTest
 
     assert_dom_equal expected, output_buffer
   end
+
+  def test_form_with_with_block_in_erb_and_local_true
+    output_buffer = render_erb("<%= form_with(url: 'http://www.example.com', local: true) do %>Hello world!<% end %>")
+
+    expected = whole_form("http://www.example.com", local: true) do
+      "Hello world!"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
 end
 
 class FormWithActsLikeFormForTest < FormWithTest


### PR DESCRIPTION
Fixes that the following ERB template would result in invalid HTML output:

```erb
 <%= form_with model: Post.new, local: true do |form| %>
 <% end %>
```

Specifically, the resulting form tag would have a spurious `remote` attribute:

```html
<form remote="false" ...>
```