### PR TITLE
Remove warning in ActiveJob

### DIFF
--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -2,7 +2,7 @@ require "rake/testtask"
 
 #TODO: add qu back to the list after it support Rails 5.1
 ACTIVEJOB_ADAPTERS = %w(async inline delayed_job que queue_classic resque sidekiq sneakers sucker_punch backburner test)
-ACTIVEJOB_ADAPTERS -= %w(queue_classic) if defined?(JRUBY_VERSION)
+ACTIVEJOB_ADAPTERS.delete("queue_classic") if defined?(JRUBY_VERSION)
 
 task default: :test
 task test: "test:default"


### PR DESCRIPTION
Currently it causes:

```
activejob/Rakefile:5: warning: already initialized constant ACTIVEJOB_ADAPTERS
```

@guilleiguaran 