### PR TITLE
Push `valid_type?` up to abstract adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -154,8 +154,8 @@ module ActiveRecord
         Arel::Visitors::ToSql.new(self)
       end
 
-      def valid_type?(type)
-        false
+      def valid_type?(type) # :nodoc:
+        !native_database_types[type].nil?
       end
 
       def schema_creation

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -648,10 +648,6 @@ module ActiveRecord
         self.class.type_cast_config_to_boolean(@config.fetch(:strict, true))
       end
 
-      def valid_type?(type)
-        !native_database_types[type].nil?
-      end
-
       def default_index_type?(index) # :nodoc:
         index.using == :btree || super
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -376,10 +376,6 @@ module ActiveRecord
         @use_insert_returning
       end
 
-      def valid_type?(type)
-        !native_database_types[type].nil?
-      end
-
       def update_table_definition(table_name, base) #:nodoc:
         PostgreSQL::Table.new(table_name, base)
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -163,7 +163,7 @@ module ActiveRecord
         true
       end
 
-      def valid_type?(type)
+      def valid_type?(type) # :nodoc:
         true
       end
 


### PR DESCRIPTION
`valid_type?` should return true if a type exists in
`native_database_types` at least.

https://github.com/rails/rails/blob/v5.1.0.beta1/activerecord/lib/active_record/schema_dumper.rb#L136