### PR TITLE
Extract transactional test code into separate module

### DIFF
--- a/actionview/test/active_record_unit.rb
+++ b/actionview/test/active_record_unit.rb
@@ -70,6 +70,7 @@ class ActiveRecordTestConnector
 end
 
 class ActiveRecordTestCase < ActionController::TestCase
+  include ActiveRecord::TransactionalTest
   include ActiveRecord::TestFixtures
 
   # Set our fixture path

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -161,6 +161,7 @@ module ActiveRecord
   end
 
   autoload :TestFixtures, "active_record/fixtures"
+  autoload :TransactionalTest, "active_record/transactional_test"
 
   def self.eager_load!
     super

--- a/activerecord/lib/active_record/transactional_test.rb
+++ b/activerecord/lib/active_record/transactional_test.rb
@@ -1,0 +1,73 @@
+require "active_support/concern"
+
+module ActiveRecord
+  # Wraps an individual test in a database transaction.
+  module TransactionalTest
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :use_transactional_tests
+      self.use_transactional_tests = true
+    end
+
+    def before_setup # :nodoc:
+      setup_transaction
+      super
+    end
+
+    def after_teardown # :nodoc:
+      super
+      teardown_transaction
+    end
+
+    def setup_transaction
+      return unless run_in_transaction?
+
+      @test_connections = []
+      @connection_subscriber = nil
+
+      # Begin transactions for connections already established
+      @test_connections = enlist_test_connections
+      @test_connections.each do |connection|
+        connection.begin_transaction joinable: false
+        connection.pool.lock_thread = true
+      end
+
+      # When connections are established in the future, begin a transaction too
+      @connection_subscriber = ActiveSupport::Notifications.subscribe("!connection.active_record") do |_, _, _, _, payload|
+        spec_name = payload[:spec_name] if payload.key?(:spec_name)
+
+        if spec_name
+          begin
+            connection = ActiveRecord::Base.connection_handler.retrieve_connection(spec_name)
+          rescue ConnectionNotEstablished
+            connection = nil
+          end
+
+          if connection && !@test_connections.include?(connection)
+            connection.begin_transaction joinable: false
+            connection.pool.lock_thread = true
+            @test_connections << connection
+          end
+        end
+      end
+    end
+
+    def teardown_transaction
+      return unless run_in_transaction?
+
+      ActiveSupport::Notifications.unsubscribe(@connection_subscriber) if @connection_subscriber
+      @test_connections.each do |connection|
+        connection.rollback_transaction if connection.transaction_open?
+        connection.pool.lock_thread = false
+      end
+      @test_connections.clear
+    end
+
+    private
+
+      def enlist_test_connections
+        ActiveRecord::Base.connection_handler.connection_pool_list.map(&:connection)
+      end
+  end
+end

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -44,7 +44,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
     assert !@connection.active?
   ensure
     # Repair all fixture connections so other tests won't break.
-    @fixture_connections.each(&:verify!)
+    @test_connections.each(&:verify!)
   end
 
   def test_successful_reconnection_after_timeout_with_manual_reconnect

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -179,7 +179,7 @@ module ActiveRecord
         "successfully querying with the same connection pid."
     ensure
       # Repair all fixture connections so other tests won't break.
-      @fixture_connections.each(&:verify!)
+      @test_connections.each(&:verify!)
     end
 
     def test_set_session_variable_true

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -104,6 +104,7 @@ class FixturesTest < ActiveRecord::TestCase
     assert_nil(second_row["author_email_address"])
   end
 
+  self.uses_transaction :test_inserts_with_pre_and_suffix
   def test_inserts_with_pre_and_suffix
     # Reset cache to make finds on the new table work
     ActiveRecord::FixtureSet.reset_cache
@@ -658,7 +659,7 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
       def lock_thread=(lock_thread); false; end
     end.new
     fire_connection_notification(connection)
-    teardown_fixtures
+    teardown_transaction
     assert(connection.rollback_transaction_called, "Expected <mock connection>#rollback_transaction to be called but was not")
   end
 
@@ -709,33 +710,6 @@ class ManyToManyFixturesWithClassDefined < ActiveRecord::TestCase
   def test_this_should_run_cleanly
     assert true
   end
-end
-
-class FixturesBrokenRollbackTest < ActiveRecord::TestCase
-  def blank_setup
-    @fixture_connections = [ActiveRecord::Base.connection]
-  end
-  alias_method :ar_setup_fixtures, :setup_fixtures
-  alias_method :setup_fixtures, :blank_setup
-  alias_method :setup, :blank_setup
-
-  def blank_teardown; end
-  alias_method :ar_teardown_fixtures, :teardown_fixtures
-  alias_method :teardown_fixtures, :blank_teardown
-  alias_method :teardown, :blank_teardown
-
-  def test_no_rollback_in_teardown_unless_transaction_active
-    assert_equal 0, ActiveRecord::Base.connection.open_transactions
-    assert_raise(RuntimeError) { ar_setup_fixtures }
-    assert_equal 0, ActiveRecord::Base.connection.open_transactions
-    assert_nothing_raised { ar_teardown_fixtures }
-    assert_equal 0, ActiveRecord::Base.connection.open_transactions
-  end
-
-  private
-    def load_fixtures(config)
-      raise "argh"
-    end
 end
 
 class LoadAllFixturesTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -3,6 +3,7 @@ require "active_support/testing/autorun"
 require "active_support/testing/method_call_assertions"
 require "active_support/testing/stream"
 require "active_record/fixtures"
+require "active_record/transactional_test"
 
 require "cases/validations_repair_helper"
 
@@ -13,6 +14,7 @@ module ActiveRecord
   class TestCase < ActiveSupport::TestCase #:nodoc:
     include ActiveSupport::Testing::MethodCallAssertions
     include ActiveSupport::Testing::Stream
+    include ActiveRecord::TransactionalTest
     include ActiveRecord::TestFixtures
     include ActiveRecord::ValidationsRepairHelper
 

--- a/activerecord/test/cases/transactional_test_test.rb
+++ b/activerecord/test/cases/transactional_test_test.rb
@@ -1,9 +1,9 @@
 require "cases/helper"
 
-class TestFixturesTest < ActiveRecord::TestCase
+class TransactionalTestTest < ActiveRecord::TestCase
   setup do
     @klass = Class.new
-    @klass.include(ActiveRecord::TestFixtures)
+    @klass.include(ActiveRecord::TransactionalTest)
   end
 
   def test_use_transactional_tests_defaults_to_true

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -20,6 +20,7 @@ if defined?(ActiveRecord::Base)
 
   module ActiveSupport
     class TestCase
+      include ActiveRecord::TransactionalTest
       include ActiveRecord::TestFixtures
       self.fixture_path = "#{Rails.root}/test/fixtures/"
       self.file_fixture_path = fixture_path + "files"


### PR DESCRIPTION
### Summary

This refactoring PR extracts the code concerning transactional-test setup/teardown into a separate module from the code concerning test-fixture creation and management. This makes the code easier to read and build upon moving forward since it more cleanly isolates the transaction setup/teardown logic from the fixture-setup logic.

### Other Information

I consider this PR to be an extension of #19282, which made the initial point that the transactional tests feature "doesn't really have anything to do with fixtures." This PR fully realizes that notion by extracting the transactional-test code into its own module, further clarifying the separation of concerns.