### PR TITLE
Deprecate `scope_chain`

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -171,7 +171,7 @@ module ActiveRecord
           chain         = child.reflection.chain
           foreign_table = parent.table
           foreign_klass = parent.base_klass
-          child.join_constraints(foreign_table, foreign_klass, child, join_type, tables, child.reflection.scope_chain, chain)
+          child.join_constraints(foreign_table, foreign_klass, child, join_type, tables, chain)
         end
 
         def make_outer_joins(parent, child)

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -23,13 +23,10 @@ module ActiveRecord
 
         JoinInformation = Struct.new :joins, :binds
 
-        def join_constraints(foreign_table, foreign_klass, node, join_type, tables, scope_chain, chain)
+        def join_constraints(foreign_table, foreign_klass, node, join_type, tables, chain)
           joins         = []
           binds         = []
           tables        = tables.reverse
-
-          scope_chain_index = 0
-          scope_chain = scope_chain.reverse
 
           # The chain starts with the target table, but we want to end with it here (makes
           # more sense in this context), so we reverse
@@ -44,7 +41,7 @@ module ActiveRecord
             constraint = build_constraint(klass, table, key, foreign_table, foreign_key)
 
             predicate_builder = PredicateBuilder.new(TableMetadata.new(klass, table))
-            scope_chain_items = scope_chain[scope_chain_index].map do |item|
+            scope_chain_items = reflection.scopes.map do |item|
               if item.is_a?(Relation)
                 item
               else
@@ -52,7 +49,6 @@ module ActiveRecord
                   .instance_exec(node, &item)
               end
             end
-            scope_chain_index += 1
 
             klass_scope =
               if klass.current_scope

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -826,13 +826,9 @@ module ActiveRecord
       end
 
       def source_type_scope
-        @source_type_lambda ||= begin
-          type = foreign_type
-          source_type = options[:source_type]
-          lambda { |object|
-            where(type => source_type)
-          }
-        end
+        type = foreign_type
+        source_type = options[:source_type]
+        lambda { |object| where(type => source_type) }
       end
 
       def has_scope?

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -175,6 +175,8 @@ module ActiveRecord
         JoinKeys.new(foreign_key, active_record_primary_key)
       end
 
+      # Returns a list of scopes that should be applied for this Reflection
+      # object when querying the database.
       def scopes
         scope ? [scope] : []
       end
@@ -798,31 +800,8 @@ module ActiveRecord
         through_reflection.clear_association_scope_cache
       end
 
-      # Consider the following example:
-      #
-      #   class Person
-      #     has_many :articles
-      #     has_many :comment_tags, through: :articles
-      #   end
-      #
-      #   class Article
-      #     has_many :comments
-      #     has_many :comment_tags, through: :comments, source: :tags
-      #   end
-      #
-      #   class Comment
-      #     has_many :tags
-      #   end
-      #
-      # There may be scopes on Person.comment_tags, Article.comment_tags and/or Comment.tags,
-      # but only Comment.tags will be represented in the #chain. So this method creates an array
-      # of scopes corresponding to the chain.
       def scopes
-        if scope
-          source_reflection.scopes + [scope]
-        else
-          source_reflection.scopes
-        end
+        source_reflection.scopes + super
       end
 
       def source_type_scope

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1,5 +1,6 @@
 require "thread"
 require "active_support/core_ext/string/filters"
+require "active_support/deprecation"
 
 module ActiveRecord
   # = Active Record Reflection
@@ -184,6 +185,7 @@ module ActiveRecord
       def scope_chain
         chain.map(&:scopes)
       end
+      deprecate :scope_chain
 
       def constraints
         chain.map(&:scopes).flatten

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -258,7 +258,9 @@ class ReflectionTest < ActiveRecord::TestCase
       [Post.reflect_on_association(:first_taggings).scope],
       [Author.reflect_on_association(:misc_posts).scope]
     ]
-    actual = Author.reflect_on_association(:misc_post_first_blue_tags).scope_chain
+    actual = assert_deprecated do
+      Author.reflect_on_association(:misc_post_first_blue_tags).scope_chain
+    end
     assert_equal expected, actual
 
     expected = [
@@ -270,7 +272,9 @@ class ReflectionTest < ActiveRecord::TestCase
       [],
       []
     ]
-    actual = Author.reflect_on_association(:misc_post_first_blue_tags_2).scope_chain
+    actual = assert_deprecated do
+      Author.reflect_on_association(:misc_post_first_blue_tags_2).scope_chain
+    end
     assert_equal expected, actual
   end
 
@@ -395,9 +399,15 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_through_reflection_scope_chain_does_not_modify_other_reflections
-    orig_conds = Post.reflect_on_association(:first_blue_tags_2).scope_chain.inspect
-    Author.reflect_on_association(:misc_post_first_blue_tags_2).scope_chain
-    assert_equal orig_conds, Post.reflect_on_association(:first_blue_tags_2).scope_chain.inspect
+    orig_conds = assert_deprecated do
+      Post.reflect_on_association(:first_blue_tags_2).scope_chain
+    end.inspect
+    assert_deprecated do
+      Author.reflect_on_association(:misc_post_first_blue_tags_2).scope_chain
+    end
+    assert_equal orig_conds, assert_deprecated {
+      Post.reflect_on_association(:first_blue_tags_2).scope_chain
+    }.inspect
   end
 
   def test_symbol_for_class_name


### PR DESCRIPTION
This PR refactors reflections such that we can iterate over each reflection and ask the reflection object what scopes should be applied to the query we are currently building.  This means we don't need to construct a `scope_chain` array and iterate that array in parallel with the "chain".  Instead, we can just ask each item in the chain for the scopes that should be applied, then apply those scopes.