### PR TITLE
Throw friendly error message when fixture is not a hash

### DIFF
--- a/activerecord/lib/active_record/fixture_set/file.rb
+++ b/activerecord/lib/active_record/fixture_set/file.rb
@@ -66,10 +66,13 @@ module ActiveRecord
         # Validate our unmarshalled data.
         def validate(data)
           unless Hash === data || YAML::Omap === data
-            raise Fixture::FormatError, "fixture is not a hash"
+            raise Fixture::FormatError, "fixture is not a hash: #{@file}"
           end
 
-          raise Fixture::FormatError unless data.all? { |name, row| Hash === row }
+          invalid = data.reject { |_, row| Hash === row }
+          if invalid.any?
+            raise Fixture::FormatError, "fixture key is not a hash: #{@file}, keys: #{invalid.keys.inspect}"
+          end
           data
         end
     end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -211,9 +211,19 @@ class FixturesTest < ActiveRecord::TestCase
   end
 
   def test_dirty_dirty_yaml_file
-    assert_raise(ActiveRecord::Fixture::FormatError) do
-      ActiveRecord::FixtureSet.new(Account.connection, "courses", Course, FIXTURES_ROOT + "/naked/yml/courses")
+    fixture_path = FIXTURES_ROOT + "/naked/yml/courses"
+    error = assert_raise(ActiveRecord::Fixture::FormatError) do
+      ActiveRecord::FixtureSet.new(Account.connection, "courses", Course, fixture_path)
     end
+    assert_equal "fixture is not a hash: #{fixture_path}.yml", error.to_s
+  end
+
+  def test_yaml_file_with_one_invalid_fixture
+    fixture_path = FIXTURES_ROOT + "/naked/yml/courses_with_invalid_key"
+    error = assert_raise(ActiveRecord::Fixture::FormatError) do
+      ActiveRecord::FixtureSet.new(Account.connection, "courses", Course, fixture_path)
+    end
+    assert_equal "fixture key is not a hash: #{fixture_path}.yml, keys: [\"two\"]", error.to_s
   end
 
   def test_yaml_file_with_invalid_column

--- a/activerecord/test/fixtures/naked/yml/courses_with_invalid_key.yml
+++ b/activerecord/test/fixtures/naked/yml/courses_with_invalid_key.yml
@@ -1,0 +1,3 @@
+one:
+  id: 1
+two: ['not a hash']


### PR DESCRIPTION
Right now when the fixture is not a Hash we throw an error message saying `"fixture is not a hash"`. This is not very user friendly because it's not telling the developer *which* fixture is invalid.

@rafaelfranca 