### PR TITLE
Add "check_parameters" option to "current_page?"

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `check_parameters` option to `current_page?` which makes it more strict.
+
+    *Maksym Pugach*
+
 *   Return correct object name in form helper method after `fields_for`.
 
     Fixes #26931.

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -517,6 +517,9 @@ module ActionView
       #   current_page?('http://www.example.com/shop/checkout')
       #   # => true
       #
+      #   current_page?('http://www.example.com/shop/checkout', check_parameters: true)
+      #   # => false
+      #
       #   current_page?('/shop/checkout')
       #   # => true
       #
@@ -530,7 +533,7 @@ module ActionView
       #
       # We can also pass in the symbol arguments instead of strings.
       #
-      def current_page?(options)
+      def current_page?(options, check_parameters: false)
         unless request
           raise "You cannot use helpers that need to determine the current " \
                 "page unless your view context provides a Request object " \
@@ -539,12 +542,14 @@ module ActionView
 
         return false unless request.get? || request.head?
 
+        check_parameters ||= !options.is_a?(String) && options.try(:delete, :check_parameters)
         url_string = URI.parser.unescape(url_for(options)).force_encoding(Encoding::BINARY)
 
         # We ignore any extra parameters in the request_uri if the
         # submitted url doesn't have any either. This lets the function
         # work with things like ?order=asc
-        request_uri = url_string.index("?") ? request.fullpath : request.path
+        # the behaviour can be disabled with check_parameters: true
+        request_uri = url_string.index("?") || check_parameters ? request.fullpath : request.path
         request_uri = URI.parser.unescape(request_uri).force_encoding(Encoding::BINARY)
 
         url_string.chomp!("/") if url_string.start_with?("/") && url_string != "/"

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -496,6 +496,15 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert current_page?("http://www.example.com/")
   end
 
+  def test_current_page_considering_params
+    @request = request_for_url("/?order=desc&page=1")
+
+    assert !current_page?(url_hash, check_parameters: true)
+    assert !current_page?(url_hash.merge(check_parameters: true))
+    assert !current_page?(ActionController::Parameters.new(url_hash.merge(check_parameters: true)).permit!)
+    assert !current_page?("http://www.example.com/", check_parameters: true)
+  end
+
   def test_current_page_with_params_that_match
     @request = request_for_url("/?order=desc&page=1")
 


### PR DESCRIPTION
Example:

For `http://www.example.com/shop/checkout?order=desc&page=1`

```ruby
current_page?('http://www.example.com/shop/checkout')
# => true

current_page?(
  'http://www.example.com/shop/checkout',
  check_parameters: true
)
# => false
```

This is needed when `http://www.example.com/shop/checkout` navigation is also present on the page. Without this option both paths are considered current.