### PR TITLE
Make HWIA#compact not return nil when no nils

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -270,7 +270,7 @@ module ActiveSupport
     end
 
     def compact
-      dup.compact!
+      dup.tap(&:compact!)
     end
 
     # Convert to a regular hash with string keys.

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -597,6 +597,16 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal(@strings, compacted_hash)
     assert_equal(hash_contain_nil_value, hash)
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, compacted_hash
+
+    empty_hash = ActiveSupport::HashWithIndifferentAccess.new
+    compacted_hash = empty_hash.compact
+
+    assert_equal compacted_hash, empty_hash
+
+    non_empty_hash = ActiveSupport::HashWithIndifferentAccess.new(foo: :bar)
+    compacted_hash = non_empty_hash.compact
+
+    assert_equal compacted_hash, non_empty_hash
   end
 
   def test_indifferent_to_hash


### PR DESCRIPTION
### Summary
In ActiveSupport 5 `HashWithIndifferentAccess#compact` currently returns nil when hash doesn't contain nil values in it. This PR fixes it.

Example:

```ruby
HashWithIndifferentAccess.new.compact       # => nil, expected {}
{foo: :bar}.with_indifferent_access.compact # => nil, expected { "foo" => :bar }
```

Note: this fix will also have to be backported into 4-2 branch since the same bug was recently introduced there as well by https://github.com/rails/rails/commit/828e0199b79a23e2b098933dfc117b2ac21861a1