### PR TITLE
Correctly dump integer-like primary key with default nil

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -14,6 +14,8 @@ module ActiveRecord
         return {} if default_primary_key?(column)
         spec = { id: schema_type(column).inspect }
         spec.merge!(prepare_column_options(column).except!(:null))
+        spec[:default] ||= "nil" if explicit_primary_key_default?(column)
+        spec
       end
 
       # This can be overridden on an Adapter level basis to support other
@@ -57,6 +59,10 @@ module ActiveRecord
 
         def default_primary_key?(column)
           schema_type(column) == :bigint
+        end
+
+        def explicit_primary_key_default?(column)
+          false
         end
 
         def schema_type_with_virtual(column)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -1,16 +1,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module MySQL
-      module ColumnDumper
-        def column_spec_for_primary_key(column)
-          spec = super
-          if [:integer, :bigint].include?(schema_type(column)) && !column.auto_increment?
-            spec[:default] ||= schema_default(column) || "nil"
-          end
-          spec[:unsigned] = "true" if column.unsigned?
-          spec
-        end
-
+      module ColumnDumper # :nodoc:
         def prepare_column_options(column)
           spec = super
           spec[:unsigned] = "true" if column.unsigned?
@@ -32,6 +23,10 @@ module ActiveRecord
 
           def default_primary_key?(column)
             super && column.auto_increment?
+          end
+
+          def explicit_primary_key_default?(column)
+            column.type == :integer && !column.auto_increment?
           end
 
           def schema_type(column)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -1,15 +1,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
-      module ColumnDumper
-        def column_spec_for_primary_key(column)
-          spec = super
-          if schema_type(column) == :uuid
-            spec[:default] ||= "nil"
-          end
-          spec
-        end
-
+      module ColumnDumper # :nodoc:
         # Adds +:array+ option to the default set
         def prepare_column_options(column)
           spec = super
@@ -26,6 +18,10 @@ module ActiveRecord
 
           def default_primary_key?(column)
             schema_type(column) == :bigserial
+          end
+
+          def explicit_primary_key_default?(column)
+            column.type == :uuid || (column.type == :integer && !column.serial?)
           end
 
           def schema_type(column)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
@@ -1,11 +1,15 @@
 module ActiveRecord
   module ConnectionAdapters
     module SQLite3
-      module ColumnDumper
+      module ColumnDumper # :nodoc:
         private
 
           def default_primary_key?(column)
             schema_type(column) == :integer
+          end
+
+          def explicit_primary_key_default?(column)
+            column.bigint?
           end
       end
     end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -319,31 +319,30 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
   end
 end
 
-if current_adapter?(:Mysql2Adapter)
-  class PrimaryKeyIntegerNilDefaultTest < ActiveRecord::TestCase
-    include SchemaDumpingHelper
+class PrimaryKeyIntegerNilDefaultTest < ActiveRecord::TestCase
+  include SchemaDumpingHelper
 
-    self.use_transactional_tests = false
+  self.use_transactional_tests = false
 
-    def setup
-      @connection = ActiveRecord::Base.connection
-      @connection.create_table(:int_defaults, id: :integer, default: nil, force: true)
-    end
+  def setup
+    @connection = ActiveRecord::Base.connection
+  end
 
-    def teardown
-      @connection.drop_table :int_defaults, if_exists: true
-    end
+  def teardown
+    @connection.drop_table :int_defaults, if_exists: true
+  end
 
-    test "primary key with integer allows default override via nil" do
-      column = @connection.columns(:int_defaults).find { |c| c.name == "id" }
-      assert_equal :integer, column.type
-      assert_not column.auto_increment?
-    end
+  def test_schema_dump_primary_key_integer_with_default_nil
+    skip if current_adapter?(:SQLite3Adapter)
+    @connection.create_table(:int_defaults, id: :integer, default: nil, force: true)
+    schema = dump_table_schema "int_defaults"
+    assert_match %r{create_table "int_defaults", id: :integer, default: nil}, schema
+  end
 
-    test "schema dump primary key with int default nil" do
-      schema = dump_table_schema "int_defaults"
-      assert_match %r{create_table "int_defaults", id: :integer, default: nil}, schema
-    end
+  def test_schema_dump_primary_key_bigint_with_default_nil
+    @connection.create_table(:int_defaults, id: :bigint, default: nil, force: true)
+    schema = dump_table_schema "int_defaults"
+    assert_match %r{create_table "int_defaults", id: :bigint, default: nil}, schema
   end
 end
 


### PR DESCRIPTION
The PR #27384 changed integer-like primary key to be autoincrement
unless an explicit default. This means that integer-like primary key is
restored as autoincrement unless dumping the default nil explicitly.
We should dump integer-like primary key with default nil correctly.