### PR TITLE
Fix extract! method: return modified self instead of new instance

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -489,7 +489,7 @@ module ActionController
     #   params.extract!(:a, :b) # => <ActionController::Parameters {"a"=>1, "b"=>2} permitted: false>
     #   params                  # => <ActionController::Parameters {"c"=>3} permitted: false>
     def extract!(*keys)
-      new_instance_with_inherited_permitted_status(@parameters.extract!(*keys))
+      @parameters.extract!(*keys)
     end
 
     # Returns a new <tt>ActionController::Parameters</tt> with the results of


### PR DESCRIPTION
### Summary

This fixes a bug in the `extract!` method, which currently returns a 
new instance of `ActionController::Parameters` instead of the extracted
parameter.

### Other Information

This change makes the code behave like the documentation describes it: http://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-extract-21