### PR TITLE
Remove reference to Debugger in Rails on Rack docs

### DIFF
--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -82,7 +82,6 @@ To use `rackup` instead of Rails' `rails server`, you can put the following insi
 # Rails.root/config.ru
 require ::File.expand_path('../config/environment', __FILE__)
 
-use Rails::Rack::Debugger
 use Rack::ContentLength
 run Rails.application
 ```


### PR DESCRIPTION
**Why**:
- Instructing users to add the line `use Rails::Rack::Debugger` to
`config.ru` in a Rails 4.2 app is misleading because it’s not required
to use `rackup`. It’s optional, just like running `rails server` with
the `--debugger` flag is optional.

- Adding that line is likely to cause issues for the majority of 4.2
users because `Rails::Rack::Debugger` depends on the `debugger` gem,
which doesn’t work with Ruby >= 2.0.0, and is no longer a gem that
ships with Rails by default since version 4.2.0. If you’re installing a
brand new Rails 4.2 app today (1/23/17), you will need Ruby >= 2.1.0
due to the dependency on nokogiri.

In other words, for someone to be able to use `Rails::Rack::Debugger`
with `rackup` in a Rails 4.2 app, they will need to use Ruby 1.9.3,
and make the following Gemfile modifications: adding `debugger`,
removing `byebug` (since it requires Ruby >= 2.0.0), and locking
`nokogiri` to 1.6.8.1 (because 1.7.0+ requires Ruby >= 2.1.0).

Is the number of Rails 4.2 users on Ruby 1.9.3 and using `rackup`
instead of `rails server` large enough to warrant adding documentation
for this scenario?