### PR TITLE
Add `:args` to `process.action_mailer` event.

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `:args` to `process.action_mailer` event.
+
+    *Yuji Yaginuma*
+
 *   Add parameterized invocation of mailers as a way to share before filters and defaults between actions.
     See ActionMailer::Parameterized for a full example of the benefit.
 

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -598,7 +598,8 @@ module ActionMailer
     def process(method_name, *args) #:nodoc:
       payload = {
         mailer: self.class.name,
-        action: method_name
+        action: method_name,
+        args: args
       }
 
       ActiveSupport::Notifications.instrument("process.action_mailer", payload) do


### PR DESCRIPTION
### Summary 

I would like to add `:args` to `process.action_mailer` event.
Because `args` is useful for investigating when an unexpected error occurs in a method.