### PR TITLE
Simplify Rails engine paths since root app/* path globs all subdirs

### DIFF
--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -38,11 +38,7 @@ module Rails
 
           paths.add "app",                 eager_load: true, glob: "{*,*/concerns}"
           paths.add "app/assets",          glob: "*"
-          paths.add "app/controllers",     eager_load: true
           paths.add "app/channels",        eager_load: true, glob: "**/*_channel.rb"
-          paths.add "app/helpers",         eager_load: true
-          paths.add "app/models",          eager_load: true
-          paths.add "app/mailers",         eager_load: true
           paths.add "app/views"
 
           paths.add "lib",                 load_path: true


### PR DESCRIPTION
Since `paths.add "app", eager_load: true, glob: "{*,*/concerns}"` already globs the directories beneath it (e.g. `app/models`), there is no need to specify them as explicit paths as well.

This PR removes `app/controllers`, `app/helpers`, `app/models` and `app/mailers` from being explicitly added to the load path.