### PR TITLE
Do not let `inflect.uncountables` have duplicated values

### DIFF
--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -44,7 +44,7 @@ module ActiveSupport
         end
 
         def add(words)
-          words = words.flatten.map(&:downcase)
+          words = words.flatten.map(&:downcase).reject { |word| uncountable?(word) }
           concat(words)
           @regex_array += words.map { |word| to_regex(word) }
           self

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -461,6 +461,15 @@ class InflectorTest < ActiveSupport::TestCase
     end
   end
 
+  def test_add_does_not_allow_duplicated_values
+    ActiveSupport::Inflector.inflections(:en) do |inflect|
+      inflect.uncountable "equipment"
+      inflect.uncountable "equipment"
+
+      assert_equal 1, inflect.uncountables.count { |uncountable| uncountable == "equipment" }
+    end
+  end
+
   Irregularities.each do |singular, plural|
     define_method("test_irregularity_between_#{singular}_and_#{plural}") do
       ActiveSupport::Inflector.inflections do |inflect|


### PR DESCRIPTION
Currently ActiveSupport::Inflector::Inflections#uncountables can have duplicated values like this: 

```ruby
ActiveSupport::Inflector.inflections(:en) do |inflect|
  inflect.plural /^(ox)$/i, '\1\2en'
  inflect.singular /^(ox)en/i, '\1'
    
  inflect.irregular 'octopus', 'octopi'
    
  inflect.uncountable 'equipment'
  inflect.uncountable 'equipment'
end

# => ["equipment", "information", "rice", "money", "species", "series", "fish", "sheep", "jeans", "police", "equipment", "equipment"]
```

I think It is better to filter the values in `add` method not to accept existent values any more because there is no point in letting `uncountable` have duplicated values.