### PR TITLE
Raise ArgumentError if attempting to transliterate nil

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Changed `ActiveSupport::Inflector#transliterate` to raise `ArgumentError` when it receives
+    anything except a string.
+
+    *Kevin McPhillips*
+
 *   Fixed bugs that `StringInquirer#respond_to_missing?` and
     `ArrayInquirer#respond_to_missing?` do not fallback to `super`.
 

--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -57,6 +57,8 @@ module ActiveSupport
     #   transliterate('Jürgen')
     #   # => "Juergen"
     def transliterate(string, replacement = "?".freeze)
+      raise ArgumentError, "Can only transliterate strings. Received #{string.class.name}" unless string.is_a?(String)
+
       I18n.transliterate(ActiveSupport::Multibyte::Unicode.normalize(
         ActiveSupport::Multibyte::Unicode.tidy_bytes(string), :c),
           replacement: replacement)

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -31,4 +31,22 @@ class TransliterateTest < ActiveSupport::TestCase
   def test_transliterate_should_allow_a_custom_replacement_char
     assert_equal "a*b", ActiveSupport::Inflector.transliterate("a索b", "*")
   end
+
+  def test_transliterate_handles_empty_string
+    assert_equal "", ActiveSupport::Inflector.transliterate("")
+  end
+
+  def test_transliterate_handles_nil
+    exception = assert_raises ArgumentError do
+      ActiveSupport::Inflector.transliterate(nil)
+    end
+    assert_equal "Can only transliterate strings. Received NilClass", exception.message
+  end
+
+  def test_transliterate_handles_unknown_object
+    exception = assert_raises ArgumentError do
+      ActiveSupport::Inflector.transliterate(Object.new)
+    end
+    assert_equal "Can only transliterate strings. Received Object", exception.message
+  end
 end


### PR DESCRIPTION
## Problem

When calling:
```ruby
ActiveSupport::Inflector.transliterate(nil)
```

The method raises with an unclear error:
```
NoMethodError: undefined method `empty?' for nil:NilClass
rails/activesupport/lib/active_support/multibyte/unicode.rb:215:in `tidy_bytes'
```

This is coming from `tidy_bytes` and `I18n.transliterate` both not handling `nil` either.

## Solution

Raise an `ArgumentError` explaining what the problem is and where it comes from.

Alternately we could pass through `nil`, since by definition it is also transliterated, but this is the least functionality change.

cc @rafaelfranca 