### PR TITLE
Raise NotImplementedError when using empty_insert_statement_value with Oracle

### DIFF
--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -143,6 +143,8 @@ module ActiveRecord
     end
 
     def test_dup_without_primary_key
+      skip if current_adapter?(:OracleAdapter)
+
       klass = Class.new(ActiveRecord::Base) do
         self.table_name = "parrots_pirates"
       end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -183,6 +183,8 @@ class PrimaryKeysTest < ActiveRecord::TestCase
   end
 
   def test_create_without_primary_key_no_extra_query
+    skip if current_adapter?(:OracleAdapter)
+
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "dashboards"
     end


### PR DESCRIPTION
## Summary

Follow up to https://github.com/rsim/oracle-enhanced/pull/1180.

This PR fixes the following 2 errors when using Oracle (11g) .

### 1. PrimaryKeysTest#test_create_without_primary_key_no_extra_query

```sh
% ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]
% ARCONN=oracle bundle exec ruby -w -Itest:lib test/cases/primary_keys_test.rb -n test_create_without_primary_key_no_extra_query

(snip)

Run options: -n test_create_without_primary_key_no_extra_query --seed 5401

# Running:

E

Finished in 0.286236s, 3.4936 runs/s, 0.0000 assertions/s.

  1) Error:
PrimaryKeysTest#test_create_without_primary_key_no_extra_query:
NotImplementedError: NotImplementedError
    /home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:228:in `empty_insert_statement_value'
    /home/vagrant/src/rails/activerecord/lib/active_record/relation.rb:56:in `insert'
    /home/vagrant/src/rails/activerecord/lib/active_record/persistence.rb:578:in `_create_record'
    /home/vagrant/src/rails/activerecord/lib/active_record/counter_cache.rb:178:in `_create_record'
    /home/vagrant/src/rails/activerecord/lib/active_record/locking/optimistic.rb:78:in `_create_record'
    /home/vagrant/src/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:296:in `_create_record'
    /home/vagrant/src/rails/activerecord/lib/active_record/callbacks.rb:340:in `block in _create_record'
    /home/vagrant/src/rails/activesupport/lib/active_support/callbacks.rb:131:in `run_callbacks'
    /home/vagrant/src/rails/activesupport/lib/active_support/callbacks.rb:825:in `_run_create_callbacks'
    /home/vagrant/src/rails/activerecord/lib/active_record/callbacks.rb:340:in `_create_record'
    /home/vagrant/src/rails/activerecord/lib/active_record/timestamp.rb:95:in `_create_record'
    /home/vagrant/src/rails/activerecord/lib/active_record/persistence.rb:555:in `create_or_update'
    /home/vagrant/src/rails/activerecord/lib/active_record/callbacks.rb:336:in `block in create_or_update'
    /home/vagrant/src/rails/activesupport/lib/active_support/callbacks.rb:97:in `run_callbacks'
    /home/vagrant/src/rails/activesupport/lib/active_support/callbacks.rb:825:in `_run_save_callbacks'
    /home/vagrant/src/rails/activerecord/lib/active_record/callbacks.rb:336:in `create_or_update'
    /home/vagrant/src/rails/activerecord/lib/active_record/persistence.rb:154:in `save!'
    /home/vagrant/src/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
    /home/vagrant/src/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:43:in `save!'
    /home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:313:in `block in save!'
    /home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:384:in `block in with_transaction_returning_status'
    /home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `block in transaction'
    /home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:196:in `within_new_transaction'
    /home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `transaction'
    /home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:210:in `transaction'
    /home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:381:in `with_transaction_returning_status'
    /home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:313:in `save!'
    /home/vagrant/src/rails/activerecord/lib/active_record/suppressor.rb:46:in `save!'
    /home/vagrant/src/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
    test/cases/primary_keys_test.rb:189:in `test_create_without_primary_key_no_extra_query'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

### 2. ActiveRecord::DupTest#test_dup_without_primary_key

```sh
% ARCONN=oracle bundle exec ruby -w -Itest test/cases/dup_test.rb -n test_dup_without_primary_key

(snip)

Run options: -n test_dup_without_primary_key --seed 41695

# Running:

E

Finished in 0.197323s, 5.0678 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::DupTest#test_dup_without_primary_key:
NotImplementedError: NotImplementedError
    /home/vagrant/src/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:228:in `empty_insert_statem
ent_value'
    /home/vagrant/src/rails/activerecord/lib/active_record/relation.rb:56:in `insert'
    /home/vagrant/src/rails/activerecord/lib/active_record/persistence.rb:578:in `_create_record'
    /home/vagrant/src/rails/activerecord/lib/active_record/counter_cache.rb:178:in `_create_record'
    /home/vagrant/src/rails/activerecord/lib/active_record/locking/optimistic.rb:78:in `_create_record'
    /home/vagrant/src/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:296:in `_create_record'
    /home/vagrant/src/rails/activerecord/lib/active_record/callbacks.rb:340:in `block in _create_record'
    /home/vagrant/src/rails/activesupport/lib/active_support/callbacks.rb:131:in `run_callbacks'
    /home/vagrant/src/rails/activesupport/lib/active_support/callbacks.rb:825:in `_run_create_callbacks'
    /home/vagrant/src/rails/activerecord/lib/active_record/callbacks.rb:340:in `_create_record'
    /home/vagrant/src/rails/activerecord/lib/active_record/timestamp.rb:95:in `_create_record'
    /home/vagrant/src/rails/activerecord/lib/active_record/persistence.rb:555:in `create_or_update'
    /home/vagrant/src/rails/activerecord/lib/active_record/callbacks.rb:336:in `block in create_or_update'
    /home/vagrant/src/rails/activesupport/lib/active_support/callbacks.rb:97:in `run_callbacks'
    /home/vagrant/src/rails/activesupport/lib/active_support/callbacks.rb:825:in `_run_save_callbacks'
    /home/vagrant/src/rails/activerecord/lib/active_record/callbacks.rb:336:in `create_or_update'
    /home/vagrant/src/rails/activerecord/lib/active_record/persistence.rb:154:in `save!'
    /home/vagrant/src/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
    /home/vagrant/src/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:43:in `save!'
    /home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:313:in `block in save!'
    /home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:384:in `block in with_transaction_returning_status'
    /home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `block in transaction'
    /home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
    /home/vagrant/src/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `transaction'
    /home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:210:in `transaction'
    /home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:381:in `with_transaction_returning_status'
    /home/vagrant/src/rails/activerecord/lib/active_record/transactions.rb:313:in `save!'
    /home/vagrant/src/rails/activerecord/lib/active_record/suppressor.rb:46:in `save!'
    /home/vagrant/src/rails/activerecord/lib/active_record/persistence.rb:51:in `create!'
    test/cases/dup_test.rb:150:in `test_dup_without_primary_key'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

`empty_insert_statement_value` is not implemented by Oracle database. When using `empty_insert_statement_value` method, raises `NotImplementedError`.

### Other Information

With 5-0-stable, the `NotImplementedError` exception does not occur. So backport to 5-0-stable is unnecessary.
