### PR TITLE
Do not evaluate :if arguments when :on is not satisfied for transaction callbacks

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -283,7 +283,7 @@ module ActiveRecord
             fire_on = Array(options[:on])
             assert_valid_transaction_action(fire_on)
             options[:if] = Array(options[:if])
-            options[:if] << "transaction_include_any_action?(#{fire_on})"
+            options[:if].unshift("transaction_include_any_action?(#{fire_on})")
           end
         end
 


### PR DESCRIPTION
### Summary

This addresses #28019 by prepending the `:on` action check before the supplied `:if` argument. The previous behavior appended `:on` at the end of the list when setting up a callback, allowing `:if` conditions to be evaluated even if the `:on` transaction scope is not satisfied.

```ruby
class Topic < ActiveRecord::Base
  after_commit :do_something, on: [:create, :update], if: :check_something?
end

topic = Topic.create #=> Calls :check_something?
topic.save #=> Calls :check_something?
topic.destroy #=> No longer calls :check_something?
```