### PR TITLE
Avoid converting integer as a string into float

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Avoid converting integer as a string into float.
+
+    *namusyaka*
+
 *   Remove deprecated behavior that halts callbacks when the return is false.
 
     *Rafael Mendonça França*

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -70,6 +70,7 @@ module ActiveModel
       end
 
       def parse_raw_value_as_a_number(raw_value)
+        return raw_value.to_i if is_integer?(raw_value)
         Kernel.Float(raw_value) if raw_value !~ /\A0[xX]/
       end
 

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -260,6 +260,15 @@ class NumericalityValidationTest < ActiveModel::TestCase
     Person.clear_validators!
   end
 
+  def test_validates_numericality_with_exponent_number
+    base = 10_000_000_000_000_000
+    Topic.validates_numericality_of :approved, less_than_or_equal_to: base
+    topic = Topic.new
+    topic.approved = (base + 1).to_s
+
+    assert topic.invalid?
+  end
+
   def test_validates_numericality_with_invalid_args
     assert_raise(ArgumentError) { Topic.validates_numericality_of :approved, greater_than_or_equal_to: "foo" }
     assert_raise(ArgumentError) { Topic.validates_numericality_of :approved, less_than_or_equal_to: "foo" }


### PR DESCRIPTION
### Summary

If the number of digits increases so that exponential notation has to be done, correct comparison won't be done at present.
Thus, this makes the validator convert integer string into integer, not float.