### PR TITLE
allow to pass describe option to rake

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -168,7 +168,7 @@ module Rails::Command
   class << self
     def invoke(namespace, args = [], **config)
       namespace = namespace.to_s
-      namespace = "help" if namespace.blank? || Thor::HELP_MAPPINGS.include?(namespace)
+      namespace = "help" if namespace.blank? || HELP_MAPPINGS.include?(namespace)
       namespace = "version" if %w( -v --version ).include? namespace
     
       if command = find_by_namespace(namespace)

--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -15,6 +15,8 @@ module Rails
 
     include Behavior
 
+    HELP_MAPPINGS = %w(-h -? --help)
+
     class << self
       def hidden_commands # :nodoc:
         @hidden_commands ||= []
@@ -27,7 +29,7 @@ module Rails
       # Receives a namespace, arguments and the behavior to invoke the command.
       def invoke(namespace, args = [], **config)
         namespace = namespace.to_s
-        namespace = "help" if namespace.blank? || Thor::HELP_MAPPINGS.include?(namespace)
+        namespace = "help" if namespace.blank? || HELP_MAPPINGS.include?(namespace)
         namespace = "version" if %w( -v --version ).include? namespace
 
         if command = find_by_namespace(namespace)

--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -56,7 +56,7 @@ module Rails
         end
 
         def perform(command, args, config) # :nodoc:
-          command = nil if Thor::HELP_MAPPINGS.include?(args.first)
+          command = nil if Rails::Command::HELP_MAPPINGS.include?(args.first)
 
           dispatch(command, args.dup, nil, config)
         end


### PR DESCRIPTION
Since `Thor::HELP_MAPPINGS` contains `-D`, so `bin/rails -D` show
rails's help. But, in Rails 5.0.1, `bin/rails -D` show the description
of rake task. I think that it is better to have the same behavior.
