### PR TITLE
remove `skip_bundle` option from plugin generator

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -42,9 +42,6 @@ module Rails
         class_option :skip_gemfile,       type: :boolean, default: false,
                                           desc: "Don't create a Gemfile"
 
-        class_option :skip_bundle,        type: :boolean, aliases: "-B", default: false,
-                                          desc: "Don't run bundle install"
-
         class_option :skip_git,           type: :boolean, aliases: "-G", default: false,
                                           desc: "Skip .gitignore file"
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -175,6 +175,9 @@ module Rails
       class_option :api, type: :boolean,
                          desc: "Preconfigure smaller stack for API only apps"
 
+      class_option :skip_bundle, type: :boolean, aliases: "-B", default: false,
+                                 desc: "Don't run bundle install"
+
       def initialize(*args)
         super
 


### PR DESCRIPTION
Because `bundle install` is not executed regardless of whether the option
is specified or not.

Ref: fbd1e98cf983572ca9884f17f933ffe92833632a

