### PR TITLE
Fix typo s/permited/permitted/

### DIFF
--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -235,14 +235,14 @@ class UrlHelperTest < ActiveSupport::TestCase
     end
   end
 
-  def test_button_to_with_permited_strong_params
+  def test_button_to_with_permitted_strong_params
     assert_dom_equal(
       %{<form action="http://www.example.com" class="button_to" method="post"><input type="submit" value="Hello" /><input type="hidden" name="baz" value="quux" /><input type="hidden" name="foo" value="bar" /></form>},
       button_to("Hello", "http://www.example.com", params: FakeParams.new)
     )
   end
 
-  def test_button_to_with_unpermited_strong_params
+  def test_button_to_with_unpermitted_strong_params
     assert_raises(ArgumentError) do
       button_to("Hello", "http://www.example.com", params: FakeParams.new(false))
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1617,7 +1617,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal "David", topic2.reload.author_name
   end
 
-  def test_update_on_relation_passing_active_record_object_is_not_permited
+  def test_update_on_relation_passing_active_record_object_is_not_permitted
     topic = Topic.create!(title: "Foo", author_name: nil)
     assert_raises(ArgumentError) do
       Topic.where(id: topic.id).update(topic, title: "Bar")


### PR DESCRIPTION
```
% git grep -n permited
actionview/test/template/url_helper_test.rb:238:  def test_button_to_with_permited_strong_params
actionview/test/template/url_helper_test.rb:245:  def test_button_to_with_unpermited_strong_params
activerecord/test/cases/relations_test.rb:1620:  def test_update_on_relation_passing_active_record_object_is_not_permited
```
