### PR TITLE
Feature/active job test helper

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Push skipped jobs to `enqueued_jobs` when using `perform_enqueued_jobs` with a `only` filter in tests
+
+    *Alexander Pauly*
+  
 *   Removed deprecated support to passing the adapter class to `.queue_adapter`.
 
     *Rafael Mendonça França*

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -24,15 +24,11 @@ module ActiveJob
       end
 
       def enqueue(job) #:nodoc:
-        return if filtered?(job)
-
         job_data = job_to_hash(job)
         enqueue_or_perform(perform_enqueued_jobs, job, job_data)
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
-        return if filtered?(job)
-
         job_data = job_to_hash(job, at: timestamp)
         enqueue_or_perform(perform_enqueued_at_jobs, job, job_data)
       end
@@ -44,11 +40,11 @@ module ActiveJob
         end
 
         def enqueue_or_perform(perform, job, job_data)
-          if perform
+          if !perform || filtered?(job)
+            enqueued_jobs << job_data
+          else
             performed_jobs << job_data
             Base.execute job.serialize
-          else
-            enqueued_jobs << job_data
           end
         end
 

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -56,6 +56,17 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_enqueued_jobs_when_performing_with_only_option
+    assert_nothing_raised do
+      assert_enqueued_jobs 1, only: HelloJob do
+        perform_enqueued_jobs only: LoggingJob do
+          HelloJob.perform_later("sean")
+          LoggingJob.perform_later("yves")
+        end
+      end
+    end
+  end
+
   def test_assert_no_enqueued_jobs_with_no_block
     assert_nothing_raised do
       assert_no_enqueued_jobs


### PR DESCRIPTION
### Summary

This PR updates the `ActiveJob::QueueAdapters::TestAdapter` to add filtered jobs to the `enqueued_jobs` array. Prior to this change, skipped jobs were just ignored.

Refer to https://github.com/rails/rails/issues/27848

### Other Information

I've also updated the test suite. 
