### PR TITLE
Fix judgment spelling [ci skip]

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -67,7 +67,7 @@ can expect it to be marked "invalid" as soon as it's reviewed.
 Sometimes, the line between 'bug' and 'feature' is a hard one to draw.
 Generally, a feature is anything that adds new behavior, while a bug is
 anything that causes incorrect behavior. Sometimes,
-the core team will have to make a judgement call. That said, the distinction
+the core team will have to make a judgment call. That said, the distinction
 generally just affects which release your patch will get in to; we love feature
 submissions! They just won't get backported to maintenance branches.
 


### PR DESCRIPTION
As @maclover7 has kindly mentioned in #25239 `judgment` is the spelling that we're going with.