### PR TITLE
Deprecate `supports_migrations?` on connection adapters

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `supports_migrations?` on connection adapters.
+
+    *Ryuta Kamizono*
+
 *   Fix regression of #1969 with SELECT aliases in HAVING clause.
 
     *Eugene Kenny*

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -232,10 +232,10 @@ module ActiveRecord
         self.class::ADAPTER_NAME
       end
 
-      # Does this adapter support migrations?
-      def supports_migrations?
-        false
+      def supports_migrations? # :nodoc:
+        true
       end
+      deprecate :supports_migrations?
 
       def supports_primary_key? # :nodoc:
         true

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -89,11 +89,6 @@ module ActiveRecord
         /mariadb/i.match?(full_version)
       end
 
-      # Returns true, since this connection adapter supports migrations.
-      def supports_migrations?
-        true
-      end
-
       def supports_bulk_alter? #:nodoc:
         true
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -281,11 +281,6 @@ module ActiveRecord
         NATIVE_DATABASE_TYPES
       end
 
-      # Returns true, since this connection adapter supports migrations.
-      def supports_migrations?
-        true
-      end
-
       def set_standard_conforming_strings
         execute("SET standard_conforming_strings = on", "SCHEMA")
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -117,11 +117,6 @@ module ActiveRecord
         true
       end
 
-      # Returns true, since this connection adapter supports migrations.
-      def supports_migrations? #:nodoc:
-        true
-      end
-
       def requires_reloading?
         true
       end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -548,12 +548,10 @@ module ActiveRecord
       end
 
       def call(env)
-        if connection.supports_migrations?
-          mtime = ActiveRecord::Migrator.last_migration.mtime.to_i
-          if @last_check < mtime
-            ActiveRecord::Migration.check_pending!(connection)
-            @last_check = mtime
-          end
+        mtime = ActiveRecord::Migrator.last_migration.mtime.to_i
+        if @last_check < mtime
+          ActiveRecord::Migration.check_pending!(connection)
+          @last_check = mtime
         end
         @app.call(env)
       end
@@ -1098,8 +1096,6 @@ module ActiveRecord
     end
 
     def initialize(direction, migrations, target_version = nil)
-      raise StandardError.new("This database does not yet support migrations") unless Base.connection.supports_migrations?
-
       @direction         = direction
       @target_version    = target_version
       @migrated_versions = nil

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -288,8 +288,7 @@ db_namespace = namespace :db do
       current_config = ActiveRecord::Tasks::DatabaseTasks.current_config
       ActiveRecord::Tasks::DatabaseTasks.structure_dump(current_config, filename)
 
-      if ActiveRecord::Base.connection.supports_migrations? &&
-          ActiveRecord::SchemaMigration.table_exists?
+      if ActiveRecord::SchemaMigration.table_exists?
         File.open(filename, "a") do |f|
           f.puts ActiveRecord::Base.connection.dump_schema_information
           f.print "\n"

--- a/activerecord/test/cases/ar_schema_test.rb
+++ b/activerecord/test/cases/ar_schema_test.rb
@@ -1,146 +1,143 @@
 require "cases/helper"
 
-if ActiveRecord::Base.connection.supports_migrations?
+class ActiveRecordSchemaTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
 
-  class ActiveRecordSchemaTest < ActiveRecord::TestCase
-    self.use_transactional_tests = false
+  setup do
+    @original_verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+    @connection = ActiveRecord::Base.connection
+    ActiveRecord::SchemaMigration.drop_table
+  end
 
-    setup do
-      @original_verbose = ActiveRecord::Migration.verbose
-      ActiveRecord::Migration.verbose = false
-      @connection = ActiveRecord::Base.connection
-      ActiveRecord::SchemaMigration.drop_table
+  teardown do
+    @connection.drop_table :fruits rescue nil
+    @connection.drop_table :nep_fruits rescue nil
+    @connection.drop_table :nep_schema_migrations rescue nil
+    @connection.drop_table :has_timestamps rescue nil
+    @connection.drop_table :multiple_indexes rescue nil
+    ActiveRecord::SchemaMigration.delete_all rescue nil
+    ActiveRecord::Migration.verbose = @original_verbose
+  end
+
+  def test_has_primary_key
+    old_primary_key_prefix_type = ActiveRecord::Base.primary_key_prefix_type
+    ActiveRecord::Base.primary_key_prefix_type = :table_name_with_underscore
+    assert_equal "version", ActiveRecord::SchemaMigration.primary_key
+
+    ActiveRecord::SchemaMigration.create_table
+    assert_difference "ActiveRecord::SchemaMigration.count", 1 do
+      ActiveRecord::SchemaMigration.create version: 12
     end
+  ensure
+    ActiveRecord::SchemaMigration.drop_table
+    ActiveRecord::Base.primary_key_prefix_type = old_primary_key_prefix_type
+  end
 
-    teardown do
-      @connection.drop_table :fruits rescue nil
-      @connection.drop_table :nep_fruits rescue nil
-      @connection.drop_table :nep_schema_migrations rescue nil
-      @connection.drop_table :has_timestamps rescue nil
-      @connection.drop_table :multiple_indexes rescue nil
-      ActiveRecord::SchemaMigration.delete_all rescue nil
-      ActiveRecord::Migration.verbose = @original_verbose
-    end
-
-    def test_has_primary_key
-      old_primary_key_prefix_type = ActiveRecord::Base.primary_key_prefix_type
-      ActiveRecord::Base.primary_key_prefix_type = :table_name_with_underscore
-      assert_equal "version", ActiveRecord::SchemaMigration.primary_key
-
-      ActiveRecord::SchemaMigration.create_table
-      assert_difference "ActiveRecord::SchemaMigration.count", 1 do
-        ActiveRecord::SchemaMigration.create version: 12
+  def test_schema_define
+    ActiveRecord::Schema.define(version: 7) do
+      create_table :fruits do |t|
+        t.column :color, :string
+        t.column :fruit_size, :string  # NOTE: "size" is reserved in Oracle
+        t.column :texture, :string
+        t.column :flavor, :string
       end
-    ensure
-      ActiveRecord::SchemaMigration.drop_table
-      ActiveRecord::Base.primary_key_prefix_type = old_primary_key_prefix_type
     end
 
-    def test_schema_define
-      ActiveRecord::Schema.define(version: 7) do
-        create_table :fruits do |t|
-          t.column :color, :string
-          t.column :fruit_size, :string  # NOTE: "size" is reserved in Oracle
-          t.column :texture, :string
-          t.column :flavor, :string
-        end
+    assert_nothing_raised { @connection.select_all "SELECT * FROM fruits" }
+    assert_nothing_raised { @connection.select_all "SELECT * FROM schema_migrations" }
+    assert_equal 7, ActiveRecord::Migrator::current_version
+  end
+
+  def test_schema_define_w_table_name_prefix
+    table_name = ActiveRecord::SchemaMigration.table_name
+    old_table_name_prefix = ActiveRecord::Base.table_name_prefix
+    ActiveRecord::Base.table_name_prefix = "nep_"
+    ActiveRecord::SchemaMigration.table_name = "nep_#{table_name}"
+    ActiveRecord::Schema.define(version: 7) do
+      create_table :fruits do |t|
+        t.column :color, :string
+        t.column :fruit_size, :string  # NOTE: "size" is reserved in Oracle
+        t.column :texture, :string
+        t.column :flavor, :string
       end
-
-      assert_nothing_raised { @connection.select_all "SELECT * FROM fruits" }
-      assert_nothing_raised { @connection.select_all "SELECT * FROM schema_migrations" }
-      assert_equal 7, ActiveRecord::Migrator::current_version
     end
+    assert_equal 7, ActiveRecord::Migrator::current_version
+  ensure
+    ActiveRecord::Base.table_name_prefix = old_table_name_prefix
+    ActiveRecord::SchemaMigration.table_name = table_name
+  end
 
-    def test_schema_define_w_table_name_prefix
-      table_name = ActiveRecord::SchemaMigration.table_name
-      old_table_name_prefix = ActiveRecord::Base.table_name_prefix
-      ActiveRecord::Base.table_name_prefix = "nep_"
-      ActiveRecord::SchemaMigration.table_name = "nep_#{table_name}"
-      ActiveRecord::Schema.define(version: 7) do
-        create_table :fruits do |t|
-          t.column :color, :string
-          t.column :fruit_size, :string  # NOTE: "size" is reserved in Oracle
-          t.column :texture, :string
-          t.column :flavor, :string
-        end
-      end
-      assert_equal 7, ActiveRecord::Migrator::current_version
-    ensure
-      ActiveRecord::Base.table_name_prefix = old_table_name_prefix
-      ActiveRecord::SchemaMigration.table_name = table_name
-    end
-
-    def test_schema_raises_an_error_for_invalid_column_type
-      assert_raise NoMethodError do
-        ActiveRecord::Schema.define(version: 8) do
-          create_table :vegetables do |t|
-            t.unknown :color
-          end
+  def test_schema_raises_an_error_for_invalid_column_type
+    assert_raise NoMethodError do
+      ActiveRecord::Schema.define(version: 8) do
+        create_table :vegetables do |t|
+          t.unknown :color
         end
       end
     end
+  end
 
-    def test_schema_subclass
-      Class.new(ActiveRecord::Schema).define(version: 9) do
-        create_table :fruits
+  def test_schema_subclass
+    Class.new(ActiveRecord::Schema).define(version: 9) do
+      create_table :fruits
+    end
+    assert_nothing_raised { @connection.select_all "SELECT * FROM fruits" }
+  end
+
+  def test_normalize_version
+    assert_equal "118", ActiveRecord::SchemaMigration.normalize_migration_number("0000118")
+    assert_equal "002", ActiveRecord::SchemaMigration.normalize_migration_number("2")
+    assert_equal "017", ActiveRecord::SchemaMigration.normalize_migration_number("0017")
+    assert_equal "20131219224947", ActiveRecord::SchemaMigration.normalize_migration_number("20131219224947")
+  end
+
+  def test_schema_load_with_multiple_indexes_for_column_of_different_names
+    ActiveRecord::Schema.define do
+      create_table :multiple_indexes do |t|
+        t.string "foo"
+        t.index ["foo"], name: "multiple_indexes_foo_1"
+        t.index ["foo"], name: "multiple_indexes_foo_2"
       end
-      assert_nothing_raised { @connection.select_all "SELECT * FROM fruits" }
     end
 
-    def test_normalize_version
-      assert_equal "118", ActiveRecord::SchemaMigration.normalize_migration_number("0000118")
-      assert_equal "002", ActiveRecord::SchemaMigration.normalize_migration_number("2")
-      assert_equal "017", ActiveRecord::SchemaMigration.normalize_migration_number("0017")
-      assert_equal "20131219224947", ActiveRecord::SchemaMigration.normalize_migration_number("20131219224947")
-    end
+    indexes = @connection.indexes("multiple_indexes")
 
-    def test_schema_load_with_multiple_indexes_for_column_of_different_names
-      ActiveRecord::Schema.define do
-        create_table :multiple_indexes do |t|
-          t.string "foo"
-          t.index ["foo"], name: "multiple_indexes_foo_1"
-          t.index ["foo"], name: "multiple_indexes_foo_2"
-        end
+    assert_equal 2, indexes.length
+    assert_equal ["multiple_indexes_foo_1", "multiple_indexes_foo_2"], indexes.collect(&:name).sort
+  end
+
+  def test_timestamps_without_null_set_null_to_false_on_create_table
+    ActiveRecord::Schema.define do
+      create_table :has_timestamps do |t|
+        t.timestamps
       end
-
-      indexes = @connection.indexes("multiple_indexes")
-
-      assert_equal 2, indexes.length
-      assert_equal ["multiple_indexes_foo_1", "multiple_indexes_foo_2"], indexes.collect(&:name).sort
     end
 
-    def test_timestamps_without_null_set_null_to_false_on_create_table
-      ActiveRecord::Schema.define do
-        create_table :has_timestamps do |t|
-          t.timestamps
-        end
+    assert !@connection.columns(:has_timestamps).find { |c| c.name == "created_at" }.null
+    assert !@connection.columns(:has_timestamps).find { |c| c.name == "updated_at" }.null
+  end
+
+  def test_timestamps_without_null_set_null_to_false_on_change_table
+    ActiveRecord::Schema.define do
+      create_table :has_timestamps
+
+      change_table :has_timestamps do |t|
+        t.timestamps default: Time.now
       end
-
-      assert !@connection.columns(:has_timestamps).find { |c| c.name == "created_at" }.null
-      assert !@connection.columns(:has_timestamps).find { |c| c.name == "updated_at" }.null
     end
 
-    def test_timestamps_without_null_set_null_to_false_on_change_table
-      ActiveRecord::Schema.define do
-        create_table :has_timestamps
+    assert !@connection.columns(:has_timestamps).find { |c| c.name == "created_at" }.null
+    assert !@connection.columns(:has_timestamps).find { |c| c.name == "updated_at" }.null
+  end
 
-        change_table :has_timestamps do |t|
-          t.timestamps default: Time.now
-        end
-      end
-
-      assert !@connection.columns(:has_timestamps).find { |c| c.name == "created_at" }.null
-      assert !@connection.columns(:has_timestamps).find { |c| c.name == "updated_at" }.null
+  def test_timestamps_without_null_set_null_to_false_on_add_timestamps
+    ActiveRecord::Schema.define do
+      create_table :has_timestamps
+      add_timestamps :has_timestamps, default: Time.now
     end
 
-    def test_timestamps_without_null_set_null_to_false_on_add_timestamps
-      ActiveRecord::Schema.define do
-        create_table :has_timestamps
-        add_timestamps :has_timestamps, default: Time.now
-      end
-
-      assert !@connection.columns(:has_timestamps).find { |c| c.name == "created_at" }.null
-      assert !@connection.columns(:has_timestamps).find { |c| c.name == "updated_at" }.null
-    end
+    assert !@connection.columns(:has_timestamps).find { |c| c.name == "created_at" }.null
+    assert !@connection.columns(:has_timestamps).find { |c| c.name == "updated_at" }.null
   end
 end

--- a/activerecord/test/cases/associations/eager_singularization_test.rb
+++ b/activerecord/test/cases/associations/eager_singularization_test.rb
@@ -1,147 +1,146 @@
 require "cases/helper"
 
-if ActiveRecord::Base.connection.supports_migrations?
-  class EagerSingularizationTest < ActiveRecord::TestCase
-    class Virus < ActiveRecord::Base
-      belongs_to :octopus
-    end
+class EagerSingularizationTest < ActiveRecord::TestCase
+  class Virus < ActiveRecord::Base
+    belongs_to :octopus
+  end
 
-    class Octopus < ActiveRecord::Base
-      has_one :virus
-    end
+  class Octopus < ActiveRecord::Base
+    has_one :virus
+  end
 
-    class Pass < ActiveRecord::Base
-      belongs_to :bus
-    end
+  class Pass < ActiveRecord::Base
+    belongs_to :bus
+  end
 
-    class Bus < ActiveRecord::Base
-      has_many :passes
-    end
+  class Bus < ActiveRecord::Base
+    has_many :passes
+  end
 
-    class Mess < ActiveRecord::Base
-      has_and_belongs_to_many :crises
-    end
+  class Mess < ActiveRecord::Base
+    has_and_belongs_to_many :crises
+  end
 
-    class Crisis < ActiveRecord::Base
-      has_and_belongs_to_many :messes
-      has_many :analyses, dependent: :destroy
-      has_many :successes, through: :analyses
-      has_many :dresses, dependent: :destroy
-      has_many :compresses, through: :dresses
-    end
+  class Crisis < ActiveRecord::Base
+    has_and_belongs_to_many :messes
+    has_many :analyses, dependent: :destroy
+    has_many :successes, through: :analyses
+    has_many :dresses, dependent: :destroy
+    has_many :compresses, through: :dresses
+  end
 
-    class Analysis < ActiveRecord::Base
-      belongs_to :crisis
-      belongs_to :success
-    end
+  class Analysis < ActiveRecord::Base
+    belongs_to :crisis
+    belongs_to :success
+  end
 
-    class Success < ActiveRecord::Base
-      has_many :analyses, dependent: :destroy
-      has_many :crises, through: :analyses
-    end
+  class Success < ActiveRecord::Base
+    has_many :analyses, dependent: :destroy
+    has_many :crises, through: :analyses
+  end
 
-    class Dress < ActiveRecord::Base
-      belongs_to :crisis
-      has_many :compresses
-    end
+  class Dress < ActiveRecord::Base
+    belongs_to :crisis
+    has_many :compresses
+  end
 
-    class Compress < ActiveRecord::Base
-      belongs_to :dress
-    end
+  class Compress < ActiveRecord::Base
+    belongs_to :dress
+  end
 
-    def setup
-      connection.create_table :viri do |t|
-        t.column :octopus_id, :integer
-        t.column :species, :string
-      end
-      connection.create_table :octopi do |t|
-        t.column :species, :string
-      end
-      connection.create_table :passes do |t|
-        t.column :bus_id, :integer
-        t.column :rides, :integer
-      end
-      connection.create_table :buses do |t|
-        t.column :name, :string
-      end
-      connection.create_table :crises_messes, id: false do |t|
-        t.column :crisis_id, :integer
-        t.column :mess_id, :integer
-      end
-      connection.create_table :messes do |t|
-        t.column :name, :string
-      end
-      connection.create_table :crises do |t|
-        t.column :name, :string
-      end
-      connection.create_table :successes do |t|
-        t.column :name, :string
-      end
-      connection.create_table :analyses do |t|
-        t.column :crisis_id, :integer
-        t.column :success_id, :integer
-      end
-      connection.create_table :dresses do |t|
-        t.column :crisis_id, :integer
-      end
-      connection.create_table :compresses do |t|
-        t.column :dress_id, :integer
-      end
+  def setup
+    connection.create_table :viri do |t|
+      t.column :octopus_id, :integer
+      t.column :species, :string
     end
-
-    teardown do
-      connection.drop_table :viri
-      connection.drop_table :octopi
-      connection.drop_table :passes
-      connection.drop_table :buses
-      connection.drop_table :crises_messes
-      connection.drop_table :messes
-      connection.drop_table :crises
-      connection.drop_table :successes
-      connection.drop_table :analyses
-      connection.drop_table :dresses
-      connection.drop_table :compresses
+    connection.create_table :octopi do |t|
+      t.column :species, :string
     end
+    connection.create_table :passes do |t|
+      t.column :bus_id, :integer
+      t.column :rides, :integer
+    end
+    connection.create_table :buses do |t|
+      t.column :name, :string
+    end
+    connection.create_table :crises_messes, id: false do |t|
+      t.column :crisis_id, :integer
+      t.column :mess_id, :integer
+    end
+    connection.create_table :messes do |t|
+      t.column :name, :string
+    end
+    connection.create_table :crises do |t|
+      t.column :name, :string
+    end
+    connection.create_table :successes do |t|
+      t.column :name, :string
+    end
+    connection.create_table :analyses do |t|
+      t.column :crisis_id, :integer
+      t.column :success_id, :integer
+    end
+    connection.create_table :dresses do |t|
+      t.column :crisis_id, :integer
+    end
+    connection.create_table :compresses do |t|
+      t.column :dress_id, :integer
+    end
+  end
 
+  teardown do
+    connection.drop_table :viri
+    connection.drop_table :octopi
+    connection.drop_table :passes
+    connection.drop_table :buses
+    connection.drop_table :crises_messes
+    connection.drop_table :messes
+    connection.drop_table :crises
+    connection.drop_table :successes
+    connection.drop_table :analyses
+    connection.drop_table :dresses
+    connection.drop_table :compresses
+  end
+
+  def test_eager_no_extra_singularization_belongs_to
+    assert_nothing_raised do
+      Virus.all.merge!(includes: :octopus).to_a
+    end
+  end
+
+  def test_eager_no_extra_singularization_has_one
+    assert_nothing_raised do
+      Octopus.all.merge!(includes: :virus).to_a
+    end
+  end
+
+  def test_eager_no_extra_singularization_has_many
+    assert_nothing_raised do
+      Bus.all.merge!(includes: :passes).to_a
+    end
+  end
+
+  def test_eager_no_extra_singularization_has_and_belongs_to_many
+    assert_nothing_raised do
+      Crisis.all.merge!(includes: :messes).to_a
+      Mess.all.merge!(includes: :crises).to_a
+    end
+  end
+
+  def test_eager_no_extra_singularization_has_many_through_belongs_to
+    assert_nothing_raised do
+      Crisis.all.merge!(includes: :successes).to_a
+    end
+  end
+
+  def test_eager_no_extra_singularization_has_many_through_has_many
+    assert_nothing_raised do
+      Crisis.all.merge!(includes: :compresses).to_a
+    end
+  end
+
+  private
     def connection
       ActiveRecord::Base.connection
     end
-
-    def test_eager_no_extra_singularization_belongs_to
-      assert_nothing_raised do
-        Virus.all.merge!(includes: :octopus).to_a
-      end
-    end
-
-    def test_eager_no_extra_singularization_has_one
-      assert_nothing_raised do
-        Octopus.all.merge!(includes: :virus).to_a
-      end
-    end
-
-    def test_eager_no_extra_singularization_has_many
-      assert_nothing_raised do
-        Bus.all.merge!(includes: :passes).to_a
-      end
-    end
-
-    def test_eager_no_extra_singularization_has_and_belongs_to_many
-      assert_nothing_raised do
-        Crisis.all.merge!(includes: :messes).to_a
-        Mess.all.merge!(includes: :crises).to_a
-      end
-    end
-
-    def test_eager_no_extra_singularization_has_many_through_belongs_to
-      assert_nothing_raised do
-        Crisis.all.merge!(includes: :successes).to_a
-      end
-    end
-
-    def test_eager_no_extra_singularization_has_many_through_has_many
-      assert_nothing_raised do
-        Crisis.all.merge!(includes: :compresses).to_a
-      end
-    end
-  end
 end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -566,19 +566,17 @@ class DirtyTest < ActiveRecord::TestCase
     travel_back
   end
 
-  if ActiveRecord::Base.connection.supports_migrations?
-    class Testings < ActiveRecord::Base; end
-    def test_field_named_field
-      ActiveRecord::Base.connection.create_table :testings do |t|
-        t.string :field
-      end
-      assert_nothing_raised do
-        Testings.new.attributes
-      end
-    ensure
-      ActiveRecord::Base.connection.drop_table :testings rescue nil
-      ActiveRecord::Base.clear_cache!
+  class Testings < ActiveRecord::Base; end
+  def test_field_named_field
+    ActiveRecord::Base.connection.create_table :testings do |t|
+      t.string :field
     end
+    assert_nothing_raised do
+      Testings.new.attributes
+    end
+  ensure
+    ActiveRecord::Base.connection.drop_table :testings rescue nil
+    ActiveRecord::Base.clear_cache!
   end
 
   def test_datetime_attribute_can_be_updated_with_fractional_seconds

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -104,64 +104,62 @@ class FixturesTest < ActiveRecord::TestCase
     assert_nil(second_row["author_email_address"])
   end
 
-  if ActiveRecord::Base.connection.supports_migrations?
-    def test_inserts_with_pre_and_suffix
-      # Reset cache to make finds on the new table work
-      ActiveRecord::FixtureSet.reset_cache
+  def test_inserts_with_pre_and_suffix
+    # Reset cache to make finds on the new table work
+    ActiveRecord::FixtureSet.reset_cache
 
-      ActiveRecord::Base.connection.create_table :prefix_other_topics_suffix do |t|
-        t.column :title, :string
-        t.column :author_name, :string
-        t.column :author_email_address, :string
-        t.column :written_on, :datetime
-        t.column :bonus_time, :time
-        t.column :last_read, :date
-        t.column :content, :string
-        t.column :approved, :boolean, default: true
-        t.column :replies_count, :integer, default: 0
-        t.column :parent_id, :integer
-        t.column :type, :string, limit: 50
-      end
-
-      # Store existing prefix/suffix
-      old_prefix = ActiveRecord::Base.table_name_prefix
-      old_suffix = ActiveRecord::Base.table_name_suffix
-
-      # Set a prefix/suffix we can test against
-      ActiveRecord::Base.table_name_prefix = "prefix_"
-      ActiveRecord::Base.table_name_suffix = "_suffix"
-
-      other_topic_klass = Class.new(ActiveRecord::Base) do
-        def self.name
-          "OtherTopic"
-        end
-      end
-
-      topics = [create_fixtures("other_topics")].flatten.first
-
-      # This checks for a caching problem which causes a bug in the fixtures
-      # class-level configuration helper.
-      assert_not_nil topics, "Fixture data inserted, but fixture objects not returned from create"
-
-      first_row = ActiveRecord::Base.connection.select_one("SELECT * FROM prefix_other_topics_suffix WHERE author_name = 'David'")
-      assert_not_nil first_row, "The prefix_other_topics_suffix table appears to be empty despite create_fixtures: the row with author_name = 'David' was not found"
-      assert_equal("The First Topic", first_row["title"])
-
-      second_row = ActiveRecord::Base.connection.select_one("SELECT * FROM prefix_other_topics_suffix WHERE author_name = 'Mary'")
-      assert_nil(second_row["author_email_address"])
-
-      assert_equal :prefix_other_topics_suffix, topics.table_name.to_sym
-      # This assertion should preferably be the last in the list, because calling
-      # other_topic_klass.table_name sets a class-level instance variable
-      assert_equal :prefix_other_topics_suffix, other_topic_klass.table_name.to_sym
-
-    ensure
-      # Restore prefix/suffix to its previous values
-      ActiveRecord::Base.table_name_prefix = old_prefix
-      ActiveRecord::Base.table_name_suffix = old_suffix
-
-      ActiveRecord::Base.connection.drop_table :prefix_other_topics_suffix rescue nil
+    ActiveRecord::Base.connection.create_table :prefix_other_topics_suffix do |t|
+      t.column :title, :string
+      t.column :author_name, :string
+      t.column :author_email_address, :string
+      t.column :written_on, :datetime
+      t.column :bonus_time, :time
+      t.column :last_read, :date
+      t.column :content, :string
+      t.column :approved, :boolean, default: true
+      t.column :replies_count, :integer, default: 0
+      t.column :parent_id, :integer
+      t.column :type, :string, limit: 50
     end
+
+    # Store existing prefix/suffix
+    old_prefix = ActiveRecord::Base.table_name_prefix
+    old_suffix = ActiveRecord::Base.table_name_suffix
+
+    # Set a prefix/suffix we can test against
+    ActiveRecord::Base.table_name_prefix = "prefix_"
+    ActiveRecord::Base.table_name_suffix = "_suffix"
+
+    other_topic_klass = Class.new(ActiveRecord::Base) do
+      def self.name
+        "OtherTopic"
+      end
+    end
+
+    topics = [create_fixtures("other_topics")].flatten.first
+
+    # This checks for a caching problem which causes a bug in the fixtures
+    # class-level configuration helper.
+    assert_not_nil topics, "Fixture data inserted, but fixture objects not returned from create"
+
+    first_row = ActiveRecord::Base.connection.select_one("SELECT * FROM prefix_other_topics_suffix WHERE author_name = 'David'")
+    assert_not_nil first_row, "The prefix_other_topics_suffix table appears to be empty despite create_fixtures: the row with author_name = 'David' was not found"
+    assert_equal("The First Topic", first_row["title"])
+
+    second_row = ActiveRecord::Base.connection.select_one("SELECT * FROM prefix_other_topics_suffix WHERE author_name = 'Mary'")
+    assert_nil(second_row["author_email_address"])
+
+    assert_equal :prefix_other_topics_suffix, topics.table_name.to_sym
+    # This assertion should preferably be the last in the list, because calling
+    # other_topic_klass.table_name sets a class-level instance variable
+    assert_equal :prefix_other_topics_suffix, other_topic_klass.table_name.to_sym
+
+  ensure
+    # Restore prefix/suffix to its previous values
+    ActiveRecord::Base.table_name_prefix = old_prefix
+    ActiveRecord::Base.table_name_suffix = old_suffix
+
+    ActiveRecord::Base.connection.drop_table :prefix_other_topics_suffix rescue nil
   end
 
   def test_insert_with_datetime

--- a/activerecord/test/cases/migration/pending_migrations_test.rb
+++ b/activerecord/test/cases/migration/pending_migrations_test.rb
@@ -21,8 +21,6 @@ module ActiveRecord
       end
 
       def test_errors_if_pending
-        @connection.expect :supports_migrations?, true
-
         ActiveRecord::Migrator.stub :needs_migration?, true do
           assert_raise ActiveRecord::PendingMigrationError do
             @pending.call(nil)
@@ -31,19 +29,9 @@ module ActiveRecord
       end
 
       def test_checks_if_supported
-        @connection.expect :supports_migrations?, true
         @app.expect :call, nil, [:foo]
 
         ActiveRecord::Migrator.stub :needs_migration?, false do
-          @pending.call(:foo)
-        end
-      end
-
-      def test_doesnt_check_if_unsupported
-        @connection.expect :supports_migrations?, false
-        @app.expect :call, nil, [:foo]
-
-        ActiveRecord::Migrator.stub :needs_migration?, true do
           @pending.call(:foo)
         end
       end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1142,4 +1142,8 @@ class CopyMigrationsTest < ActiveRecord::TestCase
   def test_deprecate_migration_keys
     assert_deprecated { ActiveRecord::Base.connection.migration_keys }
   end
+
+  def test_deprecate_supports_migrations
+    assert_deprecated { ActiveRecord::Base.connection.supports_migrations? }
+  end
 end


### PR DESCRIPTION
`supports_migrations?` was added at 4160b518 to determine if schema
statements (`create_table`, `drop_table`, etc) are implemented in the
adapter. But all tested databases has been supported migrations since
a4fc93c3 at least.