### PR TITLE
Reference calling methods [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -3,10 +3,12 @@ require "action_controller/metal/exceptions"
 require "active_support/security_utils"
 
 module ActionController #:nodoc:
-  class InvalidAuthenticityToken < ActionControllerError #:nodoc:
+  # See +protect_from_forgery+
+  class InvalidAuthenticityToken < ActionControllerError
   end
 
-  class InvalidCrossOriginRequest < ActionControllerError #:nodoc:
+  # See +verify_same_origin_request+
+  class InvalidCrossOriginRequest < ActionControllerError
   end
 
   # Controller actions are protected from Cross-Site Request Forgery (CSRF) attacks


### PR DESCRIPTION
### Summary

Looking at the docs for  [`InvalidAuthenticityToken`](http://apidock.com/rails/ActionController/InvalidAuthenticityToken) and [`InvalidCrossOriginRequest`](http://apidock.com/rails/ActionController/InvalidCrossOriginRequest)

It would be nice to have a reference to this methods:

* [`protect_from_forgery`](http://apidock.com/rails/ActionController/RequestForgeryProtection/ClassMethods/protect_from_forgery)
* [`verify_same_origin_request`](http://apidock.com/rails/ActionController/RequestForgeryProtection/verify_same_origin_request)

Which explain the actual use of these exceptions.
