### PR TITLE
Indicate units of 'limit' in 'Integer' error message.

### DIFF
--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -48,7 +48,7 @@ module ActiveModel
 
         def ensure_in_range(value)
           unless range.cover?(value)
-            raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit}"
+            raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
           end
         end
 


### PR DESCRIPTION
It took a minute or two of searching online to find out what the units are referred to by this 'limit' error message, so it'd be helpful if the error message provided that information up-front.