### PR TITLE
Take failed screenshot before reset driver

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb
@@ -10,8 +10,8 @@ module ActionDispatch
         end
 
         def after_teardown
-          super
           take_failed_screenshot
+          super
           Capybara.reset_sessions!
         end
       end


### PR DESCRIPTION
Now reset the driver before take failed screenshot since #28144.
However, I think that failed screenshot should be take with the driver
actually used in the test.
So, fixed to take screenshot before reset driver.

