### PR TITLE
Remove unnecessary comments in cache_helper.rb [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -241,8 +241,6 @@ module ActionView
       end
 
       def write_fragment_for(name, options)
-        # VIEW TODO: Make #capture usable outside of ERB
-        # This dance is needed because Builder can't use capture
         pos = output_buffer.length
         yield
         output_safe = output_buffer.html_safe?


### PR DESCRIPTION
I looked into a TODO comment in cache_helper.rb.

I think we can remove those comments.

the comments were added in this commit: 9de83050d3a4b260d4aeb5d09ec4eb64f913ba64

Below is a pic of the commit opened in RubyMine.
![screen shot 2017-01-21 at 8 05 41 pm](https://cloud.githubusercontent.com/assets/6219390/22174231/93f107de-e01c-11e6-8bf0-548f35fbef27.png)



I guess he left the comment because he thought `capture` method would be able to work by its own without 'the dance' in his future.

I git-reseted to see the code at the time. The methods named `capture` were in `ActionView::Helpers::CaptureHelper(which exists in current master branch, too)` and `Rails::Generators::TestCase`. in this case, it is obvious that he meant the first one.

Now, we can use `capture` not only in erb, but builder and jbuilder with no problem even without `write_fragment_for`. 

From these reasons, those long lived comments can go.


To be honest, I'm not 100% sure the intention of his comments. 
Please let me know if there is someone who knows what he meant, and who thinks I'm wrong. If so, I want to try to deal with it.

Personally, I don't think it is a good idea to ignore TODO comments such a long time(6 years in this case).