### PR TITLE
Fix default locale code example [ci skip]

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -72,11 +72,13 @@ I18n.l Time.now
 There are also attribute readers and writers for the following attributes:
 
 ```ruby
-load_path         # Announce your custom translation files
-locale            # Get and set the current locale
-default_locale    # Get and set the default locale
-exception_handler # Use a different exception_handler
-backend           # Use a different backend
+load_path                 # Announce your custom translation files
+locale                    # Get and set the current locale
+default_locale            # Get and set the default locale
+available_locales         # Whitelist locales available for the application
+enforce_available_locales # Enforce locale whitelisting (true or false)
+exception_handler         # Use a different exception_handler
+backend                   # Use a different backend
 ```
 
 So, let's internationalize a simple Rails application from the ground up in the next chapters!
@@ -123,6 +125,9 @@ The load path must be specified before any translations are looked up. To change
 
 # Where the I18n library should search for translation files
 I18n.load_path += Dir[Rails.root.join('lib', 'locale', '*.{rb,yml}')]
+
+# Whitelist locales available for the application
+I18n.available_locales = [:en, :pt]
 
 # Set default locale to something other than :en
 I18n.default_locale = :pt


### PR DESCRIPTION
### Summary

Changing the default locale using an initializer file throws I18n::InvalidLocale exception if following the instructions on the documentation.

Error:

    /home/jari/.rvm/gems/ruby-2.4.0/gems/i18n-0.7.0/lib/i18n.rb:284:in `enforce_available_locales!': :fi is not a valid locale (I18n::InvalidLocale)
        from /home/jari/.rvm/gems/ruby-2.4.0/gems/i18n-0.7.0/lib/i18n/config.rb:34:in `default_locale='
        from /home/jari/.rvm/gems/ruby-2.4.0/gems/i18n-0.7.0/lib/i18n.rb:35:in `default_locale='
        from /home/jari/code/myapp/config/initializers/locale.rb:2:in `<top (required)>'

### Other Information

This PR changes the example code from:

    I18n.load_path += Dir[Rails.root.join('lib', 'locale', '*.{rb,yml}')]
    I18n.default_locale = :pt

to working one:

    Rails.application.config.i18n.load_path += Dir[Rails.root.join('lib', 'locale', '*.{rb,yml}')]
    Rails.application.config.i18n.default_locale = :pt