### PR TITLE
Check for forced attribute changes

### DIFF
--- a/activerecord/lib/active_record/attribute_mutation_tracker.rb
+++ b/activerecord/lib/active_record/attribute_mutation_tracker.rb
@@ -31,7 +31,7 @@ module ActiveRecord
     end
 
     def any_changes?
-      attr_names.any? { |attr| changed?(attr) }
+      attr_names.any? { |attr| changed?(attr) } || forced_changes.any?
     end
 
     def changed?(attr_name, from: OPTION_NOT_GIVEN, to: OPTION_NOT_GIVEN)

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -301,12 +301,10 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal ["arr", "arr matey!"], pirate.catchphrase_change
   end
 
-  def test_nested_attribute_will_change!
-    pirate = Pirate.create!(catchphrase: "arr")
-    parrot = pirate.parrots.create!(name: "Rruby")
-    pirate.update!(parrots_attributes: { "0" => { id: parrot.id, new_name_input: "Rrails" } })
-
-    assert_equal "Rrails", parrot.name
+  def test_virtual_attribute_will_change
+    parrot = Parrot.create!(name: "Ruby")
+    parrot.send(:attribute_will_change!, :cancel_save_from_callback)
+    assert parrot.has_changes_to_save?
   end
 
   def test_association_assignment_changes_foreign_key

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -301,6 +301,14 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal ["arr", "arr matey!"], pirate.catchphrase_change
   end
 
+  def test_nested_attribute_will_change!
+    pirate = Pirate.create!(catchphrase: "arr")
+    parrot = pirate.parrots.create!(name: "Rruby")
+    pirate.update!(parrots_attributes: { "0" => { id: parrot.id, new_name_input: "Rrails" } })
+
+    assert_equal "Rrails", parrot.name
+  end
+
   def test_association_assignment_changes_foreign_key
     pirate = Pirate.create!(catchphrase: "jarl")
     pirate.parrot = Parrot.create!(name: "Lorre")

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -18,6 +18,18 @@ class Parrot < ActiveRecord::Base
   def increment_updated_count
     self.updated_count += 1
   end
+
+  attr_accessor :new_name_input
+  remove_method "new_name_input="
+  def new_name_input=(value)
+    attribute_will_change!(:new_name_input)
+    @new_name_input = value
+  end
+
+  before_update :set_new_name_from_input, if: :new_name_input
+  def set_new_name_from_input
+    self.name = new_name_input
+  end
 end
 
 class LiveParrot < Parrot

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -18,18 +18,6 @@ class Parrot < ActiveRecord::Base
   def increment_updated_count
     self.updated_count += 1
   end
-
-  attr_accessor :new_name_input
-  remove_method "new_name_input="
-  def new_name_input=(value)
-    attribute_will_change!(:new_name_input)
-    @new_name_input = value
-  end
-
-  before_update :set_new_name_from_input, if: :new_name_input
-  def set_new_name_from_input
-    self.name = new_name_input
-  end
 end
 
 class LiveParrot < Parrot


### PR DESCRIPTION
### Summary

AttributeMutationTracker#any_changes? only looked at model attribute
changes, and ignored any forced changes. Fixes #27956
