### PR TITLE
Show subclass name in the migration error instead of the Class

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -525,7 +525,7 @@ module ActiveRecord
         raise StandardError, "Directly inheriting from ActiveRecord::Migration is not supported. " \
           "Please specify the Rails release the migration was written for:\n" \
           "\n" \
-          "  class #{self.class.name} < ActiveRecord::Migration[4.2]"
+          "  class #{subclass.name} < ActiveRecord::Migration[4.2]"
       end
     end
 


### PR DESCRIPTION
- self.class is class Class which is not really useful in the error message.

r? @matthewd 

Should I add a test for this?