### PR TITLE
Fix pool_from_any_process to use most recent spec

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -637,7 +637,7 @@ module ActiveRecord
       end
 
       def pool_from_any_process_for(owner)
-        owner_to_pool = @owner_to_pool.values.find { |v| v[owner.name] }
+        owner_to_pool = @owner_to_pool.values.reverse.find { |v| v[owner.name] }
         owner_to_pool && owner_to_pool[owner.name]
       end
     end


### PR DESCRIPTION
I was going to backport this but I can't push to 4-2-stable because it's protected 😕 
cc/ @tenderlove 

---

If a process is forked more than once, the pool was grabbing the oldest
spec, not the most recent spec. This wasn't noticed before because most
folks are lilely forking the process only once.

If you're forking the process multiple times however the wrong spec name
will be returned and an incorrect connection will be used for the
process.

This fixes the issue by reversing the list of spec names so we can grab
the most recent spec rather than the oldest spec.