### PR TITLE
add `erubis` to dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ PATH
       activesupport (= 5.1.0.alpha)
       builder (~> 3.1)
       erubi (~> 1.4)
+      erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
     activejob (5.1.0.alpha)

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "builder",       "~> 3.1"
   s.add_dependency "erubi",         "~> 1.4"
+  s.add_dependency "erubis",        "~> 2.7.0"
   s.add_dependency "rails-html-sanitizer", "~> 1.0", ">= 1.0.3"
   s.add_dependency "rails-dom-testing", "~> 2.0"
 


### PR DESCRIPTION
We still support erubis handler.
https://github.com/rails/rails/blob/master/actionview/lib/action_view/template/handlers/erb/erubis.rb

Therefore, `erubis` is required for dependency.

