### PR TITLE
Add rel="noopener" to a link by default

### DIFF
--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -310,6 +310,84 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_dom_equal %{<a href="/">Hello</a>}, link
   end
 
+  def test_link_with_href_http_and_target_blank
+    link = link_to("Hello", "http://www.example.com", target: "_blank")
+    expected = %{<a href="http://www.example.com" target="_blank" rel="noopener">Hello</a>}
+    assert_dom_equal expected, link
+  end
+
+  def test_link_with_href_https_and_target_blank
+    link = link_to("Hello", "https://www.example.com", target: "_blank")
+    expected = %{<a href="https://www.example.com" target="_blank" rel="noopener">Hello</a>}
+    assert_dom_equal expected, link
+  end
+
+  def test_link_with_href_path_and_target_blank
+    link = link_to("Hello", "/", target: "_blank")
+    expected = %{<a href="/" target="_blank">Hello</a>}
+    assert_dom_equal expected, link
+  end
+
+  def test_link_with_target_as_any_string
+    link = link_to("Hello", "http://www.example.com", target: "foo")
+    expected = %{<a href="http://www.example.com" target="foo" rel="noopener">Hello</a>}
+    assert_dom_equal expected, link
+  end
+
+  def test_link_with_target_nil
+    link = link_to("Hello", "http://www.example.com", target: nil)
+    expected = %{<a href="http://www.example.com">Hello</a>}
+    assert_dom_equal expected, link
+  end
+
+  def test_link_with_target_as_empty_string
+    link = link_to("Hello", "http://www.example.com", target: "")
+    expected = %{<a href="http://www.example.com" target="">Hello</a>}
+    assert_dom_equal expected, link
+  end
+
+  def test_link_with_target_parent
+    link = link_to("Hello", "http://www.example.com", target: "_parent")
+    expected = %{<a href="http://www.example.com" target="_parent">Hello</a>}
+    assert_dom_equal expected, link
+  end
+
+  def test_link_with_target_self
+    link = link_to("Hello", "http://www.example.com", target: "_self")
+    expected = %{<a href="http://www.example.com" target="_self">Hello</a>}
+    assert_dom_equal expected, link
+  end
+
+  def test_link_with_target_top
+    link = link_to("Hello", "http://www.example.com", target: "_top")
+    expected = %{<a href="http://www.example.com" target="_top">Hello</a>}
+    assert_dom_equal expected, link
+  end
+
+  def test_link_with_target_blank_and_rel_nonempty
+    link = link_to("Hello", "http://www.example.com", target: "_blank", rel: "nofollow")
+    expected = %{<a href="http://www.example.com" target="_blank" rel="nofollow noopener">Hello</a>}
+    assert_dom_equal expected, link
+  end
+
+  def test_link_with_target_blank_and_rel_noopener
+    link = link_to("Hello", "http://www.example.com", target: "_blank", rel: "noopener")
+    expected = %{<a href="http://www.example.com" target="_blank" rel="noopener">Hello</a>}
+    assert_dom_equal expected, link
+  end
+
+  def test_link_with_target_blank_and_opener_true
+    link = link_to("Hello", "http://www.example.com", target: "_blank", opener: true)
+    expected = %{<a href="http://www.example.com" target="_blank">Hello</a>}
+    assert_dom_equal expected, link
+  end
+
+  def test_link_with_target_blank_and_opener_false
+    link = link_to("Hello", "http://www.example.com", target: "_blank", opener: false)
+    expected = %{<a href="http://www.example.com" target="_blank" rel="noopener">Hello</a>}
+    assert_dom_equal expected, link
+  end
+
   def test_link_tag_with_custom_onclick
     link = link_to("Hello", "http://www.example.com", onclick: "alert('yay!')")
     expected = %{<a href="http://www.example.com" onclick="alert(&#39;yay!&#39;)">Hello</a>}


### PR DESCRIPTION
## Summary

[Similar pull request](https://github.com/rails/rails/pull/25548) was already published some time ago and closed for some reason. ~This pull request references to the same "issue". In brief, adding `rel="noopener"` to `link_to` by default, when particular conditions are met, will provide developers the built-in protection against phishing attacks. The difference between https://github.com/rails/rails/pull/25548 and my pull request comes down to implementation details.~

~## Implementation details~

~1. The actual code was placed in `link_to` method. I think it makes no sense to put it to `convert_options_to_data_attributes` method which is shared between `link_to` and `button_to`. `button_to` generates `<form>` which doesn't support `rel` attribute.~

~2. `rel="noopener"` will be added, if a link uses `http://` or `https://`. If a link doesn't contain an HTTP(S) prefix, it will redirect to a page inside a current application.~

~3. `rel="noopener"` will be added, if `target` is `_blank` or any other string except an empty string, `_parent`, `_self` or `_top`.~

~4. If `rel="noopener"` already exists inside `link_to`, it won't be duplicated.~

~5. If you provide `opener: true`, `rel="noopener"` won't appear by default.~

~## Other information~

~Currently `rel="noopener"` is supported by Chrome and Opera. Firefox will support this attribute in the newest upcoming version 52, the same as Safari 10.1.~

### **[UPDATE] July 12th, 2020**

## Implementation details

https://github.com/rails/rails/pull/28035#issuecomment-643765910

> I have prepared a proof of concept, here it is: https://github.com/michald/rails/commit/69a75a0d1c2518ded3b0cd553b5a7ba97b63e88a Before I implement something that can be code-reviewed, I want to make sure this is the right direction. My assumptions:
> 
> 1) We implement `rel` support only for `<a>` element (more specifically `link_to` helper). `rel` is supported by multiple tags in a different manner https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel Hence, each attribute would require its own defaults.
> 
> 2) You could define default values in a global config:
> ```
> config.action_view.link_rel_values = {
>   nofollow:   true,
>   noreferrer: false,
>   noopener:   -> (html_options) { # it should return a boolean value }
> }
> ```
> It's empty by default.
> 
> 3) You could overwrite default values on a `link_to` level this way:
> ```
> link_to "My Link", "https://github.com/rails/rails", rel: { noreferrer: true, nofollow: -> (html_options) { # do whatever you want }
> ```
> 
> 4) Until now, `link_to` supported `rel` HTML option as a string. Now, it would support a string or a hash.
> 
> 5) At the moment, `link_to` (as well as `button_to`) adds `nofollow` for non-`GET` HTTP request methods by default. https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/url_helper.rb#L690 I think we should keep it due to backward-compatibility. However, I have noticed `button_to` implements it in the wrong way I guess. It puts `nofollow` in the `button` or `input` which don't support `rel`. It should embed `nofollow` in the `form` tag instead. https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/url_helper.rb#L327-L335  Anyway, this a different story.

## Other information

Most of the modern web browsers support `noopener`, see more https://caniuse.com/#feat=rel-noopener.