### PR TITLE
No need `:doc:` for `:nodoc:` classes [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -10,7 +10,7 @@ module ActiveRecord
         #
         #   1. To get the default_scope conditions for any of the other reflections in the chain
         #   2. To get the type conditions for any STI models in the chain
-        def target_scope # :doc:
+        def target_scope
           scope = super
           reflection.chain.drop(1).each do |reflection|
             relation = reflection.klass.all

--- a/activerecord/lib/active_record/attribute.rb
+++ b/activerecord/lib/active_record/attribute.rb
@@ -135,7 +135,7 @@ module ActiveRecord
       attr_reader :original_attribute
       alias_method :assigned?, :original_attribute
 
-      def original_value_for_database # :doc:
+      def original_value_for_database
         if assigned?
           original_attribute.original_value_for_database
         else
@@ -144,17 +144,17 @@ module ActiveRecord
       end
 
     private
-      def initialize_dup(other) # :doc:
+      def initialize_dup(other)
         if defined?(@value) && @value.duplicable?
           @value = @value.dup
         end
       end
 
-      def changed_from_assignment? # :doc:
+      def changed_from_assignment?
         assigned? && type.changed?(original_value, value, value_before_type_cast)
       end
 
-      def _original_value_for_database # :doc:
+      def _original_value_for_database
         type.serialize(original_value)
       end
 

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -83,7 +83,7 @@ module ActiveRecord
         end
       end
 
-      def scope_relation(record, relation) # :doc:
+      def scope_relation(record, relation)
         Array(options[:scope]).each do |scope_item|
           scope_value = if record.class._reflect_on_association(scope_item)
             record.association(scope_item).reader
@@ -96,7 +96,7 @@ module ActiveRecord
         relation
       end
 
-      def map_enum_attribute(klass, attribute, value) # :doc:
+      def map_enum_attribute(klass, attribute, value)
         mapping = klass.defined_enums[attribute.to_s]
         value = mapping[value] if value && mapping
         value

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -23,7 +23,7 @@ module ActiveRecord
         # Sets the default migration template that is being used for the generation of the migration.
         # Depending on command line arguments, the migration template and the table name instance
         # variables are set up.
-        def set_local_assigns! # :doc:
+        def set_local_assigns!
           @migration_template = "migration.rb"
           case file_name
           when /^(add|remove)_.*_(?:to|from)_(.*)/
@@ -42,13 +42,13 @@ module ActiveRecord
           end
         end
 
-        def set_index_names # :doc:
+        def set_index_names
           attributes.each_with_index do |attr, i|
             attr.index_name = [attr, attributes[i - 1]].map { |a| index_name_for(a) }
           end
         end
 
-        def index_name_for(attribute) # :doc:
+        def index_name_for(attribute)
           if attribute.foreign_key?
             attribute.name
           else

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -35,29 +35,29 @@ module ActiveRecord
 
       private
 
-        def attributes_with_index # :doc:
+        def attributes_with_index
           attributes.select { |a| !a.reference? && a.has_index? }
         end
 
         # FIXME: Change this file to a symlink once RubyGems 2.5.0 is required.
-        def generate_application_record # :doc:
+        def generate_application_record
           if self.behavior == :invoke && !application_record_exist?
             template "application_record.rb", application_record_file_name
           end
         end
 
         # Used by the migration template to determine the parent name of the model
-        def parent_class_name # :doc:
+        def parent_class_name
           options[:parent] || "ApplicationRecord"
         end
 
-        def application_record_exist? # :doc:
+        def application_record_exist?
           file_exist = nil
           in_root { file_exist = File.exist?(application_record_file_name) }
           file_exist
         end
 
-        def application_record_file_name # :doc:
+        def application_record_file_name
           @application_record_file_name ||= if mountable_engine?
             "app/models/#{namespaced_path}/application_record.rb"
           else


### PR DESCRIPTION
Follow up to 5b14129d8d4ad302b4e11df6bd5c7891b75f393c.

http://edgeapi.rubyonrails.org/classes/ActiveRecord/Attribute.html

r? @amatsuda 