### PR TITLE
ensure `#compact` of HWIDA to return HWIDA

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -269,6 +269,10 @@ module ActiveSupport
       dup.tap { |hash| hash.transform_values!(*args, &block) }
     end
 
+    def compact
+      dup.compact!
+    end
+
     # Convert to a regular hash with string keys.
     def to_hash
       _new_hash = Hash.new

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -589,6 +589,16 @@ class HashExtTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings
   end
 
+  def test_indifferent_compact
+    hash_contain_nil_value = @strings.merge("z" => nil)
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_contain_nil_value)
+    compacted_hash = hash.compact
+
+    assert_equal(@strings, compacted_hash)
+    assert_equal(hash_contain_nil_value, hash)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, compacted_hash
+  end
+
   def test_indifferent_to_hash
     # Should convert to a Hash with String keys.
     assert_equal @strings, @mixed.with_indifferent_access.to_hash


### PR DESCRIPTION
`Hash#compact` of Ruby native returns new hash.
Therefore, in order to return HWIDA as in the past version, need to
define own `#compact` to HWIDA.

Related: #26868
