### PR TITLE
Dump schema cache for custom connection

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -269,10 +269,7 @@ db_namespace = namespace :db do
       task dump: [:environment, :load_config] do
         conn = ActiveRecord::Base.connection
         filename = File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "schema_cache.yml")
-
-        conn.schema_cache.clear!
-        conn.data_sources.each { |table| conn.schema_cache.add(table) }
-        open(filename, "wb") { |f| f.write(YAML.dump(conn.schema_cache)) }
+        ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(conn, filename)
       end
 
       desc "Clears a db/schema_cache.yml file."

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -275,6 +275,16 @@ module ActiveRecord
         end
       end
 
+      # Dumps the schema cache in YAML format for the connection into the file
+      #
+      # ==== Examples:
+      #   ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(ActiveRecord::Base.connection, "tmp/schema_dump.yaml")
+      def dump_schema_cache(conn, filename)
+        conn.schema_cache.clear!
+        conn.data_sources.each { |table| conn.schema_cache.add(table) }
+        open(filename, "wb") { |f| f.write(YAML.dump(conn.schema_cache)) }
+      end
+
       private
 
         def class_for_adapter(adapter)

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -85,6 +85,16 @@ module ActiveRecord
     end
   end
 
+  class DatabaseTasksDumpSchemaCacheTest < ActiveRecord::TestCase
+    def test_dump_schema_cache
+      path = "/tmp/my_schema_cache.yml"
+      ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(ActiveRecord::Base.connection, path)
+      assert File.file?(path)
+    ensure
+      FileUtils.rm_rf(path)
+    end
+  end
+
   class DatabaseTasksCreateAllTest < ActiveRecord::TestCase
     def setup
       @configurations = { "development" => { "database" => "my-db" } }


### PR DESCRIPTION
Today `rake db:schema:cache:dump` only supports dumping cache for a
single connection (`ActiveRecord::Base.connection`). This doesn't work
for apps with multiple databases.

This PR makes `DatabaseTasks` to provide an API for dumping schema cache
for any connection.

The use case: today at Shopify we have to patch `rake db:schema:cache:dump` to accomodate dumping schema cache for multiple databases:

```ruby
sharded_connections.each do |conn|
  conn.schema_cache.clear!
  conn.data_sources.each { |table| conn.schema_cache.add(table) }
  filename = filename_for_conn(conn)
  open(filename, "wb") { |f| f.write(YAML.dump(conn.schema_cache)) }
end
```

This could be simplified with `ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache` that the PR introduces.

@kaspth @rafaelfranca 