### PR TITLE
allow use of Proc in length validations

### DIFF
--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -31,8 +31,8 @@ module ActiveModel
         keys.each do |key|
           value = options[key]
 
-          unless (value.is_a?(Integer) && value >= 0) || value == Float::INFINITY
-            raise ArgumentError, ":#{key} must be a nonnegative Integer or Infinity"
+          unless (value.is_a?(Integer) && value >= 0) || value == Float::INFINITY || value.is_a?(Proc)
+            raise ArgumentError, ":#{key} must be a nonnegative Integer, Infinity or a proc"
           end
         end
       end
@@ -43,6 +43,10 @@ module ActiveModel
 
         CHECKS.each do |key, validity_check|
           next unless check_value = options[key]
+
+          if check_value.is_a?(Proc)
+            check_value = check_value.call(record)
+          end
 
           if !value.nil? || skip_nil_check?(key)
             next if value_length.send(validity_check, check_value)

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -26,6 +26,13 @@ class LengthValidationTest < ActiveModel::TestCase
     assert Topic.new("title" => "abcde").valid?
   end
 
+  def test_validates_length_of_with_proc
+    Topic.validates_length_of(:title, is: lambda { |topic| 5 })
+
+    assert Topic.new("title" => "ab").invalid?
+    assert Topic.new("title" => "abcde").valid?
+  end
+
   def test_validates_length_of_using_minimum
     Topic.validates_length_of :title, minimum: 5
 


### PR DESCRIPTION
### Summary

Various validations in ActiveModel allow the use of Procs a way to generate dynamic validations; however, length validations seem to be an outlier. This PR introduces the ability to use Proc in length validations.

Thanks a lot for looking at my PR!
