### PR TITLE
Fix unexpected behavior of `to_sentence` with $,

### DIFF
--- a/actionview/lib/action_view/helpers/output_safety_helper.rb
+++ b/actionview/lib/action_view/helpers/output_safety_helper.rb
@@ -60,7 +60,7 @@ module ActionView #:nodoc:
         when 2
           safe_join([array[0], array[1]], options[:two_words_connector])
         else
-          safe_join([safe_join(array[0...-1], options[:words_connector]), options[:last_word_connector], array[-1]])
+          safe_join([safe_join(array[0...-1], options[:words_connector]), options[:last_word_connector], array[-1]], nil)
         end
       end
     end

--- a/actionview/test/template/output_safety_helper_test.rb
+++ b/actionview/test/template/output_safety_helper_test.rb
@@ -87,4 +87,14 @@ class OutputSafetyHelperTest < ActionView::TestCase
     assert_equal "one, two three", to_sentence(["one", "two", "three"], last_word_connector: " ")
     assert_equal "one, two and three", to_sentence(["one", "two", "three"], last_word_connector: " and ")
   end
+
+  test "to_sentence is not affected by $," do
+    $, = "|"
+    begin
+      assert_equal "one and two", to_sentence(["one", "two"])
+      assert_equal "one, two, and three", to_sentence(["one", "two", "three"])
+    ensure
+      $, = nil
+    end
+  end
 end


### PR DESCRIPTION
When `$,` is not nil, `to_sentence` returns a strange string.

Steps to reproduce:

```
require 'action_view'
include ActionView::Helpers::OutputSafetyHelper

array = ["one", "two", "three"]
to_sentence(array)
=> "one, two, and three"

$, = "|"
to_sentence(array)
=> "one, two|, and |three"
```

`to_sentence` calls `safe_join` which uses `$,` unless the second argument is given.
Since `to_sentence` method is expected to return a comma-separated sentence, it should not be affected by `$,` even when `$,` is not nil.