### PR TITLE
Type::Decimal casting raises exceptions on ruby 2.4.0-rc1

### DIFF
--- a/activemodel/lib/active_model/type/decimal.rb
+++ b/activemodel/lib/active_model/type/decimal.rb
@@ -5,8 +5,6 @@ module ActiveModel
     class Decimal < Value # :nodoc:
       include Helpers::Numeric
 
-      NUMERIC_STRING_PREFIX_REGEX = /\A-?\d+\.?\d*/.freeze
-
       def type
         :decimal
       end
@@ -25,8 +23,7 @@ module ActiveModel
             when ::Numeric
               BigDecimal(value, precision.to_i)
             when ::String
-              num_value = value[NUMERIC_STRING_PREFIX_REGEX] || "0"
-              BigDecimal(num_value, precision.to_i)
+              value.to_d rescue BigDecimal(0)
             else
               if value.respond_to?(:to_d)
                 value.to_d

--- a/activemodel/lib/active_model/type/decimal.rb
+++ b/activemodel/lib/active_model/type/decimal.rb
@@ -23,7 +23,7 @@ module ActiveModel
             when ::Numeric
               BigDecimal(value, precision.to_i)
             when ::String
-              value.to_d rescue BigDecimal(0)
+              value.to_d rescue nil
             else
               if value.respond_to?(:to_d)
                 value.to_d

--- a/activemodel/lib/active_model/type/decimal.rb
+++ b/activemodel/lib/active_model/type/decimal.rb
@@ -5,6 +5,8 @@ module ActiveModel
     class Decimal < Value # :nodoc:
       include Helpers::Numeric
 
+      NUMERIC_STRING_PREFIX_REGEX = /\A-?\d+\.?\d*/.freeze
+
       def type
         :decimal
       end
@@ -20,8 +22,11 @@ module ActiveModel
             case value
             when ::Float
               convert_float_to_big_decimal(value)
-            when ::Numeric, ::String
+            when ::Numeric
               BigDecimal(value, precision.to_i)
+            when ::String
+              num_value = value[NUMERIC_STRING_PREFIX_REGEX] || "0"
+              BigDecimal(num_value, precision.to_i)
             else
               if value.respond_to?(:to_d)
                 value.to_d

--- a/activemodel/test/cases/type/decimal_test.rb
+++ b/activemodel/test/cases/type/decimal_test.rb
@@ -11,6 +11,14 @@ module ActiveModel
         assert_equal BigDecimal.new("1"), type.cast(:"1")
       end
 
+      def test_type_cast_decimal_from_invalid_string
+        type = Decimal.new
+        assert_nil type.cast("")
+        assert_equal BigDecimal.new("1"), type.cast("1ignore")
+        assert_equal BigDecimal.new("0"), type.cast("bad1")
+        assert_equal BigDecimal.new("0"), type.cast("bad")
+      end
+
       def test_type_cast_decimal_from_float_with_large_precision
         type = Decimal.new(precision: ::Float::DIG + 2)
         assert_equal BigDecimal.new("123.0"), type.cast(123.0)

--- a/activemodel/test/cases/type/decimal_test.rb
+++ b/activemodel/test/cases/type/decimal_test.rb
@@ -15,8 +15,12 @@ module ActiveModel
         type = Decimal.new
         assert_nil type.cast("")
         assert_equal BigDecimal.new("1"), type.cast("1ignore")
-        assert_equal BigDecimal.new("0"), type.cast("bad1")
-        assert_equal BigDecimal.new("0"), type.cast("bad")
+
+        # This must not error.
+        # Returns nil on ruby 2.4.0, where #to_d is broken. Returns 0 on
+        # versions before that.
+        type.cast("bad")
+        type.cast("bad1")
       end
 
       def test_type_cast_decimal_from_float_with_large_precision

--- a/activemodel/test/cases/type/float_test.rb
+++ b/activemodel/test/cases/type/float_test.rb
@@ -9,6 +9,14 @@ module ActiveModel
         assert_equal 1.0, type.cast("1")
       end
 
+      def test_type_cast_float_from_invalid_string
+        type = Type::Float.new
+        assert_nil type.cast("")
+        assert_equal 1.0, type.cast("1ignore")
+        assert_equal 0.0, type.cast("bad1")
+        assert_equal 0.0, type.cast("bad")
+      end
+
       def test_changing_float
         type = Type::Float.new
 

--- a/activemodel/test/cases/type/integer_test.rb
+++ b/activemodel/test/cases/type/integer_test.rb
@@ -7,6 +7,7 @@ module ActiveModel
     class IntegerTest < ActiveModel::TestCase
       test "simple values" do
         type = Type::Integer.new
+        assert_nil type.cast("")
         assert_equal 1, type.cast(1)
         assert_equal 1, type.cast("1")
         assert_equal 1, type.cast("1ignore")


### PR DESCRIPTION
### Summary

Our `active_model` numeric types accept "slightly invalid" strings like `"1ignore"` (cast to `1`) and `"bad"` (cast to `0`). This is desirable. Users input these values, and they shouldn't result in error pages.

Under ruby `2.4.0-rc1`, entering `"bad"` into a decimal attribute will raise `ArgumentError: invalid value for BigDecimal():`.

In Ruby 2.4, `BigDecimal()`, as used by the Decimal cast, was changed so that it will raise `ArgumentError` when passed an invalid string, in order to be more consistent with `Integer()`, `Float()`, etc. The other numeric types use ex. `to_i` and `to_f`.

Unfortunately, we can't simply change `BigDecimal()` to `to_d`. `String#to_d` raises errors like `BigDecimal()`, unlike all the other `to_*` methods ([I have filed this as a bug in ruby](https://bugs.ruby-lang.org/issues/13062)).

In the first commit of this PR, I've added tests to test the casting of these "invalid" strings to `Type::Integer`, `Type::Float`, and `Type::Decimal`. All of these tests pass on ruby 2.3.3 and before. On ruby 2.4.0-rc1, the new `Type::Decimal` test fails. [You can see this in a Travis run of just the first commit on ruby 2.4.0-rc1](https://travis-ci.org/rails/rails/jobs/185947970).

In the second commit I've reproduced the existing behaviour and the behaviour of the other `to_*` methods by finding a numeric string at the start of the passed in value, and parsing that using `BigDecimal()`. This might be too slow, it's certainly not the nicest solution, but I wanted to get something to show the desired behaviour.


### Other Information

``` ruby
# ruby 2.3.3 or ruby 2.4.0preview3
> BigDecimal.new('')
=> #<BigDecimal:5642adf04ec0,'0.0',9(9)>
> ''.to_d
=> #<BigDecimal:5642adda7640,'0.0',9(9)>
```

``` ruby
# ruby 2.4.0-rc1
> BigDecimal.new('')
ArgumentError: invalid value for BigDecimal(): ""
> ''.to_d
ArgumentError: invalid value for BigDecimal(): ""
```

On [Solidus](https://github.com/solidusio/solidus), where I discovered this:

``` ruby
# ruby 2.3.3 or ruby 2.4.0preview3
> Spree::Variant.new(weight: 'heavy')
=> #<Spree::Variant:0x00562c17fb5060 id: nil, ..., weight: BigDecimal(0.0), ...>
```
``` ruby
# ruby 2.4.0-rc1
> Spree::Variant.new(weight: 'heavy')
ArgumentError: invalid value for BigDecimal(): ""
```


## See also

https://bugs.ruby-lang.org/issues/10286
https://bugs.ruby-lang.org/issues/13062
https://github.com/ruby/bigdecimal/commit/3081a627cebdc1fc119425c7a9f009dbb6bec8e8

EDIT: I originally filed this with the incorrect assumption that `BigDecimal("1ignore")` would fail in the same way that `Integer("1ignore")` does, but `BigDecimal` does not error in that case.