### PR TITLE
Backport tests, changelog and docs for travel_to DateTime support to 4-2-stable

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `AS::Testing::TimeHelpers#travel_to` now changes `DateTime.now` as well as
+    `Time.now` and `Date.today`.
+
+    *Yuki Nishijima*
+
 *   Make `getlocal` and `getutc` always return instances of `Time` for
     `ActiveSupport::TimeWithZone` and `DateTime`. This eliminates a possible
     stack level too deep error in `to_time` where `ActiveSupport::TimeWithZone`

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -42,12 +42,13 @@ module ActiveSupport
     # Containing helpers that helps you test passage of time.
     module TimeHelpers
       # Changes current time to the time in the future or in the past by a given time difference by
-      # stubbing +Time.now+ and +Date.today+.
+      # stubbing +Time.now+, +Date.today+, and +DateTime.now+.
       #
-      #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
+      #   Time.current     # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       #   travel 1.day
-      #   Time.current # => Sun, 10 Nov 2013 15:34:49 EST -05:00
-      #   Date.current # => Sun, 10 Nov 2013
+      #   Time.current     # => Sun, 10 Nov 2013 15:34:49 EST -05:00
+      #   Date.current     # => Sun, 10 Nov 2013
+      #   DateTime.current # => Sun, 10 Nov 2013 15:34:49 -0500
       #
       # This method also accepts a block, which will return the current time back to its original
       # state at the end of the block:
@@ -61,13 +62,14 @@ module ActiveSupport
         travel_to Time.now + duration, &block
       end
 
-      # Changes current time to the given time by stubbing +Time.now+ and
-      # +Date.today+ to return the time or date passed into this method.
+      # Changes current time to the given time by stubbing +Time.now+,
+      # +Date.today+, and +DateTime.now+ to return the time or date passed into this method.
       #
-      #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
+      #   Time.current     # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       #   travel_to Time.new(2004, 11, 24, 01, 04, 44)
-      #   Time.current # => Wed, 24 Nov 2004 01:04:44 EST -05:00
-      #   Date.current # => Wed, 24 Nov 2004
+      #   Time.current     # => Wed, 24 Nov 2004 01:04:44 EST -05:00
+      #   Date.current     # => Wed, 24 Nov 2004
+      #   DateTime.current # => Wed, 24 Nov 2004 01:04:44 -0500
       #
       # Dates are taken as their timestamp at the beginning of the day in the
       # application time zone. <tt>Time.current</tt> returns said timestamp,

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -1,5 +1,6 @@
 require 'abstract_unit'
 require 'active_support/core_ext/date'
+require 'active_support/core_ext/date_time'
 require 'active_support/core_ext/numeric/time'
 
 class TimeTravelTest < ActiveSupport::TestCase
@@ -15,6 +16,7 @@ class TimeTravelTest < ActiveSupport::TestCase
 
         assert_equal expected_time.to_s(:db), Time.now.to_s(:db)
         assert_equal expected_time.to_date, Date.today
+        assert_equal expected_time.to_datetime.to_s(:db), DateTime.now.to_s(:db)
       ensure
         travel_back
       end
@@ -29,10 +31,12 @@ class TimeTravelTest < ActiveSupport::TestCase
         travel 1.day do
           assert_equal expected_time.to_s(:db), Time.now.to_s(:db)
           assert_equal expected_time.to_date, Date.today
+          assert_equal expected_time.to_datetime.to_s(:db), DateTime.now.to_s(:db)
         end
 
         assert_not_equal expected_time.to_s(:db), Time.now.to_s(:db)
         assert_not_equal expected_time.to_date, Date.today
+        assert_not_equal expected_time.to_datetime.to_s(:db), DateTime.now.to_s(:db)
       ensure
         travel_back
       end
@@ -47,6 +51,7 @@ class TimeTravelTest < ActiveSupport::TestCase
 
         assert_equal expected_time, Time.now
         assert_equal Date.new(2004, 11, 24), Date.today
+        assert_equal expected_time.to_datetime, DateTime.now
       ensure
         travel_back
       end
@@ -61,10 +66,12 @@ class TimeTravelTest < ActiveSupport::TestCase
         travel_to expected_time do
           assert_equal expected_time, Time.now
           assert_equal Date.new(2004, 11, 24), Date.today
+          assert_equal expected_time.to_datetime, DateTime.now
         end
 
         assert_not_equal expected_time, Time.now
         assert_not_equal Date.new(2004, 11, 24), Date.today
+        assert_not_equal expected_time.to_datetime, DateTime.now
       ensure
         travel_back
       end
@@ -79,10 +86,12 @@ class TimeTravelTest < ActiveSupport::TestCase
         travel_to expected_time
         assert_equal expected_time, Time.now
         assert_equal Date.new(2004, 11, 24), Date.today
+        assert_equal expected_time.to_datetime, DateTime.now
         travel_back
 
         assert_not_equal expected_time, Time.now
         assert_not_equal Date.new(2004, 11, 24), Date.today
+        assert_not_equal expected_time.to_datetime, DateTime.now
       ensure
         travel_back
       end
@@ -95,6 +104,8 @@ class TimeTravelTest < ActiveSupport::TestCase
         travel_to Time.utc(2014, 10, 10, 10, 10, 50, 999999) do
           assert_equal 50, Time.now.sec
           assert_equal 0, Time.now.usec
+          assert_equal 50, DateTime.now.sec
+          assert_equal 0, DateTime.now.usec
         end
       ensure
         travel_back


### PR DESCRIPTION
Support for stubbing `DateTime.now` with `travel_to` was added in https://github.com/rails/rails/pull/18758. It was later backported to 4-2-stable as part of https://github.com/rails/rails/commit/d7ac341147159ff527f9a5a726da47c0735b86f0, but the tests and changelog entry were not included.

The documentation update from https://github.com/rails/rails/pull/19303 is also included here.