### PR TITLE
do not run `git init` when specify the `pretend` option

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -54,7 +54,7 @@ module Rails
     end
 
     def version_control
-      unless options[:skip_git]
+      if !options[:skip_git] && !options[:pretend]
         run "git init"
       end
     end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -592,6 +592,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_pretend_option
     output = run_generator [File.join(destination_root, "myapp"), "--pretend"]
     assert_no_match(/run  bundle install/, output)
+    assert_no_match(/run  git init/, output)
   end
 
   def test_application_name_with_spaces


### PR DESCRIPTION
When specifying the `pretend` option, expect that no processing will be
done, so do not execute `git init` as well.
