### PR TITLE
Remove `:doc:` for `NumericalityValidator` [ci skip]

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -63,27 +63,27 @@ module ActiveModel
 
     private
 
-      def is_number?(raw_value) # :doc:
+      def is_number?(raw_value)
         !parse_raw_value_as_a_number(raw_value).nil?
       rescue ArgumentError, TypeError
         false
       end
 
-      def parse_raw_value_as_a_number(raw_value) # :doc:
+      def parse_raw_value_as_a_number(raw_value)
         Kernel.Float(raw_value) if raw_value !~ /\A0[xX]/
       end
 
-      def is_integer?(raw_value) # :doc:
+      def is_integer?(raw_value)
         /\A[+-]?\d+\z/ === raw_value.to_s
       end
 
-      def filtered_options(value) # :doc:
+      def filtered_options(value)
         filtered = options.except(*RESERVED_OPTIONS)
         filtered[:value] = value
         filtered
       end
 
-      def allow_only_integer?(record) # :doc:
+      def allow_only_integer?(record)
         case options[:only_integer]
         when Symbol
           record.send(options[:only_integer])


### PR DESCRIPTION
The `:doc:` was added in cdb9d7f but `NumericalityValidator` is already
`:nodoc:` class. `:doc:` is unneeded.

https://github.com/rails/rails/blob/master/activemodel/lib/active_model/validations/numericality.rb#L3

r? @amatsuda 