### PR TITLE
Get TODO done in `render_test`

### DIFF
--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -406,8 +406,7 @@ module RenderTestCases
     assert_equal "Before (Josh)\n\nAfter", @view.render(partial: "test/layout_for_partial", locals: { name: "Josh" })
   end
 
-  # TODO: The reason for this test is unclear, improve documentation
-  def test_render_missing_xml_partial_and_raise_missing_template
+  def test_render_partial_with_non_existent_format_and_raise_missing_template
     @view.formats = [:xml]
     assert_raises(ActionView::MissingTemplate) { @view.render(partial: "test/layout_for_partial") }
   ensure

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -411,6 +411,8 @@ render formats: :xml
 render formats: [:json, :xml]
 ```
 
+If a file with the specified extension does not exist, a `MissingTemplate` error will be raised.
+
 #### Finding Layouts
 
 To find the current layout, Rails first looks for a file in `app/views/layouts` with the same base name as the controller. For example, rendering actions from the `PhotosController` class will use `app/views/layouts/photos.html.erb` (or `app/views/layouts/photos.builder`). If there is no such controller-specific layout, Rails will use `app/views/layouts/application.html.erb` or `app/views/layouts/application.builder`. If there is no `.erb` layout, Rails will use a `.builder` layout if one exists. Rails also provides several ways to more precisely assign specific layouts to individual controllers and actions.


### PR DESCRIPTION
I examined the other TODO comment in `render_test.rb` .

The method checks that MissingTemplateError is raised if a partial with a non-existent extension is rendered.

This PR:
- renames the method to a better name.
- removes the comment.
- moves the method to a better place.
- changes `@view.formats=` to `@view.lookup_context.formats=` (`formats=` delegates to `lookup_context` in ActionView::Base). Because other test methods in `render_test.rb` use the latter style, and they should be consistent to be more readable.
