### PR TITLE
Extract `casted_true`/`casted_false` for `Type::ImmutableString`

### DIFF
--- a/activemodel/lib/active_model/type/immutable_string.rb
+++ b/activemodel/lib/active_model/type/immutable_string.rb
@@ -8,8 +8,8 @@ module ActiveModel
       def serialize(value)
         case value
         when ::Numeric, ActiveSupport::Duration then value.to_s
-        when true then "t"
-        when false then "f"
+        when true then casted_true
+        when false then casted_false
         else super
         end
       end
@@ -19,11 +19,19 @@ module ActiveModel
         def cast_value(value)
           result = \
             case value
-            when true then "t"
-            when false then "f"
+            when true then casted_true
+            when false then casted_false
             else value.to_s
             end
           result.freeze
+        end
+
+        def casted_true
+          "t".freeze
+        end
+
+        def casted_false
+          "f".freeze
         end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -979,22 +979,14 @@ module ActiveRecord
         end
 
         class MysqlString < Type::String # :nodoc:
-          def serialize(value)
-            case value
-            when true then MySQL::Quoting::QUOTED_TRUE
-            when false then MySQL::Quoting::QUOTED_FALSE
-            else super
-            end
-          end
-
           private
 
-            def cast_value(value)
-              case value
-              when true then MySQL::Quoting::QUOTED_TRUE
-              when false then MySQL::Quoting::QUOTED_FALSE
-              else super
-              end
+            def casted_true
+              MySQL::Quoting::QUOTED_TRUE
+            end
+
+            def casted_false
+              MySQL::Quoting::QUOTED_FALSE
             end
         end
 


### PR DESCRIPTION
The only difference between `Type::ImmutableString` and its subclasses
is the representation of the casted booleans. Prefer extracting
`casted_true`/`casted_false` and override these by subclasses.