### PR TITLE
Docs Command Line Arguments for Generators

### DIFF
--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -451,6 +451,26 @@ $ rails new thud -m https://gist.github.com/radar/722911/raw/
 
 Whilst the final section of this guide doesn't cover how to generate the most awesome template known to man, it will take you through the methods available at your disposal so that you can develop it yourself. These same methods are also available for generators.
 
+Adding Command Line Arguments
+-----------------------------
+Rails generators can be easily modified to accept custom command line arguments. This functionality comes from [Thor](http://www.rubydoc.info/github/erikhuda/thor/master/Thor/Base/ClassMethods#class_option-instance_method):
+
+```
+class_option :scope, type: :string, default: 'read_products'
+```
+
+Now our generator can be invoked as follows:
+
+```bash
+rails generate initializer --scope write_products
+```
+
+The command line arguments are accessed through the `options` method inside the generator class. e.g:
+
+```ruby
+@scope = options['scope']
+```
+
 Generator methods
 -----------------
 


### PR DESCRIPTION
### Summary

This PR adds a documentation section explaining how to add command line arguments to Rails generators. This functionality comes from Thor but I think its worth having a section in the Rails guide since it took some extra time to figure how to do this correctly.

Here is an example generator where I used command line arguments like this:
https://github.com/Shopify/shopify_app/blob/master/lib/generators/shopify_app/install/install_generator.rb