### PR TITLE
Deprecate `initialize_schema_migrations_table` and `initialize_internal_metadata_table`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `initialize_schema_migrations_table` and `initialize_internal_metadata_table`.
+
+    *Ryuta Kamizono*
+
 *   Support foreign key creation for SQLite3.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1008,15 +1008,15 @@ module ActiveRecord
         end
       end
 
-      # Should not be called normally, but this operation is non-destructive.
-      # The migrations module handles this automatically.
-      def initialize_schema_migrations_table
+      def initialize_schema_migrations_table # :nodoc:
         ActiveRecord::SchemaMigration.create_table
       end
+      deprecate :initialize_schema_migrations_table
 
-      def initialize_internal_metadata_table
+      def initialize_internal_metadata_table # :nodoc:
         ActiveRecord::InternalMetadata.create_table
       end
+      deprecate :initialize_internal_metadata_table
 
       def internal_string_options_for_primary_key # :nodoc:
         { primary_key: true }

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1107,8 +1107,8 @@ module ActiveRecord
 
       validate(@migrations)
 
-      Base.connection.initialize_schema_migrations_table
-      Base.connection.initialize_internal_metadata_table
+      ActiveRecord::SchemaMigration.create_table
+      ActiveRecord::InternalMetadata.create_table
     end
 
     def current_version

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -48,7 +48,7 @@ module ActiveRecord
       instance_eval(&block)
 
       if info[:version].present?
-        initialize_schema_migrations_table
+        ActiveRecord::SchemaMigration.create_table
         connection.assume_migrated_upto_version(info[:version], migrations_paths)
       end
 

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -16,7 +16,7 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
       table_name = ActiveRecord::SchemaMigration.table_name
       connection.drop_table table_name, if_exists: true
 
-      connection.initialize_schema_migrations_table
+      ActiveRecord::SchemaMigration.create_table
 
       assert connection.column_exists?(table_name, :version, :string, collation: "utf8_general_ci")
     end
@@ -27,7 +27,7 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
       table_name = ActiveRecord::InternalMetadata.table_name
       connection.drop_table table_name, if_exists: true
 
-      connection.initialize_internal_metadata_table
+      ActiveRecord::InternalMetadata.create_table
 
       assert connection.column_exists?(table_name, :key, :string, collation: "utf8_general_ci")
     end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -43,10 +43,10 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Base.table_name_prefix = ""
     ActiveRecord::Base.table_name_suffix = ""
 
-    ActiveRecord::Base.connection.initialize_schema_migrations_table
-    ActiveRecord::Base.connection.execute "DELETE FROM #{ActiveRecord::Migrator.schema_migrations_table_name}"
+    ActiveRecord::SchemaMigration.create_table
+    ActiveRecord::SchemaMigration.delete_all
 
-    %w(things awesome_things prefix_things_suffix p_awesome_things_s ).each do |table|
+    %w(things awesome_things prefix_things_suffix p_awesome_things_s).each do |table|
       Thing.connection.drop_table(table) rescue nil
     end
     Thing.reset_column_information
@@ -916,7 +916,6 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
         @indexes ||= Person.connection.indexes("delete_me")
       end
   end # AlterTableMigrationsTest
-
 end
 
 class CopyMigrationsTest < ActiveRecord::TestCase
@@ -1133,5 +1132,10 @@ class CopyMigrationsTest < ActiveRecord::TestCase
 
   def test_unknown_migration_version_should_raise_an_argument_error
     assert_raise(ArgumentError) { ActiveRecord::Migration[1.0] }
+  end
+
+  def test_deprecate_initialize_internal_tables
+    assert_deprecated { ActiveRecord::Base.connection.initialize_schema_migrations_table }
+    assert_deprecated { ActiveRecord::Base.connection.initialize_internal_metadata_table }
   end
 end


### PR DESCRIPTION
These internal initialize methods are no longer used internally.