### PR TITLE
Remove TODOs related to Exceptron [ci skip]

### DIFF
--- a/actionview/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionview/lib/action_view/renderer/streaming_template_renderer.rb
@@ -4,7 +4,6 @@ module ActionView
   # == TODO
   #
   # * Support streaming from child templates, partials and so on.
-  # * Integrate exceptions with exceptron
   # * Rack::Cache needs to support streaming bodies
   class StreamingTemplateRenderer < TemplateRenderer #:nodoc:
     # A valid Rack::Body (i.e. it responds to each).
@@ -28,7 +27,6 @@ module ActionView
       private
 
         # This is the same logging logic as in ShowExceptions middleware.
-        # TODO Once "exceptron" is in, refactor this piece to simply re-use exceptron.
         def log_error(exception)
           logger = ActionView::Base.logger
           return unless logger


### PR DESCRIPTION
I think it's high time we let TODOs related to Exceptron go...

Last commit was 6 years ago in the repository:
https://github.com/spastorino/exceptron
