### PR TITLE
Fix a tests of AR::ValueTooLong when using OracleAdapter

### DIFF
--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -372,7 +372,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
       e2 = Event.create(title: "abcdefgh")
       assert_not e2.valid?, "Created an event whose title is not unique"
-    elsif current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter, :SQLServerAdapter)
+    elsif current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter, :OracleAdapter, :SQLServerAdapter)
       assert_raise(ActiveRecord::ValueTooLong) do
         Event.create(title: "abcdefgh")
       end
@@ -391,7 +391,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
       e2 = Event.create(title: "一二三四五六七八")
       assert_not e2.valid?, "Created an event whose title is not unique"
-    elsif current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter, :SQLServerAdapter)
+    elsif current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter, :OracleAdapter, :SQLServerAdapter)
       assert_raise(ActiveRecord::ValueTooLong) do
         Event.create(title: "一二三四五六七八")
       end


### PR DESCRIPTION
### Summary

This PR fixes the following 2 failures when using Oracle (11g) .

```sh
% ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]
% ARCONN=oracle bundle exec ruby -w -Itest:lib test/cases/validations/uniqueness_validation_test.rb -n /test_validate_uniqueness_with_limit/

(snip)

Run options: -n /test_validate_uniqueness_with_limit/ --seed 4392

# Running:

FF

Finished in 0.582791s, 3.4318 runs/s, 3.4318 assertions/s.

  1) Failure:
UniquenessValidationTest#test_validate_uniqueness_with_limit [test/cases/validations/uniqueness_validation_test.rb:381]:
[ActiveRecord::StatementInvalid] exception expected, not
Class: <ActiveRecord::ValueTooLong>
Message: <"OCIError: ORA-12899: value too large for column \"ARUNIT\".\"EVENTS\".\"TITLE\" (actual: 8, maximum: 5): INSERT INTO \"EVENTS\" (\"TITLE\", \"ID\") VALUES (:a1, :a2)">

(snip)

  2) Failure:
UniquenessValidationTest#test_validate_uniqueness_with_limit_and_utf8 [test/cases/validations/uniqueness_validation_test.rb:401]:
[ActiveRecord::StatementInvalid] exception expected, not
Class: <ActiveRecord::ValueTooLong>
Message: <"OCIError: ORA-12899: value too large for column \"ARUNIT\".\"EVENTS\".\"TITLE\" (actual: 8, maximum: 5): INSERT INTO \"EVENTS\" (\"TITLE\", \"ID\") VALUES (:a1, :a2)">

(snip)

2 runs, 2 assertions, 2 failures, 0 errors, 0 skips
```

In oracle-enhanced, it seems that raise `ActiveRecord::ValueTooLong` when these test cases. Then it seems like the expected behavior according to the following references.

References:

- https://github.com/rsim/oracle-enhanced/pull/827
- https://github.com/rails/rails/pull/23522

As additional Information, I confirmed that there is the same test fails on 5-0-stable branch.

Thanks.
