### PR TITLE
Do not ping MySQL on connection checkout

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -793,7 +793,7 @@ module ActiveRecord
 
         def checkout_and_verify(c)
           c._run_checkout_callbacks do
-            c.verify!
+            c.defer_verify!
           end
           c
         rescue

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -215,9 +215,11 @@ module ActiveRecord
 
       # Executes the SQL statement in the context of this connection.
       def execute(sql, name = nil)
-        log(sql, name) do
-          ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-            @connection.query(sql)
+        with_connection_verify(::ActiveRecord::StatementInvalid) do
+          log(sql, name) do
+            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+              @connection.query(sql)
+            end
           end
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -80,9 +80,11 @@ module ActiveRecord
 
         # Queries the database and returns the results in an Array-like object
         def query(sql, name = nil) #:nodoc:
-          log(sql, name) do
-            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              result_as_array @connection.async_exec(sql)
+          with_connection_verify(::ActiveRecord::StatementInvalid) do
+            log(sql, name) do
+              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+                result_as_array @connection.async_exec(sql)
+              end
             end
           end
         end
@@ -92,9 +94,11 @@ module ActiveRecord
         # Note: the PG::Result object is manually memory managed; if you don't
         # need it specifically, you may want consider the <tt>exec_query</tt> wrapper.
         def execute(sql, name = nil)
-          log(sql, name) do
-            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              @connection.async_exec(sql)
+          with_connection_verify(::ActiveRecord::StatementInvalid) do
+            log(sql, name) do
+              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+                @connection.async_exec(sql)
+              end
             end
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -698,6 +698,12 @@ module ActiveRecord
           end
         end
 
+        def connected?
+          @connection && @connection.socket.present?
+        rescue PG::ConnectionBad
+          false
+        end
+
         # Configures the encoding, verbosity, schema search path, and time zone of the connection.
         # This is called by #connect and should not be called manually.
         def configure_connection

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -42,7 +42,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
     @connection.update("set @@wait_timeout=1")
     sleep 2
     assert !@connection.active?
-
+  ensure
     # Repair all fixture connections so other tests won't break.
     @fixture_connections.each(&:verify!)
   end
@@ -77,6 +77,12 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
     assert_raise(Mysql2::Error) do
       @connection.quote("string")
     end
+  end
+
+  def test_no_ping_on_connect
+    @connection.disconnect!
+    Mysql2::Client.any_instance.expects(:ping).never
+    @connection.reconnect!
   end
 
   def test_active_after_disconnect

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -168,8 +168,6 @@ module ActiveRecord
 
       @connection.verify!
 
-      assert @connection.active?
-
       # If we get no exception here, then either we re-connected successfully, or
       # we never actually got disconnected.
       new_connection_pid = @connection.query("select pg_backend_pid()")
@@ -178,6 +176,7 @@ module ActiveRecord
         "umm -- looks like you didn't break the connection, because we're still " +
         "successfully querying with the same connection pid."
 
+    ensure
       # Repair all fixture connections so other tests won't break.
       @fixture_connections.each(&:verify!)
     end

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -58,6 +58,19 @@ class PooledConnectionsTest < ActiveRecord::TestCase
     assert_equal 1, ActiveRecord::Base.connection_pool.connections.size
   end
 
+  def test_no_verify_called_on_checkin
+    ActiveRecord::Base.establish_connection(@connection)
+
+    begin
+      conn = ActiveRecord::Base.connection_pool.checkout
+      conn.expects(:verify!).never
+    ensure
+      ActiveRecord::Base.connection_pool.checkin(conn)
+    end
+
+    ActiveRecord::Base.connection_pool.with_connection {}
+  end
+
   def test_pooled_connection_checkin_two
     checkout_checkin_connections_loop 2, 3
     assert_equal 3, @connection_count


### PR DESCRIPTION
Now on every single connection checkout we ping MySQL with
`mysql_ping`. This is nothing for an app with a couple app servers, but in case of Shopify we have over 500 servers, each running 4 containers with 12 unicorn processes. It means that on the first request after the deploy, we checkout 500 * 4 * 12 = **24000** connections. This creates a peak of 24K QPS on the master MySQL database and makes our data ops sad.

**Why is this bad**? Because these pings are not free. On every request we (usually) checkout two connections: 1) the shard, and 2) the master shard. This is two network roundtrips of roughly 1ms each. In addition, these calls are not free on the database either. Each call takes 100μs, whereas a small, indexed query takes 500μs. Given that we have such a staggering number of them, especially on the master shard which is checked out on connections to all shards, this adds up to an absurd amount of CPU time spent in Rails pinging connections and on the database processing those pings.

**Why is the ping there**? To health-check the connection and reconnect if it's not healthy. This is problematic though, because it's racy. If you perform the ping, and reconnect, by the time you hit the first query your connection might have been lost. For the majority of production, this is a no-op ping. It's legitimate in cases where the connection has gone stale (even that is rare). If we blindly remove the ping, in those cases we'd lose the entire request. This is not unreasonable, but this patch will ensure that even requests from stale or closed connections will succeed by retrying the first query after a connection checkout.

**This is not only the Shopify problem**. Same issue have been described by [Percona](https://www.percona.com/blog/2010/05/05/checking-for-a-live-database-connection-considered-harmful/) and [by Groupon on their Rails patch](https://engineering.groupon.com/2013/rails/removing-the-ping-sting-from-rails-db-connections/). As outlined in Percona blog post, 73% of the server’s load was consumed by checking to see if the connection is still alive.

**Summary:** while the code behind my implementation is not ideal, I think that many large-scale Rails apps such as Basecamp will benefit from the option to skip MySQL ping. I'm open to the discussion how we can make it an optional thing.

All credits for discovering the issue and the patch belong to @Sirupsen and @rafaelfranca.

@tenderlove @arthurnn @sgrif @jeremy 