### PR TITLE
fix method name in `Renderer` doc [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -60,7 +60,8 @@ module ActionController
     end
 
     # Accepts a custom Rack environment to render templates in.
-    # It will be merged with ActionController::Renderer.defaults
+    # It will be merged with the default Rack environment defined by
+    # +ActionController::Renderer::DEFAULTS+.
     def initialize(controller, env, defaults)
       @controller = controller
       @defaults = defaults


### PR DESCRIPTION
`ActionController::Renderer.defaults` was removed in 2db7304

