### PR TITLE
Allocation free Integer#to_s

### DIFF
--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -99,31 +99,30 @@ module ActiveSupport::NumericWithFormat
   #  1234567.to_s(:human, precision: 1,
   #                   separator: ',',
   #                   significant: false)                   # => "1,2 Million"
-  def to_s(*args)
-    format, options = args
-    options ||= {}
-
+  def to_s(format = nil, options = nil)
     case format
+    when nil
+      super()
+    when Integer, String
+      super(format)
     when :phone
-      return ActiveSupport::NumberHelper.number_to_phone(self, options)
+      return ActiveSupport::NumberHelper.number_to_phone(self, options || {})
     when :currency
-      return ActiveSupport::NumberHelper.number_to_currency(self, options)
+      return ActiveSupport::NumberHelper.number_to_currency(self, options || {})
     when :percentage
-      return ActiveSupport::NumberHelper.number_to_percentage(self, options)
+      return ActiveSupport::NumberHelper.number_to_percentage(self, options || {})
     when :delimited
-      return ActiveSupport::NumberHelper.number_to_delimited(self, options)
+      return ActiveSupport::NumberHelper.number_to_delimited(self, options || {})
     when :rounded
-      return ActiveSupport::NumberHelper.number_to_rounded(self, options)
+      return ActiveSupport::NumberHelper.number_to_rounded(self, options || {})
     when :human
-      return ActiveSupport::NumberHelper.number_to_human(self, options)
+      return ActiveSupport::NumberHelper.number_to_human(self, options || {})
     when :human_size
-      return ActiveSupport::NumberHelper.number_to_human_size(self, options)
+      return ActiveSupport::NumberHelper.number_to_human_size(self, options || {})
+    when Symbol
+      super()
     else
-      if is_a?(Float) || format.is_a?(Symbol)
-        super()
-      else
-        super
-      end
+      super(format)
     end
   end
 end

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -394,6 +394,10 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
 
     assert_equal "1000010.0", BigDecimal("1000010").to_s
     assert_equal "10000 10.0", BigDecimal("1000010").to_s("5F")
+
+    assert_raises TypeError do
+      1.to_s({})
+    end
   end
 
   def test_in_milliseconds


### PR DESCRIPTION
We were profiling in production, and were surprised to see `NumericWithFormat#to_s` account for 2% of global object  allocations.

```
       34   (2.0%)          34   (2.0%)     ActiveSupport::NumericWithFormat#to_s
```

Looking at the code, it turns out that even if you want to call the regular `Integer#to_s` (which is fairly common, especially if you display numbers in your views) you end up allocating both an Array (splat args) and a Hash (options).

This PR prevent those allocations if you are not trying to call any advanced formatting.

I know 2 objects isn't much at all, and that this version is a bit more complex to grasp, but for such a hotspot I believe it's worth it.

@rafaelfranca @csfrancis @camilo 