### PR TITLE
Fix `define_attribute_method` with Symbol in AR

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -289,7 +289,7 @@ module ActiveModel
             generate_method = "define_method_#{matcher.method_missing_target}"
 
             if respond_to?(generate_method, true)
-              send(generate_method, attr_name)
+              send(generate_method, attr_name.to_s)
             else
               define_proxy_call true, generated_attribute_methods, method_name, matcher.method_missing_target, attr_name.to_s
             end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -866,6 +866,13 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert subklass.method_defined?(:id), "subklass is missing id method"
   end
 
+  test "define_attribute_method works with both symbol and string" do
+    klass = Class.new(ActiveRecord::Base)
+
+    assert_nothing_raised { klass.define_attribute_method(:foo) }
+    assert_nothing_raised { klass.define_attribute_method("bar") }
+  end
+
   test "read_attribute with nil should not asplode" do
     assert_nil Topic.new.read_attribute(nil)
   end


### PR DESCRIPTION
This issue is only appear when you try to call `define_attribute_method` and passing a symbol in Active Record. It does not appear in isolation in Active Model itself.

Before this patch, when you run `User.define_attribute_method :foo`, you will get:

    NoMethodError: undefined method `unpack' for :foo:Symbol
        from activerecord/lib/active_record/attribute_methods/read.rb:28:in `define_method_attribute'
        from activerecord/lib/active_record/attribute_methods/primary_key.rb:61:in `define_method_attribute'
        from activemodel/lib/active_model/attribute_methods.rb:292:in `block in define_attribute_method'
        from activemodel/lib/active_model/attribute_methods.rb:285:in `each'
        from activemodel/lib/active_model/attribute_methods.rb:285:in `define_attribute_method'

This patch contains both a fix in Active Model and a test in Active Record for this error.