### PR TITLE
Remove useless `select_values += select_values`

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -282,7 +282,6 @@ module ActiveRecord
             operation,
             distinct).as(aggregate_alias)
         ]
-        select_values += select_values unless having_clause.empty?
 
         select_values.concat group_columns.map { |aliaz, field|
           if field.respond_to?(:as)


### PR DESCRIPTION
`select_values` is a local variable defined at previous line.
`select_values += select_values` is totally useless.