### PR TITLE
Specify complete path to AR::LegacyYamlAdapter

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -43,7 +43,6 @@ module ActiveRecord
   autoload :Explain
   autoload :Inheritance
   autoload :Integration
-  autoload :LegacyYamlAdapter
   autoload :Migration
   autoload :Migrator, 'active_record/migration'
   autoload :ModelSchema
@@ -79,6 +78,8 @@ module ActiveRecord
     autoload :AttributeAssignment
     autoload :AttributeMethods
     autoload :AutosaveAssociation
+
+    autoload :LegacyYamlAdapter
 
     autoload :Relation
     autoload :AssociationRelation


### PR DESCRIPTION
We had a one-time non-reproducible error `NameError: uninitialized constant ActiveRecord::Core::LegacyYamlAdapter` originating from this line.

Backtrace:

```
/gems/activerecord-4.2.7.1/lib/active_record/core.rb:302 in init_with
/gems/activerecord-4.2.7.1/lib/active_record/persistence.rb:69 in instantiate
/gems/activerecord-4.2.7.1/lib/active_record/querying.rb:50 in block (2 levels) in find_by_sql
/gems/activerecord-4.2.7.1/lib/active_record/result.rb:51 in block in each
/gems/activerecord-4.2.7.1/lib/active_record/result.rb:51 in each
/gems/activerecord-4.2.7.1/lib/active_record/result.rb:51 in each
/gems/activerecord-4.2.7.1/lib/active_record/querying.rb:50 in map
/gems/activerecord-4.2.7.1/lib/active_record/querying.rb:50 in block in find_by_sql
/gems/activesupport-4.2.7.1/lib/active_support/notifications/instrumenter.rb:20 in instrument
/gems/activerecord-4.2.7.1/lib/active_record/querying.rb:49 in find_by_sql
/gems/activerecord-4.2.7.1/lib/active_record/relation.rb:639 in exec_queries
/gems/activerecord-4.2.7.1/lib/active_record/relation.rb:515 in load
/gems/activerecord-4.2.7.1/lib/active_record/relation.rb:243 in to_a
/gems/activerecord-4.2.7.1/lib/active_record/relation/finder_methods.rb:500 in find_nth_with_limit
/gems/activerecord-4.2.7.1/lib/active_record/relation/finder_methods.rb:484 in find_nth
/gems/activerecord-4.2.7.1/lib/active_record/relation/finder_methods.rb:127 in first
/gems/activerecord-4.2.7.1/lib/active_record/relation.rb:163 in first_or_initialize
app/models/persist_product.rb:22 in product
app/models/persist_product.rb:8 in save
app/controllers/products_controller.rb:12 in post
```