### PR TITLE
Show correct commands in help

### DIFF
--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -64,7 +64,7 @@ module Rails
         end
 
         def printing_commands
-          namespace.sub(/^rails:/, "")
+          namespaced_commands
         end
 
         def executable
@@ -134,6 +134,12 @@ module Rails
 
           def command_root_namespace
             (namespace.split(":") - %w( rails )).first
+          end
+
+          def namespaced_commands
+            commands.keys.map do |key|
+              key == command_root_namespace ? key : "#{command_root_namespace}:#{key}"
+            end
           end
       end
 

--- a/railties/lib/rails/commands/destroy/destroy_command.rb
+++ b/railties/lib/rails/commands/destroy/destroy_command.rb
@@ -3,8 +3,10 @@ require "rails/generators"
 module Rails
   module Command
     class DestroyCommand < Base # :nodoc:
-      def help
-        Rails::Generators.help self.class.command_name
+      no_commands do
+        def help
+          Rails::Generators.help self.class.command_name
+        end
       end
 
       def perform(*)

--- a/railties/lib/rails/commands/generate/generate_command.rb
+++ b/railties/lib/rails/commands/generate/generate_command.rb
@@ -3,11 +3,13 @@ require "rails/generators"
 module Rails
   module Command
     class GenerateCommand < Base # :nodoc:
-      def help
-        require_application_and_environment!
-        load_generators
+      no_commands do
+        def help
+          require_application_and_environment!
+          load_generators
 
-        Rails::Generators.help self.class.command_name
+          Rails::Generators.help self.class.command_name
+        end
       end
 
       def perform(*)

--- a/railties/lib/rails/commands/new/new_command.rb
+++ b/railties/lib/rails/commands/new/new_command.rb
@@ -1,8 +1,10 @@
 module Rails
   module Command
     class NewCommand < Base # :nodoc:
-      def help
-        Rails::Command.invoke :application, [ "--help" ]
+      no_commands do
+        def help
+          Rails::Command.invoke :application, [ "--help" ]
+        end
       end
 
       def perform(*)

--- a/railties/lib/rails/commands/runner/runner_command.rb
+++ b/railties/lib/rails/commands/runner/runner_command.rb
@@ -5,9 +5,11 @@ module Rails
         default: Rails::Command.environment.dup,
         desc: "The environment for the runner to operate under (test/development/production)"
 
-      def help
-        super
-        puts self.class.desc
+      no_commands do
+        def help
+          super
+          puts self.class.desc
+        end
       end
 
       def self.banner(*)

--- a/railties/lib/rails/commands/secrets/secrets_command.rb
+++ b/railties/lib/rails/commands/secrets/secrets_command.rb
@@ -4,10 +4,12 @@ require "rails/secrets"
 module Rails
   module Command
     class SecretsCommand < Rails::Command::Base # :nodoc:
-      def help
-        say "Usage:\n  #{self.class.banner}"
-        say ""
-        say self.class.desc
+      no_commands do
+        def help
+          say "Usage:\n  #{self.class.banner}"
+          say ""
+          say self.class.desc
+        end
       end
 
       def setup

--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -4,8 +4,10 @@ require "rails/test_unit/minitest_plugin"
 module Rails
   module Command
     class TestCommand < Base # :nodoc:
-      def help
-        perform # Hand over help printing to minitest.
+      no_commands do
+        def help
+          perform # Hand over help printing to minitest.
+        end
       end
 
       def perform(*)

--- a/railties/test/command/base_test.rb
+++ b/railties/test/command/base_test.rb
@@ -1,0 +1,11 @@
+require "abstract_unit"
+require "rails/command"
+require "rails/commands/generate/generate_command"
+require "rails/commands/secrets/secrets_command"
+
+class Rails::Command::BaseTest < ActiveSupport::TestCase
+  test "printing commands" do
+    assert_equal %w(generate), Rails::Command::GenerateCommand.printing_commands
+    assert_equal %w(secrets:setup secrets:edit), Rails::Command::SecretsCommand.printing_commands
+  end
+end


### PR DESCRIPTION
Currently rails' help shows only namespace. However, the secrets command
needs to specify command not only namespace. Therefore, command should be
displayed in help.

### Before

```
./bin/rails --help 
...

All commands can be run with -h (or --help) for more information.
In addition to those commands, there are:

Rails:
  console
  dbconsole
  destroy
  generate
  new
  runner
  secrets
  server
  test
  version 
```

### After 

```
./bin/rails --help
...

All commands can be run with -h (or --help) for more information.
In addition to those commands, there are:

Rails:
  console
  dbconsole
  destroy
  generate
  new
  runner
  secrets:edit
  secrets:setup
  server
  test
  version
```
