### PR TITLE
Handle html translations within controllers

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Handle `_html` and `.html` i18n keys within controllers.
+
+    *Gavin Miller*
+
 *   Remove deprecated `.to_prepare`, `.to_cleanup`, `.prepare!` and `.cleanup!` from `ActionDispatch::Reloader`.
 
     *Rafael Mendonça França*

--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -27,8 +27,6 @@ module AbstractController
         key = "#{path}.#{action_name}#{key}"
       end
 
-      i18n_raise = false
-
       if html_safe_translation_key?(key)
         html_safe_options = options.dup
         options.except(*I18n::RESERVED_KEYS).each do |name, value|
@@ -36,11 +34,11 @@ module AbstractController
             html_safe_options[name] = ERB::Util.html_escape(value.to_s)
           end
         end
-        translation = I18n.translate(key, html_safe_options.merge(raise: i18n_raise))
+        translation = I18n.translate(key, html_safe_options)
 
         translation.respond_to?(:html_safe) ? translation.html_safe : translation
       else
-        I18n.translate(key, options.merge(raise: i18n_raise))
+        I18n.translate(key, options)
       end
     end
     alias :t :translate

--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -1,13 +1,23 @@
 module AbstractController
   module Translation
-    # Delegates to <tt>I18n.translate</tt>. Also aliased as <tt>t</tt>.
+    # Delegates to <tt>I18n.translate</tt>. Also aliased as <tt>t</tt>. And
+    # performs two additional functions.
     #
-    # When the given key starts with a period, it will be scoped by the current
+    # First, when the given key starts with a period, it will be scoped by the current
     # controller and action. So if you call <tt>translate(".foo")</tt> from
     # <tt>PeopleController#index</tt>, it will convert the call to
     # <tt>I18n.translate("people.index.foo")</tt>. This makes it less repetitive
     # to translate many keys within the same controller / action and gives you a
     # simple framework for scoping them consistently.
+    #
+    # Second, the translation will be marked as <tt>html_safe</tt> if the key has
+    # the suffix "_html" or the last element of the key is "html". Calling
+    # <tt>translate("footer_html")</tt> or <tt>translate("footer.html")</tt>
+    # will return an HTML safe string that won't be escaped by other HTML
+    # helper methods. This naming convention helps to identify translations
+    # that include HTML tags so that you know what kind of output to expect
+    # when you call translate in a controller and translators know which keys
+    # they can provide HTML values for.
     def translate(key, options = {})
       if key.to_s.first == "."
         path = controller_path.tr("/", ".")
@@ -16,7 +26,22 @@ module AbstractController
         options[:default] = defaults
         key = "#{path}.#{action_name}#{key}"
       end
-      I18n.translate(key, options)
+
+      i18n_raise = false
+
+      if html_safe_translation_key?(key)
+        html_safe_options = options.dup
+        options.except(*I18n::RESERVED_KEYS).each do |name, value|
+          unless name == :count && value.is_a?(Numeric)
+            html_safe_options[name] = ERB::Util.html_escape(value.to_s)
+          end
+        end
+        translation = I18n.translate(key, html_safe_options.merge(raise: i18n_raise))
+
+        translation.respond_to?(:html_safe) ? translation.html_safe : translation
+      else
+        I18n.translate(key, options.merge(raise: i18n_raise))
+      end
     end
     alias :t :translate
 
@@ -25,5 +50,11 @@ module AbstractController
       I18n.localize(*args)
     end
     alias :l :localize
+
+    private
+
+      def html_safe_translation_key?(key)
+        /(\b|_|\.)html$/.match?(key.to_s)
+      end
   end
 end

--- a/actionpack/test/abstract/translation_test.rb
+++ b/actionpack/test/abstract/translation_test.rb
@@ -18,6 +18,10 @@ module AbstractController
               translation: {
                 index: {
                   foo: "bar",
+                  foo_html: "<strong>bar</strong>",
+                  baz: {
+                    html: "<strong>baz</strong>"
+                  }
                 },
                 no_action: "no_action_tr",
               },
@@ -69,6 +73,24 @@ module AbstractController
         time, expected = Time.gm(2000), "Sat, 01 Jan 2000 00:00:00 +0000"
         I18n.stub :localize, expected do
           assert_equal expected, @controller.l(time)
+        end
+      end
+
+      def test_html_suffix
+        @controller.stub :action_name, :index do
+          foo_html = @controller.t(".foo_html")
+
+          assert_equal "<strong>bar</strong>", foo_html
+          assert foo_html.html_safe?
+        end
+      end
+
+      def test_html_last_element
+        @controller.stub :action_name, :index do
+          baz_html = @controller.t(".baz.html")
+
+          assert_equal "<strong>baz</strong>", baz_html
+          assert baz_html.html_safe?
         end
       end
     end


### PR DESCRIPTION
Previously translations marked with the _html or .html suffixes were not translated into html_safe objects. As a result, the behaviour between views and controllers differed.

This change brings translations for the two scenarios into closer alignment. To address: https://github.com/rails/rails/issues/27862

----

I'm looking for a bit of guidance on further improvements here. There is a fair amount of duplicate code between this change and `ActionView::Helpers::TranslationHelper`, and so is there a better place where the two pieces of code can be merged together? Seems like `activesupport/lib/active_support/locale/` would be that place?

Additionally, would it be also good to include the [missing translation span tag functionality currently available in views](https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/translation_helper.rb#L38-L42)?

Potential Todos
--------
* [ ] Expand tests and provide better coverage for new functionality
* [ ] Add in missing translation span tags?
* [ ] Refactor to merge with existing [`translate`](https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/translation_helper.rb#L59) method in `ActionView::Helpers`