### PR TITLE
Optimize Journey::Route#score for url_for

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -92,7 +92,11 @@ module ActionDispatch
           else
             routes = non_recursive(cache, options)
 
-            hash = routes.group_by { |_, r| r.score(options) }
+            supplied_keys = options.each_with_object({}) do |(k, v), h|
+              h[k.to_s] = true if v
+            end
+
+            hash = routes.group_by { |_, r| r.score(supplied_keys) }
 
             hash.keys.sort.reverse_each do |score|
               break if score < 0

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -96,13 +96,18 @@ module ActionDispatch
         required_parts + required_defaults.keys
       end
 
-      def score(constraints)
+      def score(supplied_keys)
         required_keys = path.required_names
-        supplied_keys = constraints.map { |k, v| v && k.to_s }.compact
 
-        return -1 unless (required_keys - supplied_keys).empty?
+        required_keys.each do |k|
+          return -1 unless supplied_keys.include?(k)
+        end
 
-        score = (supplied_keys & path.names).length
+        score = 0
+        path.names.each do |k|
+          score += 1 if supplied_keys.include?(k)
+        end
+
         score + (required_defaults.length * 2)
       end
 

--- a/actionpack/test/journey/route_test.rb
+++ b/actionpack/test/journey/route_test.rb
@@ -96,7 +96,7 @@ module ActionDispatch
         path = Path::Pattern.from_string "/:controller(/:action(/:id))(.:format)"
         generic = Route.build "name", nil, path, constraints, [], {}
 
-        knowledge = { id: 20, controller: "pages", action: "show" }
+        knowledge = { "id" => true, "controller" => true, "action" => true }
 
         routes = [specific, generic]
 


### PR DESCRIPTION
### Summary

I have an application with a large routeset (a few thousand).  This application uses `url_for` in some circumstances, which, when combined with the large routeset, contribute a significant amount of allocations (and wall time) to the overall request.  Named route helpers sidestep the issue (and end up being ~25x faster against my test case).  Still, the `url_for` case can be significantly optimized.

I set up a benchmark under profiling that was (roughly):

```
view_context = ApplicationController.new.view_context

100.times do
  %w(a b c d e f).each do |id|
    view_context.url_for(controller: 'foo', action: 'bar', type: id)
  end
end
```

Against the base code, `Route#score` allocated 4.3 million objects

![baseline allocations](https://cloud.githubusercontent.com/assets/4259/21530261/4816bf2e-ccf4-11e6-8a06-31e11e80fe41.png)

and took 2.5 seconds to run.

After these changes allocations in `Route#score` were reduced to 21k.

![after allocations](https://cloud.githubusercontent.com/assets/4259/21530393/66628dc2-ccf5-11e6-984a-70892e0671a4.png)

and it took 0.57 seconds to run.
