### PR TITLE
Fix failed migration in a fresh database prevents subsequent db:drop

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1015,7 +1015,7 @@ module ActiveRecord
       deprecate :initialize_schema_migrations_table
 
       def initialize_internal_metadata_table # :nodoc:
-        ActiveRecord::InternalMetadata.create_table
+        ActiveRecord::InternalMetadata.initialize_table
       end
       deprecate :initialize_internal_metadata_table
 

--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -26,18 +26,30 @@ module ActiveRecord
         connection.table_exists?(table_name)
       end
 
-      # Creates an internal metadata table with columns +key+ and +value+
-      def create_table
-        unless table_exists?
-          key_options = connection.internal_string_options_for_primary_key
+      def initialize_table
+        create_table
+        connection.reset!
+        record_current_environment
+      end
 
-          connection.create_table(table_name, id: false) do |t|
-            t.string :key, key_options
-            t.string :value
-            t.timestamps
+      def record_current_environment
+        self[:environment] = ActiveRecord::Migrator.current_environment
+      end
+
+      private
+
+        # Creates an internal metadata table with columns +key+ and +value+
+        def create_table
+          unless table_exists?
+            key_options = connection.internal_string_options_for_primary_key
+
+            connection.create_table(table_name, id: false) do |t|
+              t.string :key, key_options
+              t.string :value
+              t.timestamps
+            end
           end
         end
-      end
     end
   end
 end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1108,7 +1108,7 @@ module ActiveRecord
       validate(@migrations)
 
       ActiveRecord::SchemaMigration.create_table
-      ActiveRecord::InternalMetadata.create_table
+      ActiveRecord::InternalMetadata.initialize_table
     end
 
     def current_version
@@ -1193,7 +1193,7 @@ module ActiveRecord
       # Stores the current environment in the database.
       def record_environment
         return if down?
-        ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Migrator.current_environment
+        ActiveRecord::InternalMetadata.record_current_environment
       end
 
       def ran?(migration)

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -3,8 +3,7 @@ require "active_record"
 db_namespace = namespace :db do
   desc "Set the environment value for the database"
   task "environment:set" => [:environment, :load_config] do
-    ActiveRecord::InternalMetadata.create_table
-    ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Migrator.current_environment
+    ActiveRecord::InternalMetadata.initialize_table
   end
 
   task check_protected_environments: [:environment, :load_config] do

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -52,8 +52,7 @@ module ActiveRecord
         connection.assume_migrated_upto_version(info[:version], migrations_paths)
       end
 
-      ActiveRecord::InternalMetadata.create_table
-      ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Migrator.current_environment
+      ActiveRecord::InternalMetadata.initialize_table
     end
 
     private

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -235,8 +235,7 @@ module ActiveRecord
         else
           raise ArgumentError, "unknown format #{format.inspect}"
         end
-        ActiveRecord::InternalMetadata.create_table
-        ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Migrator.current_environment
+        ActiveRecord::InternalMetadata.initialize_table
       end
 
       def schema_file(format = ActiveRecord::Base.schema_format)

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -27,7 +27,7 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
       table_name = ActiveRecord::InternalMetadata.table_name
       connection.drop_table table_name, if_exists: true
 
-      ActiveRecord::InternalMetadata.create_table
+      ActiveRecord::InternalMetadata.initialize_table
 
       assert connection.column_exists?(table_name, :key, :string, collation: "utf8_general_ci")
     end

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -289,7 +289,7 @@ class PostgresqlUUIDTestNilDefault < ActiveRecord::PostgreSQLTestCase
       ActiveRecord::Migration.verbose = false
 
       migration = Class.new(ActiveRecord::Migration[5.0]) do
-        def version; 101 end
+        def version; 102 end
         def migrate(x)
           create_table("pg_uuids_4", id: :uuid, default: nil)
         end


### PR DESCRIPTION
### Summary

When we create internal_metadata table, then we always record current
environment into internal_metadata table.
This pull request will fix #28001 problem.