### PR TITLE
Install Byebug gem as default in Windows (mingw and x64_mingw) platform.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Install Byebug gem as default in Windows (mingw and x64_mingw) platform.
+
+    *Junichi Ito*
+
 *   Make every Rails command work within engines.
 
     *Sean Collins*, *Yuji Yaginuma*

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -31,7 +31,7 @@ end
 <% if RUBY_ENGINE == 'ruby' -%>
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platform: :mri
+  gem 'byebug', platform: [:mri, :mingw, :x64_mingw]
 end
 
 group :development do

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -31,7 +31,7 @@ end
 <% if RUBY_ENGINE == 'ruby' -%>
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platform: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end
 
 group :development do


### PR DESCRIPTION
### Summary

In [this pull request](https://github.com/rails/rails/pull/23920), byebug gem in default Gemfile has `platform: :mri` option, but `:mri` does not include Windows platform.([see here](http://bundler.io/v1.13/man/gemfile.5.html#PLATFORMS)) So Byebug has not been installed in Windows since then.

However Byebug's CI tests are passing in Windows (mingw and x64_mingw) and the author says Byebug supports Windows.([see here](http://stackoverflow.com/questions/41674136/byebug-fully-supports-windows-or-not))

So it should be installed in Windows platform again.

@ianks, if you have any thoughts on this change, please let me know.
