### PR TITLE
Improve deprecation message for deprecated reflection class name

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1827,7 +1827,7 @@ module ActiveRecord
 
           builder = Builder::HasAndBelongsToMany.new name, self, options
 
-          join_model = builder.through_model
+          join_model = ActiveSupport::Deprecation.silence { builder.through_model }
 
           const_set join_model.name, join_model
           private_constant join_model.name
@@ -1856,7 +1856,7 @@ module ActiveRecord
             hm_options[k] = options[k] if options.key? k
           end
 
-          has_many name, scope, hm_options, &extension
+          ActiveSupport::Deprecation.silence { has_many name, scope, hm_options, &extension }
           _reflections[name.to_s].parent_reflection = habtm_reflection
         end
       end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -372,7 +372,7 @@ module ActiveRecord
             necessary and potentially creates circular dependencies.
 
             Please pass the class name as a string:
-            `belongs_to :client, class_name: 'Company'`
+            `#{macro} :#{name}, class_name: '#{options[:class_name]}'`
           MSG
         end
       end


### PR DESCRIPTION
Passing a class to `has_and_belongs_to_many` show deprecation message
three times. It is enough only once.
And improved deprecation message for deprecated reflection class name.

Before:

> DEPRECATION WARNING: Passing a class to the `class_name` is deprecated and will raise an ArgumentError in Rails 5.2. It eagerloads more classes than necessary and potentially creates circular dependencies. Please pass the class name as a string: `belongs_to :client, class_name: 'Company'` (called from initialize at /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/reflection.rb:702)

After:

> DEPRECATION WARNING: Passing a class to the `class_name` is deprecated and will raise an ArgumentError in Rails 5.2. It eagerloads more classes than necessary and potentially creates circular dependencies. Please pass the class name as a string: `has_and_belongs_to_many :projects, class_name: 'ProjectWithSymbolsForKeys'` (called from initialize at /Users/kamipo/src/github.com/rails/rails/activerecord/lib/active_record/reflection.rb:702)
