### PR TITLE
remove warning from `bin/setup` test

### DIFF
--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -40,7 +40,7 @@ module ApplicationTests
         output = `bin/setup 2>&1`
 
         # Ignore line that's only output by Bundler < 1.14
-        output.sub! /^Resolving dependencies\.\.\.\n/, ""
+        output.sub!(/^Resolving dependencies\.\.\.\n/, "")
 
         assert_equal(<<-OUTPUT, output)
 == Installing dependencies ==


### PR DESCRIPTION
This removes the following warnings.

```
test/application/bin_setup_test.rb:43: warning: ambiguous first argument; put parentheses or a space even after `/' operator
```

