### PR TITLE
Don't mutate raw_source in mailer preview interceptor

### DIFF
--- a/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
+++ b/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
@@ -26,7 +26,7 @@ module ActionMailer
     def transform! #:nodoc:
       return message if html_part.blank?
 
-      html_source.gsub!(PATTERN) do |match|
+      html_part.body = html_part.decoded.gsub(PATTERN) do |match|
         if part = find_part(match[9..-2])
           %[src="#{data_url(part)}"]
         else
@@ -44,10 +44,6 @@ module ActionMailer
 
       def html_part
         @html_part ||= message.html_part
-      end
-
-      def html_source
-        html_part.body.raw_source
       end
 
       def data_url(part)

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -671,6 +671,40 @@ module ApplicationTests
       assert_match %r[<p>Hello, World!</p>], last_response.body
     end
 
+    test "multipart mailer preview with empty parts" do
+      mailer "notifier", <<-RUBY
+        class Notifier < ActionMailer::Base
+          default from: "from@example.com"
+
+          def foo
+            mail to: "to@example.org"
+          end
+        end
+      RUBY
+
+      text_template "notifier/foo", <<-RUBY
+      RUBY
+
+      html_template "notifier/foo", <<-RUBY
+      RUBY
+
+      mailer_preview "notifier", <<-RUBY
+        class NotifierPreview < ActionMailer::Preview
+          def foo
+            Notifier.foo
+          end
+        end
+      RUBY
+
+      app("development")
+
+      get "/rails/mailers/notifier/foo?part=text/plain"
+      assert_equal 200, last_response.status
+
+      get "/rails/mailers/notifier/foo?part=text/html"
+      assert_equal 200, last_response.status
+    end
+
     private
       def build_app
         super


### PR DESCRIPTION
See https://github.com/rails/rails/issues/27702#issuecomment-275979276 for previous discussion.

The `raw_source` method is [documented as returning the exact value](https://github.com/mikel/mail/blob/2.6.4/lib/mail/body.rb#L136-L137) that was used to create the body; mutating it breaks that contract.

Additionally, if the value used to create the body is blank, `raw_source` returns a frozen string which causes the interceptor to raise an error (https://github.com/rails/rails/issues/27702).

r? @jeremy 