### PR TITLE
save attributes changed by callbacks after update_attribute

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -402,11 +402,7 @@ module ActiveRecord
       verify_readonly_attribute(name)
       public_send("#{name}=", value)
 
-      if has_changes_to_save?
-        save(validate: false)
-      else
-        true
-      end
+      save(validate: false)
     end
 
     # Updates the attributes of the model from the passed-in hash and saves the

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -633,6 +633,9 @@ class PersistenceTest < ActiveRecord::TestCase
 
     Topic.find(1).update_attribute(:approved, false)
     assert !Topic.find(1).approved?
+
+    Topic.find(1).update_attribute(:change_approved_before_save, true)
+    assert Topic.find(1).approved?
   end
 
   def test_update_attribute_for_readonly_attribute

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -65,6 +65,9 @@ class Topic < ActiveRecord::Base
 
   after_initialize :set_email_address
 
+  attr_accessor :change_approved_before_save
+  before_save :change_approved_callback
+
   class_attribute :after_initialize_called
   after_initialize do
     self.class.after_initialize_called = true
@@ -96,6 +99,10 @@ class Topic < ActiveRecord::Base
     def before_destroy_for_transaction; end
     def after_save_for_transaction; end
     def after_create_for_transaction; end
+
+    def change_approved_callback
+      self.approved = change_approved_before_save unless change_approved_before_save.nil?
+    end
 end
 
 class ImportantTopic < Topic


### PR DESCRIPTION
`update_attribute` stops execution, before running callbacks as part of save, if the record's attributes hadn't changed. [The documentation](http://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-update_attribute)
says that "Callbacks are invoked", which was not happening if the persisted attributes hadn't changed before the `before_*` callbacks were run.

Here's a test that demonstrates [the bug](https://gist.github.com/mikelikesbikes/ae2f65ef03441e2daa4825637e668998).
