### PR TITLE
Reload `through_record` that has been destroyed in `create_through_record`

### DIFF
--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -22,6 +22,10 @@ module ActiveRecord
           elsif record
             attributes = construct_join_attributes(record)
 
+            if through_record && through_record.destroyed?
+              through_record = through_proxy.tap(&:reload).target
+            end
+
             if through_record
               through_record.update(attributes)
             elsif owner.new_record?

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -86,6 +86,13 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_nil @member.club
   end
 
+  def test_set_record_after_delete_association
+    @member.club = nil
+    @member.club = clubs(:moustache_club)
+    @member.reload
+    assert_equal clubs(:moustache_club), @member.club
+  end
+
   def test_has_one_through_polymorphic
     assert_equal clubs(:moustache_club), @member.sponsor_club
   end


### PR DESCRIPTION
This is an alternative of #27714.

If `has_one :through` association has set `nil`, `through_record` is
destroyed but still remain loaded target in `through_proxy` until
`reload` or `reset` explicitly.

If `through_proxy` is not reset (remain destroyed (frozen) target),
setting new record causes `RuntimeError: Can't modify frozen hash`.

To prevent `RuntimeError`, should reload `through_record` that has been
destroyed in `create_through_record`.