### PR TITLE
Allow 3-level DB configs to group connections by environment

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -149,9 +149,18 @@ module ActiveRecord
         # Expands each key in @configurations hash into fully resolved hash
         def resolve_all
           config = configurations.dup
+
+          if env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+            env_config = config[env] if config[env].is_a?(Hash) && !(config[env].key?("adapter") || config[env].key?("url"))
+          end
+
+          config.reject! { |k, v| v.is_a?(Hash) && !(v.key?("adapter") || v.key?("url")) }
+          config.merge! env_config if env_config
+
           config.each do |key, value|
             config[key] = resolve(value) if value
           end
+
           config
         end
 


### PR DESCRIPTION
Cut-down take on the key part of #27611

Still to do:
- [ ] Teach the rake tasks that work with all the configs how to navigate this
- [ ] Relocate the `Rails.env` call, which has long been inside AR, but really shouldn't be
- [ ] Add more 3-level tests to the resolver

This gets us a shippable implementation of the headline feature for #27611, though:

```ruby
default: &default
  adapter: sqlite3
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
  timeout: 5000

development:
  primary:
    <<: *default
    database: db/development.sqlite3
  readonly:
    <<: *default
    database: db/readonly.sqlite3
```