### PR TITLE
Add .byebug_history to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 .Gemfile
 .ruby-version
+.byebug_history
 debug.log
 pkg
 /.bundle


### PR DESCRIPTION
Byebug uses local `.byebug_history` file since [version 8.1.0](https://github.com/deivid-rodriguez/byebug/commit/0d136f221c62489487441c93a268a5b68fc7d30a).