### PR TITLE
Add test for DateTime#blank?

### DIFF
--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -395,6 +395,10 @@ class DateExtBehaviorTest < ActiveSupport::TestCase
     assert Date.new.acts_like_date?
   end
 
+  def test_blank?
+    assert_not Date.new.blank?
+  end
+
   def test_freeze_doesnt_clobber_memoized_instance_methods
     assert_nothing_raised do
       Date.today.freeze.inspect

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -318,6 +318,10 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert DateTime.new.acts_like_time?
   end
 
+  def test_blank?
+    assert_not DateTime.new.blank?
+  end
+
   def test_utc?
     assert_equal true, DateTime.civil(2005, 2, 21, 10, 11, 12).utc?
     assert_equal true, DateTime.civil(2005, 2, 21, 10, 11, 12, 0).utc?

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -455,6 +455,10 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal false, ActiveSupport::TimeWithZone.new(DateTime.civil(2000), @time_zone).acts_like?(:date)
   end
 
+  def test_blank?
+    assert_not @twz.blank?
+  end
+
   def test_is_a
     assert_kind_of Time, @twz
     assert_kind_of Time, @twz


### PR DESCRIPTION
Currently there are no tests for `DateTime#blank?`
Even after I make the method return `true` as an experiment, all the tests were passed :P