### PR TITLE
Remove `initialize_schema_migrations_table` and `initialize_internal_metadata_table` internal public methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,12 +1,17 @@
-*   Place generated migrations into the path set by `config.paths["db/migrate"]`
+*   Remove `initialize_schema_migrations_table` and `initialize_internal_metadata_table`
+    internal public methods.
+
+    *Ryuta Kamizono*
+
+*   Place generated migrations into the path set by `config.paths["db/migrate"]`.
 
     *Kevin Glowacz*
-    
+
 *   Raise `ActiveRecord::InvalidForeignKey` when a foreign key constraint fails on Sqlite3.
 
     *Ryuta Kamizono*
 
-*   Add the touch option to ActiveRecord#increment! and decrement!
+*   Add the touch option to ActiveRecord#increment! and decrement!.
 
     *Hiroaki Izu*
 
@@ -15,9 +20,9 @@
 
     *Kir Shatrov*
 
-*   Raise error when has_many through is defined before through association
+*   Raise error when has_many through is defined before through association.
 
-    Fixes #26834
+    Fixes #26834.
 
     *Chris Holmes*
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1008,16 +1008,6 @@ module ActiveRecord
         end
       end
 
-      # Should not be called normally, but this operation is non-destructive.
-      # The migrations module handles this automatically.
-      def initialize_schema_migrations_table
-        ActiveRecord::SchemaMigration.create_table
-      end
-
-      def initialize_internal_metadata_table
-        ActiveRecord::InternalMetadata.create_table
-      end
-
       def internal_string_options_for_primary_key # :nodoc:
         { primary_key: true }
       end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1107,8 +1107,8 @@ module ActiveRecord
 
       validate(@migrations)
 
-      Base.connection.initialize_schema_migrations_table
-      Base.connection.initialize_internal_metadata_table
+      ActiveRecord::SchemaMigration.create_table
+      ActiveRecord::InternalMetadata.create_table
     end
 
     def current_version

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -48,7 +48,7 @@ module ActiveRecord
       instance_eval(&block)
 
       if info[:version].present?
-        initialize_schema_migrations_table
+        ActiveRecord::SchemaMigration.create_table
         connection.assume_migrated_upto_version(info[:version], migrations_paths)
       end
 

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -16,7 +16,7 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
       table_name = ActiveRecord::SchemaMigration.table_name
       connection.drop_table table_name, if_exists: true
 
-      connection.initialize_schema_migrations_table
+      ActiveRecord::SchemaMigration.create_table
 
       assert connection.column_exists?(table_name, :version, :string, collation: "utf8_general_ci")
     end
@@ -27,7 +27,7 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
       table_name = ActiveRecord::InternalMetadata.table_name
       connection.drop_table table_name, if_exists: true
 
-      connection.initialize_internal_metadata_table
+      ActiveRecord::InternalMetadata.create_table
 
       assert connection.column_exists?(table_name, :key, :string, collation: "utf8_general_ci")
     end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -43,10 +43,10 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Base.table_name_prefix = ""
     ActiveRecord::Base.table_name_suffix = ""
 
-    ActiveRecord::Base.connection.initialize_schema_migrations_table
-    ActiveRecord::Base.connection.execute "DELETE FROM #{ActiveRecord::Migrator.schema_migrations_table_name}"
+    ActiveRecord::SchemaMigration.create_table
+    ActiveRecord::SchemaMigration.delete_all
 
-    %w(things awesome_things prefix_things_suffix p_awesome_things_s ).each do |table|
+    %w(things awesome_things prefix_things_suffix p_awesome_things_s).each do |table|
       Thing.connection.drop_table(table) rescue nil
     end
     Thing.reset_column_information


### PR DESCRIPTION
These internal methods accidentally appeared in the doc, and so almost
useless. It is enough to create these internal tables directly, and
indeed do so in several places.

https://github.com/rails/rails/blob/v5.0.1/activerecord/lib/active_record/schema.rb#L55
https://github.com/rails/rails/blob/v5.0.1/activerecord/lib/active_record/railties/databases.rake#L6
https://github.com/rails/rails/blob/v5.0.1/activerecord/lib/active_record/tasks/database_tasks.rb#L230