### PR TITLE
Deprecate reflection class name to accept a class

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecate passing a class to the `class_name` because it eagerloads more classes than
+    necessary and potentially creates circular dependencies.
+
+    *Kir Shatrov*
+
 *   Raise error when has_many through is defined before through association
 
     Fixes #26834

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -364,6 +364,17 @@ module ActiveRecord
         @constructable = calculate_constructable(macro, options)
         @association_scope_cache = {}
         @scope_lock = Mutex.new
+
+        if options[:class_name] && options[:class_name].class == Class
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Passing a class to the `class_name` is deprecated and will raise
+            an ArgumentError in Rails 5.2. It eagerloads more classes than
+            necessary and potentially creates circular dependencies.
+
+            Please pass the class name as a string:
+            `belongs_to :client, class_name: 'Company'`
+          MSG
+        end
       end
 
       def association_scope_cache(conn, owner)

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -86,8 +86,10 @@ class DeveloperWithSymbolClassName < Developer
   has_and_belongs_to_many :projects, class_name: :ProjectWithSymbolsForKeys
 end
 
-class DeveloperWithConstantClassName < Developer
-  has_and_belongs_to_many :projects, class_name: ProjectWithSymbolsForKeys
+ActiveSupport::Deprecation.silence do
+  class DeveloperWithConstantClassName < Developer
+    has_and_belongs_to_many :projects, class_name: ProjectWithSymbolsForKeys
+  end
 end
 
 class DeveloperWithExtendOption < Developer

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -404,6 +404,12 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal Client, Firm.reflect_on_association(:unsorted_clients_with_symbol).klass
   end
 
+  def test_class_for_class_name
+    assert_deprecated do
+      assert_predicate ActiveRecord::Reflection.create(:has_many, :clients, nil, { class_name: Client }, Firm), :validate?
+    end
+  end
+
   def test_join_table
     category = Struct.new(:table_name, :pluralize_table_names).new("categories", true)
     product = Struct.new(:table_name, :pluralize_table_names).new("products", true)

--- a/activerecord/test/models/user.rb
+++ b/activerecord/test/models/user.rb
@@ -5,7 +5,7 @@ class User < ActiveRecord::Base
   has_secure_token :auth_token
 
   has_and_belongs_to_many :jobs_pool,
-    class_name: Job,
+    class_name: "Job",
     join_table: "jobs_pool"
 end
 


### PR DESCRIPTION
The idea of `class_name` as an option of reflection is that passing a `String` of class name would allow us to lazy autoload the reflection class.

Passing c class (`belongs_to :client, class_name: Customer`) is eagerloading more models than necessary and creating possible circular dependencies.

@rafaelfranca @casperisfine