### PR TITLE
Fix `test_apply_distinct_in_count` failure in PG adapter

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -234,6 +234,9 @@ class CalculationsTest < ActiveRecord::TestCase
     end
 
     queries.each do |query|
+      # `table_alias_length` in `column_alias_for` would execute
+      # "SHOW max_identifier_length" statement in PostgreSQL adapter.
+      next if query == "SHOW max_identifier_length"
       assert_match %r{\ASELECT(?! DISTINCT) COUNT\(DISTINCT\b}, query
     end
   end


### PR DESCRIPTION
```
% ARCONN=postgresql be ruby -w -Itest test/cases/calculations_test.rb -n test_apply_distinct_in_count
/Users/kamipo/src/github.com/rails/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using postgresql
Run options: -n test_apply_distinct_in_count --seed 27731

F

Finished in 0.163682s, 6.1094 runs/s, 30.5470 assertions/s.

  1) Failure:
CalculationsTest#test_apply_distinct_in_count [test/cases/calculations_test.rb:238]:
Expected /\ASELECT(?! DISTINCT) COUNT\(DISTINCT\b/ to match "SHOW max_identifier_length".

1 runs, 5 assertions, 1 failures, 0 errors, 0 skips
```

https://travis-ci.org/rails/rails/jobs/205493811#L1933
https://travis-ci.org/rails/rails/jobs/205496299#L1562
https://travis-ci.org/rails/rails/jobs/205514765#L1562
