### PR TITLE
Fix collection_singular_ids= ignores different primary key on relationhip

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -61,10 +61,17 @@ module ActiveRecord
 
       # Implements the ids writer method, e.g. foo.item_ids= for Foo.has_many :items
       def ids_writer(ids)
-        pk_type = reflection.primary_key_type
-        ids = Array(ids).reject { |id| id.blank? }
-        ids.map! { |i| pk_type.type_cast_from_user(i) }
-        replace(klass.find(ids).index_by { |r| r.id }.values_at(*ids))
+        pk_column = reflection.association_primary_key
+        pk_type = klass.type_for_attribute(pk_column)
+        ids = Array(ids).reject(&:blank?).map do |i|
+          pk_type.type_cast_from_user(i)
+        end
+
+        if (objs = klass.where(pk_column => ids)).size == ids.size
+          replace(objs.index_by { |r| r.send(pk_column) }.values_at(*ids))
+        else
+          objs.raise_record_not_found_exception!(ids, objs.size, ids.size)
+        end
       end
 
       def reset

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -26,12 +26,15 @@ require 'models/member'
 require 'models/membership'
 require 'models/club'
 require 'models/organization'
+require 'models/user'
+require 'models/user_business'
+require 'models/business'
 
 class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :posts, :readers, :people, :comments, :authors, :categories, :taggings, :tags,
            :owners, :pets, :toys, :jobs, :references, :companies, :members, :author_addresses,
            :subscribers, :books, :subscriptions, :developers, :categorizations, :essays,
-           :categories_posts, :clubs, :memberships, :organizations
+           :categories_posts, :clubs, :memberships, :organizations, :users, :businesses
 
   # Dummies to force column loads so query counts are clean.
   def setup
@@ -1200,5 +1203,12 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal [other_club], tenant_clubs
   ensure
     TenantMembership.current_member = nil
+  end
+
+  def test_singular_collection_ids_are_set_correctly
+    @user = users(:one)
+    assert @user.businesses.empty?
+    @user.business_ids = [businesses(:walmart).uuid]
+    assert @user.businesses.include?(businesses(:walmart))
   end
 end

--- a/activerecord/test/fixtures/businesses.yml
+++ b/activerecord/test/fixtures/businesses.yml
@@ -1,0 +1,3 @@
+walmart:
+  name: walmart
+  uuid: <%= SecureRandom.uuid %>

--- a/activerecord/test/fixtures/users.yml
+++ b/activerecord/test/fixtures/users.yml
@@ -1,0 +1,2 @@
+one:
+  name: Bob Smith

--- a/activerecord/test/models/business.rb
+++ b/activerecord/test/models/business.rb
@@ -1,0 +1,2 @@
+class Business < ActiveRecord::Base
+end

--- a/activerecord/test/models/user.rb
+++ b/activerecord/test/models/user.rb
@@ -1,0 +1,4 @@
+class User < ActiveRecord::Base
+  has_many :user_businesses
+  has_many :businesses, through: :user_businesses
+end

--- a/activerecord/test/models/user_business.rb
+++ b/activerecord/test/models/user_business.rb
@@ -1,0 +1,4 @@
+class UserBusiness < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :business, primary_key: :uuid
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -798,6 +798,20 @@ ActiveRecord::Schema.define do
     t.integer :car_id
   end
 
+  create_table :users, force: true do |t|
+    t.string :name
+  end
+
+  create_table :user_businesses, force: true do |t|
+    t.belongs_to :user
+    t.string :business_id, index: true
+  end
+
+  create_table :businesses, force: true do |t|
+    t.string :name
+    t.string :uuid
+  end
+
   create_table :variants, force: true do |t|
     t.references :product
     t.string     :name


### PR DESCRIPTION
Closely related to #14439. It looks like someone opened a PR to try and fix this(#15262) but it looks to be abandoned. This is resolved in Rails 5 but is not resolved in the 4.2. I thought I would open a PR since this isn't a feature enhancement but a bug in 4.2. 

Example Models:
```ruby
class User < ActiveRecord::Base
  has_many :user_businesses
  has_many :businesses, through: :user_businesses
end

class UserBusiness < ActiveRecord::Base
  belongs_to :user
  belongs_to :business, primary_key: :uuid
end

class Business < ActiveRecord::Base
end
```

When a different primary_key is signified on the `has_many through` relationship, using `user.business_ids = ["111-111-111"]` throws a `RecordNotFound` exception. This is due to the `ids_writers` method ignoring the `primary_key` key and using the default primary key(id) when looking for records. The `ids_writer` method essentially does this: `Business.find(["111-111-111"])` and then the ids that are passed get cast to integers. 

Here's a gist to help clear up any confusion: https://gist.github.com/npezza93/3a34d8b023669c70bf5f16d89ab0d111