### PR TITLE
Backport fix for Rails generator --help

### DIFF
--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -3,6 +3,8 @@ module Rails
     class ControllerGenerator < NamedBase # :nodoc:
       argument :actions, type: :array, default: [], banner: "action action"
       class_option :skip_routes, type: :boolean, desc: "Don't add routes to config/routes.rb."
+      class_option :helper, type: :boolean
+      class_option :assets, type: :boolean
 
       check_class_collision suffix: "Controller"
 


### PR DESCRIPTION
### Summary

This closes https://github.com/rails/rails/issues/28163 by backporting https://github.com/rails/rails/commit/a36ef6ee3ed44e6ce1636f12da59c473dddd94bb to the `5-0-stable` branch.

I couldn't figure out a better way to test other than making screenshots with `5-0-stable` and my branch.

| Before | After |
| ------- | ----- |
| <img width="1546" alt="Screenshot with issue" src="https://www.dropbox.com/s/grgz76uiwduhkc4/Screen%20Shot%202017-02-28%20at%2015.13.59.png?raw=1"> | <img width="1546" alt="Screenshot without issue" src="https://www.dropbox.com/s/iz0snzj3hu5nfkb/Screen%20Shot%202017-02-28%20at%2015.13.32.png?raw=1"> |

Please let me know if there is a better way to do this, or if there is a test I should add to avoid this regression again.

Thanks!

Also thank you to @eileencodes for answering my questions about test failures ✨ 