### PR TITLE
Give a message to `#test_duplicable` assertion

### DIFF
--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -17,7 +17,7 @@ class DuplicableTest < ActiveSupport::TestCase
                   "* https://github.com/rubinius/rubinius/issues/3089"
 
     RAISE_DUP.each do |v|
-      assert !v.duplicable?
+      assert !v.duplicable?, "#{ v.inspect } should not be duplicable"
       assert_raises(TypeError, v.class.name) { v.dup }
     end
 


### PR DESCRIPTION
Giving a message helps us to know what happened
when we look at Travis CI.