### PR TITLE
Improve `create_table force: true`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -273,8 +273,8 @@ module ActiveRecord
 
         yield td if block_given?
 
-        if options[:force] && data_source_exists?(table_name)
-          drop_table(table_name, options)
+        if options[:force]
+          drop_table(table_name, **options, if_exists: true)
         end
 
         result = execute schema_creation.accept td


### PR DESCRIPTION
Extra `data_source_exists?(table_name)` is unneeded if
`drop_table(table_name, if_exists: true)` directly.