### PR TITLE
Initalize git repo when creatin new rails app

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Initialize git repo when generating new app, if option `--skip-git`
+    is not provided.
+
+    *Dino Maric*
+
 *   Don't generate HTML/ERB templates for scaffold controller with `--api` flag.
 
     Fixes #27591.

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -53,6 +53,12 @@ module Rails
       template "gitignore", ".gitignore"
     end
 
+    def version_control
+      unless options[:skip_git]
+        run "git init"
+      end
+    end
+
     def app
       directory "app"
 
@@ -205,6 +211,7 @@ module Rails
         build(:configru)
         build(:gitignore)   unless options[:skip_git]
         build(:gemfile)     unless options[:skip_gemfile]
+        build(:version_control)
       end
 
       def create_app_files

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -731,6 +731,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_version_control_initializes_git_repo
+    run_generator [destination_root]
+    assert_directory ".git"
+  end
+
   def test_create_keeps
     run_generator
     folders_with_keep = %w(
@@ -777,7 +782,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       template
     end
 
-    sequence = ["install", "exec spring binstub --all", "echo ran after_bundle"]
+    sequence = ["git init", "install", "exec spring binstub --all", "echo ran after_bundle"]
     @sequence_step ||= 0
     ensure_bundler_first = -> command do
       assert_equal sequence[@sequence_step], command, "commands should be called in sequence #{sequence}"
@@ -792,7 +797,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       end
     end
 
-    assert_equal 3, @sequence_step
+    assert_equal 4, @sequence_step
   end
 
   private

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -109,6 +109,7 @@ module SharedGeneratorTests
   def test_skip_git
     run_generator [destination_root, "--skip-git", "--full"]
     assert_no_file(".gitignore")
+    assert_no_directory(".git")
   end
 
   def test_skip_keeps


### PR DESCRIPTION
Since Rails is already generating `.gitignore`, and in 90% of cases when creating new rails app user initialise git repo. Now Rails automatically initialises new git repo on `rails new` command  If `--skip-git` is not specified.

I've added this as new "step" in generator called `version_control` in case someone wants to override this when creating custom app builder (maybe not using git as version_control but something else)
