### PR TITLE
Only load SystemTestCase if Puma is defined

### DIFF
--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -11,7 +11,7 @@ require "rails/generators/test_case"
 
 require "active_support/testing/autorun"
 
-if defined?(Capbyara)
+if defined?(Capybara) && defined?(Puma)
   require "action_dispatch/system_test_case"
 end
 
@@ -49,7 +49,7 @@ class ActionDispatch::IntegrationTest
   end
 end
 
-if defined? Capybara
+if defined?(Capybara) && defined?(Puma)
   class ActionDispatch::SystemTestCase
     def before_setup # :nodoc:
       @routes = Rails.application.routes


### PR DESCRIPTION
SystemTestCase supports only Puma, and always load puma's file.
https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/system_testing/server.rb#L1

For that reason, the case of use Capybara but do not use Puma, it will cause an error.
So we need to check about Puma is defined as well.