### PR TITLE
Fix generator command for nested (namespaced) rails engine (take 2)

### DIFF
--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -82,6 +82,10 @@ module Rails
           !options[:skip_namespace] && namespace
         end
 
+        def namespace_dirs
+          @namespace_dirs ||= namespace.name.split("::").map(&:underscore)
+        end
+
         def file_path # :doc:
           @file_path ||= (class_path + [file_name]).join("/")
         end
@@ -95,11 +99,11 @@ module Rails
         end
 
         def namespaced_class_path # :doc:
-          @namespaced_class_path ||= [namespaced_path] + @class_path
+          @namespaced_class_path ||= namespace_dirs + @class_path
         end
 
         def namespaced_path # :doc:
-          @namespaced_path ||= namespace.name.split("::").first.underscore
+          @namespaced_path ||= namespace_dirs.join("/")
         end
 
         def class_name # :doc:

--- a/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
@@ -22,7 +22,7 @@ module TestUnit # :nodoc:
       def fixture_name
         @fixture_name ||=
           if mountable_engine?
-            "%s_%s" % [namespaced_path, table_name]
+            (namespace_dirs + [table_name]).join("_")
           else
             table_name
           end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -492,6 +492,26 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_scaffold_tests_pass_by_default_inside_namespaced_mountable_engine
+    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits-admin --mountable` }
+
+    engine_path = File.join(destination_root, "bukkits-admin")
+
+    Dir.chdir(engine_path) do
+      quietly do
+        `bin/rails g scaffold User name:string age:integer;
+        bin/rails db:migrate`
+      end
+
+      assert_file "bukkits-admin/app/controllers/bukkits/admin/users_controller.rb" do |content|
+        assert_match(/module Bukkits::Admin/, content)
+        assert_match(/class UsersController < ApplicationController/, content)
+      end
+
+      assert_match(/8 runs, 10 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+    end
+  end
+
   def test_scaffold_tests_pass_by_default_inside_full_engine
     Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --full` }
 


### PR DESCRIPTION
Rewrite https://github.com/rails/rails/pull/27550

085546df45 was reverted (b6ffb5efcb) because it change the return of `namespaced_path` from String to Array.

----------------

If we create nested (namespaced) rails engine such like bukkits-admin,
`bin/rails g scaffold User name:string age:integer`
will create
`bukkits-admin/app/controllers/bukkits/users_controller.rb`
but it should create
`bukkits-admin/app/controllers/bukkits/admin/users_controller.rb`.

In #6643, we changed `namespaced_path` as root path
because we supposed application_controller is always in root
but nested rails engine's application_controller will not.