### PR TITLE
Update `DateTime#change` to support usec and nsec

### DIFF
--- a/activerecord/test/cases/date_time_test.rb
+++ b/activerecord/test/cases/date_time_test.rb
@@ -52,7 +52,7 @@ class DateTimeTest < ActiveRecord::TestCase
   end
 
   def test_assign_in_local_timezone
-    now = DateTime.now
+    now = DateTime.civil(2017, 3, 1, 12, 0, 0)
     with_timezone_config default: :local do
       task = Task.new starting: now
       assert_equal now, task.starting

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Update `DateTime#change` to support `:usec` and `:nsec` options.
+
+    Adding support for these options now allows us to update the `DateTime#end_of`
+    methods to match the equivalent `Time#end_of` methods, e.g:
+
+        datetime = DateTime.now.end_of_day
+        datetime.nsec == 999999999 # => true
+
+    Fixes #21424.
+
+    *Dan Moore*, *Andrew White*
+
 *   Add `ActiveSupport::Duration#before` and `#after` as aliases for `#until` and `#since`
 
     These read more like English and require less mental gymnastics to read and write.
@@ -20,7 +32,7 @@
     *Robin Dupret* (#28157)
 
 *   In Core Extensions, make `MarshalWithAutoloading#load` pass through the second, optional
-    argument for `Marshal#load( source [, proc] )`. This way we don't have to do 
+    argument for `Marshal#load( source [, proc] )`. This way we don't have to do
     `Marshal.method(:load).super_method.call(source, proc)` just to be able to pass a proc.
 
     *Jeff Latz*

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -47,13 +47,23 @@ class DateTime
   #   DateTime.new(2012, 8, 29, 22, 35, 0).change(year: 1981, day: 1)  # => DateTime.new(1981, 8, 1, 22, 35, 0)
   #   DateTime.new(2012, 8, 29, 22, 35, 0).change(year: 1981, hour: 0) # => DateTime.new(1981, 8, 29, 0, 0, 0)
   def change(options)
+    if new_nsec = options[:nsec]
+      raise ArgumentError, "Can't change both :nsec and :usec at the same time: #{options.inspect}" if options[:usec]
+      new_fraction = Rational(new_nsec, 1000000000)
+    else
+      new_usec = options.fetch(:usec, (options[:hour] || options[:min] || options[:sec]) ? 0 : Rational(nsec, 1000))
+      new_fraction = Rational(new_usec, 1000000)
+    end
+
+    raise ArgumentError, "argument out of range" if new_fraction >= 1
+
     ::DateTime.civil(
       options.fetch(:year, year),
       options.fetch(:month, month),
       options.fetch(:day, day),
       options.fetch(:hour, hour),
       options.fetch(:min, options[:hour] ? 0 : min),
-      options.fetch(:sec, (options[:hour] || options[:min]) ? 0 : sec + sec_fraction),
+      options.fetch(:sec, (options[:hour] || options[:min]) ? 0 : sec) + new_fraction,
       options.fetch(:offset, offset),
       options.fetch(:start, start)
     )
@@ -122,7 +132,7 @@ class DateTime
 
   # Returns a new DateTime representing the end of the day (23:59:59).
   def end_of_day
-    change(hour: 23, min: 59, sec: 59)
+    change(hour: 23, min: 59, sec: 59, usec: Rational(999999999, 1000))
   end
   alias :at_end_of_day :end_of_day
 
@@ -134,7 +144,7 @@ class DateTime
 
   # Returns a new DateTime representing the end of the hour (hh:59:59).
   def end_of_hour
-    change(min: 59, sec: 59)
+    change(min: 59, sec: 59, usec: Rational(999999999, 1000))
   end
   alias :at_end_of_hour :end_of_hour
 
@@ -146,7 +156,7 @@ class DateTime
 
   # Returns a new DateTime representing the end of the minute (hh:mm:59).
   def end_of_minute
-    change(sec: 59)
+    change(sec: 59, usec: Rational(999999999, 1000))
   end
   alias :at_end_of_minute :end_of_minute
 


### PR DESCRIPTION
Adding support for these options now allows us to update the `DateTime#end_of` methods to match the equivalent `Time#end_of` methods, e.g:

    datetime = DateTime.now.end_of_day
    datetime.nsec == 999999999 # => true

Fixes #21424.
