### PR TITLE
make work bin/test scripts with line filter

### DIFF
--- a/tools/test.rb
+++ b/tools/test.rb
@@ -4,6 +4,8 @@ require "bundler"
 Bundler.setup
 
 require "rails/test_unit/minitest_plugin"
+require "rails/test_unit/line_filtering"
+require "active_support/test_case"
 
 module Rails
   # Necessary to get rerun-snippts working.
@@ -12,6 +14,7 @@ module Rails
   end
 end
 
+ActiveSupport::TestCase.extend Rails::LineFiltering
 Rails::TestUnitReporter.executable = "bin/test"
 Minitest.run_via[:rails] = true
 require "active_support/testing/autorun"


### PR DESCRIPTION
`Rails::LineFiltering` is not automatically loaded, need to load it explicitly.
Ref: 797f1dd, b6f935b

