### PR TITLE
Fix `bundle install` error occurring in 5-0-stable branch and Oracle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,7 +131,7 @@ if ENV['ORACLE_ENHANCED']
   platforms :ruby do
     gem 'ruby-oci8', '~> 2.2'
   end
-  gem 'activerecord-oracle_enhanced-adapter', github: 'rsim/oracle-enhanced', branch: 'master'
+  gem 'activerecord-oracle_enhanced-adapter', github: 'rsim/oracle-enhanced', branch: 'release17'
 end
 
 # A gem necessary for Active Record tests with IBM DB.


### PR DESCRIPTION
### Summary

The currently master branch of activerecord-oracle_enhanced-adapter is for AR 5.1.x.

https://github.com/rsim/oracle-enhanced/blob/5dd08072b2376a0f52a000dff6f300b665983448/activerecord-oracle_enhanced-adapter.gemspec#L90-L91

In Oracle environment, Running `bundle install` on 5-0-stable branch will cause the following error.

```sh
% echo $ORACLE_ENHANCED
true
% git rev-parse - abbrev-ref HEAD
5-0-stable
% bundle install

(Snip)

Fetching https://github.com/rsim/oracle-enhanced.git
Fetching gem metadata from https: //rubygems.org / .........
Fetching version metadata from https://rubygems.org/ ..
Fetching dependency metadata from https://rubygems.org/.
Resolving dependencies ...
Bundler could not find compatible versions for gem "arel":
  In snapshot (Gemfile.lock):
    Arel (= 7.1.4)

  In Gemfile:
    Rails was resolved to 5.0.1, which depends on
      Activerecord (= 5.0.1) was resolved to 5.0.1, which depends on
        Arel (~> 7.0)

    Rails was resolved to 5.0.1, which depends on
      Activerecord (= 5.0.1) was resolved to 5.0.1, which depends on
        Arel (~> 7.0) x64-mingw32

    Rails was resolved to 5.0.1, which depends on
      Activerecord (= 5.0.1) was resolved to 5.0.1, which depends on
        Arel (~> 7.0) x86-mingw32

    Activerecord-oracle_enhanced-adapter was resolved to 1.8.0.alpha, which depends on
      Arel (~> 8.0)

    Activerecord-oracle_enhanced-adapter was resolved to 1.8.0.alpha, which depends on
      Arel (~> 8.0) x64-mingw32

    Activerecord-oracle_enhanced-adapter was resolved to 1.8.0.alpha, which depends on
      Arel (~> 8.0) x86-mingw32

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

The version of activerecord-oracle_enhanced-adapter for AR 5.0.x is 1.7.x.

https://github.com/rsim/oracle-enhanced#rails-50

This problem can be solved by specifying the release17 branch to activerecord-oracle_enhanced-adapter for 5-0-stable branch. This PR takes that solution.
