### PR TITLE
AEAD encrypted cookies and sessions

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   AEAD encrypted cookies and sessions with GCM
+
+    Encrypted cookies now use AES-GCM which couples authentication and
+    encryption in one faster step and produces shorter ciphertexts. Cookies
+    encrypted using AES in CBC HMAC mode will be seamlessly upgraded when
+    this new mode is enabled via the
+    `action_dispatch.use_authenticated_cookie_encryption` configuration value.
+
+    *Michael J Coyne*
+
 *   Change the cache key format for fragments to make it easier to debug key churn. The new format is:
 
         views/template/action.html.erb:7a1156131a6928cb0026877f8b749ac9/projects/123

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -43,6 +43,10 @@ module ActionDispatch
       get_header Cookies::ENCRYPTED_SIGNED_COOKIE_SALT
     end
 
+    def authenticated_encrypted_cookie_salt
+      get_header Cookies::AUTHENTICATED_ENCRYPTED_COOKIE_SALT
+    end
+
     def secret_token
       get_header Cookies::SECRET_TOKEN
     end
@@ -149,6 +153,7 @@ module ActionDispatch
     SIGNED_COOKIE_SALT = "action_dispatch.signed_cookie_salt".freeze
     ENCRYPTED_COOKIE_SALT = "action_dispatch.encrypted_cookie_salt".freeze
     ENCRYPTED_SIGNED_COOKIE_SALT = "action_dispatch.encrypted_signed_cookie_salt".freeze
+    AUTHENTICATED_ENCRYPTED_COOKIE_SALT = "action_dispatch.authenticated_encrypted_cookie_salt".freeze
     SECRET_TOKEN = "action_dispatch.secret_token".freeze
     SECRET_KEY_BASE = "action_dispatch.secret_key_base".freeze
     COOKIES_SERIALIZER = "action_dispatch.cookies_serializer".freeze
@@ -207,6 +212,9 @@ module ActionDispatch
       # If +secrets.secret_key_base+ and +secrets.secret_token+ (deprecated) are both set,
       # legacy cookies signed with the old key generator will be transparently upgraded.
       #
+      # If +config.action_dispatch.encrypted_cookie_salt+ and +config.action_dispatch.encrypted_signed_cookie_salt+
+      # are both set, legacy cookies encrypted with HMAC AES-256-CBC will be transparently upgraded.
+      #
       # This jar requires that you set a suitable secret for the verification on your app's +secrets.secret_key_base+.
       #
       # Example:
@@ -219,6 +227,8 @@ module ActionDispatch
         @encrypted ||=
           if upgrade_legacy_signed_cookies?
             UpgradeLegacyEncryptedCookieJar.new(self)
+          elsif upgrade_legacy_hmac_aes_cbc_cookies?
+            UpgradeLegacyHmacAesCbcCookieJar.new(self)
           else
             EncryptedCookieJar.new(self)
           end
@@ -239,6 +249,13 @@ module ActionDispatch
 
         def upgrade_legacy_signed_cookies?
           request.secret_token.present? && request.secret_key_base.present?
+        end
+
+        def upgrade_legacy_hmac_aes_cbc_cookies?
+          request.secret_key_base.present?                       &&
+            request.authenticated_encrypted_cookie_salt.present? &&
+            request.encrypted_signed_cookie_salt.present?        &&
+            request.encrypted_cookie_salt.present?
         end
     end
 
@@ -576,9 +593,11 @@ module ActionDispatch
             "Read the upgrade documentation to learn more about this new config option."
         end
 
-        secret = key_generator.generate_key(request.encrypted_cookie_salt || "")[0, ActiveSupport::MessageEncryptor.key_len]
-        sign_secret = key_generator.generate_key(request.encrypted_signed_cookie_salt || "")
-        @encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret, digest: digest, serializer: ActiveSupport::MessageEncryptor::NullSerializer)
+        cipher = "aes-256-gcm"
+        key_len = ActiveSupport::MessageEncryptor.key_len(cipher)
+        secret = key_generator.generate_key(request.authenticated_encrypted_cookie_salt || "")[0, key_len]
+
+        @encryptor = ActiveSupport::MessageEncryptor.new(secret, cipher: cipher, serializer: ActiveSupport::MessageEncryptor::NullSerializer)
       end
 
       private
@@ -601,6 +620,32 @@ module ActionDispatch
     # encrypts and re-saves them using the new key generator to provide a smooth upgrade path.
     class UpgradeLegacyEncryptedCookieJar < EncryptedCookieJar #:nodoc:
       include VerifyAndUpgradeLegacySignedMessage
+    end
+
+    # UpgradeLegacyHmacAesCbcCookieJar is used by ActionDispatch::Session::CookieStore
+    # to upgrade cookies encrypted with AES-256-CBC with HMAC to AES-256-GCM
+    class UpgradeLegacyHmacAesCbcCookieJar < EncryptedCookieJar
+      def initialize(parent_jar)
+        super
+
+        secret = key_generator.generate_key(request.encrypted_cookie_salt || "")[0, ActiveSupport::MessageEncryptor.key_len]
+        sign_secret = key_generator.generate_key(request.encrypted_signed_cookie_salt || "")
+
+        @legacy_encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret, digest: digest, serializer: ActiveSupport::MessageEncryptor::NullSerializer)
+      end
+
+      def decrypt_and_verify_legacy_encrypted_message(name, signed_message)
+        deserialize(name, @legacy_encryptor.decrypt_and_verify(signed_message)).tap do |value|
+          self[name] = { value: value }
+        end
+      rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveSupport::MessageEncryptor::InvalidMessage
+        nil
+      end
+
+      private
+        def parse(name, signed_message)
+          super || decrypt_and_verify_legacy_encrypted_message(name, signed_message)
+        end
     end
 
     def initialize(app)

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -16,6 +16,7 @@ module ActionDispatch
     config.action_dispatch.signed_cookie_salt = "signed cookie"
     config.action_dispatch.encrypted_cookie_salt = "encrypted cookie"
     config.action_dispatch.encrypted_signed_cookie_salt = "signed encrypted cookie"
+    config.action_dispatch.use_authenticated_cookie_encryption = false
     config.action_dispatch.perform_deep_munge = true
 
     config.action_dispatch.default_headers = {
@@ -35,6 +36,8 @@ module ActionDispatch
 
       ActionDispatch::ExceptionWrapper.rescue_responses.merge!(config.action_dispatch.rescue_responses)
       ActionDispatch::ExceptionWrapper.rescue_templates.merge!(config.action_dispatch.rescue_templates)
+
+      config.action_dispatch.authenticated_encrypted_cookie_salt = "authenticated encrypted cookie" if config.action_dispatch.use_authenticated_cookie_encryption
 
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -456,10 +456,14 @@ to `'http authentication'`.
 Defaults to `'signed cookie'`.
 
 * `config.action_dispatch.encrypted_cookie_salt` sets the encrypted cookies salt
-value. Defaults to `'encrypted cookie'`.
+  value. Defaults to `'encrypted cookie'`.
 
 * `config.action_dispatch.encrypted_signed_cookie_salt` sets the signed
-encrypted cookies salt value. Defaults to `'signed encrypted cookie'`.
+  encrypted cookies salt value. Defaults to `'signed encrypted cookie'`.
+
+* `config.action_dispatch.authenticated_encrypted_cookie_salt` sets the
+  authenticated encrypted cookie salt. Defaults to `'authenticated encrypted
+  cookie'`.
 
 * `config.action_dispatch.perform_deep_munge` configures whether `deep_munge`
   method should be performed on the parameters. See [Security Guide](security.html#unsafe-query-generation)

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -95,16 +95,23 @@ Rails 2 introduced a new default session storage, CookieStore. CookieStore saves
 
 * The client can see everything you store in a session, because it is stored in clear-text (actually Base64-encoded, so not encrypted). So, of course, _you don't want to store any secrets here_. To prevent session hash tampering, a digest is calculated from the session with a server-side secret (`secrets.secret_token`) and inserted into the end of the cookie.
 
-However, since Rails 4, the default store is EncryptedCookieStore. With
-EncryptedCookieStore the session is encrypted before being stored in a cookie.
-This prevents the user from accessing and tampering the content of the cookie.
-Thus the session becomes a more secure place to store data. The encryption is
-done using a server-side secret key `secrets.secret_key_base` stored in
-`config/secrets.yml`.
+In Rails 4, encrypted cookies through AES in CBC mode with HMAC using SHA1 for
+verification was introduced. This prevents the user from accessing and tampering
+the content of the cookie. Thus the session becomes a more secure place to store
+data. The encryption is performed using a server-side `secrets.secret_key_base`.
+Two salts are used when deriving keys for encryption and verification. These
+salts are set via the `config.action_dispatch.encrypted_cookie_salt` and
+`config.action_dispatch.encrypted_signed_cookie_salt` configuration values.
 
-That means the security of this storage depends on this secret (and on the digest algorithm, which defaults to SHA1, for compatibility). So _don't use a trivial secret, i.e. a word from a dictionary, or one which is shorter than 30 characters, use `rails secret` instead_.
+Rails 5.2 uses AES-GCM for the encryption which couples authentication
+and encryption in one faster step and produces shorter ciphertexts.
 
-`secrets.secret_key_base` is used for specifying a key which allows sessions for the application to be verified against a known secure key to prevent tampering. Applications get `secrets.secret_key_base` initialized to a random key present in `config/secrets.yml`, e.g.:
+Encrypted cookies are automatically upgraded if the
+`config.action_dispatch.use_authenticated_cookie_encryption` is enabled.
+
+_Do not use a trivial secret, i.e. a word from a dictionary, or one which is shorter than 30 characters! Instead use `rails secret` to generate secret keys!_
+
+Applications get `secrets.secret_key_base` initialized to a random key present in `config/secrets.yml`, e.g.:
 
     development:
       secret_key_base: a75d...

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -260,6 +260,7 @@ module Rails
           "action_dispatch.signed_cookie_salt" => config.action_dispatch.signed_cookie_salt,
           "action_dispatch.encrypted_cookie_salt" => config.action_dispatch.encrypted_cookie_salt,
           "action_dispatch.encrypted_signed_cookie_salt" => config.action_dispatch.encrypted_signed_cookie_salt,
+          "action_dispatch.authenticated_encrypted_cookie_salt" => config.action_dispatch.authenticated_encrypted_cookie_salt,
           "action_dispatch.cookies_serializer" => config.action_dispatch.cookies_serializer,
           "action_dispatch.cookies_digest" => config.action_dispatch.cookies_digest
         )

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -88,6 +88,10 @@ module Rails
             active_record.cache_versioning = true
           end
 
+          if respond_to?(:action_dispatch)
+            action_dispatch.use_authenticated_cookie_encryption = true
+          end
+
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_5_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_5_2.rb.tt
@@ -9,3 +9,7 @@
 # Make Active Record use stable #cache_key alongside new #cache_version method.
 # This is needed for recyclable cache keys.
 # Rails.application.config.active_record.cache_versioning = true
+
+# Use AES 256 GCM authenticated encryption for encrypted cookies.
+# Existing cookies will be converted on read then written with the new scheme.
+# Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = true

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -162,6 +162,11 @@ module ApplicationTests
         end
       RUBY
 
+      add_to_config <<-RUBY
+        # Enable AEAD cookies
+        config.action_dispatch.use_authenticated_cookie_encryption = true
+      RUBY
+
       require "#{app_path}/config/environment"
 
       get "/foo/write_session"
@@ -171,9 +176,9 @@ module ApplicationTests
       get "/foo/read_encrypted_cookie"
       assert_equal "1", last_response.body
 
-      secret = app.key_generator.generate_key("encrypted cookie")
-      sign_secret = app.key_generator.generate_key("signed encrypted cookie")
-      encryptor = ActiveSupport::MessageEncryptor.new(secret[0, ActiveSupport::MessageEncryptor.key_len], sign_secret)
+      cipher = "aes-256-gcm"
+      secret = app.key_generator.generate_key("authenticated encrypted cookie")
+      encryptor = ActiveSupport::MessageEncryptor.new(secret[0, ActiveSupport::MessageEncryptor.key_len(cipher)], cipher: cipher)
 
       get "/foo/read_raw_cookie"
       assert_equal 1, encryptor.decrypt_and_verify(last_response.body)["foo"]
@@ -209,6 +214,9 @@ module ApplicationTests
 
       add_to_config <<-RUBY
         secrets.secret_token = "3b7cd727ee24e8444053437c36cc66c4"
+
+        # Enable AEAD cookies
+        config.action_dispatch.use_authenticated_cookie_encryption = true
       RUBY
 
       require "#{app_path}/config/environment"
@@ -220,9 +228,9 @@ module ApplicationTests
       get "/foo/read_encrypted_cookie"
       assert_equal "1", last_response.body
 
-      secret = app.key_generator.generate_key("encrypted cookie")
-      sign_secret = app.key_generator.generate_key("signed encrypted cookie")
-      encryptor = ActiveSupport::MessageEncryptor.new(secret[0, ActiveSupport::MessageEncryptor.key_len], sign_secret)
+      cipher = "aes-256-gcm"
+      secret = app.key_generator.generate_key("authenticated encrypted cookie")
+      encryptor = ActiveSupport::MessageEncryptor.new(secret[0, ActiveSupport::MessageEncryptor.key_len(cipher)], cipher: cipher)
 
       get "/foo/read_raw_cookie"
       assert_equal 1, encryptor.decrypt_and_verify(last_response.body)["foo"]
@@ -264,6 +272,9 @@ module ApplicationTests
 
       add_to_config <<-RUBY
         secrets.secret_token = "3b7cd727ee24e8444053437c36cc66c4"
+
+        # Enable AEAD cookies
+        config.action_dispatch.use_authenticated_cookie_encryption = true
       RUBY
 
       require "#{app_path}/config/environment"
@@ -279,9 +290,73 @@ module ApplicationTests
       get "/foo/read_encrypted_cookie"
       assert_equal "2", last_response.body
 
-      secret = app.key_generator.generate_key("encrypted cookie")
-      sign_secret = app.key_generator.generate_key("signed encrypted cookie")
-      encryptor = ActiveSupport::MessageEncryptor.new(secret[0, ActiveSupport::MessageEncryptor.key_len], sign_secret)
+      cipher = "aes-256-gcm"
+      secret = app.key_generator.generate_key("authenticated encrypted cookie")
+      encryptor = ActiveSupport::MessageEncryptor.new(secret[0, ActiveSupport::MessageEncryptor.key_len(cipher)], cipher: cipher)
+
+      get "/foo/read_raw_cookie"
+      assert_equal 2, encryptor.decrypt_and_verify(last_response.body)["foo"]
+    end
+
+    test "session upgrading from AES-CBC-HMAC encryption to AES-GCM encryption" do
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get ':controller(/:action)'
+        end
+      RUBY
+
+      controller :foo, <<-RUBY
+        class FooController < ActionController::Base
+          def write_raw_session
+            # AES-256-CBC with SHA1 HMAC
+            # {"session_id"=>"1965d95720fffc123941bdfb7d2e6870", "foo"=>1}
+            cookies[:_myapp_session] = "TlgrdS85aUpDd1R2cDlPWlR6K0FJeGExckwySjZ2Z0pkR3d2QnRObGxZT25aalJWYWVvbFVLcHF4d0VQVDdSaFF2QjFPbG9MVjJzeWp3YjcyRUlKUUU2ZlR4bXlSNG9ZUkJPRUtld0E3dVU9LS0xNDZXbGpRZ3NjdW43N2haUEZJSUNRPT0=--3639b5ce54c09495cfeaae928cd5634e0c4b2e96"
+            head :ok
+          end
+
+          def write_session
+            session[:foo] = session[:foo] + 1
+            head :ok
+          end
+
+          def read_session
+            render plain: session[:foo]
+          end
+
+          def read_encrypted_cookie
+            render plain: cookies.encrypted[:_myapp_session]['foo']
+          end
+
+          def read_raw_cookie
+            render plain: cookies[:_myapp_session]
+          end
+        end
+      RUBY
+
+      add_to_config <<-RUBY
+        # Use a static key
+        secrets.secret_key_base = "known key base"
+
+        # Enable AEAD cookies
+        config.action_dispatch.use_authenticated_cookie_encryption = true
+      RUBY
+
+      require "#{app_path}/config/environment"
+
+      get "/foo/write_raw_session"
+      get "/foo/read_session"
+      assert_equal "1", last_response.body
+
+      get "/foo/write_session"
+      get "/foo/read_session"
+      assert_equal "2", last_response.body
+
+      get "/foo/read_encrypted_cookie"
+      assert_equal "2", last_response.body
+
+      cipher = "aes-256-gcm"
+      secret = app.key_generator.generate_key("authenticated encrypted cookie")
+      encryptor = ActiveSupport::MessageEncryptor.new(secret[0, ActiveSupport::MessageEncryptor.key_len(cipher)], cipher: cipher)
 
       get "/foo/read_raw_cookie"
       assert_equal 2, encryptor.decrypt_and_verify(last_response.body)["foo"]


### PR DESCRIPTION
### Summary

This PR is the start of migrating from HMAC AES-CBC encrypted cookies to AEAD encrypted cookies. Commit d4ea18a8 added AES-256-GCM for Authenticated Encryption support. I'm hoping this PR could be the start of migrating cookies and sessions to this form of encryption.

I think it's worth considering to what degree we should be supporting legacy signed and encrypted cookies as well. This PR includes a `UpgradeLegacyHmacAesCbcCookieJar` class which aims to seamlessly upgrade encrypted cookies. Should we be looking to deprecate older legacy schemes now?

### Other Information

This PR comments out some tests that are now broken. Depending on how we move forward with encrypted cookies and to the degree to which legacy cookies are supported, I will update, fix, and add any tests as needed.
