### PR TITLE
Add missing spaces to button_tag api doc [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -461,7 +461,7 @@ module ActionView
       end
 
       # Creates a button element that defines a <tt>submit</tt> button,
-      # <tt>reset</tt>button or a generic button which can be used in
+      # <tt>reset</tt> button or a generic button which can be used in
       # JavaScript, for example. You can use the button tag as a regular
       # submit tag but it isn't supported in legacy browsers. However,
       # the button tag does allow for richer labels such as images and emphasis,


### PR DESCRIPTION
### Summary

Introduced missing space in reset button description. 

