### PR TITLE
Use temporary connection pool for sqlite3_mem adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,9 @@ matrix:
         - "GEM=ar:mysql2 MYSQL=mariadb"
       addons:
         mariadb: 10.0
+    - rvm: 2.4.0
+      env:
+        - "GEM=ar:sqlite3_mem"
     - rvm: jruby-9.1.7.0
       jdk: oraclejdk8
       env:


### PR DESCRIPTION
### Summary
This pull request fixes #27826 by referring https://github.com/rails/rails/commit/f7b317175430a2d9300d9c4acfc1f34f4fdb2fbc 

sqlite3 in memory option, each connections has its own database. then it needs to create `:tasks` table and load its fixtures.

[In-Memory Databases](https://www.sqlite.org/inmemorydb.html)

> When this is done, no disk file is opened. Instead, a new database is created purely in memory. The database ceases to exist as soon as the database connection is closed. Every :memory: database is distinct from every other. So, opening two database connections each with the filename ":memory:" will create two independent in-memory databases.

Also it adds `sqlite3_mem` to Travis CI. Since `sqlite3_mem` has not been tested. I do not think we need to test with all of Ruby versions, then just testing with 2.4.0.

### Other Information
This pull request has been tested with all bundled adapters.

```
$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]
$ for i in sqlite3 sqlite3_mem postgresql mysql2; do echo $i; ARCONN=$i  bundle exec ruby -w -Itest test/cases/query_cache_test.rb -n test_cache_is_not_available_when_using_a_not_connected_connection; done
sqlite3
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using sqlite3
Run options: -n test_cache_is_not_available_when_using_a_not_connected_connection --seed 65336

# Running:

.

Finished in 0.050699s, 19.7242 runs/s, 39.4484 assertions/s.

1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
sqlite3_mem
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using sqlite3_mem
Run options: -n test_cache_is_not_available_when_using_a_not_connected_connection --seed 8735

# Running:

.

Finished in 0.054039s, 18.5053 runs/s, 37.0106 assertions/s.

1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
postgresql
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using postgresql
Run options: -n test_cache_is_not_available_when_using_a_not_connected_connection --seed 65377

# Running:

.

Finished in 0.129367s, 7.7300 runs/s, 15.4599 assertions/s.

1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
mysql2
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using mysql2
Run options: -n test_cache_is_not_available_when_using_a_not_connected_connection --seed 46330

# Running:

.

Finished in 0.130431s, 7.6669 runs/s, 15.3338 assertions/s.

1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
$
```