### PR TITLE
Explain what action_mailer.perform_caching does

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -30,6 +30,7 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  # Enable/disable caching. By default caching is disabled.
   config.action_mailer.perform_caching = false
   <%- end -%>
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -64,6 +64,7 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "<%= app_name %>_#{Rails.env}"
   <%- unless options.skip_action_mailer? -%>
+  # Enable/disable caching. By default caching is disabled.
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
The reason for this commit is to keep the environment files consistent.

Every configuration is preceded by a line that explains the default value,
except for `config.action_mailer.perform_caching = false`.

<img width="480" alt="newly generated app" src="https://cloud.githubusercontent.com/assets/10076/23000122/dc72017c-f393-11e6-9b09-164628cf47d6.png">


I have two questions for the reviewers:

1) Is my comment explanatory enough or should it be more verbose?

2) Is the code correct? Should caching be *disabled* by default even in production?

Thanks!