### PR TITLE
Fix typo in test/cases/connection_pool_test.rb

### DIFF
--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -307,7 +307,7 @@ module ActiveRecord
         end
       end
 
-      def test_automatic_reconnect=
+      def test_automatic_reconnect
         pool = ConnectionPool.new ActiveRecord::Base.connection_pool.spec
         assert pool.automatic_reconnect
         assert pool.connection


### PR DESCRIPTION
It looks like the sign in the test method name is a typo.

review @rafaelfranca @matthewd 