### PR TITLE
eager_load with duplicate object in multiple relations

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -271,6 +271,12 @@ module ActiveRecord
             model = seen[ar_parent.object_id][node.base_klass][id]
 
             if model
+              is_collection = node.reflection.collection?
+              unless is_collection && other.target.include?(model)
+                other = ar_parent.association(node.reflection.name)
+                update_association(model, other, is_collection)
+              end
+
               construct(model, node, row, rs, seen, model_cache, aliases)
             else
               model = construct_model(ar_parent, node, row, model_cache, id, aliases)
@@ -292,14 +298,17 @@ module ActiveRecord
             node.instantiate(row, aliases.column_aliases(node)) do |m|
               other.set_inverse_instance(m)
             end
-
-          if node.reflection.collection?
-            other.target.push(model)
-          else
-            other.target = model
-          end
+          update_association(model, other, node.reflection.collection?)
 
           model
+        end
+
+        def update_association(object, association, is_collection)
+          if is_collection
+            association.target.push(object)
+          else
+            association.target = object
+          end
         end
     end
   end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1480,6 +1480,19 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal posts(:welcome), post
   end
 
+  test "eager-loading belongs_to and has_many association with object included in both" do
+    post = Post.create!(title: "foo", body: "I like cars!")
+    base_comment = Comment.create!(body: "Me too!", post_id: post.id)
+
+    parent_and_child_comment = base_comment.children.create!(body: "+1", post_id: post.id)
+    child_comment = base_comment.children.create!(body: "Not me...", post_id: post.id)
+    base_comment.update(parent: parent_and_child_comment)
+
+    comment = Comment.eager_load(:parent, :children).find(base_comment.id)
+    assert_equal parent_and_child_comment, comment.parent
+    assert_equal [parent_and_child_comment, child_comment], comment.children
+  end
+
   # CollectionProxy#reader is expensive, so the preloader avoids calling it.
   test "preloading has_many_through association avoids calling association.reader" do
     ActiveRecord::Associations::HasManyAssociation.any_instance.expects(:reader).never

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1490,7 +1490,9 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
     comment = Comment.eager_load(:parent, :children).find(base_comment.id)
     assert_equal parent_and_child_comment, comment.parent
-    assert_equal [parent_and_child_comment, child_comment], comment.children
+    [parent_and_child_comment, child_comment].each do |child|
+      assert_includes comment.children, child
+    end
   end
 
   # CollectionProxy#reader is expensive, so the preloader avoids calling it.


### PR DESCRIPTION
### Summary

Hi,
if an object was included in a `has_many`-  and a `belongs_to`-relation and
both relations were eager loaded the object was missing from the
`has_many` relation. This issue is also described in #26805

### Other Information

In the test, one `Comment` is both the parent and the child of an other comment. That is a bit odd in the real world but i didn't find an other existing test model i could use for this test.
