### PR TITLE
use double quotes, follow new string literal convention

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -259,7 +259,7 @@ module ActionDispatch
       host = uri_or_host.host unless path
       path ||= uri_or_host.path
 
-      params = { "PATH_INFO"      => path,
+      params = { "PATH_INFO"     => path,
                 "REQUEST_METHOD" => method,
                 "HTTP_HOST"      => host }
 

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -280,18 +280,18 @@ class QueryCacheTest < ActiveRecord::TestCase
 
     # Warm up the cache by running the query
     assert_queries(1) do
-      assert_equal 0, Post.where(title: 'test').to_a.count
+      assert_equal 0, Post.where(title: "test").to_a.count
     end
 
     # Check that if the same query is run again, no queries are executed
     assert_queries(0) do
-      assert_equal 0, Post.where(title: 'test').to_a.count
+      assert_equal 0, Post.where(title: "test").to_a.count
     end
 
     ActiveRecord::Base.connection.uncached do
       # Check that new query is executed, avoiding the cache
       assert_queries(1) do
-        assert_equal 0, Post.where(title: 'test').to_a.count
+        assert_equal 0, Post.where(title: "test").to_a.count
       end
     end
   end

--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -74,7 +74,7 @@ end
 class Symbol
   begin
     :symbol.dup # Ruby 2.4.x.
-    'symbol_from_string'.to_sym.dup # Some symbols can't `dup` in Ruby 2.4.0.
+    "symbol_from_string".to_sym.dup # Some symbols can't `dup` in Ruby 2.4.0.
   rescue TypeError
 
     # Symbols are not duplicable:

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/numeric/time"
 
 class DuplicableTest < ActiveSupport::TestCase
   if RUBY_VERSION >= "2.4.0"
-    RAISE_DUP = [method(:puts), Complex(1), Rational(1), 'symbol_from_string'.to_sym]
+    RAISE_DUP = [method(:puts), Complex(1), Rational(1), "symbol_from_string".to_sym]
     ALLOW_DUP = ["1", Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal.new("4.56"), nil, false, true, 1, 2.3]
   else
     RAISE_DUP = [nil, false, true, :symbol, 1, 2.3, method(:puts), Complex(1), Rational(1)]

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -214,7 +214,6 @@ module ApplicationTests
       assert_equal expected_output, output
     end
 
-
     def test_rails_routes_displays_message_when_no_routes_are_defined
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do


### PR DESCRIPTION
* https://github.com/rails/rails/commit/a731125f - applies new string literal convention
* https://github.com/rails/rails/commit/c6c3b130e1123a1a6220b893bd392a954c7f569f - here missed to follow new string literal convention

also fixed rubocop warning