### PR TITLE
Fix behavior #url_for with string as argument

### DIFF
--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -165,28 +165,36 @@ module ActionDispatch
       # last +url_for+ calls.
       def url_for(options = nil)
         case options
-        when nil
-          _routes.url_for(url_options.symbolize_keys)
+        when String
+          if options =~ /[\/\#\?\s]/
+            options
+          else
+            HelperMethodBuilder.url.handle_string_call self, options
+          end
+        when Symbol
+          HelperMethodBuilder.url.handle_string_call self, options
         when Hash
           route_name = options.delete :use_route
-          _routes.url_for(options.symbolize_keys.reverse_merge!(url_options),
-                         route_name)
+          _routes.url_for(
+            options.symbolize_keys.reverse_merge!(url_options),
+            route_name
+          )
         when ActionController::Parameters
           unless options.permitted?
             raise ArgumentError.new(ActionDispatch::Routing::INSECURE_URL_PARAMETERS_MESSAGE)
           end
           route_name = options.delete :use_route
-          _routes.url_for(options.to_h.symbolize_keys.
-                          reverse_merge!(url_options), route_name)
-        when String
-          options
-        when Symbol
-          HelperMethodBuilder.url.handle_string_call self, options
+          _routes.url_for(
+            options.to_h.symbolize_keys.reverse_merge!(url_options),
+            route_name
+          )
         when Array
           components = options.dup
           polymorphic_url(components, components.extract_options!)
         when Class
           HelperMethodBuilder.url.handle_class_call self, options
+        when nil
+          _routes.url_for(url_options.symbolize_keys)
         else
           HelperMethodBuilder.url.handle_model_call self, options
         end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -134,7 +134,7 @@ XML
     end
 
     def create
-      head :created, location: "created resource"
+      head :created, location: "/resource"
     end
 
     def render_cookie
@@ -880,7 +880,7 @@ XML
     assert_response :created
 
     # Redirect url doesn't care that it wasn't a :redirect response.
-    assert_equal "created resource", @response.redirect_url
+    assert_equal "/resource", @response.redirect_url
     assert_equal @response.redirect_url, redirect_to_url
 
     # Must be a :redirect response.

--- a/actionview/test/activerecord/polymorphic_routes_test.rb
+++ b/actionview/test/activerecord/polymorphic_routes_test.rb
@@ -86,10 +86,7 @@ class PolymorphicRoutesTest < ActionController::TestCase
 
   def test_string
     with_test_routes do
-      # FIXME: why are these different? Symbol case passes through to
-      # `polymorphic_url`, but the String case doesn't.
-      assert_equal "http://example.com/projects", polymorphic_url("projects")
-      assert_equal "projects", url_for("projects")
+      assert_url "http://example.com/projects", "projects"
     end
   end
 

--- a/actionview/test/template/erb/tag_helper_test.rb
+++ b/actionview/test/template/erb/tag_helper_test.rb
@@ -18,8 +18,8 @@ module ERBTest
     end
 
     test "percent equals works with form tags" do
-      expected_output = %r{<form.*action="foo".*method="post">.*hello*</form>}
-      assert_match expected_output, render_content("form_tag('foo')", "<%= 'hello' %>")
+      expected_output = %r{<form.*action="/foo".*method="post">.*hello*</form>}
+      assert_match expected_output, render_content("form_tag('/foo')", "<%= 'hello' %>")
     end
 
     test "percent equals works with fieldset tags" do

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -257,11 +257,11 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_label_with_non_active_record_object
-    form_for(OpenStruct.new(name: "ok"), as: "person", url: "an_url", html: { id: "create-person" }) do |f|
+    form_for(OpenStruct.new(name: "ok"), as: "person", url: "/an", html: { id: "create-person" }) do |f|
       f.label(:name)
     end
 
-    expected = whole_form("an_url", "create-person", "new_person", method: "post") do
+    expected = whole_form("/an", "create-person", "new_person", method: "post") do
       '<label for="person_name">Name</label>'
     end
 


### PR DESCRIPTION
Fix inconsistency between String and Symbol #url_for handling

Related to 37d4415a7b433fcb987b1c6a5b51bf2d8efc5d5e

/cc @tenderlove