### PR TITLE
Explicitly require ActionView::Helpers::TagHelper dependencies

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -1,5 +1,8 @@
 # frozen-string-literal: true
 
+require "action_view/helpers/capture_helper"
+require "action_view/helpers/output_safety_helper"
+require "active_support/concern"
 require "active_support/core_ext/string/output_safety"
 require "set"
 


### PR DESCRIPTION
### Summary

It turns out that TagHelper depends on additional view helpers, as well
as ActiveSupport::Concern. This isn't explicitly required because when
Rails is loaded all at once, these constants will have been required
elsewhere, but it's necessary to declare the dependency explicitly if
anyone is going to require something from ActionView directly.

### Other Information

I stumbled upon this because I was trying to require just DateHelper:

> require "action_view/helpers/date_helper"
NameError: uninitialized constant ActiveSupport::Concern
from …rails/actionview/lib/action_view/helpers/tag_helper.rb:12:in `<module:TagHelper>'
