### PR TITLE
Do not display template files on API doc [ci skip]

### DIFF
--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -70,7 +70,7 @@ module Rails
             lib/**/*.rb
           ),
           exclude: %w(
-            lib/rails/generators/rails/**/templates/**/*.rb
+            lib/rails/generators/**/templates/**/*.rb
             lib/rails/test_unit/*
             lib/rails/api/generator.rb
           )


### PR DESCRIPTION
Currently templates files are displayed in API doc(e.g. http://edgeapi.rubyonrails.org/files/railties/lib/rails/generators/test_unit/system/templates/application_system_test_case_rb.html). 
This is because only `lib/rails/generators/rails` is excluded. I modified to exclude everything about templates files.
