### PR TITLE
Reset `through_proxy` when `through_record` is destroyed

### DIFF
--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -19,6 +19,7 @@ module ActiveRecord
 
           if through_record && !record
             through_record.destroy
+            through_proxy.reset
           elsif record
             attributes = construct_join_attributes(record)
 

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -81,9 +81,20 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_set_record_to_nil_should_delete_association
     @member.club = nil
-    @member.reload
+    assert_nil @member.joined_on
     assert_nil @member.current_membership
     assert_nil @member.club
+    @member.reload
+    assert_nil @member.joined_on
+    assert_nil @member.current_membership
+    assert_nil @member.club
+  end
+
+  def test_set_record_after_delete_association
+    @member.club = nil
+    @member.club = clubs(:moustache_club)
+    @member.reload
+    assert_equal clubs(:moustache_club), @member.club
   end
 
   def test_has_one_through_polymorphic

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -33,6 +33,8 @@ class Member < ActiveRecord::Base
 
   belongs_to :admittable, polymorphic: true
   has_one :premium_club, through: :admittable
+
+  delegate :joined_on, to: :current_membership, allow_nil: true
 end
 
 class SelfMember < ActiveRecord::Base

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -475,7 +475,7 @@ ActiveRecord::Schema.define do
 
   create_table :memberships, force: true do |t|
     t.datetime :joined_on
-    t.integer :club_id, :member_id
+    t.integer :club_id, :member_id, null: false
     t.boolean :favourite, default: false
     t.string :type
   end


### PR DESCRIPTION
If `has_one :through` association has set `nil`, `through_record` is
destroyed but still remain loaded target in `through_proxy` until
`reload` or `reset` explicitly.
It is caused by `through_proxy.stale_target?` always return `false`.
But it is difficult to fix to work `stale_state` and `stale_target?`
properly for now. So reset `through_proxy` when `through_record` is
destroyed until `stale_state` and `stale_target?` has fixed.