### PR TITLE
Fix inspection behavior when the :id column is not primary key

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix inspection behavior when the :id column is not primary key.
+
+    *namusyaka*
+
 *   Deprecate locking records with unpersisted changes.
 
     *Marc Schütz*

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -54,7 +54,7 @@ module ActiveRecord
           attr_name.to_s
         end
 
-        name = self.class.primary_key if name == "id".freeze
+        name = self.class.primary_key if name == "id".freeze && self.class.primary_key
         _read_attribute(name, &block)
       end
 

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -7,6 +7,7 @@ require "models/movie"
 require "models/keyboard"
 require "models/mixed_case_monkey"
 require "models/dashboard"
+require "models/non_primary_key"
 
 class PrimaryKeysTest < ActiveRecord::TestCase
   fixtures :topics, :subscribers, :movies, :mixed_case_monkeys
@@ -87,6 +88,12 @@ class PrimaryKeysTest < ActiveRecord::TestCase
 
     subscriberReloaded = Subscriber.find("jdoe")
     assert_equal("John Doe", subscriberReloaded.name)
+  end
+
+  def test_id_column_that_is_not_primary_key
+    NonPrimaryKey.create!(id: 100)
+    actual = NonPrimaryKey.find_by(id: 100)
+    assert_match %r{<NonPrimaryKey id: 100}, actual.inspect
   end
 
   def test_find_with_more_than_one_string_key

--- a/activerecord/test/models/non_primary_key.rb
+++ b/activerecord/test/models/non_primary_key.rb
@@ -1,0 +1,2 @@
+class NonPrimaryKey < ActiveRecord::Base
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1039,6 +1039,10 @@ ActiveRecord::Schema.define do
   create_table :test_with_keyword_column_name, force: true do |t|
     t.string :desc
   end
+
+  create_table :non_primary_keys, force: true, id: false do |t|
+    t.integer :id
+  end
 end
 
 Course.connection.create_table :courses, force: true do |t|


### PR DESCRIPTION
### Summary

When the `:id` column is not primary key,  inspection does not work correctly.
So I fixed the issue by adding condition to force overwrite attribute name for reading value

Currently, I think that attribute name is false when reading the `:id` column.
