### PR TITLE
remove unreachable code

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -187,10 +187,6 @@ module Rails
       def initialize(*args)
         super
 
-        unless app_path
-          raise Error, "Application name should be provided in arguments. For details run: rails --help"
-        end
-
         if !options[:skip_active_record] && !DATABASES.include?(options[:database])
           raise Error, "Invalid value for --database option. Supported for preconfiguration are: #{DATABASES.join(", ")}."
         end

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -195,10 +195,6 @@ task default: :test
       def initialize(*args)
         @dummy_path = nil
         super
-
-        unless plugin_path
-          raise Error, "Plugin name should be provided in arguments. For details run: rails plugin new --help"
-        end
       end
 
       public_task :set_default_accessors!


### PR DESCRIPTION
`app_path` is a required argument. Therefore, if `app_path` is not specified, it becomes an error in thor's option parsing, does not reach this check.