### PR TITLE
Remove `not required by default` test for belongs_to association

### DIFF
--- a/activerecord/test/cases/associations/required_test.rb
+++ b/activerecord/test/cases/associations/required_test.rb
@@ -22,30 +22,6 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
     @connection.drop_table "children", if_exists: true
   end
 
-  test "belongs_to associations are not required by default" do
-    model = subclass_of(Child) do
-      belongs_to :parent, inverse_of: false,
-        class_name: "RequiredAssociationsTest::Parent"
-    end
-
-    assert model.new.save
-    assert model.new(parent: Parent.new).save
-  end
-
-  test "required belongs_to associations have presence validated" do
-    model = subclass_of(Child) do
-      belongs_to :parent, required: true, inverse_of: false,
-        class_name: "RequiredAssociationsTest::Parent"
-    end
-
-    record = model.new
-    assert_not record.save
-    assert_equal ["Parent must exist"], record.errors.full_messages
-
-    record.parent = Parent.new
-    assert record.save
-  end
-
   test "has_one associations are not required by default" do
     model = subclass_of(Parent) do
       has_one :child, inverse_of: false,


### PR DESCRIPTION
### Summary

Since #18937 `belongs_to` associations implies `required: true` by
default, with that option replaced for `optional: false`.


### Other Information

I think that some may have forgot the tests that ensure that `required` was by default `false` on `belongs_to` associations.
