### PR TITLE
Add header support to #process method in controller test case

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add the support for custom headers for #process in controller test case
+
+    *Daniel Deng*
+
 *   Remove deprecated `.to_prepare`, `.to_cleanup`, `.prepare!` and `.cleanup!` from `ActionDispatch::Reloader`.
 
     *Rafael Mendonça França*

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -376,6 +376,10 @@ module ActionController
       #   (<tt>application/x-www-form-urlencoded</tt> or <tt>multipart/form-data</tt>).
       # - +session+: A hash of parameters to store in the session. This may be +nil+.
       # - +flash+: A hash of parameters to store in the flash. This may be +nil+.
+      # - +format+: Request format. Defaults to +nil+. Can be string or symbol.
+      # - +as+: Content type. Defaults to +nil+. Must be a symbol that corresponds
+      #   to a mime type.
+      # - +custom_headers+: A hash of parameters to append to the request headers. This may be +nil+.
       #
       # You can also simulate POST, PATCH, PUT, DELETE, and HEAD requests with
       # +post+, +patch+, +put+, +delete+, and +head+.
@@ -438,6 +442,7 @@ module ActionController
       # - +format+: Request format. Defaults to +nil+. Can be string or symbol.
       # - +as+: Content type. Defaults to +nil+. Must be a symbol that corresponds
       #   to a mime type.
+      # - +custom_headers+: A hash of parameters to append to the request headers. This may be +nil+.
       #
       # Example calling +create+ action and sending two params:
       #
@@ -454,7 +459,7 @@ module ActionController
       # respectively which will make tests more expressive.
       #
       # Note that the request method is not verified.
-      def process(action, method: "GET", params: {}, session: nil, body: nil, flash: {}, format: nil, xhr: false, as: nil)
+      def process(action, method: "GET", params: {}, session: nil, body: nil, flash: {}, format: nil, xhr: false, as: nil, custom_headers: {})
         check_required_ivars
 
         if body
@@ -506,6 +511,12 @@ module ActionController
 
         @request.fetch_header("SCRIPT_NAME") do |k|
           @request.set_header k, @controller.config.relative_url_root
+        end
+
+        if custom_headers.is_a?(Hash)
+          custom_headers.each do |key, val|
+            @request.set_header key, val
+          end
         end
 
         begin

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -360,6 +360,13 @@ XML
     assert_equal "q=test", @response.body
   end
 
+  def test_progress_with_custom_headers
+    process :test_query_string,
+      method: "GET",
+      custom_headers: { "foo" => "bar" }
+    assert_equal "bar", @request.get_header("foo")
+  end
+
   def test_process_with_query_string_with_explicit_uri
     @request.env["PATH_INFO"] = "/explicit/uri"
     @request.env["QUERY_STRING"] = "q=test?extra=question"


### PR DESCRIPTION
### Summary

Currently in controller test cases the base method is #process (and thus #get, #post etc.).
The base method does not support custom headers.
The current interface looks like:
```
(action, method: "GET", params: {}, session: nil, body: nil, flash: {}, format: nil, xhr: false, as: nil)
```
Digging into the source code, found that it’s “genetically” limiting custom headers.
This PR adds support for custom headers when doing test calls.
The argument is deliberately put in the end so that nothing is implicated.

### Other Information

Please let me know if you have any concerns to the change.