### PR TITLE
Make adding gemfile entry work even if specify only the plugin name

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -432,7 +432,7 @@ end
       end
 
       def inside_application?
-        rails_app_path && app_path =~ /^#{rails_app_path}/
+        rails_app_path && destination_root.start_with?(rails_app_path.to_s)
       end
 
       def relative_path

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -535,6 +535,21 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     FileUtils.rm gemfile_path
   end
 
+  def test_creating_plugin_only_specify_plugin_name_in_app_directory_adds_gemfile_entry
+    # simulate application existence
+    gemfile_path = "#{Rails.root}/Gemfile"
+    Object.const_set("APP_PATH", Rails.root)
+    FileUtils.touch gemfile_path
+
+    FileUtils.cd(destination_root)
+    run_generator ["bukkits"]
+
+    assert_file gemfile_path, /gem 'bukkits', path: 'bukkits'/
+  ensure
+    Object.send(:remove_const, "APP_PATH")
+    FileUtils.rm gemfile_path
+  end
+
   def test_skipping_gemfile_entry
     # simulate application existence
     gemfile_path = "#{Rails.root}/Gemfile"


### PR DESCRIPTION
Whether the command was executed within the rails application is checked
by whether or not the application's path matches `app_path`.
https://github.com/rails/rails/blob/5-0-stable/railties/lib/rails/generators/rails/plugin/plugin_generator.rb#L439..L441

Therefore, if only plugin name is specified in `app_path`, addition to Gemfile is not done.
However, in the rails guide an example of specifying only plugin name is given, and it is considered that there are many cases where only plugin name is specified.
For that reason, made it work even if only plugin name was specified.
