### PR TITLE
Suppress deprecation warning `implementing to_yaml is deprecated`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/type_metadata.rb
@@ -2,6 +2,8 @@ module ActiveRecord
   module ConnectionAdapters
     module MySQL
       class TypeMetadata < DelegateClass(SqlTypeMetadata) # :nodoc:
+        undef to_yaml if method_defined?(:to_yaml)
+
         attr_reader :extra
 
         def initialize(type_metadata, extra: "")

--- a/activerecord/lib/active_record/connection_adapters/postgresql/type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/type_metadata.rb
@@ -1,6 +1,8 @@
 module ActiveRecord
   module ConnectionAdapters
     class PostgreSQLTypeMetadata < DelegateClass(SqlTypeMetadata)
+      undef to_yaml if method_defined?(:to_yaml)
+
       attr_reader :oid, :fmod, :array
 
       def initialize(type_metadata, oid: nil, fmod: nil)

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -1,6 +1,8 @@
 module ActiveRecord
   module Type
     class Serialized < DelegateClass(ActiveModel::Type::Value) # :nodoc:
+      undef to_yaml if method_defined?(:to_yaml)
+
       include ActiveModel::Type::Helpers::Mutable
 
       attr_reader :subtype, :coder


### PR DESCRIPTION
### Summary

Following script will output deprecation warning:

```ruby
require 'delegate'
require 'yaml'
class Delegated < DelegateClass(Object)
  def initialize
    super(Object.new)
  end
end

$VERBOSE = true
YAML.dump(Delegated.new)
# implementing to_yaml is deprecated, please implement "encode_with"
```

We can avoid the warning by `under to_yaml`.
([@nobu tells me how we can avoid](https://bugs.ruby-lang.org/issues/13115), thank you!)

### Other Information

At this time, deprecated messages are outputted on AR tests only
but probably we should apply this hack to all classes which use `DelegateClass` 

```ruby
[3] pry(main)> Travis.build(201772198).jobs.select {|j| j.log.body.include?('implementing to_yaml is deprecated') }.map {|j| j.config["env"]}
=> ["GEM=ar:mysql2",
 "GEM=ar:mysql2",
 "GEM=ar:mysql2",
 "GEM=ar:postgresql",
 "GEM=ar:postgresql",
 "GEM=ar:postgresql",
 "GEM=ar:mysql2 MYSQL=mariadb",
 "GEM=ar:mysql2",
 "GEM=ar:postgresql"]
```