### PR TITLE
Fixes #21948 by introducing a persistent CSRF token cookie

### DIFF
--- a/actionpack/lib/action_controller/metal/cookies.rb
+++ b/actionpack/lib/action_controller/metal/cookies.rb
@@ -6,9 +6,8 @@ module ActionController #:nodoc:
       helper_method :cookies if defined?(helper_method)
     end
 
-    private
-      def cookies
-        request.cookie_jar
-      end
+    def cookies
+      request.cookie_jar
+    end
   end
 end

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -325,6 +325,7 @@ module ActionDispatch
     # be included by the session middleware.
     def reset_session
       if session && session.respond_to?(:destroy)
+        controller_instance.token_store.clean(controller_instance)
         session.destroy
       else
         self.session = {}


### PR DESCRIPTION
### Summary

This will change the `real_csrf_token` method which generates a CSRF token and stores it in the session. The downsides of the original method, the bugs it causes and the steps to reproduce it are well described by @zetter in #21948. The session cookie is not persistent, so it is destroyed when you close the browser. Therefore next time you open the browser (if it has a "restore last visited pages" feature enabled), the page will contain the old token in the body but not in the cookie, so if you will submit a form from that page, the submit will fail.

@zetter has discovered that Django uses a separate persistent cookie to deal with that. Actually, they allow you to choose which way to go: https://github.com/django/django/blob/master/django/middleware/csrf.py#L166. I use a similar approach.

### Other Information

I didn't get why the `real_csrf_token` method accepts a session as a parameter. Perhaps, I need to pass the cookie as well? Or, instead, get rid of it.

Also, we might want to parameterize the cookie's name.