### PR TITLE
Fix update_all and delete_all when using eager_load.

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -373,7 +373,11 @@ module ActiveRecord
       stmt.set Arel.sql(@klass.send(:sanitize_sql_for_assignment, updates))
       stmt.table(table)
 
-      if has_join_values?
+      if eager_loading?
+        relation = self
+        find_with_associations { |rel| relation = rel }
+        @klass.connection.join_to_update(stmt, relation.arel, arel_attribute(primary_key))
+      elsif has_join_values?
         @klass.connection.join_to_update(stmt, arel, arel_attribute(primary_key))
       else
         stmt.key = arel_attribute(primary_key)
@@ -506,7 +510,11 @@ module ActiveRecord
       stmt = Arel::DeleteManager.new
       stmt.from(table)
 
-      if has_join_values?
+      if eager_loading?
+        relation = self
+        find_with_associations { |rel| relation = rel }
+        @klass.connection.join_to_delete(stmt, relation.arel, arel_attribute(primary_key))
+      elsif has_join_values?
         @klass.connection.join_to_delete(stmt, arel, arel_attribute(primary_key))
       else
         stmt.wheres = arel.constraints

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1024,6 +1024,13 @@ class RelationTest < ActiveRecord::TestCase
     assert davids.loaded?
   end
 
+  def test_delete_all_with_eager_loading
+    posts = Post.eager_load(:author).where("authors.id" => nil)
+
+    assert_difference("Post.count", -1) { posts.delete_all }
+    assert ! posts.loaded?
+  end
+
   def test_delete_all_with_unpermitted_relation_raises_error
     assert_raises(ActiveRecord::ActiveRecordError) { Author.limit(10).delete_all }
     assert_raises(ActiveRecord::ActiveRecordError) { Author.distinct.delete_all }
@@ -1602,6 +1609,14 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal count - 1, comments.update_all(post_id: posts(:thinking).id)
     assert_equal posts(:thinking), comments(:more_greetings).post
     assert_equal posts(:welcome),  comments(:greetings).post
+  end
+
+  def test_update_all_with_eager_loading
+    posts = Post.eager_load(:author).where("authors.id" => nil)
+    count = posts.count
+
+    assert_equal count, posts.update_all(author_id: authors(:david).id)
+    assert_equal authors(:david), posts(:authorless).author
   end
 
   def test_update_on_relation


### PR DESCRIPTION
delete_all and update_all do not work properly when eager_load is used. This PR fixes the following bugs.

#### Steps to reproduce the bugs (mysql)

`Item.has_one :tag`

```
> Item.eager_load(:tag).where("tags.id is null").update_all(updated_at: Time.current)
  SQL (0.6ms)  UPDATE `items` SET `items`.`updated_at` = '2017-02-27 04:44:33' WHERE (tags.id is null)
ActiveRecord::StatementInvalid: Mysql2::Error: Unknown column 'tags.id' in 'where clause': UPDATE `items` SET `items`.`updated_at` = '2017-02-27 04:44:33' WHERE (tags.id is null)
```

```
> Item.eager_load(:tag).where("tags.id is null").delete_all
  SQL (0.6ms)  DELETE FROM `items` WHERE (tags.id is null)
ActiveRecord::StatementInvalid: Mysql2::Error: Unknown column 'tags.id' in 'where clause': DELETE FROM `items` WHERE (tags.id is null)
```