### PR TITLE
Add Duration#before and #after as aliases for #ago and #since

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add `ActiveSupport::Duration#before` and `#after` as aliases for `#until` and `#since`
+
+    These read more like English and require less mental gymnastics to read and write.
+
+    Before:
+
+        2.weeks.since(customer_start_date)
+        5.days.until(today)
+
+    After:
+
+        2.weeks.after(customer_start_date)
+        5.days.before(today)
+
+    *Nick Johnstone*
+
 *   Deprecate `.halt_callback_chains_on_return_false`.
 
     *Rafael Mendonça França*

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -180,6 +180,7 @@ module ActiveSupport
       sum(1, time)
     end
     alias :from_now :since
+    alias :after :since
 
     # Calculates a new Time or Date that is as far in the past
     # as this Duration represents.
@@ -187,6 +188,7 @@ module ActiveSupport
       sum(-1, time)
     end
     alias :until :ago
+    alias :before :ago
 
     def inspect #:nodoc:
       parts.

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -179,6 +179,19 @@ class DurationTest < ActiveSupport::TestCase
     Time.zone = nil
   end
 
+  def test_before_and_afer
+    t = Time.local(2000)
+    assert_equal t + 1, 1.second.after(t)
+    assert_equal t - 1, 1.second.before(t)
+  end
+
+  def test_before_and_after_without_argument
+    now = Time.now
+    assert 1.second.before >= now + 1
+    now = Time.now
+    assert 1.second.after >= now - 1
+  end
+
   def test_adding_hours_across_dst_boundary
     with_env_tz "CET" do
       assert_equal Time.local(2009, 3, 29, 0, 0, 0) + 24.hours, Time.local(2009, 3, 30, 1, 0, 0)


### PR DESCRIPTION
It's common in test cases at my job to have code like this:

```ruby
let(:today) { customer_start_date + 2.weeks }
let(:earlier_date) { today - 5.days }
```

With this change, we can instead write:

```ruby
let(:today) { 2.weeks.after(customer_start_date) }
let(:earlier_date) { 5.days.before(today) }
```

I find this to be much more readable, and it makes me happy 😄

A small downside I see is that `before` and `after` don't make very much sense when used without an argument.

I would be happy to pull these into a new set of methods that always take an argument, but I figured that the lowest impact change was an alias.

I also did not add a test case, as I saw there was no additional test coverage for `since` and `ago`. If desired I will happily add a test case.

Please let me know if there's anything else I can address. Additionally, if this change isn't desired, please feel free to close it.