### PR TITLE
[doc] Fix wrong class name in testing.md

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -712,7 +712,7 @@ Now let's open that file and write our first assertion:
 ```ruby
 require "application_system_test_case"
 
-class UsersTest < ApplicationSystemTestCase
+class ArticlesTest < ApplicationSystemTestCase
   test "viewing the index" do
     visit articles_path
     assert_selector "h1", text: "Articles"


### PR DESCRIPTION
As the specified command is `rails g system_test articles`, the generated class name
is `ArticlesTest`, not `UsersTest`

my first PR, I looked at Guidelines and Guidelines for docs and didn't find specific instructions, hope everything is ok :)
