### PR TITLE
Add protect_from_forgery to ActionController::Base

### DIFF
--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -250,7 +250,9 @@ module ActionController
       include mod
     end
     setup_renderer!
-
+    
+    protect_from_forgery with: :null_session
+    
     # Define some internal variables that should not be propagated to the view.
     PROTECTED_IVARS = AbstractController::Rendering::DEFAULT_PROTECTED_INSTANCE_VARIABLES + %i(
       @_params @_response @_request @_config @_url_options @_action_has_layout @_view_context_class

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -234,7 +234,8 @@ module ActionController #:nodoc:
       # forgery protection enabled for this request) then also verify that
       # we aren't serving an unauthorized cross-origin response.
       def verify_same_origin_request # :doc:
-        if marked_for_same_origin_verification? && non_xhr_javascript_response?
+        if protect_against_forgery? && marked_for_same_origin_verification? &&
+             non_xhr_javascript_response?
           if logger && log_warning_on_csrf_failure
             logger.warn CROSS_ORIGIN_JAVASCRIPT_WARNING
           end

--- a/actionpack/test/controller/content_type_test.rb
+++ b/actionpack/test/controller/content_type_test.rb
@@ -1,6 +1,8 @@
 require "abstract_unit"
 
 class OldContentTypeController < ActionController::Base
+  self.allow_forgery_protection = false
+
   # :ported:
   def render_content_type_from_body
     response.content_type = Mime[:rss]

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -552,15 +552,15 @@ class FilterTest < ActionController::TestCase
   end
 
   def test_added_action_to_inheritance_graph
-    assert_equal [ :ensure_login ], TestController.before_actions
+    assert_equal [ :verify_authenticity_token, :ensure_login ], TestController.before_actions
   end
 
   def test_base_class_in_isolation
-    assert_equal [ ], ActionController::Base.before_actions
+    assert_equal [ :verify_authenticity_token ], ActionController::Base.before_actions
   end
 
   def test_prepending_action
-    assert_equal [ :wonderful_life, :ensure_login ], PrependingController.before_actions
+    assert_equal [ :wonderful_life, :verify_authenticity_token, :ensure_login ], PrependingController.before_actions
   end
 
   def test_running_actions

--- a/actionpack/test/controller/mime/accept_format_test.rb
+++ b/actionpack/test/controller/mime/accept_format_test.rb
@@ -1,6 +1,8 @@
 require "abstract_unit"
 
 class StarStarMimeController < ActionController::Base
+  self.allow_forgery_protection = false
+
   layout nil
 
   def index
@@ -29,6 +31,8 @@ class StarStarMimeControllerTest < ActionController::TestCase
 end
 
 class AbstractPostController < ActionController::Base
+  self.allow_forgery_protection = false
+
   self.view_paths = File.dirname(__FILE__) + "/../../fixtures/post_test/"
 end
 

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -2,6 +2,8 @@ require "abstract_unit"
 require "active_support/log_subscriber/test_helper"
 
 class RespondToController < ActionController::Base
+  self.allow_forgery_protection = false
+
   layout :set_layout
 
   before_action {

--- a/actionpack/test/controller/new_base/render_layout_test.rb
+++ b/actionpack/test/controller/new_base/render_layout_test.rb
@@ -67,6 +67,8 @@ module ControllerLayouts
   end
 
   class MismatchFormatController < ::ApplicationController
+    self.allow_forgery_protection = false
+
     self.view_paths = [ActionView::FixtureResolver.new(
       "layouts/application.html.erb" => "<html><%= yield %></html>",
       "controller_layouts/mismatch_format/index.xml.builder" => "xml.instruct!",
@@ -101,6 +103,8 @@ module ControllerLayouts
   end
 
   class FalseLayoutMethodController < ::ApplicationController
+    self.allow_forgery_protection = false
+
     self.view_paths = [ActionView::FixtureResolver.new(
       "controller_layouts/false_layout_method/index.js.erb" => "alert('foo');"
     )]


### PR DESCRIPTION
This PR fixes all the test failures that are introduced by https://github.com/rails/rails/pull/27362. 