### PR TITLE
Use `count(:all)` in HasManyAssociation#count_records

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Use `count(:all)` in `HasManyAssociation#count_records` to prevent invalid
+    SQL queries for association counting.
+
+    *Klas Eskilson*
+
 *   Deprecate locking records with unpersisted changes.
 
     *Marc Schütz*

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -66,7 +66,7 @@ module ActiveRecord
           count = if reflection.has_cached_counter?
             owner._read_attribute(reflection.counter_cache_column).to_i
           else
-            scope.count
+            scope.count(:all)
           end
 
           # If there's nothing in the database and @target has no new records

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2446,6 +2446,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal [first_bulb, second_bulb], car.bulbs
   end
 
+  test "association size calculation works with default scoped selects when not previously fetched" do
+    firm = Firm.create!(name: "Firm")
+    5.times { firm.developers_with_select << Developer.create!(name: "Developer") }
+
+    same_firm = Firm.find(firm.id)
+    assert_equal 5, same_firm.developers_with_select.size
+  end
+
   test "double insertion of new object to association when same association used in the after create callback of a new object" do
     reset_callbacks(:save, Bulb) do
       Bulb.after_save { |record| record.car.bulbs.load }

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -85,6 +85,8 @@ class Firm < Company
 
   has_many :association_with_references, -> { references(:foo) }, class_name: "Client"
 
+  has_many :developers_with_select, -> { select("id, name, first_name") }, class_name: "Developer"
+
   has_one :lead_developer, class_name: "Developer"
   has_many :projects
 


### PR DESCRIPTION
Problem: Calling `count` on an association can cause invalid SQL queries to be created where the `SELECT COUNT(a, b, c)` function receives multiple  columns. This will cause a `StatementInvalid` exception later on.

Solution: Use `count(:all)`, which generates a `SELECT COUNT(*)...` query independently of the association.

Background: This appears to be previously an known problem, see https://github.com/rails/rails/issues/15138 and https://github.com/rails/rails/issues/13648.

Hit me with your feedback! 👍 