### PR TITLE
Fix bug with symbolized keys in .where with nested join (alternative to #27598)

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause_factory.rb
+++ b/activerecord/lib/active_record/relation/where_clause_factory.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         when Hash
           attributes = predicate_builder.resolve_column_aliases(opts)
           attributes = klass.send(:expand_hash_conditions_for_aggregates, attributes)
-          attributes.stringify_keys!
+          attributes.deep_stringify_keys!
 
           attributes, binds = predicate_builder.create_binds(attributes)
 

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -648,11 +648,17 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
   class SpecialBook < ActiveRecord::Base
     self.table_name = "books"
     belongs_to :author, class_name: "SpecialAuthor"
+    has_one :subscription, class_name: "SpecialSupscription", foreign_key: "subscriber_id"
   end
 
   class SpecialAuthor < ActiveRecord::Base
     self.table_name = "authors"
     has_one :book, class_name: "SpecialBook", foreign_key: "author_id"
+  end
+
+  class SpecialSupscription < ActiveRecord::Base
+    self.table_name = "subscriptions"
+    belongs_to :book, class_name: "SpecialBook"
   end
 
   def test_assocation_enum_works_properly
@@ -661,5 +667,16 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     author.book = book
 
     refute_equal 0, SpecialAuthor.joins(:book).where(books: { status: "published" }).count
+  end
+
+  def test_assocation_enum_works_properly_with_nested_join
+    author = SpecialAuthor.create!(name: "Test")
+    book = SpecialBook.create!(status: "published")
+    author.book = book
+
+    where_clause = { books: { subscriptions: { subscriber_id: nil } } }
+    assert_nothing_raised do
+      SpecialAuthor.joins(book: :subscription).where.not(where_clause)
+    end
   end
 end


### PR DESCRIPTION
Summary
-------
In https://github.com/rails/rails/pull/25146, code was added to fix making where clauses against tables with an `enum` column with a `join` present as part of the query.  As part of this fix, it called `singularize` on the `table_name` variable that was passed into the `associated_table` method.

`table_name`, in some circumstances, can also be a symbol if more than one level of joins exists in the Relation (i.e `joins(:book => :subscription)`).  This fixes that by adding chaning the `.stringify_keys!` (found in `ActiveRecord::Relation::WhereClauseFactory`) to be a `.deep_stringify_keys!` to stringfy keys at all levels.


Other Information
-----------------
This bug only surfaces when a join is made more than 1 level deep since the `where_clause_builder` calls `stringify_keys!` on the top level of the `.where` hash:

https://github.com/rails/rails/blob/21e5fd4/activerecord/lib/active_record/relation/where_clause_factory.rb#L16

So this hides this edge case from showing up in the test suite with the current coverage and the test that was in PR #25146.

This is the alternative to https://github.com/rails/rails/pull/27598 in which the change from PR #25146 was fixed in isolation.  Instead, here we fix the false assumption that all `table_name` values being passed into `.associated_table` are a string.  This might have wider effects because of that, so that should be considered when reviewing.