### PR TITLE
Fully initialize routes before the first request is handled

### DIFF
--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -31,6 +31,13 @@ module ActionDispatch
           Visitors::FormatBuilder.new.accept(spec)
         end
 
+        def eager_load!
+          required_names
+          offsets
+          to_regexp
+          nil
+        end
+
         def ast
           @spec.find_all(&:symbol?).each do |node|
             re = @requirements[node.to_sym]

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -73,6 +73,14 @@ module ActionDispatch
         @internal          = internal
       end
 
+      def eager_load!
+        path.eager_load!
+        ast
+        parts
+        required_defaults
+        nil
+      end
+
       def ast
         @decorated_ast ||= begin
           decorated_ast = path.ast

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -22,6 +22,13 @@ module ActionDispatch
         @routes = routes
       end
 
+      def eager_load!
+        # Eagerly trigger the simulator's initialization so
+        # it doesn't happen during a request cycle.
+        simulator
+        nil
+      end
+
       def serve(req)
         find_routes(req).each do |match, parameters, route|
           set_params  = req.path_parameters

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -349,6 +349,12 @@ module ActionDispatch
         @formatter = Journey::Formatter.new self
       end
 
+      def eager_load!
+        router.eager_load!
+        routes.each(&:eager_load!)
+        nil
+      end
+
       def relative_url_root
         @config.relative_url_root
       end

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -124,6 +124,7 @@ module Rails
       # the hook are taken into account.
       initializer :set_routes_reloader_hook do |app|
         reloader = routes_reloader
+        reloader.eager_load = app.config.eager_load
         reloader.execute_if_updated
         reloaders << reloader
         app.reloader.to_run do

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -4,11 +4,13 @@ module Rails
   class Application
     class RoutesReloader
       attr_reader :route_sets, :paths
-      delegate :execute_if_updated, :execute, :updated?, to: :updater
+      attr_accessor :eager_load
+      delegate :updated?, to: :updater
 
       def initialize
         @paths      = []
         @route_sets = []
+        @eager_load = false
       end
 
       def reload!
@@ -17,6 +19,19 @@ module Rails
         finalize!
       ensure
         revert
+      end
+
+      def execute
+        ret = updater.execute
+        route_sets.each(&:eager_load!) if eager_load
+        ret
+      end
+
+      def execute_if_updated
+        if updated = updater.execute_if_updated
+          route_sets.each(&:eager_load!) if eager_load
+        end
+        updated
       end
 
     private


### PR DESCRIPTION
`AD::Journey::GTG::Simulator` is lazily built the first time `Journey::Router#find_routes` is invoked, which happens when the first request is served.

On small applications with only a few dozen routes, it only takes a few milliseconds. But on large applications with hundreds of routes, building the simulator can take several hundred milliseconds (~700ms for us).

Triggering this initialization during the boot process reduces the impact of deploys on the application response time.

@rafaelfranca 