### PR TITLE
Show development mode exceptions with alert dialog for JavaScript requests

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,10 +1,14 @@
+*   Show development mode exceptions with alert dialog for JavaScript requests.
+
+    *Patrik Bóna*
+
 *   Use accept header in integration tests with `as: :json`
 
     Instead of appending the `format` to the request path. Rails will figure
     out the format from the header instead.
 
     This allows devs to use `:as` on routes that don't have a format.
-    
+
     Fixes #27144.
 
     *Kasper Timm Hansen*

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -93,7 +93,10 @@ module ActionDispatch
         template = create_template(request, wrapper)
         file = "rescues/#{wrapper.rescue_template}"
 
-        if request.xhr?
+        if request.format == "text/javascript"
+          body = template.render(template: file, layout: "rescues/javascript_layout", formats: [:text])
+          format = "text/javascript"
+        elsif request.xhr?
           body = template.render(template: file, layout: false, formats: [:text])
           format = "text/plain"
         else

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/javascript_layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/javascript_layout.erb
@@ -1,0 +1,1 @@
+alert("<%= j yield %>");

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -284,6 +284,15 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "rescue with JavaScript format for JavaScript requests" do
+    @app = DevelopmentApp
+
+    get "/", headers: { "action_dispatch.show_exceptions" => true,  "Accept" => "text/javascript" }
+    assert_response 500
+    assert_equal "text/javascript", response.content_type
+    assert_match(/alert\(\"RuntimeError\\npuke/, body)
+  end
+
   test "does not show filtered parameters" do
     @app = DevelopmentApp
 


### PR DESCRIPTION
### Summary

Previously when an exception occurred for a SJR request, then no error was shown. You had to check the server log, or request information via browser's web development tools.

This PRs shows backend exceptions for SJR requests immediately in the alert dialog.

Before:

![sjr-rails](https://cloud.githubusercontent.com/assets/522375/21256361/23684188-c372-11e6-9094-a89437b41262.gif)

After:

![sjr-rails-improved](https://cloud.githubusercontent.com/assets/522375/21256373/2f17a2ee-c372-11e6-99a6-28f24b137c1b.gif)

### Other Information

* I've tested it with Google Chrome, Safari and Firefox. It works great with all of them.
* I've tested it with `jquery_ujs` and `rails_ujs`. 