### PR TITLE
Add a quote to an SQL insert statement of schema migration

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -994,15 +994,15 @@ module ActiveRecord
       end
 
       def insert_versions_sql(versions) # :nodoc:
-        sm_table = ActiveRecord::Migrator.schema_migrations_table_name
+        sm_table = quote_table_name(ActiveRecord::Migrator.schema_migrations_table_name)
 
         if versions.is_a?(Array)
           sql = "INSERT INTO #{sm_table} (version) VALUES\n"
-          sql << versions.map { |v| "('#{v}')" }.join(",\n")
+          sql << versions.map { |v| "(#{quote(v)})" }.join(",\n")
           sql << ";\n\n"
           sql
         else
-          "INSERT INTO #{sm_table} (version) VALUES ('#{versions}');"
+          "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions)});"
         end
       end
 
@@ -1032,7 +1032,7 @@ module ActiveRecord
         end
 
         unless migrated.include?(version)
-          execute "INSERT INTO #{sm_table} (version) VALUES ('#{version}')"
+          execute "INSERT INTO #{sm_table} (version) VALUES (#{quote(version)})"
         end
 
         inserting = (versions - migrated).select { |v| v < version }


### PR DESCRIPTION
I think it would be better to use `quote` method for SQL statements, because an evaluation of quote varies depending on the RDBMS.

Example code:

 ```ruby
 "INSERT INTO #{ActiveRecord::Base.connection.quote_table_name('schema_migrations')} (version) VALUES (#{ActiveRecord::Base.connection.quote('20161223120000')});"
 ```

 For example, there are the following differences in the above execution results.

 ## SQLite / PostgreSQL

 ```ruby
 "INSERT INTO \"schema_migrations\" (version) VALUES ('20161223120000');"
 ```

 ## MySQL

 ```ruby
 "INSERT INTO `schema_migrations` (version) VALUES ('20161223120000');"
 ```

 Thanks.