### PR TITLE
Fix collection_singular_ids= bug

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `association_primary_key_type` for reflections with symbol primary key
+
+    Fixes #27864
+
+    *Daniel Colson*
+
 *   Virtual/generated column support for MySQL 5.7.5+ and MariaDB 5.2.0+.
 
     MySQL generated columns: https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -421,7 +421,7 @@ module ActiveRecord
       end
 
       def association_primary_key_type
-        klass.type_for_attribute(association_primary_key)
+        klass.type_for_attribute(association_primary_key.to_s)
       end
 
       def active_record_primary_key
@@ -835,7 +835,7 @@ module ActiveRecord
       end
 
       def association_primary_key_type
-        klass.type_for_attribute(association_primary_key)
+        klass.type_for_attribute(association_primary_key.to_s)
       end
 
       # Gets an array of possible <tt>:through</tt> source reflection names in both singular and plural form.

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -335,6 +335,15 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal "custom_primary_key", Author.reflect_on_association(:tags_with_primary_key).association_primary_key.to_s # nested
   end
 
+  def test_association_primary_key_type
+    # Normal Association
+    assert_equal :integer, Author.reflect_on_association(:posts).association_primary_key_type.type
+    assert_equal :string,  Author.reflect_on_association(:essay).association_primary_key_type.type
+
+    # Through Association
+    assert_equal :string, Author.reflect_on_association(:essay_category).association_primary_key_type.type
+  end
+
   def test_association_primary_key_raises_when_missing_primary_key
     reflection = ActiveRecord::Reflection.create(:has_many, :edge, nil, {}, Author)
     assert_raises(ActiveRecord::UnknownPrimaryKey) { reflection.association_primary_key }


### PR DESCRIPTION
When the association's primary key is set as a symbol,
`CollectionAssociation#ids_writer` fails to cast the ids to integers.
This is because `AssociationReflection#association_primary_key_type`
and `ThroughReflection#association_primary_key_type` rely on
`ModelSchema.type_for_attribute`, which only accepts a string.
The result is an `ActiveRecord::RecordNotFound` error.

Fixes #27864
