### PR TITLE
Prevent multiple values being set to `run_via`

### DIFF
--- a/activesupport/lib/active_support/testing/autorun.rb
+++ b/activesupport/lib/active_support/testing/autorun.rb
@@ -2,8 +2,8 @@ gem "minitest"
 
 require "minitest"
 
-if Minitest.respond_to?(:run_via) && !Minitest.run_via[:rails]
-  Minitest.run_via[:ruby] = true
+if Minitest.respond_to?(:run_via) && !Minitest.run_via.set?
+  Minitest.run_via = :ruby
 end
 
 Minitest.autorun

--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -11,7 +11,7 @@ module Rails
       def perform(*)
         $LOAD_PATH << Rails::Command.root.join("test")
 
-        Minitest.run_via[:rails] = true
+        Minitest.run_via = :rails
 
         require "active_support/testing/autorun"
       end

--- a/railties/lib/rails/generators/rails/plugin/templates/bin/test.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/test.tt
@@ -5,6 +5,6 @@ require 'rails/test_unit/minitest_plugin'
 
 Rails::TestUnitReporter.executable = 'bin/test'
 
-Minitest.run_via[:rails] = true
+Minitest.run_via = :rails
 
 require "active_support/testing/autorun"

--- a/tools/test.rb
+++ b/tools/test.rb
@@ -16,5 +16,5 @@ end
 
 ActiveSupport::TestCase.extend Rails::LineFiltering
 Rails::TestUnitReporter.executable = "bin/test"
-Minitest.run_via[:rails] = true
+Minitest.run_via = :rails
 require "active_support/testing/autorun"


### PR DESCRIPTION
When executing the test via rake, since `rake` is set for `run_via`, `ruby` should not be set.
Related 2cb6c27