### PR TITLE
Fix regression in collection_singular_ids to handle duplicate ids.

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -67,10 +67,14 @@ module ActiveRecord
           pk_type.type_cast_from_user(i)
         end
 
-        if (objs = klass.where(pk_column => ids)).size == ids.size
-          replace(objs.index_by { |r| r.send(pk_column) }.values_at(*ids))
+        records = klass.where(pk_column => ids).index_by do |r|
+          r.send(pk_column)
+        end.values_at(*ids).compact
+
+        if records.size != ids.size
+          klass.all.raise_record_not_found_exception!(ids, records.size, ids.size)
         else
-          objs.raise_record_not_found_exception!(ids, objs.size, ids.size)
+          replace(records)
         end
       end
 


### PR DESCRIPTION
Prior to ae83c5b duplicate ids were acceptable in the ids_writer.

These changes are based on the master code, which does handle duplicate ids without throwing an error.

This gist shows the error: https://gist.github.com/slamere/67c089aa66fdd02b743bb6866abbfa1e

We could have just removed duplicates from ids or checked the uniq size of ids by changing this line
```ruby
  if (objs = klass.where(pk_column => ids)).size == ids.size
```
to
```ruby
  if (objs = klass.where(pk_column => ids)).size == ids.uniq.size
```
but instead we load the duplicates into `records` just like master does.