### PR TITLE
Let 'current_page?' return false when the argument path is not defined

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -559,6 +559,8 @@ module ActionView
         else
           url_string == request_uri
         end
+      rescue ActionController::UrlGenerationError
+        false
       end
 
       private

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -544,6 +544,14 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert current_page?("/posts/")
   end
 
+  def test_current_page_with_not_defined_path
+    @request = request_for_url("/posts")
+
+    refute current_page?(action: "no_such_an_action")
+    refute current_page?(controller: "no_such_a_controller")
+    refute current_page?(controller: "no_such_a_controller", action: "no_such_an_action")
+  end
+
   def test_link_unless_current
     @request = request_for_url("/")
 


### PR DESCRIPTION
```
<%= current_page?('/not/exists') %>
=> false
<%= current_page?(controller: 'not', action: 'exists') %>
No route matches {:action=>"exists", :controller=>"not"}
```

Since `current_page?('/not/exists')` returns false, I think `current_page?(controller: 'not', action: 'exists')` should also return `false` instead of raising an error.

When there is no route for the arguments of `current_page?`, it is obvious that the path is not current page.