### PR TITLE
Preserve `up` and `down` return type

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1169,9 +1169,10 @@ module ActiveRecord
     def run_without_lock
       migration = migrations.detect { |m| m.version == @target_version }
       raise UnknownMigrationVersionError.new(@target_version) if migration.nil?
-      execute_migration_in_transaction(migration, @direction)
+      result = execute_migration_in_transaction(migration, @direction)
 
       record_environment
+      result
     end
 
     # Used for running multiple migrations up to or down to a certain value.
@@ -1180,11 +1181,12 @@ module ActiveRecord
         raise UnknownMigrationVersionError.new(@target_version)
       end
 
-      runnable.each do |migration|
+      result = runnable.each do |migration|
         execute_migration_in_transaction(migration, @direction)
       end
 
       record_environment
+      result
     end
 
     # Stores the current environment in the database.

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -290,7 +290,7 @@ class MigratorTest < ActiveRecord::TestCase
     assert_equal [[:up, 1], [:up, 2], [:up, 3]], calls
   end
 
-  def test_migrator_output
+  def test_migrator_output_when_running_multiple_migrations
     _, migrator = migrator_class(3)
 
     result = migrator.migrate("valid")
@@ -302,6 +302,13 @@ class MigratorTest < ActiveRecord::TestCase
 
     result = migrator.rollback("valid")
     assert_equal(1, result.count)
+  end
+
+  def test_migrator_output_when_running_single_migration
+    _, migrator = migrator_class(1)
+    result = migrator.run(:up, "valid", 1)
+
+    assert_equal(1, result.version)
   end
 
   def test_migrator_rollback

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -290,6 +290,20 @@ class MigratorTest < ActiveRecord::TestCase
     assert_equal [[:up, 1], [:up, 2], [:up, 3]], calls
   end
 
+  def test_migrator_output
+    _, migrator = migrator_class(3)
+
+    result = migrator.migrate("valid")
+    assert_equal(3, result.count)
+
+    # Nothing migrated from duplicate run
+    result = migrator.migrate("valid")
+    assert_equal(0, result.count)
+
+    result = migrator.rollback("valid")
+    assert_equal(1, result.count)
+  end
+
   def test_migrator_rollback
     _, migrator = migrator_class(3)
 


### PR DESCRIPTION
In Rails 4.2 calling `ActiveRecord::Migrator.migrate` would return an array of results. Without realizing that this return type was expected I accidentally introduced a change in https://github.com/rails/rails/commit/4d60e93174a3d6d90b1a06fc7515cb5cd749a6f3

This PR preserves the previous behavior and adds a test on the return type. This is a backport of #27596 to the 5-0-stable branch.
