### PR TITLE
Remove meaningless line from adapter_test.rb

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -31,7 +31,6 @@ module ActiveRecord
     end
 
     def test_tables
-      tables = nil
       tables = @connection.tables
       assert_includes tables, "accounts"
       assert_includes tables, "authors"


### PR DESCRIPTION
`tables` is defined twice.