### PR TITLE
Bump bug report template versions to 5.0.1 in master

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -8,7 +8,7 @@ end
 gemfile(true) do
   source "https://rubygems.org"
   # Activate the gem you are reporting the issue against.
-  gem "rails", "5.0.0"
+  gem "rails", "5.0.1"
 end
 
 require "rack/test"

--- a/guides/bug_report_templates/active_job_gem.rb
+++ b/guides/bug_report_templates/active_job_gem.rb
@@ -8,7 +8,7 @@ end
 gemfile(true) do
   source "https://rubygems.org"
   # Activate the gem you are reporting the issue against.
-  gem "activejob", "5.0.0"
+  gem "activejob", "5.0.1"
 end
 
 require "minitest/autorun"

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -8,7 +8,7 @@ end
 gemfile(true) do
   source "https://rubygems.org"
   # Activate the gem you are reporting the issue against.
-  gem "activerecord", "5.0.0"
+  gem "activerecord", "5.0.1"
   gem "sqlite3"
 end
 

--- a/guides/bug_report_templates/active_record_migrations_gem.rb
+++ b/guides/bug_report_templates/active_record_migrations_gem.rb
@@ -8,7 +8,7 @@ end
 gemfile(true) do
   source "https://rubygems.org"
   # Activate the gem you are reporting the issue against.
-  gem "activerecord", "5.0.0.1"
+  gem "activerecord", "5.0.1"
   gem "sqlite3"
 end
 

--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -8,7 +8,7 @@ end
 gemfile(true) do
   source "https://rubygems.org"
   # Activate the gem you are reporting the issue against.
-  gem "activesupport", "5.0.0"
+  gem "activesupport", "5.0.1"
 end
 
 require "active_support/core_ext/object/blank"


### PR DESCRIPTION
### Summary

While investigating how to create a bug report for #27803 I realised the gem version numbers of the templates were slightly out of date.


Very similar to https://github.com/rails/rails/pull/27809 but on `master` since these are the files linked from http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#creating-a-bug-report