### PR TITLE
Remove `ActiveModel::TestCase` from lib

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove unused `ActiveModel::TestCase` class.
+
+    *Yuji Yaginuma*
+
 *   Moved DecimalWithoutScale, Text, and UnsignedInteger from Active Model to Active Record
 
     *Iain Beeston*

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -42,7 +42,6 @@ module ActiveModel
   autoload :Naming
   autoload :SecurePassword
   autoload :Serialization
-  autoload :TestCase
   autoload :Translation
   autoload :Validations
   autoload :Validator

--- a/activemodel/lib/active_model/test_case.rb
+++ b/activemodel/lib/active_model/test_case.rb
@@ -1,4 +1,0 @@
-module ActiveModel #:nodoc:
-  class TestCase < ActiveSupport::TestCase #:nodoc:
-  end
-end

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -9,7 +9,7 @@ I18n.enforce_available_locales = false
 require "active_support/testing/autorun"
 require "active_support/testing/method_call_assertions"
 
-class ActiveModel::TestCase
+class ActiveModel::TestCase < ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 
   # Skips the current run on Rubinius using Minitest::Assertions#skip


### PR DESCRIPTION
`ActiveModel::TestCase` is used only for the test of Active Model.
Also, it is a private API and can not be used in applications.
Therefore, it is not necessary to include it in lib.
