### PR TITLE
Use `max_identifier_length` for `index_name_length`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use `max_identifier_length` for `index_name_length` in PostgreSQL adapter.
+
+    *Ryuta Kamizono*
+
 *   Deprecate `supports_migrations?` on connection adapters.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -615,10 +615,6 @@ module ActiveRecord
           end
         end
 
-        def index_name_length
-          63
-        end
-
         # Maps logical Rails types to PostgreSQL-specific data types.
         def type_to_sql(type, limit: nil, precision: nil, scale: nil, array: nil, **) # :nodoc:
           sql = \

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -215,7 +215,7 @@ module ActiveRecord
 
         # @local_tz is initialized as nil to avoid warnings when connect tries to use it
         @local_tz = nil
-        @table_alias_length = nil
+        @max_identifier_length = nil
 
         connect
         add_pg_encoders
@@ -358,8 +358,9 @@ module ActiveRecord
 
       # Returns the configured supported identifier length supported by PostgreSQL
       def table_alias_length
-        @table_alias_length ||= query("SHOW max_identifier_length", "SCHEMA")[0][0].to_i
+        @max_identifier_length ||= select_value("SHOW max_identifier_length", "SCHEMA").to_i
       end
+      alias index_name_length table_alias_length
 
       # Set the authorized user for this session
       def session_auth=(user)

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -105,7 +105,7 @@ module ActiveRecord
     end
 
     def test_table_alias_length_logs_name
-      @connection.instance_variable_set("@table_alias_length", nil)
+      @connection.instance_variable_set("@max_identifier_length", nil)
       @connection.table_alias_length
       assert_equal "SCHEMA", @subscriber.logged[0][1]
     end
@@ -177,7 +177,6 @@ module ActiveRecord
       assert_not_equal original_connection_pid, new_connection_pid,
         "umm -- looks like you didn't break the connection, because we're still " \
         "successfully querying with the same connection pid."
-
     ensure
       # Repair all fixture connections so other tests won't break.
       @fixture_connections.each(&:verify!)


### PR DESCRIPTION
Actually `index_name_length` depend on `max_identifier_length`, not
always 63.