### PR TITLE
call `gem` `erubis` before require

### DIFF
--- a/actionview/lib/action_view/template/handlers/erb/erubis.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubis.rb
@@ -1,3 +1,4 @@
+gem "erubis"
 require "erubis"
 
 module ActionView


### PR DESCRIPTION
For inform that need to add `erubis` to gemfile.

Context: https://github.com/rails/rails/pull/27868#issuecomment-276566062