### PR TITLE
Simplify the version specifier generated by prereleases

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -261,14 +261,13 @@ module Rails
       end
 
       def rails_version_specifier(gem_version = Rails.gem_version)
-        if gem_version.prerelease?
-          next_series = gem_version
-          next_series = next_series.bump while next_series.segments.size > 2
-
-          [">= #{gem_version}", "< #{next_series}"]
-        elsif gem_version.segments.size == 3
+        if gem_version.segments.size == 3 || gem_version.release.segments.size == 3
+          # ~> 1.2.3
+          # ~> 1.2.3.pre4
           "~> #{gem_version}"
         else
+          # ~> 1.2.3, >= 1.2.3.4
+          # ~> 1.2.3, >= 1.2.3.4.pre5
           patch = gem_version.segments[0, 3].join(".")
           ["~> #{patch}", ">= #{gem_version}"]
         end

--- a/railties/test/generators/generator_test.rb
+++ b/railties/test/generators/generator_test.rb
@@ -88,12 +88,12 @@ module Rails
         specifier_for = -> v { generator.send(:rails_version_specifier, Gem::Version.new(v)) }
 
         assert_equal "~> 4.1.13", specifier_for["4.1.13"]
-        assert_equal [">= 4.1.6.rc1", "< 4.2"], specifier_for["4.1.6.rc1"]
+        assert_equal "~> 4.1.6.rc1", specifier_for["4.1.6.rc1"]
         assert_equal ["~> 4.1.7", ">= 4.1.7.1"], specifier_for["4.1.7.1"]
         assert_equal ["~> 4.1.7", ">= 4.1.7.1.2"], specifier_for["4.1.7.1.2"]
-        assert_equal [">= 4.1.7.1.rc2", "< 4.2"], specifier_for["4.1.7.1.rc2"]
-        assert_equal [">= 4.2.0.beta1", "< 4.3"], specifier_for["4.2.0.beta1"]
-        assert_equal [">= 5.0.0.beta1", "< 5.1"], specifier_for["5.0.0.beta1"]
+        assert_equal ["~> 4.1.7", ">= 4.1.7.1.rc2"], specifier_for["4.1.7.1.rc2"]
+        assert_equal "~> 4.2.0.beta1", specifier_for["4.2.0.beta1"]
+        assert_equal "~> 5.0.0.beta1", specifier_for["5.0.0.beta1"]
       end
     end
   end


### PR DESCRIPTION
"~> 1.2.3.pre4" will automatically allow "1.2.4" -- no need for an explicit range.

I was being needlessly complicated in #22657. This changes the string we output, but not the set of versions it permits.
