### PR TITLE
Remove the top-level `HashWithIndifferentAccess` contant

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -50,7 +50,7 @@ module ActiveRecord
         super.tap do
           @previous_mutation_tracker = nil
           clear_mutation_trackers
-          @changed_attributes = HashWithIndifferentAccess.new
+          @changed_attributes = ActiveSupport::HashWithIndifferentAccess.new
         end
       end
 
@@ -70,13 +70,13 @@ module ActiveRecord
 
       def changes_applied
         @previous_mutation_tracker = mutation_tracker
-        @changed_attributes = HashWithIndifferentAccess.new
+        @changed_attributes = ActiveSupport::HashWithIndifferentAccess.new
         clear_mutation_trackers
       end
 
       def clear_changes_information
         @previous_mutation_tracker = nil
-        @changed_attributes = HashWithIndifferentAccess.new
+        @changed_attributes = ActiveSupport::HashWithIndifferentAccess.new
         forget_attribute_assignments
         clear_mutation_trackers
       end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecated the top level `HashWithIndifferentAccess` constant.
+
+    Only `ActiveSupport::HashWithIndifferentAccess` should be used now.
+
+    *Robin Dupret* (#27925)
+
 *   Deprecate `.halt_callback_chains_on_return_false`.
 
     *Rafael Mendonça França*

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -316,4 +316,20 @@ module ActiveSupport
   end
 end
 
-HashWithIndifferentAccess = ActiveSupport::HashWithIndifferentAccess
+class HashWithIndifferentAccess < ActiveSupport::HashWithIndifferentAccess
+  def initialize(*)
+    ActiveSupport::Deprecation.warn "HashWithIndifferentAccess is deprecated!" \
+                                    "Use ActiveSupport::HashWithIndifferentAccess instead."
+    super
+  end
+
+  def self.inherited(*)
+    ActiveSupport::Deprecation.warn "HashWithIndifferentAccess is deprecated!" \
+                                    "Use ActiveSupport::HashWithIndifferentAccess instead."
+    super
+  end
+
+  def encode_with(coder)
+    coder.represent_object(nil, ActiveSupport::HashWithIndifferentAccess.new(self))
+  end
+end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -8,6 +8,8 @@ require "active_support/core_ext/object/deep_dup"
 require "active_support/inflections"
 
 class HashExtTest < ActiveSupport::TestCase
+  HashWithIndifferentAccess = ActiveSupport::HashWithIndifferentAccess
+
   class IndifferentHash < ActiveSupport::HashWithIndifferentAccess
   end
 
@@ -1078,6 +1080,25 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal 1, hash[:a]
     assert_equal 3, hash[:b]
   end
+
+  def test_top_level_hash_with_indifferent_access_is_deprecated
+    assert_deprecated do
+      ::HashWithIndifferentAccess.new
+    end
+  end
+
+  def test_top_level_hash_with_indifferent_access_can_be_extended
+    assert_deprecated do
+      Class.new(::HashWithIndifferentAccess)
+    end
+  end
+
+  def test_yaml_encoding_outputs_an_activesupport_namespaced_constant
+    ActiveSupport::Deprecation.silence do
+      instance = ::HashWithIndifferentAccess.new
+      assert_includes instance.to_yaml, "ActiveSupport::HashWithIndifferentAccess"
+    end
+  end
 end
 
 class IWriteMyOwnXML
@@ -1123,6 +1144,8 @@ class HashExtToParamTests < ActiveSupport::TestCase
 end
 
 class HashToXmlTest < ActiveSupport::TestCase
+  HashWithIndifferentAccess = ActiveSupport::HashWithIndifferentAccess
+
   def setup
     @xml_options = { root: :person, skip_instruct: true, indent: 0 }
   end


### PR DESCRIPTION
Hi,

This pull request removes the top level `HashWithIndifferentAccess` constant. It was kept for the sake of backward compatibility; it is still available under `ActiveSupport::HashWithIndifferentAccess`.

Furthermore, since Ruby 2.5 (https://bugs.ruby-lang.org/issues/11547) won't support top level constant lookup, people would have to update their code anyway.

I defined a `HashWithIndifferentAccess` constant inside tests to avoid polluting the log and make blames harder but let me know if I should rather update the different tests with the full constant qualifier.

Cross refs #27863.

Have a nice day !
