### PR TITLE
Simplify and optimize Postgres query for primary_keys()

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -442,16 +442,14 @@ module ActiveRecord
 
         def primary_keys(table_name) # :nodoc:
           select_values(<<-SQL.strip_heredoc, "SCHEMA")
-            WITH pk_constraint AS (
-              SELECT conrelid, unnest(conkey) AS connum FROM pg_constraint
-              WHERE contype = 'p'
-                AND conrelid = #{quote(quote_table_name(table_name))}::regclass
-            ), cons AS (
-              SELECT conrelid, connum, row_number() OVER() AS rownum FROM pk_constraint
-            )
-            SELECT attr.attname FROM pg_attribute attr
-            INNER JOIN cons ON attr.attrelid = cons.conrelid AND attr.attnum = cons.connum
-            ORDER BY cons.rownum
+                SELECT a.attname
+                  FROM pg_index i
+            CROSS JOIN unnest(i.indkey) as k
+                  JOIN pg_attribute a
+                    ON a.attrelid = i.indrelid
+                   AND a.attnum = k
+                 WHERE i.indrelid = #{quote(quote_table_name(table_name))}::regclass
+                   AND i.indisprimary
           SQL
         end
 

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -298,6 +298,10 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
       t.string :region
       t.integer :code
     end
+    @connection.create_table(:barcodes_reverse, primary_key: ["code", "region"], force: true) do |t|
+      t.string :region
+      t.integer :code
+    end
   end
 
   def teardown
@@ -305,6 +309,11 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
   end
 
   def test_composite_primary_key
+    assert_equal ["region", "code"], @connection.primary_keys("barcodes")
+  end
+
+  def test_composite_primary_key_out_of_order
+    skip if current_adapter?(:SQLite3Adapter)
     assert_equal ["region", "code"], @connection.primary_keys("barcodes")
   end
 


### PR DESCRIPTION
`primary_keys(table)` needs to query various metadata tables in Postgres to determine the primary key for the table. Previously, it did so using a complex common table expression against `pg_constraint` and `pg_attribute`.

This patch simplifies the query by joining `pg_index` against `pg_attribute` instead of going through `pg_constraint`. This simplifies the logic, making the query far easier to understand, and additionally avoids an expensive unnest, window function query, and common table expression.

`EXPLAIN`ing these queries in Postgres against a database with a single table with a composite primary key shows a ~66% reduction in the plan and execute latencies. This is significant during application startup time, especially against very large schemas, where these queries would be even slower and more numerous.

I tested querying for the primary keys of the following simple table with the old and new queries. The following plans have representative plan and execution time; timing of both was consistent across several runs.
```
CREATE TABLE comp (a int, b int, c text, d numeric, primary key(a, b));
```

Before:
```
jordan=# EXPLAIN ANALYZE WITH pk_constraint AS (
  SELECT conrelid, unnest(conkey) AS connum FROM pg_constraint
  WHERE contype = 'p'
    AND conrelid = '"comp"'::regclass
), cons AS (
  SELECT conrelid, connum, row_number() OVER() AS rownum FROM pk_constraint
)
SELECT attr.attname FROM pg_attribute attr
INNER JOIN cons ON attr.attrelid = cons.conrelid AND attr.attnum = cons.connum
ORDER BY cons.rownum;
                                                          QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=101.59..101.61 rows=8 width=72) (actual time=0.900..0.900 rows=2 loops=1)
   Sort Key: cons.rownum
   Sort Method: quicksort  Memory: 25kB
   CTE pk_constraint
     ->  Seq Scan on pg_constraint  (cost=0.00..1.53 rows=100 width=6) (actual time=0.016..0.018 rows=2 loops=1)
           Filter: ((contype = 'p'::"char") AND (conrelid = '25096'::oid))
           Rows Removed by Filter: 11
   CTE cons
     ->  WindowAgg  (cost=0.00..3.25 rows=100 width=14) (actual time=0.020..0.026 rows=2 loops=1)
           ->  CTE Scan on pk_constraint  (cost=0.00..2.00 rows=100 width=6) (actual time=0.017..0.021 rows=2 loops=1)
   ->  Hash Join  (cost=3.50..96.70 rows=8 width=72) (actual time=0.869..0.875 rows=2 loops=1)
         Hash Cond: ((attr.attrelid = cons.conrelid) AND (attr.attnum = cons.connum))
         ->  Seq Scan on pg_attribute attr  (cost=0.00..73.78 rows=2578 width=70) (actual time=0.007..0.277 rows=2615 loops=1)
         ->  Hash  (cost=2.00..2.00 rows=100 width=14) (actual time=0.047..0.047 rows=2 loops=1)
               Buckets: 1024  Batches: 1  Memory Usage: 9kB
               ->  CTE Scan on cons  (cost=0.00..2.00 rows=100 width=14) (actual time=0.026..0.032 rows=2 loops=1)
 Planning time: 0.249 ms
 Execution time: 1.009 ms
(18 rows)
```

After:
```
jordan=# EXPLAIN ANALYZE SELECT a.attname
FROM   pg_index i
JOIN   pg_attribute a ON a.attrelid = i.indrelid
                     AND a.attnum = ANY(i.indkey)
WHERE  i.indrelid = 'comp'::regclass
AND    i.indisprimary;
                                                                       QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=0.28..18.81 rows=1 width=64) (actual time=0.040..0.042 rows=2 loops=1)
   Join Filter: (a.attnum = ANY ((i.indkey)::smallint[]))
   Rows Removed by Join Filter: 8
   ->  Seq Scan on pg_index i  (cost=0.00..4.51 rows=1 width=31) (actual time=0.026..0.026 rows=1 loops=1)
         Filter: (indisprimary AND (indrelid = '25096'::oid))
         Rows Removed by Filter: 130
   ->  Index Scan using pg_attribute_relid_attnum_index on pg_attribute a  (cost=0.28..14.20 rows=4 width=70) (actual time=0.008..0.010 rows=10 loops=1)
         Index Cond: (attrelid = '25096'::oid)
 Planning time: 0.140 ms
 Execution time: 0.072 ms
(10 rows)
```