### PR TITLE
Delegate `to_sentence` and `to_fomatted_s` to `records`

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -38,6 +38,7 @@ module ActiveRecord
 
     delegate :to_xml, :encode_with, :length, :collect, :map, :each, :all?, :include?, :to_ary, :join,
              :[], :&, :|, :+, :-, :sample, :reverse, :compact, :in_groups, :in_groups_of,
+             :to_sentence, :to_formatted_s,
              :shuffle, :split, :index, to: :records
 
     delegate :table_name, :quoted_table_name, :primary_key, :quoted_primary_key,

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -32,7 +32,8 @@ module ActiveRecord
       :exclude?, :find_all, :flat_map, :group_by, :include?, :length,
       :map, :none?, :one?, :partition, :reject, :reverse,
       :sample, :second, :sort, :sort_by, :third,
-      :to_ary, :to_set, :to_xml, :to_yaml, :join
+      :to_ary, :to_set, :to_xml, :to_yaml, :join,
+      :in_groups, :in_groups_of, :to_sentence, :to_formatted_s
     ]
 
     ARRAY_DELEGATES.each do |method|


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/27901