### PR TITLE
Fix random failure on system test with ajax

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb
@@ -11,8 +11,8 @@ module ActionDispatch
 
         def after_teardown
           take_failed_screenshot
-          super
           Capybara.reset_sessions!
+          super
         end
       end
     end


### PR DESCRIPTION
### Summary

If application has ajax, browser may begin request after rollback.
It breaks tests randomly.

https://github.com/mtsmfm/rails-system-test-example is a demo application.

#### ajax request

https://github.com/mtsmfm/rails-system-test-example/blob/fail/app/assets/javascripts/application.js#L15

#### system test (scaffold)

https://github.com/mtsmfm/rails-system-test-example/blob/fail/test/system/posts_test.rb#L11-L20

#### build results

- https://circleci.com/gh/mtsmfm/rails-system-test-example/11 (failed)
- https://circleci.com/gh/mtsmfm/rails-system-test-example/12 (fixed by using this branch)

### Other Information

@iangreenleaf wrote great article about this problem :star2:

http://technotes.iangreenleaf.com/posts/the-one-true-guide-to-database-transactions-with-capybara.html

It helped me to notice what happened in system test, thanks!

In the article, suggesting solution is wait until ajax finished by `evaluate_script` but I think we can guard from ajax request after teardown by ~~inserting rack middleware~~ call `Capybara.reset_session!` before rollback.