### PR TITLE
Revert back to the original of using package.json in the root of the project

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -68,7 +68,7 @@
 
     *DHH*
 
-*   Add Yarn support in new apps with a yarn binstub and vendor/package.json. Skippable via --skip-yarn option.
+*   Add Yarn support in new apps with a yarn binstub and package.json. Skippable via --skip-yarn option.
 
     *Liceth Ovalles*, *Guillermo Iguaran*, *DHH*
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -166,7 +166,7 @@ module Rails
       empty_directory_with_keep_file "vendor"
 
       unless options[:skip_yarn]
-        template "package.json", "vendor/package.json"
+        template "package.json"
       end
     end
   end
@@ -280,7 +280,7 @@ module Rails
         build(:vendor)
 
         if options[:skip_yarn]
-          remove_file "vendor/package.json"
+          remove_file "package.json"
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn
@@ -1,4 +1,4 @@
-VENDOR_PATH = File.expand_path('../vendor', __dir__)
+VENDOR_PATH = File.expand_path('..', __dir__)
 Dir.chdir(VENDOR_PATH) do
   begin
     exec "yarnpkg #{ARGV.join(" ")}"

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
@@ -7,7 +7,7 @@ Rails.application.config.assets.version = '1.0'
 # Rails.application.config.assets.paths << Emoji.images_path
 <%- unless options[:skip_yarn] -%>
 # Add Yarn node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join('vendor/node_modules')
+Rails.application.config.assets.paths << Rails.root.join('node_modules')
 <%- end -%>
 
 # Precompile additional assets.

--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -22,8 +22,8 @@
 <% end -%>
 
 <% unless options[:skip_yarn] -%>
-/vendor/node_modules
-/vendor/yarn-error.log
+/node_modules
+/yarn-error.log
 
 <% end -%>
 .byebug_history

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -117,7 +117,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
          public/apple-touch-icon-precomposed.png
          public/apple-touch-icon.png
          public/favicon.icon
-         vendor/package.json
+         package.json
       )
     end
 end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -422,7 +422,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_generator_if_skip_yarn_is_given
     run_generator [destination_root, "--skip-yarn"]
 
-    assert_no_file "vendor/package.json"
+    assert_no_file "package.json"
     assert_no_file "bin/yarn"
   end
 
@@ -497,21 +497,21 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_generator_for_yarn
     run_generator([destination_root])
-    assert_file "vendor/package.json", /dependencies/
+    assert_file "package.json", /dependencies/
     assert_file "config/initializers/assets.rb", /node_modules/
   end
 
   def test_generator_for_yarn_skipped
     run_generator([destination_root, "--skip-yarn"])
-    assert_no_file "vendor/package.json"
+    assert_no_file "package.json"
 
     assert_file "config/initializers/assets.rb" do |content|
       assert_no_match(/node_modules/, content)
     end
 
     assert_file ".gitignore" do |content|
-      assert_no_match(/vendor\/node_modules/, content)
-      assert_no_match(/vendor\/yarn-error\.log/, content)
+      assert_no_match(/node_modules/, content)
+      assert_no_match(/yarn-error\.log/, content)
     end
   end
 


### PR DESCRIPTION
After further deliberation, and reflecting on how disruptive the proposed change for Gemfile->gems.rb/gems.locked is for the comparable gain, we're going to revert to the original plan of putting package.json in the root. I don't love adding to a messy/overloaded root, but the pain of patching around this isn't worth it. So we'll live with some scar tissue. Without scars you haven't lived!