### PR TITLE
Use appropriate type for `test_framework` option

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -63,7 +63,7 @@ module Rails
         stylesheet_engine: :css,
         scaffold_stylesheet: true,
         system_tests: nil,
-        test_framework: false,
+        test_framework: nil,
         template_engine: :erb
       }
     }


### PR DESCRIPTION
This fixes the following warning.

```
Expected string default value for '--test-framework'; got false (boolean)
```
