### PR TITLE
Sync the visibility of `sql_for_insert` to private

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -134,7 +134,7 @@ module ActiveRecord
 
           super
         end
-        protected :sql_for_insert
+        private :sql_for_insert
 
         def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil)
           if use_insert_returning? || pk == false


### PR DESCRIPTION
The visibility of all internal protected methods was changed to private
since 5b14129.