### PR TITLE
Use ensure block for things we cleanup in tests

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -42,7 +42,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
     @connection.update("set @@wait_timeout=1")
     sleep 2
     assert !@connection.active?
-
+  ensure
     # Repair all fixture connections so other tests won't break.
     @fixture_connections.each(&:verify!)
   end

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -178,6 +178,7 @@ module ActiveRecord
         "umm -- looks like you didn't break the connection, because we're still " \
         "successfully querying with the same connection pid."
 
+    ensure
       # Repair all fixture connections so other tests won't break.
       @fixture_connections.each(&:verify!)
     end


### PR DESCRIPTION
In connection pool tests, we do some things that require the connection reset after the test run. However if these tests fail, the line with cleanup will never run. It needs the `ensure` block.

I discovered it when working on https://github.com/rails/rails/pull/27651.

review @matthewd @arthurnn @rafaelfranca 