### PR TITLE
activerecord/test: Fix Mysql2ConnectionTest#test_execute_after_disconnect

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -66,9 +66,10 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   def test_execute_after_disconnect
     @connection.disconnect!
 
-    assert_raise(ActiveRecord::StatementInvalid) do
+    error = assert_raise(ActiveRecord::StatementInvalid) do
       @connection.execute("SELECT 1")
     end
+    assert_kind_of Mysql2::Error, error.cause
   end
 
   def test_quote_after_disconnect


### PR DESCRIPTION
cc @arthurnn & @prathamesh-sonpatki

Mysql2ConnectionTest#test_execute_after_disconnect was originally added in #26434 to catch a NoMethodError occurring in execute when the Mysql2Adapter has a nil`@connection`. Pull request #26869 removed the error message check in that test because the error message changed in the mysql2 gem, which caused the test to fail. Now the test wouldn't catch the original bug since the
NoMethodError would get turned into a ActiveRecord::StatementInvalid exception.

Check the cause of the StatementInvalid exception to make sure it is of the correct type.