### PR TITLE
Make `table_name=` reset current statement cache

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Make `table_name=` reset current statement cache,
+    so queries are not run against the previous table name.
+
+    *namusyaka*
+
 *   Allow ActiveRecord::Base#as_json to be passed a frozen Hash.
 
     *Isaac Betesh*

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -432,6 +432,7 @@ module ActiveRecord
         connection.schema_cache.clear_data_source_cache!(table_name)
 
         reload_schema_from_cache
+        initialize_find_by_cache
       end
 
       private

--- a/activerecord/test/cases/statement_cache_test.rb
+++ b/activerecord/test/cases/statement_cache_test.rb
@@ -105,5 +105,31 @@ module ActiveRecord
 
       refute_equal book, other_book
     end
+
+    def test_find_by_does_not_use_statement_cache_if_table_name_is_changed
+      book = Book.create(name: "my book")
+
+      Book.find_by(name: "my book") # warming the statement cache.
+
+      # changing the table name should change the query that is not cached.
+      Book.table_name = :birds
+      assert_nil Book.find_by(name: "my book")
+    ensure
+      Book.table_name = :books
+    end
+
+    def test_find_does_not_use_statement_cache_if_table_name_is_changed
+      book = Book.create(name: "my book")
+
+      Book.find(book.id) # warming the statement cache.
+
+      # changing the table name should change the query that is not cached.
+      Book.table_name = :birds
+      assert_raise ActiveRecord::RecordNotFound do
+        Book.find(book.id)
+      end
+    ensure
+      Book.table_name = :books
+    end
   end
 end


### PR DESCRIPTION
### Summary

In our project some exceptional, we have the function of dynamically swapping table names.
It hasn't been working since those features upgraded to rails-4.2 (or maybe latest 4.1?)
It is due to the implementation of Adequate Record which is a wonderful feature.
I solved this problem by including table names in cache key.

@tenderlove @rafaelfranca  Could you review my changes?
