### PR TITLE
Fix a test of AR::Type::TypeMap#lookup when using Oracle

### DIFF
--- a/activerecord/test/cases/connection_adapters/type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/type_lookup_test.rb
@@ -89,12 +89,20 @@ unless current_adapter?(:PostgreSQLAdapter) # PostgreSQL does not use type strin
         end
 
         def test_decimal_without_scale
-          types = %w{decimal(2) decimal(2,0) numeric(2) numeric(2,0) number(2) number(2,0)}
-          types.each do |type|
-            cast_type = @connection.type_map.lookup(type)
+          if current_adapter?(:OracleAdapter)
+            {
+              decimal: %w{decimal(2) decimal(2,0) numeric(2) numeric(2,0)},
+              integer: %w{number(2) number(2,0)}
+            }
+          else
+            { decimal: %w{decimal(2) decimal(2,0) numeric(2) numeric(2,0) number(2) number(2,0)} }
+          end.each do |expected_type, types|
+            types.each do |type|
+              cast_type = @connection.type_map.lookup(type)
 
-            assert_equal :decimal, cast_type.type
-            assert_equal 2, cast_type.cast(2.1)
+              assert_equal expected_type, cast_type.type
+              assert_equal 2, cast_type.cast(2.1)
+            end
           end
         end
 


### PR DESCRIPTION
### Summary

This PR fixes the following failure when using Oracle (11g) .

```sh
% ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]
% ARCONN=oracle bundle exec ruby -w -Itest:lib test/cases/connection_adapters/type_lookup_test.rb

(snip)

  1) Failure:
  ActiveRecord::ConnectionAdapters::TypeLookupTest#test_decimal_without_scale
[test/cases/connection_adapters/type_lookup_test.rb:96]:
Expected: :decimal
  Actual: :integer

12 runs, 51 assertions, 1 failures, 0 errors, 0 skips
```

In oracle_enhanced, it seems that expecting `:integer` when scale of number is 0.

https://github.com/rsim/oracle-enhanced/blob/8338e2ee6b7d455bbb99d5c5bf01a024df64d406/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb#L971-L975

Related Oracle document ... https://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm#CNCPT1832
