### PR TITLE
Lazy connection verification on pool checkout

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -803,7 +803,7 @@ module ActiveRecord
 
         def checkout_and_verify(c)
           c._run_checkout_callbacks do
-            c.verify!
+            c.defer_verify!
           end
           c
         rescue

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -220,9 +220,11 @@ module ActiveRecord
 
       # Executes the SQL statement in the context of this connection.
       def execute(sql, name = nil)
-        log(sql, name) do
-          ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-            @connection.query(sql)
+        with_connection_verify(::ActiveRecord::StatementInvalid) do
+          log(sql, name) do
+            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+              @connection.query(sql)
+            end
           end
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -80,7 +80,9 @@ module ActiveRecord
       #++
 
       def quote_string(string)
-        @connection.escape(string)
+        with_connection_verify(Mysql2::Error) do
+          @connection.escape(string)
+        end
       end
 
       #--

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -80,9 +80,11 @@ module ActiveRecord
 
         # Queries the database and returns the results in an Array-like object
         def query(sql, name = nil) #:nodoc:
-          log(sql, name) do
-            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              result_as_array @connection.async_exec(sql)
+          with_connection_verify(::ActiveRecord::StatementInvalid) do
+            log(sql, name) do
+              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+                result_as_array @connection.async_exec(sql)
+              end
             end
           end
         end
@@ -92,9 +94,11 @@ module ActiveRecord
         # Note: the PG::Result object is manually memory managed; if you don't
         # need it specifically, you may want consider the <tt>exec_query</tt> wrapper.
         def execute(sql, name = nil)
-          log(sql, name) do
-            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              @connection.async_exec(sql)
+          with_connection_verify(::ActiveRecord::StatementInvalid) do
+            log(sql, name) do
+              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+                @connection.async_exec(sql)
+              end
             end
           end
         end

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -58,6 +58,19 @@ class PooledConnectionsTest < ActiveRecord::TestCase
     assert_equal 1, ActiveRecord::Base.connection_pool.connections.size
   end
 
+  def test_no_verify_called_on_checkin
+    ActiveRecord::Base.establish_connection(@connection)
+
+    begin
+      conn = ActiveRecord::Base.connection_pool.checkout
+      conn.expects(:verify!).never
+    ensure
+      ActiveRecord::Base.connection_pool.checkin(conn)
+    end
+
+    ActiveRecord::Base.connection_pool.with_connection {}
+  end
+
   def test_pooled_connection_checkin_two
     checkout_checkin_connections_loop 2, 3
     assert_equal 3, @connection_count


### PR DESCRIPTION
This is an alternative implementation for https://github.com/rails/rails/pull/27651.

It's way cleaner than the first implementation. It doesn't introduce methods like `connected?` to the connection and doesn't require changing `active?` method. It also uses the retry strategy and includes more test scenarios.

The reasons to defer verifications have been extensively described in https://github.com/rails/rails/pull/27651. TL;DR we used to verify connection by pinging the server on **every** connection checkout. The problem with this approach is that pings are not free, especially on large scale Rails deployments.

review @arthurnn @sgrif @matthewd @sirupsen