### PR TITLE
Fix test failure when output includes warnings

### DIFF
--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -58,7 +58,7 @@ module ApplicationTests
 
       test "migration status when schema migrations table is not present" do
         output = Dir.chdir(app_path) { `bin/rails db:migrate:status 2>&1` }
-        assert_equal "Schema migrations table does not exist yet.\n", output
+        assert_match /Schema migrations table does not exist yet.\n$/, output
       end
 
       test "test migration status" do


### PR DESCRIPTION
Right now we are getting a lot of warnings using Ruby 2.4.0-rc1 due to
Fixnum / Bignum deprecation, and even though functionality is correct,
the test fails.