### PR TITLE
Allow log remote ip addres when config.action_dispatch.trusted_proxie…

### DIFF
--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -42,11 +42,12 @@ module Rails
           middleware.use ::Rack::MethodOverride unless config.api_only
           middleware.use ::ActionDispatch::RequestId
 
+          middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
           # Must come after Rack::MethodOverride to properly log overridden methods
+          # Must come after ActionDispatch::RemoteIP to properly log ip address
           middleware.use ::Rails::Rack::Logger, config.log_tags
           middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
           middleware.use ::ActionDispatch::DebugExceptions, app, config.debug_exception_response_format
-          middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
 
           unless config.cache_classes
             middleware.use ::ActionDispatch::Reloader, app.reloader

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -30,10 +30,10 @@ module ApplicationTests
         "Rack::Runtime",
         "Rack::MethodOverride",
         "ActionDispatch::RequestId",
+        "ActionDispatch::RemoteIp", # Must come before Rails::Rack::Logger to properly log request_id
         "Rails::Rack::Logger", # must come after Rack::MethodOverride to properly log overridden methods
         "ActionDispatch::ShowExceptions",
         "ActionDispatch::DebugExceptions",
-        "ActionDispatch::RemoteIp",
         "ActionDispatch::Reloader",
         "ActionDispatch::Callbacks",
         "ActiveRecord::Migration::CheckPending",


### PR DESCRIPTION
My attempt to push #19710 forward (by @batizhevsky)
I changed comment to read `ip address` vs `remote_id`.
Please let me know if `remote_id` was indeed the correct text.
/cc @matthewd 

Closes #19710

----
original pr as follows:

Related to #5223
Logger set before remote_ip detected properly, in view of config.action_dispatch.trusted_proxies was set custom list of local IP addressed

settings in `application.rb`

```ruby
config.log_tags = [:uuid, :remote_ip]
config.action_dispatch.trusted_proxies = %w(127.0.0.1 ::1 fc00::/7 172.16.0.0/12).map {
  |proxy| IPAddr.new(proxy) }
```

command to test:

```
curl localhost:3000 -H "X-Forwarded-For: 192.168.1.1"
```
in log before:

```
[2015-04-09 17:54:01.796 SAMT] DEBUG [4b554d96-8348-4cd7-96ab-124fdd6499d2] [127.0.0.1]
```

after patch:

```
[2015-04-09 17:59:15.600 SAMT] DEBUG [33d07bf1-a74a-4e42-a6b2-66f82133d797] [192.168.1.1]
```