### PR TITLE
Revert "Remove useless `column_alias` in `subquery_for_count`"

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -364,14 +364,15 @@ module ActiveRecord
       end
 
       def build_count_subquery(relation, column_name, distinct)
+        column_alias = Arel.sql("count_column")
         subquery_alias = Arel.sql("subquery_for_count")
 
-        aliased_column = aggregate_column(column_name == :all ? "1" : column_name)
+        aliased_column = aggregate_column(column_name == :all ? 1 : column_name).as(column_alias)
         relation.select_values = [aliased_column]
         subquery = relation.arel.as(subquery_alias)
 
         sm = Arel::SelectManager.new relation.engine
-        select_value = operation_over_aggregate_column(Arel.star, "count", distinct)
+        select_value = operation_over_aggregate_column(column_alias, "count", distinct)
         sm.project(select_value).from(subquery)
       end
   end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -170,7 +170,6 @@ class CalculationsTest < ActiveRecord::TestCase
 
     assert_equal 3, accounts.count(:firm_id)
     assert_equal 3, accounts.select(:firm_id).count
-    assert_equal 3, accounts.select("firm_id firm_id").count
   end
 
   def test_limit_should_apply_before_count_arel_attribute


### PR DESCRIPTION
This reverts commit 28977f1fa3d7b15c1608174a165e60b71ddf3995.

Because this change causes CI failure.