### PR TITLE
Support for mysql schema with spatial types/indexes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Support for spatial data types in database schema for mysql2 adapter
+
+    Now it is possible to have:
+
+        create_table :some_table do |t|
+          t.geometry   :geometry_field
+          t.polygon    :polygon_field, null: false, index: { type: :spatial }
+          t.point      :point_field, multi: true
+          t.linestring :linestring_field
+        end
+
+    without switching to sql schema format and raw sql in migrations.
+
+    *Vasily Fedoseyev*
+
 *   Virtual/generated column support for MySQL 5.7.5+ and MariaDB 5.2.0+.
 
     MySQL generated columns: https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -1056,25 +1056,25 @@ module ActiveRecord
 
         class MysqlGeometryCollection < ActiveModel::Type::Binary # :nodoc:
           def type
-            :multi_geometry
+            :geometry
           end
         end
 
         class MysqlMultiPoint < MysqlGeometryCollection # :nodoc:
           def type
-            :multi_point
+            :point
           end
         end
 
         class MysqlMultiLineString < MysqlGeometryCollection # :nodoc:
           def type
-            :multi_linestring
+            :linestring
           end
         end
 
         class MysqlMultiPolygon < MysqlGeometryCollection # :nodoc:
           def type
-            :multi_polygon
+            :polygon
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -55,6 +55,10 @@ module ActiveRecord
         point:       { name: "point" },
         linestring:  { name: "linestring" },
         polygon:     { name: "polygon" },
+        multi_geometry:    { name: "geometrycollection" },
+        multi_point:       { name: "multipoint" },
+        multi_linestring:  { name: "multilinestring" },
+        multi_polygon:     { name: "multipolygon" },
       }
 
       INDEX_TYPES  = [:fulltext, :spatial]
@@ -688,10 +692,14 @@ module ActiveRecord
           m.alias_type %r(year)i,          "integer"
           m.alias_type %r(bit)i,           "binary"
 
-          m.register_type %r(geometry)i,   MysqlGeometry.new
-          m.register_type %r(point)i,      MysqlPoint.new
-          m.register_type %r(linestring)i, MysqlLineString.new
-          m.register_type %r(polygon)i,    MysqlPolygon.new
+          m.register_type %r(^geometry)i,            MysqlGeometry.new
+          m.register_type %r(^point)i,               MysqlPoint.new
+          m.register_type %r(^linestring)i,          MysqlLineString.new
+          m.register_type %r(^polygon)i,             MysqlPolygon.new
+          m.register_type %r(^geometrycollection)i,  MysqlGeometryCollection.new
+          m.register_type %r(^multipoint)i,          MysqlMultiPoint.new
+          m.register_type %r(^multilinestring)i,     MysqlMultiLineString.new
+          m.register_type %r(^multipolygon)i,        MysqlMultiPolygon.new
 
           m.register_type(%r(enum)i) do |sql_type|
             limit = sql_type[/^enum\((.+)\)/i, 1]
@@ -1046,6 +1054,30 @@ module ActiveRecord
           end
         end
 
+        class MysqlGeometryCollection < ActiveModel::Type::Binary # :nodoc:
+          def type
+            :multi_geometry
+          end
+        end
+
+        class MysqlMultiPoint < MysqlGeometryCollection # :nodoc:
+          def type
+            :multi_point
+          end
+        end
+
+        class MysqlMultiLineString < MysqlGeometryCollection # :nodoc:
+          def type
+            :multi_linestring
+          end
+        end
+
+        class MysqlMultiPolygon < MysqlGeometryCollection # :nodoc:
+          def type
+            :multi_polygon
+          end
+        end
+
         ActiveRecord::Type.register(:json, MysqlJson, adapter: :mysql2)
         ActiveRecord::Type.register(:string, MysqlString, adapter: :mysql2)
         ActiveRecord::Type.register(:unsigned_integer, Type::UnsignedInteger, adapter: :mysql2)
@@ -1053,6 +1085,10 @@ module ActiveRecord
         ActiveRecord::Type.register(:point, MysqlPoint, adapter: :mysql2)
         ActiveRecord::Type.register(:linestring, MysqlLineString, adapter: :mysql2)
         ActiveRecord::Type.register(:polygon, MysqlPolygon, adapter: :mysql2)
+        ActiveRecord::Type.register(:multi_geometry, MysqlGeometryCollection, adapter: :mysql2)
+        ActiveRecord::Type.register(:multi_point, MysqlMultiPoint, adapter: :mysql2)
+        ActiveRecord::Type.register(:multi_linestring, MysqlMultiLineString, adapter: :mysql2)
+        ActiveRecord::Type.register(:multi_polygon, MysqlMultiPolygon, adapter: :mysql2)
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/mysql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/column.rb
@@ -19,6 +19,10 @@ module ActiveRecord
         def virtual?
           /\b(?:VIRTUAL|STORED|PERSISTENT)\b/.match?(extra)
         end
+
+        def multi?
+          /^(geometrycollection|multi)/i.match?(sql_type)
+        end
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -56,19 +56,39 @@ module ActiveRecord
         end
 
         def geometry(*args, **options)
+          return multi_geometry(*args, **options) if options[:multi] == true
           args.each { |name| column(name, :geometry, options) }
         end
 
         def point(*args, **options)
+          return multi_point(*args, **options) if options[:multi] == true
           args.each { |name| column(name, :point, options) }
         end
 
         def linestring(*args, **options)
+          return multi_linestring(*args, **options) if options[:multi] == true
           args.each { |name| column(name, :linestring, options) }
         end
 
         def polygon(*args, **options)
+          return multi_polygon(*args, **options) if options[:multi] == true
           args.each { |name| column(name, :polygon, options) }
+        end
+
+        def multi_geometry(*args, **options)
+          args.each { |name| column(name, :multi_geometry, options) }
+        end
+
+        def multi_point(*args, **options)
+          args.each { |name| column(name, :multi_point, options) }
+        end
+
+        def multi_linestring(*args, **options)
+          args.each { |name| column(name, :multi_linestring, options) }
+        end
+
+        def multi_polygon(*args, **options)
+          args.each { |name| column(name, :multi_polygon, options) }
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -54,6 +54,23 @@ module ActiveRecord
         def unsigned_decimal(*args, **options)
           args.each { |name| column(name, :unsigned_decimal, options) }
         end
+
+        def geometry(*args, **options)
+          args.each { |name| column(name, :geometry, options) }
+        end
+
+        def point(*args, **options)
+          args.each { |name| column(name, :point, options) }
+        end
+
+        def linestring(*args, **options)
+          args.each { |name| column(name, :linestring, options) }
+        end
+
+        def polygon(*args, **options)
+          args.each { |name| column(name, :polygon, options) }
+        end
+
       end
 
       class ColumnDefinition < ActiveRecord::ConnectionAdapters::ColumnDefinition

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -70,7 +70,6 @@ module ActiveRecord
         def polygon(*args, **options)
           args.each { |name| column(name, :polygon, options) }
         end
-
       end
 
       class ColumnDefinition < ActiveRecord::ConnectionAdapters::ColumnDefinition

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -55,40 +55,24 @@ module ActiveRecord
           args.each { |name| column(name, :unsigned_decimal, options) }
         end
 
-        def geometry(*args, **options)
-          return multi_geometry(*args, **options) if options[:multi] == true
-          args.each { |name| column(name, :geometry, options) }
+        def geometry(*args, multi: false, **options)
+          type = multi ? :multi_geometry : :geometry
+          args.each { |name| column(name, type, options) }
         end
 
-        def point(*args, **options)
-          return multi_point(*args, **options) if options[:multi] == true
-          args.each { |name| column(name, :point, options) }
+        def point(*args, multi: false, **options)
+          type = multi ? :multi_point : :point
+          args.each { |name| column(name, type, options) }
         end
 
-        def linestring(*args, **options)
-          return multi_linestring(*args, **options) if options[:multi] == true
-          args.each { |name| column(name, :linestring, options) }
+        def linestring(*args, multi: false, **options)
+          type = multi ? :multi_linestring : :linestring
+          args.each { |name| column(name, type, options) }
         end
 
-        def polygon(*args, **options)
-          return multi_polygon(*args, **options) if options[:multi] == true
-          args.each { |name| column(name, :polygon, options) }
-        end
-
-        def multi_geometry(*args, **options)
-          args.each { |name| column(name, :multi_geometry, options) }
-        end
-
-        def multi_point(*args, **options)
-          args.each { |name| column(name, :multi_point, options) }
-        end
-
-        def multi_linestring(*args, **options)
-          args.each { |name| column(name, :multi_linestring, options) }
-        end
-
-        def multi_polygon(*args, **options)
-          args.each { |name| column(name, :multi_polygon, options) }
+        def polygon(*args, multi: false, **options)
+          type = multi ? :multi_polygon : :polygon
+          args.each { |name| column(name, type, options) }
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -14,6 +14,7 @@ module ActiveRecord
         def prepare_column_options(column)
           spec = super
           spec[:unsigned] = "true" if column.unsigned?
+          spec[:multi] = "true" if column.multi?
 
           if supports_virtual_columns? && column.virtual?
             spec[:as] = extract_expression_for_virtual_column(column)

--- a/activerecord/test/cases/adapters/mysql2/spatial_types_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/spatial_types_test.rb
@@ -9,7 +9,7 @@ class Mysql2SpatialTypesTest < ActiveRecord::Mysql2TestCase
     @connection = ActiveRecord::Base.connection
     @connection.create_table("spatial_types", force: true) do |t|
       t.geometry   :geometry_field
-      t.polygon    :polygon_field, null:false, index:{ type: :spatial}
+      t.polygon    :polygon_field, null: false, index: { type: :spatial }
       t.point      :point_field
       t.linestring :linestring_field
     end
@@ -30,9 +30,8 @@ class Mysql2SpatialTypesTest < ActiveRecord::Mysql2TestCase
   test "schema dump can be restored" do
     schema = dump_table_schema "spatial_types"
     @connection.drop_table "spatial_types", if_exists: true
-    silence_stdout{ eval schema }
+    silence_stdout { eval schema }
     schema2 = dump_table_schema "spatial_types"
     assert_equal schema, schema2
   end
-
 end

--- a/activerecord/test/cases/adapters/mysql2/spatial_types_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/spatial_types_test.rb
@@ -1,0 +1,38 @@
+require "cases/helper"
+require "support/schema_dumping_helper"
+
+class Mysql2SpatialTypesTest < ActiveRecord::Mysql2TestCase
+  include SchemaDumpingHelper
+  self.use_transactional_tests = false
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table("spatial_types", force: true) do |t|
+      t.geometry   :geometry_field
+      t.polygon    :polygon_field, null:false, index:{ type: :spatial}
+      t.point      :point_field
+      t.linestring :linestring_field
+    end
+  end
+
+  teardown do
+    @connection.drop_table "spatial_types", if_exists: true
+  end
+
+  test "schema dump includes spatial types" do
+    schema = dump_table_schema "spatial_types"
+    assert_match %r{t.geometry\s+"geometry_field"$}, schema
+    assert_match %r{t.polygon\s+"polygon_field",\s+null: false$}, schema
+    assert_match %r{t.point\s+"point_field"$}, schema
+    assert_match %r{t.linestring\s+"linestring_field"$}, schema
+  end
+
+  test "schema dump can be restored" do
+    schema = dump_table_schema "spatial_types"
+    @connection.drop_table "spatial_types", if_exists: true
+    silence_stdout{ eval schema }
+    schema2 = dump_table_schema "spatial_types"
+    assert_equal schema, schema2
+  end
+
+end

--- a/activerecord/test/cases/adapters/mysql2/spatial_types_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/spatial_types_test.rb
@@ -7,7 +7,7 @@ class Mysql2SpatialTypesTest < ActiveRecord::Mysql2TestCase
 
   setup do
     @connection = ActiveRecord::Base.connection
-    @connection.create_table("spatial_types", force: true) do |t|
+    @connection.create_table("spatial_types", force: true, options: "ENGINE=MyISAM") do |t|
       t.geometry   :geometry_field
       t.polygon    :polygon_field, null: false, index: { type: :spatial }
       t.point      :point_field

--- a/activerecord/test/cases/adapters/mysql2/spatial_types_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/spatial_types_test.rb
@@ -31,10 +31,10 @@ class Mysql2SpatialTypesTest < ActiveRecord::Mysql2TestCase
     assert_match %r{t.point\s+"point_field"$}, schema
     assert_match %r{t.linestring\s+"linestring_field"$}, schema
 
-    assert_match %r{t.multi_geometry\s+"geometry_multi"$}, schema
-    assert_match %r{t.multi_polygon\s+"polygon_multi"$}, schema
-    assert_match %r{t.multi_point\s+"point_multi"$}, schema
-    assert_match %r{t.multi_linestring\s+"linestring_multi"$}, schema
+    assert_match %r{t.geometry\s+"geometry_multi",\s+multi: true$}, schema
+    assert_match %r{t.polygon\s+"polygon_multi",\s+multi: true$}, schema
+    assert_match %r{t.point\s+"point_multi",\s+multi: true$}, schema
+    assert_match %r{t.linestring\s+"linestring_multi",\s+multi: true$}, schema
   end
 
   test "schema dump can be restored" do

--- a/activerecord/test/cases/adapters/mysql2/spatial_types_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/spatial_types_test.rb
@@ -12,6 +12,11 @@ class Mysql2SpatialTypesTest < ActiveRecord::Mysql2TestCase
       t.polygon    :polygon_field, null: false, index: { type: :spatial }
       t.point      :point_field
       t.linestring :linestring_field
+
+      t.geometry   :geometry_multi, multi: true
+      t.polygon    :polygon_multi, multi: true
+      t.point      :point_multi, multi: true
+      t.linestring :linestring_multi, multi: true
     end
   end
 
@@ -25,6 +30,11 @@ class Mysql2SpatialTypesTest < ActiveRecord::Mysql2TestCase
     assert_match %r{t.polygon\s+"polygon_field",\s+null: false$}, schema
     assert_match %r{t.point\s+"point_field"$}, schema
     assert_match %r{t.linestring\s+"linestring_field"$}, schema
+
+    assert_match %r{t.multi_geometry\s+"geometry_multi"$}, schema
+    assert_match %r{t.multi_polygon\s+"polygon_multi"$}, schema
+    assert_match %r{t.multi_point\s+"point_multi"$}, schema
+    assert_match %r{t.multi_linestring\s+"linestring_multi"$}, schema
   end
 
   test "schema dump can be restored" do

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -129,21 +129,25 @@ def disable_extension!(extension, connection)
   connection.reconnect!
 end
 
-def load_schema
-  # silence verbose schema loading
+def silence_stdout
   original_stdout = $stdout
   $stdout = StringIO.new
+  yield
+ensure
+  $stdout = original_stdout
+end
 
+def load_schema
   adapter_name = ActiveRecord::Base.connection.adapter_name.downcase
   adapter_specific_schema_file = SCHEMA_ROOT + "/#{adapter_name}_specific_schema.rb"
 
-  load SCHEMA_ROOT + "/schema.rb"
+  silence_stdout do
+    load SCHEMA_ROOT + "/schema.rb"
 
-  if File.exist?(adapter_specific_schema_file)
-    load adapter_specific_schema_file
+    if File.exist?(adapter_specific_schema_file)
+      load adapter_specific_schema_file
+    end
   end
-ensure
-  $stdout = original_stdout
 end
 
 load_schema


### PR DESCRIPTION
### Summary

This allows one to have spatial fields and indexes in database without switching to sql schema format.
