### PR TITLE
Fix typo in I18n Guide

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -417,7 +417,7 @@ If your translations are stored in YAML files, certain keys must be escaped. The
 Examples:
 
 ```erb
-# confing/locales/en.yml
+# config/locales/en.yml
 en:
   success:
     'true':  'True!'


### PR DESCRIPTION
### Summary

Fix typo in YAML example from I18n Guide.