### PR TITLE
update CREATE TABLE statements generated by `sqlite3` command

### DIFF
--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -175,7 +175,7 @@ module ApplicationTests
           `bin/rails generate model book title:string;
            bin/rails db:migrate db:structure:dump`
           structure_dump = File.read("db/structure.sql")
-          assert_match(/CREATE TABLE \"books\"/, structure_dump)
+          assert_match(/CREATE TABLE (?:IF NOT EXISTS )?\"books\"/, structure_dump)
           `bin/rails environment db:drop db:structure:load`
           assert_match expected_database, ActiveRecord::Base.connection_config[:database]
           require "#{app_path}/app/models/book"
@@ -203,7 +203,7 @@ module ApplicationTests
           stderr_output = capture(:stderr) { `bin/rails db:structure:dump` }
           assert_empty stderr_output
           structure_dump = File.read("db/structure.sql")
-          assert_match(/CREATE TABLE \"posts\"/, structure_dump)
+          assert_match(/CREATE TABLE (?:IF NOT EXISTS )?\"posts\"/, structure_dump)
         end
       end
 


### PR DESCRIPTION
From SQLite 3.16.0, `IF NOT EXISTS` set to CREATE TABLE statements.
Ref: https://www.sqlite.org/src/info/c7021960f5c070fb

Fixes #27635.