### PR TITLE
Transactional test cases

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -984,8 +984,7 @@ module ActiveRecord
             end
 
             if connection && !@fixture_connections.include?(connection)
-              connection.begin_transaction joinable: false
-              connection.pool.lock_thread = true
+              connection.begin_transaction joinable: false, lock_thread: true
               @fixture_connections << connection
             end
           end

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -969,8 +969,7 @@ module ActiveRecord
         # Begin transactions for connections already established
         @fixture_connections = enlist_fixture_connections
         @fixture_connections.each do |connection|
-          connection.begin_transaction joinable: false
-          connection.pool.lock_thread = true
+          connection.begin_transaction joinable: false, lock_thread: true
         end
 
         # When connections are established in the future, begin a transaction too
@@ -1009,9 +1008,6 @@ module ActiveRecord
         ActiveSupport::Notifications.unsubscribe(@connection_subscriber) if @connection_subscriber
         @fixture_connections.each do |connection|
           connection.rollback_transaction if connection.transaction_open?
-          connection.pool.lock_thread = false unless defined?(use_transactional_tests?) &&
-            use_transactional_test_case?
-
         end
         @fixture_connections.clear
       else

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -1009,7 +1009,9 @@ module ActiveRecord
         ActiveSupport::Notifications.unsubscribe(@connection_subscriber) if @connection_subscriber
         @fixture_connections.each do |connection|
           connection.rollback_transaction if connection.transaction_open?
-          connection.pool.lock_thread = false
+          connection.pool.lock_thread = false unless defined?(use_transactional_tests?) &&
+            use_transactional_test_case?
+
         end
         @fixture_connections.clear
       else

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1057,6 +1057,11 @@ class TransactionalTestCaseTest < ActiveRecord::TestCase
   def test_topics_created
     assert_equal 5, Topic.count
   end
+
+  teardown_all do
+    # Ensure the connection pool is not thread-unlocked after each individual test transaction.
+    assert_not_nil ActiveRecord::Base.connection.pool.instance_variable_get(:@lock_thread)
+  end
 end
 
 class TransactionalTestCasePostTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1042,3 +1042,25 @@ class SameNameDifferentDatabaseFixturesTest < ActiveRecord::TestCase
     assert_kind_of OtherDog, other_dogs(:lassie)
   end
 end
+
+class TransactionalTestCasePreTest < ActiveRecord::TestCase
+  setup_all do
+    Topic.destroy_all
+  end
+end
+
+class TransactionalTestCaseTest < ActiveRecord::TestCase
+  self.use_transactional_test_case = true
+
+  fixtures :topics
+
+  def test_topics_created
+    assert_equal 5, Topic.count
+  end
+end
+
+class TransactionalTestCasePostTest < ActiveRecord::TestCase
+  def test_topics_rolled_back
+    assert_equal 0, Topic.count
+  end
+end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -639,7 +639,7 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
 
   def test_transaction_created_on_connection_notification
     connection = stub(transaction_open?: false)
-    connection.expects(:begin_transaction).with(joinable: false)
+    connection.expects(:begin_transaction).with(joinable: false, lock_thread: true)
     pool = connection.stubs(:pool).returns(ActiveRecord::ConnectionAdapters::ConnectionPool.new(ActiveRecord::Base.connection_pool.spec))
     pool.stubs(:lock_thread=).with(false)
     fire_connection_notification(connection)

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -9,6 +9,8 @@ require "active_support/testing/isolation"
 require "active_support/testing/constant_lookup"
 require "active_support/testing/time_helpers"
 require "active_support/testing/file_fixtures"
+require "active_support/testing/setup_all_and_teardown_all"
+require "active_support/testing/transactional_test_case"
 require "active_support/core_ext/kernel/reporting"
 
 module ActiveSupport
@@ -44,6 +46,8 @@ module ActiveSupport
 
     include ActiveSupport::Testing::TaggedLogging
     include ActiveSupport::Testing::SetupAndTeardown
+    include ActiveSupport::Testing::SetupAllAndTeardownAll
+    include ActiveSupport::Testing::TransactionalTestCase
     include ActiveSupport::Testing::Assertions
     include ActiveSupport::Testing::Deprecation
     include ActiveSupport::Testing::TimeHelpers

--- a/activesupport/lib/active_support/testing/setup_all_and_teardown_all.rb
+++ b/activesupport/lib/active_support/testing/setup_all_and_teardown_all.rb
@@ -1,0 +1,56 @@
+require "active_support/concern"
+require "active_support/callbacks"
+
+module ActiveSupport
+  module Testing
+    # Add support for +setup_all+ and +teardown_all+ callbacks.
+    module SetupAllAndTeardownAll
+      extend ActiveSupport::Concern
+
+      included do
+        include ActiveSupport::Callbacks
+        define_callbacks :setup_all, :teardown_all
+      end
+
+      module ClassMethods
+        def run(reporter, options = {})
+          @reporter = reporter
+          @instance = run_callbacks :setup_all
+          super(reporter, options)
+          run_callbacks :teardown_all
+        end
+
+        # Return a singleton instance for running individual tests,
+        # so instance variables can be duplicated across all tests and callbacks.
+        def new(name)
+          @instance ||= super
+          instance = @instance.dup
+          instance.name = name
+          instance.failures = []
+          instance
+        end
+
+        private
+
+          def run_callbacks(name)
+            instance = new("run_callbacks")
+            instance.time_it do
+              instance.capture_exceptions do
+                instance.run_callbacks(name)
+              end
+            end
+            @reporter.record instance if instance.failure
+            instance
+          end
+
+          def setup_all(*args, &block)
+            set_callback(:setup_all, :before, *args, &block)
+          end
+
+          def teardown_all(*args, &block)
+            set_callback(:teardown_all, :after, *args, &block)
+          end
+      end
+    end
+  end
+end

--- a/activesupport/lib/active_support/testing/setup_all_and_teardown_all.rb
+++ b/activesupport/lib/active_support/testing/setup_all_and_teardown_all.rb
@@ -16,6 +16,8 @@ module ActiveSupport
         def run(reporter, options = {})
           @reporter = reporter
           @instance = run_callbacks :setup_all
+          # @time is set by `time_it`, and needs to be removed before the instance is reused.
+          @instance.remove_instance_variable :@time
           super(reporter, options)
           run_callbacks :teardown_all
         end
@@ -33,7 +35,7 @@ module ActiveSupport
         private
 
           def run_callbacks(name)
-            instance = new("run_callbacks")
+            instance = new(name)
             instance.time_it do
               instance.capture_exceptions do
                 instance.run_callbacks(name)

--- a/activesupport/lib/active_support/testing/transactional_test_case.rb
+++ b/activesupport/lib/active_support/testing/transactional_test_case.rb
@@ -13,7 +13,7 @@ module ActiveSupport
 
         setup_all do
           if use_transactional_test_case?
-            @test_case_connections = enlist_fixture_connections
+            @test_case_connections = enlist_fixture_connections.select(&:supports_savepoints?)
             @test_case_connections.each do |connection|
               connection.begin_transaction joinable: false
               connection.pool.lock_thread = true

--- a/activesupport/lib/active_support/testing/transactional_test_case.rb
+++ b/activesupport/lib/active_support/testing/transactional_test_case.rb
@@ -15,8 +15,7 @@ module ActiveSupport
           if use_transactional_test_case?
             @test_case_connections = enlist_fixture_connections.select(&:supports_savepoints?)
             @test_case_connections.each do |connection|
-              connection.begin_transaction joinable: false
-              connection.pool.lock_thread = true
+              connection.begin_transaction joinable: false, lock_thread: true
             end
           end
         end
@@ -25,7 +24,6 @@ module ActiveSupport
           if use_transactional_test_case && @test_case_connections
             @test_case_connections.each do |connection|
               connection.rollback_transaction if connection.transaction_open?
-              connection.pool.lock_thread = false
             end
           end
         end

--- a/activesupport/lib/active_support/testing/transactional_test_case.rb
+++ b/activesupport/lib/active_support/testing/transactional_test_case.rb
@@ -1,0 +1,35 @@
+require "active_support/concern"
+require "active_support/callbacks"
+
+module ActiveSupport
+  module Testing
+    # Wraps the entire test case in a transaction.
+    module TransactionalTestCase
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :use_transactional_test_case
+        self.use_transactional_test_case = false
+
+        setup_all do
+          if use_transactional_test_case?
+            @test_case_connections = enlist_fixture_connections
+            @test_case_connections.each do |connection|
+              connection.begin_transaction joinable: false
+              connection.pool.lock_thread = true
+            end
+          end
+        end
+
+        teardown_all do
+          if use_transactional_test_case && @test_case_connections
+            @test_case_connections.each do |connection|
+              connection.rollback_transaction if connection.transaction_open?
+              connection.pool.lock_thread = false
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -338,3 +338,35 @@ class TestOrderTest < ActiveSupport::TestCase
     assert_equal :random, Class.new(ActiveSupport::TestCase).test_order
   end
 end
+
+class SetupAllAndTeardownAllTest < ActiveSupport::TestCase
+  self.test_order = :sorted
+
+  setup_all :reset_callback_record, :foo
+  setup :bar, :baz
+  teardown :quux, :qux
+  teardown_all :sentinel, :garply
+
+  def test_setup_all
+    assert_equal %w(foo bar baz), @called_back
+  end
+
+  def test_setup_all_2
+    assert_equal %w(foo bar baz qux quux bar baz), @called_back
+  end
+
+  private
+    %w(foo bar baz qux quux garply).each do |method|
+      define_method(method) do
+        @called_back << method
+      end
+    end
+
+    def reset_callback_record
+      @called_back = []
+    end
+
+    def sentinel
+      assert_equal %w(foo bar baz qux quux bar baz qux quux garply), @called_back
+    end
+end


### PR DESCRIPTION
### Summary

This PR adds support for wrapping an entire test case within a transaction.

Set `self.use_transactional_test_case = true` in an `ActiveSupport::TestCase` class to wrap the entire test case in a transaction that will rollback when the tests in the case class are finished.

Wrapping the entire test case in a single transaction has two use cases:

1. Efficiently reusing a set of setup actions (e.g., in a `setup_all` callback) across many tests in a test case, without multiplying the creation cost for each individual test.
2. Enabling fixture data to be rolled back (rather than left behind) after all tests in the test case have completed, reducing the possibility of fixture-data collision across test cases.

This PR also adds support for `setup_all` and `teardown_all` callbacks which can be used with or without transactional test cases, since these hooks might be useful in other scenarios (for example, to efficiently construct [FactoryGirl](https://github.com/thoughtbot/factory_girl) data once per test suite).

### Other Information

The `:setup_all` and `:teardown_all` callbacks are implemented through overriding the `Runnable.run` method in Minitest. The transactional test case concern is then implemented using these callbacks.

I refactored the `lock_thread` property (recently added in #28083) to support arbitrary nesting within multiple transactions, which was necessary so that setting `lock_thread` to `true` by the outer test-case transaction would not be reverted to `false` every time an inner test transaction was rolled back.