### PR TITLE
Fix the return of `deprecate_methods` in doc [ci skip]

### DIFF
--- a/activesupport/lib/active_support/deprecation/method_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/method_wrappers.rb
@@ -18,7 +18,7 @@ module ActiveSupport
       #
       # Using the default deprecator:
       #   ActiveSupport::Deprecation.deprecate_methods(Fred, :aaa, bbb: :zzz, ccc: 'use Bar#ccc instead')
-      #   # => [:aaa, :bbb, :ccc]
+      #   # => Fred
       #
       #   Fred.aaa
       #   # DEPRECATION WARNING: aaa is deprecated and will be removed from Rails 5.1. (called from irb_binding at (irb):10)


### PR DESCRIPTION
https://github.com/rails/rails/blob/master/activesupport/lib/active_support/deprecation/method_wrappers.rb#L66

Module#prepend is supposed to return the receiver. So, in this case,  the return value is `Fred`, not an Array.