### PR TITLE
deprecate `halt_callback_chains_on_return_false` instead of `halt_and_display_warning_on_return_false`

### DIFF
--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -1,7 +1,6 @@
 require "active_job"
 require "support/job_buffer"
 
-ActiveSupport.halt_callback_chains_on_return_false = false
 GlobalID.app = "aj"
 
 @adapter = ENV["AJ_ADAPTER"] || "inline"

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Deprecate `.halt_and_display_warning_on_return_false`.
+*   Deprecate `.halt_callback_chains_on_return_false`.
 
     *Rafael Mendonça França*
 

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -80,11 +80,15 @@ module ActiveSupport
   cattr_accessor :test_order # :nodoc:
 
   def self.halt_callback_chains_on_return_false
-    Callbacks.halt_and_display_warning_on_return_false
+    ActiveSupport::Deprecation.warn(<<-MSG.squish)
+      ActiveSupport.halt_callback_chains_on_return_false is deprecated and will be removed in Rails 5.2.
+    MSG
   end
 
   def self.halt_callback_chains_on_return_false=(value)
-    Callbacks.halt_and_display_warning_on_return_false = value
+    ActiveSupport::Deprecation.warn(<<-MSG.squish)
+      ActiveSupport.halt_callback_chains_on_return_false= is deprecated and will be removed in Rails 5.2.
+    MSG
   end
 
   def self.to_time_preserves_timezone

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -69,19 +69,6 @@ module ActiveSupport
 
     CALLBACK_FILTER_TYPES = [:before, :after, :around]
 
-    def self.halt_and_display_warning_on_return_false=(value)
-
-      ActiveSupport::Deprecation.warn(<<-MSG.squish)
-        .halt_and_display_warning_on_return_false= is deprecated and will be removed in Rails 5.2.
-      MSG
-    end
-
-    def self.halt_and_display_warning_on_return_false
-      ActiveSupport::Deprecation.warn(<<-MSG.squish)
-        .halt_and_display_warning_on_return_false is deprecated and will be removed in Rails 5.2.
-      MSG
-    end
-
     # Runs the callbacks for the given event.
     #
     # Calls the before and around callbacks in the order they were set, yields

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -626,8 +626,6 @@ There are a few configuration options available in Active Support:
 
 * `config.active_support.time_precision` sets the precision of JSON encoded time values. Defaults to `3`.
 
-* `ActiveSupport.halt_callback_chains_on_return_false` specifies whether Active Record and Active Model callback chains can be halted by returning `false` in a 'before' callback. When set to `false`, callback chains are halted only when explicitly done so with `throw(:abort)`. When set to `true`, callback chains are halted when a callback returns `false` (the previous behavior before Rails 5) and a deprecation warning is given. Defaults to `true` during the deprecation period. New Rails 5 apps generate an initializer file called `new_framework_defaults.rb` which sets the value to `false`. This file is *not* added when running `rails app:update`, so returning `false` will still work on older apps ported to Rails 5 and display a deprecation warning to prompt users to update their code.
-
 * `ActiveSupport::Logger.silencer` is set to `false` to disable the ability to silence logging in a block. The default is `true`.
 
 * `ActiveSupport::Cache::Store.logger` specifies the logger to use within cache store operations.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
@@ -24,9 +24,6 @@ ActiveSupport.to_time_preserves_timezone = <%= options[:update] ? false : true %
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = <%= options[:update] ? false : true %>
 <%- end -%>
-
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = <%= options[:update] ? true : false %>
 <%- unless options[:update] -%>
 
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -208,7 +208,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
       quietly { generator.send(:update_config_files) }
 
       assert_file "#{app_root}/config/initializers/new_framework_defaults.rb" do |content|
-        assert_match(/ActiveSupport\.halt_callback_chains_on_return_false = true/, content)
         assert_match(/Rails\.application\.config.active_record\.belongs_to_required_by_default = false/, content)
         assert_no_match(/Rails\.application\.config\.ssl_options/, content)
       end


### PR DESCRIPTION
### Summary

`halt_and_display_warning_on_return_false` is not a public API and
application is using `halt_callback_chains_on_return_false`.

https://github.com/rails/rails/blob/5-0-stable/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt#L29
https://github.com/rails/rails/blob/5-0-stable/activesupport/lib/active_support.rb#L86..L88

Therefore, deprecate messages should be issued for
`halt_callback_chains_on_return_false` instead of
`halt_and_display_warning_on_return_false`.

r? @rafaelfranca 