### PR TITLE
compute_asset_extname should explicitly return nil in else clause

### DIFF
--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -237,7 +237,11 @@ module ActionView
       def compute_asset_extname(source, options = {})
         return if options[:extname] == false
         extname = options[:extname] || ASSET_EXTENSIONS[options[:type]]
-        extname if extname && File.extname(source) != extname
+        if extname && File.extname(source) != extname
+          extname
+        else
+          nil
+        end
       end
 
       # Maps asset types to public directory.


### PR DESCRIPTION
As is
```
# Compute extname to append to asset path. Returns +nil+ if
# nothing should be added.
def compute_asset_extname(source, options = {})   
  return if options[:extname] == false   
  extname = options[:extname] || ASSET_EXTENSIONS[options[:type]]   
  extname if extname && File.extname(source) != extname end
end
```

Nothing specified as a return value when the last condition is false. An else clause should be here and explicitly return nil. 