### PR TITLE
Fix `new_cipher': uninitialized constant #<Class:Rails::Secrets>::OpenSSL (NameError)

### DIFF
--- a/railties/lib/rails/secrets.rb
+++ b/railties/lib/rails/secrets.rb
@@ -1,4 +1,5 @@
 require "yaml"
+require "openssl"
 
 module Rails
   # Greatly inspired by Ara T. Howard's magnificent sekrets gem. 😘


### PR DESCRIPTION
rails 5.1.0 master
ruby-head

~~~
Macbook-Pro:test_app sharevari$ bundle exec rails secrets:setup
  from bin/rails:4:in `<main>'
  from bin/rails:4:in `load'
  from /Users/sharevari/repository/sharevari/test_app/bin/spring:16:in `<top (required)>'
  from /Users/sharevari/repository/sharevari/test_app/bin/spring:16:in `require'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/spring-2.0.1/lib/spring/binstub.rb:31:in `<top (required)>'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/spring-2.0.1/lib/spring/binstub.rb:31:in `load'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/spring-2.0.1/bin/spring:49:in `<top (required)>'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/spring-2.0.1/lib/spring/client.rb:30:in `run'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/spring-2.0.1/lib/spring/client/command.rb:7:in `call'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/spring-2.0.1/lib/spring/client/rails.rb:28:in `call'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/spring-2.0.1/lib/spring/client/rails.rb:28:in `load'
  from /Users/sharevari/repository/sharevari/test_app/bin/rails:10:in `<top (required)>'
  from /Users/sharevari/repository/sharevari/test_app/bin/rails:10:in `require'
  from /Users/sharevari/.rvm/gems/ruby-head@test/bundler/gems/rails-89d5d975e540/railties/lib/rails/commands.rb:16:in `<top (required)>'
  from /Users/sharevari/.rvm/gems/ruby-head@test/bundler/gems/rails-89d5d975e540/railties/lib/rails/command.rb:44:in `invoke'
  from /Users/sharevari/.rvm/gems/ruby-head@test/bundler/gems/rails-89d5d975e540/railties/lib/rails/command/base.rb:63:in `perform'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
  from /Users/sharevari/.rvm/gems/ruby-head@test/bundler/gems/rails-89d5d975e540/railties/lib/rails/commands/secrets/secrets_command.rb:17:in `setup'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/thor-0.19.4/lib/thor/group.rb:232:in `dispatch'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `invoke_all'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `map'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `each'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/thor-0.19.4/lib/thor/invocation.rb:133:in `block in invoke_all'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
  from /Users/sharevari/.rvm/gems/ruby-head@test/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
  from /Users/sharevari/.rvm/gems/ruby-head@test/bundler/gems/rails-89d5d975e540/railties/lib/rails/generators/rails/encrypted_secrets/encrypted_secrets_generator.rb:9:in `add_secrets_key_file'
  from /Users/sharevari/.rvm/gems/ruby-head@test/bundler/gems/rails-89d5d975e540/railties/lib/rails/secrets.rb:33:in `generate_key'
/Users/sharevari/.rvm/gems/ruby-head@test/bundler/gems/rails-89d5d975e540/railties/lib/rails/secrets.rb:101:in `new_cipher': uninitialized constant #<Class:Rails::Secrets>::OpenSSL (NameError)
~~~
