### PR TITLE
explicitly require `listen` in `EventedFileUpdateCheckerTest`

### DIFF
--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -7,6 +7,7 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
 
   def setup
     skip if ENV["LISTEN"] == "0"
+    require "listen"
     super
   end
 


### PR DESCRIPTION
Currently, executing the `test_initialize_raises_an_ArgumentError_if_no_block_given`
test alone will result in an error.

```
$ ./bin/test test/evented_file_update_checker_test.rb -n test_initialize_raises_an_ArgumentError_if_no_block_given
Run options: -n test_initialize_raises_an_ArgumentError_if_no_block_given --seed 6692

# Running:

E

Error:
EventedFileUpdateCheckerTest#test_initialize_raises_an_ArgumentError_if_no_block_given:
NameError: uninitialized constant EventedFileUpdateCheckerTest::Listen
    rails/activesupport/test/evented_file_update_checker_test.rb:21:in `teardown'
```

This is because if do not specify a file or directory for
`EventedFileUpdateChecker`, do not require `listen`, and using listen
method in teardown.
https://github.com/rails/rails/blob/master/activesupport/lib/active_support/evented_file_update_checker.rb#L53..L65

Therefore, added listen's require to avoid errors.

