### PR TITLE
Handle non-existing $ARCONN

### DIFF
--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -10,7 +10,10 @@ module ARTest
   end
 
   def self.connection_config
-    config["connections"][connection_name]
+    config.fetch("connections").fetch(connection_name) do
+      puts "Connection #{connection_name.inspect} not found. Available connections: #{config['connections'].keys.join(', ')}"
+      exit 1
+    end
   end
 
   def self.connect


### PR DESCRIPTION
I always forget it's `postgresql`, not `postgres`. When you pass `$ARCONN` that doesn't exist, the test fails with `can't dup NilClass` that doesn't tell you what exactly went wrong.

Before:

```
$ ARCONN=postgres bundle exec ruby -Itest test/cases/adapters/postgresql/connection_test.rb
Using postgres
/Users/kir/Projects/opensource/rails/activerecord/lib/active_record/connection_handling.rb:63:in `dup': can't dup NilClass (TypeError)
        from /Users/kir/Projects/opensource/rails/activerecord/lib/active_record/connection_handling.rb:63:in `initialize'
        from /Users/kir/Projects/opensource/rails/activerecord/lib/active_record/core.rb:46:in `new'
        from /Users/kir/Projects/opensource/rails/activerecord/lib/active_record/core.rb:46:in `configurations='
        from /Users/kir/Projects/opensource/rails/activerecord/test/support/connection.rb:19:in `connect'
        from /Users/kir/Projects/opensource/rails/activerecord/test/cases/helper.rb:24:in `<top (required)>'
        from test/cases/adapters/postgresql/connection_test.rb:1:in `require'
        from test/cases/adapters/postgresql/connection_test.rb:1:in `<main>'
```

After:


```
$ ARCONN=postgres bundle exec ruby -Itest test/cases/adapters/postgresql/connection_test.rb
Using postgres
Connection "postgres" not found. Available connections: jdbcderby, jdbch2, jdbchsqldb, jdbcmysql, jdbcpostgresql, jdbcsqlite3, db2, mysql, mysql2, oracle, postgresql, sqlite3, sqlite3_mem
```

review @sgrif @matthewd 