### PR TITLE
Add missing gzip footer check in ActiveSupport::Gzip.decompress

### DIFF
--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -224,7 +224,7 @@ module StaticTests
 
     def assert_gzip(file_name, response)
       expected = File.read("#{FIXTURE_LOAD_PATH}/#{public_path}" + file_name)
-      actual   = Zlib::GzipReader.new(StringIO.new(response.body)).read
+      actual   = ActiveSupport::Gzip.decompress(response.body)
       assert_equal expected, actual
     end
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 5.1.0.beta1 (February 23, 2017) ##
 
+*   `ActiveSupport::Gzip.decompress` now checks checksum and length in footer.
+
+    *Dylan Thacker-Smith*
+
 *   Cache `ActiveSupport::TimeWithZone#to_datetime` before freezing.
 
     *Adam Rice*

--- a/activesupport/lib/active_support/gzip.rb
+++ b/activesupport/lib/active_support/gzip.rb
@@ -21,7 +21,7 @@ module ActiveSupport
 
     # Decompresses a gzipped string.
     def self.decompress(source)
-      Zlib::GzipReader.new(StringIO.new(source)).read
+      Zlib::GzipReader.wrap(StringIO.new(source), &:read)
     end
 
     # Compresses a string using gzip.

--- a/activesupport/test/gzip_test.rb
+++ b/activesupport/test/gzip_test.rb
@@ -30,4 +30,14 @@ class GzipTest < ActiveSupport::TestCase
 
     assert_equal true, (gzipped_by_best_compression.bytesize < gzipped_by_speed.bytesize)
   end
+
+  def test_decompress_checks_crc
+    compressed = ActiveSupport::Gzip.compress("Hello World")
+    first_crc_byte_index = compressed.bytesize - 8
+    compressed.setbyte(first_crc_byte_index, compressed.getbyte(first_crc_byte_index) ^ 0xff)
+
+    assert_raises(Zlib::GzipFile::CRCError) do
+      ActiveSupport::Gzip.decompress(compressed)
+    end
+  end
 end


### PR DESCRIPTION
### Problem

I noticed that gzip data decompressed with `ActiveSupport::Gzip.decompress` didn't check the crc in the footer for the compressed data.  After digging into why this wasn't happening I found the following in the [ruby documentation for Zlib::GzipReader](http://ruby-doc.org/stdlib-2.3.3/libdoc/zlib/rdoc/Zlib/GzipReader.html#class-Zlib::GzipReader-label-Method+Catalogue)

> Be careful of the footer of the gzip file. A gzip file has the checksum of pre-compressed data in its footer. GzipReader checks all uncompressed data against that checksum at the following cases, and if it fails, raises Zlib::GzipFile::NoFooter, Zlib::GzipFile::CRCError, or Zlib::GzipFile::LengthError exception.
> 
> * When an reading request is received beyond the end of file (the end of compressed data). That is, when #read, #gets, or some other methods for reading returns nil.
> * When Zlib::GzipFile#close method is called after the object reaches the end of file.
> * When #unused method is called after the object reaches the end of file.

So calling Zlib::GzipReader#read isn't enough, the Zlib::GzipReader also needs to be closed to make sure the footer is checked.

### Solution

I added a failing test that showed that the footer wasn't being checked by flipping some bits in the CRC32 field of the footer.  Details on the gzip file format can be found in [RFC 1952](http://www.zlib.org/rfc-gzip.html#file-format) which documents the end of the file as having a 4 byte CRC32 field and a 4 byte input size field.

> ```
>   0   1   2   3   4   5   6   7
> +---+---+---+---+---+---+---+---+
> |     CRC32     |     ISIZE     |
> +---+---+---+---+---+---+---+---+
> ```

To fix this bug I used `Zlib::GzipReader.wrap` which closes the Zlib::GzipReader after the given block is called which reads the compressed data.