### PR TITLE
Generate migrations at path set by `config.paths["db/migrate"]`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Place generated migrations into the path set by `config.paths["db/migrate"]`
+
+    *Kevin Glowacz*
+    
 *   Raise `ActiveRecord::InvalidForeignKey` when a foreign key constraint fails on Sqlite3.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -10,7 +10,7 @@ module ActiveRecord
       def create_migration_file
         set_local_assigns!
         validate_file_name!
-        migration_template @migration_template, "db/migrate/#{file_name}.rb"
+        migration_template @migration_template, File.join(db_migrate_path, "#{file_name}.rb")
       end
 
       # TODO Change this to private once we've dropped Ruby 2.2 support.
@@ -70,6 +70,14 @@ module ActiveRecord
 
         def normalize_table_name(_table_name)
           pluralize_table_names? ? _table_name.pluralize : _table_name.singularize
+        end
+
+        def db_migrate_path
+          if defined?(Rails) && Rails.application
+            Rails.application.config.paths["db/migrate"].to_ary.first
+          else
+            "db/migrate"
+          end
         end
     end
   end

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -17,7 +17,7 @@ module ActiveRecord
       def create_migration_file
         return unless options[:migration] && options[:parent].nil?
         attributes.each { |a| a.attr_options.delete(:index) if a.reference? && !a.has_index? } if options[:indexes] == false
-        migration_template "../../migration/templates/create_table_migration.rb", "db/migrate/create_#{table_name}.rb"
+        migration_template "../../migration/templates/create_table_migration.rb", File.join(db_migrate_path, "create_#{table_name}.rb")
       end
 
       def create_model_file
@@ -62,6 +62,14 @@ module ActiveRecord
             "app/models/#{namespaced_path}/application_record.rb"
           else
             "app/models/application_record.rb"
+          end
+        end
+
+        def db_migrate_path
+          if defined?(Rails) && Rails.application
+            Rails.application.config.paths["db/migrate"].to_ary.first
+          else
+            "db/migrate"
           end
         end
     end

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -309,6 +309,16 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_add_migration_to_configured_path
+    old_paths = Rails.application.config.paths["db/migrate"]
+    Rails.application.config.paths.add "db/migrate", with: "db2/migrate"
+
+    migration = "migration_in_custom_path"
+    run_generator [migration]
+    Rails.application.config.paths["db/migrate"] = old_paths
+    assert_migration "db2/migrate/#{migration}.rb", /.*/
+  end
+
   private
 
     def with_singular_table_name

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -220,6 +220,16 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     ActiveRecord::Base.timestamped_migrations = true
   end
 
+  def test_migration_with_configured_path
+    old_paths = Rails.application.config.paths["db/migrate"]
+    Rails.application.config.paths.add "db/migrate", with: "db2/migrate"
+
+    run_generator
+
+    Rails.application.config.paths["db/migrate"] = old_paths
+    assert_migration "db2/migrate/create_accounts.rb", /class CreateAccounts < ActiveRecord::Migration\[[0-9.]+\]/
+  end
+
   def test_model_with_references_attribute_generates_belongs_to_associations
     run_generator ["product", "name:string", "supplier:references"]
     assert_file "app/models/product.rb", /belongs_to :supplier/


### PR DESCRIPTION
### Summary

Generate new database migrations at path set by `config.paths["db/migrate"]` instead of hardcoding the generations to db/migrate.