### PR TITLE
#xml_http_request? does not return true

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -237,7 +237,7 @@ module ActionDispatch
       super.to_i
     end
 
-    # Returns true if the "X-Requested-With" header contains "XMLHttpRequest"
+    # Returns truthy if the "X-Requested-With" header contains "XMLHttpRequest"
     # (case-insensitive), which may need to be manually added depending on the
     # choice of JavaScript libraries and frameworks.
     def xml_http_request?


### PR DESCRIPTION
Nitpick on wording, but a regex match will return the index of the match (truthy) or nil (falsy), not strictly true.

It came up over on IRC and it was a fairly trivial change so I decided to put it up.