### PR TITLE
Default fixtures path to spec/fixtures if it exists

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -78,6 +78,8 @@ module ActiveRecord
       def fixtures_path
         @fixtures_path ||= if ENV["FIXTURES_PATH"]
           File.join(root, ENV["FIXTURES_PATH"])
+        elsif File.exists?(File.join(root, "spec", "fixtures"))
+          File.join(root, "spec", "fixtures")
         else
           File.join(root, "test", "fixtures")
         end

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -16,7 +16,13 @@ if defined?(ActiveRecord::Base)
 
   class ActiveSupport::TestCase
     include ActiveRecord::TestFixtures
-    self.fixture_path = "#{Rails.root}/test/fixtures/"
+    self.fixture_path = if ENV["FIXTURES_PATH"]
+      "#{Rails.root}/#{ENV["FIXTURES_PATH"]}"
+    elsif File.exists?("#{Rails.root}/spec/fixtures/")
+      "#{Rails.root}/spec/fixtures/"
+    else
+      "#{Rails.root}/test/fixtures/"
+    end
     self.file_fixture_path = self.fixture_path + "files"
   end
 


### PR DESCRIPTION
### Summary

This patch allows the use of rspec + fixtures without having to override FIXTURES_PATH.

### Other Information

I couldn't find any existing areas in the tests related to fixtures_path handling, so I didn't write one.
If you'd like one, please advise where it should live.