### PR TITLE
Test `--skip-git` generator option

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -437,6 +437,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_generator_if_skip_git_is_given
+    run_generator [destination_root, "--skip-git"]
+    assert_no_file ".gitignore"
+  end
+
   def test_action_cable_redis_gems
     run_generator
     assert_file "Gemfile", /^# gem 'redis'/


### PR DESCRIPTION
While researching rails app generator I noticed that test case for `--skip-git` is missing, so I added it :)

