### PR TITLE
Fix an issue where `ActiveSupport::Reloader.reload!` would cause `to_prepare` callbacks to be called twice

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix a bug where `ActiveSupport::Reloader#reload!` would invoke `to_prepare` callbacks twice
+
+    *Brian John*
+
 *   Cache `ActiveSupport::TimeWithZone#to_datetime` before freezing.
 
     *Adam Rice*

--- a/activesupport/lib/active_support/reloader.rb
+++ b/activesupport/lib/active_support/reloader.rb
@@ -51,7 +51,6 @@ module ActiveSupport
           end
         end
       end
-      prepare!
     end
 
     def self.run! # :nodoc:

--- a/activesupport/test/reloader_test.rb
+++ b/activesupport/test/reloader_test.rb
@@ -56,7 +56,7 @@ class ReloaderTest < ActiveSupport::TestCase
 
     called = []
     reloader.reload!
-    assert_equal [:executor_run, :reloader_run, :prepare, :reloader_complete, :executor_complete, :prepare], called
+    assert_equal [:executor_run, :reloader_run, :prepare, :reloader_complete, :executor_complete], called
 
     reloader.check = lambda { false }
 
@@ -66,7 +66,7 @@ class ReloaderTest < ActiveSupport::TestCase
 
     called = []
     reloader.reload!
-    assert_equal [:executor_run, :reloader_run, :prepare, :reloader_complete, :executor_complete, :prepare], called
+    assert_equal [:executor_run, :reloader_run, :prepare, :reloader_complete, :executor_complete], called
   end
 
   def test_class_unload_block

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -51,9 +51,9 @@ class ConsoleTest < ActiveSupport::TestCase
     a = b = c = nil
 
     # TODO: These should be defined on the initializer
-    ActiveSupport::Reloader.to_complete { a = b = c = 1 }
+    ActiveSupport::Reloader.to_prepare { a = b = c = 1 }
     ActiveSupport::Reloader.to_complete { b = c = 2 }
-    ActiveSupport::Reloader.to_prepare { c = 3 }
+    ActiveSupport::Reloader.to_complete { c = 3 }
 
     irb_context.reload!(false)
 


### PR DESCRIPTION
See https://github.com/rails/rails/issues/28108 for details