### PR TITLE
Fix migration tasks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `bin/rails db:forward` first migration.
+
+    *bogdanvlviv*
+
 *   Support Descending Indexes for MySQL.
 
     MySQL 8.0.1 and higher supports descending indexes: `DESC` in an index definition is no longer ignored.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Raise error `UnknownMigrationVersionError` on the movement of migrations
+    when the current migration does not exist.
+
+    *bogdanvlviv*
+
 *   Fix `bin/rails db:forward` first migration.
 
     *bogdanvlviv*

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1104,7 +1104,13 @@ module ActiveRecord
 
       def move(direction, migrations_paths, steps)
         migrator = new(direction, migrations(migrations_paths))
-        start_index = migrator.migrations.index(migrator.current_migration)
+
+        start_index =
+          if current_version == 0
+            0
+          else
+            migrator.migrations.index(migrator.current_migration)
+          end
 
         if start_index
           finish = migrator.migrations[start_index + steps]

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1105,6 +1105,10 @@ module ActiveRecord
       def move(direction, migrations_paths, steps)
         migrator = new(direction, migrations(migrations_paths))
 
+        if current_version != 0 && !migrator.current_migration
+          raise UnknownMigrationVersionError.new(current_version)
+        end
+
         start_index =
           if current_version == 0
             0
@@ -1112,11 +1116,9 @@ module ActiveRecord
             migrator.migrations.index(migrator.current_migration)
           end
 
-        if start_index
-          finish = migrator.migrations[start_index + steps]
-          version = finish ? finish.version : 0
-          send(direction, migrations_paths, version)
-        end
+        finish = migrator.migrations[start_index + steps]
+        version = finish ? finish.version : 0
+        send(direction, migrations_paths, version)
       end
     end
 

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -167,6 +167,37 @@ module ApplicationTests
         end
       end
 
+      test "raise error on any move when current migration does not exist" do
+        Dir.chdir(app_path) do
+          `bin/rails generate model user username:string password:string;
+           bin/rails generate migration add_email_to_users email:string;
+           bin/rails db:migrate
+           rm db/migrate/*email*.rb`
+
+          output = `bin/rails db:migrate:status`
+          assert_match(/up\s+\d{14}\s+Create users/, output)
+          assert_match(/up\s+\d{14}\s+\** NO FILE \**/, output)
+
+          output = `bin/rails db:rollback 2>&1`
+          assert_match(/rails aborted!/, output)
+          assert_match(/ActiveRecord::UnknownMigrationVersionError:/, output)
+          assert_match(/No migration with version number\s\d{14}\./, output)
+
+          output = `bin/rails db:migrate:status`
+          assert_match(/up\s+\d{14}\s+Create users/, output)
+          assert_match(/up\s+\d{14}\s+\** NO FILE \**/, output)
+
+          output = `bin/rails db:forward 2>&1`
+          assert_match(/rails aborted!/, output)
+          assert_match(/ActiveRecord::UnknownMigrationVersionError:/, output)
+          assert_match(/No migration with version number\s\d{14}\./, output)
+
+          output = `bin/rails db:migrate:status`
+          assert_match(/up\s+\d{14}\s+Create users/, output)
+          assert_match(/up\s+\d{14}\s+\** NO FILE \**/, output)
+        end
+      end
+
       test "migration status after rollback and redo without timestamps" do
         add_to_config("config.active_record.timestamped_migrations = false")
 
@@ -257,7 +288,6 @@ module ApplicationTests
            rm db/migrate/*email*.rb`
 
           output = `bin/rails db:migrate:status`
-          File.write("test.txt", output)
 
           assert_match(/up\s+\d{14}\s+Create users/, output)
           assert_match(/up\s+\d{14}\s+\** NO FILE \**/, output)


### PR DESCRIPTION
1) Fix `bin/rails db:forward` first migration.

    When `rails db:rollback` all migrations and then run
    `bin/rails db:forward`
    it doesn't work because we search current_migration by version.
    Migration with 0 version doesn't exist, because of that we can't
    to know current_migration index.
    When current_version migration is 0, we should start from 0.

2) Add additional `raise UnknownMigrationVersionError`

    Raise error on the movement of migrations
    when the current migration does not exist.

    This situation happens often in development when to use `git checkout branch_name` :)
    After deleted last migration's file (with git for example)
    `bin/rails db:rollback` is confusing. It doesn't logs anything and effect on `db/schema.rb` by change version of current migration.

3) Show description `rake db:forward` on `rake -T`

    I decided to show the description because `rake db:forward` is useful with `rake db:rollback`.
    Currently `rake -T` is showing the description for `rake db:rollback`. Should be consistency.