### PR TITLE
Ensure all gems for SQL Server app setup.

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -280,6 +280,7 @@ module Rails
         case options[:database]
         when "mysql"          then ["mysql2", [">= 0.3.18", "< 0.5"]]
         when "postgresql"     then ["pg", ["~> 0.18"]]
+        when "sqlserver"      then ["tiny_tds", nil]
         when "oracle"         then ["ruby-oci8", nil]
         when "frontbase"      then ["ruby-frontbase", nil]
         when "sqlserver"      then ["activerecord-sqlserver-adapter", nil]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -291,6 +291,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_config_sqlserver_database
+    run_generator([destination_root, "-d", "sqlserver"])
+    assert_file "config/database.yml", /sqlserver/
+    assert_gem "activerecord-sqlserver-adapter"
+    assert_gem "tiny_tds"
+  end
+
   def test_config_jdbcmysql_database
     run_generator([destination_root, "-d", "jdbcmysql"])
     assert_file "config/database.yml", /mysql/


### PR DESCRIPTION
This pull request is related to #27820 which ensures that new applications setup with SQL Server have all conventions in place. However, when working today on the [SQL Server - Getting Started](https://www.microsoft.com/en-us/sql-server/developer-get-started/) pages I found out that the TinyTDS gem was not included in the Gemfile when generating a new application. This gem is the low level `raw_connection` for the adapter for all platforms of the SQL Server adapter. 

I will also be making a pull request to 5-0-stable as well. Thanks in advance!