### PR TITLE
AliasTracker is using the wrong type caster

### DIFF
--- a/activerecord/lib/active_record/associations/alias_tracker.rb
+++ b/activerecord/lib/active_record/associations/alias_tracker.rb
@@ -6,21 +6,21 @@ module ActiveRecord
     class AliasTracker # :nodoc:
       attr_reader :aliases
 
-      def self.create(connection, initial_table, type_caster)
+      def self.create(connection, initial_table)
         aliases = Hash.new(0)
         aliases[initial_table] = 1
-        new connection, aliases, type_caster
+        new connection, aliases
       end
 
-      def self.create_with_joins(connection, initial_table, joins, type_caster)
+      def self.create_with_joins(connection, initial_table, joins)
         if joins.empty?
-          create(connection, initial_table, type_caster)
+          create(connection, initial_table)
         else
           aliases = Hash.new { |h, k|
             h[k] = initial_count_for(connection, k, joins)
           }
           aliases[initial_table] = 1
-          new connection, aliases, type_caster
+          new connection, aliases
         end
       end
 
@@ -53,17 +53,16 @@ module ActiveRecord
       end
 
       # table_joins is an array of arel joins which might conflict with the aliases we assign here
-      def initialize(connection, aliases, type_caster)
+      def initialize(connection, aliases)
         @aliases    = aliases
         @connection = connection
-        @type_caster = type_caster
       end
 
-      def aliased_table_for(table_name, aliased_name)
+      def aliased_table_for(table_name, aliased_name, type_caster)
         if aliases[table_name].zero?
           # If it's zero, we can have our table_name
           aliases[table_name] = 1
-          Arel::Table.new(table_name, type_caster: @type_caster)
+          Arel::Table.new(table_name, type_caster: type_caster)
         else
           # Otherwise, we need to use an alias
           aliased_name = @connection.table_alias_for(aliased_name)
@@ -76,7 +75,7 @@ module ActiveRecord
           else
             aliased_name
           end
-          Arel::Table.new(table_name, type_caster: @type_caster).alias(table_alias)
+          Arel::Table.new(table_name, type_caster: type_caster).alias(table_alias)
         end
       end
 

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -21,7 +21,7 @@ module ActiveRecord
         reflection = association.reflection
         scope = klass.unscoped
         owner = association.owner
-        alias_tracker = AliasTracker.create connection, association.klass.table_name, klass.type_caster
+        alias_tracker = AliasTracker.create connection, association.klass.table_name
         chain_head, chain_tail = get_chain(reflection, association, alias_tracker)
 
         scope.extending! Array(reflection.options[:extend])
@@ -112,7 +112,11 @@ module ActiveRecord
           runtime_reflection = Reflection::RuntimeReflection.new(reflection, association)
           previous_reflection = runtime_reflection
           reflection.chain.drop(1).each do |refl|
-            alias_name = tracker.aliased_table_for(refl.table_name, refl.alias_candidate(name))
+            alias_name = tracker.aliased_table_for(
+              refl.table_name,
+              refl.alias_candidate(name),
+              refl.klass.type_caster
+            )
             proxy = ReflectionProxy.new(refl, alias_name)
             previous_reflection.next = proxy
             previous_reflection = proxy

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -93,7 +93,7 @@ module ActiveRecord
       #    joins # =>  []
       #
       def initialize(base, associations, joins, eager_loading: true)
-        @alias_tracker = AliasTracker.create_with_joins(base.connection, base.table_name, joins, base.type_caster)
+        @alias_tracker = AliasTracker.create_with_joins(base.connection, base.table_name, joins)
         @eager_loading = eager_loading
         tree = self.class.make_tree associations
         @join_root = JoinBase.new base, build(tree, base)
@@ -202,7 +202,8 @@ module ActiveRecord
           node.reflection.chain.map { |reflection|
             alias_tracker.aliased_table_for(
               reflection.table_name,
-              table_alias_for(reflection, parent, reflection != node.reflection)
+              table_alias_for(reflection, parent, reflection != node.reflection),
+              reflection.klass.type_caster
             )
           }
         end


### PR DESCRIPTION
The AliasTracker seems to be creating Arel::Table instances with the wrong type caster. While this doesn't seem to cause any problems (that I'm aware of), it also doesn't seem to be *correct*.

The behavior seems to have changed in this commit: https://github.com/rails/rails/commit/39abe8355a56992b32ed95e1ea1eb588c0ad7a6f.

Here's a reproduction case:

```ruby
require 'bundler/inline'
require 'minitest/spec'
require 'minitest/autorun'

gemfile true do
  source 'https://rubygems.org'
  gem 'activerecord', require: 'active_record'
  gem 'sqlite3'
  gem 'pry'
end

ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')

ActiveRecord::Schema.define do
  create_table :stations, force: true do |t|
    t.float :frequency
  end

  create_table :shows, force: true do |t|
    t.belongs_to :station
  end
end

class Station < ActiveRecord::Base
  has_many :shows
end

class Show < ActiveRecord::Base
  belongs_to :station
end

class Test < Minitest::Spec
  let :join_dependency do
    ::ActiveRecord::Associations::JoinDependency.new(
      Station,
      [:shows],
      []
    )
  end

  let :shows do
    join_dependency.join_root.children.first.table
  end

  it 'is the shows table' do
    shows.name.must_equal 'shows'
  end

  # Here's the symptom
  #   Expected: "foo"
  #   Actual:   0.0
  it 'type casts the string using the correct type caster' do
    shows.type_cast_for_database(:frequency, 'foo').must_equal 'foo'
  end

  # Here's the reason for the problem
  #   Expected: Show
  #   Actual:   Station
  it 'has the right type caster' do
    shows.send(:type_caster).send(:types).must_equal Show
  end
end
```

The solution is to pass the `type_caster` of the model you're trying to join to `AliasTracker#aliased_table_for`.
