### PR TITLE
Yield array from AC::Parameters#each for block with one arg

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -335,7 +335,7 @@ module ActionController
     # the same way as <tt>Hash#each_pair</tt>.
     def each_pair(&block)
       @parameters.each_pair do |key, value|
-        yield key, convert_hashes_to_parameters(key, value)
+        yield [key, convert_hashes_to_parameters(key, value)]
       end
     end
     alias_method :each, :each_pair

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -51,6 +51,14 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     @params.each { |key, value| assert_not(value.permitted?) if key == "person" }
   end
 
+  test "each returns key,value array for block with arity 1" do
+    @params.each do |arg|
+      assert_kind_of Array, arg
+      assert_equal "person", arg[0]
+      assert_kind_of ActionController::Parameters, arg[1]
+    end
+  end
+
   test "each_pair carries permitted status" do
     @params.permit!
     @params.each_pair { |key, value| assert(value.permitted?) if key == "person" }
@@ -58,6 +66,14 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
 
   test "each_pair carries unpermitted status" do
     @params.each_pair { |key, value| assert_not(value.permitted?) if key == "person" }
+  end
+
+  test "each_pair returns key,value array for block with arity 1" do
+    @params.each_pair do |arg|
+      assert_kind_of Array, arg
+      assert_equal "person", arg[0]
+      assert_kind_of ActionController::Parameters, arg[1]
+    end
   end
 
   test "empty? returns true when params contains no key/value pairs" do


### PR DESCRIPTION
Matches Hash#each behaviour as used in Rails 4.

### Other Information

Reproducer: https://gist.github.com/df6296853a73ca3f714174278ec01138 (passes on 4-2-stable, fails on 5-0-stable or master)

Ruby's `Hash#each_pair` implementation, which also switches on the block arity: https://github.com/ruby/ruby/blob/v2_4_0/hash.c#L1810