### PR TITLE
Update i18n guide to cover :zero key support in pluralization [ci skip]

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -707,6 +707,7 @@ The `:count` interpolation variable has a special role in that it both is interp
 
 ```ruby
 I18n.backend.store_translations :en, inbox: {
+  zero: 'no messages', # optional
   one: 'one message',
   other: '%{count} messages'
 }
@@ -715,15 +716,20 @@ I18n.translate :inbox, count: 2
 
 I18n.translate :inbox, count: 1
 # => 'one message'
+
+I18n.translate :inbox, count: 0
+# => 'no messages'
 ```
 
 The algorithm for pluralizations in `:en` is as simple as:
 
 ```ruby
-entry[count == 1 ? 0 : 1]
+lookup_key = :zero if count == 0 && entry.has_key?(:zero)
+lookup_key ||= count == 1 ? :one : :other
+entry[lookup_key]
 ```
 
-I.e. the translation denoted as `:one` is regarded as singular, the other is used as plural (including the count being zero).
+The translation denoted as `:one` is regarded as singular, and the `:other` is used as plural. If the count is zero, and a `:zero` entry is present, then it will be used instead of `:other`.
 
 If the lookup for the key does not return a Hash suitable for pluralization, an `I18n::InvalidPluralizationData` exception is raised.
 


### PR DESCRIPTION
### Summary

This pull request updates the Rails i18n Guide's pluralization section to cover support for the `:zero` key (in addition to `:one` and `:other`).

[Here's a link to the relevant code in the i18n gem](https://github.com/svenfuchs/i18n/blob/master/lib/i18n/backend/base.rb#L133-L148).