### PR TITLE
Modernize SQL Server database YAML for Linux/vNext.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
@@ -1,4 +1,4 @@
-# SQL Server (2005 or higher recommended)
+# SQL Server (2012 or higher recommended)
 #
 # Install the adapters and driver
 #   gem install tiny_tds
@@ -8,28 +8,12 @@
 #   gem 'tiny_tds'
 #   gem 'activerecord-sqlserver-adapter'
 #
-# You should make sure freetds is configured correctly first.
-# freetds.conf contains host/port/protocol_versions settings.
-# http://freetds.schemamania.org/userguide/freetdsconf.htm
-#
-# A typical Microsoft server
-#   [mssql]
-#   host = mssqlserver.yourdomain.com
-#   port = 1433
-#   tds version = 7.1
-
-# If you can connect with "tsql -S servername", your basic FreeTDS installation is working.
-# 'man tsql' for more info
-# Set timeout to a larger number if valid queries against a live db fail
-#
 default: &default
   adapter: sqlserver
   encoding: utf8
-  reconnect: false
-  username: <%= app_name %>
-  password:
-  timeout: 25
-  dataserver: from_freetds.conf
+  username: sa
+  password: <%= ENV['SA_PASSWORD'] %>
+  host: localhost
 
 development:
   <<: *default


### PR DESCRIPTION
In order to make things smooth for developers getting started with SQL Server and Rails, we need to make a few changes to the adapters database.yml template. The goal would be to get Ruby/Rails on the [SQL Server - Getting Started](https://www.microsoft.com/en-us/sql-server/developer-get-started/) page. Changes include:

* Fix comments. SQL Server Adapter v4.2 and up requires 2012 DB versions.
* Advocate development user of `sa` vs per user app name.
* Assume localhost for everyone given Linux/vNext Docker image.

This pull request targets the 5-0-stable branch so that the next release will include this information. I would like to have these changes drop into master as well. Should I open another PR for that? Thanks in advance!

cc @ajlam 