### PR TITLE
Fix indent

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -106,10 +106,10 @@ module ActionDispatch
     #   driven_by :selenium, screen_size: [800, 800]
     def self.driven_by(driver, using: :chrome, screen_size: [1400, 1400])
       driver = if selenium?(driver)
-                 SystemTesting::Browser.new(using, screen_size)
-               else
-                 SystemTesting::Driver.new(driver)
-               end
+        SystemTesting::Browser.new(using, screen_size)
+      else
+        SystemTesting::Driver.new(driver)
+      end
 
       setup { driver.use }
       teardown { driver.reset }


### PR DESCRIPTION
```
$ bundle exec rubocop actionpack/lib/action_dispatch/system_test_case.rb
Inspecting 1 file
W

Offenses:

actionpack/lib/action_dispatch/system_test_case.rb:109:7: C: Use 2 (not 11) spaces for indentation.
                 SystemTesting::Browser.new(using, screen_size)
      ^^^^^^^^^^^
actionpack/lib/action_dispatch/system_test_case.rb:112:16: W: end at 112, 15 is not aligned with driver = if at 108, 6.
               end
               ^^^

1 file inspected, 2 offenses detected
```