### PR TITLE
 `find_templates` should be able to handle 5 arguments

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -164,8 +164,8 @@ module ActionView
     # This is what child classes implement. No defaults are needed
     # because Resolver guarantees that the arguments are present and
     # normalized.
-    def find_templates(name, prefix, partial, details)
-      raise NotImplementedError, "Subclasses must implement a find_templates(name, prefix, partial, details) method"
+    def find_templates(name, prefix, partial, details, outside_app_allowed = false)
+      raise NotImplementedError, "Subclasses must implement a find_templates(name, prefix, partial, details, outside_app_allowed = false) method"
     end
 
     # Helpers that builds a path. Useful for building virtual paths.


### PR DESCRIPTION
`Resolver#find_templates` is designed to be overridden by a child class. but the method is called from `Resolver#find_all_anywhere` which calls `find_templates` with 5 arguments.
 
https://github.com/rails/rails/blob/master/actionview/lib/action_view/template/resolver.rb#L152

As long as the child class' `find_templates` can handle 5 arguments, it is OK. However, `Resolver#find_templates` should also be able to handle 5 arguments and should raise a NotImplementedError with a suitable message I suppose.
