### PR TITLE
include_selected option for CollectionSelect, options_from_collection_for_select, options_for_select

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -355,9 +355,9 @@ module ActionView
         selected, disabled = [selected, disabled].map do |r|
           Array(r).map(&:to_s)
         end
-        
+
         if include_selected
-          include = selected.select{|s| container.find{|element| option_text_and_value(element).last == s}.nil?}
+          include = selected.select { |s| container.find { |element| option_text_and_value(element).last == s }.nil? }
           unless include.empty?
             container = [include] + container
           end

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -406,7 +406,8 @@ module ActionView
         selected, disabled, include_selected = extract_selected_and_disabled(selected)
         select_deselect = {
           selected: extract_values_from_collection(collection, value_method, selected),
-          disabled: extract_values_from_collection(collection, value_method, disabled)
+          disabled: extract_values_from_collection(collection, value_method, disabled),
+          include_selected: include_selected
         }
 
         options_for_select(options, select_deselect)

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -359,7 +359,7 @@ module ActionView
         if include_selected
           include = selected.select{|s| container.find{|element| option_text_and_value(element).last == s}.nil?}
           unless include.empty?
-            container = [selected] + container
+            container = [include] + container
           end
         end
 

--- a/actionview/lib/action_view/helpers/tags/collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_select.rb
@@ -14,6 +14,7 @@ module ActionView
         def render
           option_tags_options = {
             selected: @options.fetch(:selected) { value(@object) },
+            include_selected: @options.fetch(:include_selected, false),
             disabled: @options[:disabled]
           }
 


### PR DESCRIPTION
Hi guys,

I'm wondering if this could be useful to anybody else...

This PR adds an option to select/options rendering, for when the currently selected value is not within the collection or supplied options (it will add the selected value as the first option).

I think it's quite a handy solution for situations when you want to limit the available options, but don't want to loose any pre-existing/legacy data.

### Example
```ruby
options_for_select([["English", "en"], ["German", "de"]], selected: "Deutsch", include_selected: true)
```
will result in:
```html
<option value="Deutsch" selected="selected">Deutsch<option>
<option value="en">English<option>
<option value="de">German<option>
```
without `include_selected` it would have been:
```html
<option value="en">English<option>
<option value="de">German<option>
```
which easily could result in an error: "Deutsch" being overwritten by "English"