### PR TITLE
Default to not supporting `/:controller/:action`

### DIFF
--- a/actionmailer/test/i18n_with_controller_test.rb
+++ b/actionmailer/test/i18n_with_controller_test.rb
@@ -24,6 +24,8 @@ end
 
 class ActionMailerI18nWithControllerTest < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new
+  Routes.deprecated_routing = true
+
   Routes.draw do
     ActiveSupport::Deprecation.silence do
       get ":controller(/:action(/:id))"

--- a/actionmailer/test/url_test.rb
+++ b/actionmailer/test/url_test.rb
@@ -5,6 +5,8 @@ class WelcomeController < ActionController::Base
 end
 
 AppRoutes = ActionDispatch::Routing::RouteSet.new
+AppRoutes.deprecated_routing = true
+
 
 class ActionMailer::Base
   include AppRoutes.url_helpers

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Default to not supporting dynamic `:controller` and `:action` path segments
+
+    *Andrew White*
+
 *   Prefer `remove_method` over `undef_method` when reloading routes
 
     When `undef_method` is used it prevents access to other implementations of that

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -17,6 +17,7 @@ module ActionDispatch
     config.action_dispatch.encrypted_cookie_salt = "encrypted cookie"
     config.action_dispatch.encrypted_signed_cookie_salt = "signed encrypted cookie"
     config.action_dispatch.perform_deep_munge = true
+    config.action_dispatch.deprecated_routing = false
 
     config.action_dispatch.default_headers = {
       "X-Frame-Options" => "SAMEORIGIN",
@@ -32,6 +33,7 @@ module ActionDispatch
       ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge
       ActionDispatch::Response.default_charset = app.config.action_dispatch.default_charset || app.config.encoding
       ActionDispatch::Response.default_headers = app.config.action_dispatch.default_headers
+      ActionDispatch::Routing::RouteSet.deprecated_routing = app.config.action_dispatch.deprecated_routing
 
       ActionDispatch::ExceptionWrapper.rescue_responses.merge!(config.action_dispatch.rescue_responses)
       ActionDispatch::ExceptionWrapper.rescue_templates.merge!(config.action_dispatch.rescue_templates)

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -11,6 +11,9 @@ module ActionDispatch
   module Routing
     # :stopdoc:
     class RouteSet
+      cattr_accessor :deprecated_routing
+      self.deprecated_routing = false
+
       # Since the router holds references to many parts of the system
       # like engines, controllers and the application itself, inspecting
       # the route set can actually be really slow, therefore we default
@@ -580,17 +583,25 @@ module ActionDispatch
         named_routes[name] = route if name
 
         if route.segment_keys.include?(:controller)
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            Using a dynamic :controller segment in a route is deprecated and
-            will be removed in Rails 5.2.
-          MSG
+          if deprecated_routing
+            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+              Using a dynamic :controller segment in a route is deprecated and
+              will be removed in Rails 5.2.
+            MSG
+          else
+            raise ArgumentError, "Using a dynamic :controller segment is not allowed."
+          end
         end
 
         if route.segment_keys.include?(:action)
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            Using a dynamic :action segment in a route is deprecated and
-            will be removed in Rails 5.2.
-          MSG
+          if deprecated_routing
+            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+              Using a dynamic :action segment in a route is deprecated and
+              will be removed in Rails 5.2.
+            MSG
+          else
+            raise ArgumentError, "Using a dynamic :action segment is not allowed."
+          end
         end
 
         route

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -58,6 +58,8 @@ I18n.enforce_available_locales = false
 
 FIXTURE_LOAD_PATH = File.join(File.dirname(__FILE__), "fixtures")
 
+# Enable deprecated `/:controller/:action` routing for the test suite.
+ActionDispatch::Routing::RouteSet.deprecated_routing = true
 SharedTestRoutes = ActionDispatch::Routing::RouteSet.new
 
 SharedTestRoutes.draw do

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -71,6 +71,9 @@ module RenderERBUtils
   end
 end
 
+# Enable deprecated `/:controller/:action` routing for the test suite.
+ActionDispatch::Routing::RouteSet.deprecated_routing = true
+
 SharedTestRoutes = ActionDispatch::Routing::RouteSet.new
 
 module ActionDispatch

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 #
-# This file contains migration options to ease your Rails 5.0 upgrade.
+# This file contains migration options to ease your Rails 5.1 upgrade.
 #
 <%- if options[:update] -%>
 # Once upgraded flip defaults one by one to migrate to the new default.
@@ -35,3 +35,6 @@ Rails.application.config.ssl_options = { hsts: { subdomains: true } }
 # asset is not present in the asset pipeline.
 Rails.application.config.assets.unknown_asset_fallback = <%= options[:update] ? true : false %>
 <%- end -%>
+
+# Enable support for deprecated `/:controller/:action` dynamic route segments.
+Rails.application.config.action_dispatch.deprecated_routing = <%= options[:update] ? true : false %>

--- a/railties/test/application/multiple_applications_test.rb
+++ b/railties/test/application/multiple_applications_test.rb
@@ -116,8 +116,13 @@ module ApplicationTests
 
       assert_equal 0, run_count, "Without loading the initializers, the count should be 0"
 
-      # Set config.eager_load to false so that an eager_load warning doesn't pop up
-      AppTemplate::Application.create { config.eager_load = false }.initialize!
+      AppTemplate::Application.create do
+        # Set config.eager_load to false so that an eager_load warning doesn't pop up
+        config.eager_load = false
+
+        # Enable deprecated routing so that we can use `/:controller/:action`
+        config.action_dispatch.deprecated_routing = true
+      end.initialize!
 
       assert_equal 3, run_count, "There should have been three initializers that incremented the count"
     end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -149,6 +149,7 @@ module TestHelpers
         config.active_support.test_order = :random
         config.action_controller.allow_forgery_protection = false
         config.log_level = :info
+        config.action_dispatch.deprecated_routing = true
       RUBY
     end
 
@@ -170,6 +171,7 @@ module TestHelpers
       @app.config.active_support.deprecation = :log
       @app.config.active_support.test_order = :random
       @app.config.log_level = :info
+      @app.config.action_dispatch.deprecated_routing = true
 
       yield @app if block_given?
       @app.initialize!


### PR DESCRIPTION
Although the plan was to completely remove support for dynamic `:controller` and `:action` in Rails 5.1, the test suite is heavily dependent on them so for now just raise an error by default and allow turning back on via a config option.