### PR TITLE
Deprecate the EventedRedis subscription adapter

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/evented_redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/evented_redis.rb
@@ -24,6 +24,12 @@ module ActionCable
       cattr_accessor(:redis_connector) { ->(config) { ::Redis.new(url: config[:url]) } }
 
       def initialize(*)
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          The "evented_redis" subscription adapter is deprecated and
+          will be removed in Rails 5.2. Please use the "redis" adapter
+          instead.
+        MSG
+
         super
         @redis_connection_for_broadcasts = @redis_connection_for_subscriptions = nil
       end

--- a/actioncable/test/subscription_adapter/evented_redis_test.rb
+++ b/actioncable/test/subscription_adapter/evented_redis_test.rb
@@ -7,7 +7,9 @@ class EventedRedisAdapterTest < ActionCable::TestCase
   include ChannelPrefixTest
 
   def setup
-    super
+    assert_deprecated do
+      super
+    end
 
     # em-hiredis is warning-rich
     @previous_verbose, $VERBOSE = $VERBOSE, nil


### PR DESCRIPTION
Unlike [Faye support](https://github.com/rails/rails/pull/26676), it seems a bit too documented to remove without warning. So, here's a warning.