### PR TITLE
don't dump user credentials when failing to create prod db

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -120,7 +120,7 @@ module ActiveRecord
         $stderr.puts "Database '#{configuration['database']}' already exists"
       rescue Exception => error
         $stderr.puts error
-        $stderr.puts "Couldn't create database for #{configuration.inspect}"
+        $stderr.puts "Couldn't create database for #{configuration.except("username","password").inspect}"
         raise
       end
 


### PR DESCRIPTION
### Summary

This issue is introduced [here](https://github.com/rails/rails/issues/27852).  When failing to create a database in a production environment, the user's credentials from their `database.yml` are leaked into stderr by printing the inspected config.  This is problematic as @anicholson points out in that the credentials could very well be legitimate and the failure could be due to another reason; in this instance it is not acceptable to leak them into error logs.

### Other Info

This is my first contribution to rails.  Apologies for any faux-pas committed or processes overlooked (I did read the [Contributing to Ruby on Rails](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html) guide), I'm happy to revise any code/PR text or fix anything improper.

Thanks!