### PR TITLE
remove unnecessary addition of `lib`

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -415,7 +415,6 @@ task default: :test
 require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << 'lib'
   t.libs << 'test'
   t.pattern = 'test/**/*_test.rb'
   t.verbose = false


### PR DESCRIPTION
`TestTask` add `lib` directory by default.
Ref: https://github.com/ruby/rake/blob/master/lib/rake/testtask.rb#L39..L41
