### PR TITLE
Skip record_name argument when using #fields_for helper with nested attributes

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Change `ActionView::FormHelper#fields_for` for skipping
+    record_name argument when making nested attributes forms.
+
+    For example,
+
+    ```erb
+    <%= form_for @user, url: '' do |f| %>
+      <%= f.fields_for :post, @user.post do |pf| %>
+        <%= pf.text_field :title %>
+      <% end %>
+    <% end %>
+    ```
+
+    would be equivalent to
+
+    ```erb
+    <%= form_for @user, url: '' do |f| %>
+      <%= f.fields_for @user.post do |pf| %>
+        <%= pf.text_field :title %>
+      <% end %>
+    <% end %>
+    ```
+
+    In both cases title field's name would both be `user[post_attributes][title]`.
+
+    *Stan Lo*
+
 *   Change the ERB handler from Erubis to Erubi.
 
     Erubi is an Erubis fork that's svelte, simple, and currently maintained.

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1914,22 +1914,19 @@ module ActionView
         fields_options[:namespace] = options[:namespace]
         fields_options[:parent_builder] = self
 
-        case record_name
-        when String, Symbol
-          if nested_attributes_association?(record_name)
-            return fields_for_with_nested_attributes(record_name, record_object, fields_options, block)
-          end
-        else
+        if !record_name.is_a?(String) && !record_name.is_a?(Symbol)
           record_object = record_name
-          if record_object.is_a?(Array)
-            object_for_model_name = record_object.last
-            record_name = model_name_from_record_or_class(object_for_model_name).param_key.pluralize
-          else
-            record_name = model_name_from_record_or_class(record_object).param_key
-          end
-          if nested_attributes_association?(record_name)
-            return fields_for_with_nested_attributes(record_name, record_object, fields_options, block)
-          end
+          record_name =
+            if record_object.is_a?(Array)
+              object_for_model_name = record_object.last
+              model_name_from_record_or_class(object_for_model_name).param_key.pluralize
+            else
+              model_name_from_record_or_class(record_object).param_key
+            end
+        end
+
+        if nested_attributes_association?(record_name)
+          return fields_for_with_nested_attributes(record_name, record_object, fields_options, block)
         end
 
         object_name = @object_name

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1920,8 +1920,16 @@ module ActionView
             return fields_for_with_nested_attributes(record_name, record_object, fields_options, block)
           end
         else
-          record_object = record_name.is_a?(Array) ? record_name.last : record_name
-          record_name   = model_name_from_record_or_class(record_object).param_key
+          record_object = record_name
+          if record_object.is_a?(Array)
+            object_for_model_name = record_object.last
+            record_name = model_name_from_record_or_class(object_for_model_name).param_key.pluralize
+          else
+            record_name = model_name_from_record_or_class(record_object).param_key
+          end
+          if nested_attributes_association?(record_name)
+            return fields_for_with_nested_attributes(record_name, record_object, fields_options, block)
+          end
         end
 
         object_name = @object_name

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2513,73 +2513,6 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
-  def test_nested_fields_for_with_existing_records_without_record_name_on_a_nested_attributes_collection_association_with_explicit_hidden_field_placement
-    @post.comments = Array.new(2) { |id| Comment.new(id + 1) }
-
-    form_for(@post) do |f|
-      concat f.text_field(:title)
-      @post.comments.each do |comment|
-        concat f.fields_for(comment) { |cf|
-          concat cf.hidden_field(:id)
-          concat cf.text_field(:name)
-        }
-      end
-    end
-
-    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
-    end
-
-    assert_dom_equal expected, output_buffer
-  end
-
-  def test_nested_fields_for_with_new_records_without_record_name_on_a_nested_attributes_collection_association
-    @post.comments = [Comment.new, Comment.new]
-
-    form_for(@post) do |f|
-      concat f.text_field(:title)
-      @post.comments.each do |comment|
-        concat f.fields_for(comment) { |cf|
-          concat cf.text_field(:name)
-        }
-      end
-    end
-
-    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="new comment" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment" />'
-    end
-
-    assert_dom_equal expected, output_buffer
-  end
-
-  def test_nested_fields_for_with_existing_and_new_records_without_record_name_on_a_nested_attributes_collection_association
-    @post.comments = [Comment.new(321), Comment.new]
-
-    form_for(@post) do |f|
-      concat f.text_field(:title)
-      @post.comments.each do |comment|
-        concat f.fields_for(comment) { |cf|
-          concat cf.text_field(:name)
-        }
-      end
-    end
-
-    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #321" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment" />'
-    end
-
-    assert_dom_equal expected, output_buffer
-  end
-
   def test_nested_fields_for_with_existing_records_without_record_name_on_a_supplied_nested_attributes_collection
     @post.comments = Array.new(2) { |id| Comment.new(id + 1) }
 
@@ -2601,27 +2534,27 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
-  def test_nested_fields_for_arel_like_without_record_name
-    @post.comments = ArelLike.new
+#   Not sure if we should support arel like objects without record_name given.
+#   def test_nested_fields_for_arel_like_without_record_name
+#     @post.comments = ArelLike.new
 
-    form_for(@post) do |f|
-      concat f.text_field(:title)
-      concat f.fields_for(@post.comments) { |cf|
-        concat cf.text_field(:name)
-      }
-    end
+#     form_for(@post) do |f|
+#       concat f.text_field(:title)
+#       concat f.fields_for(@post.comments) { |cf|
+#         concat cf.text_field(:name)
+#       }
+#     end
 
-    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' \
-      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />'
-    end
+#     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
+#       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
+#       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
+#       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' \
+#       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' \
+#       '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />'
+#     end
 
-    assert_dom_equal expected, output_buffer
-  end
-
+#     assert_dom_equal expected, output_buffer
+#   end
 
   def test_nested_fields_for_with_existing_records_without_record_name_on_a_supplied_nested_attributes_collection_different_from_record_one
     comments = Array.new(2) { |id| Comment.new(id + 1) }

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2534,28 +2534,6 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
-#   Not sure if we should support arel like objects without record_name given.
-#   def test_nested_fields_for_arel_like_without_record_name
-#     @post.comments = ArelLike.new
-
-#     form_for(@post) do |f|
-#       concat f.text_field(:title)
-#       concat f.fields_for(@post.comments) { |cf|
-#         concat cf.text_field(:name)
-#       }
-#     end
-
-#     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-#       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-#       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-#       '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' \
-#       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' \
-#       '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />'
-#     end
-
-#     assert_dom_equal expected, output_buffer
-#   end
-
   def test_nested_fields_for_with_existing_records_without_record_name_on_a_supplied_nested_attributes_collection_different_from_record_one
     comments = Array.new(2) { |id| Comment.new(id + 1) }
     @post.comments = []
@@ -2968,6 +2946,18 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_nested_fields_label_translation_with_more_than_10_records
+    @post.comments = Array.new(11) { |id| Comment.new(id + 1) }
+
+    params = 11.times.map { ["post.comments.body", default: [:"comment.body", ""], scope: "helpers.label"] }
+    assert_called_with(I18n, :t, params, returns: "Write body here") do
+      form_for(@post) do |f|
+        f.fields_for(:comments) do |cf|
+          concat cf.label(:body)
+        end
+      end
+    end
+  end
 
   def test_nested_fields_for_with_existing_records_on_a_supplied_nested_attributes_collection_different_from_record_one
     comments = Array.new(2) { |id| Comment.new(id + 1) }
@@ -3069,19 +3059,6 @@ class FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal expected, output_buffer
-  end
-
-  def test_nested_fields_label_translation_with_more_than_10_records
-    @post.comments = Array.new(11) { |id| Comment.new(id + 1) }
-
-    params = 11.times.map { ["post.comments.body", default: [:"comment.body", ""], scope: "helpers.label"] }
-    assert_called_with(I18n, :t, params, returns: "Write body here") do
-      form_for(@post) do |f|
-        f.fields_for(:comments) do |cf|
-          concat cf.label(:body)
-        end
-      end
-    end
   end
 
   def test_nested_fields_for_index_method_with_existing_records_on_a_nested_attributes_collection_association


### PR DESCRIPTION
Currently if we want to use `#fields_for` with nested attributes, we need to pass record's name before record object:
```ruby
<%= form_for @role, url: '' do |f| %>
  <%= f.fields_for :user, @role.user do |uf| %>
    <%= uf.email_field :email %>
  <% end %>
<% end %>
```
So we can get `role[user_attributes][email]` for email field's name.

And this PR allow we skip the first argument and just pass the object and get same result.
```ruby
<%= form_for @role, url: '' do |f| %>
  <%= f.fields_for @role.user do |uf| %>
    <%= uf.email_field :email %>
  <% end %>
<% end %>
```

This is inspired by #27892 