### PR TITLE
add `bin/test` script for railties

### DIFF
--- a/railties/bin/test
+++ b/railties/bin/test
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+COMPONENT_ROOT = File.expand_path("..", __dir__)
+require File.expand_path("../tools/test", COMPONENT_ROOT)


### PR DESCRIPTION
The railties test does not require specific setup performed in the rake-tasks,
so we can use test runner as well as other components.

