### PR TITLE
Unfreeze interpolated string because it's unnecessary.

### DIFF
--- a/actionpack/lib/abstract_controller/caching/fragments.rb
+++ b/actionpack/lib/abstract_controller/caching/fragments.rb
@@ -136,7 +136,7 @@ module AbstractController
 
       def instrument_fragment_cache(name, key) # :nodoc:
         payload = instrument_payload(key)
-        ActiveSupport::Notifications.instrument("#{name}.#{instrument_name}".freeze, payload) { yield }
+        ActiveSupport::Notifications.instrument("#{name}.#{instrument_name}", payload) { yield }
       end
     end
   end

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -345,7 +345,7 @@ module ActionView
       end
 
       def instrument(action, &block) # :doc:
-        ActiveSupport::Notifications.instrument("#{action}.action_view".freeze, instrument_payload, &block)
+        ActiveSupport::Notifications.instrument("#{action}.action_view", instrument_payload, &block)
       end
 
       def instrument_render_template(&block)


### PR DESCRIPTION
### Summary

Freeze doesn't work on interpolated string. So change it back for preventing confusion.
Thank for @eljojo's report.

Benchmark:

```ruby
    GC.start
    before = GC.stat(:total_allocated_objects)

    this_is_static = "hello".freeze
    100_000.times do |i|
      "#{this_is_static} this is also static".freeze
    end

    GC.start
    after = GC.stat(:total_allocated_objects)
    puts "Objects added: #{after - before}" #=> 100000
```

r? @rafaelfranca 