### PR TITLE
Fix rake guides:generate:kindle error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :doc do
   gem "sdoc", "1.0.0.beta2"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators"
-  gem "kindlerb", ">= 1.0.1"
+  gem "kindlerb", "~> 1.2.0"
 end
 
 # Active Support.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.0.2)
-    kindlerb (1.0.1)
+    kindlerb (1.2.0)
       mustache
       nokogiri
     libxml-ruby (2.9.0)
@@ -396,7 +396,7 @@ DEPENDENCIES
   hiredis
   jquery-rails
   json (>= 2.0.0)
-  kindlerb (>= 1.0.1)
+  kindlerb (~> 1.2.0)
   libxml-ruby
   listen (>= 3.0.5, < 3.2)
   minitest (< 5.3.4)

--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -13,8 +13,9 @@ namespace :guides do
 
     desc "Generate .mobi file. The kindlegen executable must be in your PATH. You can get it for free from http://www.amazon.com/gp/feature.html?docId=1000765211"
     task :kindle do
-      unless `kindlerb -v 2> /dev/null` =~ /kindlerb 1.0.1/
-        abort "Please `gem install kindlerb` and make sure you have `kindlegen` in your PATH"
+      require 'kindlerb'
+      unless Kindlerb.kindlegen_available?
+        abort "Please run `setupkindlerb` to install kindlegen"
       end
       unless `convert` =~ /convert/
         abort "Please install ImageMagick`"

--- a/guides/rails_guides/kindle.rb
+++ b/guides/rails_guides/kindle.rb
@@ -1,9 +1,6 @@
 #!/usr/bin/env ruby
 
-unless `which kindlerb`
-  abort "Please gem install kindlerb"
-end
-
+require 'kindlerb'
 require "nokogiri"
 require "fileutils"
 require "yaml"
@@ -28,10 +25,9 @@ module Kindle
       generate_document_metadata(mobi_outfile)
 
       puts "Creating MOBI document with kindlegen. This may take a while."
-      cmd = "kindlerb . > #{File.absolute_path logfile} 2>&1"
-      puts cmd
-      system(cmd)
-      puts "MOBI document generated at #{File.expand_path(mobi_outfile, output_dir)}"
+      if Kindlerb.run(output_dir)
+        puts "MOBI document generated at #{File.expand_path(mobi_outfile, output_dir)}"
+      end
     end
   end
 


### PR DESCRIPTION
### Summary

PR #26851 updated kindlerb from 0.1.1 to 1.0.1 without changing the usage of kindlerb, but in fact kindlerb 1.0 has a breaking change: it does not provide `kindlerb` executable anymore. 

So the rake task `guides:generate:kindle` always reports "Please \`gem install kindlerb\` and make sure you have \`kindlegen\` in your PATH".

This PR updates kindlerb to 1.2.0, also updates the codes that use kindlerb.