### PR TITLE
Add `current_year?` check on Date&Time

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `current_year?` check to Date&Time
+
+    *Dino Maric*
+
 *   Deprecate `.halt_callback_chains_on_return_false`.
 
     *Rafael Mendonça França*

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -38,6 +38,11 @@ module DateAndTime
       to_date == ::Date.current
     end
 
+    # Returns true if the date/time is in current year.
+    def current_year?
+      to_date.year == ::Date.current.year
+    end
+
     # Returns true if the date/time is in the past.
     def past?
       self < self.class.current

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -249,6 +249,20 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_current_year_with_offset
+    Date.stub(:current, Date.new(2000, 1, 1)) do
+      assert_equal false, DateTime.civil(1999, 12, 31, 23, 59, 59, Rational(-18000, 86400)).current_year?
+      assert_equal true,  DateTime.civil(2000, 1, 1, 0, 0, 0, Rational(-18000, 86400)).current_year?
+    end
+  end
+
+  def test_current_year_without_offset
+    Date.stub(:current, Date.new(2000, 1, 1)) do
+      assert_equal false, DateTime.civil(1999, 12, 31, 23, 59, 59).current_year?
+      assert_equal true,  DateTime.civil(2000, 1, 1, 0).current_year?
+    end
+  end
+
   def test_past_with_offset
     DateTime.stub(:current, DateTime.civil(2005, 2, 10, 15, 30, 45, Rational(-18000, 86400))) do
       assert_equal true,  DateTime.civil(2005, 2, 10, 15, 30, 44, Rational(-18000, 86400)).past?

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -667,12 +667,30 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_current_year_with_time_local
+    Date.stub(:current, Date.new(2000, 1, 1)) do
+      assert_equal true,  Time.local(2000, 1, 1, 0).current_year?
+      assert_equal true,  Time.local(2000, 1, 1, 23, 59, 59).current_year?
+      assert_equal false, Time.local(1999, 12, 31, 23, 59, 59).current_year?
+      assert_equal false, Time.local(1999, 12, 31, 0).current_year?
+    end
+  end
+
   def test_today_with_time_utc
     Date.stub(:current, Date.new(2000, 1, 1)) do
       assert_equal false, Time.utc(1999, 12, 31, 23, 59, 59).today?
       assert_equal true,  Time.utc(2000, 1, 1, 0).today?
       assert_equal true,  Time.utc(2000, 1, 1, 23, 59, 59).today?
       assert_equal false, Time.utc(2000, 1, 2, 0).today?
+    end
+  end
+
+  def test_current_year_with_time_utc
+    Date.stub(:current, Date.new(2000, 1, 1)) do
+      assert_equal false, Time.utc(1999, 12, 31, 23, 59, 59).current_year?
+      assert_equal false, Time.utc(1999, 12, 31, 0).current_year?
+      assert_equal true,  Time.utc(2000, 1, 1, 0).current_year?
+      assert_equal true,  Time.utc(2000, 1, 1, 23, 59, 59).current_year?
     end
   end
 

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -234,6 +234,15 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     end
   end
 
+  def test_current_year
+    Date.stub(:current, Date.new(2000, 1, 1)) do
+      assert_equal true, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.utc(2000, 1, 1, 0)).current_year?
+      assert_equal true, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.utc(2000, 1, 1, 23, 59, 59)).current_year?
+      assert_equal false, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.utc(1999, 12, 31, 23, 59, 59)).current_year?
+      assert_equal false, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.utc(1999, 12, 31, 0)).current_year?
+    end
+  end
+
   def test_past_with_time_current_as_time_local
     with_env_tz "US/Eastern" do
       Time.stub(:current, Time.local(2005, 2, 10, 15, 30, 45)) do


### PR DESCRIPTION
Extend Date&Time to add `current_year?` check. Similar as `today?`,
but it checks wheter Date or Time belongs to the current year.

Surprising number of `Rails` projects that I was envolved in needed some way to check whether Date or Time belongs to the current_year. So I think that adding this check to `ActiveSupport` will be a nice addition to the gem :)

