### PR TITLE
PostgreSQL JSONB columns do not preserve the key order of hashes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Ignore key order when checking whether JSONB columns have changed in PostgreSQL
+
+    *Bradley Priest*
+
 *   Add type caster to `RuntimeReflection#alias_name`
 
     Fixes #28959.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,5 @@
-*   Ignore key order when checking whether JSONB columns have changed in PostgreSQL
+*   Compare deserialized values for all JSON types when
+    calling `ActiveRecord::Dirty#changed_in_place?`.
 
     *Bradley Priest*
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -841,11 +841,6 @@ module ActiveRecord
         end
 
         class MysqlJson < Type::Internal::AbstractJson # :nodoc:
-          def changed_in_place?(raw_old_value, new_value)
-            # Normalization is required because MySQL JSON data format includes
-            # the space between the elements.
-            super(serialize(deserialize(raw_old_value)), new_value)
-          end
         end
 
         class MysqlString < Type::String # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/jsonb.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/jsonb.rb
@@ -6,31 +6,6 @@ module ActiveRecord
           def type
             :jsonb
           end
-
-          def changed_in_place?(raw_old_value, new_value)
-            # Postgres does not preserve insignificant whitespaces or key order when
-            # round-tripping jsonb columns. This causes some false positives for
-            # the comparison here. Therefore, we need to parse and re-dump the
-            # raw value here to ensure the insignificant whitespaces are
-            # consistent with our encoder's output and that the serialized values
-            # aren't affected by key order.
-
-            raw_old_value = serialize(sort_json_hash_keys(deserialize(raw_old_value)))
-            new_value     = sort_json_hash_keys(new_value)
-            super(raw_old_value, new_value)
-          end
-
-          private
-            def sort_json_hash_keys(parsed_json)
-              case parsed_json
-              when ::Array
-                parsed_json.map { |item| sort_json_hash_keys(item) }
-              when ::Hash
-                ::Hash[parsed_json.sort]
-              else
-                parsed_json
-              end
-            end
         end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/jsonb.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/jsonb.rb
@@ -8,14 +8,29 @@ module ActiveRecord
           end
 
           def changed_in_place?(raw_old_value, new_value)
-            # Postgres does not preserve insignificant whitespaces when
+            # Postgres does not preserve insignificant whitespaces or key order when
             # round-tripping jsonb columns. This causes some false positives for
             # the comparison here. Therefore, we need to parse and re-dump the
             # raw value here to ensure the insignificant whitespaces are
-            # consistent with our encoder's output.
-            raw_old_value = serialize(deserialize(raw_old_value))
+            # consistent with our encoder's output and that the serialized values
+            # aren't affected by key order.
+
+            raw_old_value = serialize(sort_json_hash_keys(deserialize(raw_old_value)))
+            new_value     = sort_json_hash_keys(new_value)
             super(raw_old_value, new_value)
           end
+
+          private
+            def sort_json_hash_keys(parsed_json)
+              case parsed_json
+              when ::Array
+                parsed_json.map { |item| sort_json_hash_keys(item) }
+              when ::Hash
+                ::Hash[parsed_json.sort]
+              else
+                parsed_json
+              end
+            end
         end
       end
     end

--- a/activerecord/lib/active_record/type/internal/abstract_json.rb
+++ b/activerecord/lib/active_record/type/internal/abstract_json.rb
@@ -27,6 +27,14 @@ module ActiveRecord
         def accessor
           ActiveRecord::Store::StringKeyedHashAccessor
         end
+
+        # Normalization is required because MySQL/PostgreSQL store JSON
+        # data in multiple formats.
+        # PostgreSQL JSONB and MySQL JSON add whitespace between the elements,
+        # and PostgreSQL JSONB does not respect key order.
+        def changed_in_place?(raw_old_value, new_value)
+          deserialize(raw_old_value) != new_value
+        end
       end
     end
   end

--- a/activerecord/test/cases/adapters/mysql2/json_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/json_test.rb
@@ -177,6 +177,25 @@ if ActiveRecord::Base.connection.supports_json?
       assert_not json.changed?
     end
 
+    def test_changes_in_place_ignores_key_order
+      json = JsonDataType.new
+      assert_not json.changed?
+
+      json.payload = { "three" => "four", "one" => "two" }
+      json.save!
+      json.reload
+
+      json.payload = { "three" => "four", "one" => "two" }
+      assert_not json.changed?
+
+      json.payload = [{ "three" => "four", "one" => "two" }, { "seven" => "eight", "five" => "six" }]
+      json.save!
+      json.reload
+
+      json.payload = [{ "three" => "four", "one" => "two" }, { "seven" => "eight", "five" => "six" }]
+      assert_not json.changed?
+    end
+
     def test_assigning_string_literal
       json = JsonDataType.create(payload: "foo")
       assert_equal "foo", json.payload

--- a/activerecord/test/cases/adapters/mysql2/json_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/json_test.rb
@@ -1,16 +1,12 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
+require "cases/adapters/shared_json_test"
 
 if ActiveRecord::Base.connection.supports_json?
   class Mysql2JSONTest < ActiveRecord::Mysql2TestCase
     include SchemaDumpingHelper
+    include JSONSharedTestCases
     self.use_transactional_tests = false
-
-    class JsonDataType < ActiveRecord::Base
-      self.table_name = "json_data_type"
-
-      store_accessor :settings, :resolution
-    end
 
     def setup
       @connection = ActiveRecord::Base.connection
@@ -20,20 +16,6 @@ if ActiveRecord::Base.connection.supports_json?
           t.json "settings"
         end
       end
-    end
-
-    def teardown
-      @connection.drop_table :json_data_type, if_exists: true
-      JsonDataType.reset_column_information
-    end
-
-    def test_column
-      column = JsonDataType.columns_hash["payload"]
-      assert_equal :json, column.type
-      assert_equal "json", column.sql_type
-
-      type = JsonDataType.type_for_attribute("payload")
-      assert_not type.binary?
     end
 
     def test_change_table_supports_json
@@ -50,165 +32,8 @@ if ActiveRecord::Base.connection.supports_json?
       assert_match(/t\.json\s+"settings"/, output)
     end
 
-    def test_cast_value_on_write
-      x = JsonDataType.new payload: { "string" => "foo", :symbol => :bar }
-      assert_equal({ "string" => "foo", :symbol => :bar }, x.payload_before_type_cast)
-      assert_equal({ "string" => "foo", "symbol" => "bar" }, x.payload)
-      x.save
-      assert_equal({ "string" => "foo", "symbol" => "bar" }, x.reload.payload)
-    end
-
-    def test_type_cast_json
-      type = JsonDataType.type_for_attribute("payload")
-
-      data = "{\"a_key\":\"a_value\"}"
-      hash = type.deserialize(data)
-      assert_equal({ "a_key" => "a_value" }, hash)
-      assert_equal({ "a_key" => "a_value" }, type.deserialize(data))
-
-      assert_equal({}, type.deserialize("{}"))
-      assert_equal({ "key" => nil }, type.deserialize('{"key": null}'))
-      assert_equal({ "c" => "}", '"a"' => 'b "a b' }, type.deserialize(%q({"c":"}", "\"a\"":"b \"a b"})))
-    end
-
-    def test_rewrite
-      @connection.execute "insert into json_data_type (payload) VALUES ('{\"k\":\"v\"}')"
-      x = JsonDataType.first
-      x.payload = { '"a\'' => "b" }
-      assert x.save!
-    end
-
-    def test_select
-      @connection.execute "insert into json_data_type (payload) VALUES ('{\"k\":\"v\"}')"
-      x = JsonDataType.first
-      assert_equal({ "k" => "v" }, x.payload)
-    end
-
-    def test_select_multikey
-      @connection.execute %q|insert into json_data_type (payload) VALUES ('{"k1":"v1", "k2":"v2", "k3":[1,2,3]}')|
-      x = JsonDataType.first
-      assert_equal({ "k1" => "v1", "k2" => "v2", "k3" => [1, 2, 3] }, x.payload)
-    end
-
-    def test_null_json
-      @connection.execute "insert into json_data_type (payload) VALUES(null)"
-      x = JsonDataType.first
-      assert_nil(x.payload)
-    end
-
-    def test_select_array_json_value
-      @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
-      x = JsonDataType.first
-      assert_equal(["v0", { "k1" => "v1" }], x.payload)
-    end
-
-    def test_select_nil_json_after_create
-      json = JsonDataType.create(payload: nil)
-      x = JsonDataType.where(payload: nil).first
-      assert_equal(json, x)
-    end
-
-    def test_select_nil_json_after_update
-      json = JsonDataType.create(payload: "foo")
-      x = JsonDataType.where(payload: nil).first
-      assert_nil(x)
-
-      json.update_attributes payload: nil
-      x = JsonDataType.where(payload: nil).first
-      assert_equal(json.reload, x)
-    end
-
-    def test_rewrite_array_json_value
-      @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
-      x = JsonDataType.first
-      x.payload = ["v1", { "k2" => "v2" }, "v3"]
-      assert x.save!
-    end
-
-    def test_with_store_accessors
-      x = JsonDataType.new(resolution: "320×480")
-      assert_equal "320×480", x.resolution
-
-      x.save!
-      x = JsonDataType.first
-      assert_equal "320×480", x.resolution
-
-      x.resolution = "640×1136"
-      x.save!
-
-      x = JsonDataType.first
-      assert_equal "640×1136", x.resolution
-    end
-
-    def test_duplication_with_store_accessors
-      x = JsonDataType.new(resolution: "320×480")
-      assert_equal "320×480", x.resolution
-
-      y = x.dup
-      assert_equal "320×480", y.resolution
-    end
-
-    def test_yaml_round_trip_with_store_accessors
-      x = JsonDataType.new(resolution: "320×480")
-      assert_equal "320×480", x.resolution
-
-      y = YAML.load(YAML.dump(x))
-      assert_equal "320×480", y.resolution
-    end
-
-    def test_changes_in_place
-      json = JsonDataType.new
-      assert_not json.changed?
-
-      json.payload = { "one" => "two" }
-      assert json.changed?
-      assert json.payload_changed?
-
-      json.save!
-      assert_not json.changed?
-
-      json.payload["three"] = "four"
-      assert json.payload_changed?
-
-      json.save!
-      json.reload
-
-      assert_equal({ "one" => "two", "three" => "four" }, json.payload)
-      assert_not json.changed?
-    end
-
-    def test_changes_in_place_ignores_key_order
-      json = JsonDataType.new
-      assert_not json.changed?
-
-      json.payload = { "three" => "four", "one" => "two" }
-      json.save!
-      json.reload
-
-      json.payload = { "three" => "four", "one" => "two" }
-      assert_not json.changed?
-
-      json.payload = [{ "three" => "four", "one" => "two" }, { "seven" => "eight", "five" => "six" }]
-      json.save!
-      json.reload
-
-      json.payload = [{ "three" => "four", "one" => "two" }, { "seven" => "eight", "five" => "six" }]
-      assert_not json.changed?
-    end
-
-    def test_assigning_string_literal
-      json = JsonDataType.create(payload: "foo")
-      assert_equal "foo", json.payload
-    end
-
-    def test_assigning_number
-      json = JsonDataType.create(payload: 1.234)
-      assert_equal 1.234, json.payload
-    end
-
-    def test_assigning_boolean
-      json = JsonDataType.create(payload: true)
-      assert_equal true, json.payload
+    def column_type
+      :json
     end
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -1,14 +1,10 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
+require "cases/adapters/shared_json_test"
 
 module PostgresqlJSONSharedTestCases
   include SchemaDumpingHelper
-
-  class JsonDataType < ActiveRecord::Base
-    self.table_name = "json_data_type"
-
-    store_accessor :settings, :resolution
-  end
+  include JSONSharedTestCases
 
   def setup
     @connection = ActiveRecord::Base.connection
@@ -21,21 +17,6 @@ module PostgresqlJSONSharedTestCases
     rescue ActiveRecord::StatementInvalid
       skip "do not test on PostgreSQL without #{column_type} type."
     end
-  end
-
-  def teardown
-    @connection.drop_table :json_data_type, if_exists: true
-    JsonDataType.reset_column_information
-  end
-
-  def test_column
-    column = JsonDataType.columns_hash["payload"]
-    assert_equal column_type, column.type
-    assert_equal column_type.to_s, column.sql_type
-    assert_not column.array?
-
-    type = JsonDataType.type_for_attribute("payload")
-    assert_not type.binary?
   end
 
   def test_default
@@ -68,14 +49,6 @@ module PostgresqlJSONSharedTestCases
     assert_match(/t\.#{column_type.to_s}\s+"payload",\s+default: {}/, output)
   end
 
-  def test_cast_value_on_write
-    x = JsonDataType.new payload: { "string" => "foo", :symbol => :bar }
-    assert_equal({ "string" => "foo", :symbol => :bar }, x.payload_before_type_cast)
-    assert_equal({ "string" => "foo", "symbol" => "bar" }, x.payload)
-    x.save
-    assert_equal({ "string" => "foo", "symbol" => "bar" }, x.reload.payload)
-  end
-
   def test_deserialize_with_array
     x = JsonDataType.new(objects: ["foo" => "bar"])
     assert_equal ["foo" => "bar"], x.objects
@@ -83,159 +56,6 @@ module PostgresqlJSONSharedTestCases
     assert_equal ["foo" => "bar"], x.objects
     x.reload
     assert_equal ["foo" => "bar"], x.objects
-  end
-
-  def test_type_cast_json
-    type = JsonDataType.type_for_attribute("payload")
-
-    data = "{\"a_key\":\"a_value\"}"
-    hash = type.deserialize(data)
-    assert_equal({ "a_key" => "a_value" }, hash)
-    assert_equal({ "a_key" => "a_value" }, type.deserialize(data))
-
-    assert_equal({}, type.deserialize("{}"))
-    assert_equal({ "key" => nil }, type.deserialize('{"key": null}'))
-    assert_equal({ "c" => "}", '"a"' => 'b "a b' }, type.deserialize(%q({"c":"}", "\"a\"":"b \"a b"})))
-  end
-
-  def test_rewrite
-    @connection.execute "insert into json_data_type (payload) VALUES ('{\"k\":\"v\"}')"
-    x = JsonDataType.first
-    x.payload = { '"a\'' => "b" }
-    assert x.save!
-  end
-
-  def test_select
-    @connection.execute "insert into json_data_type (payload) VALUES ('{\"k\":\"v\"}')"
-    x = JsonDataType.first
-    assert_equal({ "k" => "v" }, x.payload)
-  end
-
-  def test_select_multikey
-    @connection.execute %q|insert into json_data_type (payload) VALUES ('{"k1":"v1", "k2":"v2", "k3":[1,2,3]}')|
-    x = JsonDataType.first
-    assert_equal({ "k1" => "v1", "k2" => "v2", "k3" => [1, 2, 3] }, x.payload)
-  end
-
-  def test_null_json
-    @connection.execute "insert into json_data_type (payload) VALUES(null)"
-    x = JsonDataType.first
-    assert_nil(x.payload)
-  end
-
-  def test_select_nil_json_after_create
-    json = JsonDataType.create(payload: nil)
-    x = JsonDataType.where(payload: nil).first
-    assert_equal(json, x)
-  end
-
-  def test_select_nil_json_after_update
-    json = JsonDataType.create(payload: "foo")
-    x = JsonDataType.where(payload: nil).first
-    assert_nil(x)
-
-    json.update_attributes payload: nil
-    x = JsonDataType.where(payload: nil).first
-    assert_equal(json.reload, x)
-  end
-
-  def test_select_array_json_value
-    @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
-    x = JsonDataType.first
-    assert_equal(["v0", { "k1" => "v1" }], x.payload)
-  end
-
-  def test_rewrite_array_json_value
-    @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
-    x = JsonDataType.first
-    x.payload = ["v1", { "k2" => "v2" }, "v3"]
-    assert x.save!
-  end
-
-  def test_with_store_accessors
-    x = JsonDataType.new(resolution: "320×480")
-    assert_equal "320×480", x.resolution
-
-    x.save!
-    x = JsonDataType.first
-    assert_equal "320×480", x.resolution
-
-    x.resolution = "640×1136"
-    x.save!
-
-    x = JsonDataType.first
-    assert_equal "640×1136", x.resolution
-  end
-
-  def test_duplication_with_store_accessors
-    x = JsonDataType.new(resolution: "320×480")
-    assert_equal "320×480", x.resolution
-
-    y = x.dup
-    assert_equal "320×480", y.resolution
-  end
-
-  def test_yaml_round_trip_with_store_accessors
-    x = JsonDataType.new(resolution: "320×480")
-    assert_equal "320×480", x.resolution
-
-    y = YAML.load(YAML.dump(x))
-    assert_equal "320×480", y.resolution
-  end
-
-  def test_changes_in_place
-    json = JsonDataType.new
-    assert_not json.changed?
-
-    json.payload = { "one" => "two" }
-    assert json.changed?
-    assert json.payload_changed?
-
-    json.save!
-    assert_not json.changed?
-
-    json.payload["three"] = "four"
-    assert json.payload_changed?
-
-    json.save!
-    json.reload
-
-    assert_equal({ "one" => "two", "three" => "four" }, json.payload)
-    assert_not json.changed?
-  end
-
-  def test_changes_in_place_ignores_key_order
-    json = JsonDataType.new
-    assert_not json.changed?
-
-    json.payload = { "three" => "four", "one" => "two" }
-    json.save!
-    json.reload
-
-    json.payload = { "three" => "four", "one" => "two" }
-    assert_not json.changed?
-
-    json.payload = [{ "three" => "four", "one" => "two" }, { "seven" => "eight", "five" => "six" }]
-    json.save!
-    json.reload
-
-    json.payload = [{ "three" => "four", "one" => "two" }, { "seven" => "eight", "five" => "six" }]
-    assert_not json.changed?
-  end
-
-  def test_assigning_string_literal
-    json = JsonDataType.create(payload: "foo")
-    assert_equal "foo", json.payload
-  end
-
-  def test_assigning_number
-    json = JsonDataType.create(payload: 1.234)
-    assert_equal 1.234, json.payload
-  end
-
-  def test_assigning_boolean
-    json = JsonDataType.create(payload: true)
-    assert_equal true, json.payload
   end
 end
 

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -202,6 +202,20 @@ module PostgresqlJSONSharedTestCases
 
     assert_equal({ "one" => "two", "three" => "four" }, json.payload)
     assert_not json.changed?
+
+    json.payload = { "three" => "four", "one" => "two" }
+    json.save!
+    json.reload
+
+    json.payload = { "three" => "four", "one" => "two" }
+    assert_not json.changed?
+
+    json.payload = [{ "three" => "four", "one" => "two" }, { "seven" => "eight", "five" => "six" }]
+    json.save!
+    json.reload
+
+    json.payload = [{ "three" => "four", "one" => "two" }, { "seven" => "eight", "five" => "six" }]
+    assert_not json.changed?
   end
 
   def test_assigning_string_literal

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -202,6 +202,11 @@ module PostgresqlJSONSharedTestCases
 
     assert_equal({ "one" => "two", "three" => "four" }, json.payload)
     assert_not json.changed?
+  end
+
+  def test_changes_in_place_ignores_key_order
+    json = JsonDataType.new
+    assert_not json.changed?
 
     json.payload = { "three" => "four", "one" => "two" }
     json.save!

--- a/activerecord/test/cases/adapters/shared_json_test.rb
+++ b/activerecord/test/cases/adapters/shared_json_test.rb
@@ -1,0 +1,183 @@
+module JSONSharedTestCases
+  class JsonDataType < ActiveRecord::Base
+    self.table_name = "json_data_type"
+
+    store_accessor :settings, :resolution
+  end
+
+  def teardown
+    @connection.drop_table :json_data_type, if_exists: true
+    JsonDataType.reset_column_information
+  end
+
+  def test_column
+    column = JsonDataType.columns_hash["payload"]
+    assert_equal column_type, column.type
+    assert_equal column_type.to_s, column.sql_type
+    assert_not column.array?
+
+    type = JsonDataType.type_for_attribute("payload")
+    assert_not type.binary?
+  end
+
+  def test_cast_value_on_write
+    x = JsonDataType.new payload: { "string" => "foo", :symbol => :bar }
+    assert_equal({ "string" => "foo", :symbol => :bar }, x.payload_before_type_cast)
+    assert_equal({ "string" => "foo", "symbol" => "bar" }, x.payload)
+    x.save
+    assert_equal({ "string" => "foo", "symbol" => "bar" }, x.reload.payload)
+  end
+
+  def test_type_cast_json
+    type = JsonDataType.type_for_attribute("payload")
+
+    data = "{\"a_key\":\"a_value\"}"
+    hash = type.deserialize(data)
+    assert_equal({ "a_key" => "a_value" }, hash)
+    assert_equal({ "a_key" => "a_value" }, type.deserialize(data))
+
+    assert_equal({}, type.deserialize("{}"))
+    assert_equal({ "key" => nil }, type.deserialize('{"key": null}'))
+    assert_equal({ "c" => "}", '"a"' => 'b "a b' }, type.deserialize(%q({"c":"}", "\"a\"":"b \"a b"})))
+  end
+
+  def test_rewrite
+    @connection.execute "insert into json_data_type (payload) VALUES ('{\"k\":\"v\"}')"
+    x = JsonDataType.first
+    x.payload = { '"a\'' => "b" }
+    assert x.save!
+  end
+
+  def test_select
+    @connection.execute "insert into json_data_type (payload) VALUES ('{\"k\":\"v\"}')"
+    x = JsonDataType.first
+    assert_equal({ "k" => "v" }, x.payload)
+  end
+
+  def test_select_multikey
+    @connection.execute %q|insert into json_data_type (payload) VALUES ('{"k1":"v1", "k2":"v2", "k3":[1,2,3]}')|
+    x = JsonDataType.first
+    assert_equal({ "k1" => "v1", "k2" => "v2", "k3" => [1, 2, 3] }, x.payload)
+  end
+
+  def test_null_json
+    @connection.execute "insert into json_data_type (payload) VALUES(null)"
+    x = JsonDataType.first
+    assert_nil(x.payload)
+  end
+
+  def test_select_nil_json_after_create
+    json = JsonDataType.create(payload: nil)
+    x = JsonDataType.where(payload: nil).first
+    assert_equal(json, x)
+  end
+
+  def test_select_nil_json_after_update
+    json = JsonDataType.create(payload: "foo")
+    x = JsonDataType.where(payload: nil).first
+    assert_nil(x)
+
+    json.update_attributes payload: nil
+    x = JsonDataType.where(payload: nil).first
+    assert_equal(json.reload, x)
+  end
+
+  def test_select_array_json_value
+    @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
+    x = JsonDataType.first
+    assert_equal(["v0", { "k1" => "v1" }], x.payload)
+  end
+
+  def test_rewrite_array_json_value
+    @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
+    x = JsonDataType.first
+    x.payload = ["v1", { "k2" => "v2" }, "v3"]
+    assert x.save!
+  end
+
+  def test_with_store_accessors
+    x = JsonDataType.new(resolution: "320×480")
+    assert_equal "320×480", x.resolution
+
+    x.save!
+    x = JsonDataType.first
+    assert_equal "320×480", x.resolution
+
+    x.resolution = "640×1136"
+    x.save!
+
+    x = JsonDataType.first
+    assert_equal "640×1136", x.resolution
+  end
+
+  def test_duplication_with_store_accessors
+    x = JsonDataType.new(resolution: "320×480")
+    assert_equal "320×480", x.resolution
+
+    y = x.dup
+    assert_equal "320×480", y.resolution
+  end
+
+  def test_yaml_round_trip_with_store_accessors
+    x = JsonDataType.new(resolution: "320×480")
+    assert_equal "320×480", x.resolution
+
+    y = YAML.load(YAML.dump(x))
+    assert_equal "320×480", y.resolution
+  end
+
+  def test_changes_in_place
+    json = JsonDataType.new
+    assert_not json.changed?
+
+    json.payload = { "one" => "two" }
+    assert json.changed?
+    assert json.payload_changed?
+
+    json.save!
+    assert_not json.changed?
+
+    json.payload["three"] = "four"
+    assert json.payload_changed?
+
+    json.save!
+    json.reload
+
+    assert_equal({ "one" => "two", "three" => "four" }, json.payload)
+    assert_not json.changed?
+  end
+
+  def test_changes_in_place_ignores_key_order
+    json = JsonDataType.new
+    assert_not json.changed?
+
+    json.payload = { "three" => "four", "one" => "two" }
+    json.save!
+    json.reload
+
+    json.payload = { "three" => "four", "one" => "two" }
+    assert_not json.changed?
+
+    json.payload = [{ "three" => "four", "one" => "two" }, { "seven" => "eight", "five" => "six" }]
+    json.save!
+    json.reload
+
+    json.payload = [{ "three" => "four", "one" => "two" }, { "seven" => "eight", "five" => "six" }]
+    assert_not json.changed?
+  end
+
+  def test_assigning_string_literal
+    json = JsonDataType.create(payload: "foo")
+    assert_equal "foo", json.payload
+  end
+
+  def test_assigning_number
+    json = JsonDataType.create(payload: 1.234)
+    assert_equal 1.234, json.payload
+  end
+
+  def test_assigning_boolean
+    json = JsonDataType.create(payload: true)
+    assert_equal true, json.payload
+  end
+end


### PR DESCRIPTION
### Summary

PostgreSQL JSONB columns do not preserve the key order of hashes

https://www.postgresql.org/docs/9.6/static/datatype-json.html

Due to this setting a JSONB column to the same hash twice can cause `model.changed?` to return false positives
