### PR TITLE
add warnings option to test runner

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add option to configure Ruby's warning behaviour to test runner.
+
+    *Yuji Yaginuma*
+
 *   Initialize git repo when generating new app, if option `--skip-git`
     is not provided.
 

--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -52,6 +52,11 @@ module Minitest
       options[:color] = value
     end
 
+    opts.on("-w", "--warnings",
+            "Enable ruby warnings") do
+      $VERBOSE = true
+    end
+
     options[:color] = true
     options[:output_inline] = true
     options[:patterns] = defined?(@rake_patterns) ? @rake_patterns : opts.order!

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -536,6 +536,17 @@ module ApplicationTests
       assert_match "seed=1234", output, "passing TEST= should run selected test"
     end
 
+    def test_warnings_option
+      app_file "test/models/warnings_test.rb", <<-RUBY
+        require 'test_helper'
+        def test_warnings
+          a = 1
+        end
+      RUBY
+      assert_match(/warning: assigned but unused variable/,
+        capture(:stderr) { run_test_command("test/models/warnings_test.rb -w") })
+    end
+
     private
       def run_test_command(arguments = "test/unit/test_test.rb")
         Dir.chdir(app_path) { `bin/rails t #{arguments}` }

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -92,6 +92,17 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
     assert_equal 1, result.scan(/1 runs, 1 assertions, 0 failures/).length
   end
 
+  def test_warnings_option
+    plugin_file "test/models/warnings_test.rb", <<-RUBY
+      require 'test_helper'
+      def test_warnings
+        a = 1
+      end
+    RUBY
+    assert_match(/warning: assigned but unused variable/,
+      capture(:stderr) { run_test_command("test/models/warnings_test.rb -w") })
+  end
+
   private
     def plugin_path
       "#{@destination_root}/bukkits"


### PR DESCRIPTION
### Summary

Ruby's warning show useful information. However, there is no easy way to enable it with the current test runner(As far as I know). Therefore, I would like to be able to enable it by option. How about that?
