### PR TITLE
Ruby 2.4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ env:
 rvm:
   - 2.2.6
   - 2.3.3
+  - 2.4.0-rc1
   - ruby-head
 
 matrix:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.3)
     connection_pool (2.2.0)
     cookiejar (0.3.3)
     curses (1.0.2)
@@ -329,7 +329,7 @@ GEM
       serverengine (~> 1.5.11)
       thor
       thread (~> 0.1.7)
-    sprockets (3.7.0)
+    sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-export (0.9.1)

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -173,7 +173,7 @@ module ApplicationTests
 
       secret = app.key_generator.generate_key("encrypted cookie")
       sign_secret = app.key_generator.generate_key("signed encrypted cookie")
-      encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret)
+      encryptor = ActiveSupport::MessageEncryptor.new(secret[0, ActiveSupport::MessageEncryptor.key_len], sign_secret)
 
       get "/foo/read_raw_cookie"
       assert_equal 1, encryptor.decrypt_and_verify(last_response.body)["foo"]
@@ -222,7 +222,7 @@ module ApplicationTests
 
       secret = app.key_generator.generate_key("encrypted cookie")
       sign_secret = app.key_generator.generate_key("signed encrypted cookie")
-      encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret)
+      encryptor = ActiveSupport::MessageEncryptor.new(secret[0, ActiveSupport::MessageEncryptor.key_len], sign_secret)
 
       get "/foo/read_raw_cookie"
       assert_equal 1, encryptor.decrypt_and_verify(last_response.body)["foo"]
@@ -281,7 +281,7 @@ module ApplicationTests
 
       secret = app.key_generator.generate_key("encrypted cookie")
       sign_secret = app.key_generator.generate_key("signed encrypted cookie")
-      encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret)
+      encryptor = ActiveSupport::MessageEncryptor.new(secret[0, ActiveSupport::MessageEncryptor.key_len], sign_secret)
 
       get "/foo/read_raw_cookie"
       assert_equal 2, encryptor.decrypt_and_verify(last_response.body)["foo"]


### PR DESCRIPTION
### Summary

This PR adds Ruby 2.4 compatibility to Rails. Below are the current test suite statuses for each of the Rails components:

- [x] Cable: PASSING
- [x] Mailer: PASSING
- [x] Pack: PASSING
- [x] View: PASSING
- [x] Job: PASSING
- [x] Model: PASSING
- [x] Record: PASSING
- [x] Support: PASSING
- [x] Railties: PASSING

This PR also adds Ruby v2.4.0-rc1 to the Travis matrix, to prevent any regressions, and also just to add this release line to our Travis matrix.

### Other Information

Small adjustments were needed in order to get CI passing. This includes two dependency upgrades (concurrent-ruby and sprockets), and one slight modification to the railties test suite (a similar patch was already applied on master in a different location).