### PR TITLE
Remove version number from API links when coming from Edge Guides

### DIFF
--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -113,9 +113,9 @@ HTML
         end
 
         def api_link(url)
-          if version && !url.match(/v\d\.\d\.\d/)
+          released_version = version && version[0] == "v"
+          if released_version && !url.match(/v\d\.\d\.\d/)
             url.insert(url.index(".org") + 4, "/#{version}")
-            url.sub("http://edgeapi", "http://api") if url.include?("edgeapi")
           end
 
           url


### PR DESCRIPTION
### Summary
Rails Guides links to the API documentation include a version number matching
the Rails Guide providing the link. However, the "version number" for Edge
Guides is a git commit hash, not a true version number, which results in a
404 when you try to follow the documentation link.

This change fixes that problem by only including "true" version numbers.
It also removes some unused code -- the "edgeapi" -> "api" substitution isn't
necessary, since `api_link` is only called on urls which start with "http<nolink>://api."