### PR TITLE
Preload to_datetime before freezing a TimeWithZone instance

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -427,7 +427,8 @@ module ActiveSupport
     end
 
     def freeze
-      period; utc; time # preload instance variables before freezing
+      # preload instance variables before freezing
+      period; utc; time; to_datetime
       super
     end
 

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -507,6 +507,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_nothing_raised do
       @twz.period
       @twz.time
+      @twz.to_datetime
     end
   end
 


### PR DESCRIPTION
Fixes #28101: after freezing an ActiveSupport::TimeWithZone instance, it is not possible to call to_datetime because the value is cached in an instance variable. To avoid this issue, the instance variable is preloaded before the freeze occurs.