### PR TITLE
Remove redundant namespaces from sample code of `deprecated_method_wa…

### DIFF
--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -48,11 +48,11 @@ module ActiveSupport
       private
         # Outputs a deprecation warning message
         #
-        #   ActiveSupport::Deprecation.deprecated_method_warning(:method_name)
+        #   deprecated_method_warning(:method_name)
         #   # => "method_name is deprecated and will be removed from Rails #{deprecation_horizon}"
-        #   ActiveSupport::Deprecation.deprecated_method_warning(:method_name, :another_method)
+        #   deprecated_method_warning(:method_name, :another_method)
         #   # => "method_name is deprecated and will be removed from Rails #{deprecation_horizon} (use another_method instead)"
-        #   ActiveSupport::Deprecation.deprecated_method_warning(:method_name, "Optional message")
+        #   deprecated_method_warning(:method_name, "Optional message")
         #   # => "method_name is deprecated and will be removed from Rails #{deprecation_horizon} (Optional message)"
         def deprecated_method_warning(method_name, message = nil)
           warning = "#{method_name} is deprecated and will be removed from #{gem_name} #{deprecation_horizon}"


### PR DESCRIPTION
`deprecated_method_warning` is a private method. Name spaces should not be here.