### PR TITLE
Preload to_datetime before freezing a TimeWithZone instance

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -338,7 +338,7 @@ module ActiveSupport
     alias_method :kind_of?, :is_a?
 
     def freeze
-      period; utc; time # preload instance variables before freezing
+      period; utc; time; to_datetime # preload instance variables before freezing
       super
     end
 

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -467,6 +467,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_nothing_raised do
       @twz.period
       @twz.time
+      @twz.to_datetime
     end
   end
 


### PR DESCRIPTION
### Summary

Fixes #28101: after freezing an ActiveSupport::TimeWithZone instance, it is not possible to call to_datetime because the value is cached in an instance variable. To avoid this issue, the instance variable is preloaded before the freeze occurs.