### PR TITLE
Delete PATH_INFO after each controller test request

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -534,6 +534,7 @@ module ActionController
             @request.delete_header "HTTP_ACCEPT"
           end
           @request.query_string = ""
+          @request.env.delete "PATH_INFO"
 
           @response.sent!
         end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -728,6 +728,20 @@ XML
     assert_equal "text/html", @response.body
   end
 
+  def test_request_path_info_and_format_reset
+    get :test_format, format: "json"
+    assert_equal "application/json", @response.body
+
+    get :test_uri, format: "json"
+    assert_equal "/test_case_test/test/test_uri.json", @response.body
+
+    get :test_format
+    assert_equal "text/html", @response.body
+
+    get :test_uri
+    assert_equal "/test_case_test/test/test_uri", @response.body
+  end
+
   def test_request_format_kwarg_overrides_params
     get :test_format, format: "json", params: { format: "html" }
     assert_equal "application/json", @response.body


### PR DESCRIPTION
Prevents PATH_INFO from being used to infer the request format in later
test requests when no explicit format is given.

As the request PATH_INFO may be set before a request, it can't be
deleted during pre-request scrubbing.

Fixes #27774