### PR TITLE
make backburner integration test to work

### DIFF
--- a/activejob/test/support/integration/adapters/backburner.rb
+++ b/activejob/test/support/integration/adapters/backburner.rb
@@ -23,12 +23,12 @@ module BackburnerJobsManager
   end
 
   def tube
-    @tube ||= Beaneater::Tube.new(Backburner::Worker.connection, "backburner.worker.queue.integration-tests") # backburner dasherizes the queue name
+    @tube ||= Beaneater::Tube.new(@worker.connection, "backburner.worker.queue.integration-tests") # backburner dasherizes the queue name
   end
 
   def can_run?
     begin
-      Backburner::Worker.connection.send :connect!
+      @worker = Backburner::Worker.new
     rescue
       return false
     end


### PR DESCRIPTION
Currently, backburner integration test is not running on CI.
https://travis-ci.org/rails/rails/jobs/196005322#L610

Using `Backburner::Worker.connection` to check whether beanstalkd is
running. But `Backburner::Worker.connection` was removed in backburner
1.2.0.
https://github.com/nesquena/backburner/commit/81fde499c2263abe8dedee59a3d0e03e92d72627

Therefore, this check process always becomes false, so the test is no
longer done. I fixed it so that check processing is done correctly.