### PR TITLE
Rails env for empty string env vars

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make `Rails.env` fall back to `development` when `RAILS_ENV` and `RACK_ENV` is an empty string.
+
+   *Daniel Deng*
+
 *   Add Webpack support in new apps via the --webpack option, which will delegate to the rails/webpacker gem.
 
     To generate a new app that has Webpack dependencies configured and binstubs for webpack and webpack-watcher:

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -7,6 +7,7 @@ require "active_support/dependencies/autoload"
 require "active_support/core_ext/kernel/reporting"
 require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/array/extract_options"
+require "active_support/core_ext/object/blank"
 
 require "rails/application"
 require "rails/version"
@@ -67,7 +68,7 @@ module Rails
     #   Rails.env.development? # => true
     #   Rails.env.production? # => false
     def env
-      @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development")
+      @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development")
     end
 
     # Sets the Rails environment.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -78,6 +78,18 @@ module ApplicationTests
       end
     end
 
+    test "Rails.env falls back to development if RAILS_ENV is blank and RACK_ENV is nil" do
+      with_rails_env("") do
+        assert_equal "development", Rails.env
+      end
+    end
+
+    test "Rails.env falls back to development if RACK_ENV is blank and RAILS_ENV is nil" do
+      with_rack_env("") do
+        assert_equal "development", Rails.env
+      end
+    end
+
     test "By default logs tags are not set in development" do
       restore_default_config
 


### PR DESCRIPTION
### The story:
I've got a weird issue where `Rails.application.config_for(:app_config)` returns `nil`.   
So I looked into the console and found out that `Rails.env` is an empty string.   
That was because I'm using `docker-compose` and it's setting `RAILS_ENV` to an empty string because I specified in `docker-compose.yml` but not set in my local env vars.  
That was an easy fix on my side but I always thought rails handles that edge case.   
That's why I'm submitting this PR to give rails the ability to fall back to `development` mode when this happens.

### The changes:
I've added 2 tests with `RAILS_ENV` and `RACK_ENV` being set to an empty string and `Rails.env` should be `development`. Also added the message to `CHANGELOG.md`.   

### P.S.
This is my first commit to rails repo and I tried to follow the guidelines for contributing. I skipped some steps that seems irrelevant but if I'm missing any step please let me know.

Daniel
