### PR TITLE
Remove `encode_special_chars` option from `strip_tags`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Remove the option `encode_special_chars` misnomer from `strip_tags`
+
+    As of rails-html-sanitizer v1.0.3 sanitizer will ignore the
+    `encode_special_chars` option. Fixes #28060.
+
+    *Andrew Hood*
+
 ## Rails 5.1.0.beta1 (February 23, 2017) ##
 
 *   Change the ERB handler from Erubis to Erubi.

--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -13,6 +13,7 @@ module ActionView
       # It also strips href/src attributes with unsafe protocols like
       # <tt>javascript:</tt>, while also protecting against attempts to use Unicode,
       # ASCII, and hex character references to work around these protocol filters.
+      # All special characters will be escaped.
       #
       # The default sanitizer is Rails::Html::WhiteListSanitizer. See {Rails HTML
       # Sanitizers}[https://github.com/rails/rails-html-sanitizer] for more information.
@@ -20,8 +21,7 @@ module ActionView
       # Custom sanitization rules can also be provided.
       #
       # Please note that sanitizing user-provided text does not guarantee that the
-      # resulting markup is valid or even well-formed. For example, the output may still
-      # contain unescaped characters like <tt><</tt>, <tt>></tt>, or <tt>&</tt>.
+      # resulting markup is valid or even well-formed.
       #
       # ==== Options
       #
@@ -86,7 +86,7 @@ module ActionView
         self.class.white_list_sanitizer.sanitize_css(style)
       end
 
-      # Strips all HTML tags from +html+, including comments.
+      # Strips all HTML tags from +html+, including comments and special characters.
       #
       #   strip_tags("Strip <i>these</i> tags!")
       #   # => Strip these tags!
@@ -96,8 +96,11 @@ module ActionView
       #
       #   strip_tags("<div id='top-bar'>Welcome to my website!</div>")
       #   # => Welcome to my website!
+      #
+      #   strip_tags("> A quote from Smith & Wesson")
+      #   # => &gt; A quote from Smith &amp; Wesson
       def strip_tags(html)
-        self.class.full_sanitizer.sanitize(html, encode_special_chars: false)
+        self.class.full_sanitizer.sanitize(html)
       end
 
       # Strips all link tags from +html+ leaving just the link text.
@@ -110,6 +113,9 @@ module ActionView
       #
       #   strip_links('Blog: <a href="http://www.myblog.com/" class="nav" target=\"_blank\">Visit</a>.')
       #   # => Blog: Visit.
+      #
+      #   strip_links('<<a href="https://example.org">malformed & link</a>')
+      #   # => &lt;malformed &amp; link
       def strip_links(html)
         self.class.link_sanitizer.sanitize(html)
       end

--- a/actionview/test/template/sanitize_helper_test.rb
+++ b/actionview/test/template/sanitize_helper_test.rb
@@ -10,6 +10,7 @@ class SanitizeHelperTest < ActionView::TestCase
     assert_equal "on my mind\nall day long", strip_links("<a href='almost'>on my mind</a>\n<A href='almost'>all day long</A>")
     assert_equal "Magic", strip_links("<a href='http://www.rubyonrails.com/'>Mag<a href='http://www.ruby-lang.org/'>ic")
     assert_equal "My mind\nall <b>day</b> long", strip_links("<a href='almost'>My mind</a>\n<A href='almost'>all <b>day</b> long</A>")
+    assert_equal "&lt;malformed &amp; link", strip_links('<<a href="https://example.org">malformed & link</a>')
   end
 
   def test_sanitize_form
@@ -26,6 +27,7 @@ class SanitizeHelperTest < ActionView::TestCase
     assert_equal("Dont touch me", strip_tags("Dont touch me"))
     assert_equal("This is a test.", strip_tags("<p>This <u>is<u> a <a href='test.html'><strong>test</strong></a>.</p>"))
     assert_equal "This has a  here.", strip_tags("This has a <!-- comment --> here.")
+    assert_equal("Jekyll &amp; Hyde", strip_tags("Jekyll & Hyde"))
     assert_equal "", strip_tags("<script>")
   end
 


### PR DESCRIPTION
This pr removes the misnomer option `encode_special_chars: false` from the `strip_tags` helper.

Fixes: https://github.com/rails/rails/issues/28060