### PR TITLE
Bump Arel version to 8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "jquery-rails"
 gem "coffee-rails"
 gem "sass-rails"
 gem "turbolinks", "~> 5"
+gem "arel", github: "rails/arel", branch: "master"
 
 # require: false so bcrypt is loaded only when has_secure_password is used.
 # This is to avoid Active Model (and by extension the entire framework)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,13 @@ GIT
       websocket
 
 GIT
+  remote: https://github.com/rails/arel.git
+  revision: b26638ef041953992010590b31615c519fa0ea7d
+  branch: master
+  specs:
+    arel (8.0.0)
+
+GIT
   remote: https://github.com/resque/resque.git
   revision: 835a4a7e61a2e33832dbf11975ecfab54af293c6
   specs:
@@ -83,7 +90,7 @@ PATH
     activerecord (5.1.0.alpha)
       activemodel (= 5.1.0.alpha)
       activesupport (= 5.1.0.alpha)
-      arel (~> 7.0)
+      arel (~> 8.0)
     activesupport (5.1.0.alpha)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -114,7 +121,6 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     amq-protocol (2.0.1)
-    arel (7.1.4)
     ast (2.3.0)
     backburner (1.3.1)
       beaneater (~> 1.0)
@@ -193,6 +199,8 @@ GEM
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     ffi (1.9.14)
+    ffi (1.9.14-x64-mingw32)
+    ffi (1.9.14-x86-mingw32)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hiredis (0.6.1)
@@ -373,6 +381,7 @@ DEPENDENCIES
   activerecord-jdbcmysql-adapter (>= 1.3.0)
   activerecord-jdbcpostgresql-adapter (>= 1.3.0)
   activerecord-jdbcsqlite3-adapter (>= 1.3.0)
+  arel!
   backburner
   bcrypt (~> 3.1.11)
   benchmark-ips

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", version
   s.add_dependency "activemodel",   version
 
-  s.add_dependency "arel", "~> 7.0"
+  s.add_dependency "arel", "~> 8.0"
 end

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -246,6 +246,7 @@ module Rails
 
       def rails_gemfile_entry
         dev_edge_common = [
+          GemfileEntry.github("arel", "rails/arel")
         ]
         if options.dev?
           [


### PR DESCRIPTION
### Summary

Since rails/arel#462 including https://github.com/rails/arel/commit/ce700cb9bd750703f19d71c47e7c709f76773b86 Arel::VERSION is now '8.0.0'. This pull request updates ActiveRecord dependency with Arel.

