### PR TITLE
Improve error message on such as `first!` on ActiveRecord::FinderMethods

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -126,7 +126,7 @@ module ActiveRecord
     # Same as #first but raises ActiveRecord::RecordNotFound if no record
     # is found. Note that #first! accepts no arguments.
     def first!
-      first || raise_record_not_found_exception!
+      first || raise_exception_with_conditions
     end
 
     # Find the last record (or last N records if a parameter is supplied).
@@ -157,7 +157,7 @@ module ActiveRecord
     # Same as #last but raises ActiveRecord::RecordNotFound if no record
     # is found. Note that #last! accepts no arguments.
     def last!
-      last || raise_record_not_found_exception!
+      last || raise_exception_with_conditions
     end
 
     # Find the second record.
@@ -173,7 +173,7 @@ module ActiveRecord
     # Same as #second but raises ActiveRecord::RecordNotFound if no record
     # is found.
     def second!
-      second || raise_record_not_found_exception!
+      second || raise_exception_with_conditions
     end
 
     # Find the third record.
@@ -189,7 +189,7 @@ module ActiveRecord
     # Same as #third but raises ActiveRecord::RecordNotFound if no record
     # is found.
     def third!
-      third || raise_record_not_found_exception!
+      third || raise_exception_with_conditions
     end
 
     # Find the fourth record.
@@ -205,7 +205,7 @@ module ActiveRecord
     # Same as #fourth but raises ActiveRecord::RecordNotFound if no record
     # is found.
     def fourth!
-      fourth || raise_record_not_found_exception!
+      fourth || raise_exception_with_conditions
     end
 
     # Find the fifth record.
@@ -221,7 +221,7 @@ module ActiveRecord
     # Same as #fifth but raises ActiveRecord::RecordNotFound if no record
     # is found.
     def fifth!
-      fifth || raise_record_not_found_exception!
+      fifth || raise_exception_with_conditions
     end
 
     # Find the forty-second record. Also known as accessing "the reddit".
@@ -562,6 +562,17 @@ module ActiveRecord
 
       def find_last(limit)
         limit ? records.last(limit) : records.last
+      end
+
+      def raise_exception_with_conditions
+        conditions = arel.where_sql(@klass.arel_engine)
+        if conditions
+          raise_record_not_found_exception!
+        else
+          order = caller_locations.first.label.delete("!")
+          error = "Couldn't find #{order} #{@klass.name} with '#{primary_key}'"
+          raise RecordNotFound.new(error, @klass.name, primary_key)
+        end
       end
   end
 end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -393,7 +393,7 @@ class FinderTest < ActiveRecord::TestCase
   def test_model_class_responds_to_first_bang
     assert Topic.first!
     Topic.delete_all
-    assert_raises_with_message ActiveRecord::RecordNotFound, "Couldn't find Topic" do
+    assert_raises_with_message ActiveRecord::RecordNotFound, "Couldn't find first Topic with 'id'" do
       Topic.first!
     end
   end
@@ -415,7 +415,7 @@ class FinderTest < ActiveRecord::TestCase
   def test_model_class_responds_to_second_bang
     assert Topic.second!
     Topic.delete_all
-    assert_raises_with_message ActiveRecord::RecordNotFound, "Couldn't find Topic" do
+    assert_raises_with_message ActiveRecord::RecordNotFound, "Couldn't find second Topic with 'id'" do
       Topic.second!
     end
   end
@@ -437,7 +437,7 @@ class FinderTest < ActiveRecord::TestCase
   def test_model_class_responds_to_third_bang
     assert Topic.third!
     Topic.delete_all
-    assert_raises_with_message ActiveRecord::RecordNotFound, "Couldn't find Topic" do
+    assert_raises_with_message ActiveRecord::RecordNotFound, "Couldn't find third Topic with 'id'" do
       Topic.third!
     end
   end
@@ -459,7 +459,7 @@ class FinderTest < ActiveRecord::TestCase
   def test_model_class_responds_to_fourth_bang
     assert Topic.fourth!
     Topic.delete_all
-    assert_raises_with_message ActiveRecord::RecordNotFound, "Couldn't find Topic" do
+    assert_raises_with_message ActiveRecord::RecordNotFound, "Couldn't find fourth Topic with 'id'" do
       Topic.fourth!
     end
   end
@@ -481,7 +481,7 @@ class FinderTest < ActiveRecord::TestCase
   def test_model_class_responds_to_fifth_bang
     assert Topic.fifth!
     Topic.delete_all
-    assert_raises_with_message ActiveRecord::RecordNotFound, "Couldn't find Topic" do
+    assert_raises_with_message ActiveRecord::RecordNotFound, "Couldn't find fifth Topic with 'id'" do
       Topic.fifth!
     end
   end
@@ -560,7 +560,7 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_model_class_responds_to_last_bang
     assert_equal topics(:fifth), Topic.last!
-    assert_raises_with_message ActiveRecord::RecordNotFound, "Couldn't find Topic" do
+    assert_raises_with_message ActiveRecord::RecordNotFound, "Couldn't find last Topic with 'id'" do
       Topic.delete_all
       Topic.last!
     end


### PR DESCRIPTION
Currently finder methods such as `first!` raises simple error message when record not found.

```console
> User.first!
ActiveRecord::RecordNotFound: Couldn't find User
```

I think it should improve more easy to understand, to include information about order and primary key like this:

```console
> User.first!
ActiveRecord::RecordNotFound: Couldn't find first User with 'id'
```