### PR TITLE
Modifications to parameter `DEFAULT_PARSERS` are not reflected by the default `parameter_parsers`

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -20,15 +20,11 @@ module ActionDispatch
         end
       end
 
-      included do
-        class << self
-          attr_reader :parameter_parsers
+      module ClassMethods
+        def parameter_parsers
+          @parameter_parsers ||= DEFAULT_PARSERS.transform_keys! { |key| key.respond_to?(:symbol) ? key.symbol : key }
         end
 
-        self.parameter_parsers = DEFAULT_PARSERS
-      end
-
-      module ClassMethods
         def parameter_parsers=(parsers) # :nodoc:
           @parameter_parsers = parsers.transform_keys { |key| key.respond_to?(:symbol) ? key.symbol : key }
         end


### PR DESCRIPTION
### Summary

This fixes an issue where the default parsers are copied when set on `ActionDispatch::Request`. From b93c226d19 it seems the initial intent is for the parameter parsers to be a singleton for the middleware stack. Later in a087cf4312 things were updated so that existing apps would not break if a parser was added which did not use symbol keys. That update _copied_ the parsers when setting them, even if only the default parser constant was used.

This copying breaks apps which expect the default parsers constant to be mutable in initializers (e.g. `config/initializers/mime_types.rb`), then later used by requests when no other set of parsers has been explicitly set.

In an attempt to reconcile both of these intents this lazy loads the parameter parsers. In the case where the parameters are not set (which is the default as of 53d2b7335a) the default constant will be used - which will reflect modifications by initializers. Otherwise, a copy of the custom set it used with symbol keys.

This chooses to implement the lazy loading via a custom reader inside the `ClassMethods` module to be consistent with the existing code. Other implementations that were considered include:

  - Eager load `@parameter_parsers` directly in the `included` block

    ```ruby
    included do
      class << self
        attr_reader :parameter_parsers
      end

      @parameter_parsers = DEFAULT_PARSERS
    end
    ```

    While this works as expected it doesn't follow existing conventions. To remain consistent with the existing code we won't us this.

  - In the setter check if all keys are symbols and not copying the hash in this case

    This behavior is surprising as sometimes the hash is used directly and other times a copy is used. Since this may be surprising we won't use it.

  - Drop transposing keys in the setter

    This doesn't appear to be a viable option given the current release cycle, so we won't do this either.

### Background

This modification of the `DEFAULT_PARSERS` was implemented in a Rails 4.2 application based on information from rails-api/active_model_serializers#1027. After updating to Rails 5.0.1 this stopped working.

For this app, the custom parser is setup in `config/initializers/mime_types.rb`. The custom parser is used to by-pass realtime parsing for large JSON data set for a particular endpoint. When the controller receives this particular format it pushes the data into a background job for further processing.

### Other Information

I wasn't clear on the module's intended behavior based on the above mentioned commits and seeing that the implementation of `params_parsers` delegates directly to `ActionDispatch::Request.parameter_parsers`. I guessed on the intended behavior based on the prior behavior and the statement _"there is only one set of parameter parsers in an app"_.

Also, I was a little concerned that the lazy loading may have threading implications, but I don't have enough knowledge of the Rails loading process to make a call on that.

 I'm happy to adjust things as necessary.