### PR TITLE
`valid_type?` should accept only supported types

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -158,10 +158,6 @@ module ActiveRecord
         true
       end
 
-      def valid_type?(type) # :nodoc:
-        true
-      end
-
       # Returns 62. SQLite supports index names up to 64
       # characters. The rest is used by Rails internally to perform
       # temporary rename operations

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -30,6 +30,16 @@ module ActiveRecord
       assert_nothing_raised { Book.destroy(0) }
     end
 
+    def test_valid_column
+      @connection.native_database_types.each_key do |type|
+        assert @connection.valid_type?(type)
+      end
+    end
+
+    def test_invalid_column
+      assert_not @connection.valid_type?(:foobar)
+    end
+
     def test_tables
       tables = @connection.tables
       assert_includes tables, "accounts"

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -17,17 +17,6 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     end
   end
 
-  def test_valid_column
-    with_example_table do
-      column = @conn.columns("ex").find { |col| col.name == "id" }
-      assert @conn.valid_type?(column.type)
-    end
-  end
-
-  def test_invalid_column
-    assert_not @conn.valid_type?(:foobar)
-  end
-
   def test_columns_for_distinct_zero_orders
     assert_equal "posts.id",
       @conn.columns_for_distinct("posts.id", [])

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -21,17 +21,6 @@ module ActiveRecord
         end
       end
 
-      def test_valid_column
-        with_example_table do
-          column = @connection.columns("ex").find { |col| col.name == "id" }
-          assert @connection.valid_type?(column.type)
-        end
-      end
-
-      def test_invalid_column
-        assert_not @connection.valid_type?(:foobar)
-      end
-
       def test_primary_key
         with_example_table do
           assert_equal "id", @connection.primary_key("ex")

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -49,22 +49,6 @@ module ActiveRecord
         end
       end
 
-      def test_valid_column
-        with_example_table do
-          column = @conn.columns("ex").find { |col| col.name == "id" }
-          assert @conn.valid_type?(column.type)
-        end
-      end
-
-      # sqlite3 databases should be able to support any type and not just the
-      # ones mentioned in the native_database_types.
-      #
-      # Therefore test_invalid column should always return true even if the
-      # type is not valid.
-      def test_invalid_column
-        assert @conn.valid_type?(:foobar)
-      end
-
       def test_column_types
         owner = Owner.create!(name: "hello".encode("ascii-8bit"))
         owner.reload


### PR DESCRIPTION
`valid_type?` is used in schema dumper to determine if a type is
supported. So if `valid_type?(:foobar)` is true, it means that schema
dumper is allowed to create `t.foobar`. But it doesn't work. I think
that `valid_type?` should accept only supported types.

https://github.com/rails/rails/blob/v5.1.0.beta1/activerecord/lib/active_record/schema_dumper.rb#L135-L142

```ruby
  columns.each do |column|
    raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
    next if column.name == pk
    type, colspec = @connection.column_spec(column)
    tbl.print "    t.#{type} #{column.name.inspect}"
    tbl.print ", #{format_colspec(colspec)}" if colspec.present?
    tbl.puts
  end
```