### PR TITLE
Update rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,7 +113,7 @@ Style/UnneededPercentQ:
 # assignments, where it should be aligned with the LHS.
 Lint/EndAlignment:
   Enabled: true
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 # Use my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
 Lint/RequireParentheses:

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem "rb-inotify", github: "matthewd/rb-inotify", branch: "close-handling", requi
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
 gem "json", ">= 2.0.0"
 
-gem "rubocop", require: false
+gem "rubocop", ">= 0.47", require: false
 
 group :doc do
   gem "sdoc", "1.0.0.rc1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ GEM
       nokogiri (~> 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rainbow (2.1.0)
+    rainbow (2.2.1)
     rake (12.0.0)
     rb-fsevent (0.9.8)
     rdoc (5.0.0)
@@ -287,8 +287,8 @@ GEM
       redis (~> 3.3)
       resque (~> 1.26)
       rufus-scheduler (~> 3.2)
-    rubocop (0.46.0)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.47.0)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -358,7 +358,7 @@ GEM
       tzinfo (>= 1.0.0)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.1.2)
+    unicode-display_width (1.1.3)
     useragent (0.16.8)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -417,7 +417,7 @@ DEPENDENCIES
   redis
   resque!
   resque-scheduler
-  rubocop
+  rubocop (>= 0.47)
   sass-rails
   sdoc (= 1.0.0.rc1)
   sequel


### PR DESCRIPTION
### Summary

Since rubocop v0.47, AlignWith became obsolete.

```
$ bundle exec rubocop
Error: obsolete parameter AlignWith (for Lint/EndAlignment) found in.rubocop.yml
`AlignWith` has been renamed to `EnforcedStyleAlignWith`
```

see also. https://github.com/bbatsov/rubocop/pull/3765

After this change, `rubocop` command works again.

```
$ bundle exec rubocop
Inspecting 2144 files
..............................................................
```

---

**[Update]**

CodeClimate raises new issues. If I need to fix it, I'll auto-collect the issues.
