### PR TITLE
add combination of Ruby 2.4 + aj:integration to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,12 @@ matrix:
         - memcached
         - redis
         - rabbitmq
+    - rvm: 2.4.0
+      env: "GEM=aj:integration"
+      services:
+        - memcached
+        - redis
+        - rabbitmq
     - rvm: ruby-head
       env: "GEM=aj:integration"
       services:


### PR DESCRIPTION
### Summary

The test of the combination of Ruby 2.4 + aj:integration was not executed, so it add.
