### PR TITLE
Simplify and optimize Postgres query for primary_keys()

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -54,12 +54,6 @@ module ActiveRecord
         end
       end
 
-      def test_primary_key_raises_error_if_table_not_found
-        assert_raises(ActiveRecord::StatementInvalid) do
-          @connection.primary_key("unobtainium")
-        end
-      end
-
       def test_exec_insert_with_returning_disabled
         connection = connection_without_insert_returning
         result = connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id", "postgresql_partitioned_table_parent_id_seq")

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -366,14 +366,6 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
-  def test_primary_key_raises_error_if_table_not_found_on_schema_search_path
-    with_schema_search_path(SCHEMA2_NAME) do
-      assert_raises(ActiveRecord::StatementInvalid) do
-        @connection.primary_key(PK_TABLE_NAME)
-      end
-    end
-  end
-
   def test_pk_and_sequence_for_with_schema_specified
     pg_name = ActiveRecord::ConnectionAdapters::PostgreSQL::Name
     [


### PR DESCRIPTION
Take two on #27949, which was flawed because `unnest` doesn't always return in a consistent order. Now we use `generate_subscripts` which should always return rows in a consistent order. It is available since Postgres 8.4.

In summary, this pull request simplifies the query used to determine the primary keys of a table in Postgres to achieve a ~%66 speedup per table primary key query during application startup.

cc @kamipo (thanks for your patience!)

Here's the `EXPLAIN` data with the new and old queries on a sample table:

```
CREATE TABLE comp (a int, b int, c text, d numeric, primary key(a, b));
```

Before:

```
jordan=# EXPLAIN ANALYZE WITH pk_constraint AS (
  SELECT conrelid, unnest(conkey) AS connum FROM pg_constraint
  WHERE contype = 'p'
    AND conrelid = '"comp"'::regclass
), cons AS (
  SELECT conrelid, connum, row_number() OVER() AS rownum FROM pk_constraint
)
SELECT attr.attname FROM pg_attribute attr
INNER JOIN cons ON attr.attrelid = cons.conrelid AND attr.attnum = cons.connum
ORDER BY cons.rownum;
                                                          QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=101.59..101.61 rows=8 width=72) (actual time=0.900..0.900 rows=2 loops=1)
   Sort Key: cons.rownum
   Sort Method: quicksort  Memory: 25kB
   CTE pk_constraint
     ->  Seq Scan on pg_constraint  (cost=0.00..1.53 rows=100 width=6) (actual time=0.016..0.018 rows=2 loops=1)
           Filter: ((contype = 'p'::"char") AND (conrelid = '25096'::oid))
           Rows Removed by Filter: 11
   CTE cons
     ->  WindowAgg  (cost=0.00..3.25 rows=100 width=14) (actual time=0.020..0.026 rows=2 loops=1)
           ->  CTE Scan on pk_constraint  (cost=0.00..2.00 rows=100 width=6) (actual time=0.017..0.021 rows=2 loops=1)
   ->  Hash Join  (cost=3.50..96.70 rows=8 width=72) (actual time=0.869..0.875 rows=2 loops=1)
         Hash Cond: ((attr.attrelid = cons.conrelid) AND (attr.attnum = cons.connum))
         ->  Seq Scan on pg_attribute attr  (cost=0.00..73.78 rows=2578 width=70) (actual time=0.007..0.277 rows=2615 loops=1)
         ->  Hash  (cost=2.00..2.00 rows=100 width=14) (actual time=0.047..0.047 rows=2 loops=1)
               Buckets: 1024  Batches: 1  Memory Usage: 9kB
               ->  CTE Scan on cons  (cost=0.00..2.00 rows=100 width=14) (actual time=0.026..0.032 rows=2 loops=1)
 Planning time: 0.249 ms
 Execution time: 1.009 ms
(18 rows)
```

After:
```
jordan=# EXPLAIN ANALYZE SELECT a.attname
                  FROM pg_index i
            CROSS JOIN generate_subscripts(i.indkey, 1) k
                  JOIN pg_attribute a
                    ON a.attrelid=i.indrelid
                   AND a.attnum=i.indkey[k]
                 WHERE i.indrelid='comp'::regclass
                   AND i.indisprimary;
                                                                          QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------
 Hash Join  (cost=14.26..46.47 rows=20 width=64) (actual time=0.061..0.064 rows=2 loops=1)
   Hash Cond: (i.indkey[k.k] = a.attnum)
   ->  Nested Loop  (cost=0.00..24.52 rows=1000 width=35) (actual time=0.035..0.037 rows=2 loops=1)
         ->  Seq Scan on pg_index i  (cost=0.00..4.51 rows=1 width=31) (actual time=0.026..0.028 rows=1 loops=1)
               Filter: (indisprimary AND (indrelid = '16903'::oid))
               Rows Removed by Filter: 123
         ->  Function Scan on generate_subscripts k  (cost=0.00..10.00 rows=1000 width=4) (actual time=0.007..0.007 rows=2 loops=1)
   ->  Hash  (cost=14.20..14.20 rows=4 width=70) (actual time=0.017..0.017 rows=8 loops=1)
         Buckets: 1024  Batches: 1  Memory Usage: 9kB
         ->  Index Scan using pg_attribute_relid_attnum_index on pg_attribute a  (cost=0.28..14.20 rows=4 width=70) (actual time=0.011..0.012 rows=8 loops=1)
               Index Cond: (attrelid = '16903'::oid)
 Planning time: 0.183 ms
 Execution time: 0.095 ms
(13 rows)
```