### PR TITLE
Should not update children when the parent creation with no reason

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -38,10 +38,12 @@ module ActiveRecord
       def insert_record(record, validate = true, raise = false)
         ensure_not_nested
 
-        if raise
-          record.save!(validate: validate)
-        else
-          return unless record.save(validate: validate)
+        if record.new_record? || record.has_changes_to_save?
+          if raise
+            record.save!(validate: validate)
+          else
+            return unless record.save(validate: validate)
+          end
         end
 
         save_through_record(record)

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1391,6 +1391,14 @@ module AutosaveAssociationOnACollectionAssociationTests
     assert_equal "Squawky", parrot.reload.name
   end
 
+  def test_should_not_update_children_when_parent_creation_with_no_reason
+    parrot = Parrot.create!(name: "Polly")
+    assert_equal 0, parrot.updated_count
+
+    Pirate.create!(parrot_ids: [parrot.id], catchphrase: "Arrrr")
+    assert_equal 0, parrot.reload.updated_count
+  end
+
   def test_should_automatically_validate_the_associated_models
     @pirate.send(@association_name).each { |child| child.name = "" }
 

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -13,6 +13,11 @@ class Parrot < ActiveRecord::Base
   def cancel_save_callback_method
     throw(:abort)
   end
+
+  before_update :increment_updated_count
+  def increment_updated_count
+    self.updated_count += 1
+  end
 end
 
 class LiveParrot < Parrot

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -574,6 +574,7 @@ ActiveRecord::Schema.define do
     t.column :color, :string
     t.column :parrot_sti_class, :string
     t.column :killer_id, :integer
+    t.column :updated_count, :integer, default: 0
     if subsecond_precision_supported?
       t.column :created_at, :datetime, precision: 0
       t.column :created_on, :datetime, precision: 0


### PR DESCRIPTION
This issue was introduced with d849f42 to solve #19782. However, we can
solve #19782 without causing the issue. It is enough to save only when
necessary.

Fixes #27338.