### PR TITLE
Fix update counters of multiple records with touch: true

### DIFF
--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -105,7 +105,7 @@ module ActiveRecord
         end
 
         if touch
-          object = find(id)
+          object = find(id.is_a?(Array) ? id.first : id)
           updates << object.class.send(:sanitize_sql_for_assignment, touch_updates(object, touch))
         end
 

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -46,7 +46,7 @@ module ActiveRecord
           counter_name = reflection.counter_cache_column
 
           updates = { counter_name.to_sym => object.send(counter_association).count(:all) }
-          updates.merge!(touch_updates(object, touch)) if touch
+          updates.merge!(touch_updates(touch)) if touch
 
           unscoped.where(primary_key => object.id).update_all(updates)
         end
@@ -105,8 +105,7 @@ module ActiveRecord
         end
 
         if touch
-          object = find(id.is_a?(Array) ? id.first : id)
-          updates << object.class.send(:sanitize_sql_for_assignment, touch_updates(object, touch))
+          updates << sanitize_sql_for_assignment(touch_updates(touch))
         end
 
         unscoped.where(primary_key => id).update_all updates.join(", ")
@@ -165,9 +164,9 @@ module ActiveRecord
       end
 
       private
-        def touch_updates(object, touch)
-          touch = object.send(:timestamp_attributes_for_update_in_model) if touch == true
-          touch_time = object.send(:current_time_from_proper_timezone)
+        def touch_updates(touch)
+          touch = timestamp_attributes_for_update_in_model if touch == true
+          touch_time = current_time_from_proper_timezone
           Array(touch).map { |column| [ column, touch_time ] }.to_h
         end
     end

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -227,6 +227,16 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
+  test "update counters of multiple records with touch: true" do
+    t1, t2 = topics(:first, :second)
+
+    assert_touching t1, :updated_at do
+      assert_difference ["t1.reload.replies_count", "t2.reload.replies_count"], 2 do
+        Topic.update_counters([t1.id, t2.id], replies_count: 2, touch: true)
+      end
+    end
+  end
+
   test "update multiple counters with touch: true" do
     assert_touching @topic, :updated_at do
       Topic.update_counters(@topic.id, replies_count: 2, unique_replies_count: 2, touch: true)

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -430,21 +430,6 @@ class TimestampTest < ActiveRecord::TestCase
     assert_not_equal person.born_at, nil
   end
 
-  def test_timestamp_attributes_for_create
-    toy = Toy.first
-    assert_equal ["created_at", "created_on"], toy.send(:timestamp_attributes_for_create)
-  end
-
-  def test_timestamp_attributes_for_update
-    toy = Toy.first
-    assert_equal ["updated_at", "updated_on"], toy.send(:timestamp_attributes_for_update)
-  end
-
-  def test_all_timestamp_attributes
-    toy = Toy.first
-    assert_equal ["created_at", "created_on", "updated_at", "updated_on"], toy.send(:all_timestamp_attributes)
-  end
-
   def test_timestamp_attributes_for_create_in_model
     toy = Toy.first
     assert_equal ["created_at"], toy.send(:timestamp_attributes_for_create_in_model)


### PR DESCRIPTION
Currently does not work the following example in the doc:

```ruby
  # For the Posts with id of 10 and 15, increment the comment_count by 1
  # and update the updated_at value for each counter.
  Post.update_counters [10, 15], comment_count: 1, touch: true
  # Executes the following SQL:
  # UPDATE posts
  #    SET comment_count = COALESCE(comment_count, 0) + 1,
  #    `updated_at` = '2016-10-13T09:59:23-05:00'
  #  WHERE id IN (10, 15)
```