### PR TITLE
Add note about configuration to template file

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -25,6 +25,10 @@ module <%= app_const_base %>
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    # Some configuration such as config.time_zone should define here because
+    # they are initialized before Railtie's initializing process.
+    # config.time_zone = 'Central Time (US & Canada)'
 <%- if options[:api] -%>
 
     # Only loads a smaller set of middleware suitable for API only apps.

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -26,8 +26,8 @@ module <%= app_const_base %>
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    # Some configuration such as config.time_zone should define here because
-    # they are initialized before Railtie's initializing process.
+    # Some configurations such as config.time_zone should be defined here
+    # because they are initialized before Railtie's initializing process.
     # config.time_zone = 'Central Time (US & Canada)'
 <%- if options[:api] -%>
 


### PR DESCRIPTION
For example, `config.time_zone` is referred by [ActiveSupport](https://github.com/rails/rails/blob/791bdf6fb350b5cb272e4277c1b2b3d04beb7a35/activesupport/lib/active_support/railtie.rb#L25), which initializes
before Railtie's initialize process.

They should be configured before that process, so I think Rails should note to
developers about this matter.

ref: https://github.com/rails/rails/issues/24748#issuecomment-216317145

(Please close this PR if this issue is not even a thing)