### PR TITLE
Fix `find_by` and `where` consistency

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -196,12 +196,12 @@ module ActiveRecord
       end
 
       def find_by(*args) # :nodoc:
-        return super if scope_attributes? || !(Hash === args.first) || reflect_on_all_aggregations.any?
+        return super if scope_attributes? || reflect_on_all_aggregations.any?
 
         hash = args.first
 
-        return super if hash.values.any? { |v|
-          v.nil? || Array === v || Hash === v || Relation === v
+        return super if !(Hash === hash) || hash.values.any? { |v|
+          v.nil? || Array === v || Hash === v || Relation === v || Base === v
         }
 
         # We can't cache Post.find_by(author: david) ...yet

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -339,6 +339,11 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal author.post, Post.find_by(author_id: Author.where(id: author))
   end
 
+  def test_find_by_and_where_consistency_with_active_record_instance
+    author = authors(:david)
+    assert_equal Post.where(author_id: author).take, Post.find_by(author_id: author)
+  end
+
   def test_take
     assert_equal topics(:first), Topic.take
   end


### PR DESCRIPTION
The alternative of #26213.

Currently `find_by` and `where` with AR object return inconsistent
result. This is caused by statement cache does not support AR object.
Passing to finder method to fix the issue.

Fixes #26210.