### PR TITLE
Add missing tests for ActionView::Template::Text

### DIFF
--- a/actionview/test/template/text_test.rb
+++ b/actionview/test/template/text_test.rb
@@ -4,4 +4,20 @@ class TextTest < ActiveSupport::TestCase
   test "formats always return :text" do
     assert_equal [:text], ActionView::Template::Text.new("").formats
   end
+
+  test "identifier should return 'text template'" do
+    assert_equal "text template", ActionView::Template::Text.new("").identifier
+  end
+
+  test "inspect should return 'text template'" do
+    assert_equal "text template", ActionView::Template::Text.new("").inspect
+  end
+
+  test "to_str should return a given string" do
+    assert_equal "a cat", ActionView::Template::Text.new("a cat").to_str
+  end
+
+  test "render should return a given string" do
+    assert_equal "a dog", ActionView::Template::Text.new("a dog").render
+  end
 end


### PR DESCRIPTION
Currently there are no tests for some methods of ActionView::Template::Text. Just added tests for them.