### PR TITLE
remove redefined warning Enumerable#sum

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -1,4 +1,7 @@
 module Enumerable
+  if instance_methods.include?(:sum)
+    alias :orig_sum :sum
+  end
   # Calculates a sum from the elements.
   #
   #  payments.sum { |p| p.price * p.tax_rate }


### PR DESCRIPTION
Ruby2.4 has Enumerable#sum.
I found warning of redefined  Enumerable#sum.

```
$ ruby -v -w -r ./lib/active_support/core_ext/enumerable.rb  -e ''
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-darwin15]
/Users/takkanm/src/github.com/rails/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
```
