### PR TITLE
Refactor middleware stack to track delete middlewares

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -89,7 +89,7 @@ module ActionDispatch
     end
 
     def delete(target)
-      index = middlewares.index { |m| m.klass == target }
+      index = middleware_index(target)
       previous_middleware = middlewares[index - 1]
       next_middleware = middlewares[index + 1]
       @deleted_middlewares[middlewares[index].klass] = { previous: previous_middleware.klass, next: next_middleware.klass }
@@ -112,7 +112,7 @@ module ActionDispatch
         else
           index = target_deleted(index, where)
 
-          i = middlewares.index { |m| m.klass == index }
+          i = middleware_index(index)
         end
 
         raise "No such middleware to insert #{where}: #{index.inspect}" unless i
@@ -130,6 +130,10 @@ module ActionDispatch
         end
 
         new_target || target
+      end
+
+      def middleware_index(klass)
+        middlewares.index { |m| m.klass == klass }
       end
 
       def build_middleware(klass, args, block)

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -108,9 +108,13 @@ module ActionDispatch
         if index.is_a?(Integer)
           i = index
         else
-          index = target_deleted(index, where)
+          if target_deleted?(index)
+            target = target_deleted(index, where)
+          else
+            target = index
+          end
 
-          i = middleware_index(index)
+          i = middleware_index(target)
         end
 
         raise "No such middleware to insert #{where}: #{index.inspect}" unless i
@@ -118,16 +122,16 @@ module ActionDispatch
         i
       end
 
-      def target_deleted(target, where)
-        if @deleted_middlewares[target]
-          if where == :after
-            new_target = @deleted_middlewares[target][:previous]
-          else
-            new_target = @deleted_middlewares[target][:next]
-          end
-        end
+      def target_deleted?(target)
+        @deleted_middlewares.key?(target)
+      end
 
-        new_target || target
+      def target_deleted(target, where)
+        if where == :after
+          new_target = @deleted_middlewares[target][:previous]
+        else
+          new_target = @deleted_middlewares[target][:next]
+        end
       end
 
       def middleware_index(klass)

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -110,6 +110,8 @@ module ActionDispatch
         else
           if target_deleted?(index)
             target = next_target(index, where)
+
+            return -1 unless target
           else
             target = index
           end
@@ -138,7 +140,10 @@ module ActionDispatch
 
       def track_deleted_middleware_at(index)
         previous_middleware = middlewares[index - 1].klass
-        next_middleware = middlewares[index + 1].klass
+
+        next_middleware = middlewares[index + 1]
+        next_middleware = next_middleware && next_middleware.klass
+
         @deleted_middlewares[middlewares[index].klass] = { previous: previous_middleware, next: next_middleware }
       end
 

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -127,11 +127,9 @@ module ActionDispatch
       end
 
       def target_deleted(target, where)
-        if where == :after
-          new_target = @deleted_middlewares[target][:previous]
-        else
-          new_target = @deleted_middlewares[target][:next]
-        end
+        position = where == :after ? :previous : :next
+
+        @deleted_middlewares[target][position]
       end
 
       def middleware_index(klass)

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -109,7 +109,7 @@ module ActionDispatch
           i = index
         else
           if target_deleted?(index)
-            target = target_deleted(index, where)
+            target = next_target(index, where)
           else
             target = index
           end
@@ -126,7 +126,7 @@ module ActionDispatch
         @deleted_middlewares.key?(target)
       end
 
-      def target_deleted(target, where)
+      def next_target(target, where)
         position = where == :after ? :previous : :next
 
         @deleted_middlewares[target][position]

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -90,9 +90,7 @@ module ActionDispatch
 
     def delete(target)
       index = middleware_index(target)
-      previous_middleware = middlewares[index - 1]
-      next_middleware = middlewares[index + 1]
-      @deleted_middlewares[middlewares[index].klass] = { previous: previous_middleware.klass, next: next_middleware.klass }
+      track_deleted_middleware_at(index)
       middlewares.delete_at(index)
     end
 
@@ -134,6 +132,12 @@ module ActionDispatch
 
       def middleware_index(klass)
         middlewares.index { |m| m.klass == klass }
+      end
+
+      def track_deleted_middleware_at(index)
+        previous_middleware = middlewares[index - 1].klass
+        next_middleware = middlewares[index + 1].klass
+        @deleted_middlewares[middlewares[index].klass] = { previous: previous_middleware, next: next_middleware }
       end
 
       def build_middleware(klass, args, block)

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -128,4 +128,22 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     assert_equal BazMiddleware, @stack[2].klass
     assert_equal false, @stack.include?(BarMiddleware)
   end
+
+  test "allow adding middleware before a middleware that was already removed" do
+    @stack.delete FooMiddleware
+    @stack.insert_before FooMiddleware, BazMiddleware
+    assert_equal BazMiddleware, @stack.first.klass
+    assert_equal BarMiddleware, @stack[1].klass
+    assert_equal false, @stack.include?(FooMiddleware)
+  end
+
+  test "adds middleware right before the previous middleware of the deleted target" do
+    @stack.use BazMiddleware
+    @stack.delete BarMiddleware
+    @stack.insert_before BarMiddleware, HiyaMiddleware
+    assert_equal FooMiddleware, @stack.first.klass
+    assert_equal HiyaMiddleware, @stack[1].klass
+    assert_equal BazMiddleware, @stack[2].klass
+    assert_equal false, @stack.include?(BarMiddleware)
+  end
 end

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -110,4 +110,22 @@ class MiddlewareStackTest < ActiveSupport::TestCase
   test "includes a middleware" do
     assert_equal true, @stack.include?(ActionDispatch::MiddlewareStack::Middleware.new(BarMiddleware, nil, nil))
   end
+
+  test "allow adding middleware after a middleware that was already removed" do
+    @stack.delete FooMiddleware
+    @stack.insert_after FooMiddleware, BazMiddleware
+    assert_equal BarMiddleware, @stack.first.klass
+    assert_equal BazMiddleware, @stack[1].klass
+    assert_equal false, @stack.include?(FooMiddleware)
+  end
+
+  test "adds middleware right after the previous middleware of the deleted target" do
+    @stack.use BazMiddleware
+    @stack.delete BarMiddleware
+    @stack.insert_after BarMiddleware, HiyaMiddleware
+    assert_equal FooMiddleware, @stack.first.klass
+    assert_equal HiyaMiddleware, @stack[1].klass
+    assert_equal BazMiddleware, @stack[2].klass
+    assert_equal false, @stack.include?(BarMiddleware)
+  end
 end

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -146,4 +146,14 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     assert_equal BazMiddleware, @stack[2].klass
     assert_equal false, @stack.include?(BarMiddleware)
   end
+
+  test "adds middleware to the end if the deleted middlewere was in the end" do
+    @stack.use BazMiddleware
+    @stack.delete BazMiddleware
+    @stack.insert_before BazMiddleware, HiyaMiddleware
+    assert_equal FooMiddleware, @stack.first.klass
+    assert_equal BarMiddleware, @stack[1].klass
+    assert_equal HiyaMiddleware, @stack[2].klass
+    assert_equal false, @stack.include?(BazMiddleware)
+  end
 end

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -33,9 +33,8 @@ module Rails
     #     config.middleware.delete ActionDispatch::Flash
     #
     class MiddlewareStackProxy
-      def initialize(operations = [], delete_operations = [])
+      def initialize(operations = [])
         @operations = operations
-        @delete_operations = delete_operations
       end
 
       def insert_before(*args, &block)
@@ -57,7 +56,7 @@ module Rails
       end
 
       def delete(*args, &block)
-        @delete_operations << [__method__, args, block]
+        @operations << [__method__, args, block]
       end
 
       def unshift(*args, &block)
@@ -65,7 +64,7 @@ module Rails
       end
 
       def merge_into(other) #:nodoc:
-        (@operations + @delete_operations).each do |operation, args, block|
+        @operations.each do |operation, args, block|
           other.send(operation, *args, &block)
         end
 
@@ -73,16 +72,12 @@ module Rails
       end
 
       def +(other) # :nodoc:
-        MiddlewareStackProxy.new(@operations + other.operations, @delete_operations + other.delete_operations)
+        MiddlewareStackProxy.new(@operations + other.operations)
       end
 
       protected
         def operations
           @operations
-        end
-
-        def delete_operations
-          @delete_operations
         end
     end
 

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -187,6 +187,13 @@ module ApplicationTests
       assert_not middleware.include?("Rack::Runtime")
     end
 
+    test "can re-insert a deleted middleware" do
+      add_to_config "config.middleware.delete Rack::Runtime"
+      add_to_config "config.middleware.use Rack::Runtime"
+      boot!
+      assert_includes middleware, "Rack::Runtime"
+    end
+
     test "can delete a middleware from the stack even if insert_after is added after delete" do
       add_to_config "config.middleware.delete Rack::Runtime"
       add_to_config "config.middleware.insert_after(Rack::Runtime, Rack::Config)"


### PR DESCRIPTION
Right now it is hard to re-insert delete middleware in the stack. The reason is that we only apply the delete operations after the insert operations and this will remove the middleware in the end.

To fix this instead of recording the delete operations separately in the MiddlewareStackProxy we keep track of deleted middleware so it is possible to add after and before them. 

Fixes #26303 without reverting #16433.

cc @naw @sirupsen @tgxworld.