### PR TITLE
Backport `fd87169` to 5-0-stable

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -992,15 +992,13 @@ module ActiveRecord
       def insert_versions_sql(versions) # :nodoc:
         sm_table = ActiveRecord::Migrator.schema_migrations_table_name
 
-        if supports_multi_insert?
+        if versions.is_a?(Array)
           sql = "INSERT INTO #{sm_table} (version) VALUES\n"
           sql << versions.map {|v| "('#{v}')" }.join(",\n")
           sql << ";\n\n"
           sql
         else
-          versions.map { |version|
-            "INSERT INTO #{sm_table} (version) VALUES ('#{version}');"
-          }.join "\n\n"
+          "INSERT INTO #{sm_table} (version) VALUES ('#{versions}');"
         end
       end
 
@@ -1038,7 +1036,13 @@ module ActiveRecord
           if (duplicate = inserting.detect {|v| inserting.count(v) > 1})
             raise "Duplicate migration #{duplicate}. Please renumber your migrations to resolve the conflict."
           end
-          execute insert_versions_sql(inserting)
+          if supports_multi_insert?
+            execute insert_versions_sql(inserting)
+          else
+            inserting.each do |v|
+              execute insert_versions_sql(v)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
### Summary
This PR is backporting of https://github.com/rails/rails/commit/fd87169eb11fc4cfd9082dabe0a85f3bfa385c29.

I want this commit. Because I want to solve this problem.
https://github.com/rsim/oracle-enhanced/pull/1084