### PR TITLE
Fix inherit from deprecated `ActionView::Template::Handlers::Erubis`

### DIFF
--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -1,7 +1,7 @@
 module ActionView
   class Template
     module Handlers
-      Erubis = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("Erubis", "ActionView::Template::Handlers::ERB::Erubis", message: "ActionView::Template::Handlers::Erubis is deprecated and will be removed from Rails 5.2. Switch to ActionView::Template::Handlers::ERB::Erubi instead.")
+      autoload :Erubis, "action_view/template/handlers/erb/deprecated_erubis"
 
       class ERB
         autoload :Erubi, "action_view/template/handlers/erb/erubi"

--- a/actionview/lib/action_view/template/handlers/erb/deprecated_erubis.rb
+++ b/actionview/lib/action_view/template/handlers/erb/deprecated_erubis.rb
@@ -1,0 +1,9 @@
+::ActiveSupport::Deprecation.warn("ActionView::Template::Handlers::Erubis is deprecated and will be removed from Rails 5.2. Switch to ActionView::Template::Handlers::ERB::Erubi instead.")
+
+module ActionView
+  class Template
+    module Handlers
+      Erubis = ERB::Erubis
+    end
+  end
+end

--- a/actionview/test/template/erb/deprecated_erubis_implementation_test.rb
+++ b/actionview/test/template/erb/deprecated_erubis_implementation_test.rb
@@ -5,6 +5,8 @@ module ERBTest
     test "Erubis implementation is deprecated" do
       assert_deprecated "ActionView::Template::Handlers::Erubis is deprecated and will be removed from Rails 5.2. Switch to ActionView::Template::Handlers::ERB::Erubi instead." do
         assert_equal "ActionView::Template::Handlers::ERB::Erubis", ActionView::Template::Handlers::Erubis.to_s
+
+        assert_nothing_raised { Class.new(ActionView::Template::Handlers::Erubis) }
       end
     end
   end


### PR DESCRIPTION
There are some classes inherit from `ActionView::Template::Handlers::Erubis`.
(ex. https://github.com/haml/haml/blob/4.0.7/lib/haml/helpers/safe_erubis_template.rb#L3)

```
Class.new(ActionView::Template::Handlers::Erubis)
# => TypeError: superclass must be a Class (ActiveSupport::Deprecation::DeprecatedConstantProxy given)
```