### PR TITLE
Allow skipping of turbolinks for test dummy application for plugin/engine

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -92,6 +92,7 @@ task default: :test
       opts[:api] = options.api?
       opts[:skip_listen] = true
       opts[:skip_git] = true
+      opts[:skip_turbolinks] = true
 
       invoke Rails::Generators::AppGenerator,
         [ File.expand_path(dummy_path, destination_root) ], opts


### PR DESCRIPTION
NOTE: I think this should be the expected behavior. At least that's what I
expected. Let me know if you think differently. Maybe this PR should be dropped
altogether?

When `rails new plugin` is invoked with `--skip-turbolinks`, turbolinks
should be skipped in the dummy application generated by the plugin
generator.