### PR TITLE
Revise the "XML is not HTML" test

### DIFF
--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -100,11 +100,11 @@ HTML
     end
 
     def test_xml_output
-      response.content_type = "application/xml"
+      response.content_type = params[:response_as]
       render plain: <<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <root>
-  <area>area is an empty tag in HTML, raising an error if not in xml mode</area>
+  <area><p>area is an empty tag in HTML, so it won't contain this content</p></area>
 </root>
 XML
     end
@@ -374,18 +374,18 @@ XML
     assert_equal "OK", @response.body
   end
 
+  def test_should_impose_childless_html_tags_in_html
+    process :test_xml_output, params: { response_as: "text/html" }
+
+    # <area> auto-closes, so the <p> becomes a sibling
+    assert_select "root > area + p"
+  end
+
   def test_should_not_impose_childless_html_tags_in_xml
-    process :test_xml_output
+    process :test_xml_output, params: { response_as: "application/xml" }
 
-    begin
-      $stderr = StringIO.new
-      assert_select "area" #This will cause a warning if content is processed as HTML
-      $stderr.rewind && err = $stderr.read
-    ensure
-      $stderr = STDERR
-    end
-
-    assert err.empty?, err.inspect
+    # <area> is not special, so the <p> is its child
+    assert_select "root > area > p"
   end
 
   def test_assert_generates


### PR DESCRIPTION
It was depending on [a side-effect of the old html-scanner](https://github.com/rails/rails/blob/32553a2d76f4520e1456d5463c691310c22ebd2b/actionpack/lib/action_controller/vendor/html-scanner/html/document.rb#L31-L39), so was no longer proving what it intended to. Instead, assert more directly about the resulting observable difference.

@kaspth should this test even exist, or is this now really rails-html-sanitizer's job?

@maclover7 while we still ultimately want the Fixnum warning to go away, this removes the assertion it was tripping, freeing #27412