### PR TITLE
Include selects in group query with having clause

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -282,6 +282,7 @@ module ActiveRecord
             operation,
             distinct).as(aggregate_alias)
         ]
+        select_values += self.select_values unless having_clause.empty?
 
         select_values.concat group_columns.map { |aliaz, field|
           if field.respond_to?(:as)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -246,7 +246,8 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_group_by_summed_field_having_condition_from_select
-    c = Account.select("MIN(credit_limit) AS min_credit_limit").group(:firm_id).having("MIN(credit_limit) > 50").sum(:credit_limit)
+    skip if current_adapter?(:PostgreSQLAdapter)
+    c = Account.select("MIN(credit_limit) AS min_credit_limit").group(:firm_id).having("min_credit_limit > 50").sum(:credit_limit)
     assert_nil       c[1]
     assert_equal 60, c[2]
     assert_equal 53, c[9]


### PR DESCRIPTION
When a grouped calculation contains a having clause that references a selected value, we need to include that selected value in the query.

Postgres doesn't support referencing a selected value in a having clause, but other databases do; we can skip the test on the pg adapter but run it for the others.

This was fixed before in https://github.com/rails/rails/pull/1969, but the test coverage was lost in 5a05207d99b7e2678f9b42db2d9ffc21ec2c8c3b. The fix regressed in 6311975fb3c02f50730fd1e11b8dba8dd9c05306 and was removed in https://github.com/rails/rails/pull/28179.

r? @pixeltrix 

/fyi @kamipo 