### PR TITLE
`type_condition` should be overwritten by `create_with_value` in `scope_for_create`

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -308,7 +308,7 @@ module ActiveRecord
           relation = Relation.create(self, arel_table, predicate_builder)
 
           if finder_needs_type_condition? && !ignore_default_scope?
-            relation.where(type_condition).create_with(inheritance_column.to_sym => sti_name)
+            relation.where(type_condition).create_with(inheritance_column.to_s => sti_name)
           else
             relation
           end


### PR DESCRIPTION
`type_condition` should be overwritten by `create_with_value`. So `type`
in `create_with_value` should be a string because `where_values_hash`
keys are converted to string.

Fixes #27600.