### PR TITLE
CI against JRuby 9.1.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,17 +74,17 @@ matrix:
         - "GEM=ar:mysql2 MYSQL=mariadb"
       addons:
         mariadb: 10.0
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       jdk: oraclejdk8
       env:
         - "GEM=ap"
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       jdk: oraclejdk8
       env:
         - "GEM=am,aj"
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
     - env: "GEM=ac:integration"
   fast_finish: true
 


### PR DESCRIPTION
JRuby 9.1.7.0 Released.

http://jruby.org/2017/01/11/jruby-9-1-7-0.html