### PR TITLE
Don't create new connections during test transaction setup

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -8,9 +8,9 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
 
   def setup
     super
+    @connection = ActiveRecord::Base.connection
     @subscriber = SQLSubscriber.new
     @subscription = ActiveSupport::Notifications.subscribe("sql.active_record", @subscriber)
-    @connection = ActiveRecord::Base.connection
   end
 
   def teardown

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -12,9 +12,9 @@ module ActiveRecord
 
     def setup
       super
+      @connection = ActiveRecord::Base.connection
       @subscriber = SQLSubscriber.new
       @subscription = ActiveSupport::Notifications.subscribe("sql.active_record", @subscriber)
-      @connection = ActiveRecord::Base.connection
     end
 
     def teardown

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1867,7 +1867,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_calling_first_nth_or_last_on_new_record_should_not_run_queries
     firm = Firm.new
 
-    assert_no_queries do
+    assert_no_queries(ignore_none: false) do
       firm.clients.first
       firm.clients.second
       firm.clients.last

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -189,7 +189,7 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_limit_is_kept
     return if current_adapter?(:OracleAdapter)
 
-    queries = assert_sql { Account.limit(1).count }
+    queries = capture_sql(false) { Account.limit(1).count }
     assert_equal 1, queries.length
     assert_match(/LIMIT/, queries.first)
   end
@@ -197,7 +197,7 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_offset_is_kept
     return if current_adapter?(:OracleAdapter)
 
-    queries = assert_sql { Account.offset(1).count }
+    queries = capture_sql(false) { Account.offset(1).count }
     assert_equal 1, queries.length
     assert_match(/OFFSET/, queries.first)
   end
@@ -205,14 +205,14 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_limit_with_offset_is_kept
     return if current_adapter?(:OracleAdapter)
 
-    queries = assert_sql { Account.limit(1).offset(1).count }
+    queries = capture_sql(false) { Account.limit(1).offset(1).count }
     assert_equal 1, queries.length
     assert_match(/LIMIT/, queries.first)
     assert_match(/OFFSET/, queries.first)
   end
 
   def test_no_limit_no_offset
-    queries = assert_sql { Account.count }
+    queries = capture_sql(false) { Account.count }
     assert_equal 1, queries.length
     assert_no_match(/LIMIT/, queries.first)
     assert_no_match(/OFFSET/, queries.first)
@@ -228,7 +228,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_apply_distinct_in_count
-    queries = assert_sql do
+    queries = capture_sql(false) do
       Account.distinct.count
       Account.group(:firm_id).distinct.count
     end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -504,7 +504,6 @@ unless in_memory_db?
     fixtures :people, :readers
 
     def setup
-      Person.connection_pool.clear_reloadable_connections!
       # Avoid introspection queries during tests.
       Person.columns; Reader.columns
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -760,7 +760,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_to_sql_on_eager_join
-    expected = assert_sql {
+    expected = capture_sql(false) {
       Post.eager_load(:last_comment).order("comments.id DESC").to_a
     }.first
     actual = Post.eager_load(:last_comment).order("comments.id DESC").to_sql

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -28,10 +28,10 @@ module ActiveRecord
       SQLCounter.clear_log
     end
 
-    def capture_sql
+    def capture_sql(ignore_none = true)
       SQLCounter.clear_log
       yield
-      SQLCounter.log_all.dup
+      ignore_none ? SQLCounter.log_all.dup : SQLCounter.log.dup
     end
 
     def assert_sql(*patterns_to_match)
@@ -111,7 +111,7 @@ module ActiveRecord
     oracle_ignored     = [/^select .*nextval/i, /^SAVEPOINT/, /^ROLLBACK TO/, /^\s*select .* from all_triggers/im, /^\s*select .* from all_constraints/im, /^\s*select .* from all_tab_cols/im]
     mysql_ignored      = [/^SHOW FULL TABLES/i, /^SHOW FULL FIELDS/, /^SHOW CREATE TABLE /i, /^SHOW VARIABLES /, /^\s*SELECT (?:column_name|table_name)\b.*\bFROM information_schema\.(?:key_column_usage|tables)\b/im]
     postgresql_ignored = [/^\s*select\b.*\bfrom\b.*pg_namespace\b/im, /^\s*select tablename\b.*from pg_tables\b/im, /^\s*select\b.*\battname\b.*\bfrom\b.*\bpg_attribute\b/im, /^SHOW search_path/i]
-    sqlite3_ignored =    [/^\s*SELECT name\b.*\bFROM sqlite_master/im, /^\s*SELECT sql\b.*\bFROM sqlite_master/im]
+    sqlite3_ignored =    [/^\s*SELECT name\b.*\bFROM sqlite_master/im, /^\s*SELECT sql\b.*\bFROM sqlite_master/im, /^begin transaction/]
 
     [oracle_ignored, mysql_ignored, postgresql_ignored, sqlite3_ignored].each do |db_ignored_sql|
       ignored_sql.concat db_ignored_sql


### PR DESCRIPTION
### Summary

This PR prevents new connections from being eagerly created on all connection pools during test-transaction setup.
Fixes #27581.

### Other Information

The current implementation's attempt to consistently apply transactions to all present and future connections within a transactional test suffers from an issue where the transactional test setup eagerly checks out connections on all connection pools, including those that do not currently contain any connections.

This PR fixes this issue via the following changes:

- Renames the existing `!connection.active_record` notification from #20818, which is triggered when a connection pool (not an individual connection) is newly established, to `!connection_pool.active_record`.
- Creates a new `!connection_pool.active_record` notification hook that fires when a connection is checked out (in the `checkout_and_verify` method), alongside the existing `:checkout` callback runner.
- Updates the existing notification subscription to accept a connection rather than a connection-pool specification when invoked.
- Updates `enlist_fixture_connections` to only return the currently-active connection from each pool, rather than actively checking out a new connection on a pool without any active connection.