### PR TITLE
Some improvements to the API site's sidebar

### DIFF
--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -2,6 +2,8 @@ require "active_support"
 require "active_support/file_update_checker"
 require "active_support/core_ext/array/wrap"
 
+# :enddoc:
+
 module I18n
   class Railtie < Rails::Railtie
     config.i18n = ActiveSupport::OrderedOptions.new

--- a/activesupport/lib/active_support/xml_mini/libxml.rb
+++ b/activesupport/lib/active_support/xml_mini/libxml.rb
@@ -74,5 +74,7 @@ module LibXML #:nodoc:
   end
 end
 
+# :enddoc:
+
 LibXML::XML::Document.include(LibXML::Conversions::Document)
 LibXML::XML::Node.include(LibXML::Conversions::Node)

--- a/railties/lib/rails/api/generator.rb
+++ b/railties/lib/rails/api/generator.rb
@@ -1,0 +1,28 @@
+require "sdoc"
+
+class RDoc::Generator::API < RDoc::Generator::SDoc # :nodoc:
+  RDoc::RDoc.add_generator self
+
+  def generate_class_tree_level(classes, visited = {})
+    # Only process core extensions on the first visit.
+    if visited.empty?
+      core_exts, classes = classes.partition { |klass| core_extension?(klass) }
+
+      super.unshift([ "Core extensions", "", "", build_core_ext_subtree(core_exts, visited) ])
+    else
+      super
+    end
+  end
+
+  private
+    def build_core_ext_subtree(classes, visited)
+      classes.map do |klass|
+        [ klass.name, klass.document_self_or_methods ? klass.path : "", "",
+            generate_class_tree_level(klass.classes_and_modules, visited) ]
+      end
+    end
+
+    def core_extension?(klass)
+      klass.name != "ActiveSupport" && klass.in_files.any? { |file| file.absolute_name.include?("core_ext") }
+    end
+end

--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -1,4 +1,5 @@
 require "rdoc/task"
+require "rails/api/generator"
 
 module Rails
   module API
@@ -83,7 +84,7 @@ module Rails
         # Be lazy computing stuff to have as light impact as possible to
         # the rest of tasks.
         before_running_rdoc do
-          load_and_configure_sdoc
+          configure_sdoc
           configure_rdoc_files
           setup_horo_variables
         end
@@ -94,20 +95,15 @@ module Rails
         # no-op
       end
 
-      def load_and_configure_sdoc
-        require "sdoc"
-
+      def configure_sdoc
         self.title    = "Ruby on Rails API"
         self.rdoc_dir = api_dir
 
         options << "-m"  << api_main
         options << "-e"  << "UTF-8"
 
-        options << "-f"  << "sdoc"
+        options << "-f"  << "api"
         options << "-T"  << "rails"
-      rescue LoadError
-        $stderr.puts %(Unable to load SDoc, please add\n\n    gem 'sdoc', require: false\n\nto the Gemfile.)
-        exit 1
       end
 
       def configure_rdoc_files
@@ -150,7 +146,7 @@ module Rails
     end
 
     class RepoTask < Task
-      def load_and_configure_sdoc
+      def configure_sdoc
         super
         options << "-g" # link to GitHub, SDoc flag
       end

--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -8,8 +8,7 @@ module Rails
           include: %w(
             README.rdoc
             lib/active_support/**/*.rb
-          ),
-          exclude: "lib/active_support/vendor/*"
+          )
         },
 
         "activerecord" => {
@@ -69,7 +68,11 @@ module Rails
             README.rdoc
             lib/**/*.rb
           ),
-          exclude: "lib/rails/generators/rails/**/templates/**/*.rb"
+          exclude: %w(
+            lib/rails/generators/rails/**/templates/**/*.rb
+            lib/rails/test_unit/*
+            lib/rails/api/generator.rb
+          )
         }
       }
 

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -14,10 +14,12 @@ require "active_support/testing/autorun"
 if defined?(ActiveRecord::Base)
   ActiveRecord::Migration.maintain_test_schema!
 
-  class ActiveSupport::TestCase
-    include ActiveRecord::TestFixtures
-    self.fixture_path = "#{Rails.root}/test/fixtures/"
-    self.file_fixture_path = fixture_path + "files"
+  module ActiveSupport
+    class TestCase
+      include ActiveRecord::TestFixtures
+      self.fixture_path = "#{Rails.root}/test/fixtures/"
+      self.file_fixture_path = fixture_path + "files"
+    end
   end
 
   ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
@@ -26,6 +28,8 @@ if defined?(ActiveRecord::Base)
     FixtureSet.create_fixtures(ActiveSupport::TestCase.fixture_path, fixture_set_names, {}, &block)
   end
 end
+
+# :enddoc:
 
 class ActionController::TestCase
   def before_setup # :nodoc:


### PR DESCRIPTION
Hello,

That's a tiny pull request that improves a bit the sidebar on the API site removing some useless or duplicated entries. Also, all the core classes are now under a "Core extensions" label. Here's the result:

![sidebar](https://cloud.githubusercontent.com/assets/354185/22484884/aaf18938-e803-11e6-9afa-c8aa9daa60bc.png)

There's still the `SourceAnnotationExtractor` class because there's no `:nodoc:` comment on it but since there's an API to register annotations, is it still needed to keep this documented ?

I'm not very happy of the generator's code but that's not really easy to hook into SDoc. Let me know if there's anything wrong or missing !

Have a nice day ! :-)