### PR TITLE
Fix bigint primary key with unsigned

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -22,7 +22,7 @@ module ActiveRecord
         private
 
           def default_primary_key?(column)
-            super && column.auto_increment?
+            super && column.auto_increment? && !column.unsigned?
           end
 
           def explicit_primary_key_default?(column)


### PR DESCRIPTION
Currently schema dumper lost the unsigned option when primary key is
defined as bigint with unsigned. This PR fixes the issue.