### PR TITLE
improve numericality validator error messages

### DIFF
--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -34,3 +34,4 @@ en:
       other_than: "must be other than %{count}"
       odd: "must be odd"
       even: "must be even"
+      incomparable: "%{validator} validator returns an incomparable value"

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -54,6 +54,11 @@ module ActiveModel
               option_value = record.send(option_value)
             end
 
+            unless option_value.is_a?(Numeric)
+              record.errors.add(attr_name, :incomparable, filtered_options(value).merge!(validator: option))
+              next
+            end
+
             unless value.send(CHECKS[option], option_value)
               record.errors.add(attr_name, option, filtered_options(value).merge!(count: option_value))
             end

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -260,6 +260,22 @@ class NumericalityValidationTest < ActiveModel::TestCase
     Person.clear_validators!
   end
 
+  def test_validates_numericality_with_invalid_types
+    Topic.send(:define_method, :returns_nil, lambda { nil })
+    Topic.validates_numericality_of :approved,
+                                    greater_than: :returns_nil,
+                                    less_than: Proc.new(&:returns_nil)
+
+    topic = Topic.new(title: "numeric test", approved: 10)
+
+    assert topic.invalid?
+    assert_equal ["greater_than validator returns an incomparable value",
+                  "less_than validator returns an incomparable value"],
+                 topic.errors[:approved]
+  ensure
+    Topic.send(:remove_method, :returns_nil)
+  end
+
   def test_validates_numericality_with_invalid_args
     assert_raise(ArgumentError) { Topic.validates_numericality_of :approved, greater_than_or_equal_to: "foo" }
     assert_raise(ArgumentError) { Topic.validates_numericality_of :approved, less_than_or_equal_to: "foo" }


### PR DESCRIPTION
Attempt to improve numericality validator error messages when validators cannot return a numeric value. Fix for https://github.com/rails/rails/issues/27968