### PR TITLE
Module#parent_name broken for frozen classes

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/introspection.rb
+++ b/activesupport/lib/active_support/core_ext/module/introspection.rb
@@ -5,10 +5,12 @@ class Module
   #
   #   M::N.parent_name # => "M"
   def parent_name
-    if defined? @parent_name
+    if defined?(@parent_name)
       @parent_name
     else
-      @parent_name = name =~ /::[^:]+\Z/ ? $`.freeze : nil
+      parent_name = name =~ /::[^:]+\Z/ ? $`.freeze : nil
+      @parent_name = parent_name unless frozen?
+      parent_name
     end
   end
 

--- a/activesupport/test/core_ext/module/introspection_test.rb
+++ b/activesupport/test/core_ext/module/introspection_test.rb
@@ -1,0 +1,37 @@
+require "abstract_unit"
+require "active_support/core_ext/module/introspection"
+
+module ParentA
+  module B
+    module C; end
+    module FrozenC; end
+    FrozenC.freeze
+  end
+
+  module FrozenB; end
+  FrozenB.freeze
+end
+
+class IntrospectionTest < ActiveSupport::TestCase
+  def test_parent_name
+    assert_equal "ParentA", ParentA::B.parent_name
+    assert_equal "ParentA::B", ParentA::B::C.parent_name
+    assert_nil ParentA.parent_name
+  end
+
+  def test_parent_name_when_frozen
+    assert_equal "ParentA", ParentA::FrozenB.parent_name
+    assert_equal "ParentA::B", ParentA::B::FrozenC.parent_name
+  end
+
+  def test_parent
+    assert_equal ParentA::B, ParentA::B::C.parent
+    assert_equal ParentA, ParentA::B.parent
+    assert_equal Object, ParentA.parent
+  end
+
+  def test_parents
+    assert_equal [ParentA::B, ParentA, Object], ParentA::B::C.parents
+    assert_equal [ParentA, Object], ParentA::B.parents
+  end
+end

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -1,25 +1,6 @@
 require "abstract_unit"
 require "active_support/core_ext/module"
 
-module One
-  Constant1 = "Hello World"
-  Constant2 = "What's up?"
-end
-
-class Ab
-  include One
-  Constant1 = "Hello World" # Will have different object id than One::Constant1
-  Constant3 = "Goodbye World"
-end
-
-module Yz
-  module Zy
-    class Cd
-      include One
-    end
-  end
-end
-
 Somewhere = Struct.new(:street, :city) do
   attr_accessor :name
 end
@@ -373,17 +354,6 @@ class ModuleTest < ActiveSupport::TestCase
     end
 
     assert_match(/undefined method `my_fake_method' for/, e.message)
-  end
-
-  def test_parent
-    assert_equal Yz::Zy, Yz::Zy::Cd.parent
-    assert_equal Yz, Yz::Zy.parent
-    assert_equal Object, Yz.parent
-  end
-
-  def test_parents
-    assert_equal [Yz::Zy, Yz, Object], Yz::Zy::Cd.parents
-    assert_equal [Yz, Object], Yz::Zy.parents
   end
 
   def test_delegate_with_case


### PR DESCRIPTION
Previously memoization inside of `Module.parent_name` resulted in a runtime error when called for the first time on a frozen module. This patch adds a regression test and refactors the method to resolve the issue. 

Note: introspection tests were previously lumped into `test/core_ext/module_test.rb` despite the code having been extracted to `core_exts/module/introspection.rb`. I isolated the tests similarly, following convention (e.g., `core_exts/module/anonymous.rb` to `test/core_ext/module/anonymous_test.rb`). In the process, I removed some old (over 10 years) setup objects that were no longer being referenced.