### PR TITLE
Only assume kwargs if one hash is passed to process/get etc.

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -653,7 +653,7 @@ module ActionController
       REQUEST_KWARGS = %i(params session flash method body xhr)
       FORMAT_KWARGS = %i(format as)
       def kwarg_request?(args)
-        args[0].respond_to?(:keys) && (
+        args.size == 1 && args[0].respond_to?(:keys) && (
           args[0].keys.all? { |k| FORMAT_KWARGS.include?(k) } ||
           args[0].keys.any? { |k| REQUEST_KWARGS.include?(k) }
         )

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -327,6 +327,11 @@ XML
     assert_equal 'value2', session[:symbol]
   end
 
+  def test_deprecated_process_with_session_and_empty_params
+    assert_deprecated { get :no_op, {}, { 'string' => 'value1' } }
+    assert_equal 'value1', session['string']
+  end
+
   def test_deprecated_process_merges_session_arg
     session[:foo] = 'bar'
     assert_deprecated {
@@ -877,6 +882,12 @@ XML
   def test_request_format_kwarg_overrides_params
     get :test_format, format: 'json', params: { format: 'html' }
     assert_equal 'application/json', @response.body
+  end
+
+  def test_deprecated_request_format_params_with_session
+    assert_deprecated { get :test_format, { format: 'json' }, { 'string': 'value1' } }
+    assert_equal 'application/json', @response.body
+    assert_equal 'value1', session['string']
   end
 
   def test_should_have_knowledge_of_client_side_cookie_state_even_if_they_are_not_set


### PR DESCRIPTION
Calling `get` etc. with either an empty params hash or a hash with only
`:format` plus a session hash was assumed to be keyword arguments,
causing the session hash to be ignored.

cada080 (new on 5-0-stable since 5.0.1) introduced the regression for an
empty params hash as `{}.all?` returns true.

---

Targeted at 5-0-stable as non-kwarg support has been removed on master.