### PR TITLE
Add module name to BacktraceCleaner usage example [ci skip]

### DIFF
--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -12,7 +12,7 @@ module ActiveSupport
   # is to exclude the output of a noisy library from the backtrace, so that you
   # can focus on the rest.
   #
-  #   bc = BacktraceCleaner.new
+  #   bc = ActiveSupport::BacktraceCleaner.new
   #   bc.add_filter   { |line| line.gsub(Rails.root.to_s, '') } # strip the Rails.root prefix
   #   bc.add_silencer { |line| line =~ /puma|rubygems/ } # skip any lines from puma or rubygems
   #   bc.clean(exception.backtrace) # perform the cleanup


### PR DESCRIPTION
`NameError: uninitialized constant BacktraceCleaner` will occur if BacktraceCleaner is called without ActiveSupport.