### PR TITLE
fix error indexes

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -317,7 +317,12 @@ module ActiveRecord
       def validate_collection_association(reflection)
         if association = association_instance_get(reflection.name)
           if records = associated_records_to_validate_or_save(association, new_record?, reflection.options[:autosave])
-            records.each_with_index { |record, index| association_valid?(reflection, record, index) }
+
+            association.target.collect.with_index do |record_from_target, index_from_target|
+              next unless record = records.find{|record| record == record_from_target }
+
+              [record, index_from_target]
+            end.compact.each { |record, index| association_valid?(reflection, record, index) }
           end
         end
       end


### PR DESCRIPTION
I didn't have enough info. to run `rails` tests, so I created a repo to test this issue.

### Summary

https://github.com/github0013/index_errors/blob/master/spec/models/post_spec.rb#L44-L45
A post has 2 comments.   

A. When the first comment has errors, the index is correct (first == 0).
B. When the first comment is valid, but the second is invalid, the error index should be 1; however the index is 0.

### Other Information

https://github.com/github0013/index_errors/blob/master/spec/models/post_spec.rb#L62-L66
this checks error child's correct index
