### PR TITLE
Add verification for column type for enum

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -149,9 +149,13 @@ module ActiveRecord
 
     def enum(definitions)
       klass = self
+      puts klass
+
+      
       enum_prefix = definitions.delete(:_prefix)
       enum_suffix = definitions.delete(:_suffix)
       definitions.each do |name, values|
+        raise ArgumentError, "Type of column #{name} should be Integer instead of #{klass.column_for_attribute(name).type}" if klass.column_for_attribute(name).type != :integer
         # statuses = { }
         enum_values = ActiveSupport::HashWithIndifferentAccess.new
         name        = name.to_sym

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -149,9 +149,6 @@ module ActiveRecord
 
     def enum(definitions)
       klass = self
-      puts klass
-
-      
       enum_prefix = definitions.delete(:_prefix)
       enum_suffix = definitions.delete(:_suffix)
       definitions.each do |name, values|


### PR DESCRIPTION
### Summary

Added error if you try to use enum() on column which is not integer type. This PR is not completed yet, I'm just trying to understand if we need this kind of improvement. And if so - I will add tests and update docs, and codestyle.

It looks like

```
ArgumentError: Type of column status should be Integer instead of string
	from app/models/test.rb:2:in `<class:Test>'

```


Or need to update docs with undocumented behavior - if your column in db is string, then you can have following enum

`enum  status: { 'active': 'ActiveStatus' }`