### PR TITLE
Fix inconsistent parsing of Durations with both months and years

### DIFF
--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -130,7 +130,7 @@ class StrictTransportSecurityTest < SSLTest
   end
 
   test ":expires supports AS::Duration arguments" do
-    assert_hsts "max-age=31557600; includeSubDomains", hsts: { expires: 1.year }
+    assert_hsts "max-age=31556952; includeSubDomains", hsts: { expires: 1.year }
   end
 
   test "include subdomains" do

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,28 @@
+*   Fix inconsistent results when parsing large durations and constructing durations from code
+
+        ActiveSupport::Duration.parse('P3Y') == 3.years # It should be true
+
+    Duration parsing made independent from any moment of time:
+    Fixed length in seconds is assigned to each duration part during parsing.
+
+    Changed duration of months and years in seconds to more accurate and logical:
+
+     1. The value of 365.2425 days in Gregorian year is more accurate
+        as it accounts for every 400th non-leap year.
+
+     2. Month's length is bound to year's duration, which makes
+        sensible comparisons like `12.months == 1.year` to be `true`
+        and nonsensical ones like `30.days == 1.month` to be `false`.
+
+    Calculations on times and dates with durations shouldn't be affected as
+    duration's numeric value isn't used in calculations, only parts are used.
+
+    Methods on `Numeric` like `2.days` now use these predefined durations
+    to avoid duplicating of duration constants through the codebase and
+    eliminate creation of intermediate durations.
+
+    *Andrey Novikov, Andrew White*
+
 *   Change return value of `Rational#duplicable?`, `ComplexClass#duplicable?`
     to false.
 

--- a/activesupport/lib/active_support/core_ext/integer/time.rb
+++ b/activesupport/lib/active_support/core_ext/integer/time.rb
@@ -18,12 +18,12 @@ class Integer
   #   # equivalent to Time.now.advance(months: 4, years: 5)
   #   (4.months + 5.years).from_now
   def months
-    ActiveSupport::Duration.new(self * 30.days, [[:months, self]])
+    ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:months].to_i, [[:months, self]])
   end
   alias :month :months
 
   def years
-    ActiveSupport::Duration.new(self * 365.25.days.to_i, [[:years, self]])
+    ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:years].to_i, [[:years, self]])
   end
   alias :year :years
 end

--- a/activesupport/lib/active_support/core_ext/numeric/time.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/time.rb
@@ -27,7 +27,7 @@ class Numeric
   #
   #   2.minutes # => 2 minutes
   def minutes
-    ActiveSupport::Duration.new(self * 60, [[:minutes, self]])
+    ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:minutes], [[:minutes, self]])
   end
   alias :minute :minutes
 
@@ -35,7 +35,7 @@ class Numeric
   #
   #   2.hours # => 2 hours
   def hours
-    ActiveSupport::Duration.new(self * 3600, [[:hours, self]])
+    ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:hours], [[:hours, self]])
   end
   alias :hour :hours
 
@@ -43,7 +43,7 @@ class Numeric
   #
   #   2.days # => 2 days
   def days
-    ActiveSupport::Duration.new(self * 24.hours, [[:days, self]])
+    ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:days], [[:days, self]])
   end
   alias :day :days
 
@@ -51,7 +51,7 @@ class Numeric
   #
   #   2.weeks # => 2 weeks
   def weeks
-    ActiveSupport::Duration.new(self * 7.days, [[:weeks, self]])
+    ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:weeks], [[:weeks, self]])
   end
   alias :week :weeks
 
@@ -59,7 +59,7 @@ class Numeric
   #
   #   2.fortnights # => 4 weeks
   def fortnights
-    ActiveSupport::Duration.new(self * 2.weeks, [[:weeks, self * 2]])
+    ActiveSupport::Duration.new(self * 2 * ActiveSupport::Duration::PARTS_IN_SECONDS[:weeks], [[:weeks, self * 2]])
   end
   alias :fortnight :fortnights
 

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -340,6 +340,7 @@ class DurationTest < ActiveSupport::TestCase
         travel_to Time.utc(2016, 11, 4) do
           assert_equal 604800, ActiveSupport::Duration.parse("P7D").to_i
           assert_equal 604800, ActiveSupport::Duration.parse("P1W").to_i
+          assert_equal ActiveSupport::Duration.parse(3.years.iso8601).to_i, 3.years.to_i
         end
       end
     end

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -12,7 +12,7 @@ class NumericExtTimeAndDateTimeTest < ActiveSupport::TestCase
       10.minutes => 600,
       1.hour + 15.minutes => 4500,
       2.days + 4.hours + 30.minutes => 189000,
-      5.years + 1.month + 1.fortnight => 161589600
+      5.years + 1.month + 1.fortnight => 161624106
     }
   end
 
@@ -61,10 +61,10 @@ class NumericExtTimeAndDateTimeTest < ActiveSupport::TestCase
   end
 
   def test_duration_after_conversion_is_no_longer_accurate
-    assert_equal 30.days.to_i.seconds.since(@now), 1.month.to_i.seconds.since(@now)
-    assert_equal 365.25.days.to_f.seconds.since(@now), 1.year.to_f.seconds.since(@now)
-    assert_equal 30.days.to_i.seconds.since(@dtnow), 1.month.to_i.seconds.since(@dtnow)
-    assert_equal 365.25.days.to_f.seconds.since(@dtnow), 1.year.to_f.seconds.since(@dtnow)
+    assert_equal (1.year / 12).to_i.seconds.since(@now), 1.month.to_i.seconds.since(@now)
+    assert_equal 365.2425.days.to_f.seconds.since(@now), 1.year.to_f.seconds.since(@now)
+    assert_equal (1.year / 12).to_i.seconds.since(@dtnow), 1.month.to_i.seconds.since(@dtnow)
+    assert_equal 365.2425.days.to_f.seconds.since(@dtnow), 1.year.to_f.seconds.since(@dtnow)
   end
 
   def test_add_one_year_to_leap_day

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -683,7 +683,7 @@ Ruby instruction to be executed -- in this case, Active Support's `week` method.
    51:   #
    52:   #   2.weeks # => 14 days
    53:   def weeks
-=> 54:     ActiveSupport::Duration.new(self * 7.days, [[:days, self * 7]])
+=> 54:     ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:weeks], [[:weeks, self]])
    55:   end
    56:   alias :week :weeks
    57:


### PR DESCRIPTION
@boazy reported in https://github.com/rails/rails/pull/16919#issuecomment-263035188 that the following code may fail (success depends on the current time):

```rb
ActiveSupport::Duration.parse(2.months.iso8601) == 2.months
ActiveSupport::Duration.parse(3.years.iso8601) == 3.years
```

The solution is make duration parsing independent of any moment of time and just assign fixed values of seconds to each duration part (as it's really done in methods like [`2.days`](https://github.com/rails/rails/blob/7f19f30819dd5a5a788ad9d8b12b5dda76559a12/activesupport/lib/active_support/core_ext/numeric/time.rb#L45-L47)).

I have not used suggested solution with `total_seconds += value.send(part.to_sym)` as it will create many intermediate durations, slowing down parsing and littering memory. Instead I've added a part-to-seconds mapping hash constant to durations itself.

Failing regression test is included.

Duration parsing got 1.5x faster: https://gist.github.com/Envek/d0763db337d34ef78bf8d0a1aceca9aa

r? @pixeltrix 

### P.S>

Methods like beforementioned `2.days` can be changed to use this constant too, this will speed up them, move all magic duration constants in single file and constants and eliminate creation of a bunch of intermediate durations. Now calling [`2.years`](https://github.com/rails/rails/blob/7f19f30819dd5a5a788ad9d8b12b5dda76559a12/activesupport/lib/active_support/core_ext/integer/time.rb#L25-L27) will call [`365.25.days`](https://github.com/rails/rails/blob/7f19f30819dd5a5a788ad9d8b12b5dda76559a12/activesupport/lib/active_support/core_ext/numeric/time.rb#L45-L47) which in turn will call [`24.hours`](https://github.com/rails/rails/blob/7f19f30819dd5a5a788ad9d8b12b5dda76559a12/activesupport/lib/active_support/core_ext/numeric/time.rb#L37-L39) which in turn will [create duration for `2 * 365.25 * 24 * 3600` seconds](https://github.com/rails/rails/blob/7f19f30819dd5a5a788ad9d8b12b5dda76559a12/activesupport/lib/active_support/core_ext/numeric/time.rb#L21-L23) from which seconds will be taken and all 3 intermediate durations will be thrown. I can change them too in this or separate pull request.

So

```rb
def years
  ActiveSupport::Duration.new(self * 365.25.days.to_i, [[:years, self]])
end
```

will become

```rb
def years
  ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:years].to_i, [[:years, self]])
end
```