### PR TITLE
Remove useless `belongs_to_touch_method`

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -106,11 +106,11 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
     def self.add_touch_callbacks(model, reflection)
       foreign_key = reflection.foreign_key
-      n           = reflection.name
+      name        = reflection.name
       touch       = reflection.options[:touch]
 
       callback = lambda { |changes_method| lambda { |record|
-        BelongsTo.touch_record(record, record.send(changes_method), foreign_key, n, touch, belongs_to_touch_method)
+        BelongsTo.touch_record(record, record.send(changes_method), foreign_key, name, touch, :touch_later)
       }}
 
       model.after_save    callback.(:saved_changes), if: :saved_changes?

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -70,7 +70,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
       klass.attr_readonly cache_column if klass && klass.respond_to?(:attr_readonly)
     end
 
-    def self.touch_record(o, changes, foreign_key, name, touch, touch_method) # :nodoc:
+    def self.touch_record(o, changes, foreign_key, name, touch) # :nodoc:
       old_foreign_id = changes[foreign_key] && changes[foreign_key].first
 
       if old_foreign_id
@@ -87,9 +87,9 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
         if old_record
           if touch != true
-            old_record.send(touch_method, touch)
+            old_record.touch_later(touch)
           else
-            old_record.send(touch_method)
+            old_record.touch_later
           end
         end
       end
@@ -97,9 +97,9 @@ module ActiveRecord::Associations::Builder # :nodoc:
       record = o.send name
       if record && record.persisted?
         if touch != true
-          record.send(touch_method, touch)
+          record.touch_later(touch)
         else
-          record.send(touch_method)
+          record.touch_later
         end
       end
     end
@@ -110,7 +110,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
       touch       = reflection.options[:touch]
 
       callback = lambda { |changes_method| lambda { |record|
-        BelongsTo.touch_record(record, record.send(changes_method), foreign_key, name, touch, :touch_later)
+        BelongsTo.touch_record(record, record.send(changes_method), foreign_key, name, touch)
       }}
 
       model.after_save    callback.(:saved_changes), if: :saved_changes?

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -587,10 +587,6 @@ module ActiveRecord
       @_association_destroy_exception = nil
     end
 
-    def belongs_to_touch_method
-      :touch
-    end
-
     def _raise_readonly_record_error
       raise ReadOnlyRecord, "#{self.class} is marked as readonly"
     end

--- a/activerecord/lib/active_record/touch_later.rb
+++ b/activerecord/lib/active_record/touch_later.rb
@@ -25,7 +25,7 @@ module ActiveRecord
       # touch the parents as we are not calling the after_save callbacks
       self.class.reflect_on_all_associations(:belongs_to).each do |r|
         if touch = r.options[:touch]
-          ActiveRecord::Associations::Builder::BelongsTo.touch_record(self, changes_to_save, r.foreign_key, r.name, touch, :touch_later)
+          ActiveRecord::Associations::Builder::BelongsTo.touch_record(self, changes_to_save, r.foreign_key, r.name, touch)
         end
       end
     end

--- a/activerecord/lib/active_record/touch_later.rb
+++ b/activerecord/lib/active_record/touch_later.rb
@@ -54,9 +54,5 @@ module ActiveRecord
       def has_defer_touch_attrs?
         defined?(@_defer_touch_attrs) && @_defer_touch_attrs.present?
       end
-
-      def belongs_to_touch_method
-        :touch_later
-      end
   end
 end


### PR DESCRIPTION
`TouchLater` module is included after `Persistence` module to
`ActiveRecord::Base` so `belongs_to_touch_method` always return
`:touch_later`.