### PR TITLE
Allow Marshal#load_with_autoloading to take a Proc as optional 2nd argument

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Make `Marshal#load_with_autoloading` pass through the second, optional
+    argument for `Marshal#load( source [, proc] )`. Necessitated because
+    `Marshal#load` and `Marshal#load_with_autoloading` are alias_method_chain'd.
+
+    *Jeff Latz*
+
 *   Make `getlocal` and `getutc` always return instances of `Time` for
     `ActiveSupport::TimeWithZone` and `DateTime`. This eliminates a possible
     stack level too deep error in `to_time` where `ActiveSupport::TimeWithZone`

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,6 +1,9 @@
 *   Make `Marshal#load_with_autoloading` pass through the second, optional
     argument for `Marshal#load( source [, proc] )`. Necessitated because
-    `Marshal#load` and `Marshal#load_with_autoloading` are alias_method_chain'd.
+    `Marshal#load` and `Marshal#load_with_autoloading` are alias_method_chain'd,
+    and ideally, we shouldn't have to call `Marshal#load_without_autoloading` 
+    just to be able to pass a proc.
+
 
     *Jeff Latz*
 

--- a/activesupport/lib/active_support/core_ext/marshal.rb
+++ b/activesupport/lib/active_support/core_ext/marshal.rb
@@ -2,8 +2,8 @@ require 'active_support/core_ext/module/aliasing'
 
 module Marshal
   class << self
-    def load_with_autoloading(source)
-      load_without_autoloading(source)
+    def load_with_autoloading(source, other_proc=nil)
+      load_without_autoloading(source, other_proc)
     rescue ArgumentError, NameError => exc
       if exc.message.match(%r|undefined class/module (.+?)(::)?\z|)
         # try loading the class/module

--- a/activesupport/lib/active_support/core_ext/marshal.rb
+++ b/activesupport/lib/active_support/core_ext/marshal.rb
@@ -2,8 +2,10 @@ require 'active_support/core_ext/module/aliasing'
 
 module Marshal
   class << self
-    def load_with_autoloading(source, other_proc=nil)
-      load_without_autoloading(source, other_proc)
+    # def load_with_autoloading(source, other_proc=nil)
+    #   load_without_autoloading(source, other_proc)
+    def load_with_autoloading(source)
+      load_without_autoloading(source)
     rescue ArgumentError, NameError => exc
       if exc.message.match(%r|undefined class/module (.+?)(::)?\z|)
         # try loading the class/module

--- a/activesupport/lib/active_support/core_ext/marshal.rb
+++ b/activesupport/lib/active_support/core_ext/marshal.rb
@@ -2,10 +2,8 @@ require 'active_support/core_ext/module/aliasing'
 
 module Marshal
   class << self
-    # def load_with_autoloading(source, other_proc=nil)
-    #   load_without_autoloading(source, other_proc)
-    def load_with_autoloading(source)
-      load_without_autoloading(source)
+    def load_with_autoloading(source, other_proc=nil)
+      load_without_autoloading(source, other_proc)
     rescue ArgumentError, NameError => exc
       if exc.message.match(%r|undefined class/module (.+?)(::)?\z|)
         # try loading the class/module

--- a/activesupport/test/core_ext/marshal_test.rb
+++ b/activesupport/test/core_ext/marshal_test.rb
@@ -19,6 +19,27 @@ class MarshalTest < ActiveSupport::TestCase
     end
   end
 
+  test "that Marshal#load still works when passed a proc" do
+    sanity_string = "test"
+    other_sanity_data = [[1, 2, 3], {a: [1, 2, 3]}, ActiveSupport::TestCase]
+    
+    example_proc = Proc.new do |o|
+      if o.is_a?(String)
+        o.capitalize!
+      end
+    end
+
+    string_dumped = Marshal.dump(sanity_string)
+    assert_equal Marshal.load(string_dumped, example_proc), "Test"
+    assert_equal Marshal.load_without_autoloading(string_dumped, example_proc), "Test"
+    assert_equal Marshal.load(string_dumped, example_proc), Marshal.load_without_autoloading(string_dumped, example_proc)
+
+    other_sanity_data.each do |obj|
+      dumped = Marshal.dump(obj)
+      assert_equal Marshal.load_without_autoloading(dumped, example_proc), Marshal.load(dumped, proc)
+    end
+  end
+
   test "that a missing class is autoloaded from string" do
     dumped = nil
     with_autoloading_fixtures do

--- a/activesupport/test/core_ext/marshal_test.rb
+++ b/activesupport/test/core_ext/marshal_test.rb
@@ -20,8 +20,7 @@ class MarshalTest < ActiveSupport::TestCase
   end
 
   test "that Marshal#load still works when passed a proc" do
-    sanity_string = "test"
-    other_sanity_data = [[1, 2, 3], {a: [1, 2, 3]}, ActiveSupport::TestCase]
+    example_string = "test"
     
     example_proc = Proc.new do |o|
       if o.is_a?(String)
@@ -29,15 +28,10 @@ class MarshalTest < ActiveSupport::TestCase
       end
     end
 
-    string_dumped = Marshal.dump(sanity_string)
-    assert_equal Marshal.load(string_dumped, example_proc), "Test"
-    assert_equal Marshal.load_without_autoloading(string_dumped, example_proc), "Test"
-    assert_equal Marshal.load(string_dumped, example_proc), Marshal.load_without_autoloading(string_dumped, example_proc)
-
-    other_sanity_data.each do |obj|
-      dumped = Marshal.dump(obj)
-      assert_equal Marshal.load_without_autoloading(dumped, example_proc), Marshal.load(dumped, proc)
-    end
+    dumped = Marshal.dump(example_string)
+    assert_nothing_raised Marshal.load(dumped, example_proc)
+    assert_equal Marshal.load(dumped, example_proc), "Test"
+    assert_equal Marshal.load(dumped, example_proc), Marshal.load_without_autoloading(dumped, example_proc)
   end
 
   test "that a missing class is autoloaded from string" do

--- a/activesupport/test/core_ext/marshal_test.rb
+++ b/activesupport/test/core_ext/marshal_test.rb
@@ -29,7 +29,11 @@ class MarshalTest < ActiveSupport::TestCase
     end
 
     dumped = Marshal.dump(example_string)
-    assert_nothing_raised Marshal.load(dumped, example_proc)
+
+    assert_nothing_raised do 
+      Marshal.load(dumped, example_proc)
+    end
+
     assert_equal Marshal.load(dumped, example_proc), "Test"
     assert_equal Marshal.load(dumped, example_proc), Marshal.load_without_autoloading(dumped, example_proc)
   end


### PR DESCRIPTION
### Summary

From my entry in the **ActiveSupport** changelog:

Make `Marshal#load_with_autoloading( source)` pass through the second, optional argument for `Marshal#load( source [, proc] )`. Necessitated because `Marshal#load` and `Marshal#load_with_autoloading` are alias_method_chain'd, and ideally, we shouldn't have to call `Marshal#load_without_autoloading` just to be able to pass a proc.

For reference: [https://ruby-doc.org/core-2.2.0/Marshal.html#method-c-load](https://ruby-doc.org/core-2.2.0/Marshal.html#method-c-load
)

### Other Information

Please excuse disproportionately large number of commits for such a small change; this is my first Rails contribution and I had to struggle through getting my development environment to run the tests. Admittedly, this contribution is a yak-shave necessitated by upgrading a legacy app to Rails 4.