### PR TITLE
Improve test for TaggedLogging "keeps each tag in their own thread"

### DIFF
--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -72,11 +72,12 @@ class TaggedLoggingTest < ActiveSupport::TestCase
   test "keeps each tag in their own thread" do
     @logger.tagged("BCX") do
       Thread.new do
+        @logger.info "Dull story"
         @logger.tagged("OMG") { @logger.info "Cool story" }
       end.join
       @logger.info "Funky time"
     end
-    assert_equal "[OMG] Cool story\n[BCX] Funky time\n", @output.string
+    assert_equal "Dull story\n[OMG] Cool story\n[BCX] Funky time\n", @output.string
   end
 
   test "keeps each tag in their own instance" do


### PR DESCRIPTION
### Summary

The logger has no tags in a fresh new thread, which is pointed out in https://github.com/rails/rails/issues/28156 

Improve the TaggedLogging test "keeps each tag in their own thread" to make sure this behavior is covered.
