### PR TITLE
Fix duplicable? for Complex and Rational

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Change return value of `Rational#duplicable?`, `ComplexClass#duplicable?`
+    to false.
+
+    *utilum*
+
 *   Change return value of `NilClass#duplicable?`, `FalseClass#duplicable?`,
     `TrueClass#duplicable?`, `Symbol#duplicable?` and `Numeric#duplicable?`
     to true with Ruby 2.4+. These classes can dup with Ruby 2.4+.

--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -121,3 +121,23 @@ class Method
     false
   end
 end
+
+class Complex
+  # Complexes are not duplicable:
+  #
+  # Complex(1).duplicable? # => false
+  # Complex(1).dup         # => TypeError: can't copy Complex
+  def duplicable?
+    false
+  end
+end
+
+class Rational
+  # Rationals are not duplicable:
+  #
+  # Rational(1).duplicable? # => false
+  # Rational(1).dup         # => TypeError: can't copy Rational
+  def duplicable?
+    false
+  end
+end

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -5,10 +5,10 @@ require "active_support/core_ext/numeric/time"
 
 class DuplicableTest < ActiveSupport::TestCase
   if RUBY_VERSION >= "2.4.0"
-    RAISE_DUP = [method(:puts)]
+    RAISE_DUP = [method(:puts), Complex(1), Rational(1)]
     ALLOW_DUP = ["1", Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal.new("4.56"), nil, false, true, :symbol, 1, 2.3]
   else
-    RAISE_DUP = [nil, false, true, :symbol, 1, 2.3, method(:puts)]
+    RAISE_DUP = [nil, false, true, :symbol, 1, 2.3, method(:puts), Complex(1), Rational(1)]
     ALLOW_DUP = ["1", Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal.new("4.56")]
   end
 


### PR DESCRIPTION
`ComplexClass` and `RationalClass` can not be duplicated but are not taken into account by `duplicable?`.

```
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", github: "rails/rails"
end

require "active_support"
require "active_support/core_ext/object/duplicable"
require "minitest/autorun"

class BugTest < Minitest::Test
  def test_complex_duplicable
    assert_raises(TypeError) { Complex(1).dup }
    refute Complex(1).duplicable?, "expected instance of Complex not to be `duplicable?`"
  end

  def test_rational_duplicable
    assert_raises(TypeError) { Rational(1).dup }
    refute Rational(1).duplicable?, "expected instance of Rational not to be `duplicable?`"
  end
end
```