### PR TITLE
Backport Active Support Date/Time changes for Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - "GEM=railties"
     - "GEM=ap"
     - "GEM=am,amo,as,av,aj"
+    - "GEM=as PRESERVE_TIMEZONES=1"
     - "GEM=ar:mysql"
     - "GEM=ar:mysql2"
     - "GEM=ar:sqlite3"

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 *   Add `ActiveSupport.to_time_preserves_timezone` config option to control
     how `to_time` handles timezones. In Ruby 2.4+ the behavior will change
-    from converting to the local system timezone to preserving the timezone
+    from converting to the local system timezone, to preserving the timezone
     of the receiver. This config option defaults to false so that apps made
     with earlier versions of Rails are not affected when upgrading, e.g:
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Make `getlocal` and `getutc` always return instances of `Time` for
+    `ActiveSupport::TimeWithZone` and `DateTime`. This eliminates a possible
+    stack level too deep error in `to_time` where `ActiveSupport::TimeWithZone`
+    was wrapping a `DateTime` instance. As a consequence of this the internal
+    time value in `ActiveSupport::TimeWithZone` is now always an instance of
+    `Time` in the UTC timezone, whether that's as the UTC time directly or
+    a representation of the local time in the timezone. There should be no
+    consequences of this internal change and if there are it's a bug due to
+    leaky abstractions.
+
+    *Andrew White*
+
 *   Add `DateTime#subsec` to return the fraction of a second as a `Rational`.
 
     *Andrew White*

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `DateTime#subsec` to return the fraction of a second as a `Rational`.
+
+    *Andrew White*
+
 *   Add additional aliases for `DateTime#utc` to mirror the ones on
     `ActiveSupport::TimeWithZone` and `Time`.
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add additional aliases for `DateTime#utc` to mirror the ones on
+    `ActiveSupport::TimeWithZone` and `Time`.
+
+    *Andrew White*
+
 *   Add `DateTime#localtime` to return an instance of `Time` in the system's
     local timezone. Also aliased to `getlocal`.
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `Time#sec_fraction` to return the fraction of a second as a `Rational`.
+
+    *Andrew White*
+
 *   Add `ActiveSupport.to_time_preserves_timezone` config option to control
     how `to_time` handles timezones. In Ruby 2.4+ the behavior will change
     from converting to the local system timezone to preserving the timezone

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `DateTime#localtime` to return an instance of `Time` in the system's
+    local timezone. Also aliased to `getlocal`.
+
+    *Andrew White*, *Yuichiro Kaneko*
+
 *   Add `Time#sec_fraction` to return the fraction of a second as a `Rational`.
 
     *Andrew White*

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Add `ActiveSupport.to_time_preserves_timezone` config option to control
+    how `to_time` handles timezones. In Ruby 2.4+ the behavior will change
+    from converting to the local system timezone to preserving the timezone
+    of the receiver. This config option defaults to false so that apps made
+    with earlier versions of Rails are not affected when upgrading, e.g:
+
+        >> ENV['TZ'] = 'US/Eastern'
+
+        >> "2016-04-23T10:23:12.000Z".to_time
+        => "2016-04-23T06:23:12.000-04:00"
+
+        >> ActiveSupport.to_time_preserves_timezone = true
+
+        >> "2016-04-23T10:23:12.000Z".to_time
+        => "2016-04-23T10:23:12.000Z"
+
+    Fixes #24617.
+
+    *Andrew White*
+
 *   Add `init_with` to `ActiveSupport::TimeWithZone` and `ActiveSupport::TimeZone`
 
     It is helpful to be able to run apps concurrently written in successive

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -26,6 +26,7 @@ require "active_support/dependencies/autoload"
 require "active_support/version"
 require "active_support/logger"
 require "active_support/lazy_load_hooks"
+require "active_support/core_ext/date_and_time/compatibility"
 
 module ActiveSupport
   extend ActiveSupport::Autoload
@@ -79,6 +80,14 @@ module ActiveSupport
 
   def self.test_order # :nodoc:
     @@test_order
+  end
+
+  def self.to_time_preserves_timezone
+    DateAndTime::Compatibility.preserve_timezone
+  end
+
+  def self.to_time_preserves_timezone=(value)
+    DateAndTime::Compatibility.preserve_timezone = value
   end
 end
 

--- a/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
@@ -12,7 +12,11 @@ module DateAndTime
     mattr_accessor(:preserve_timezone, instance_writer: false) { false }
 
     def to_time
-      preserve_timezone ? getlocal(utc_offset) : getlocal
+      if preserve_timezone
+        @_to_time_with_instance_offset ||= getlocal(utc_offset)
+      else
+        @_to_time_with_system_offset ||= getlocal
+      end
     end
   end
 end

--- a/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
@@ -1,0 +1,16 @@
+module DateAndTime
+  module Compatibility
+    # If true, +to_time+ preserves the the timezone offset.
+    #
+    # NOTE: With Ruby 2.4+ the default for +to_time+ changed from
+    # converting to the local system time to preserving the offset
+    # of the receiver. For backwards compatibility we're overriding
+    # this behavior but new apps will have an initializer that sets
+    # this to true because the new behavior is preferred.
+    mattr_accessor(:preserve_timezone, instance_writer: false) { false }
+
+    def to_time
+      preserve_timezone ? getlocal(utc_offset) : getlocal
+    end
+  end
+end

--- a/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module/attribute_accessors'
+
 module DateAndTime
   module Compatibility
     # If true, +to_time+ preserves the the timezone offset.

--- a/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/module/attribute_accessors'
+require 'active_support/core_ext/module/remove_method'
 
 module DateAndTime
   module Compatibility
@@ -11,11 +12,17 @@ module DateAndTime
     # this to true, because the new behavior is preferred.
     mattr_accessor(:preserve_timezone, instance_writer: false) { false }
 
-    def to_time
-      if preserve_timezone
-        @_to_time_with_instance_offset ||= getlocal(utc_offset)
-      else
-        @_to_time_with_system_offset ||= getlocal
+    def self.included(base)
+      base.class_eval do
+        remove_possible_method :to_time
+
+        def to_time
+          if preserve_timezone
+            @_to_time_with_instance_offset ||= getlocal(utc_offset)
+          else
+            @_to_time_with_system_offset ||= getlocal
+          end
+        end
       end
     end
   end

--- a/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
@@ -2,13 +2,13 @@ require 'active_support/core_ext/module/attribute_accessors'
 
 module DateAndTime
   module Compatibility
-    # If true, +to_time+ preserves the the timezone offset.
+    # If true, +to_time+ preserves the timezone offset of receiver.
     #
     # NOTE: With Ruby 2.4+ the default for +to_time+ changed from
-    # converting to the local system time to preserving the offset
+    # converting to the local system time, to preserving the offset
     # of the receiver. For backwards compatibility we're overriding
-    # this behavior but new apps will have an initializer that sets
-    # this to true because the new behavior is preferred.
+    # this behavior, but new apps will have an initializer that sets
+    # this to true, because the new behavior is preferred.
     mattr_accessor(:preserve_timezone, instance_writer: false) { false }
 
     def to_time

--- a/activesupport/lib/active_support/core_ext/date_time.rb
+++ b/activesupport/lib/active_support/core_ext/date_time.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/date_time/acts_like'
 require 'active_support/core_ext/date_time/calculations'
+require 'active_support/core_ext/date_time/compatibility'
 require 'active_support/core_ext/date_time/conversions'
 require 'active_support/core_ext/date_time/zones'

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -148,6 +148,18 @@ class DateTime
   end
   alias_method :getutc, :utc
 
+  # Returns a <tt>Time.local()</tt> instance of the simultaneous time in your
+  # system's <tt>ENV['TZ']</tt> zone.
+  def localtime(utc_offset = nil)
+    utc = getutc
+
+    Time.utc(
+      utc.year, utc.month, utc.day,
+      utc.hour, utc.min, utc.sec + utc.sec_fraction
+    ).getlocal(utc_offset)
+  end
+  alias_method :getlocal, :localtime
+
   # Returns +true+ if <tt>offset == 0</tt>.
   def utc?
     offset == 0

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -146,21 +146,9 @@ class DateTime
   end
   alias :at_end_of_minute :end_of_minute
 
-  # Adjusts DateTime to UTC by adding its offset value; offset is set to 0.
-  #
-  #   DateTime.civil(2005, 2, 21, 10, 11, 12, Rational(-6, 24))     # => Mon, 21 Feb 2005 10:11:12 -0600
-  #   DateTime.civil(2005, 2, 21, 10, 11, 12, Rational(-6, 24)).utc # => Mon, 21 Feb 2005 16:11:12 +0000
-  def utc
-    new_offset(0)
-  end
-  alias_method :getgm, :utc
-  alias_method :getutc, :utc
-  alias_method :gmtime, :utc
-
-  # Returns a <tt>Time.local()</tt> instance of the simultaneous time in your
-  # system's <tt>ENV['TZ']</tt> zone.
+  # Returns a <tt>Time</tt> instance of the simultaneous time in the system timezone.
   def localtime(utc_offset = nil)
-    utc = getutc
+    utc = new_offset(0)
 
     Time.utc(
       utc.year, utc.month, utc.day,
@@ -168,6 +156,22 @@ class DateTime
     ).getlocal(utc_offset)
   end
   alias_method :getlocal, :localtime
+
+  # Returns a <tt>Time</tt> instance of the simultaneous time in the UTC timezone.
+  #
+  #   DateTime.civil(2005, 2, 21, 10, 11, 12, Rational(-6, 24))     # => Mon, 21 Feb 2005 10:11:12 -0600
+  #   DateTime.civil(2005, 2, 21, 10, 11, 12, Rational(-6, 24)).utc # => Mon, 21 Feb 2005 16:11:12 UTC
+  def utc
+    utc = new_offset(0)
+
+    Time.utc(
+      utc.year, utc.month, utc.day,
+      utc.hour, utc.min, utc.sec + utc.sec_fraction
+    )
+  end
+  alias_method :getgm, :utc
+  alias_method :getutc, :utc
+  alias_method :gmtime, :utc
 
   # Returns +true+ if <tt>offset == 0</tt>.
   def utc?

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -146,7 +146,9 @@ class DateTime
   def utc
     new_offset(0)
   end
+  alias_method :getgm, :utc
   alias_method :getutc, :utc
+  alias_method :gmtime, :utc
 
   # Returns a <tt>Time.local()</tt> instance of the simultaneous time in your
   # system's <tt>ENV['TZ']</tt> zone.

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -24,6 +24,13 @@ class DateTime
     end_of_day.to_i - to_i
   end
 
+  # Returns the fraction of a second as a +Rational+
+  #
+  #   DateTime.new(2012, 8, 29, 0, 0, 0.5).subsec # => (1/2)
+  def subsec
+    sec_fraction
+  end
+
   # Returns a new DateTime where one or more of the elements have been changed
   # according to the +options+ parameter. The time options (<tt>:hour</tt>,
   # <tt>:min</tt>, <tt>:sec</tt>) reset cascadingly, so if only the hour is

--- a/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
@@ -2,15 +2,4 @@ require 'active_support/core_ext/date_and_time/compatibility'
 
 class DateTime
   prepend DateAndTime::Compatibility
-
-  # Returns a <tt>Time.local()</tt> instance of the simultaneous time in your
-  # system's <tt>ENV['TZ']</tt> zone.
-  def getlocal(utc_offset = nil)
-    utc = getutc
-
-    Time.utc(
-      utc.year, utc.month, utc.day,
-      utc.hour, utc.min, utc.sec + utc.sec_fraction
-    ).getlocal(utc_offset)
-  end
 end

--- a/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
@@ -1,0 +1,16 @@
+require 'active_support/core_ext/date_and_time/compatibility'
+
+class DateTime
+  prepend DateAndTime::Compatibility
+
+  # Returns a <tt>Time.local()</tt> instance of the simultaneous time in your
+  # system's <tt>ENV['TZ']</tt> zone.
+  def getlocal(utc_offset = nil)
+    utc = getutc
+
+    Time.utc(
+      utc.year, utc.month, utc.day,
+      utc.hour, utc.min, utc.sec + utc.sec_fraction
+    ).getlocal(utc_offset)
+  end
+end

--- a/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
@@ -1,5 +1,5 @@
 require 'active_support/core_ext/date_and_time/compatibility'
 
 class DateTime
-  prepend DateAndTime::Compatibility
+  include DateAndTime::Compatibility
 end

--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -31,7 +31,7 @@ class String
       parts.fetch(:offset, form == :utc ? 0 : nil)
     )
 
-    form == :utc ? time.utc : time.getlocal
+    form == :utc ? time.utc : time.to_time
   end
 
   # Converts a string to a Date value.

--- a/activesupport/lib/active_support/core_ext/time.rb
+++ b/activesupport/lib/active_support/core_ext/time.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/time/acts_like'
 require 'active_support/core_ext/time/calculations'
+require 'active_support/core_ext/time/compatibility'
 require 'active_support/core_ext/time/conversions'
 require 'active_support/core_ext/time/marshal'
 require 'active_support/core_ext/time/zones'

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -63,6 +63,13 @@ class Time
     end_of_day.to_i - to_i
   end
 
+  # Returns the fraction of a second as a +Rational+
+  #
+  #    Time.new(2012, 8, 29, 0, 0, 0.5).sec_fraction # => (1/2)
+  def sec_fraction
+    Rational(nsec, 1000000000)
+  end
+
   # Returns a new Time where one or more of the elements have been changed according
   # to the +options+ parameter. The time options (<tt>:hour</tt>, <tt>:min</tt>,
   # <tt>:sec</tt>, <tt>:usec</tt>, <tt>:nsec</tt>) reset cascadingly, so if only

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -65,9 +65,9 @@ class Time
 
   # Returns the fraction of a second as a +Rational+
   #
-  #    Time.new(2012, 8, 29, 0, 0, 0.5).sec_fraction # => (1/2)
+  #   Time.new(2012, 8, 29, 0, 0, 0.5).sec_fraction # => (1/2)
   def sec_fraction
-    Rational(nsec, 1000000000)
+    subsec
   end
 
   # Returns a new Time where one or more of the elements have been changed according

--- a/activesupport/lib/active_support/core_ext/time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/time/compatibility.rb
@@ -1,0 +1,5 @@
+require 'active_support/core_ext/date_and_time/compatibility'
+
+class Time
+  prepend DateAndTime::Compatibility
+end

--- a/activesupport/lib/active_support/core_ext/time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/time/compatibility.rb
@@ -1,5 +1,5 @@
 require 'active_support/core_ext/date_and_time/compatibility'
 
 class Time
-  prepend DateAndTime::Compatibility
+  include DateAndTime::Compatibility
 end

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -45,16 +45,17 @@ module ActiveSupport
     attr_reader :time_zone
 
     def initialize(utc_time, time_zone, local_time = nil, period = nil)
-      @utc, @time_zone, @time = utc_time, time_zone, local_time
+      @utc = utc_time ? transfer_time_values_to_utc_constructor(utc_time) : nil
+      @time_zone, @time = time_zone, local_time
       @period = @utc ? period : get_period_and_ensure_valid_local_time(period)
     end
 
-    # Returns a Time or DateTime instance that represents the time in +time_zone+.
+    # Returns a <tt>Time</tt> instance that represents the time in +time_zone+.
     def time
       @time ||= period.to_local(@utc)
     end
 
-    # Returns a Time or DateTime instance that represents the time in UTC.
+    # Returns a <tt>Time</tt> instance of the simultaneous time in the UTC timezone.
     def utc
       @utc ||= period.to_utc(@time)
     end
@@ -74,10 +75,9 @@ module ActiveSupport
       utc.in_time_zone(new_zone)
     end
 
-    # Returns a <tt>Time.local()</tt> instance of the simultaneous time in your
-    # system's <tt>ENV['TZ']</tt> zone.
+    # Returns a <tt>Time</tt> instance of the simultaneous time in the system timezone.
     def localtime(utc_offset = nil)
-      utc.respond_to?(:getlocal) ? utc.getlocal(utc_offset) : utc.to_time.getlocal(utc_offset)
+      utc.getlocal(utc_offset)
     end
     alias_method :getlocal, :localtime
 
@@ -361,7 +361,6 @@ module ActiveSupport
     # Ensure proxy class responds to all methods that underlying time instance
     # responds to.
     def respond_to_missing?(sym, include_priv)
-      # consistently respond false to acts_like?(:date), regardless of whether #time is a Time or DateTime
       return false if sym.to_sym == :acts_like_date?
       time.respond_to?(sym, include_priv)
     end
@@ -389,7 +388,7 @@ module ActiveSupport
       end
 
       def transfer_time_values_to_utc_constructor(time)
-        ::Time.utc(time.year, time.month, time.day, time.hour, time.min, time.sec, Rational(time.nsec, 1000))
+        ::Time.utc(time.year, time.month, time.day, time.hour, time.min, time.sec + time.subsec)
       end
 
       def duration_of_variable_length?(obj)

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -1,5 +1,6 @@
 require 'active_support/values/time_zone'
 require 'active_support/core_ext/object/acts_like'
+require 'active_support/core_ext/date_and_time/compatibility'
 
 module ActiveSupport
   # A Time-like class that can represent a time in any time zone. Necessary
@@ -40,7 +41,7 @@ module ActiveSupport
       'Time'
     end
 
-    include Comparable
+    include Comparable, DateAndTime::Compatibility
     attr_reader :time_zone
 
     def initialize(utc_time, time_zone, local_time = nil, period = nil)
@@ -319,11 +320,6 @@ module ActiveSupport
 
     def to_r
       utc.to_r
-    end
-
-    # Return an instance of Time in the system timezone.
-    def to_time
-      @to_time ||= utc.to_time
     end
 
     def to_datetime

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -24,6 +24,9 @@ Thread.abort_on_exception = true
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveSupport::Deprecation.debug = true
 
+# Default to old to_time behavior but allow running tests with new behavior
+ActiveSupport.to_time_preserves_timezone = ENV['PRESERVE_TIMEZONES'] == '1'
+
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false
 

--- a/activesupport/test/core_ext/date_and_time_compatibility_test.rb
+++ b/activesupport/test/core_ext/date_and_time_compatibility_test.rb
@@ -1,0 +1,110 @@
+require 'abstract_unit'
+require 'active_support/time'
+require 'time_zone_test_helpers'
+
+class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
+  include TimeZoneTestHelpers
+
+  def setup
+    @utc_time = Time.utc(2016, 4, 23, 14, 11, 12)
+    @utc_offset = 3600
+    @system_offset = -14400
+    @zone = ActiveSupport::TimeZone['London']
+  end
+
+  def test_time_to_time_preserves_timezone
+    with_preserve_timezone(true) do
+      with_env_tz 'US/Eastern' do
+        time = Time.new(2016, 4, 23, 15, 11, 12, 3600).to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_equal @utc_offset, time.utc_offset
+      end
+    end
+  end
+
+  def test_time_to_time_does_not_preserve_time_zone
+    with_preserve_timezone(false) do
+      with_env_tz 'US/Eastern' do
+        time = Time.new(2016, 4, 23, 15, 11, 12, 3600).to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_equal @system_offset, time.utc_offset
+      end
+    end
+  end
+
+  def test_datetime_to_time_preserves_timezone
+    with_preserve_timezone(true) do
+      with_env_tz 'US/Eastern' do
+        time = DateTime.new(2016, 4, 23, 15, 11, 12, Rational(1,24)).to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_equal @utc_offset, time.utc_offset
+      end
+    end
+  end
+
+  def test_datetime_to_time_does_not_preserve_time_zone
+    with_preserve_timezone(false) do
+      with_env_tz 'US/Eastern' do
+        time = DateTime.new(2016, 4, 23, 15, 11, 12, Rational(1,24)).to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_equal @system_offset, time.utc_offset
+      end
+    end
+  end
+
+  def test_twz_to_time_preserves_timezone
+    with_preserve_timezone(true) do
+      with_env_tz 'US/Eastern' do
+        time = ActiveSupport::TimeWithZone.new(@utc_time, @zone).to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_equal @utc_offset, time.utc_offset
+      end
+    end
+  end
+
+  def test_twz_to_time_does_not_preserve_time_zone
+    with_preserve_timezone(false) do
+      with_env_tz 'US/Eastern' do
+        time = ActiveSupport::TimeWithZone.new(@utc_time, @zone).to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_equal @system_offset, time.utc_offset
+      end
+    end
+  end
+
+  def test_string_to_time_preserves_timezone
+    with_preserve_timezone(true) do
+      with_env_tz 'US/Eastern' do
+        time = "2016-04-23T15:11:12+01:00".to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_equal @utc_offset, time.utc_offset
+      end
+    end
+  end
+
+  def test_string_to_time_does_not_preserve_time_zone
+    with_preserve_timezone(false) do
+      with_env_tz 'US/Eastern' do
+        time = "2016-04-23T15:11:12+01:00".to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_equal @system_offset, time.utc_offset
+      end
+    end
+  end
+end

--- a/activesupport/test/core_ext/date_and_time_compatibility_test.rb
+++ b/activesupport/test/core_ext/date_and_time_compatibility_test.rb
@@ -7,6 +7,7 @@ class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
 
   def setup
     @utc_time = Time.utc(2016, 4, 23, 14, 11, 12)
+    @date_time = DateTime.new(2016, 4, 23, 14, 11, 12, 0)
     @utc_offset = 3600
     @system_offset = -14400
     @zone = ActiveSupport::TimeZone['London']
@@ -67,6 +68,14 @@ class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
 
         assert_instance_of Time, time
         assert_equal @utc_time, time.getutc
+        assert_instance_of Time, time.getutc
+        assert_equal @utc_offset, time.utc_offset
+
+        time = ActiveSupport::TimeWithZone.new(@date_time, @zone).to_time
+
+        assert_instance_of Time, time
+        assert_equal @date_time, time.getutc
+        assert_instance_of Time, time.getutc
         assert_equal @utc_offset, time.utc_offset
       end
     end
@@ -79,6 +88,14 @@ class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
 
         assert_instance_of Time, time
         assert_equal @utc_time, time.getutc
+        assert_instance_of Time, time.getutc
+        assert_equal @system_offset, time.utc_offset
+
+        time = ActiveSupport::TimeWithZone.new(@date_time, @zone).to_time
+
+        assert_instance_of Time, time
+        assert_equal @date_time, time.getutc
+        assert_instance_of Time, time.getutc
         assert_equal @system_offset, time.utc_offset
       end
     end

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -69,8 +69,14 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   def test_to_time
     with_env_tz 'US/Eastern' do
       assert_instance_of Time, DateTime.new(2005, 2, 21, 10, 11, 12, 0).to_time
-      assert_equal Time.local(2005, 2, 21, 5, 11, 12), DateTime.new(2005, 2, 21, 10, 11, 12, 0).to_time
-      assert_equal Time.local(2005, 2, 21, 5, 11, 12).utc_offset, DateTime.new(2005, 2, 21, 10, 11, 12, 0).to_time.utc_offset
+
+      if ActiveSupport.to_time_preserves_timezone
+        assert_equal Time.local(2005, 2, 21, 5, 11, 12).getlocal(0), DateTime.new(2005, 2, 21, 10, 11, 12, 0).to_time
+        assert_equal Time.local(2005, 2, 21, 5, 11, 12).getlocal(0).utc_offset, DateTime.new(2005, 2, 21, 10, 11, 12, 0).to_time.utc_offset
+      else
+        assert_equal Time.local(2005, 2, 21, 5, 11, 12), DateTime.new(2005, 2, 21, 10, 11, 12, 0).to_time
+        assert_equal Time.local(2005, 2, 21, 5, 11, 12).utc_offset, DateTime.new(2005, 2, 21, 10, 11, 12, 0).to_time.utc_offset
+      end
     end
   end
 

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -40,6 +40,14 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     Time::DATE_FORMATS.delete(:custom)
   end
 
+  def test_getlocal
+    with_env_tz 'US/Eastern' do
+      assert_equal Time.local(2016, 3, 11, 10, 11, 12), DateTime.new(2016, 3, 11, 15, 11, 12, 0).getlocal
+      assert_equal Time.local(2016, 3, 21, 11, 11, 12), DateTime.new(2016, 3, 21, 15, 11, 12, 0).getlocal
+      assert_equal Time.local(2016, 4, 1, 11, 11, 12), DateTime.new(2016, 4, 1, 16, 11, 12, Rational(1,24)).getlocal
+    end
+  end
+
   def test_to_date
     assert_equal Date.new(2005, 2, 21), DateTime.new(2005, 2, 21, 14, 30, 0).to_date
   end

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -370,4 +370,9 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal 0, DateTime.civil(2000).nsec
     assert_equal 500000000, DateTime.civil(2000, 1, 1, 0, 0, Rational(1,2)).nsec
   end
+
+  def test_subsec
+    assert_equal 0, DateTime.civil(2000).subsec
+    assert_equal Rational(1,2), DateTime.civil(2000, 1, 1, 0, 0, Rational(1,2)).subsec
+  end
 end

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -40,8 +40,18 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     Time::DATE_FORMATS.delete(:custom)
   end
 
+  def test_localtime
+    with_env_tz 'US/Eastern' do
+      assert_instance_of Time, DateTime.new(2016, 3, 11, 15, 11, 12, 0).localtime
+      assert_equal Time.local(2016, 3, 11, 10, 11, 12), DateTime.new(2016, 3, 11, 15, 11, 12, 0).localtime
+      assert_equal Time.local(2016, 3, 21, 11, 11, 12), DateTime.new(2016, 3, 21, 15, 11, 12, 0).localtime
+      assert_equal Time.local(2016, 4, 1, 11, 11, 12), DateTime.new(2016, 4, 1, 16, 11, 12, Rational(1,24)).localtime
+    end
+  end
+
   def test_getlocal
     with_env_tz 'US/Eastern' do
+      assert_instance_of Time, DateTime.new(2016, 3, 11, 15, 11, 12, 0).getlocal
       assert_equal Time.local(2016, 3, 11, 10, 11, 12), DateTime.new(2016, 3, 11, 15, 11, 12, 0).getlocal
       assert_equal Time.local(2016, 3, 21, 11, 11, 12), DateTime.new(2016, 3, 21, 15, 11, 12, 0).getlocal
       assert_equal Time.local(2016, 4, 1, 11, 11, 12), DateTime.new(2016, 4, 1, 16, 11, 12, Rational(1,24)).getlocal
@@ -58,7 +68,7 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_to_time
     with_env_tz 'US/Eastern' do
-      assert_equal Time, DateTime.new(2005, 2, 21, 10, 11, 12, 0).to_time.class
+      assert_instance_of Time, DateTime.new(2005, 2, 21, 10, 11, 12, 0).to_time
       assert_equal Time.local(2005, 2, 21, 5, 11, 12), DateTime.new(2005, 2, 21, 10, 11, 12, 0).to_time
       assert_equal Time.local(2005, 2, 21, 5, 11, 12).utc_offset, DateTime.new(2005, 2, 21, 10, 11, 12, 0).to_time.utc_offset
     end
@@ -306,6 +316,7 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_utc
+    assert_instance_of Time, DateTime.civil(2005, 2, 21, 10, 11, 12, Rational(-6, 24)).utc
     assert_equal DateTime.civil(2005, 2, 21, 16, 11, 12, 0), DateTime.civil(2005, 2, 21, 10, 11, 12, Rational(-6, 24)).utc
     assert_equal DateTime.civil(2005, 2, 21, 15, 11, 12, 0), DateTime.civil(2005, 2, 21, 10, 11, 12, Rational(-5, 24)).utc
     assert_equal DateTime.civil(2005, 2, 21, 10, 11, 12, 0), DateTime.civil(2005, 2, 21, 10, 11, 12, 0).utc

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -421,10 +421,17 @@ class StringConversionsTest < ActiveSupport::TestCase
 
   def test_string_to_time_utc_offset
     with_env_tz "US/Eastern" do
-      assert_equal 0, "2005-02-27 23:50".to_time(:utc).utc_offset
-      assert_equal(-18000, "2005-02-27 23:50".to_time.utc_offset)
-      assert_equal 0, "2005-02-27 22:50 -0100".to_time(:utc).utc_offset
-      assert_equal(-18000, "2005-02-27 22:50 -0100".to_time.utc_offset)
+      if ActiveSupport.to_time_preserves_timezone
+        assert_equal 0, "2005-02-27 23:50".to_time(:utc).utc_offset
+        assert_equal(-18000, "2005-02-27 23:50".to_time.utc_offset)
+        assert_equal 0, "2005-02-27 22:50 -0100".to_time(:utc).utc_offset
+        assert_equal(-3600, "2005-02-27 22:50 -0100".to_time.utc_offset)
+      else
+        assert_equal 0, "2005-02-27 23:50".to_time(:utc).utc_offset
+        assert_equal(-18000, "2005-02-27 23:50".to_time.utc_offset)
+        assert_equal 0, "2005-02-27 22:50 -0100".to_time(:utc).utc_offset
+        assert_equal(-18000, "2005-02-27 22:50 -0100".to_time.utc_offset)
+      end
     end
   end
 

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -107,6 +107,20 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_sec_fraction
+    time = Time.utc(2016, 4, 23, 0, 0, Rational(1,10000000000))
+    assert_equal Rational(1,10000000000), time.sec_fraction
+
+    time = Time.utc(2016, 4, 23, 0, 0, 0.0000000001)
+    assert_equal 0.0000000001.to_r, time.sec_fraction
+
+    time = Time.utc(2016, 4, 23, 0, 0, 0, Rational(1,10000))
+    assert_equal Rational(1,10000000000), time.sec_fraction
+
+    time = Time.utc(2016, 4, 23, 0, 0, 0, 0.0001)
+    assert_equal 0.0001.to_r / 1000000, time.sec_fraction
+  end
+
   def test_beginning_of_day
     assert_equal Time.local(2005,2,4,0,0,0), Time.local(2005,2,4,10,10,10).beginning_of_day
     with_env_tz 'US/Eastern' do

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -10,10 +10,13 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     @utc = Time.utc(2000, 1, 1, 0)
     @time_zone = ActiveSupport::TimeZone['Eastern Time (US & Canada)']
     @twz = ActiveSupport::TimeWithZone.new(@utc, @time_zone)
+    @dt_twz = ActiveSupport::TimeWithZone.new(@utc.to_datetime, @time_zone)
   end
 
   def test_utc
     assert_equal @utc, @twz.utc
+    assert_instance_of Time, @twz.utc
+    assert_instance_of Time, @dt_twz.utc
   end
 
   def test_time
@@ -46,6 +49,8 @@ class TimeWithZoneTest < ActiveSupport::TestCase
 
   def test_localtime
     assert_equal @twz.localtime, @twz.utc.getlocal
+    assert_instance_of Time, @twz.localtime
+    assert_instance_of Time, @dt_twz.localtime
   end
 
   def test_utc?

--- a/activesupport/test/time_zone_test_helpers.rb
+++ b/activesupport/test/time_zone_test_helpers.rb
@@ -13,4 +13,12 @@ module TimeZoneTestHelpers
   ensure
     old_tz ? ENV['TZ'] = old_tz : ENV.delete('TZ')
   end
+
+  def with_preserve_timezone(value)
+    old_preserve_tz = ActiveSupport.to_time_preserves_timezone
+    ActiveSupport.to_time_preserves_timezone = value
+    yield
+  ensure
+    ActiveSupport.to_time_preserves_timezone = old_preserve_tz
+  end
 end

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `config/initializers/to_time_preserves_timezone.rb`, which tells
+    Active Support to preserve the receiver's timezone when calling `to_time`.
+    This matches the new behavior that will be part of Ruby 2.4.
+
+    Fixes #24617.
+
+    *Andrew White*
+
 *   Reset a new session directly after its creation in ActionDispatch::IntegrationTest#open_session
 
     Fixes Issue #22742

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -88,11 +88,16 @@ module Rails
 
     def config_when_updating
       cookie_serializer_config_exist = File.exist?('config/initializers/cookies_serializer.rb')
+      to_time_preserves_timezone_config_exist = File.exist?('config/initializers/to_time_preserves_timezone.rb')
 
       config
 
       unless cookie_serializer_config_exist
         gsub_file 'config/initializers/cookies_serializer.rb', /json/, 'marshal'
+      end
+
+      unless to_time_preserves_timezone_config_exist
+        remove_file 'config/initializers/to_time_preserves_timezone.rb'
       end
     end
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/to_time_preserves_timezone.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/to_time_preserves_timezone.rb
@@ -1,0 +1,10 @@
+# Be sure to restart your server when you modify this file.
+
+# Preserve the timezone of the receiver when calling to `to_time`.
+# Ruby 2.4 will change the behavior of `to_time` to preserve the timezone
+# when converting to an instance of `Time` instead of the previous behavior
+# of converting to the local system timezone.
+#
+# Rails 5.0 introduced this config option so that apps made with earlier
+# versions of Rails are not affected when upgrading.
+ActiveSupport.to_time_preserves_timezone = true

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -176,6 +176,34 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file("#{app_root}/config/initializers/cookies_serializer.rb", /Rails\.application\.config\.action_dispatch\.cookies_serializer = :marshal/)
   end
 
+  def test_rails_update_does_not_create_to_time_preserves_timezone
+    app_root = File.join(destination_root, 'myapp')
+    run_generator [app_root]
+
+    FileUtils.rm("#{app_root}/config/initializers/to_time_preserves_timezone.rb")
+
+    stub_rails_application(app_root) do
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
+      generator.send(:app_const)
+      quietly { generator.send(:update_config_files) }
+      assert_no_file "#{app_root}/config/initializers/to_time_preserves_timezone.rb"
+    end
+  end
+
+  def test_rails_update_does_not_remove_to_time_preserves_timezone_if_already_present
+    app_root = File.join(destination_root, 'myapp')
+    run_generator [app_root]
+
+    FileUtils.touch("#{app_root}/config/initializers/to_time_preserves_timezone.rb")
+
+    stub_rails_application(app_root) do
+      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
+      generator.send(:app_const)
+      quietly { generator.send(:update_config_files) }
+      assert_file "#{app_root}/config/initializers/to_time_preserves_timezone.rb"
+    end
+  end
+
   def test_application_names_are_not_singularized
     run_generator [File.join(destination_root, "hats")]
     assert_file "hats/config/environment.rb", /Rails\.application\.initialize!/

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -182,12 +182,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     FileUtils.rm("#{app_root}/config/initializers/to_time_preserves_timezone.rb")
 
-    stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
-      generator.send(:app_const)
-      quietly { generator.send(:update_config_files) }
-      assert_no_file "#{app_root}/config/initializers/to_time_preserves_timezone.rb"
-    end
+    Rails.application.config.root = app_root
+    Rails.application.class.stubs(:name).returns("Myapp")
+    Rails.application.stubs(:is_a?).returns(Rails::Application)
+
+    generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
+    generator.send(:app_const)
+    quietly { generator.send(:update_config_files) }
+    assert_no_file "#{app_root}/config/initializers/to_time_preserves_timezone.rb"
   end
 
   def test_rails_update_does_not_remove_to_time_preserves_timezone_if_already_present
@@ -196,12 +198,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     FileUtils.touch("#{app_root}/config/initializers/to_time_preserves_timezone.rb")
 
-    stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
-      generator.send(:app_const)
-      quietly { generator.send(:update_config_files) }
-      assert_file "#{app_root}/config/initializers/to_time_preserves_timezone.rb"
-    end
+    Rails.application.config.root = app_root
+    Rails.application.class.stubs(:name).returns("Myapp")
+    Rails.application.stubs(:is_a?).returns(Rails::Application)
+
+    generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
+    generator.send(:app_const)
+    quietly { generator.send(:update_config_files) }
+    assert_file "#{app_root}/config/initializers/to_time_preserves_timezone.rb"
   end
 
   def test_application_names_are_not_singularized


### PR DESCRIPTION
This backports the changes made to Rails 5.0 required for supporting Ruby 2.4. This was mainly around the behaviour of `to_time` but since the changes required the backporting of a later fix for a possible stack level too deep error (ee5e476) and the caching of `to_time` it was safest to include a number of small changes which possibly aren't entirely necessary, but would've meant rewriting patches to make them apply cleanly. However larger changes like duration parsing were left out since they could be safely ignored.

Needed for #27473.