### PR TITLE
Add test for update_counters with empty touch array

### DIFF
--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -221,6 +221,15 @@ class CounterCacheTest < ActiveRecord::TestCase
     assert_equal previously_updated_at, @topic.updated_at
   end
 
+  test "update counters doesn't touch timestamps with touch: []" do
+    @topic.update_column :updated_at, 5.minutes.ago
+    previously_updated_at = @topic.updated_at
+
+    Topic.update_counters(@topic.id, replies_count: -1, touch: [])
+
+    assert_equal previously_updated_at, @topic.updated_at
+  end
+
   test "update counters with touch: true" do
     assert_touching @topic, :updated_at do
       Topic.update_counters(@topic.id, replies_count: -1, touch: true)


### PR DESCRIPTION
This is a regression test for a fix included in https://github.com/rails/rails/pull/27660 - see https://github.com/rails/rails/pull/27660#discussion_r95855113.

Without that change, this test would fail with:

    ActiveRecord::StatementInvalid: SQLite3::SQLException: near "WHERE": syntax error: UPDATE "topics" SET "replies_count" = COALESCE("replies_count", 0) - 1,  WHERE "topics"."id" = ?

r? @kaspth (I have no idea if I'm allowed to r?, but let's see 😄)

/fyi @akihiro17 