### PR TITLE
🙈 :nodoc: `AS::Duration::ISO8601Serializer`

### DIFF
--- a/activesupport/lib/active_support/duration/iso8601_serializer.rb
+++ b/activesupport/lib/active_support/duration/iso8601_serializer.rb
@@ -4,7 +4,7 @@ require "active_support/core_ext/hash/transform_values"
 module ActiveSupport
   class Duration
     # Serializes duration to string according to ISO 8601 Duration format.
-    class ISO8601Serializer
+    class ISO8601Serializer # :nodoc:
       def initialize(duration, precision: nil)
         @duration = duration
         @precision = precision


### PR DESCRIPTION
Like the `ISO8601Parser` (which is `:nodoc:`-ed), this class should not be used directly, the public API is `AS::Duration#iso8601`.

cc @pixeltrix 