### PR TITLE
Set correct host except development environment

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -99,8 +99,9 @@ module Rails
 
       class_option :port, aliases: "-p", type: :numeric,
         desc: "Runs Rails on the specified port.", banner: :port, default: 3000
-      class_option :binding, aliases: "-b", type: :string, default: "localhost",
-        desc: "Binds Rails to the specified IP.", banner: :IP
+      class_option :binding, aliases: "-b", type: :string,
+        desc: "Binds Rails to the specified IP - defaults to 'localhost' in development and '0.0.0.0' in other environments'.",
+        banner: :IP
       class_option :config, aliases: "-c", type: :string, default: "config.ru",
         desc: "Uses a custom rackup configuration.", banner: :file
       class_option :daemon, aliases: "-d", type: :boolean, default: false,
@@ -187,7 +188,10 @@ module Rails
         end
 
         def host
-          ENV.fetch("HOST", options[:binding])
+          unless (default_host = options[:binding])
+            default_host = environment == "development" ? "localhost" : "0.0.0.0"
+          end
+          ENV.fetch("HOST", default_host)
         end
 
         def environment

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -121,6 +121,24 @@ class Rails::ServerTest < ActiveSupport::TestCase
     end
   end
 
+  def test_host
+    with_rails_env "development" do
+      options = parse_arguments([])
+      assert_equal "localhost", options[:Host]
+    end
+
+    with_rails_env "production" do
+      options = parse_arguments([])
+      assert_equal "0.0.0.0", options[:Host]
+    end
+
+    with_rails_env "development" do
+      args = ["-b", "127.0.0.1"]
+      options = parse_arguments(args)
+      assert_equal "127.0.0.1", options[:Host]
+    end
+  end
+
   def test_records_user_supplied_options
     server_options = parse_arguments(["-p", 3001])
     assert_equal [:Port], server_options[:user_supplied_options]


### PR DESCRIPTION
Currently `localhost` is used for the default host in all environments.
But up to Rails 5.0, `0.0.0.0` is used except for development.
So fixed to use the same value as 5.0.

Fixes #28184

