### PR TITLE
Add `Style/EmptyLinesAroundMethodBody` in `.rubocop.yml` and remove extra empty lines

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,10 @@ Style/EmptyLines:
 Style/EmptyLinesAroundClassBody:
   Enabled: true
 
+# In a regular method definition, no empty lines around the body.
+Style/EmptyLinesAroundMethodBody:
+  Enabled: true
+
 # In a regular module definition, no empty lines around the body.
 Style/EmptyLinesAroundModuleBody:
   Enabled: true

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -810,7 +810,6 @@ XML
     new_content_type = "new content_type"
     file.content_type = new_content_type
     assert_equal new_content_type, file.content_type
-
   end
 
   def test_fixture_path_is_accessed_from_self_instead_of_active_support_test_case

--- a/actionpack/test/dispatch/reloader_test.rb
+++ b/actionpack/test/dispatch/reloader_test.rb
@@ -161,6 +161,5 @@ class ReloaderTest < ActiveSupport::TestCase
                       reloader.check = check
                       reloader
                     end
-
     end
 end

--- a/actionpack/test/dispatch/runner_test.rb
+++ b/actionpack/test/dispatch/runner_test.rb
@@ -4,7 +4,6 @@ class RunnerTest < ActiveSupport::TestCase
   test "runner preserves the setting of integration_session" do
     runner = Class.new do
       def before_setup
-
       end
     end.new
 

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -1407,7 +1407,6 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime_with_custom_prompt
-
     expected =  %(<select id="date_first_year" name="date[first][year]">\n)
     expected << %(<option value="">Choose year</option>\n<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -767,7 +767,6 @@ class FormHelperTest < ActionView::TestCase
       '<input name="post[bar][comment_ids][]" type="hidden" value="0" /><input checked="checked" id="post_bar_comment_ids_3" name="post[bar][comment_ids][]" type="checkbox" value="3" />',
       check_box("post", "comment_ids", { multiple: true, index: "bar" }, 3)
     )
-
   end
 
   def test_checkbox_disabled_disables_hidden_field

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -347,7 +347,6 @@ class PostgresqlUUIDTestInverseOf < ActiveRecord::PostgreSQLTestCase
       assert_raise ActiveRecord::RecordNotFound do
         UuidPost.find(123456)
       end
-
     end
 
     def test_find_by_with_uuid

--- a/activerecord/test/cases/adapters/sqlite3/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/statement_pool_test.rb
@@ -3,7 +3,6 @@ require "cases/helper"
 class SQLite3StatementPoolTest < ActiveRecord::SQLite3TestCase
   if Process.respond_to?(:fork)
     def test_cache_is_per_pid
-
       cache = ActiveRecord::ConnectionAdapters::SQLite3Adapter::StatementPool.new(10)
       cache["foo"] = "bar"
       assert_equal "bar", cache["foo"]

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -883,7 +883,6 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       book.subscriber_ids = []
       assert_equal [], book.subscribers.reload
     end
-
   end
 
   def test_collection_singular_ids_setter_with_changed_primary_key

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -552,7 +552,6 @@ class DependenciesTest < ActiveSupport::TestCase
 
       assert_equal autoload + "/conflict.rb", ActiveSupport::Dependencies.search_for_file("conflict")
     end
-
   end
 
   def test_custom_const_missing_should_work

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -664,7 +664,6 @@ class MultibyteCharsExtrasTest < ActiveSupport::TestCase
   end
 
   def test_tidy_bytes_should_tidy_bytes
-
     single_byte_cases = {
       "\x21" => "!",   # Valid ASCII byte, low
       "\x41" => "A",   # Valid ASCII byte, mid

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -661,7 +661,6 @@ module Rails
       end
 
       def self.find_root_with_flag(flag, root_path, default = nil) #:nodoc:
-
         while root_path && File.directory?(root_path) && !File.exist?("#{root_path}/#{flag}")
           parent = File.dirname(root_path)
           root_path = parent != root_path && parent


### PR DESCRIPTION
r? @fxn 