### PR TITLE
Avoid assigning multi parameter hash into attributes

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -53,7 +53,7 @@ module ActiveRecord
             if values_with_empty_parameters.each_value.all?(&:nil?)
               values = nil
             else
-              values = values_with_empty_parameters
+              values = read_value(name, values_with_empty_parameters)
             end
             send("#{name}=", values)
           rescue => ex
@@ -64,6 +64,14 @@ module ActiveRecord
           error_descriptions = errors.map(&:message).join(",")
           raise MultiparameterAssignmentErrors.new(errors), "#{errors.size} error(s) on assignment of multiparameter attributes [#{error_descriptions}]"
         end
+      end
+
+      MULTIPARAMETER_ACCEPTABLE_TYPES = [:date, :datetime, :time].freeze
+
+      def read_value(name, value)
+        cast_type = type_for_attribute(name)
+        return value unless MULTIPARAMETER_ACCEPTABLE_TYPES.include?(cast_type.type) && value.is_a?(Hash)
+        cast_type.cast(value)
       end
 
       def extract_callstack_for_multiparameter_attributes(pairs)

--- a/activerecord/test/cases/multiparameter_attributes_test.rb
+++ b/activerecord/test/cases/multiparameter_attributes_test.rb
@@ -364,4 +364,16 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
 
     assert_equal("address", ex.errors[0].attribute)
   end
+
+  def test_multiparameter_attributes_should_not_be_converted_into_hash
+    with_timezone_config default: :utc do
+      attributes = {
+        "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
+        "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
+      }
+      topic = Topic.find(1)
+      topic.attributes = attributes
+      assert_equal Time.utc(2004, 6, 24, 16, 24, 0), topic.written_on_before_type_cast
+    end
+  end
 end


### PR DESCRIPTION
### Summary

Just the other day, I upgraded from rails-4.1.1 to rails-5.0.1.
But I found a painful problem in my head there.
Related to: https://github.com/rails/rails/commit/631707a572fe14f3bbea2779cc97fcc581048d62

### Other Information

In the actual case, it takes a value from an element using `datetime_select` etc, embeds it in `hidden_field` on the confirm page, and then POST, the value  will not be taken in normally.
Because, the time value is embedded in ruby's hash format on the confirm page, and it will not work properly.
