### PR TITLE
remove unnecessary `remove_file`

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -323,7 +323,6 @@ module Rails
 
       def delete_action_mailer_files_skipping_action_mailer
         if options[:skip_action_mailer]
-          remove_file "app/mailers/application_mailer.rb"
           remove_file "app/views/layouts/mailer.html.erb"
           remove_file "app/views/layouts/mailer.text.erb"
           remove_dir "app/mailers"


### PR DESCRIPTION
It deletes the `app/mailers` directory itself, it is not necessary to delete
the file individually.
https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/app/app_generator.rb#L329
