### PR TITLE
Remove json gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,8 @@ group :test do
 end
 
 platforms :ruby do
-  gem 'nokogiri', '>= 1.4.5'
+  # 1.7.0 drops support for Ruby 1.9.3 and 2.0.
+  gem 'nokogiri', '>= 1.4.5', '< 1.7.0'
 
   # Needed for compiling the ActionDispatch::Journey parser
   gem 'racc', '>=1.4.6', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,6 @@ platforms :ruby do
 end
 
 platforms :jruby do
-  gem 'json'
   if ENV['AR_JDBC']
     gem 'activerecord-jdbcsqlite3-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: 'master'
     group :db do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ DEPENDENCIES
   mustache (~> 0.99.8)
   mysql (>= 2.9.0)
   mysql2 (>= 0.3.13, < 0.4)
-  nokogiri (>= 1.4.5)
+  nokogiri (>= 1.4.5, < 1.7.0)
   pg (>= 0.11.0)
   racc (>= 1.4.6)
   rack-cache (~> 1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,6 @@ PATH
       arel (~> 5.0.0)
     activesupport (4.1.16)
       i18n (~> 0.6, >= 0.6.9)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
@@ -131,7 +130,6 @@ DEPENDENCIES
   coffee-rails (~> 4.0.0)
   dalli (>= 2.2.1)
   jquery-rails (~> 3.1.0)
-  json
   kindlerb (= 0.1.1)
   mime-types (< 3)
   minitest (< 5.3.4)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.rdoc_options.concat ['--encoding',  'UTF-8']
 
   s.add_dependency 'i18n',       '~> 0.6', '>= 0.6.9'
-  s.add_dependency 'json',       '~> 1.7', '>= 1.7.7'
   s.add_dependency 'tzinfo',     '~> 1.1'
   s.add_dependency 'minitest',   '~> 5.1'
   s.add_dependency 'thread_safe','~> 0.1'


### PR DESCRIPTION
Backport of https://github.com/rails/rails/commit/f3433f7c757ef8352c3ea3796a9b350b4454a2b6 to 4.1-stable.

All modern Rubies ship JSON as part of stdlib.  Using the gem actually hurts multi-platform support due to build difficulties on Windows.