### PR TITLE
Change `timestamp_attributes_for_{create,update}` from symbol to string

### DIFF
--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   # = Active Record \Timestamp
   #
@@ -58,7 +59,6 @@ module ActiveRecord
         current_time = current_time_from_proper_timezone
 
         all_timestamp_attributes.each do |column|
-          column = column.to_s
           if has_attribute?(column) && !attribute_present?(column)
             write_attribute(column, current_time)
           end
@@ -73,7 +73,6 @@ module ActiveRecord
         current_time = current_time_from_proper_timezone
 
         timestamp_attributes_for_update_in_model.each do |column|
-          column = column.to_s
           next if will_save_change_to_attribute?(column)
           write_attribute(column, current_time)
         end
@@ -86,11 +85,11 @@ module ActiveRecord
     end
 
     def timestamp_attributes_for_create_in_model
-      timestamp_attributes_for_create.select { |c| self.class.column_names.include?(c.to_s) }
+      timestamp_attributes_for_create.select { |c| self.class.column_names.include?(c) }
     end
 
     def timestamp_attributes_for_update_in_model
-      timestamp_attributes_for_update.select { |c| self.class.column_names.include?(c.to_s) }
+      timestamp_attributes_for_update.select { |c| self.class.column_names.include?(c) }
     end
 
     def all_timestamp_attributes_in_model
@@ -98,11 +97,11 @@ module ActiveRecord
     end
 
     def timestamp_attributes_for_update
-      [:updated_at, :updated_on]
+      ["updated_at", "updated_on"]
     end
 
     def timestamp_attributes_for_create
-      [:created_at, :created_on]
+      ["created_at", "created_on"]
     end
 
     def all_timestamp_attributes

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -432,32 +432,32 @@ class TimestampTest < ActiveRecord::TestCase
 
   def test_timestamp_attributes_for_create
     toy = Toy.first
-    assert_equal [:created_at, :created_on], toy.send(:timestamp_attributes_for_create)
+    assert_equal ["created_at", "created_on"], toy.send(:timestamp_attributes_for_create)
   end
 
   def test_timestamp_attributes_for_update
     toy = Toy.first
-    assert_equal [:updated_at, :updated_on], toy.send(:timestamp_attributes_for_update)
+    assert_equal ["updated_at", "updated_on"], toy.send(:timestamp_attributes_for_update)
   end
 
   def test_all_timestamp_attributes
     toy = Toy.first
-    assert_equal [:created_at, :created_on, :updated_at, :updated_on], toy.send(:all_timestamp_attributes)
+    assert_equal ["created_at", "created_on", "updated_at", "updated_on"], toy.send(:all_timestamp_attributes)
   end
 
   def test_timestamp_attributes_for_create_in_model
     toy = Toy.first
-    assert_equal [:created_at], toy.send(:timestamp_attributes_for_create_in_model)
+    assert_equal ["created_at"], toy.send(:timestamp_attributes_for_create_in_model)
   end
 
   def test_timestamp_attributes_for_update_in_model
     toy = Toy.first
-    assert_equal [:updated_at], toy.send(:timestamp_attributes_for_update_in_model)
+    assert_equal ["updated_at"], toy.send(:timestamp_attributes_for_update_in_model)
   end
 
   def test_all_timestamp_attributes_in_model
     toy = Toy.first
-    assert_equal [:created_at, :updated_at], toy.send(:all_timestamp_attributes_in_model)
+    assert_equal ["created_at", "updated_at"], toy.send(:all_timestamp_attributes_in_model)
   end
 
   def test_index_is_created_for_both_timestamps


### PR DESCRIPTION
`timestamp_attributes_for_{create,update}` is defined as symbol but
always used as string with `to_s`. This allocates extra strings. To
avoid extra allocation, change the definitions from symbol to string.

```ruby
pp ObjectSpace::AllocationTracer.trace {
  1_000.times { |i|
    Post.create!
  }
}
```

Before:

```
["~/rails/activerecord/lib/active_record/timestamp.rb", 121]=>[1002, 0, 750, 0, 1, 18528],
["~/rails/activerecord/lib/active_record/timestamp.rb", 105]=>[1002, 0, 750, 0, 1, 7720],
["~/rails/activerecord/lib/active_record/timestamp.rb", 101]=>[1002, 0, 750, 0, 1, 7720],
["~/rails/activerecord/lib/active_record/timestamp.rb", 109]=>[1002, 0, 750, 0, 1, 13896],
["~/rails/activerecord/lib/active_record/timestamp.rb", 61]=>[4008, 0, 3000, 0, 1, 30880],
```

After:

```
["~/rails/activerecord/lib/active_record/timestamp.rb", 120]=>[1000, 0, 756, 0, 1, 17184],
["~/rails/activerecord/lib/active_record/timestamp.rb", 104]=>[1000, 0, 756, 0, 1, 7160],
["~/rails/activerecord/lib/active_record/timestamp.rb", 100]=>[1000, 0, 756, 0, 1, 7160],
["~/rails/activerecord/lib/active_record/timestamp.rb", 108]=>[1000, 0, 756, 0, 1, 12888],
```