### PR TITLE
move `db_migrate_path` method to `Migration` module

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration.rb
@@ -20,6 +20,14 @@ module ActiveRecord
           key_type = options[:primary_key_type]
           ", id: :#{key_type}" if key_type
         end
+
+        def db_migrate_path
+          if defined?(Rails) && Rails.application
+            Rails.application.config.paths["db/migrate"].to_ary.first
+          else
+            "db/migrate"
+          end
+        end
     end
   end
 end

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -71,14 +71,6 @@ module ActiveRecord
         def normalize_table_name(_table_name)
           pluralize_table_names? ? _table_name.pluralize : _table_name.singularize
         end
-
-        def db_migrate_path
-          if defined?(Rails) && Rails.application
-            Rails.application.config.paths["db/migrate"].to_ary.first
-          else
-            "db/migrate"
-          end
-        end
     end
   end
 end

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -64,14 +64,6 @@ module ActiveRecord
             "app/models/application_record.rb"
           end
         end
-
-        def db_migrate_path
-          if defined?(Rails) && Rails.application
-            Rails.application.config.paths["db/migrate"].to_ary.first
-          else
-            "db/migrate"
-          end
-        end
     end
   end
 end


### PR DESCRIPTION
Since `Migration` module is included in both `MigrationGenerator` and
`ModelGenerator`, no need to define a common method for each class.
