### PR TITLE
Clear active connections after initialization

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -166,5 +166,13 @@ end_warning
       path = app.paths["db"].first
       config.watchable_files.concat ["#{path}/schema.rb", "#{path}/structure.sql"]
     end
+
+    initializer "active_record.clear_active_connections" do
+      config.after_initialize do
+        ActiveSupport.on_load(:active_record) do
+          clear_active_connections!
+        end
+      end
+    end
   end
 end

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -262,5 +262,13 @@ module ApplicationTests
         Rails.env = orig_rails_env if orig_rails_env
       end
     end
+
+    test "connections checked out during initialization are returned to the pool" do
+      app_file "config/initializers/active_record.rb", <<-RUBY
+        ActiveRecord::Base.connection
+      RUBY
+      require "#{app_path}/config/environment"
+      assert !ActiveRecord::Base.connection_pool.active_connection?
+    end
   end
 end


### PR DESCRIPTION
Any connections that were checked out during initialization should be checked back in before the first request is processed, for two reasons:

 - Returning the connection to the pool allows it to be health checked before it's used again. If the connection dies before the first request arrives, the health check will replace it with a new one.

 - If the thread that initialized Rails is not the same thread that will be performing work, checking in the connection will allow it to be reused instead of being stuck to the initialization thread forever.

The second use case was the reason I wrote this patch - we run a *lot* of Sidekiq processes at @intercom, and deploying this reduced the peak open connection count on our database by 13%.