### PR TITLE
Allow similar chained value methods in or queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow chained value methods with same arguments in `or` queries
+
+    *Blake Hitchcock*
+
 *   Deprecate `initialize_schema_migrations_table` and `initialize_internal_metadata_table`.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1163,7 +1163,7 @@ module ActiveRecord
       STRUCTURAL_OR_METHODS = Relation::VALUE_METHODS - [:extending, :where, :having]
       def structurally_incompatible_values_for_or(other)
         STRUCTURAL_OR_METHODS.reject do |method|
-          get_value(method) == other.get_value(method)
+          get_value(method).try(:uniq) == other.get_value(method).try(:uniq)
         end
       end
 

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -1,5 +1,6 @@
 require "cases/helper"
 require "models/post"
+require "models/comment"
 
 module ActiveRecord
   class OrTest < ActiveRecord::TestCase
@@ -86,6 +87,13 @@ module ActiveRecord
     def test_or_with_non_relation_object_raises_error
       assert_raises ArgumentError do
         Post.where(id: [1, 2, 3]).or(title: "Rails")
+      end
+    end
+
+    def test_or_with_chained_value_methods_with_same_arguments
+      assert_nothing_raised do
+        Post.joins(:comment).where(comments: { id: 1 })
+          .or(Post.joins(:comment).where(comments: { id: 2 }).joins(:comment).where(comments: { id: 3 }))
       end
     end
   end


### PR DESCRIPTION
The purpose of this change is most easily expressed via a code example:

    class Post
      has_many :comments
    end

    class Comment
      belongs_to :post

      def self.on_contributor_posts
        joins(:post).where(posts: { role: 'contributor' })
      end

      def self.on_writer_posts
        joins(:post).where(posts: { role: 'writer' })
      end
    end

    Comment.joins(:post).where(posts: { id: 1 })
      .or(Comment.on_contributor_posts.on_writer_posts)

Prior to this changeset, the above example would raise an exception due to incompatible structure of the two queries, even though the ActiveRecord handles chained calls with the same arguments just fine.

I added a test case specifically for this use case (chained `joins`), but I would be happy to add more if needed. I did run all of the other tests locally, and this change seemed to have no ill-effects. ActiveRecord is very complex, though, so I recognize this may have some unintended side effects. It was a simple enough change, so I thought it made the most sense to get early feedback on it in case it is of interest to the maintainers.

I am happy to answer any questions or make any changes required. Thanks in advance to the reviewers for their consideration of this change!