### PR TITLE
Several representation of BigDecimal has changed in Ruby 2.4.0+ [ci skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -107,6 +107,13 @@ class BigDecimal
   # BigDecimals are duplicable:
   #
   # BigDecimal.new("1.2").duplicable? # => true
+  #
+  # In Ruby 2.4.0:
+  #
+  # BigDecimal.new("1.2").dup         # => 0.12e1
+  #
+  # Whereas in Ruby 2.2 and 2.3:
+  #
   # BigDecimal.new("1.2").dup         # => #<BigDecimal:...,'0.12E1',18(18)>
   def duplicable?
     true

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1980,7 +1980,15 @@ and that symbol specifiers are also supported:
 BigDecimal.new(5.00, 6).to_s(:db)  # => "5.0"
 ```
 
-Engineering notation is still supported:
+Engineering notation is still supported.
+
+In Ruby 2.4:
+
+```ruby
+BigDecimal.new(5.00, 6).to_s("e")  # => "0.5e1"
+```
+
+Whereas in Ruby 2.2 and 2.3:
 
 ```ruby
 BigDecimal.new(5.00, 6).to_s("e")  # => "0.5E1"


### PR DESCRIPTION
cf. https://github.com/ruby/bigdecimal/pull/42
