### PR TITLE
Fix regression introduced by 88b335e

### DIFF
--- a/railties/lib/rails/commands/test.rb
+++ b/railties/lib/rails/commands/test.rb
@@ -6,6 +6,6 @@ else
   $LOAD_PATH << File.expand_path("../../test", APP_PATH)
 end
 
-Minitest.run_via[:rails] = true
+Minitest.run_via = :rails
 
 require "active_support/testing/autorun"


### PR DESCRIPTION
### Summary

Symptom:

```
/home/rubys/git/rails/railties/lib/rails/commands/test.rb:9:in `<top (required)>': wrong number of arguments (given 2, expected 1) (ArgumentError)
	from /home/rubys/git/rails/railties/lib/rails/commands/commands_tasks.rb:138:in `require'
	from /home/rubys/git/rails/railties/lib/rails/commands/commands_tasks.rb:138:in `require_command!'
	from /home/rubys/git/rails/railties/lib/rails/commands/commands_tasks.rb:95:in `test'
	from /home/rubys/git/rails/railties/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
	from /home/rubys/git/rails/railties/lib/rails/commands.rb:18:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```

### Other Information

See:

http://intertwingly.net/projects/AWDwR4/checkdepot-50/section-7.1.html#cmd9
