### PR TITLE
Add a record to target before any callbacks loads the record

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -206,10 +206,6 @@ module ActiveRecord
         def invertible_for?(record)
           false
         end
-
-        def append_record(record)
-          @target << record
-        end
     end
   end
 end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2475,7 +2475,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   test "double insertion of new object to association when same association used in the after create callback of a new object" do
     reset_callbacks(:save, Bulb) do
-      Bulb.after_save { |record| record.car.bulbs.to_a }
+      Bulb.after_save { |record| record.car.bulbs.load }
       car = Car.create!
       car.bulbs << Bulb.new
       assert_equal 1, car.bulbs.size


### PR DESCRIPTION
`append_record` was added at 15ddd51 for not double adding the record.
But adding `append_record` (checking `@target.include?(record)`) caused
performance regression #27434. Instead of checking not double adding the
record, add a record to target before any callbacks loads the record.

Fixes #27434.