### PR TITLE
[Railties] Add config rake_eager_load

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow configuration of eager_load behaviour for rake environment:
+    
+        `config.rake_eager_load`
+
+    Defaults to `false` as per previous behaviour.
+
+    *Thierry Joyal*
+
 ## Rails 5.1.0.beta1 (February 23, 2017) ##
 
 *   Fix running multiple tests in one `rake` command

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -438,7 +438,7 @@ module Rails
       super
       require "rails/tasks"
       task :environment do
-        ActiveSupport.on_load(:before_initialize) { config.eager_load = false }
+        ActiveSupport.on_load(:before_initialize) { config.eager_load = config.rake_eager_load }
 
         require_environment!
       end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -14,7 +14,7 @@ module Rails
                     :ssl_options, :public_file_server,
                     :session_options, :time_zone, :reload_classes_only_on_change,
                     :beginning_of_week, :filter_redirect, :x, :enable_dependency_loading,
-                    :read_encrypted_secrets
+                    :rake_eager_load, :read_encrypted_secrets
 
       attr_writer :log_level
       attr_reader :encoding, :api_only
@@ -52,6 +52,7 @@ module Rails
         @debug_exception_response_format = nil
         @x                               = Custom.new
         @enable_dependency_loading       = false
+        @rake_eager_load                 = false
         @read_encrypted_secrets          = false
       end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1545,5 +1545,21 @@ module ApplicationTests
       assert_equal 301, last_response.status
       assert_equal "https://example.org/", last_response.location
     end
+
+    test "rake_eager_load is false by default" do
+      app "development"
+      assert_equal false,  Rails.application.config.rake_eager_load
+    end
+
+    test "rake_eager_load is set correctly" do
+      add_to_config <<-RUBY
+        config.root = "#{app_path}"
+        config.rake_eager_load = true
+      RUBY
+
+      app "development"
+
+      assert_equal true, Rails.application.config.rake_eager_load
+    end
   end
 end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -94,7 +94,7 @@ module ApplicationTests
       assert_match "Hello world", output
     end
 
-    def test_should_not_eager_load_model_for_rake
+    def test_should_not_eager_load_model_for_rake_when_rake_eager_load_is_false
       add_to_config <<-RUBY
         rake_tasks do
           task do_nothing: :environment do
@@ -114,6 +114,29 @@ module ApplicationTests
         assert system("bin/rails do_nothing RAILS_ENV=production"),
                "should not be pre-required for rake even eager_load=true"
       end
+    end
+
+    def test_should_eager_load_model_for_rake_when_rake_eager_load_is_true
+      add_to_config <<-RUBY
+        rake_tasks do
+          task do_something: :environment do
+            puts "Answer: " + Hello::TEST.to_s
+          end
+        end
+      RUBY
+
+      add_to_env_config "production", <<-RUBY
+        config.rake_eager_load = true
+      RUBY
+
+      app_file "app/models/hello.rb", <<-RUBY
+        class Hello
+          TEST = 42
+        end
+      RUBY
+
+      output = Dir.chdir(app_path) { `bin/rails do_something RAILS_ENV=production` }
+      assert_equal "Answer: 42\n", output
     end
 
     def test_code_statistics_sanity


### PR DESCRIPTION
### Summary

Rake environment disable `config.eager_load` for from what I understand legacy reasons.

https://github.com/rails/rails/blob/v5.0.1/railties/lib/rails/application.rb#L446

I would wish to be able to control that behaviour so regardless how the application is accessed, the load order remains the same.

I added a new accessor in `Rails::Application::Configuration` to minimize the diff, but it could be nice to split the mass creation to one per line and 🔡 ?