### PR TITLE
Do not take screenshot when test skipped

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -22,12 +22,12 @@ module ActionDispatch
         # fails add +take_failed_screenshot+ to the teardown block before clearing
         # sessions.
         def take_failed_screenshot
-          take_screenshot unless passed?
+          take_screenshot if failed?
         end
 
         private
           def image_name
-            passed? ? method_name : "failures_#{method_name}"
+            failed? ? "failures_#{method_name}" : method_name
           end
 
           def image_path
@@ -50,6 +50,10 @@ module ActionDispatch
 
           def inline_base64(path)
             Base64.encode64(path).gsub("\n", "")
+          end
+
+          def failed?
+            !passed? && !skipped?
           end
       end
     end

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -15,4 +15,14 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
       assert_equal "tmp/screenshots/failures_x.png", new_test.send(:image_path)
     end
   end
+
+  test "image path does not include failures text if test skipped" do
+    new_test = ActionDispatch::SystemTestCase.new("x")
+
+    new_test.stub :passed?, false do
+      new_test.stub :skipped?, true do
+        assert_equal "tmp/screenshots/x.png", new_test.send(:image_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
`passed?` also returns false when skipping tests. 
https://github.com/seattlerb/minitest/blob/db8108374565d3d1829689c7c7f52e1d5da80f59/lib/minitest/test.rb#L228..L236  

However, I think screenshot is unnecessary when test skipped.
