### PR TITLE
Fix missing partial iteration

### DIFF
--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -458,7 +458,7 @@ module ActionView
           locals[counter]   = index
           locals[iteration] = partial_iteration
 
-          template = (cache[path] ||= find_template(path, keys + [as, counter]))
+          template = (cache[path] ||= find_template(path, keys + [as, counter, iteration]))
           content = template.render(view, locals)
           partial_iteration.iterate!
           content

--- a/actionview/test/fixtures/test/_partial_iteration_1.erb
+++ b/actionview/test/fixtures/test/_partial_iteration_1.erb
@@ -1,0 +1,1 @@
+<%= defined?(partial_iteration_1_iteration) %>

--- a/actionview/test/fixtures/test/_partial_iteration_2.erb
+++ b/actionview/test/fixtures/test/_partial_iteration_2.erb
@@ -1,0 +1,1 @@
+<%= defined?(partial_iteration_2_iteration) -%>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -301,6 +301,15 @@ module RenderTestCases
       @view.render(partial: "test/local_inspector", collection: [ Customer.new("mary") ])
   end
 
+  def test_render_partial_collection_with_different_partials_still_provides_partial_iteration
+    a = {}
+    b = {}
+    def a.to_partial_path; "test/partial_iteration_1"; end
+    def b.to_partial_path; "test/partial_iteration_2"; end
+
+    assert_equal "local-variable\nlocal-variable", @controller_view.render([a, b])
+  end
+
   def test_render_partial_with_empty_collection_should_return_nil
     assert_nil @view.render(partial: "test/customer", collection: [])
   end


### PR DESCRIPTION
### Summary

Fixes #27794 

The iteration variable was being assigned to the correct key in the `locals` hash, but the name of the iteration variable (`<partial_name>_iteration`) was not included in the keys to `find_template`, meaning it was excluded from `keys`, a partial to be loaded without the `<partial_name>_iteration` variable defined as one of it's locals during initialization. 

### Other Information

I produced a [simple POC against Rails 5.0.1](https://github.com/meagar/partial-iteration-test), and [created screenshots of the actual and expected behavior](https://github.com/meagar/partial-iteration-test/blob/master/README.md).
