### PR TITLE
quiet generators log in test

### DIFF
--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -177,7 +177,7 @@ module ApplicationTests
       FileUtils.cd(rails_root) do
         ARGV = ["mailer", "notifier", "foo"]
         Rails::Command.const_set("ARGV", ARGV)
-        Rails::Command.invoke :generate, ARGV
+        quietly { Rails::Command.invoke :generate, ARGV }
 
         assert_equal ["notifier", "foo"], ARGV
       end


### PR DESCRIPTION
This quiet the following log.

```
   create  app/mailers/notifier_mailer.rb
   invoke  erb
   create    app/views/notifier_mailer
identical    app/views/layouts/mailer.text.erb
identical    app/views/layouts/mailer.html.erb
   create    app/views/notifier_mailer/foo.text.erb
   create    app/views/notifier_mailer/foo.html.erb
   invoke  test_unit
   create    test/mailers/notifier_mailer_test.rb
   create    test/mailers/previews/notifier_mailer_preview.rb
```
