### PR TITLE
Use ActiveRecord `bigint` type, not SQL literal bigint

### DIFF
--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -94,20 +94,23 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
         end
 
         def test_add_foreign_key_with_non_standard_primary_key
-          with_example_table @connection, "space_shuttles", "pk BIGINT PRIMARY KEY" do
-            @connection.add_foreign_key(:astronauts, :space_shuttles,
-                                        column: "rocket_id", primary_key: "pk", name: "custom_pk")
-
-            foreign_keys = @connection.foreign_keys("astronauts")
-            assert_equal 1, foreign_keys.size
-
-            fk = foreign_keys.first
-            assert_equal "astronauts", fk.from_table
-            assert_equal "space_shuttles", fk.to_table
-            assert_equal "pk", fk.primary_key
-
-            @connection.remove_foreign_key :astronauts, name: "custom_pk"
+          @connection.create_table :space_shuttles, id: false, force: true do |t|
+            t.bigint :pk, primary_key: true
           end
+
+          @connection.add_foreign_key(:astronauts, :space_shuttles,
+            column: "rocket_id", primary_key: "pk", name: "custom_pk")
+
+          foreign_keys = @connection.foreign_keys("astronauts")
+          assert_equal 1, foreign_keys.size
+
+          fk = foreign_keys.first
+          assert_equal "astronauts", fk.from_table
+          assert_equal "space_shuttles", fk.to_table
+          assert_equal "pk", fk.primary_key
+        ensure
+          @connection.remove_foreign_key :astronauts, name: "custom_pk"
+          @connection.drop_table :space_shuttles
         end
 
         def test_add_on_delete_restrict_foreign_key


### PR DESCRIPTION
### Summary

This pull request addresses this error when tested with Oracle enhanced adapter.

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/migration/foreign_key_test.rb -n test_add_foreign_key_with_non_standard_primary_key
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using oracle

... snip ...
E

Finished in 0.132320s, 7.5574 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::Migration::ForeignKeyTest#test_add_foreign_key_with_non_standard_primary_key:
ActiveRecord::StatementInvalid: OCIError: ORA-00942: table or view does not exist: DROP TABLE space_shuttles
    stmt.c:243:in oci8lib_240.so
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/oci8.rb:276:in `exec_internal'
    /home/yahonda/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/ruby-oci8-2.2.3/lib/oci8/oci8.rb:267:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:443:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:90:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:608:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:601:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1048:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
    /home/yahonda/git/rails/activerecord/test/support/ddl_helper.rb:6:in `ensure in with_example_table'
    /home/yahonda/git/rails/activerecord/test/support/ddl_helper.rb:6:in `with_example_table'
    test/cases/migration/foreign_key_test.rb:97:in `test_add_foreign_key_with_non_standard_primary_key'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

### Other Information

This test fails due to `CREATE TABLE space_shuttles(pk BIGINT PRIMARY KEY)` SQL statement gets `ORA-00902: invalid datatype` error. Then `space_shuttles` table was not created, At the end of this test it tries to drop non-existent table. Finally `ORA-00942: table or view does not exist: DROP TABLE space_shuttles`

```sql
SQL> CREATE TABLE space_shuttles(pk BIGINT PRIMARY KEY)
  2  ;
CREATE TABLE space_shuttles(pk BIGINT PRIMARY KEY)
                               *
ERROR at line 1:
ORA-00902: invalid datatype
```

Oracle database itself does not have `bigint` SQL type, then it gets `ORA-00902: invalid datatype`.

It can be addressed by using ActiveRecord `bigint` type because Oracle enhanced adapter recognizes ActiveRecord `bigint` type and transfer it to its equivalent SQL type `NUMBER(19)`.

This pull request has been tested with mysql2 and postgresql adapters which support foreign keys.

#### SQL statements executed to create space_shuttles WITH this commit:

- oracle_enhanced

```ruby
CREATE TABLE "SPACE_SHUTTLES" ("PK" NUMBER(19) NOT NULL PRIMARY KEY)
```

- mysql2

```ruby
CREATE TABLE `space_shuttles` (`pk` bigint NOT NULL PRIMARY KEY) ENGINE=InnoDB
```

- postgresql

```sql
CREATE TABLE "space_shuttles" ("pk" bigint NOT NULL PRIMARY KEY)
```

#### SQL statements executed to create space_shuttles WITHOUT this commit:

- oracle_enhanced
```sql
CREATE TABLE space_shuttles(pk BIGINT PRIMARY KEY)
```

- mysql2 
```sql
CREATE TABLE space_shuttles(pk BIGINT PRIMARY KEY)
```

- postgresql
```sql
CREATE TABLE space_shuttles(pk BIGINT PRIMARY KEY)
```

I believe sql statements executed at mysql2 and postgresql adapters are equivalent before and after with this commit.