### PR TITLE
Skip environment check when environments is not stored

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1256,9 +1256,7 @@ module ActiveRecord
         return nil if current_version == 0
         raise NoEnvironmentInSchemaError unless ActiveRecord::InternalMetadata.table_exists?
 
-        environment = ActiveRecord::InternalMetadata[:environment]
-        raise NoEnvironmentInSchemaError unless environment
-        environment
+        ActiveRecord::InternalMetadata[:environment]
       end
 
       def self.current_environment


### PR DESCRIPTION
### Summary

When environments is not stored, then just skip the environment check.
This will fix #28001 

### Other Information

I have already sent other pull request #28046 
This pull request is based on the comment https://github.com/rails/rails/pull/28046#issuecomment-280617743
