### PR TITLE
Fix w3c_validator.rb validation script

### DIFF
--- a/guides/w3c_validator.rb
+++ b/guides/w3c_validator.rb
@@ -32,7 +32,8 @@ include W3CValidators
 module RailsGuides
   class Validator
     def validate
-      validator = MarkupValidator.new
+      # https://github.com/w3c-validators/w3c_validators/issues/25
+      validator = NuValidator.new
       STDOUT.sync = true
       errors_on_guides = {}
 
@@ -44,11 +45,11 @@ module RailsGuides
           next
         end
 
-        if results.validity
-          print "."
-        else
+        if results.errors.length > 0
           print "E"
           errors_on_guides[f] = results.errors
+        else
+          print "."
         end
       end
 


### PR DESCRIPTION
### Summary

`w3c_validator.rb` currently failing with:

```
/usr/bin/ruby2.3 w3c_validator.rb

Could not validate ./output/credits.html because of 302 "Found"
Could not validate ./output/3_2_release_notes.html because of 302 "Found"
Could not validate ./output/rails_application_templates.html because of 302 "Found"
Could not validate ./output/active_record_basics.html because of 302 "Found"
```

### Other Information

PR submitted to the gem https://github.com/w3c-validators/w3c_validators/pull/33