### PR TITLE
Implicit `DEFAULT_LIMIT` should be 8 bytes (64-bit signed integer)

### DIFF
--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -5,10 +5,6 @@ module ActiveModel
     class Integer < Value # :nodoc:
       include Helpers::Numeric
 
-      # Column storage size in bytes.
-      # 4 bytes means an integer as opposed to smallint etc.
-      DEFAULT_LIMIT = 4
-
       def initialize(*)
         super
         @range = min_value...max_value
@@ -63,7 +59,7 @@ module ActiveModel
         end
 
         def _limit
-          limit || DEFAULT_LIMIT
+          limit || 8 # 8 bytes means a bigint as opposed to smallint etc.
         end
     end
   end

--- a/activemodel/test/cases/type/integer_test.rb
+++ b/activemodel/test/cases/type/integer_test.rb
@@ -64,13 +64,13 @@ module ActiveModel
 
       test "values below int min value are out of range" do
         assert_raises(ActiveModel::RangeError) do
-          Integer.new.serialize(-2147483649)
+          Integer.new(limit: 4).serialize(-2147483649)
         end
       end
 
       test "values above int max value are out of range" do
         assert_raises(ActiveModel::RangeError) do
-          Integer.new.serialize(2147483648)
+          Integer.new(limit: 4).serialize(2147483648)
         end
       end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -891,11 +891,9 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal 2147483648, company.rating
   end
 
-  unless current_adapter?(:SQLite3Adapter)
-    def test_bignum_pk
-      company = Company.create!(id: 2147483648, name: "foo")
-      assert_equal company, Company.find(company.id)
-    end
+  def test_bignum_pk
+    company = Company.create!(id: 2147483648, name: "foo")
+    assert_equal company, Company.find(company.id)
   end
 
   # TODO: extend defaults tests to other databases!


### PR DESCRIPTION
SQLite integer type is stored in 8 bytes. Assuming as 4 bytes causes
that valid in range value cannot be stored and existing value cannot be
found.

https://www.sqlite.org/datatype3.html

Fixes #22594.