### PR TITLE
Ignore yarn error log file

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -23,6 +23,7 @@
 
 <% unless options[:skip_yarn] -%>
 /vendor/node_modules
+/vendor/yarn-error.log
 
 <% end -%>
 .byebug_history

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -508,6 +508,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "config/initializers/assets.rb" do |content|
       assert_no_match(/node_modules/, content)
     end
+
+    assert_file ".gitignore" do |content|
+      assert_no_match(/vendor\/node_modules/, content)
+      assert_no_match(/vendor\/yarn-error\.log/, content)
+    end
   end
 
   def test_inclusion_of_jbuilder


### PR DESCRIPTION
Yarn will generate a `yarn-error.log` if error has occurred.
https://github.com/yarnpkg/yarn/blob/v0.20.0/src/cli/index.js#L353 

This is a log file, so do not need to include it in the repository. So, I think that it is better to ignore by default.

