### PR TITLE
Fix random failure related to migration environment

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -399,6 +399,7 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Migrator.migrations_paths = old_path
     ENV["RAILS_ENV"] = original_rails_env
     ENV["RACK_ENV"]  = original_rack_env
+    ActiveRecord::Migrator.up(migrations_path)
   end
 
   def test_migration_sets_internal_metadata_even_when_fully_migrated
@@ -425,6 +426,7 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Migrator.migrations_paths = old_path
     ENV["RAILS_ENV"] = original_rails_env
     ENV["RACK_ENV"]  = original_rack_env
+    ActiveRecord::Migrator.up(migrations_path)
   end
 
   def test_internal_metadata_stores_environment_when_other_data_exists


### PR DESCRIPTION
- Reference: https://travis-ci.org/rails/rails/jobs/189764676

- Reproduction command:

    MTB_VERBOSE=2 bundle exec minitest_bisect --seed 33328 -Itest "test/cases/migration_test.rb" "test/cases/tasks/database_tasks_test.rb"

- You need to also add minitest_bisect gem to the Gemfile to reproduce
  this failure.

r? @schneems 