### PR TITLE
fix with_routing test helper to make it work with api-only controllers

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make `with_routing` test helper work when testing controllers inheriting from `ActionController::API`
+
+    *Julia López*
+
 *   Use accept header in integration tests with `as: :json`
 
     Instead of appending the `format` to the request path, Rails will figure

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -152,8 +152,11 @@ module ActionDispatch
           _routes = @routes
 
           @controller.singleton_class.include(_routes.url_helpers)
-          @controller.view_context_class = Class.new(@controller.view_context_class) do
-            include _routes.url_helpers
+
+          if @controller.respond_to? :view_context_class
+            @controller.view_context_class = Class.new(@controller.view_context_class) do
+              include _routes.url_helpers
+            end
           end
         end
         yield @routes

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -128,6 +128,16 @@ module Admin
   end
 end
 
+class ApiOnlyController < ActionController::API
+  def nothing
+    head :ok
+  end
+
+  def redirect_to_new_route
+    redirect_to new_route_url
+  end
+end
+
 class ActionPackAssertionsControllerTest < ActionController::TestCase
   def test_render_file_absolute_path
     get :render_file_absolute_path
@@ -167,6 +177,20 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
       set.draw do
         get "photos", to: "action_pack_assertions#nothing", constraints: { subdomain: "admin" }
       end
+    end
+  end
+
+  def test_with_routing_works_with_api_only_controllers
+    @controller = ApiOnlyController.new
+
+    with_routing do |set|
+      set.draw do
+        get "new_route", to: "api_only#nothing"
+        get "redirect_to_new_route", to: "api_only#redirect_to_new_route"
+      end
+
+      process :redirect_to_new_route
+      assert_redirected_to "http://test.host/new_route"
     end
   end
 


### PR DESCRIPTION
Hi again! 👋 

I found another regression while migrating my api-only app to Rails 5 (I'm on fire 🔥) The `with_routing` test helper doesn't work for controllers that inherit from `ActionController::API` because the `ActionView::Rendering` module is not longer included as it was in the `rails-api` gem https://github.com/rails-api/rails-api/blob/master/lib/rails-api/action_controller/api.rb#L128

Hope you like the fix! ❤️ 
