### PR TITLE
Fixed precision lost when intend highly number_to_currency precision.

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
@@ -6,9 +6,12 @@ module ActiveSupport
       self.namespace = :currency
 
       def convert
-        number = self.number.to_s.strip
-        format = options[:format]
-
+        if number.is_a?(Float)
+          number = BigDecimal.new(self.number, 0).to_s.strip
+        else
+          number = self.number.to_s.strip
+        end
+        
         if number.to_f.negative?
           format = options[:negative_format]
           number = absolute_value(number)


### PR DESCRIPTION
Do not use method Float.to_s , as helper.number_to_currency will looses precision.

### Summary

Fixed [#27645](https://github.com/rails/rails/issues/27645)
AS @gregnavis mentioned, if we intend want highly precision. `helper.number_to_currency`
we shouldn't use Float.to_s, it will convert to float and then convert to string and lost precision.

Like that:
`0.10000000000000000555.to_s
 => "0.1" 
`