### PR TITLE
Freeze default empty string for sql_type in get_oid_type

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -438,7 +438,7 @@ module ActiveRecord
           end
         end
 
-        def get_oid_type(oid, fmod, column_name, sql_type = "")
+        def get_oid_type(oid, fmod, column_name, sql_type = "".freeze)
           if !type_map.key?(oid)
             load_additional_types(type_map, [oid])
           end


### PR DESCRIPTION
### Summary

On my app I ran a benchmark on object allocation on one json endpoint using [derailed benchmark](https://github.com/schneems/derailed_benchmarks). The result shows this : 
```
Allocated String Report
-----------------------------------
     12850  ""
      5600  /Users/bti/.rvm/gems/ruby-2.3.0@app/gems/activerecord-4.2.5.2/lib/active_record/connection_adapters/postgresql_adapter.rb:429
````
I ran the test again on a fresh [Rails5 api](https://github.com/benoittgt/testing_active_record_string_allocation) with the same result.

It seems we allocate one empty string per column per row [in the postgresql_adapter in `get_oid_type`](https://github.com/rails/rails/blob/127509c071b4f983f2beafc8766e990670a21215/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L441). We can easily get rid of this allocation using `freeze`.

I dig into [previous PR with the same type of change](https://github.com/rails/rails/pull/17658) and know they [are not always accepted](https://github.com/rails/rails/pull/19061). Feel free to make any feedbacks.

Thanks in advance