### PR TITLE
Prefer to place a table options before `force: :cascade`

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -132,14 +132,13 @@ HEADER
           else
             tbl.print ", id: false"
           end
-          tbl.print ", force: :cascade"
 
           table_options = @connection.table_options(table)
           if table_options.present?
             tbl.print ", #{format_options(table_options)}"
           end
 
-          tbl.puts " do |t|"
+          tbl.puts ", force: :cascade do |t|"
 
           # then dump all non-primary key columns
           columns.each do |column|

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -17,28 +17,28 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
   test "table options with ENGINE" do
     @connection.create_table "mysql_table_options", force: true, options: "ENGINE=MyISAM"
     output = dump_table_schema("mysql_table_options")
-    options = %r{create_table "mysql_table_options", force: :cascade, options: "(?<options>.*)"}.match(output)[:options]
+    options = %r{create_table "mysql_table_options", options: "(?<options>.*)"}.match(output)[:options]
     assert_match %r{ENGINE=MyISAM}, options
   end
 
   test "table options with ROW_FORMAT" do
     @connection.create_table "mysql_table_options", force: true, options: "ROW_FORMAT=REDUNDANT"
     output = dump_table_schema("mysql_table_options")
-    options = %r{create_table "mysql_table_options", force: :cascade, options: "(?<options>.*)"}.match(output)[:options]
+    options = %r{create_table "mysql_table_options", options: "(?<options>.*)"}.match(output)[:options]
     assert_match %r{ROW_FORMAT=REDUNDANT}, options
   end
 
   test "table options with CHARSET" do
     @connection.create_table "mysql_table_options", force: true, options: "CHARSET=utf8mb4"
     output = dump_table_schema("mysql_table_options")
-    options = %r{create_table "mysql_table_options", force: :cascade, options: "(?<options>.*)"}.match(output)[:options]
+    options = %r{create_table "mysql_table_options", options: "(?<options>.*)"}.match(output)[:options]
     assert_match %r{CHARSET=utf8mb4}, options
   end
 
   test "table options with COLLATE" do
     @connection.create_table "mysql_table_options", force: true, options: "COLLATE=utf8mb4_bin"
     output = dump_table_schema("mysql_table_options")
-    options = %r{create_table "mysql_table_options", force: :cascade, options: "(?<options>.*)"}.match(output)[:options]
+    options = %r{create_table "mysql_table_options", options: "(?<options>.*)"}.match(output)[:options]
     assert_match %r{COLLATE=utf8mb4_bin}, options
   end
 end

--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -111,7 +111,7 @@ if ActiveRecord::Base.connection.supports_comments?
 
       # And check that these changes are reflected in dump
       output = dump_table_schema "commenteds"
-      assert_match %r[create_table "commenteds",.+\s+comment: "A table with comment"], output
+      assert_match %r[create_table "commenteds",.*\s+comment: "A table with comment"], output
       assert_match %r[t\.string\s+"name",\s+comment: "Comment should help clarify the column purpose"], output
       assert_match %r[t\.string\s+"obvious"\n], output
       assert_match %r[t\.string\s+"content",\s+comment: "Whoa, content describes itself!"], output

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -434,7 +434,7 @@ if current_adapter?(:PostgreSQLAdapter, :Mysql2Adapter)
     test "schema dump primary key with serial/integer" do
       @connection.create_table(:widgets, id: @pk_type, force: true)
       schema = dump_table_schema "widgets"
-      assert_match %r{create_table "widgets", id: :#{@pk_type}, force: :cascade}, schema
+      assert_match %r{create_table "widgets", id: :#{@pk_type}, }, schema
     end
 
     if current_adapter?(:Mysql2Adapter)
@@ -447,7 +447,7 @@ if current_adapter?(:PostgreSQLAdapter, :Mysql2Adapter)
         assert column.unsigned?
 
         schema = dump_table_schema "widgets"
-        assert_match %r{create_table "widgets", id: :integer, unsigned: true, force: :cascade}, schema
+        assert_match %r{create_table "widgets", id: :integer, unsigned: true, }, schema
       end
 
       test "bigint primary key with unsigned" do
@@ -459,7 +459,7 @@ if current_adapter?(:PostgreSQLAdapter, :Mysql2Adapter)
         assert column.unsigned?
 
         schema = dump_table_schema "widgets"
-        assert_match %r{create_table "widgets", id: :bigint, unsigned: true, force: :cascade}, schema
+        assert_match %r{create_table "widgets", id: :bigint, unsigned: true, }, schema
       end
     end
   end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -66,7 +66,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
   def test_schema_dump_uses_force_cascade_on_create_table
     output = dump_table_schema "authors"
-    assert_match %r{create_table "authors", force: :cascade}, output
+    assert_match %r{create_table "authors",.* force: :cascade}, output
   end
 
   def test_schema_dump_excludes_sqlite_sequence


### PR DESCRIPTION
I was added a table options after `force: :cascade` in #17569 for not
touching existing tests (reducing diff). But `force: :cascade` is not an
important information. So I prefer to place a table options before
`force: :cascade`.