### PR TITLE
Use Puma 3.7

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -190,7 +190,7 @@ module Rails
       def webserver_gemfile_entry # :doc:
         return [] if options[:skip_puma]
         comment = "Use Puma as the app server"
-        GemfileEntry.new("puma", "~> 3.0", comment)
+        GemfileEntry.new("puma", "~> 3.7", comment)
       end
 
       def include_all_railties? # :doc:

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -339,7 +339,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_generator_defaults_to_puma_version
     run_generator [destination_root]
-    assert_gem "puma", "'~> 3.0'"
+    assert_gem "puma", "'~> 3.7'"
   end
 
   def test_generator_if_skip_puma_is_given


### PR DESCRIPTION
### Summary
rails service -p is not working properly, since there's a bug on he puma server, ref this commit seems that has not been merged into 3.7 https://github.com/puma/puma/commit/42bec4600c51ab8a1c1ee5a0e1b738a4ffd82bf2

Rails should be suggesting to use 3.6.x or olders versions instead?