### PR TITLE
Allow ActiveSupport::MarshalWithAutoloading#load to take a Proc

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   In Core Extensions, make `MarshalWithAutoloading#load` pass through the second, optional
+    argument for `Marshal#load( source [, proc] )`. This way we don't have to do 
+    `Marshal.method(:load).super_method.call(sourse, proc)` just to be able to pass a proc.
+
+    *Jeff Latz*
+
 ## Rails 5.1.0.beta1 (February 23, 2017) ##
 
 *   Cache `ActiveSupport::TimeWithZone#to_datetime` before freezing.

--- a/activesupport/lib/active_support/core_ext/marshal.rb
+++ b/activesupport/lib/active_support/core_ext/marshal.rb
@@ -1,7 +1,7 @@
 module ActiveSupport
   module MarshalWithAutoloading # :nodoc:
-    def load(source)
-      super(source)
+    def load(source, proc = nil)
+      super(source, proc)
     rescue ArgumentError, NameError => exc
       if exc.message.match(%r|undefined class/module (.+?)(?:::)?\z|)
         # try loading the class/module

--- a/activesupport/test/core_ext/marshal_test.rb
+++ b/activesupport/test/core_ext/marshal_test.rb
@@ -19,6 +19,19 @@ class MarshalTest < ActiveSupport::TestCase
     end
   end
 
+  test "that Marshal#load still works when passed a proc" do
+    example_string = "test"
+
+    example_proc = Proc.new do |o|
+      if o.is_a?(String)
+        o.capitalize!
+      end
+    end
+
+    dumped = Marshal.dump(example_string)
+    assert_equal Marshal.load(dumped, example_proc), "Test"
+  end
+
   test "that a missing class is autoloaded from string" do
     dumped = nil
     with_autoloading_fixtures do


### PR DESCRIPTION
### Summary

From my entry in the **ActiveSupport** changelog:

> In Core Extensions, make `MarshalWithAutoloading#load` pass through the second, optional argument for `Marshal#load( source [, proc] )`. This way we don't have to do `Marshal.method(:load).super_method.call(sourse, proc)` just to be able to pass a proc.

For reference: [https://ruby-doc.org/core-2.2.0/Marshal.html#method-c-load](https://ruby-doc.org/core-2.2.0/Marshal.html#method-c-load
)

### Other Information

I originally [submitted a similar pull request](https://github.com/rails/rails/pull/27894) to 4-2-stable a couple weeks ago. What's the standard practice for backporting changes like this?