### PR TITLE
ActionCable should not raise when a connection is already open

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable/connection.coffee
+++ b/actioncable/app/assets/javascripts/action_cable/connection.coffee
@@ -23,7 +23,7 @@ class ActionCable.Connection
   open: =>
     if @isActive()
       ActionCable.log("Attempted to open WebSocket, but existing socket is #{@getState()}")
-      throw new Error("Existing connection must be closed before opening")
+      false
     else
       ActionCable.log("Opening WebSocket, current state is #{@getState()}, subprotocols: #{protocols}")
       @uninstallEventHandlers() if @webSocket?

--- a/actioncable/test/javascript/src/unit/consumer_test.coffee
+++ b/actioncable/test/javascript/src/unit/consumer_test.coffee
@@ -2,8 +2,11 @@
 {consumerTest} = ActionCable.TestHelpers
 
 module "ActionCable.Consumer", ->
-  consumerTest "#connect", connect: false, ({consumer, server, done}) ->
-    server.on("connection", done)
+  consumerTest "#connect", connect: false, ({consumer, server, assert, done}) ->
+    server.on "connection", ->
+      assert.equal consumer.connect(), false
+      done()
+
     consumer.connect()
 
   consumerTest "#disconnect", ({consumer, client, done}) ->


### PR DESCRIPTION
ActionCable was throwing a "Existing connection must be closed before
opening" exception which was being picked up as a production issue in
our error monitoring software. Since this happens pretty often on any
device that allows the browser to sleep (mobile) this error was getting
triggered often.

This change removes the exception, but keeps logging the occurrence. We
now return `false` to let the caller now that `open` failed.