### PR TITLE
remove unused variable

### DIFF
--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -276,7 +276,7 @@ module FileUpdateCheckerSharedTests
 
   test "initialize raises an ArgumentError if no block given" do
     assert_raise ArgumentError do
-      checker = new_checker([])
+      new_checker([])
     end
   end
 end


### PR DESCRIPTION
This removes the following warnings.

```
activesupport/test/file_update_checker_shared_tests.rb:279: warning: assigned but unused variable - checker
```

