### PR TITLE
Add wrapper for plugin's test runner

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/bin/test.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/test.tt
@@ -1,10 +1,4 @@
 $: << File.expand_path(File.expand_path('../../test', __FILE__))
 
 require 'bundler/setup'
-require 'rails/test_unit/minitest_plugin'
-
-Rails::TestUnitReporter.executable = 'bin/test'
-
-Minitest.run_via = :rails
-
-require "active_support/testing/autorun"
+require 'rails/plugin/test'

--- a/railties/lib/rails/plugin/test.rb
+++ b/railties/lib/rails/plugin/test.rb
@@ -1,0 +1,7 @@
+require "rails/test_unit/minitest_plugin"
+
+Rails::TestUnitReporter.executable = "bin/test"
+
+Minitest.run_via = :rails
+
+require "active_support/testing/autorun"


### PR DESCRIPTION
### Summary

Currently, private API is directly used in `bin/test`. So it is necessary to change
`bin/test` when changing private API.
To avoid this, provide a wrapper file and modify `bin/test` to just require that
file.

r? @kaspth 

