### PR TITLE
Followup of #27596, test output of "run" method as well

### DIFF
--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -290,7 +290,7 @@ class MigratorTest < ActiveRecord::TestCase
     assert_equal [[:up, 1], [:up, 2], [:up, 3]], calls
   end
 
-  def test_migrator_output
+  def test_migrator_output_when_running_multiple_migrations
     _, migrator = migrator_class(3)
 
     result = migrator.migrate("valid")
@@ -302,6 +302,13 @@ class MigratorTest < ActiveRecord::TestCase
 
     result = migrator.rollback("valid")
     assert_equal(1, result.count)
+  end
+
+  def test_migrator_output_when_running_single_migration
+    _, migrator = migrator_class(1)
+    result = migrator.run(:up, "valid", 1)
+
+    assert_equal(1, result.version)
   end
 
   def test_migrator_rollback


### PR DESCRIPTION
- #27596 Updated "run" and "migrate" method for returning correct
   value but only added test for "migrate" method. This commit adds a
   test for "run" as well.

r? @schneems 