### PR TITLE
Collect all file patterns when running multiple rake test tasks

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix running multiple tests in one `rake` command
+
+    e.g. `bin/rake test:models test:controllers`
+
+    *Dominic Cleal*
+
 *   Don't generate HTML/ERB templates for scaffold controller with `--api` flag.
 
     Fixes #27591.

--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -54,19 +54,18 @@ module Minitest
 
     options[:color] = true
     options[:output_inline] = true
-    options[:patterns] = defined?(@rake_patterns) ? @rake_patterns : opts.order!
+    options[:patterns] = opts.order! unless run_via[:rake]
   end
 
-  # Running several Rake tasks in a single command would trip up the runner,
-  # as the patterns would also contain the other Rake tasks.
   def self.rake_run(patterns) # :nodoc:
-    @rake_patterns = patterns
+    run_via[:rake] = true
+    ::Rails::TestRequirer.require_files(patterns)
     autorun
   end
 
   module RunRespectingRakeTestopts
     def run(args = [])
-      if defined?(@rake_patterns)
+      if run_via[:rake]
         args = Shellwords.split(ENV["TESTOPTS"] || "")
       end
 
@@ -81,8 +80,9 @@ module Minitest
   def self.plugin_rails_init(options)
     ENV["RAILS_ENV"] = options[:environment] || "test"
 
-    # If run via `ruby` we've been passed the files to run directly.
-    unless run_via[:ruby]
+    # If run via `ruby` we've been passed the files to run directly, or if run
+    # via `rake` then they have already been eagerly required.
+    unless run_via[:ruby] || run_via[:rake]
       ::Rails::TestRequirer.require_files(options[:patterns])
     end
 

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -536,6 +536,21 @@ module ApplicationTests
       assert_match "seed=1234", output, "passing TEST= should run selected test"
     end
 
+    def test_rake_runs_multiple_test_tasks
+      create_test_file :models, "account"
+      create_test_file :controllers, "accounts_controller"
+      output = Dir.chdir(app_path) { `bin/rake test:models test:controllers TESTOPTS='-v'` }
+      assert_match "AccountTest#test_truth", output
+      assert_match "AccountsControllerTest#test_truth", output
+    end
+
+    def test_rake_db_and_test_tasks_parses_args_correctly
+      create_test_file :models, "account"
+      output = Dir.chdir(app_path) { `bin/rake db:migrate test:models TESTOPTS='-v' && echo ".tables" | rails dbconsole` }
+      assert_match "AccountTest#test_truth", output
+      assert_match "ar_internal_metadata", output
+    end
+
     private
       def run_test_command(arguments = 'test/unit/test_test.rb')
         Dir.chdir(app_path) { `bin/rails t #{arguments}` }


### PR DESCRIPTION
Replaces the rake_patterns instance variable with simple require, as
`autorun` will run tests from all eagerly required test files.

Fixes #27801

(**backport of merged #27802**, cherry picked from commit 1c8a4cdf63134f34d638703a956c2706d8e3789f on master)