### PR TITLE
Reduce `serialize` in `changed_in_place?`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -981,7 +981,7 @@ module ActiveRecord
           def changed_in_place?(raw_old_value, new_value)
             # Normalization is required because MySQL JSON data format includes
             # the space between the elements.
-            super(serialize(deserialize(raw_old_value)), new_value)
+            deserialize(raw_old_value) != new_value
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/jsonb.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/jsonb.rb
@@ -13,8 +13,7 @@ module ActiveRecord
             # the comparison here. Therefore, we need to parse and re-dump the
             # raw value here to ensure the insignificant whitespaces are
             # consistent with our encoder's output.
-            raw_old_value = serialize(deserialize(raw_old_value))
-            super(raw_old_value, new_value)
+            deserialize(raw_old_value) != new_value
           end
         end
       end


### PR DESCRIPTION
If `raw_old_value` is needed `deserialize` to normalization, unneeded
`serialize` again because `new_value` is deserialized value.