### PR TITLE
[close #24435] Send user_supplied_options to server

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -133,22 +133,55 @@ module Rails
       no_commands do
         def server_options
           {
-            server:             @server,
-            log_stdout:         @log_stdout,
-            Port:               port,
-            Host:               host,
-            DoNotReverseLookup: true,
-            config:             options[:config],
-            environment:        environment,
-            daemonize:          options[:daemon],
-            pid:                pid,
-            caching:            options["dev-caching"],
-            restart_cmd:        restart_command
+            user_supplied_options: user_supplied_options,
+            server:                @server,
+            log_stdout:            @log_stdout,
+            Port:                  port,
+            Host:                  host,
+            DoNotReverseLookup:    true,
+            config:                options[:config],
+            environment:           environment,
+            daemonize:             options[:daemon],
+            pid:                   pid,
+            caching:               options["dev-caching"],
+            restart_cmd:           restart_command
           }
         end
       end
 
       private
+        def user_supplied_options
+          @user_supplied_options ||= begin
+            # Convert incoming options array to a hash of flags
+            #   ["-p", "3001", "-c", "foo"] # => {"-p" => true, "-c" => true}
+            user_flag = {}
+            @original_options.each_with_index { |command, i| user_flag[command] = true if i.even? }
+
+            # Collect all options that the user has explicitly defined so we can
+            # differentiate them from defaults
+            user_supplied_options = []
+            self.class.class_options.select do |key, option|
+              if option.aliases.any? { |name| user_flag[name] } || user_flag["--#{option.name}"]
+                name = option.name.to_sym
+                case name
+                when :port
+                  name = :Port
+                when :binding
+                  name = :Host
+                when :"dev-caching"
+                  name = :caching
+                when :daemonize
+                  name = :daemon
+                end
+                user_supplied_options << name
+              end
+            end
+            user_supplied_options << :Host if ENV["Host"]
+            user_supplied_options << :Port if ENV["PORT"]
+            user_supplied_options.uniq
+          end
+        end
+
         def port
           ENV.fetch("PORT", options[:port]).to_i
         end

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -121,6 +121,14 @@ class Rails::ServerTest < ActiveSupport::TestCase
     end
   end
 
+  def test_records_user_supplied_options
+    server_options = parse_arguments(["-p", 3001])
+    assert_equal [:Port], server_options[:user_supplied_options]
+
+    server_options = parse_arguments(["--port", 3001])
+    assert_equal [:Port], server_options[:user_supplied_options]
+  end
+
   def test_default_options
     server = Rails::Server.new
     old_default_options = server.default_options


### PR DESCRIPTION
Currently when Puma gets a `:Port` it doesn't know if it is Rails' default port or if it is one that is specified by a user. Because of this it assumes that the port passed in is always a user defined port and therefor 3000 always "wins" even if you specify `port` inside of the `config/puma.rb` file when booting your server with `rails s`.

The fix is to record the options that are explicitly passed in from the user and pass those to the Puma server (or all servers really). Puma then has enough information to know when `:Port` is the default and when it is user defined. I went ahead and did this for all values rails server exposes as server side options for completeness.

The hardest thing was converting the input say `-p` or `--port` into the appropriate "name", in this case `Port`. There may be a more straightforward way to do this with Thor, but I'm not an expert here.

