### PR TITLE
Fix generator command for nested (namespaced) rails engine

### DIFF
--- a/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
+++ b/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
@@ -26,7 +26,7 @@ module Rails
 
         def application_mailer_file_name
           @_application_mailer_file_name ||= if mountable_engine?
-            "app/mailers/#{namespaced_path}/application_mailer.rb"
+            File.join("app/mailers", namespaced_path, "application_mailer.rb")
           else
             "app/mailers/application_mailer.rb"
           end

--- a/activejob/lib/rails/generators/job/job_generator.rb
+++ b/activejob/lib/rails/generators/job/job_generator.rb
@@ -28,7 +28,7 @@ module Rails # :nodoc:
       private
         def application_job_file_name
           @application_job_file_name ||= if mountable_engine?
-            "app/jobs/#{namespaced_path}/application_job.rb"
+            File.join("app/jobs", namespaced_path, "application_job.rb")
           else
             "app/jobs/application_job.rb"
           end

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -59,7 +59,7 @@ module ActiveRecord
 
         def application_record_file_name
           @application_record_file_name ||= if mountable_engine?
-            "app/models/#{namespaced_path}/application_record.rb"
+            File.join("app/models", namespaced_path, "application_record.rb")
           else
             "app/models/application_record.rb"
           end

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -95,11 +95,11 @@ module Rails
         end
 
         def namespaced_class_path # :doc:
-          @namespaced_class_path ||= [namespaced_path] + @class_path
+          @namespaced_class_path ||= namespaced_path + @class_path
         end
 
         def namespaced_path # :doc:
-          @namespaced_path ||= namespace.name.split("::").first.underscore
+          @namespaced_path ||= namespace.name.split("::").map(&:underscore)
         end
 
         def class_name # :doc:

--- a/railties/lib/rails/generators/rails/controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/controller/templates/controller.rb
@@ -1,5 +1,5 @@
 <% if namespaced? -%>
-require_dependency "<%= namespaced_path %>/application_controller"
+require_dependency "<%= File.join(namespaced_path) %>/application_controller"
 
 <% end -%>
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb
@@ -1,5 +1,5 @@
 <% if namespaced? -%>
-require_dependency "<%= namespaced_path %>/application_controller"
+require_dependency "<%= File.join(namespaced_path) %>/application_controller"
 
 <% end -%>
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -1,5 +1,5 @@
 <% if namespaced? -%>
-require_dependency "<%= namespaced_path %>/application_controller"
+require_dependency "<%= File.join(namespaced_path) %>/application_controller"
 
 <% end -%>
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
@@ -22,7 +22,7 @@ module TestUnit # :nodoc:
       def fixture_name
         @fixture_name ||=
           if mountable_engine?
-            "%s_%s" % [namespaced_path, table_name]
+            "%s_%s" % [namespaced_path.join("_"), table_name]
           else
             table_name
           end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -492,6 +492,26 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_scaffold_tests_pass_by_default_inside_namespaced_mountable_engine
+    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits-admin --mountable` }
+
+    engine_path = File.join(destination_root, "bukkits-admin")
+
+    Dir.chdir(engine_path) do
+      quietly do
+        `bin/rails g scaffold User name:string age:integer;
+        bin/rails db:migrate`
+      end
+
+      assert_file "bukkits-admin/app/controllers/bukkits/admin/users_controller.rb" do |content|
+        assert_match(/module Bukkits::Admin/, content)
+        assert_match(/class UsersController < ApplicationController/, content)
+      end
+
+      assert_match(/8 runs, 10 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+    end
+  end
+
   def test_scaffold_tests_pass_by_default_inside_full_engine
     Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --full` }
 


### PR DESCRIPTION
### Summary

If we create nested (namespaced) rails engine such like bukkits-admin,
`bin/rails g scaffold User name:string age:integer`
will create
`bukkits-admin/app/controllers/bukkits/users_controller.rb`
but it should create
`bukkits-admin/app/controllers/bukkits/admin/users_controller.rb`.

### Other Information

In #6643, we changed `namespaced_path` as root path
because we supposed application_controller is always in root
but nested rails engine's application_controller will not.