### PR TITLE
Correctly count methods when using declarative `#test` in minitest

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Drop old test locations from `rake stats`
+    - test/functional
+    - test/unit
+
+    *Ravil Bayramgalin*
+
+*   Update `rake stats` to  correctly count declarative tests
+    as methods in `_test.rb` files.
+
+    *Ravil Bayramgalin*
+
 *   Add `config/initializers/to_time_preserves_timezone.rb`, which tells
     Active Support to preserve the receiver's timezone when calling `to_time`.
     This matches the new behavior that will be part of Ruby 2.4.

--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -7,9 +7,7 @@ class CodeStatistics #:nodoc:
                 'Model tests',
                 'Mailer tests',
                 'Job tests',
-                'Integration tests',
-                'Functional tests (old)',
-                'Unit tests (old)']
+                'Integration tests']
 
   def initialize(*pairs)
     @pairs      = pairs

--- a/railties/lib/rails/code_statistics_calculator.rb
+++ b/railties/lib/rails/code_statistics_calculator.rb
@@ -24,6 +24,8 @@ class CodeStatisticsCalculator #:nodoc:
     }
   }
 
+  PATTERNS[:minitest] = PATTERNS[:rb].merge method: /^\s*(def|test)\s+['"_a-z]/
+
   def initialize(lines = 0, code_lines = 0, classes = 0, methods = 0)
     @lines = lines
     @code_lines = code_lines
@@ -74,6 +76,10 @@ class CodeStatisticsCalculator #:nodoc:
 
   private
     def file_type(file_path)
-      File.extname(file_path).sub(/\A\./, '').downcase.to_sym
+      if file_path.end_with? '_test.rb'
+        :minitest
+      else
+        File.extname(file_path).sub(/\A\./, '').downcase.to_sym
+      end
     end
 end

--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -14,10 +14,8 @@ STATS_DIRECTORIES = [
   %w(Helper\ tests      test/helpers),
   %w(Model\ tests       test/models),
   %w(Mailer\ tests      test/mailers),
-  %w(Job\ tests      test/jobs),
+  %w(Job\ tests         test/jobs),
   %w(Integration\ tests test/integration),
-  %w(Functional\ tests\ (old)  test/functional),
-  %w(Unit\ tests \ (old)       test/unit)
 ].collect do |name, dir|
   [ name, "#{File.dirname(Rake.application.rakefile_location)}/#{dir}" ]
 end.select { |name, dir| File.directory?(dir) }


### PR DESCRIPTION
Correctly count methods when using declarative `#test` in minitest

Drop old test locations from `rake stats`

(cherry picked from commit 6eb499f600206ba6e61f15a8cba988dd6d2ad2f8)

/cc @dhh @brainopia