### PR TITLE
Fix bug with symbolized keys in .where with nested join

### DIFF
--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -44,7 +44,7 @@ module ActiveRecord
     end
 
     def associated_table(table_name)
-      association = klass._reflect_on_association(table_name) || klass._reflect_on_association(table_name.singularize)
+      association = klass._reflect_on_association(table_name) || klass._reflect_on_association(table_name.to_s.singularize)
 
       if !association && table_name == arel_table.name
         return self

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -648,11 +648,17 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
   class SpecialBook < ActiveRecord::Base
     self.table_name = "books"
     belongs_to :author, class_name: "SpecialAuthor"
+    has_one :subscription, class_name: "SpecialSupscription", foreign_key: "subscriber_id"
   end
 
   class SpecialAuthor < ActiveRecord::Base
     self.table_name = "authors"
     has_one :book, class_name: "SpecialBook", foreign_key: "author_id"
+  end
+
+  class SpecialSupscription < ActiveRecord::Base
+    self.table_name = "subscriptions"
+    belongs_to :book, class_name: "SpecialBook"
   end
 
   def test_assocation_enum_works_properly
@@ -661,5 +667,16 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     author.book = book
 
     refute_equal 0, SpecialAuthor.joins(:book).where(books: { status: "published" }).count
+  end
+
+  def test_assocation_enum_works_properly_with_nested_join
+    author = SpecialAuthor.create!(name: "Test")
+    book = SpecialBook.create!(status: "published")
+    author.book = book
+
+    where_clause = { books: { subscriptions: { subscriber_id: nil } } }
+    assert_nothing_raised do
+      SpecialAuthor.joins(book: :subscription).where.not(where_clause)
+    end
   end
 end


### PR DESCRIPTION
Summary
-------
In https://github.com/rails/rails/pull/25146, code was added to fix making where clauses against tables with an `enum` column with a `join` present as part of the query.  As part of this fix, it called `singularize` on the `table_name` variable that was passed into the `associated_table` method.

`table_name`, in some circumstances, can also be a symbol if more than one level of joins exists in the Relation (i.e `joins(:book => :subscription)`).  This fixes that by adding `.to_s` before calling `.singularize` on the `table_name` variable.


Other Information
-----------------
This bug only surfaces when a join is made more than 1 level deep since the `where_clause_builder` calls `stringify_keys!` on the top level of the `.where` hash:

https://github.com/rails/rails/blob/21e5fd4/activerecord/lib/active_record/relation/where_clause_factory.rb#L16

So this hides this edge case from showing up in the test suite with the current coverage and the test that was in PR #25146.

The other solution to this problem is to deeply stringify the keys in the `where_clause_builder` and all method calls following that can safely assume strings are being passed in as keys.  This is a heavier hammer, but the assumption is already being made on the top level to do this, so it seems like a better place to put it instead of scattered throughout the codebase and having it handle both strings/symbols in multiple places.  This alternative will be proposed in a separate PR.


Also of note, the this probably isn't the best place for a test like this, but it was the simplest way I could get a test in place without familiarizing myself with the entire ActiveRecord test suite (copying what was done in the previous PR).  Suggestions welcome for a better place for this test to live, but it is worth noting that this same test will also be used to confirm the same working functionality in the alternative form for this PR.