### PR TITLE
Raises exception when nesting respond_to calls

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -10,6 +10,15 @@ module AbstractController
   class ActionNotFound < StandardError
   end
 
+  # Raised when a nested respond_to is triggered.
+  class DoubleRespondToError < StandardError
+    DEFAULT_MESSAGE = "respond_to was called multiple times and matched with conflicting formats in this action. Please note that you may only call respond_to and match on a single format per action."
+
+    def initialize(message = nil)
+      super(message || DEFAULT_MESSAGE)
+    end
+  end
+
   # AbstractController::Base is a low-level API. Nobody should be
   # using it directly, and subclasses (like ActionController::Base) are
   # expected to provide their own +render+ method, since rendering means

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -195,10 +195,14 @@ module ActionController #:nodoc:
       yield collector if block_given?
 
       if format = collector.negotiate_format(request)
-        _process_format(format)
-        _set_rendered_content_type format
-        response = collector.response
-        response.call if response
+        if self.content_type && self.content_type != format.to_s
+          raise ::AbstractController::DoubleRespondToError
+        else
+          _process_format(format)
+          _set_rendered_content_type format
+          response = collector.response
+          response.call if response
+        end
       else
         raise ActionController::UnknownFormat
       end

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -100,6 +100,26 @@ class RespondToController < ActionController::Base
     end
   end
 
+  def using_conflicting_nested_js_then_html
+    respond_to do |outer_type|
+      outer_type.js do
+        respond_to do |inner_type|
+          inner_type.html { render body: "HTML" }
+        end
+      end
+    end
+  end
+
+  def using_non_conflicting_nested_js_then_js
+    respond_to do |outer_type|
+      outer_type.js do
+        respond_to do |inner_type|
+          inner_type.js { render body: "JS" }
+        end
+      end
+    end
+  end
+
   def custom_type_handling
     respond_to do |type|
       type.html { render body: "HTML"    }
@@ -426,6 +446,20 @@ class RespondToControllerTest < ActionController::TestCase
     get :using_defaults_with_type_list
     assert_equal "application/xml", @response.content_type
     assert_equal "<p>Hello world!</p>\n", @response.body
+  end
+
+  def test_using_conflicting_nested_js_then_html
+    @request.accept = "*/*"
+    assert_raises(AbstractController::DoubleRespondToError) do
+      get :using_conflicting_nested_js_then_html
+    end
+  end
+
+  def test_using_non_conflicting_nested_js_then_js
+    @request.accept = "*/*"
+    get :using_non_conflicting_nested_js_then_js
+    assert_equal "text/javascript", @response.content_type
+    assert_equal "JS", @response.body
   end
 
   def test_with_atom_content_type


### PR DESCRIPTION
Nesting `respond_to` calls can lead to unexpected behavior, so it should be
avoided. Currently, the first `respond_to` format match sets the content-type
for the resulting response. But, if a nested `respond_to` call occurs, it is possible
to match on a different format. For example:

``` ruby
    respond_to do |outer_type|
      outer_type.js do
        respond_to do |inner_type|
          inner_type.html { render body: "HTML" }
        end
      end
    end
```

Browsers will often include `*/*` in their `Accept` headers. In the above example,
such a request would result in the `outer_type.js` match setting the `content-type` of the response to `text/javascript`, while the `inner_type.html` match will
cause the actual response to return an "HTML" response body.

This change tries to minimize potential breakage by only raising an exception
if the nested respond_to calls are in conflict with each other. So, something
like the following example would not raise an exception:

``` ruby
    respond_to do |outer_type|
      outer_type.js do
        respond_to do |inner_type|
          inner_type.js { render body: "JS" }
        end
      end
    end
```

While the above is nested, it doesn't affect the content-type of the response. If people think it simpler/more obvious to just raise anytime a double `respond_to` occurs (ala a double render) that seems fine too. I'm conjecturing this could be a breaking change for some people, which is why I wanted to minimize breakage by only raising when we are in actual conflict. 

/cc @tenderlove - Since we had chatted about "expected behavior" of nested `respond_to` calls and the general feeling was "raise YugeError" :smile:. 