### PR TITLE
Test inconsistent behavior of infinite values in PG date columns.

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/infinity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/infinity_test.rb
@@ -42,7 +42,7 @@ class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
   end
 
   test "type casting string on a datetime column" do
-    record = PostgresqlInfinity.create!(datetime: 'infinity')
+    record = PostgresqlInfinity.create!(datetime: "infinity")
     record.reload
     assert_equal Float::INFINITY, record.datetime
   end
@@ -54,7 +54,7 @@ class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
   end
 
   test "type casting string on a date column" do
-    record = PostgresqlInfinity.create!(date: 'infinity')
+    record = PostgresqlInfinity.create!(date: "infinity")
     record.reload
     assert_equal Float::INFINITY, record.date
   end
@@ -88,7 +88,7 @@ class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
 
   test "where clause with infinite range (strings) on a datetime column" do
     record = PostgresqlInfinity.create!(datetime: Time.current)
-    found = PostgresqlInfinity.where(datetime: '-infinity'..'infinity').first
+    found = PostgresqlInfinity.where(datetime: "-infinity".."infinity").first
     assert_equal record, found
   end
 
@@ -100,7 +100,7 @@ class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
 
   test "where clause with infinite range (strings) on a date column" do
     record = PostgresqlInfinity.create!(date: Date.current)
-    found = PostgresqlInfinity.where(date: '-infinity'..'infinity').first
+    found = PostgresqlInfinity.where(date: "-infinity".."infinity").first
     assert_equal record, found
   end
 

--- a/activerecord/test/cases/adapters/postgresql/infinity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/infinity_test.rb
@@ -11,6 +11,7 @@ class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
     @connection.create_table(:postgresql_infinities) do |t|
       t.float :float
       t.datetime :datetime
+      t.date :date
     end
   end
 
@@ -40,10 +41,28 @@ class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
     assert_equal Float::INFINITY, record.float
   end
 
-  test "type casting infinity on a datetime column" do
+  test "type casting string on a datetime column" do
+    record = PostgresqlInfinity.create!(datetime: 'infinity')
+    record.reload
+    assert_equal Float::INFINITY, record.datetime
+  end
+
+  test "type casting constant on a datetime column" do
     record = PostgresqlInfinity.create!(datetime: Float::INFINITY)
     record.reload
     assert_equal Float::INFINITY, record.datetime
+  end
+
+  test "type casting string on a date column" do
+    record = PostgresqlInfinity.create!(date: 'infinity')
+    record.reload
+    assert_equal Float::INFINITY, record.date
+  end
+
+  test "type casting constant on a date column" do
+    record = PostgresqlInfinity.create!(date: Float::INFINITY)
+    record.reload
+    assert_equal Float::INFINITY, record.date
   end
 
   test "update_all with infinity on a datetime column" do
@@ -65,5 +84,29 @@ class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
       # There is no way to do this automatically since it can be set on a superclass
       PostgresqlInfinity.reset_column_information
     end
+  end
+
+  test "where clause with infinite range (strings) on a datetime column" do
+    record = PostgresqlInfinity.create!(datetime: Time.current)
+    found = PostgresqlInfinity.where(datetime: '-infinity'..'infinity').first
+    assert_equal record, found
+  end
+
+  test "where clause with infinite range (constants) on a datetime column" do
+    record = PostgresqlInfinity.create!(datetime: Time.current)
+    found = PostgresqlInfinity.where(datetime: -::Float::INFINITY..::Float::INFINITY).first
+    assert_equal record, found
+  end
+
+  test "where clause with infinite range (strings) on a date column" do
+    record = PostgresqlInfinity.create!(date: Date.current)
+    found = PostgresqlInfinity.where(date: '-infinity'..'infinity').first
+    assert_equal record, found
+  end
+
+  test "where clause with infinite range (constants) on a date column" do
+    record = PostgresqlInfinity.create!(date: Date.current)
+    found = PostgresqlInfinity.where(date: -::Float::INFINITY..::Float::INFINITY).first
+    assert_equal record, found
   end
 end


### PR DESCRIPTION
Of the three failing tests in this PR, the range-related one works when run
on v5.0.0.1, but fails on v5.0.1 and master. So it's a behavior change but I'm not
sure what caused it.

The SQL generated by the range test in various versions looks like:
```
v501_sql_with_strings = <<-SQL
  SELECT "postgresql_infinities".*
  FROM "postgresql_infinities"
  WHERE ("postgresql_infinities"."date" BETWEEN NULL AND NULL)
SQL

v5001_sql_with_strings = <<-SQL
  SELECT "postgresql_infinities".*
  FROM "postgresql_infinities"
  WHERE ("postgresql_infinities"."date" BETWEEN '-infinity' AND 'infinity')
SQL

v501_sql_with_constants = <<-SQL
  SELECT "postgresql_infinities".* FROM "postgresql_infinities" WHERE (1=1)
SQL
```

The workaround for the change in behavior is to use `::Float::INFINITY` instead
of `'infinity'` or `'-infinity'` in your ranges.

The other two tests failed in v5.0.0.1 as well as in v5.0.1 and master.

I think that `date` columns should behave the same way as `timestamp` columns
do with respect to infinite values. Specifically, `'infinity'`, `'-infinity'`,
`::Float::INFINITY` and `-::Float::INFINITY` should all be valid values in
`update` statements and `where` clauses. I suspect that this might require the
creation of an `ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date` that
works similarly to `ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime`.