### PR TITLE
do not mutate `object_name` of class in `fields_for`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Return correct object name in form helper method after `fields_for`.
+
+    Fixes #26931.
+
+    *Yuji Yaginuma*
+
 *   Use `ActionView::Resolver.caching?` (`config.action_view.cache_template_loading`)
     to enable template recompilation.
 

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1924,10 +1924,11 @@ module ActionView
           record_name   = model_name_from_record_or_class(record_object).param_key
         end
 
+        object_name = @object_name
         index = if options.has_key?(:index)
           options[:index]
         elsif defined?(@auto_index)
-          self.object_name = @object_name.to_s.sub(/\[\]$/, "")
+          object_name = object_name.to_s.sub(/\[\]$/, "")
           @auto_index
         end
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2262,11 +2262,13 @@ class FormHelperTest < ActionView::TestCase
       concat f.fields_for("comment[]", @comment) { |c|
         concat c.text_field(:name)
       }
+      concat f.text_field(:body)
     end
 
     expected = whole_form("/posts/123", "edit_post[]", "edit_post[]", method: "patch") do
       "<input name='post[123][title]' type='text' id='post_123_title' value='Hello World' />" +
-      "<input name='post[123][comment][][name]' type='text' id='post_123_comment__name' value='new comment' />"
+      "<input name='post[123][comment][][name]' type='text' id='post_123_comment__name' value='new comment' />" +
+      "<input name='post[123][body]' type='text' id='post_123_body' value='Back to the hill and over it again!' />"
     end
 
     assert_dom_equal expected, output_buffer


### PR DESCRIPTION
Since it affects the entire form, should not mutate `object_name` of class.

Fixes #26931

