### PR TITLE
Fix broken sample code for EventedFileUpdateChecker [ci skip]

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -17,7 +17,7 @@ module ActiveSupport
   #
   # Example:
   #
-  #     checker = EventedFileUpdateChecker.new(["/tmp/foo"], -> { puts "changed" })
+  #     checker = ActiveSupport::EventedFileUpdateChecker.new(["/tmp/foo"]) { puts "changed" }
   #     checker.updated?
   #     # => false
   #     checker.execute_if_updated


### PR DESCRIPTION
The second parameter should not be a lambda, a block should be given instead. otherwise it will raise an error below.
`NoMethodError: undefined method `each' for #<Proc:0x007f92ecb9e160@(irb):1 (lambda)>`
