### PR TITLE
Keep the value of `$,` and restore it

### DIFF
--- a/actionview/test/template/output_safety_helper_test.rb
+++ b/actionview/test/template/output_safety_helper_test.rb
@@ -94,12 +94,13 @@ class OutputSafetyHelperTest < ActionView::TestCase
   end
 
   test "to_sentence is not affected by $," do
+    separator_was = $,
     $, = "|"
     begin
       assert_equal "one and two", to_sentence(["one", "two"])
       assert_equal "one, two, and three", to_sentence(["one", "two", "three"])
     ensure
-      $, = nil
+      $, = separator_was
     end
   end
 end


### PR DESCRIPTION
As unit tests, we do not know the value of `$,` when this
test case started. It' better to keep the value when the
test case fnished.
