### PR TITLE
Update `cookies` helper on all HTTP requests

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -389,9 +389,7 @@ module ActionController
       # Note that the request method is not verified. The different methods are
       # available to make the tests more expressive.
       def get(action, **args)
-        res = process(action, method: "GET", **args)
-        cookies.update res.cookies
-        res
+        process(action, method: "GET", **args)
       end
 
       # Simulate a POST request with the given parameters and set/volley the response.
@@ -519,6 +517,7 @@ module ActionController
             unless @request.cookie_jar.committed?
               @request.cookie_jar.write(@response)
               cookies.update(@request.cookie_jar.instance_variable_get(:@cookies))
+              cookies.update(@response.cookies)
             end
           end
           @response.prepare!

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -395,6 +395,15 @@ class CookiesTest < ActionController::TestCase
     assert_equal false, cookies.deleted?("another")
   end
 
+  # Ensure all HTTP methods have their cookies updated
+  [:get, :post, :patch, :put, :delete, :head].each do |method|
+    define_method("test_deleting_cookie_#{method}") do
+      request.cookies[:user_name] = "Joe"
+      public_send method, :logout
+      assert_nil cookies[:user_name]
+    end
+  end
+
   def test_deleted_cookie_predicate_with_mismatching_options
     cookies[:user_name] = "Joe"
     cookies.delete("user_name", path: "/path")


### PR DESCRIPTION
### Summary

Regression introduced by ae29142142324545a328948e059e8b8118fd7a33 / 8363b879fe759f0645179f4521cc64795efbee6e.

Previously, cookies were only updated on `GET` requests. Now we will
update the helper for all requests, as part of `process`. Added
regression tests for all available HTTP method helpers in
`ActionController::TestCase`.

### Other Information

- ref #27584 
- very similar to #27145, #27146