### PR TITLE
Fix inconsistent results when parsing large durations and constructing durations from code

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix inconsistent results when parsing large durations and constructing durations from code
+
+        ActiveSupport::Duration.parse('P3Y') == 3.years # It should be true
+
+    Duration parsing made independent from any moment of time:
+    Fixed length in seconds is assigned to each duration part during parsing.
+
+    Methods on `Numeric` like `2.days` now use these predefined durations
+    to avoid duplicating of duration constants through the codebase and
+    eliminate creation of intermediate durations.
+
+    *Andrey Novikov, Andrew White*
+
 ## Rails 5.0.1 (December 21, 2016) ##
 
 *   No changes.

--- a/activesupport/lib/active_support/core_ext/integer/time.rb
+++ b/activesupport/lib/active_support/core_ext/integer/time.rb
@@ -18,12 +18,12 @@ class Integer
   #   # equivalent to Time.now.advance(months: 4, years: 5)
   #   (4.months + 5.years).from_now
   def months
-    ActiveSupport::Duration.new(self * 30.days, [[:months, self]])
+    ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:months].to_i, [[:months, self]])
   end
   alias :month :months
 
   def years
-    ActiveSupport::Duration.new(self * 365.25.days.to_i, [[:years, self]])
+    ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:years].to_i, [[:years, self]])
   end
   alias :year :years
 end

--- a/activesupport/lib/active_support/core_ext/numeric/time.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/time.rb
@@ -27,7 +27,7 @@ class Numeric
   #
   #   2.minutes # => 2 minutes
   def minutes
-    ActiveSupport::Duration.new(self * 60, [[:minutes, self]])
+    ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:minutes], [[:minutes, self]])
   end
   alias :minute :minutes
 
@@ -35,7 +35,7 @@ class Numeric
   #
   #   2.hours # => 2 hours
   def hours
-    ActiveSupport::Duration.new(self * 3600, [[:hours, self]])
+    ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:hours], [[:hours, self]])
   end
   alias :hour :hours
 
@@ -43,7 +43,7 @@ class Numeric
   #
   #   2.days # => 2 days
   def days
-    ActiveSupport::Duration.new(self * 24.hours, [[:days, self]])
+    ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:days], [[:days, self]])
   end
   alias :day :days
 
@@ -51,7 +51,7 @@ class Numeric
   #
   #   2.weeks # => 2 weeks
   def weeks
-    ActiveSupport::Duration.new(self * 7.days, [[:weeks, self]])
+    ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:weeks], [[:weeks, self]])
   end
   alias :week :weeks
 
@@ -59,7 +59,7 @@ class Numeric
   #
   #   2.fortnights # => 4 weeks
   def fortnights
-    ActiveSupport::Duration.new(self * 2.weeks, [[:weeks, self * 2]])
+    ActiveSupport::Duration.new(self * 2 * ActiveSupport::Duration::PARTS_IN_SECONDS[:weeks], [[:weeks, self * 2]])
   end
   alias :fortnight :fortnights
 

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -8,13 +8,13 @@ module ActiveSupport
   #   1.month.ago       # equivalent to Time.now.advance(months: -1)
   class Duration
     PARTS_IN_SECONDS = {
-      seconds:                       1, # Used in parse method for ease of handling part hashes with seconds
-      minutes:                      60,
-      hours:                   60 * 60,
-      days:               24 * 60 * 60,
-      weeks:       7    * 24 * 60 * 60,
-      months:     30    * 24 * 60 * 60,
-      years:    (365.25 * 24 * 60 * 60).ceil,
+      seconds:          1, # Used in parse method for ease of handling part hashes with seconds
+      minutes:         60,
+      hours:        3_600,
+      days:        86_400,
+      weeks:      604_800,
+      months:   2_592_000, #  30 days
+      years:   31_557_600, # 365.25 days
     }.freeze
 
     attr_accessor :value, :parts

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -7,7 +7,15 @@ module ActiveSupport
   #
   #   1.month.ago       # equivalent to Time.now.advance(months: -1)
   class Duration
-    EPOCH = ::Time.utc(2000)
+    PARTS_IN_SECONDS = {
+      seconds:                       1, # Used in parse method for ease of handling part hashes with seconds
+      minutes:                      60,
+      hours:                   60 * 60,
+      days:               24 * 60 * 60,
+      weeks:       7    * 24 * 60 * 60,
+      months:     30    * 24 * 60 * 60,
+      years:    (365.25 * 24 * 60 * 60).ceil,
+    }.freeze
 
     attr_accessor :value, :parts
 
@@ -142,7 +150,10 @@ module ActiveSupport
     # If invalid string is provided, it will raise +ActiveSupport::Duration::ISO8601Parser::ParsingError+.
     def self.parse(iso8601duration)
       parts = ISO8601Parser.new(iso8601duration).parse!
-      new(EPOCH.advance(parts) - EPOCH, parts)
+      total_seconds = parts.inject(0) do |total, (part, value)|
+        total + value * PARTS_IN_SECONDS[part]
+      end
+      new(total_seconds, parts)
     end
 
     # Build ISO 8601 Duration string for this duration.

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -335,6 +335,7 @@ class DurationTest < ActiveSupport::TestCase
         travel_to Time.utc(2016, 11, 4) do
           assert_equal 604800, ActiveSupport::Duration.parse("P7D").to_i
           assert_equal 604800, ActiveSupport::Duration.parse("P1W").to_i
+          assert_equal ActiveSupport::Duration.parse(3.years.iso8601).to_i, 3.years.to_i
         end
       end
     end

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -683,7 +683,7 @@ Ruby instruction to be executed -- in this case, Active Support's `week` method.
    51:   #
    52:   #   2.weeks # => 14 days
    53:   def weeks
-=> 54:     ActiveSupport::Duration.new(self * 7.days, [[:days, self * 7]])
+=> 54:     ActiveSupport::Duration.new(self * ActiveSupport::Duration::PARTS_IN_SECONDS[:weeks], [[:weeks, self]])
    55:   end
    56:   alias :week :weeks
    57:


### PR DESCRIPTION
Fixes next comparison:

    ActiveSupport::Duration.parse('P3Y') == 3.years # It should be true

Duration parsing made independent from any moment of time:
Fixed length in seconds is assigned to each duration part during parsing.

Methods on `Numeric` like `2.days` now use these predefined durations to avoid duplicating of duration constants through the codebase and eliminate creation of intermediate durations.

Partial backport of https://github.com/rails/rails/pull/27610 except changes in month and year duration lengths.

r? @pixeltrix 