### PR TITLE
Set port environment variable when using the puma webserver

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -62,9 +62,9 @@ module Rails
     end
 
     def puma_server?
-      ActiveSupport::Inflector.demodulize(server) == 'Puma'
+      ActiveSupport::Inflector.demodulize(server) == "Puma"
     end
-    
+
     private
       def setup_dev_caching
         if options[:environment] == "development"

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -15,6 +15,7 @@ module Rails
     def initialize(options = nil)
       @default_options = options || {}
       super(@default_options)
+      set_port if puma_server?
       set_environment
     end
 
@@ -32,6 +33,10 @@ module Rails
 
     def set_environment
       ENV["RAILS_ENV"] ||= options[:environment]
+    end
+
+    def set_port
+      ENV["PORT"] ||= options[:Port].to_s
     end
 
     def start
@@ -56,6 +61,10 @@ module Rails
       super.merge(@default_options)
     end
 
+    def puma_server?
+      ActiveSupport::Inflector.demodulize(server) == 'Puma'
+    end
+    
     private
       def setup_dev_caching
         if options[:environment] == "development"

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -15,7 +15,7 @@ module Rails
     def initialize(options = nil)
       @default_options = options || {}
       super(@default_options)
-      set_port if puma_server?
+      set_port
       set_environment
     end
 
@@ -59,10 +59,6 @@ module Rails
 
     def default_options
       super.merge(@default_options)
-    end
-
-    def puma_server?
-      ActiveSupport::Inflector.demodulize(server) == "Puma"
     end
 
     private

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -130,6 +130,13 @@ class Rails::ServerTest < ActiveSupport::TestCase
     end
   end
 
+  def test_port_environment_variable_with_default_server
+    args = ["-p", 3001]
+    options = parse_arguments(args)
+    Rails::Server.new(options)
+    assert_equal "3001", ENV["PORT"]
+  end
+
   def test_restart_command_contains_customized_options
     original_args = ARGV.dup
     args = %w(-p 4567 -b 127.0.0.1 -c dummy_config.ru -d -e test -P tmp/server.pid -C)

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -130,9 +130,10 @@ class Rails::ServerTest < ActiveSupport::TestCase
     end
   end
 
-  def test_port_environment_variable_with_default_server
+  def test_port_environment_variable
     args = ["-p", 3001]
     options = parse_arguments(args)
+    ENV['PORT'] = nil
     Rails::Server.new(options)
     assert_equal "3001", ENV["PORT"]
   end


### PR DESCRIPTION
### Summary
This pull request references the bug recorded in issue #27834. 

**Bug**
When running the command `rails server -p 3001` the following is logged.
```
=> Booting Puma
=> Rails 5.0.1 application starting in development on http://localhost:3001
=> Run `rails server -h` for more startup options
Puma starting in single mode...
* Version 3.7.0 (ruby 2.3.0-p0), codename: Snowy Sagebrush
* Min threads: 5, max threads: 5
* Environment: development
* Listening on tcp://0.0.0.0:3000
```
Note the last line Listening on tcp://0.0.0.0:3000 should read  Listening on tcp://0.0.0.0:3001

This is because of this line in `config/puma.rb`
`port        ENV.fetch("PORT") { 3000 }`

No ENV variable named "PORT" exists, so it is defaulting to port 3000.

My code changes will check to see if the server being started is Puma and if so it will set ENV["PORT"] equal to the passed parameter.
