### PR TITLE
add missing code in "Extracting Partials" documentation

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1798,15 +1798,17 @@ the article. Create the file `app/views/comments/_comment.html.erb` and put the
 following into it:
 
 ```html+erb
-<p>
-  <strong>Commenter:</strong>
-  <%= comment.commenter %>
-</p>
+<% @article.comments.each do |comment| %>
+  <p>
+    <strong>Commenter:</strong>
+    <%= comment.commenter %>
+  </p>
 
-<p>
-  <strong>Comment:</strong>
-  <%= comment.body %>
-</p>
+  <p>
+    <strong>Comment:</strong>
+    <%= comment.body %>
+  </p>
+<% end %>
 ```
 
 Then you can change `app/views/articles/show.html.erb` to look like the


### PR DESCRIPTION
In the Rails Documentation > Rails Guides > Getting Started
Section 7.1 "Rendering Partial Collections"

### Summary

The comment partial being extracted lacks the looping block to iterate through comments.
i.e.: there was no surrounding "<% @article.comments.each do |comment| %>" and "<% end %>"