### PR TITLE
New minitest 'assert false' message

### DIFF
--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -55,7 +55,7 @@ module ApplicationTests
         end
       RUBY
 
-      assert_unsuccessful_run "unit/foo_test.rb", "Failed assertion"
+      assert_unsuccessful_run "unit/foo_test.rb", "Expected false to be truthy"
     end
 
     test "integration test" do


### PR DESCRIPTION
Minitest has new 'assert false' message since 5.9. It is checked for in the Railties tests.
