### PR TITLE
Deprecate `supports_primary_key?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `supports_primary_key?`.
+
+    *Ryuta Kamizono*
+
 *   Allow ActiveRecord::Base#as_json to be passed a frozen Hash.
 
     *Isaac Betesh*

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -236,11 +236,10 @@ module ActiveRecord
         false
       end
 
-      # Can this adapter determine the primary key for tables not attached
-      # to an Active Record class, such as join tables?
-      def supports_primary_key?
-        false
+      def supports_primary_key? # :nodoc:
+        true
       end
+      deprecate :supports_primary_key?
 
       # Does this adapter support DDL rollbacks in transactions? That is, would
       # CREATE TABLE or ALTER TABLE get rolled back by a transaction?

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -93,10 +93,6 @@ module ActiveRecord
         true
       end
 
-      def supports_primary_key?
-        true
-      end
-
       def supports_bulk_alter? #:nodoc:
         true
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -282,11 +282,6 @@ module ActiveRecord
         true
       end
 
-      # Does PostgreSQL support finding primary key on non-Active Record tables?
-      def supports_primary_key? #:nodoc:
-        true
-      end
-
       def set_standard_conforming_strings
         execute("SET standard_conforming_strings = on", "SCHEMA")
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -122,10 +122,6 @@ module ActiveRecord
         true
       end
 
-      def supports_primary_key? #:nodoc:
-        true
-      end
-
       def requires_reloading?
         true
       end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -141,22 +141,24 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_nothing_raised { MixedCaseMonkey.find(1).destroy }
   end
 
-  if ActiveRecord::Base.connection.supports_primary_key?
-    def test_primary_key_returns_value_if_it_exists
-      klass = Class.new(ActiveRecord::Base) do
-        self.table_name = "developers"
-      end
+  def test_deprecate_supports_primary_key
+    assert_deprecated { ActiveRecord::Base.connection.supports_primary_key? }
+  end
 
-      assert_equal "id", klass.primary_key
+  def test_primary_key_returns_value_if_it_exists
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "developers"
     end
 
-    def test_primary_key_returns_nil_if_it_does_not_exist
-      klass = Class.new(ActiveRecord::Base) do
-        self.table_name = "developers_projects"
-      end
+    assert_equal "id", klass.primary_key
+  end
 
-      assert_nil klass.primary_key
+  def test_primary_key_returns_nil_if_it_does_not_exist
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "developers_projects"
     end
+
+    assert_nil klass.primary_key
   end
 
   def test_quoted_primary_key_after_set_primary_key


### PR DESCRIPTION
`supports_primary_key?` was added to determine if `primary_key` is
implemented in the adapter in f060221. But we already use `primary_key`
without `supports_primary_key?` (207f266, 5f3cf42) and using
`supports_primary_key?` has been removed in #1318. This means that
`supports_primary_key?` is no longer used in the internal and Active
Record doesn't work without `primary_key` is implemented (all adapters
must implement `primary_key`).