### PR TITLE
Fix Model.create! and Model.create with empty array

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -45,7 +45,11 @@ module ActiveRecord
       # multiple objects when given an Array of Hashes.
       def create!(attributes = nil, &block)
         if attributes.is_a?(Array)
-          attributes.collect { |attr| create!(attr, &block) }
+          if attributes.empty?
+            new.save!
+          else
+            attributes.collect { |attr| create!(attr, &block) }
+          end
         else
           object = new(attributes, &block)
           object.save!

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -28,7 +28,11 @@ module ActiveRecord
       #   end
       def create(attributes = nil, &block)
         if attributes.is_a?(Array)
-          attributes.collect { |attr| create(attr, &block) }
+          if attributes.empty?
+            new.save
+          else
+            attributes.collect { |attr| create(attr, &block) }
+          end
         else
           object = new(attributes, &block)
           object.save

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -333,6 +333,10 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal "David", topic2.author_name
   end
 
+  def test_create_bang_with_empty_array
+    assert_raise(ActiveRecord::RecordInvalid) { WrongReply.create!([]) }
+  end
+
   def test_update_object
     topic = Topic.new
     topic.title = "Another New Topic"

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -337,6 +337,10 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::RecordInvalid) { WrongReply.create!([]) }
   end
 
+  def test_create_with_empty_array
+    assert_equal WrongReply.create([]), false
+  end
+
   def test_update_object
     topic = Topic.new
     topic.title = "Another New Topic"


### PR DESCRIPTION
### Summary

If an model (say User) has validations and
```ruby
User.create!([])
```
should raise `ActiveRecord::RecordInvalid`
```ruby
User.create([])
```
 should return false.

But currently it will return `[]` in both cases. This is because `[].collect` returns an empty array directly instead of evaluates the block.

(This should fix #27910 )