### PR TITLE
Fix typo in guide: _articles should be _article

### DIFF
--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -1155,7 +1155,7 @@ To pass a local variable to a partial in only specific cases use the `local_assi
   <%= render article, full: true %>
   ```
 
-* `_articles.html.erb`
+* `_article.html.erb`
 
   ```erb
   <h2><%= article.title %></h2>


### PR DESCRIPTION
The guide contains a typo in the "local_assigns" section, where rendering a a collection of `Article` models via `render @articles` or a singular model via `render @article` is shown to render a partial called `_articles.html.erb`, when in fact the necessary partial name is `_article.html.erb`

See the 6th code block under http://edgeguides.rubyonrails.org/layouts_and_rendering.html#passing-local-variables

![screenshot 2017-02-03 11 42 26](https://cloud.githubusercontent.com/assets/242474/22599748/e60c6a98-ea05-11e6-9e7a-b34335ba1883.png)
