### PR TITLE
Reduce the chance db:migrate end up rollback all version

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -551,5 +551,9 @@
 
     *Ralin Chimev*
 
+*   Reduce the edge case when ENV['VERSION'] is set can cause db:migrate rollback all
+    possible versions.
+
+    *Long Nguyen*
 
 Please check [5-0-stable](https://github.com/rails/rails/blob/5-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -91,7 +91,7 @@ db_namespace = namespace :db do
 
     # desc 'Runs the "up" for a given migration VERSION.'
     task up: [:environment, :load_config] do
-      version = ENV["VERSION"].to_s.size == 14 ? Integer(ENV["VERSION"]) : nil
+      version = ENV["VERSION"] ? Integer(ENV["VERSION"]) : nil
       raise "VERSION is required" unless version
       ActiveRecord::Migrator.run(:up, ActiveRecord::Tasks::DatabaseTasks.migrations_paths, version)
       db_namespace["_dump"].invoke
@@ -99,7 +99,7 @@ db_namespace = namespace :db do
 
     # desc 'Runs the "down" for a given migration VERSION.'
     task down: [:environment, :load_config] do
-      version = ENV["VERSION"].to_s.size == 14 ? Integer(ENV["VERSION"]) : nil
+      version = ENV["VERSION"] ? Integer(ENV["VERSION"]) : nil
       raise "VERSION is required - To go down one migration, run db:rollback" unless version
       ActiveRecord::Migrator.run(:down, ActiveRecord::Tasks::DatabaseTasks.migrations_paths, version)
       db_namespace["_dump"].invoke

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -91,7 +91,7 @@ db_namespace = namespace :db do
 
     # desc 'Runs the "up" for a given migration VERSION.'
     task up: [:environment, :load_config] do
-      version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
+      version = ENV["VERSION"] ? Integer(ENV["VERSION"]) : nil
       raise "VERSION is required" unless version
       ActiveRecord::Migrator.run(:up, ActiveRecord::Tasks::DatabaseTasks.migrations_paths, version)
       db_namespace["_dump"].invoke
@@ -99,7 +99,7 @@ db_namespace = namespace :db do
 
     # desc 'Runs the "down" for a given migration VERSION.'
     task down: [:environment, :load_config] do
-      version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
+      version = ENV["VERSION"] ? Integer(ENV["VERSION"]) : nil
       raise "VERSION is required - To go down one migration, run db:rollback" unless version
       ActiveRecord::Migrator.run(:down, ActiveRecord::Tasks::DatabaseTasks.migrations_paths, version)
       db_namespace["_dump"].invoke
@@ -140,14 +140,14 @@ db_namespace = namespace :db do
 
   desc "Rolls the schema back to the previous version (specify steps w/ STEP=n)."
   task rollback: [:environment, :load_config] do
-    step = ENV["STEP"] ? ENV["STEP"].to_i : 1
+    step = ENV["STEP"] ? Integer(ENV["STEP"]) : 1
     ActiveRecord::Migrator.rollback(ActiveRecord::Tasks::DatabaseTasks.migrations_paths, step)
     db_namespace["_dump"].invoke
   end
 
   # desc 'Pushes the schema to the next version (specify steps w/ STEP=n).'
   task forward: [:environment, :load_config] do
-    step = ENV["STEP"] ? ENV["STEP"].to_i : 1
+    step = ENV["STEP"] ? Integer(ENV["STEP"]) : 1
     ActiveRecord::Migrator.forward(ActiveRecord::Tasks::DatabaseTasks.migrations_paths, step)
     db_namespace["_dump"].invoke
   end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -91,7 +91,7 @@ db_namespace = namespace :db do
 
     # desc 'Runs the "up" for a given migration VERSION.'
     task up: [:environment, :load_config] do
-      version = ENV["VERSION"] ? Integer(ENV["VERSION"]) : nil
+      version = ENV["VERSION"].to_s.size == 14 ? Integer(ENV["VERSION"]) : nil
       raise "VERSION is required" unless version
       ActiveRecord::Migrator.run(:up, ActiveRecord::Tasks::DatabaseTasks.migrations_paths, version)
       db_namespace["_dump"].invoke
@@ -99,7 +99,7 @@ db_namespace = namespace :db do
 
     # desc 'Runs the "down" for a given migration VERSION.'
     task down: [:environment, :load_config] do
-      version = ENV["VERSION"] ? Integer(ENV["VERSION"]) : nil
+      version = ENV["VERSION"].to_s.size == 14 ? Integer(ENV["VERSION"]) : nil
       raise "VERSION is required - To go down one migration, run db:rollback" unless version
       ActiveRecord::Migrator.run(:down, ActiveRecord::Tasks::DatabaseTasks.migrations_paths, version)
       db_namespace["_dump"].invoke


### PR DESCRIPTION
### Summary
Improve an edge case when ENV['VERSION'] is set and db:migrate end up with rolling back all possible versions - which is dangerous since we might loose all the data.

### Steps to reproduce
Set `ENV['VERSION'] = "A RANDOM STRING"`

Run `rake db:migrate`

### Cause of the problem
In the codes we check if current_version > target_version we will do db:rollback (migrate down)
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/migration.rb#L990
but we call ENV['VERSION'].to_i for the target_version, it works fine if developers don't have this ENV in their ENVs.