### PR TITLE
Add ability to create join table with primary_key.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add ability to create join table with primary_key.
+
+    *bogdanvlviv*
+
 *   Deprecate using `#quoted_id` in quoting.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -171,7 +171,7 @@ module ActiveRecord
       # The +options+ hash can include the following keys:
       # [<tt>:id</tt>]
       #   Whether to automatically add a primary key column. Defaults to true.
-      #   Join tables for {ActiveRecord::Base.has_and_belongs_to_many}[rdoc-ref:Associations::ClassMethods#has_and_belongs_to_many] should set it to false.
+      #   Join tables for {ActiveRecord::Base.has_and_belongs_to_many}[rdoc-ref:Associations::ClassMethods#has_and_belongs_to_many] defaults to false.
       #
       #   A Symbol can be used to specify the type of the generated primary key column.
       # [<tt>:primary_key</tt>]
@@ -303,6 +303,13 @@ module ActiveRecord
       #   create_join_table(:assemblies, :parts)
       #
       # You can pass an +options+ hash which can include the following keys:
+      # [<tt>:id</tt>]
+      #   Whether to automatically add a primary key column. Defaults to false.
+      #
+      #   A Symbol can be used to specify the type of the generated primary key column.
+      # [<tt>:primary_key</tt>]
+      #   The name of the primary key, if one is to be added automatically.
+      #   Defaults to +id+. If <tt>:id</tt> is false, then this option is ignored.
       # [<tt>:table_name</tt>]
       #   Sets the table name, overriding the default.
       # [<tt>:column_options</tt>]
@@ -334,7 +341,9 @@ module ActiveRecord
       #     part_id int NOT NULL,
       #   ) ENGINE=InnoDB DEFAULT CHARSET=utf8
       #
-      def create_join_table(table_1, table_2, options = {})
+      def create_join_table(table_1, table_2, **options)
+        options.reverse_merge!(id: false)
+
         join_table_name = find_join_table_name(table_1, table_2, options)
 
         column_options = options.delete(:column_options) || {}
@@ -343,7 +352,7 @@ module ActiveRecord
 
         t1_column, t2_column = [table_1, table_2].map { |t| t.to_s.singularize.foreign_key }
 
-        create_table(join_table_name, options.merge!(id: false)) do |td|
+        create_table(join_table_name, options) do |td|
           td.send type, t1_column, column_options
           td.send type, t2_column, column_options
           yield td if block_given?

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -22,6 +22,60 @@ module ActiveRecord
         assert_equal %w(artist_id music_id), connection.columns(:artists_musics).map(&:name).sort
       end
 
+      def test_create_join_table_with_id
+        connection.create_join_table :artists, :musics, id: :integer
+
+        assert_equal %w(artist_id id music_id), connection.columns(:artists_musics).map(&:name).sort
+      end
+
+      def test_create_join_table_with_specified_primary_key
+        connection.create_join_table :artists, :musics, id: :integer, primary_key: :custom_name_id
+
+        assert_equal %w(artist_id custom_name_id music_id), connection.columns(:artists_musics).map(&:name).sort
+      end
+
+      def test_create_join_table_without_id_primary_key_is_ignored
+        connection.create_join_table :artists, :musics, primary_key: :custom_name_id
+
+        assert_equal %w(artist_id music_id), connection.columns(:artists_musics).map(&:name).sort
+      end
+
+      def test_create_join_table_with_id_sets_specified_type_integer
+        connection.create_join_table :artists, :musics, id: :integer
+
+        assert_equal(
+          :integer,
+          connection.columns(:artists_musics).find { |c| c.name == "id" }.type
+        )
+      end
+
+      def test_create_join_table_with_id_sets_specified_type_string
+        connection.create_join_table :artists, :musics, id: :string
+
+        assert_equal(
+          :string,
+          connection.columns(:artists_musics).find { |c| c.name == "id" }.type
+        )
+      end
+
+      def test_create_join_table_with_specified_primary_key_sets_specified_type_integer
+        connection.create_join_table :artists, :musics, id: :integer, primary_key: :custom_name_id
+
+        assert_equal(
+          :integer,
+          connection.columns(:artists_musics).find { |c| c.name == "custom_name_id" }.type
+        )
+      end
+
+      def test_create_join_table_with_specified_primary_key_sets_specified_type_string
+        connection.create_join_table :artists, :musics, id: :string, primary_key: :custom_name_id
+
+        assert_equal(
+          :string,
+          connection.columns(:artists_musics).find { |c| c.name == "custom_name_id" }.type
+        )
+      end
+
       def test_create_join_table_set_not_null_by_default
         connection.create_join_table :artists, :musics
 


### PR DESCRIPTION
Related to https://github.com/rails/rails/issues/26884

This isn't fixed related issue, but i see sense to refer to it.

This PR is the chance to give more flexibility when creating join table with method `create_join_table`. It doesn't break old behavior that by default, it only gives the possibility to add primary_key if need.

Your thoughts?
