### PR TITLE
Upgrade to nio4r 2.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ PATH
   specs:
     actioncable (5.1.0.alpha)
       actionpack (= 5.1.0.alpha)
-      nio4r (~> 1.2)
+      nio4r (~> 2.0)
       websocket-driver (~> 0.6.1)
     actionmailer (5.1.0.alpha)
       actionpack (= 5.1.0.alpha)
@@ -231,7 +231,7 @@ GEM
     mysql2 (0.4.5)
     mysql2 (0.4.5-x64-mingw32)
     mysql2 (0.4.5-x86-mingw32)
-    nio4r (1.2.1)
+    nio4r (2.0.0)
     nokogiri (1.7.0)
       mini_portile2 (~> 2.1.0)
     nokogiri (1.7.0-x64-mingw32)

--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "actionpack", version
 
-  s.add_dependency "nio4r",            "~> 1.2"
+  s.add_dependency "nio4r",            "~> 2.0"
   s.add_dependency "websocket-driver", "~> 0.6.1"
 end


### PR DESCRIPTION
I've just released nio4r 2.0.0.

nio4r 2.0.0 primarily includes new features and bugfixes, with few breaking changes. The primary reason for bumping nio4r's major version is dropping support for all Ruby versions prior to 2.2.2, so as to match Rails 5.

Full release announcement here:

https://groups.google.com/forum/#!topic/socketry/ZDIUj1ufiJ8