### PR TITLE
Backport #26732 for 4-2-stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,9 @@ group :test do
 end
 
 platforms :ruby do
-  gem 'nokogiri', '>= 1.4.5'
+  # 1.7.0 drops support for Ruby 1.9.3 and 2.0.
+  # See sparklemotion/nokogiri@8487038.
+  gem 'nokogiri', '>= 1.4.5', '< 1.7.0'
 
   # Needed for compiling the ActionDispatch::Journey parser
   gem 'racc', '>=1.4.6', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,7 @@ DEPENDENCIES
   mustache (~> 0.99.8)
   mysql (>= 2.9.0)
   mysql2 (>= 0.4.0)
-  nokogiri (>= 1.4.5)
+  nokogiri (>= 1.4.5, < 1.7.0)
   pg (>= 0.15.0)
   psych (~> 2.0)
   qu-rails!

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -24,7 +24,8 @@ module ActiveJob
 
   module Arguments
     extend self
-    TYPE_WHITELIST = [ NilClass, String, Integer, Fixnum, Bignum, Float, BigDecimal, TrueClass, FalseClass ].uniq
+    TYPE_WHITELIST = [ NilClass, String, Integer, Float, BigDecimal, TrueClass, FalseClass ].uniq
+    TYPE_WHITELIST.push(Fixnum, Bignum) unless 1.class == Integer
 
     # Serializes a set of arguments. Whitelisted types are returned
     # as-is. Arrays/Hashes are serialized element by element.

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -186,7 +186,7 @@ class QueryCacheTest < ActiveRecord::TestCase
         assert_kind_of Numeric, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
       elsif current_adapter?(:SQLite3Adapter, :Mysql2Adapter)
         # Future versions of the sqlite3 adapter will return numeric
-        assert_instance_of Fixnum, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
+        assert_instance_of 0.class, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
       else
         assert_instance_of String, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
       end

--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -122,7 +122,7 @@ class Numeric
     klass.send(:alias_method, :to_default_s, :to_s)
 
     # Ruby 2.4+ unifies Fixnum & Bignum into Integer.
-    if Integer == Fixnum
+    if 0.class == Integer
       next if klass == Fixnum || klass == Bignum
     end
 

--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -48,8 +48,8 @@ module ActiveSupport
       }
 
       # No need to map these on Ruby 2.4+
-      TYPE_NAMES["Fixnum"] = "integer" unless Fixnum == Integer
-      TYPE_NAMES["Bignum"] = "integer" unless Bignum == Integer
+      TYPE_NAMES["Fixnum"] = "integer" unless 0.class == Integer
+      TYPE_NAMES["Bignum"] = "integer" unless 0.class == Integer
     end
 
     FORMATTING = {

--- a/activesupport/test/core_ext/array/grouping_test.rb
+++ b/activesupport/test/core_ext/array/grouping_test.rb
@@ -4,11 +4,11 @@ require 'active_support/core_ext/array'
 class GroupingTest < ActiveSupport::TestCase
   def setup
     # In Ruby < 2.4, test we avoid Integer#/ (redefined by mathn)
-    Fixnum.send :private, :/ unless Fixnum == Integer
+    Fixnum.send :private, :/ unless 0.class == Integer
   end
 
   def teardown
-    Fixnum.send :public, :/ unless Fixnum == Integer
+    Fixnum.send :public, :/ unless 0.class == Integer
   end
 
   def test_in_groups_of_with_perfect_fit


### PR DESCRIPTION
Updates 4-2-stable to include the Ruby 2.4 fixes from #26732.

cc @jeremy @matthewd as you were both on the original pull request.