### PR TITLE
Add Time#blank? to blank_test

### DIFF
--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -15,7 +15,7 @@ class BlankTest < ActiveSupport::TestCase
   end
 
   BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", [], {} ]
-  NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 } ]
+  NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now ]
 
   def test_blank
     BLANK.each { |v| assert_equal true, v.blank?,  "#{v.inspect} should be blank" }


### PR DESCRIPTION
Test for Time#blank? is missing.

Sorry for issuing similar PR (like https://github.com/rails/rails/pull/27924) again. I check the behavior of public methods one by one. I realized that the test was missing just a moment ago.