### PR TITLE
Use appropriate assertion based on expectation

### DIFF
--- a/activesupport/test/json/decoding_test.rb
+++ b/activesupport/test/json/decoding_test.rb
@@ -75,12 +75,17 @@ class TestJSONDecoding < ActiveSupport::TestCase
   }
 
   TESTS.each_with_index do |(json, expected), index|
+    fail_message = "JSON decoding failed for #{json}"
+
     test "json decodes #{index}" do
       with_tz_default "Eastern Time (US & Canada)" do
         with_parse_json_times(true) do
           silence_warnings do
-            assert_equal expected, ActiveSupport::JSON.decode(json), "JSON decoding \
-            failed for #{json}"
+            if expected.nil?
+              assert_nil ActiveSupport::JSON.decode(json), fail_message
+            else
+              assert_equal expected, ActiveSupport::JSON.decode(json), fail_message
+            end
           end
         end
       end


### PR DESCRIPTION
This resolves a stern Minitest “warning” about an upcoming behavior change in MiniTest 6 that will result in the test failing.

More information on the change is available at https://github.com/seattlerb/minitest/issues/666
