### PR TITLE
`ARGV.shift` before calling Rails generators

### DIFF
--- a/railties/lib/rails/commands/generate/generate_command.rb
+++ b/railties/lib/rails/commands/generate/generate_command.rb
@@ -14,6 +14,8 @@ module Rails
         require_application_and_environment!
         load_generators
 
+        ARGV.shift
+
         Rails::Generators.invoke generator, args, behavior: :invoke, destination_root: Rails::Command.root
       end
     end

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -169,5 +169,20 @@ module ApplicationTests
       assert File.exist?(File.join(rails_root, "app/views/notifier_mailer/foo.text.erb"))
       assert File.exist?(File.join(rails_root, "app/views/notifier_mailer/foo.html.erb"))
     end
+
+    test "ARGV is mutated as expected" do
+      require "#{app_path}/config/environment"
+      Rails::Command.const_set("APP_PATH", "rails/all")
+
+      FileUtils.cd(rails_root) do
+        ARGV = ["mailer", "notifier", "foo"]
+        Rails::Command.const_set("ARGV", ARGV)
+        Rails::Command.invoke :generate, ARGV
+
+        assert_equal ["notifier", "foo"], ARGV
+      end
+
+      Rails::Command.send(:remove_const, "APP_PATH")
+    end
   end
 end


### PR DESCRIPTION
### Summary

Gems like rspec-rails depend on `ARGV` being shifted, and `scaffold`
(for example) not being the first item in `ARGV`. This behavior was lost in #26414. This should allow
rspec-rails to be passing on Rails master.

cc @kaspth 