### PR TITLE
Allow SQLServerAdapter To Opt Into A Few Tests

### DIFF
--- a/activerecord/test/cases/date_time_precision_test.rb
+++ b/activerecord/test/cases/date_time_precision_test.rb
@@ -73,7 +73,7 @@ if subsecond_precision_supported?
       assert_match %r{t\.datetime\s+"updated_at",\s+precision: 6,\s+null: false$}, output
     end
 
-    if current_adapter?(:PostgreSQLAdapter)
+    if current_adapter?(:PostgreSQLAdapter, :SQLServerAdapter)
       def test_datetime_precision_with_zero_should_be_dumped
         @connection.create_table(:foos, force: true) do |t|
           t.timestamps precision: 0

--- a/activerecord/test/cases/time_precision_test.rb
+++ b/activerecord/test/cases/time_precision_test.rb
@@ -68,7 +68,7 @@ if subsecond_precision_supported?
       assert_match %r{t\.time\s+"finish",\s+precision: 6$}, output
     end
 
-    if current_adapter?(:PostgreSQLAdapter)
+    if current_adapter?(:PostgreSQLAdapter, :SQLServerAdapter)
       def test_time_precision_with_zero_should_be_dumped
         @connection.create_table(:foos, force: true) do |t|
           t.time :start,  precision: 0

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -154,7 +154,7 @@ if ActiveRecord::Base.connection.supports_views?
   end
 
   # sqlite dose not support CREATE, INSERT, and DELETE for VIEW
-  if current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter)
+  if current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter, :SQLServerAdapter)
     class UpdateableViewTest < ActiveRecord::TestCase
       self.use_transactional_tests = false
       fixtures :books
@@ -200,7 +200,7 @@ if ActiveRecord::Base.connection.supports_views?
         end
       end
     end
-  end # end of `if current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter)`
+  end # end of `if current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter, :SQLServerAdapter)`
 end # end of `if ActiveRecord::Base.connection.supports_views?`
 
 if ActiveRecord::Base.connection.respond_to?(:supports_materialized_views?) &&


### PR DESCRIPTION
Hi! I am the author of the [SQLServer adapter](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter) for Rails. While working on the long awaited Rails v5 releases, I found a few tests in core that we would like to opt-into. 

Our tests run the full ActiveRecord suite and we have a [coercion system](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/master/test/support/coerceable_test_sqlserver.rb) that enables us to keep most of our changes out of the core test suite. However, these changes open up tests that we do not want to regress on. Willing to answer any questions if needed. Thanks!!!

cc @sgrif 