### PR TITLE
Add methods [days, weeks, months, years]_between

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*    Add methods calculation: `#days_between`, `#weeks_between`,`#months_between`, `#years_between`
+     for "date" and "time" objects, that return the number of days, weeks, months, years
+     to given date, default to `Date.current`
+
+    *bogdanvlviv*
+
 *   Deprecate `.halt_callback_chains_on_return_false`.
 
     *Rafael Mendonça França*

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -2,6 +2,9 @@ require "active_support/core_ext/object/try"
 
 module DateAndTime
   module Calculations
+    AMOUNT_DAYS_PER_YEAR = 365
+    AMOUNT_WEEKS_PER_YEAR = 52
+    AMOUNT_MONTHS_PER_YEAR = 12
     DAYS_INTO_WEEK = {
       monday: 0,
       tuesday: 1,
@@ -68,6 +71,13 @@ module DateAndTime
       advance(days: days)
     end
 
+    # Returns the number of days to given date, default to +Date.current+.
+    def days_between(date = ::Date.current)
+      date1, date2 = self.to_date, date.to_date
+
+      ((date2.yday - date1.yday) + AMOUNT_DAYS_PER_YEAR * (date2.year - date1.year)).abs
+    end
+
     # Returns a new date/time the specified number of weeks ago.
     def weeks_ago(weeks)
       advance(weeks: -weeks)
@@ -76,6 +86,13 @@ module DateAndTime
     # Returns a new date/time the specified number of weeks in the future.
     def weeks_since(weeks)
       advance(weeks: weeks)
+    end
+
+    # Returns the number of weeks to given date, default to +Date.current+.
+    def weeks_between(date = ::Date.current)
+      date1, date2 = self.to_date, date.to_date
+
+      ((date2.cweek - date1.cweek) + AMOUNT_WEEKS_PER_YEAR * (date2.year - date1.year)).abs
     end
 
     # Returns a new date/time the specified number of months ago.
@@ -88,6 +105,13 @@ module DateAndTime
       advance(months: months)
     end
 
+    # Returns the number of months to given date, default to +Date.current+.
+    def months_between(date = ::Date.current)
+      date1, date2 = self.to_date, date.to_date
+
+      ((date2.month - date1.month) + AMOUNT_MONTHS_PER_YEAR * (date2.year - date1.year)).abs
+    end
+
     # Returns a new date/time the specified number of years ago.
     def years_ago(years)
       advance(years: -years)
@@ -96,6 +120,13 @@ module DateAndTime
     # Returns a new date/time the specified number of years in the future.
     def years_since(years)
       advance(years: years)
+    end
+
+    # Returns the number of years to given date, default to +Date.current+.
+    def years_between(date = ::Date.current)
+      date1, date2 = self.to_date, date.to_date
+
+      (date2.year - date1.year).abs
     end
 
     # Returns a new date/time at the start of the month.

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -31,6 +31,20 @@ module DateAndTimeBehavior
     assert_equal date_time_init(2005, 1, 1, 10, 10, 10), date_time_init(2004, 12, 31, 10, 10, 10).days_since(1)
   end
 
+  def test_days_between
+    assert_equal 0, date_time_init(2017, 2, 10, 10, 10, 10).days_between(date_time_init(2017, 2, 10, 10, 10, 10))
+
+    assert_equal 0, date_time_init(2017, 2, 10, 9, 10, 10).days_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 0, date_time_init(2017, 2, 10, 10, 10, 10).days_between(date_time_init(2017, 2, 10, 9, 10, 10))
+
+    assert_equal 1, date_time_init(2017, 2, 9, 10, 10, 10).days_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 1, date_time_init(2017, 2, 10, 10, 10, 10).days_between(date_time_init(2017, 2, 9, 10, 10, 10))
+    assert_equal 9, date_time_init(2017, 2, 1, 10, 10, 10).days_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 9, date_time_init(2017, 2, 10, 10, 10, 10).days_between(date_time_init(2017, 2, 1, 10, 10, 10))
+    assert_equal 365, date_time_init(2016, 2, 10, 10, 10, 10).days_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 365, date_time_init(2017, 2, 10, 10, 10, 10).days_between(date_time_init(2016, 2, 10, 10, 10, 10))
+  end
+
   def test_weeks_ago
     assert_equal date_time_init(2005, 5, 29, 10, 10, 10),  date_time_init(2005, 6, 5, 10, 10, 10).weeks_ago(1)
     assert_equal date_time_init(2005, 5, 1, 10, 10, 10),   date_time_init(2005, 6, 5, 10, 10, 10).weeks_ago(5)
@@ -44,6 +58,20 @@ module DateAndTimeBehavior
     assert_equal date_time_init(2005, 7, 14, 10, 10, 10), date_time_init(2005, 7, 7, 10, 10, 10).weeks_since(1)
     assert_equal date_time_init(2005, 7, 4, 10, 10, 10),  date_time_init(2005, 6, 27, 10, 10, 10).weeks_since(1)
     assert_equal date_time_init(2005, 1, 4, 10, 10, 10),  date_time_init(2004, 12, 28, 10, 10, 10).weeks_since(1)
+  end
+
+  def test_weeks_between
+    assert_equal 0, date_time_init(2017, 2, 10, 10, 10, 10).weeks_between(date_time_init(2017, 2, 10, 10, 10, 10))
+
+    assert_equal 0, date_time_init(2017, 2, 10, 9, 10, 10).weeks_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 0, date_time_init(2017, 2, 10, 10, 10, 10).weeks_between(date_time_init(2017, 2, 10, 9, 10, 10))
+
+    assert_equal 1, date_time_init(2017, 2, 3, 10, 10, 10).weeks_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 1, date_time_init(2017, 2, 10, 10, 10, 10).weeks_between(date_time_init(2017, 2, 3, 10, 10, 10))
+    assert_equal 9, date_time_init(2016, 12, 9, 10, 10, 10).weeks_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 9, date_time_init(2017, 2, 10, 10, 10, 10).weeks_between(date_time_init(2016, 12, 9, 10, 10, 10))
+    assert_equal 52, date_time_init(2016, 2, 10, 10, 10, 10).weeks_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 52, date_time_init(2017, 2, 10, 10, 10, 10).weeks_between(date_time_init(2016, 2, 10, 10, 10, 10))
   end
 
   def test_months_ago
@@ -68,6 +96,20 @@ module DateAndTimeBehavior
     assert_equal date_time_init(2005, 2, 28, 10, 10, 10),  date_time_init(2005, 1, 31, 10, 10, 10).months_since(1)
   end
 
+  def test_months_between
+    assert_equal 0, date_time_init(2017, 2, 10, 10, 10, 10).months_between(date_time_init(2017, 2, 10, 10, 10, 10))
+
+    assert_equal 0, date_time_init(2017, 2, 9, 10, 10, 10).months_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 0, date_time_init(2017, 2, 10, 10, 10, 10).months_between(date_time_init(2017, 2, 9, 10, 10, 10))
+
+    assert_equal 1, date_time_init(2017, 1, 10, 10, 10, 10).months_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 1, date_time_init(2017, 2, 10, 10, 10, 10).months_between(date_time_init(2017, 1, 10, 10, 10, 10))
+    assert_equal 9, date_time_init(2016, 5, 10, 10, 10, 10).months_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 9, date_time_init(2017, 2, 10, 10, 10, 10).months_between(date_time_init(2016, 5, 1, 10, 10, 10))
+    assert_equal 12, date_time_init(2016, 2, 10, 10, 10, 10).months_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 12, date_time_init(2017, 2, 10, 10, 10, 10).months_between(date_time_init(2016, 2, 10, 10, 10, 10))
+  end
+
   def test_years_ago
     assert_equal date_time_init(2004, 6, 5, 10, 10, 10),  date_time_init(2005, 6, 5, 10, 10, 10).years_ago(1)
     assert_equal date_time_init(1998, 6, 5, 10, 10, 10),  date_time_init(2005, 6, 5, 10, 10, 10).years_ago(7)
@@ -79,6 +121,18 @@ module DateAndTimeBehavior
     assert_equal date_time_init(2012, 6, 5, 10, 10, 10),  date_time_init(2005, 6, 5, 10, 10, 10).years_since(7)
     assert_equal date_time_init(2005, 2, 28, 10, 10, 10), date_time_init(2004, 2, 29, 10, 10, 10).years_since(1) # 1 year since leap day
     assert_equal date_time_init(2182, 6, 5, 10, 10, 10),  date_time_init(2005, 6, 5, 10, 10, 10).years_since(177)
+  end
+
+  def test_years_between
+    assert_equal 0, date_time_init(2017, 2, 10, 10, 10, 10).years_between(date_time_init(2017, 2, 10, 10, 10, 10))
+
+    assert_equal 0, date_time_init(2017, 1, 10, 10, 10, 10).years_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 0, date_time_init(2017, 2, 10, 10, 10, 10).years_between(date_time_init(2017, 1, 10, 10, 10, 10))
+
+    assert_equal 1, date_time_init(2016, 2, 10, 10, 10, 10).years_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 1, date_time_init(2017, 2, 10, 10, 10, 10).years_between(date_time_init(2016, 2, 10, 10, 10, 10))
+    assert_equal 9, date_time_init(2008, 2, 10, 10, 10, 10).years_between(date_time_init(2017, 2, 10, 10, 10, 10))
+    assert_equal 9, date_time_init(2017, 2, 10, 10, 10, 10).years_between(date_time_init(2008, 2, 10, 10, 10, 10))
   end
 
   def test_beginning_of_month


### PR DESCRIPTION
I think it might be useful, so i decided to make this PR.

Added methods:
  `#days_between`
  returns the number of days to given date, default to +Date.current+.

  `#weeks_between`
  returns the number of weeks to given date, default to +Date.current+.

  `#months_between`
  returns the number of months to given date, default to +Date.current+.

  `#years_between`
  returns the number of years to given date, default to +Date.current+.

Your thoughts guys?