### PR TITLE
Do not use `Arel.star` when `ignored_columns`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1042,7 +1042,11 @@ module ActiveRecord
         if select_values.any?
           arel.project(*arel_columns(select_values.uniq))
         else
-          arel.project(@klass.arel_table[Arel.star])
+          if @klass.ignored_columns.any?
+            arel.project(*arel_columns(@klass.column_names))
+          else
+            arel.project(@klass.arel_table[Arel.star])
+          end
         end
       end
 

--- a/activerecord/test/cases/adapters/mysql2/explain_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/explain_test.rb
@@ -1,21 +1,21 @@
 require "cases/helper"
-require "models/developer"
-require "models/computer"
+require "models/author"
+require "models/post"
 
 class Mysql2ExplainTest < ActiveRecord::Mysql2TestCase
-  fixtures :developers
+  fixtures :authors
 
   def test_explain_for_one_query
-    explain = Developer.where(id: 1).explain
-    assert_match %(EXPLAIN for: SELECT `developers`.* FROM `developers` WHERE `developers`.`id` = 1), explain
-    assert_match %r(developers |.* const), explain
+    explain = Author.where(id: 1).explain
+    assert_match %(EXPLAIN for: SELECT `authors`.* FROM `authors` WHERE `authors`.`id` = 1), explain
+    assert_match %r(authors |.* const), explain
   end
 
   def test_explain_with_eager_loading
-    explain = Developer.where(id: 1).includes(:audit_logs).explain
-    assert_match %(EXPLAIN for: SELECT `developers`.* FROM `developers` WHERE `developers`.`id` = 1), explain
-    assert_match %r(developers |.* const), explain
-    assert_match %(EXPLAIN for: SELECT `audit_logs`.* FROM `audit_logs` WHERE `audit_logs`.`developer_id` = 1), explain
-    assert_match %r(audit_logs |.* ALL), explain
+    explain = Author.where(id: 1).includes(:posts).explain
+    assert_match %(EXPLAIN for: SELECT `authors`.* FROM `authors` WHERE `authors`.`id` = 1), explain
+    assert_match %r(authors |.* const), explain
+    assert_match %(EXPLAIN for: SELECT `posts`.* FROM `posts` WHERE `posts`.`author_id` = 1), explain
+    assert_match %r(posts |.* ALL), explain
   end
 end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1525,4 +1525,25 @@ class BasicsTest < ActiveRecord::TestCase
     assert Developer.new.respond_to?(:last_name=)
     assert Developer.new.respond_to?(:last_name?)
   end
+
+  test "when #reload called, ignored columns' attribute methods are not defined" do
+    developer = Developer.create!(name: "Developer")
+    refute developer.respond_to?(:first_name)
+    refute developer.respond_to?(:first_name=)
+
+    developer.reload
+
+    refute developer.respond_to?(:first_name)
+    refute developer.respond_to?(:first_name=)
+  end
+
+  test "ignored columns not included in SELECT" do
+    query = Developer.all.to_sql
+
+    # ignored column
+    refute query.include?("first_name")
+
+    # regular column
+    assert query.include?("name")
+  end
 end

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -469,9 +469,9 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   test "a scope can remove the condition from the default scope" do
-    scope = DeveloperCalledJamis.david2
+    scope = DeveloperCalledJamis.jamis2
     assert_equal 1, scope.where_clause.ast.children.length
-    assert_equal Developer.where(name: "David"), scope
+    assert_equal DeveloperCalledJamis.where("salary < 10000").to_a, scope.to_a
   end
 
   def test_with_abstract_class_where_clause_should_not_be_duplicated

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -175,6 +175,7 @@ class DeveloperCalledJamis < ActiveRecord::Base
 
   default_scope { where(name: "Jamis") }
   scope :poor, -> { where("salary < 150000") }
+  scope :jamis2, -> { unscoped.where("salary < 10000") }
   scope :david, -> { where name: "David" }
   scope :david2, -> { unscoped.where name: "David" }
 end


### PR DESCRIPTION
### Summary

If there are any ignored columns, we will now list out all columns we
want to be returned from the database.

### Other Information

- Includes a regression test.
- Re: the test I had to change, it should have never been passing in the
first place, due to the ignored `first_name` column on `Developer.