### PR TITLE
Indicate action that failed in YamlColumn

### DIFF
--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -14,7 +14,7 @@ module ActiveRecord
       def dump(obj)
         return if obj.nil?
 
-        assert_valid_value(obj)
+        assert_valid_value(obj, action: "dump")
         YAML.dump obj
       end
 
@@ -23,16 +23,16 @@ module ActiveRecord
         return yaml unless yaml.is_a?(String) && /^---/.match?(yaml)
         obj = YAML.load(yaml)
 
-        assert_valid_value(obj)
+        assert_valid_value(obj, action: "load")
         obj ||= object_class.new if object_class != Object
 
         obj
       end
 
-      def assert_valid_value(obj)
+      def assert_valid_value(obj, action:)
         unless obj.nil? || obj.is_a?(object_class)
           raise SerializationTypeMismatch,
-            "Attribute `#{@attr_name}` was supposed to be a #{object_class}, but was a #{obj.class}. -- #{obj.inspect}"
+            "can't #{action} `#{@attr_name}`: was supposed to be a #{object_class}, but was a #{obj.class}. -- #{obj.inspect}"
         end
       end
 

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -43,7 +43,7 @@ module ActiveRecord
 
       def assert_valid_value(value)
         if coder.respond_to?(:assert_valid_value)
-          coder.assert_valid_value(value)
+          coder.assert_valid_value(value, action: "serialize")
         end
       end
 

--- a/activerecord/test/cases/coders/yaml_column_test.rb
+++ b/activerecord/test/cases/coders/yaml_column_test.rb
@@ -10,19 +10,19 @@ module ActiveRecord
       end
 
       def test_type_mismatch_on_different_classes_on_dump
-        coder = YAMLColumn.new("attr_name", Array)
+        coder = YAMLColumn.new("tags", Array)
         error = assert_raises(SerializationTypeMismatch) do
           coder.dump("a")
         end
-        assert_equal %{Attribute `attr_name` was supposed to be a Array, but was a String. -- "a"}, error.to_s
+        assert_equal %{can't dump `tags`: was supposed to be a Array, but was a String. -- "a"}, error.to_s
       end
 
       def test_type_mismatch_on_different_classes
-        coder = YAMLColumn.new("attr_name", Array)
+        coder = YAMLColumn.new("tags", Array)
         error = assert_raises(SerializationTypeMismatch) do
           coder.load "--- foo"
         end
-        assert_equal %{Attribute `attr_name` was supposed to be a Array, but was a String. -- "foo"}, error.to_s
+        assert_equal %{can't load `tags`: was supposed to be a Array, but was a String. -- "foo"}, error.to_s
       end
 
       def test_nil_is_ok

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -250,7 +250,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     error = assert_raise(ActiveRecord::SerializationTypeMismatch) do
       topic.content
     end
-    expected = "Attribute `content` was supposed to be a Array, but was a Hash. -- {:zomg=>true}"
+    expected = "can't load `content`: was supposed to be a Array, but was a Hash. -- {:zomg=>true}"
     assert_equal expected, error.to_s
   end
 


### PR DESCRIPTION
Let's indicate whether serialization failed to load or dump of the attribute.

@rafaelfranca @kaspth 