### PR TITLE
Oracle database also does not allow aliases in the having clause

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -249,7 +249,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_group_by_summed_field_having_condition_from_select
-    skip if current_adapter?(:PostgreSQLAdapter)
+    skip if current_adapter?(:PostgreSQLAdapter, :OracleAdapter)
     c = Account.select("MIN(credit_limit) AS min_credit_limit").group(:firm_id).having("min_credit_limit > 50").sum(:credit_limit)
     assert_nil       c[1]
     assert_equal 60, c[2]


### PR DESCRIPTION
Follow up #28183

### Summary

This pull request addresses following error `ORA-00904: "MIN_CREDIT_LIMIT": invalid identifier`.
Oracle database also does not allow aliases in the having clause as PostgreSQL does not.  

[Database SQL Language Reference](https://docs.oracle.com/database/121/SQLRF/statements_10002.htm#SQLRF01702)

> The alias can be used in the `order_by_clause` but not other clauses in the query.

This test needs skipped for Oracle database adapter.

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/calculations_test.rb -n test_should_group_by_summed_field_having_condition_from_select
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using oracle
Run options: -n test_should_group_by_summed_field_having_condition_from_select --seed 13476

# Running:

E

Finished in 0.420931s, 2.3757 runs/s, 0.0000 assertions/s.

  1) Error:
CalculationsTest#test_should_group_by_summed_field_having_condition_from_select:
ActiveRecord::StatementInvalid: OCIError: ORA-00904: "MIN_CREDIT_LIMIT": invalid identifier: SELECT SUM("ACCOUNTS"."CREDIT_LIMIT") AS sum_credit_limit, MIN(credit_limit) AS min_credit_limit, "ACCOUNTS"."FIRM_ID" AS accounts_firm_id FROM "ACCOUNTS" GROUP BY "ACCOUNTS"."FIRM_ID" HAVING (min_credit_limit > 50)
    stmt.c:243:in oci8lib_250.so
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/ruby-oci8-2.2.3/lib/oci8/cursor.rb:126:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:148:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:39:in `block in exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:614:in `block (2 levels) in log'
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/monitor.rb:214:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:613:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:605:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:1039:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:22:in `exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:361:in `select'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:42:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:97:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/calculations.rb:299:in `execute_grouped_calculation'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/calculations.rb:205:in `perform_calculation'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/calculations.rb:121:in `calculate'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/calculations.rb:80:in `sum'
    test/cases/calculations_test.rb:253:in `test_should_group_by_summed_field_having_condition_from_select'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

This pull request has been tested with all bundled adapters and Oracle enhanced adapter.

```ruby
$ for i in sqlite3 postgresql mysql2 oracle
> do
> echo $i
> ARCONN=$i  bundle exec ruby -w -Itest test/cases/calculations_test.rb -n test_should_group_by_summed_field_having_condition_from_select
> done
sqlite3
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using sqlite3
Run options: -n test_should_group_by_summed_field_having_condition_from_select --seed 38587

# Running:

.

Finished in 0.038695s, 25.8429 runs/s, 77.5287 assertions/s.

1 runs, 3 assertions, 0 failures, 0 errors, 0 skips
postgresql
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using postgresql
Run options: -n test_should_group_by_summed_field_having_condition_from_select --seed 1137

# Running:

S

Finished in 0.128557s, 7.7786 runs/s, 0.0000 assertions/s.

1 runs, 0 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
mysql2
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using mysql2
Run options: -n test_should_group_by_summed_field_having_condition_from_select --seed 46311

# Running:

.

Finished in 0.113834s, 8.7847 runs/s, 26.3542 assertions/s.

1 runs, 3 assertions, 0 failures, 0 errors, 0 skips
oracle
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using oracle
Run options: -n test_should_group_by_summed_field_having_condition_from_select --seed 26292

# Running:

S

Finished in 0.441990s, 2.2625 runs/s, 0.0000 assertions/s.

1 runs, 0 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
$
```