### PR TITLE
Switch minitest to development dependency, fixes gjtorikian/html-proofer#380

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "i18n",       "~> 0.7"
   s.add_dependency "tzinfo",     "~> 1.1"
-  s.add_dependency "minitest",   "~> 5.1"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
+  s.add_development_dependency "minitest",   "~> 5.1"
 end


### PR DESCRIPTION
Related discussion: https://github.com/gjtorikian/html-proofer/issues/380#issuecomment-280484629

`minitest` is currently a dependency of `activesupport`. However these does not appear to be an end-user benefit of this. I have switched this to a development_dependency so that end users are not bothered with downloading this unnecessary dependency.