### PR TITLE
Make required by default test for belongs_to association clearer

### DIFF
--- a/activerecord/test/cases/associations/required_test.rb
+++ b/activerecord/test/cases/associations/required_test.rb
@@ -23,18 +23,20 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
   end
 
   test "belongs_to associations can be optional by default" do
-    original_value = ActiveRecord::Base.belongs_to_required_by_default
-    ActiveRecord::Base.belongs_to_required_by_default = false
+    begin
+      original_value = ActiveRecord::Base.belongs_to_required_by_default
+      ActiveRecord::Base.belongs_to_required_by_default = false
 
-    model = subclass_of(Child) do
-      belongs_to :parent, inverse_of: false,
-        class_name: "RequiredAssociationsTest::Parent"
+      model = subclass_of(Child) do
+        belongs_to :parent, inverse_of: false,
+          class_name: "RequiredAssociationsTest::Parent"
+      end
+
+      assert model.new.save
+      assert model.new(parent: Parent.new).save
+    ensure
+      ActiveRecord::Base.belongs_to_required_by_default = original_value
     end
-
-    assert model.new.save
-    assert model.new(parent: Parent.new).save
-
-    ActiveRecord::Base.belongs_to_required_by_default = original_value
   end
 
   test "required belongs_to associations have presence validated" do
@@ -52,22 +54,24 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
   end
 
   test "belongs_to associations can be required by default" do
-    original_value = ActiveRecord::Base.belongs_to_required_by_default
-    ActiveRecord::Base.belongs_to_required_by_default = true
+    begin
+      original_value = ActiveRecord::Base.belongs_to_required_by_default
+      ActiveRecord::Base.belongs_to_required_by_default = true
 
-    model = subclass_of(Child) do
-      belongs_to :parent, inverse_of: false,
-        class_name: "RequiredAssociationsTest::Parent"
+      model = subclass_of(Child) do
+        belongs_to :parent, inverse_of: false,
+          class_name: "RequiredAssociationsTest::Parent"
+      end
+
+      record = model.new
+      assert_not record.save
+      assert_equal ["Parent must exist"], record.errors.full_messages
+
+      record.parent = Parent.new
+      assert record.save
+    ensure
+      ActiveRecord::Base.belongs_to_required_by_default = original_value
     end
-
-    record = model.new
-    assert_not record.save
-    assert_equal ["Parent must exist"], record.errors.full_messages
-
-    record.parent = Parent.new
-    assert record.save
-
-    ActiveRecord::Base.belongs_to_required_by_default = original_value
   end
 
   test "has_one associations are not required by default" do


### PR DESCRIPTION
### Summary

Since #18937 `belongs_to` associations receive a setting to determine if
it should be or not treated as `required` by default.

While the tests were still passing, it was not evident that the
"default" behaviour for `required` could change in fuction of a setting,
that is set by default for fresh Rails5 apps, but not for upgraded
apps.

### Other Information

This commit try to relate make it clear what is the behaviour
expected when the the setting `belongs_to_required_by_default` is set to `true` or not set, to prevent misunderstandings like the discussed here https://github.com/rails/rails/pull/28206#discussion_r103298460