### PR TITLE
Fix RemoteConnections warning (redefined "#identifiers" method)

### DIFF
--- a/actioncable/lib/action_cable/remote_connections.rb
+++ b/actioncable/lib/action_cable/remote_connections.rb
@@ -34,6 +34,8 @@ module ActionCable
 
         include Connection::Identification, Connection::InternalChannel
 
+        delegate :connection_identifiers, to: :server
+
         def initialize(server, ids)
           @server = server
           set_identifier_instance_vars(ids)
@@ -42,11 +44,6 @@ module ActionCable
         # Uses the internal channel to disconnect the connection.
         def disconnect
           server.broadcast internal_channel, type: "disconnect"
-        end
-
-        # Returns all the identifiers that were applied to this connection.
-        def identifiers
-          server.connection_identifiers
         end
 
         private
@@ -59,7 +56,7 @@ module ActionCable
 
           def valid_identifiers?(ids)
             keys = ids.keys
-            identifiers.all? { |id| keys.include?(id) }
+            connection_identifiers.all? { |id| keys.include?(id) }
           end
       end
   end


### PR DESCRIPTION
Fixes this warning ([travis build log](https://travis-ci.org/rails/rails/jobs/205271825)):

<img width="903" alt="screen shot 2017-02-25 at 16 38 47" src="https://cloud.githubusercontent.com/assets/1516722/23331535/4b2539fa-fb81-11e6-8aeb-ff026f048c45.png">
 
