### PR TITLE
Change `SystemTestCase.driven_by` to use `setup`/`teardown` hooks

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -105,9 +105,16 @@ module ActionDispatch
     #
     #   driven_by :selenium, screen_size: [800, 800]
     def self.driven_by(driver, using: :chrome, screen_size: [1400, 1400])
-      SystemTesting::Driver.new(driver).run
+      driver = if selenium?(driver)
+                 SystemTesting::Browser.new(using, screen_size)
+               else
+                 SystemTesting::Driver.new(driver)
+               end
+
+      setup { driver.use }
+      teardown { driver.reset }
+
       SystemTesting::Server.new.run
-      SystemTesting::Browser.new(using, screen_size).run if selenium?(driver)
     end
 
     def self.selenium?(driver) # :nodoc:

--- a/actionpack/lib/action_dispatch/system_testing/browser.rb
+++ b/actionpack/lib/action_dispatch/system_testing/browser.rb
@@ -1,14 +1,17 @@
+require "action_dispatch/system_testing/driver"
+
 module ActionDispatch
   module SystemTesting
-    class Browser # :nodoc:
+    class Browser < Driver # :nodoc:
       def initialize(name, screen_size)
+        super(name)
         @name = name
         @screen_size = screen_size
       end
 
-      def run
+      def use
         register
-        setup
+        super
       end
 
       private
@@ -18,10 +21,6 @@ module ActionDispatch
               driver.browser.manage.window.size = Selenium::WebDriver::Dimension.new(*@screen_size)
             end
           end
-        end
-
-        def setup
-          Capybara.default_driver = @name.to_sym
         end
     end
   end

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -5,14 +5,14 @@ module ActionDispatch
         @name = name
       end
 
-      def run
-        register
+      def use
+        @current = Capybara.current_driver
+        Capybara.current_driver = @name
       end
 
-      private
-        def register
-          Capybara.default_driver = @name
-        end
+      def reset
+        Capybara.current_driver = @current
+      end
     end
   end
 end

--- a/actionpack/test/dispatch/system_testing/system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/system_test_case_test.rb
@@ -1,21 +1,23 @@
 require "abstract_unit"
 
-class SystemTestCaseTest < ActiveSupport::TestCase
-  test "driven_by sets Capybara's default driver to poltergeist" do
-    ActionDispatch::SystemTestCase.driven_by :poltergeist
-
-    assert_equal :poltergeist, Capybara.default_driver
-  end
-
-  test "driven_by sets Capybara's drivers respectively" do
-    ActionDispatch::SystemTestCase.driven_by :selenium, using: :chrome
-
-    assert_includes Capybara.drivers, :selenium
-    assert_includes Capybara.drivers, :chrome
-    assert_equal :chrome, Capybara.default_driver
-  end
-
+class DrivenByCaseTestTest < ActiveSupport::TestCase
   test "selenium? returns false if driver is poltergeist" do
     assert_not ActionDispatch::SystemTestCase.selenium?(:poltergeist)
+  end
+end
+
+class DrivenByRackTestTest < ActionDispatch::SystemTestCase
+  driven_by :rack_test
+
+  test "uses rack_test" do
+    assert_equal :rack_test, Capybara.current_driver
+  end
+end
+
+class DrivenBySeleniumWithChromeTest < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :chrome
+
+  test "uses selenium" do
+    assert_equal :chrome, Capybara.current_driver
   end
 end


### PR DESCRIPTION
Previously, `driven_by` would change the Capybara configuration when the test case is loaded, and having multiple test classes with different `driven_by` configs would fail as the last loaded would be effective.
