### PR TITLE
Move some ActionCable logs to debug level

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -205,7 +205,7 @@ module ActionCable
         # Transmit a hash of data to the subscriber. The hash will automatically be wrapped in a JSON envelope with
         # the proper channel identifier marked as the recipient.
         def transmit(data, via: nil) # :doc:
-          logger.info "#{self.class.name} transmitting #{data.inspect.truncate(300)}".tap { |m| m << " (via #{via})" if via }
+          logger.debug "#{self.class.name} transmitting #{data.inspect.truncate(300)}".tap { |m| m << " (via #{via})" if via }
 
           payload = { channel_class: self.class.name, data: data, via: via }
           ActiveSupport::Notifications.instrument("transmit.action_cable", payload) do

--- a/actioncable/lib/action_cable/server/broadcasting.rb
+++ b/actioncable/lib/action_cable/server/broadcasting.rb
@@ -38,7 +38,7 @@ module ActionCable
           end
 
           def broadcast(message)
-            server.logger.info "[ActionCable] Broadcasting to #{broadcasting}: #{message.inspect}"
+            server.logger.debug "[ActionCable] Broadcasting to #{broadcasting}: #{message.inspect}"
 
             payload = { broadcasting: broadcasting, message: message, coder: coder }
             ActiveSupport::Notifications.instrument("broadcast.action_cable", payload) do


### PR DESCRIPTION
### Summary

Currently, ActionCable logs all broadcasted/transmitted info with level 'info'. This seems unnecessary; we don't log complete HTTP responses either. To avoid filling up production logs I propose to move the 'FooBarChannel transmitting …' and '[ActionCable] broadcasting to …' to debug level.
