### PR TITLE
Freeze fragment cache related instrument name.

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -972,7 +972,7 @@ module ActionMailer
       end
 
       def instrument_name
-        "action_mailer"
+        "action_mailer".freeze
       end
 
       ActiveSupport.run_load_hooks(:action_mailer, self)

--- a/actionpack/lib/abstract_controller/caching/fragments.rb
+++ b/actionpack/lib/abstract_controller/caching/fragments.rb
@@ -136,7 +136,7 @@ module AbstractController
 
       def instrument_fragment_cache(name, key) # :nodoc:
         payload = instrument_payload(key)
-        ActiveSupport::Notifications.instrument("#{name}.#{instrument_name}", payload) { yield }
+        ActiveSupport::Notifications.instrument("#{name}.#{instrument_name}".freeze, payload) { yield }
       end
     end
   end

--- a/actionpack/lib/action_controller/caching.rb
+++ b/actionpack/lib/action_controller/caching.rb
@@ -38,7 +38,7 @@ module ActionController
       end
 
       def instrument_name
-        "action_controller"
+        "action_controller".freeze
       end
   end
 end


### PR DESCRIPTION
### Summary

`ActionMailer::Base#instrument_name` and
`ActionController::Base#instrument_name` will be frequently called once
caching is enabled. So it's better to freeze them instead of creating new
string on every call.

Also, the instrument name in #instrument_fragment_cache will usually
be `"write_fragment.action_controller"` or
`"read_fragment.action_controller"`. So freezing them might also gain some
performance improvement. We have done something like this in other places:
https://github.com/rails/rails/blob/master/actionview/lib/action_view/template.rb#L348
