### PR TITLE
Removes unnecessary require lines

### DIFF
--- a/activerecord/test/support/config.rb
+++ b/activerecord/test/support/config.rb
@@ -1,6 +1,5 @@
 require "yaml"
 require "erb"
-require "fileutils"
 require "pathname"
 
 module ARTest

--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -1,5 +1,4 @@
 require 'pathname'
-require 'fileutils'
 include FileUtils
 
 # path to your application root.

--- a/railties/lib/rails/generators/rails/app/templates/bin/update.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/update.tt
@@ -1,5 +1,4 @@
 require 'pathname'
-require 'fileutils'
 include FileUtils
 
 # path to your application root.


### PR DESCRIPTION
`"fileutils"` functionality is provided by `"pathname"`.