### PR TITLE
Raise an error if FileUpdateChecker#execute is called with no block

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -74,7 +74,11 @@ module ActiveSupport
 
     def execute
       @updated.make_false
-      @block.call
+      if @block.nil?
+        raise ArgumentError, "no block given: #{self.inspect}, please pass a block when you initialize #{self.class}"
+      else
+        @block.call
+      end
     end
 
     def execute_if_updated

--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -74,7 +74,11 @@ module ActiveSupport
     def execute
       @last_watched   = watched
       @last_update_at = updated_at(@last_watched)
-      @block.call
+      if @block.nil?
+        raise ArgumentError, "no block given: #{self.inspect}, please pass a block when you initialize #{self.class}"
+      else
+        @block.call
+      end
     ensure
       @watched = nil
       @updated_at = nil

--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -273,4 +273,11 @@ module FileUpdateCheckerSharedTests
     assert checker.execute_if_updated
     assert_equal 2, i
   end
+
+  test "execute raises an ArgumentError if no block given" do
+    checker = new_checker([])
+    assert_raise ArgumentError do
+      checker.execute
+    end
+  end
 end


### PR DESCRIPTION
If `ActiveSupport::FileUpdateChecker` or `ActiveSupport::EventedFileUpdateChecker` is initialized with no block and its `execute` is called , it will raise an error:
`NoMethodError: undefined method `call' for nil:NilClass`

We should raise a better error to make it easier to understand what leads to an error.