### PR TITLE
Remove bin/yarn if yarn is skipped, tidy up tests

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -350,8 +350,8 @@ module Rails
         end
       end
 
-      def delete_bin_yarn_if_api_option
-        remove_file "bin/yarn" if options[:api]
+      def delete_bin_yarn_if_skip_yarn_option
+        remove_file "bin/yarn" if options[:skip_yarn]
       end
 
       def finish_template

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -419,6 +419,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_generator_if_skip_yarn_is_given
+    run_generator [destination_root, "--skip-yarn"]
+
+    assert_no_file "vendor/package.json"
+    assert_no_file "bin/yarn"
+  end
+
   def test_generator_if_skip_action_cable_is_given
     run_generator [destination_root, "--skip-action-cable"]
     assert_file "config/application.rb", /#\s+require\s+["']action_cable\/engine["']/


### PR DESCRIPTION
- No need to remove bin/yarn separately for API only apps because
  :skip_yarn is set to true for API only apps.
- Added a test for :skip_yarn config.