### PR TITLE
Get neglected TODO done in render_test

### DIFF
--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -393,8 +393,7 @@ module RenderTestCases
     assert_equal :partial_name_local_variable, exception.cause.name
   end
 
-  # TODO: The reason for this test is unclear, improve documentation
-  def test_render_partial_and_fallback_to_layout
+  def test_render_partial_with_no_block_given_to_yield
     assert_equal "Before (Josh)\n\nAfter", @view.render(partial: "test/layout_for_partial", locals: { name: "Josh" })
   end
 


### PR DESCRIPTION
I looked into one of the neglected TODOs in render_test.rb.

What `test_render_partial_and_fallback_to_layout` tests seems to be the same as what `test_render_partial_with_locals` tests.

So, I think it is OK to let go of `test_render_partial_and_fallback_to_layout`

`test_render_partial_with_locals` is here:
https://github.com/rails/rails/blob/master/actionview/test/template/render_test.rb#L188
