### PR TITLE
prevent leaking user credentials when prod db fails to create

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -120,7 +120,7 @@ module ActiveRecord
         $stderr.puts "Database '#{configuration['database']}' already exists"
       rescue Exception => error
         $stderr.puts error
-        $stderr.puts "Couldn't create database for #{configuration.inspect}"
+        $stderr.puts "Couldn't create database for #{configuration['database']}"
         raise
       end
 

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -210,6 +210,25 @@ module ActiveRecord
         ActiveSupport::StringInquirer.new("development")
       )
     end
+
+    def test_db_create_with_error_prints_message
+      old_env = ENV["RAILS_ENV"]
+      ENV["RAILS_ENV"] = "production"
+
+      ActiveRecord::Base.stubs(:establish_connection).raises(Exception)
+
+      $stderr.stubs(:puts).returns(true)
+      $stderr.expects(:puts).
+        with("Couldn't create database for prod-db")
+
+      begin
+        ActiveRecord::Tasks::DatabaseTasks.create_current(
+          ActiveSupport::StringInquirer.new("production")
+        )
+      rescue; end
+    ensure
+      ENV["RAILS_ENV"] = old_env
+    end
   end
 
   class DatabaseTasksDropTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -59,16 +59,6 @@ if current_adapter?(:SQLite3Adapter)
 
         ActiveRecord::Tasks::DatabaseTasks.create @configuration, "/rails/root"
       end
-
-      def test_db_create_with_error_prints_message
-        ActiveRecord::Base.stubs(:establish_connection).raises(Exception)
-
-        $stderr.stubs(:puts).returns(true)
-        $stderr.expects(:puts).
-          with("Couldn't create database for #{@configuration.inspect}")
-
-        assert_raises(Exception) { ActiveRecord::Tasks::DatabaseTasks.create @configuration, "/rails/root" }
-      end
     end
 
     class SqliteDBDropTest < ActiveRecord::TestCase


### PR DESCRIPTION
### Summary

This is in reference to issue #27852, wherein a user's database credentials are leaked inappropriately to `$stderr` when a database fails to initialize.

**Note** the original problem and its respective test case are with respect to a production database, however the actual code change applies to any environment.  Please comment on whether to remove the production-dependent behavior implied in the test, or whether more logic should be added to the 

### Other Information

This is my first attempt at contributing to Rails, and I'll try to fix any issues necessary.  I have read the Contributing to Ruby on Rails guide, but pardon any faux-pas.
