### PR TITLE
Add channel_prefix support to AC redis/evented_redis adapters 

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter.rb
+++ b/actioncable/lib/action_cable/subscription_adapter.rb
@@ -4,5 +4,6 @@ module ActionCable
 
     autoload :Base
     autoload :SubscriberMap
+    autoload :ChannelPrefix
   end
 end

--- a/actioncable/lib/action_cable/subscription_adapter/channel_prefix.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/channel_prefix.rb
@@ -1,0 +1,26 @@
+module ActionCable
+  module SubscriptionAdapter
+    module ChannelPrefix # :nodoc:
+      def broadcast(channel, payload)
+        channel = channel_with_prefix(channel)
+        super
+      end
+
+      def subscribe(channel, callback, success_callback = nil)
+        channel = channel_with_prefix(channel)
+        super
+      end
+
+      def unsubscribe(channel, callback)
+        channel = channel_with_prefix(channel)
+        super
+      end
+
+      private
+        # Returns the channel name, including channel_prefix specified in cable.yml
+        def channel_with_prefix(channel)
+          [@server.config.cable[:channel_prefix], channel].compact.join(":")
+        end
+    end
+  end
+end

--- a/actioncable/lib/action_cable/subscription_adapter/evented_redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/evented_redis.rb
@@ -11,6 +11,8 @@ EventMachine.kqueue if EventMachine.kqueue?
 module ActionCable
   module SubscriptionAdapter
     class EventedRedis < Base # :nodoc:
+      prepend ChannelPrefix
+
       @@mutex = Mutex.new
 
       # Overwrite this factory method for EventMachine Redis connections if you want to use a different Redis connection library than EM::Hiredis.

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -6,6 +6,8 @@ require "redis"
 module ActionCable
   module SubscriptionAdapter
     class Redis < Base # :nodoc:
+      prepend ChannelPrefix
+
       # Overwrite this factory method for redis connections if you want to use a different Redis library than Redis.
       # This is needed, for example, when using Makara proxies for distributed Redis.
       cattr_accessor(:redis_connector) { ->(config) { ::Redis.new(url: config[:url]) } }

--- a/actioncable/test/subscription_adapter/channel_prefix.rb
+++ b/actioncable/test/subscription_adapter/channel_prefix.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class ActionCable::Server::WithIndependentConfig < ActionCable::Server::Base
+  # ActionCable::Server::Base defines config as a class variable.
+  # Need config to be an instance variable here as we're testing 2 separate configs
+  def config
+    @config ||= ActionCable::Server::Configuration.new
+  end
+end
+
+module ChannelPrefixTest
+  def test_channel_prefix
+    server2 = ActionCable::Server::WithIndependentConfig.new
+    server2.config.cable = alt_cable_config
+    server2.config.logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
+
+    adapter_klass = server2.config.pubsub_adapter
+
+    rx_adapter2 = adapter_klass.new(server2)
+    tx_adapter2 = adapter_klass.new(server2)
+
+    subscribe_as_queue("channel") do |queue|
+      subscribe_as_queue("channel", rx_adapter2) do |queue2|
+        @tx_adapter.broadcast("channel", "hello world")
+        tx_adapter2.broadcast("channel", "hello world 2")
+
+        assert_equal "hello world", queue.pop
+        assert_equal "hello world 2", queue2.pop
+      end
+    end
+  end
+
+  def alt_cable_config
+    cable_config.merge(channel_prefix: "foo")
+  end
+end

--- a/actioncable/test/subscription_adapter/evented_redis_test.rb
+++ b/actioncable/test/subscription_adapter/evented_redis_test.rb
@@ -1,8 +1,10 @@
 require "test_helper"
 require_relative "./common"
+require_relative "./channel_prefix"
 
 class EventedRedisAdapterTest < ActionCable::TestCase
   include CommonSubscriptionAdapterTest
+  include ChannelPrefixTest
 
   def setup
     super

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -1,8 +1,10 @@
 require "test_helper"
 require_relative "./common"
+require_relative "./channel_prefix"
 
 class RedisAdapterTest < ActionCable::TestCase
   include CommonSubscriptionAdapterTest
+  include ChannelPrefixTest
 
   def cable_config
     { adapter: "redis", driver: "ruby", url: "redis://127.0.0.1:6379/12" }

--- a/railties/lib/rails/generators/rails/app/templates/config/cable.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/cable.yml
@@ -7,3 +7,4 @@ test:
 production:
   adapter: redis
   url: redis://localhost:6379/1
+  channel_prefix: <%= app_name %>_production


### PR DESCRIPTION
### Summary

#27224 

In Redis, Pub/Sub has no relation to the key space. It was made to not interfere with it on any level, including database numbers.
Publishing on db 10, will be heard by a subscriber on db 1. 
(https://redis.io/topics/pubsub#database-amp-scoping)

To avoid problems when multiple Rails applications use the same Redis instance, the redis/evented_redis subscription adapters now support a channel_prefix option (specified in cable.yml)

Other backends do not appear to have this issue.

The generated cable.yml has also been updated to reflect this change. 