### PR TITLE
Describe missing singleton methods in autoloading in guides [ci skip]

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -1347,8 +1347,15 @@ In the above example, you certainly expect that the table name of `Blog::Post`
 should be `blog_posts` because a singleton method called `table_name_prefix` is
 defined in `app/models/blog.rb`.
 
-However, you possibly come across an error or weird behavior which indicate that
-Rails tries to read `posts` table.
+However, you possibly come across an error or weird behavior which indicates that
+Rails attempts to connect to `posts` table instead of `blog_posts`. For example,
+when you want to retrieve objects from database via query interfaces such as
+`Blog::Post.all` in your controller, it fails and you might see the error
+(in case you choose SQLite3 as a database):
+
+```bash
+SQLite3::SQLException: no such table: posts: SELECT "posts".* FROM "posts"
+```
 
 Problem is that both `app/helpers/blog/posts_helper.rb` and `app/models/blog.rb`
 define `Blog` module. Under the hood, one of them defines `Blog` module, and the

--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -1314,7 +1314,7 @@ class C < BasicObject
 end
 ```
 
-### Missing Singleton Methods
+### Reusing Constants as Namespaces
 
 On-demand autoloading and reopening sometimes do not work well together. This kind of
 pitfall typically happens when defining singleton methods on a module for namespace,
@@ -1377,7 +1377,7 @@ end
 If `Blog` module is unknown at that point, autoloading will be triggered and
 `app/models/blog.rb` will be loaded.
 
-Alternatively, you could use `require_relative` on top of
+Alternatively, you could use `require_dependency` on top of
 `app/models/application_record.rb`:
 
 ```ruby


### PR DESCRIPTION
### Summary

This pull request is to add another gotcha related to issue #27841 to guides.

Since I think that missing singleton methods in module for namespaced models which caused by autoloading constants execution path is a very common and also diffuclt to find out the cause of a problem, I have added the detailed explanation in #27841 to "Common Gotchas" in "Autoloading and Reloading Constants".
