### PR TITLE
enable :doc: for matched_attribute_method and merged_options [ci skip]

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -464,7 +464,7 @@ module ActiveModel
 
       # Returns a struct representing the matching attribute method.
       # The struct's attributes are prefix, base and suffix.
-      def matched_attribute_method(method_name)
+      def matched_attribute_method(method_name) # :doc:
         matches = self.class.send(:attribute_method_matchers_matching, method_name)
         matches.detect { |match| attribute_method?(match.attr_name) }
       end

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -510,7 +510,7 @@ module ActiveSupport
         end
 
         # Merges the default options with ones specific to a method call.
-        def merged_options(call_options)
+        def merged_options(call_options) # :doc:
           if call_options
             options.merge(call_options)
           else


### PR DESCRIPTION
* matched_attribute_method have proper documentation, it's calling from method_missing and respond_to methods so we can enable for doc 

* merged_options is also calling from various methods in same class so it can be enable for doc
