### PR TITLE
Update backtrace cleaner to use `Regexp#match?`

### DIFF
--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -16,7 +16,7 @@ module Rails
       add_filter { |line| line.sub(DOT_SLASH, SLASH) } # for tests
 
       add_gem_filters
-      add_silencer { |line| line !~ APP_DIRS_PATTERN }
+      add_silencer { |line| !APP_DIRS_PATTERN.match?(line) }
     end
 
     private


### PR DESCRIPTION
In https://github.com/rails/rails/commit/575dbeeefcaafeb566afc07cdd8b55603b698d9f a backport for Ruby 2.4's [`Regexp#match?`](https://bugs.ruby-lang.org/issues/8110) was introduced. On Ruby 2.4 this method [is about 13% faster](http://blog.bigbinary.com/2016/11/04/ruby-2-4-implements-regexp-match-without-polluting-global-variables.html) than `=~` because it doesn't allocate a MatchData object and sets the value of `$~`. Since the silencer only cares about a boolean return value, we should use `match?`.