### PR TITLE
Enable Active Model testing for JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ matrix:
     - rvm: jruby-9.1.7.0
       jdk: oraclejdk8
       env:
-        - "GEM=am,aj"
+        - "GEM=am,amo,aj"
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-9.1.7.0


### PR DESCRIPTION
### Summary

Active Model is passing locally on JRuby 9.1.7.0 for me 🎉 