### PR TITLE
Make BigDecimal casting consistent on different platforms

### DIFF
--- a/activemodel/lib/active_model/type/decimal.rb
+++ b/activemodel/lib/active_model/type/decimal.rb
@@ -4,6 +4,7 @@ module ActiveModel
   module Type
     class Decimal < Value # :nodoc:
       include Helpers::Numeric
+      BIGDECIMAL_PRECISION = 18
 
       def type
         :decimal
@@ -21,7 +22,7 @@ module ActiveModel
             when ::Float
               convert_float_to_big_decimal(value)
             when ::Numeric, ::String
-              BigDecimal(value, precision.to_i)
+              BigDecimal(value, precision || BIGDECIMAL_PRECISION)
             else
               if value.respond_to?(:to_d)
                 value.to_d


### PR DESCRIPTION
Right now it behaves differently on JRuby:

```
--- expected
+++ actual
@@ -1 +1 @@
-#<BigDecimal:5f3c866c,'0.333333333333333333',18(20)>
+#<BigDecimal:16e0afab,'0.3333333333333333',16(20)>
```

My initial PR (https://github.com/rails/rails/pull/27324) offered to let the precision to be decided by the platform and change the test expectation, but other contributors suggested that we should change the default precision in Rails to be consistent of all platforms instead.

I got the value of `18` from the max default precision that comes from casting `Rational(1/3)` to `BigDecimal`.

@sgrif @matthewd @guilleiguaran 