### PR TITLE
fix indents of routes generated by controller generator

### DIFF
--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -44,7 +44,8 @@ module Rails
 
           # Create route
           #     get 'baz/index'
-          route = indent(%{  get '#{file_name}/#{action}'\n}, depth * 2)
+          leading_spaces = depth.zero? ? "" : "  "
+          route = indent(%{#{leading_spaces}get '#{file_name}/#{action}'\n}, depth * 2)
 
           # Create `end` ladder
           #   end

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -65,7 +65,7 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
 
   def test_add_routes
     run_generator
-    assert_file "config/routes.rb", /get 'account\/foo'/, /get 'account\/bar'/
+    assert_file "config/routes.rb", /^  get 'account\/foo'/, /^  get 'account\/bar'/
   end
 
   def test_skip_routes


### PR DESCRIPTION
```ruby
# Before:

  Rails.application.routes.draw do
      get 'account/bar'
  end

# After:

  Rails.application.routes.draw do
    get 'account/bar'
  end
```

