### PR TITLE
Remove useless `MySQL::Column` tests

### DIFF
--- a/activerecord/test/cases/column_definition_test.rb
+++ b/activerecord/test/cases/column_definition_test.rb
@@ -37,48 +37,6 @@ module ActiveRecord
           column.limit, column.precision, column.scale, column.default, column.null)
         assert_equal "title varchar(20) DEFAULT 'Hello' NOT NULL", @viz.accept(column_def)
       end
-
-      if current_adapter?(:Mysql2Adapter)
-        def test_should_set_default_for_mysql_binary_data_types
-          type = SqlTypeMetadata.new(type: :binary, sql_type: "binary(1)")
-          binary_column = MySQL::Column.new("title", "a", type)
-          assert_equal "a", binary_column.default
-
-          type = SqlTypeMetadata.new(type: :binary, sql_type: "varbinary")
-          varbinary_column = MySQL::Column.new("title", "a", type)
-          assert_equal "a", varbinary_column.default
-        end
-
-        def test_should_be_empty_string_default_for_mysql_binary_data_types
-          type = SqlTypeMetadata.new(type: :binary, sql_type: "binary(1)")
-          binary_column = MySQL::Column.new("title", "", type, false)
-          assert_equal "", binary_column.default
-
-          type = SqlTypeMetadata.new(type: :binary, sql_type: "varbinary")
-          varbinary_column = MySQL::Column.new("title", "", type, false)
-          assert_equal "", varbinary_column.default
-        end
-
-        def test_should_not_set_default_for_blob_and_text_data_types
-          text_type = MySQL::TypeMetadata.new(SqlTypeMetadata.new(type: :text))
-
-          text_column = MySQL::Column.new("title", nil, text_type)
-          assert_nil text_column.default
-
-          not_null_text_column = MySQL::Column.new("title", nil, text_type, false)
-          assert_nil not_null_text_column.default
-        end
-
-        def test_has_default_should_return_false_for_blob_and_text_data_types
-          binary_type = SqlTypeMetadata.new(sql_type: "blob")
-          blob_column = MySQL::Column.new("title", nil, binary_type)
-          assert !blob_column.has_default?
-
-          text_type = SqlTypeMetadata.new(type: :text)
-          text_column = MySQL::Column.new("title", nil, text_type)
-          assert !text_column.has_default?
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Since text default treated as an empty string in non-strict mode has
been removed in #26154, `MySQL::Column` behaves like any other column.
Also, The difference between strict and non-strict mode is covered by
`test_mysql_not_null_defaults_strict` and `test_mysql_not_null_defaults_non_strict`.