### PR TITLE
show correct class name in migration inherited directly error

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -525,7 +525,7 @@ module ActiveRecord
         raise StandardError, "Directly inheriting from ActiveRecord::Migration is not supported. " \
           "Please specify the Rails release the migration was written for:\n" \
           "\n" \
-          "  class #{self.class.name} < ActiveRecord::Migration[4.2]"
+          "  class #{subclass} < ActiveRecord::Migration[4.2]"
       end
     end
 

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -103,9 +103,10 @@ module ActiveRecord
       end
 
       def test_legacy_migrations_raises_exception_when_inherited
-        assert_raises(StandardError) do
-          Class.new(ActiveRecord::Migration)
+        e = assert_raises(StandardError) do
+          class_eval("class LegacyMigration < ActiveRecord::Migration; end")
         end
+        assert_match(/LegacyMigration < ActiveRecord::Migration\[4\.2\]/, e.message)
       end
     end
   end


### PR DESCRIPTION
Follow up to 249f71a
