### PR TITLE
Allow ActiveRecord::Base.as_json to accept a frozen Hash

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow ActiveRecord::Base#as_json to be passed a frozen Hash.
+
+    *Isaac Betesh*
+
 *   Deprecate locking records with unpersisted changes.
 
     *Marc Schütz*

--- a/activerecord/lib/active_record/serialization.rb
+++ b/activerecord/lib/active_record/serialization.rb
@@ -9,7 +9,7 @@ module ActiveRecord #:nodoc:
     end
 
     def serializable_hash(options = nil)
-      options = options.try(:clone) || {}
+      options = options.try(:dup) || {}
 
       options[:except] = Array(options[:except]).map(&:to_s)
       options[:except] |= Array(self.class.inheritance_column)

--- a/activerecord/test/cases/json_serialization_test.rb
+++ b/activerecord/test/cases/json_serialization_test.rb
@@ -101,6 +101,17 @@ class JsonSerializationTest < ActiveRecord::TestCase
     assert_match %r{"favorite_quote":"Constraints are liberating"}, methods_json
   end
 
+  def test_uses_serializable_hash_with_frozen_hash
+    def @contact.serializable_hash(options = nil)
+      super({ only: %w(name) }.freeze)
+    end
+
+    json = @contact.to_json
+    assert_match %r{"name":"Konata Izumi"}, json
+    assert_no_match %r{awesome}, json
+    assert_no_match %r{age}, json
+  end
+
   def test_uses_serializable_hash_with_only_option
     def @contact.serializable_hash(options = nil)
       super(only: %w(name))


### PR DESCRIPTION
### Summary

ActiveRecord::Base.as_json takes an options Hash, which is cloned.  The clone is then modified.
Since Object#clone preserves frozen state, a frozen Hash will not work here.

This commit resolves that by changing `clone` to `dup`, which does not preserve frozen state.

### Other Information

There are many situations where one would want to pass a frozen Hash to as_json.  I came across this issue when trying to create a default JSON representation:

    class User < ApplicationRecord
      DEFAULT_JSON = { only: [:name, :email] }.freeze

      def as_json(options = nil)
        super(options.presence || DEFAULT_JSON)
      end
    end

Doing this in a seemingly innocuous and correct way, I got this stack trace:

     RuntimeError:
       can't modify frozen Hash
    # ~/.rvm/gems/ruby-2.3.0/gems/activerecord-5.0.1/lib/active_record/serialization.rb:14:in `serializable_hash'
    # ~/.rvm/gems/ruby-2.3.0/gems/activemodel-5.0.1/lib/active_model/serializers/json.rb:99:in `as_json'
    # ./app/models/user.rb:5:in `as_json'
