### PR TITLE
correctly check error message

### DIFF
--- a/actioncable/test/channel/periodic_timers_test.rb
+++ b/actioncable/test/channel/periodic_timers_test.rb
@@ -38,23 +38,26 @@ class ActionCable::Channel::PeriodicTimersTest < ActiveSupport::TestCase
 
   test "disallow negative and zero periods" do
     [ 0, 0.0, 0.seconds, -1, -1.seconds, "foo", :foo, Object.new ].each do |invalid|
-      assert_raise ArgumentError, /Expected every:/ do
+      e = assert_raise ArgumentError do
         ChatChannel.periodically :send_updates, every: invalid
       end
+      assert_match(/Expected every:/, e.message)
     end
   end
 
   test "disallow block and arg together" do
-    assert_raise ArgumentError, /not both/ do
+    e = assert_raise ArgumentError do
       ChatChannel.periodically(:send_updates, every: 1) { ping }
     end
+    assert_match(/not both/, e.message)
   end
 
   test "disallow unknown args" do
     [ "send_updates", Object.new, nil ].each do |invalid|
-      assert_raise ArgumentError, /Expected a Symbol/ do
+      e = assert_raise ArgumentError do
         ChatChannel.periodically invalid, every: 1
       end
+      assert_match(/Expected a Symbol/, e.message)
     end
   end
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -739,18 +739,25 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_with_invalid_association_reference
-    assert_raise(ActiveRecord::AssociationNotFoundError, "Association was not found; perhaps you misspelled it?  You specified :include => :monkeys") {
+    e = assert_raise(ActiveRecord::AssociationNotFoundError) {
       Post.all.merge!(includes: :monkeys).find(6)
     }
-    assert_raise(ActiveRecord::AssociationNotFoundError, "Association was not found; perhaps you misspelled it?  You specified :include => :monkeys") {
+    assert_equal("Association named 'monkeys' was not found on Post; perhaps you misspelled it?", e.message)
+
+    e = assert_raise(ActiveRecord::AssociationNotFoundError) {
       Post.all.merge!(includes: [ :monkeys ]).find(6)
     }
-    assert_raise(ActiveRecord::AssociationNotFoundError, "Association was not found; perhaps you misspelled it?  You specified :include => :monkeys") {
+    assert_equal("Association named 'monkeys' was not found on Post; perhaps you misspelled it?", e.message)
+
+    e = assert_raise(ActiveRecord::AssociationNotFoundError) {
       Post.all.merge!(includes: [ "monkeys" ]).find(6)
     }
-    assert_raise(ActiveRecord::AssociationNotFoundError, "Association was not found; perhaps you misspelled it?  You specified :include => :monkeys, :elephants") {
+    assert_equal("Association named 'monkeys' was not found on Post; perhaps you misspelled it?", e.message)
+
+    e = assert_raise(ActiveRecord::AssociationNotFoundError) {
       Post.all.merge!(includes: [ :monkeys, :elephants ]).find(6)
     }
+    assert_equal("Association named 'monkeys' was not found on Post; perhaps you misspelled it?", e.message)
   end
 
   def test_eager_has_many_through_with_order

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -45,10 +45,11 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_migrator_with_duplicate_names
-    assert_raises(ActiveRecord::DuplicateMigrationNameError, "Multiple migrations have the name Chunky") do
+    e = assert_raises(ActiveRecord::DuplicateMigrationNameError) do
       list = [ActiveRecord::Migration.new("Chunky"), ActiveRecord::Migration.new("Chunky")]
       ActiveRecord::Migrator.new(:up, list)
     end
+    assert_match(/Multiple migrations have the name Chunky/, e.message)
   end
 
   def test_migrator_with_duplicate_versions

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -271,7 +271,8 @@ class DependenciesTest < ActiveSupport::TestCase
 
   def test_raising_discards_autoloaded_constants
     with_autoloading_fixtures do
-      assert_raises(Exception, "arbitray exception message") { RaisesArbitraryException }
+      e = assert_raises(Exception) { RaisesArbitraryException }
+      assert_equal("arbitray exception message", e.message)
       assert_not defined?(A)
       assert_not defined?(RaisesArbitraryException)
     end

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -94,11 +94,12 @@ class TimeTravelTest < ActiveSupport::TestCase
       outer_expected_time = Time.new(2004, 11, 24, 01, 04, 44)
       inner_expected_time = Time.new(2004, 10, 24, 01, 04, 44)
       travel_to outer_expected_time do
-        assert_raises(RuntimeError, /Calling `travel_to` with a block, when we have previously already made a call to `travel_to`, can lead to confusing time stubbing./) do
+        e = assert_raises(RuntimeError) do
           travel_to(inner_expected_time) do
             #noop
           end
         end
+        assert_match(/Calling `travel_to` with a block, when we have previously already made a call to `travel_to`, can lead to confusing time stubbing./, e.message)
       end
     end
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -623,9 +623,10 @@ module ApplicationTests
 
       assert_equal "", app.config.secret_token
       assert_nil app.secrets.secret_key_base
-      assert_raise ArgumentError, /\AA secret is required/ do
+      e = assert_raise ArgumentError do
         app.key_generator
       end
+      assert_match(/\AA secret is required/, e.message)
     end
 
     test "that nested keys are symbolized the same as parents for hashes more than one level deep" do
@@ -1184,11 +1185,12 @@ module ApplicationTests
     end
 
     test "config.session_store with :active_record_store without activerecord-session_store gem" do
-      assert_raise RuntimeError, /activerecord-session_store/ do
+      e = assert_raise RuntimeError do
         make_basic_app do |application|
           application.config.session_store :active_record_store
         end
       end
+      assert_match(/activerecord-session_store/, e.message)
     end
 
     test "default session store initializer does not overwrite the user defined session store even if it is disabled" do


### PR DESCRIPTION
`assert_raise` does not check error message. However, in some tests, it seems like expecting error message checking with `assert_raise`.　Instead of specifying an error message in `assert_raise`, modify to use another assert to check the error message.