### PR TITLE
Deprecate AbstractAdapter#verify! with arguments

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -439,6 +439,9 @@ module ActiveRecord
       # This is done under the hood by calling #active?. If the connection
       # is no longer active, then this method will reconnect to the database.
       def verify!(*ignored)
+        if ignored.size > 0
+          ActiveSupport::Deprecation.warn("Passing arguments to #verify method of the connection has no affect and has been deprecated. Please remove all arguments from the #verify method call.")
+        end
         reconnect! unless active?
       end
 

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -63,6 +63,18 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
     assert @connection.active?
   end
 
+  def test_verify_with_args_is_deprecated
+    assert_deprecated do
+      @connection.verify!(option: true)
+    end
+    assert_deprecated do
+      @connection.verify!([])
+    end
+    assert_deprecated do
+      @connection.verify!({})
+    end
+  end
+
   def test_execute_after_disconnect
     @connection.disconnect!
 


### PR DESCRIPTION
Since 2008 (https://github.com/rails/rails/commit/7ba28726150f5d4ee3b3cb676d6b73cc3b62e186), all arguments passed to `verify!` have been ignored. I think it's now time to print a deprecation warning and stop accepting any arguments in future.

@matthewd @kaspth 