### PR TITLE
Add assertion to polymorphic_routes_test.rb

### DIFF
--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -134,7 +134,7 @@ XML
     end
 
     def create
-      head :created, location: "created resource"
+      head :created, location: "/resource"
     end
 
     def render_cookie
@@ -893,12 +893,12 @@ XML
     assert_response :created
 
     # Redirect url doesn't care that it wasn't a :redirect response.
-    assert_equal "created resource", @response.redirect_url
+    assert_equal "/resource", @response.redirect_url
     assert_equal @response.redirect_url, redirect_to_url
 
     # Must be a :redirect response.
     assert_raise(ActiveSupport::TestCase::Assertion) do
-      assert_redirected_to "created resource"
+      assert_redirected_to "/resource"
     end
   end
 

--- a/actionview/test/activerecord/polymorphic_routes_test.rb
+++ b/actionview/test/activerecord/polymorphic_routes_test.rb
@@ -86,8 +86,7 @@ class PolymorphicRoutesTest < ActionController::TestCase
 
   def test_string
     with_test_routes do
-      # FIXME: why are these different? Symbol case passes through to
-      # `polymorphic_url`, but the String case doesn't.
+      assert_equal "/projects", polymorphic_path("projects")
       assert_equal "http://example.com/projects", polymorphic_url("projects")
       assert_equal "projects", url_for("projects")
     end

--- a/actionview/test/template/erb/tag_helper_test.rb
+++ b/actionview/test/template/erb/tag_helper_test.rb
@@ -18,8 +18,8 @@ module ERBTest
     end
 
     test "percent equals works with form tags" do
-      expected_output = %r{<form.*action="foo".*method="post">.*hello*</form>}
-      assert_match expected_output, render_content("form_tag('foo')", "<%= 'hello' %>")
+      expected_output = %r{<form.*action="/foo".*method="post">.*hello*</form>}
+      assert_match expected_output, render_content("form_tag('/foo')", "<%= 'hello' %>")
     end
 
     test "percent equals works with fieldset tags" do

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -257,11 +257,11 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_label_with_non_active_record_object
-    form_for(OpenStruct.new(name: "ok"), as: "person", url: "an_url", html: { id: "create-person" }) do |f|
+    form_for(OpenStruct.new(name: "ok"), as: "person", url: "/an", html: { id: "create-person" }) do |f|
       f.label(:name)
     end
 
-    expected = whole_form("an_url", "create-person", "new_person", method: "post") do
+    expected = whole_form("/an", "create-person", "new_person", method: "post") do
       '<label for="person_name">Name</label>'
     end
 


### PR DESCRIPTION
Add assertion to polymorphic_routes_test.rb
The assertion will ensure that the behavior doesn't regress.
```ruby
  assert_equal "/projects", polymorphic_path("projects")
```

Remove FIXME related to polymorphic_url behavior.
polymorphic_url with Symbol or String works equally.
Example:
```ruby
  default_url_options[:host] = "example.com"

  polymorphic_url(:projects)  # => "http://example.com/projects"
  polymorphic_url("projects") # => "http://example.com/projects"
```
Related to 37d4415

/cc @tenderlove

<hr/>

Set correct "routes" in tests cases for consistency.

<hr/>

This PR closes my previous wrong PR #27755