### PR TITLE
Fix typo about sort in finder_methods.rb

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -17,8 +17,8 @@ module ActiveRecord
     #   Person.where("administrator = 1").order("created_on DESC").find(1)
     #
     # NOTE: The returned records may not be in the same order as the ids you
-    # provide since database rows are unordered. You'd need to provide an explicit QueryMethods#order
-    # option if you want the results are sorted.
+    # provide since database rows are unordered. You will need to provide an explicit QueryMethods#order
+    # option if you want the results to be sorted.
     #
     # ==== Find with lock
     #


### PR DESCRIPTION
### Summary


This PR is a quick typo/grammar fix in the documentation for `FinderMethods`. There are a couple typos in `activerecord/lib/active_record/relation/finder_methods.rb` related to applying sort to `find`. 

The main typo is `if you want the results are sorted.` 

-- this should be `if you want the results **to be** sorted.`
