### PR TITLE
Use released resque

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem "erubis", "~> 2.7.0", require: false
 
 # Active Job.
 group :job do
-  gem "resque", github: "resque/resque", require: false
+  gem "resque", require: false
   gem "resque-scheduler", require: false
   gem "sidekiq", require: false
   gem "sucker_punch", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,17 +29,6 @@ GIT
   specs:
     arel (8.0.0)
 
-GIT
-  remote: https://github.com/resque/resque.git
-  revision: 835a4a7e61a2e33832dbf11975ecfab54af293c6
-  specs:
-    resque (1.27.0)
-      mono_logger (~> 1.0)
-      multi_json (~> 1.0)
-      redis-namespace (~> 1.3)
-      sinatra (>= 0.9.2)
-      vegas (~> 0.1.2)
-
 PATH
   remote: .
   specs:
@@ -273,6 +262,12 @@ GEM
     redis (3.3.2)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    resque (1.27.0)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.3)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
     resque-scheduler (4.3.0)
       mono_logger (~> 1.0)
       redis (~> 3.3)
@@ -407,7 +402,7 @@ DEPENDENCIES
   rb-inotify!
   redcarpet (~> 3.2.3)
   redis
-  resque!
+  resque
   resque-scheduler
   rubocop (>= 0.47)
   sass-rails


### PR DESCRIPTION
Since https://github.com/resque/resque/pull/1439 caused the test to fail, so specified master. However, it is not necessary to specify master because the latest version containing the fix was released. 

Ref: #25691
