### PR TITLE
Deprecate `ColumnDumper#migration_keys`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `ColumnDumper#migration_keys`.
+
+    *Ryuta Kamizono*
+
 *   Fix `association_primary_key_type` for reflections with symbol primary key
 
     Fixes #27864

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -49,9 +49,10 @@ module ActiveRecord
       end
 
       # Lists the valid migration options
-      def migration_keys
-        [:limit, :precision, :scale, :default, :null, :collation, :comment]
+      def migration_keys # :nodoc:
+        column_options_keys
       end
+      deprecate :migration_keys
 
       private
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -122,7 +122,7 @@ module ActiveRecord
         checks = []
         checks << lambda { |c| c.name == column_name }
         checks << lambda { |c| c.type == type } if type
-        migration_keys.each do |attr|
+        column_options_keys.each do |attr|
           checks << lambda { |c| c.send(attr) == options[attr] } if options.key?(attr)
         end
 
@@ -1172,6 +1172,9 @@ module ActiveRecord
       end
 
       private
+        def column_options_keys
+          [:limit, :precision, :scale, :default, :null, :collation, :comment]
+        end
 
         def add_index_sort_order(quoted_columns, **options)
           if order = options[:order]

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module MySQL
-      module ColumnDumper
+      module ColumnDumper # :nodoc:
         def column_spec_for_primary_key(column)
           spec = super
           if [:integer, :bigint].include?(schema_type(column)) && !column.auto_increment?

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
-      module ColumnDumper
+      module ColumnDumper # :nodoc:
         def column_spec_for_primary_key(column)
           spec = super
           if schema_type(column) == :uuid

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module SQLite3
-      module ColumnDumper
+      module ColumnDumper # :nodoc:
         private
 
           def default_primary_key?(column)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1138,4 +1138,8 @@ class CopyMigrationsTest < ActiveRecord::TestCase
     assert_deprecated { ActiveRecord::Base.connection.initialize_schema_migrations_table }
     assert_deprecated { ActiveRecord::Base.connection.initialize_internal_metadata_table }
   end
+
+  def test_deprecate_migration_keys
+    assert_deprecated { ActiveRecord::Base.connection.migration_keys }
+  end
 end


### PR DESCRIPTION
`ColumnDumper#migration_keys` was extracted to customize keys for
standardized column arguments widths. But the feature was removed in
df84e98. The internal method is no longer used for that.