### PR TITLE
Fix postgres array date with overridden date format

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -80,6 +80,7 @@ module ActiveRecord
                 value
               end
             when nil then "NULL"
+            when ::Date, ::DateTime, ::Time then subtype.type_cast_for_schema(value)
             else value
             end
           end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -208,6 +208,18 @@ class PostgresqlArrayTest < ActiveRecord::TestCase
     assert_equal x.tags_before_type_cast, PgArray.columns_hash['tags'].type_cast_for_database(tags)
   end
 
+  def test_string_datetime_array_match_pg_behavior
+    date = Date.new(2017, 1, 2)
+    oid = OID::Array.new(ActiveRecord::Type::Date.new)
+
+    date_default = Date::DATE_FORMATS[:default]
+    Date::DATE_FORMATS[:default] = '%d.%m.%Y'
+
+    assert_equal "{'2017-01-02'}", oid.type_cast_for_database([date])
+
+    Date::DATE_FORMATS[:default] = date_default
+  end
+
   def test_quoting_non_standard_delimiters
     strings = ["hello,", "world;"]
     comma_delim = OID::Array.new(ActiveRecord::Type::String.new, ',')


### PR DESCRIPTION
### Summary

For postgresql arrays when the default date format has been altered then the wrong format is sent to the database.  This is fixed in rails 5 due by https://github.com/rails/rails/commit/647eb2cf1cd65b0391e3584361f0fc76246e64f3#diff-71a38fd3eeeff55fbd47a03809ded3bdL67
but this error is still in rails 4.2