### PR TITLE
Use DEFAULT_CIPHER constant in MessageEncryptor

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -61,7 +61,7 @@ module ActiveSupport
       sign_secret = signature_key_or_options.first
       @secret = secret
       @sign_secret = sign_secret
-      @cipher = options[:cipher] || "aes-256-cbc"
+      @cipher = options[:cipher] || DEFAULT_CIPHER
       @digest = options[:digest] || "SHA1" unless aead_mode?
       @verifier = resolve_verifier
       @serializer = options[:serializer] || Marshal


### PR DESCRIPTION
Constant is not re-used in this code which could lead to inconsistency between
default cipher and default key length. This could be serious so it's better to
fix it right away.