### PR TITLE
TaggedLogging to return a new logger instance

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Changed `ActiveSupport::TaggedLogging.new` to return a new logger instance instead of mutating the one received as parameter.
+
+    *Thierry Joyal*
+
 *   Add `ActiveSupport::Duration#before` and `#after` as aliases for `#until` and `#since`
 
     These read more like English and require less mental gymnastics to read and write.

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -57,8 +57,15 @@ module ActiveSupport
     end
 
     def self.new(logger)
-      # Ensure we set a default formatter so we aren't extending nil!
-      logger.formatter ||= ActiveSupport::Logger::SimpleFormatter.new
+      logger = logger.dup
+
+      if logger.formatter
+        logger.formatter = logger.formatter.dup
+      else
+        # Ensure we set a default formatter so we aren't extending nil!
+        logger.formatter = ActiveSupport::Logger::SimpleFormatter.new
+      end
+
       logger.formatter.extend Formatter
       logger.extend(self)
     end

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -17,9 +17,10 @@ class TaggedLoggingTest < ActiveSupport::TestCase
   test "sets logger.formatter if missing and extends it with a tagging API" do
     logger = Logger.new(StringIO.new)
     assert_nil logger.formatter
-    ActiveSupport::TaggedLogging.new(logger)
-    assert_not_nil logger.formatter
-    assert logger.formatter.respond_to?(:tagged)
+
+    other_logger = ActiveSupport::TaggedLogging.new(logger)
+    assert_not_nil other_logger.formatter
+    assert other_logger.formatter.respond_to?(:tagged)
   end
 
   test "tagged once" do
@@ -80,16 +81,28 @@ class TaggedLoggingTest < ActiveSupport::TestCase
   end
 
   test "keeps each tag in their own instance" do
-    @other_output = StringIO.new
-    @other_logger = ActiveSupport::TaggedLogging.new(MyLogger.new(@other_output))
+    other_output = StringIO.new
+    other_logger = ActiveSupport::TaggedLogging.new(MyLogger.new(other_output))
     @logger.tagged("OMG") do
-      @other_logger.tagged("BCX") do
+      other_logger.tagged("BCX") do
         @logger.info "Cool story"
-        @other_logger.info "Funky time"
+        other_logger.info "Funky time"
       end
     end
     assert_equal "[OMG] Cool story\n", @output.string
-    assert_equal "[BCX] Funky time\n", @other_output.string
+    assert_equal "[BCX] Funky time\n", other_output.string
+  end
+
+  test "does not share the same formatter instance of the original logger" do
+    other_logger = ActiveSupport::TaggedLogging.new(@logger)
+
+    @logger.tagged("OMG") do
+      other_logger.tagged("BCX") do
+        @logger.info "Cool story"
+        other_logger.info "Funky time"
+      end
+    end
+    assert_equal "[OMG] Cool story\n[BCX] Funky time\n", @output.string
   end
 
   test "cleans up the taggings on flush" do


### PR DESCRIPTION
### Summary

I have a small question and what is better than a PR to discuss it.

`ActiveSupport::TaggedLogging` through the `new` method would mutate the argument instead of returning a new instance. This might be my design but it really got me confused at first. I would have expected some other kind of method to provide such mutation (eg.: `ActiveSupport::TaggedLogging.tag(logger)`)

The changes in here would clone the logger received in argument (and the associated formatter that `ActiveSupport::TaggedLogging` perform on) returning a new instance.

The associated test is what made me really confused the first time I hit the original behaviour.

Todo:
- [x] If this go forward it'll require an entry in changelog?