### PR TITLE
Tweak bigint PK handling

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -3,10 +3,8 @@ module ActiveRecord
     module MySQL
       module ColumnMethods
         def primary_key(name, type = :primary_key, **options)
-          if type == :primary_key && !options.key?(:default)
-            options[:auto_increment] = true
-            options[:limit] = 8
-          end
+          options[:auto_increment] = true if [:primary_key, :integer, :bigint].include?(type) && !options.key?(:default)
+          options[:limit] = 8 if [:primary_key].include?(type)
           super
         end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -4,8 +4,8 @@ module ActiveRecord
       module ColumnDumper
         def column_spec_for_primary_key(column)
           spec = super
-          if column.type == :integer && !column.auto_increment?
-            spec[:default] = schema_default(column) || "nil"
+          if [:integer, :bigint].include?(schema_type(column)) && !column.auto_increment?
+            spec[:default] ||= schema_default(column) || "nil"
           end
           spec[:unsigned] = "true" if column.unsigned?
           spec

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -42,6 +42,7 @@ module ActiveRecord
         # a record (as primary keys cannot be +nil+). This might be done via the
         # +SecureRandom.uuid+ method and a +before_save+ callback, for instance.
         def primary_key(name, type = :primary_key, **options)
+          options[:auto_increment] = true if [:primary_key, :integer, :bigint].include?(type) && !options.key?(:default)
           if type == :uuid
             options[:default] = options.fetch(:default, "gen_random_uuid()")
           elsif options.delete(:auto_increment) == true && %i(integer bigint).include?(type)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_definitions.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     module SQLite3
       module ColumnMethods
         def primary_key(name, type = :primary_key, **options)
-          if options.delete(:auto_increment) == true && %i(integer bigint).include?(type)
+          if %i(integer bigint).include?(type) && (options.delete(:auto_increment) == true || !options.key?(:default))
             type = :primary_key
           end
 

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -24,9 +24,8 @@ module ActiveRecord
           # Since 5.1 Postgres adapter uses bigserial type for primary
           # keys by default and MySQL uses bigint. This compat layer makes old migrations utilize
           # serial/int type instead -- the way it used to work before 5.1.
-          if options[:id].blank?
+          unless options.key?(:id)
             options[:id] = :integer
-            options[:auto_increment] = true
           end
 
           super


### PR DESCRIPTION
* Don't force PKs on tables that have explicitly opted out
* All integer-like PKs are autoincrement unless they have an explicit default

I think this should improve things for at least some of the issues @eileencodes ran into in #27374 -- it'll still require the manual upgrade process (schema load in 5.0, then fresh schema dump in 5.1 to get the updated `schema.rb`), but the resulting schema seems more likely to recreate a correct-looking DB.

(I'm also pondering whether we can/should improve on that upgrade-transition process.. but I consider that secondary for now, because it was a known limitation, not a straight bug.)

cc @jmccartie 

No test changes yet -- I'll see what breaks first, then hopefully just fix the tests to match.