### PR TITLE
Change ActiveModel::Type::Helpers to :nodoc: [ci skip] 

### DIFF
--- a/activemodel/lib/active_model/type/helpers/accepts_multiparameter_time.rb
+++ b/activemodel/lib/active_model/type/helpers/accepts_multiparameter_time.rb
@@ -1,7 +1,7 @@
 module ActiveModel
   module Type
-    module Helpers
-      class AcceptsMultiparameterTime < Module # :nodoc:
+    module Helpers # :nodoc: all
+      class AcceptsMultiparameterTime < Module
         def initialize(defaults: {})
           define_method(:cast) do |value|
             if value.is_a?(Hash)

--- a/activemodel/lib/active_model/type/helpers/mutable.rb
+++ b/activemodel/lib/active_model/type/helpers/mutable.rb
@@ -1,7 +1,7 @@
 module ActiveModel
   module Type
-    module Helpers
-      module Mutable # :nodoc:
+    module Helpers # :nodoc: all
+      module Mutable
         def cast(value)
           deserialize(serialize(value))
         end

--- a/activemodel/lib/active_model/type/helpers/numeric.rb
+++ b/activemodel/lib/active_model/type/helpers/numeric.rb
@@ -1,7 +1,7 @@
 module ActiveModel
   module Type
-    module Helpers
-      module Numeric # :nodoc:
+    module Helpers # :nodoc: all
+      module Numeric
         def cast(value)
           value = \
             case value

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -2,8 +2,8 @@ require "active_support/core_ext/time/zones"
 
 module ActiveModel
   module Type
-    module Helpers
-      module TimeValue # :nodoc:
+    module Helpers # :nodoc: all
+      module TimeValue
         def serialize(value)
           value = apply_seconds_precision(value)
 


### PR DESCRIPTION
### Summary

`ActiveModel::Type::Helpers` is a namespace 'placeholder', as it has no native methods or constants.  All of its namespace class/module children are `:nodoc:`. but it is not.

PR changes it to `:nodoc:`

See #27385