### PR TITLE
Bust ActiveSupport::TimeZone.all cache

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Bust `ActiveSupport::TimeZone.all` cache when looking up timezones
+
+    Fixes #7245
+
+    *Daniel Colson*
+
 *   Deprecate `.halt_callback_chains_on_return_false`.
 
     *Rafael Mendonça França*

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -228,7 +228,12 @@ module ActiveSupport
         case arg
         when String
           begin
-            @lazy_zones_map[arg] ||= create(arg)
+            if @lazy_zones_map[arg].nil?
+              @lazy_zones_map[arg] = create(arg)
+              @zones = nil
+            end
+
+            @lazy_zones_map[arg]
           rescue TZInfo::InvalidTimezoneIdentifier
             nil
           end

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -501,6 +501,13 @@ class TimeZoneTest < ActiveSupport::TestCase
     end
   end
 
+  def test_new_zone_busts_all_cache
+    old_all = ActiveSupport::TimeZone.all
+    chicago = ActiveSupport::TimeZone["America/Chicago"]
+    assert_not(old_all.include?(chicago))
+    assert(ActiveSupport::TimeZone.all.include?(chicago))
+  end
+
   def test_index
     assert_nil ActiveSupport::TimeZone["bogus"]
     assert_instance_of ActiveSupport::TimeZone, ActiveSupport::TimeZone["Central Time (US & Canada)"]


### PR DESCRIPTION
Fixes #7245 as discussed in #22651.