### PR TITLE
make `render` work with AC::Params

### DIFF
--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -313,7 +313,6 @@ class ExpiresInRenderTest < ActionController::TestCase
   end
 
   def test_permitted_dynamic_render_file_hash
-    skip "FIXME: this test passes on 4-2-stable but not master. Why?"
     assert File.exist?(File.join(File.dirname(__FILE__), "../../test/abstract_unit.rb"))
     response = get :dynamic_render_permit, params: { id: { file: '../\\../test/abstract_unit.rb' } }
     assert_equal File.read(File.join(File.dirname(__FILE__), "../../test/abstract_unit.rb")),

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -124,7 +124,11 @@ module ActionView
           key = action.include?(?/) ? :template : :action
           options[key] = action
         else
-          options[:partial] = action
+          if action.respond_to?(:permitted?) && action.permitted?
+            options = action
+          else
+            options[:partial] = action
+          end
         end
 
         options


### PR DESCRIPTION
In 4.2, since AC::Params inherited `Hash`, processing in the case of
`Hash` was done. But in 5.x, since AC::Params does not inherit `Hash`,
need to add care for AC::Params.

Related to 00285e7cf75c96553719072a27c27e4ab7d25b40
