### PR TITLE
Mark :GeneratedAssociationMethods also as private_constant

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -239,7 +239,9 @@ module ActiveRecord
       def generated_association_methods
         @generated_association_methods ||= begin
           mod = const_set(:GeneratedAssociationMethods, Module.new)
+          private_constant :GeneratedAssociationMethods
           include mod
+
           mod
         end
       end


### PR DESCRIPTION
- After https://github.com/rails/rails/commit/64e5b897ac944a05a33275e3828a3d4047a6b457,
  only :GeneratedAssociationMethods was remaining to be marked as
  private constant, so marked it as well.
- Before:
        >> User.constants(false)
        => [:GeneratedAssociationMethods]
- After:
        >> User.constants(false)
        => []

r? @matthewd 

