### PR TITLE
Revert "Merge pull request #27619 from dixpac/add_missing_generator_test

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -437,11 +437,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_generator_if_skip_git_is_given
-    run_generator [destination_root, "--skip-git"]
-    assert_no_file ".gitignore"
-  end
-
   def test_action_cable_redis_gems
     run_generator
     assert_file "Gemfile", /^# gem 'redis'/


### PR DESCRIPTION
This reverts commit 8cb3cdffdb70f3575518d24ea96ec891e40d21d0, reversing
changes made to 3bc747bd8676dc940b531067e2861dcd4ac28efc.

Reason: This test already exists in `SharedGeneratorTests`.
Ref:
https://github.com/rails/rails/blob/master/railties/test/generators/shared_generator_tests.rb#L109..L112
https://github.com/rails/rails/blob/master/railties/test/generators/app_generator_test.rb#L55..L56

