### PR TITLE
Introduce ApplicationTestCase

### DIFF
--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -10,7 +10,7 @@ module ActionMailer
     end
   end
 
-  class TestCase < ActiveSupport::TestCase
+  class TestCase < ApplicationTestCase
     module ClearTestDeliveries
       extend ActiveSupport::Concern
 

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -322,7 +322,7 @@ module ActionController
   # If you're using named routes, they can be easily tested using the original named routes' methods straight in the test case.
   #
   #  assert_redirected_to page_url(title: 'foo')
-  class TestCase < ActiveSupport::TestCase
+  class TestCase < ApplicationTestCase
     module Behavior
       extend ActiveSupport::Concern
       include ActionDispatch::TestProcess

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -7,7 +7,7 @@ require "rails-dom-testing"
 
 module ActionView
   # = Action View Test Case
-  class TestCase < ActiveSupport::TestCase
+  class TestCase < ApplicationTestCase
     class TestController < ActionController::Base
       include ActionDispatch::TestProcess
 

--- a/activejob/lib/active_job/test_case.rb
+++ b/activejob/lib/active_job/test_case.rb
@@ -1,7 +1,7 @@
 require "active_support/test_case"
 
 module ActiveJob
-  class TestCase < ActiveSupport::TestCase
+  class TestCase < ApplicationTestCase
     include ActiveJob::TestHelper
 
     ActiveSupport.run_load_hooks(:active_job_test_case, self)

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -10,7 +10,7 @@ module ActiveRecord
   # = Active Record Test Case
   #
   # Defines some test assertions to test against SQL queries.
-  class TestCase < ActiveSupport::TestCase #:nodoc:
+  class TestCase < ApplicationTestCase #:nodoc:
     include ActiveSupport::Testing::MethodCallAssertions
     include ActiveSupport::Testing::Stream
     include ActiveRecord::TestFixtures

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -2,7 +2,7 @@ require "abstract_unit"
 require "active_support/core_ext/module/delegation"
 
 module Notifications
-  class TestCase < ActiveSupport::TestCase
+  class TestCase < ApplicationTestCase
     def setup
       @old_notifier = ActiveSupport::Notifications.notifier
       @notifier = ActiveSupport::Notifications::Fanout.new

--- a/railties/lib/rails/generators/test_case.rb
+++ b/railties/lib/rails/generators/test_case.rb
@@ -25,7 +25,7 @@ module Rails
     #     destination File.expand_path("../tmp", File.dirname(__FILE__))
     #     setup :prepare_destination
     #   end
-    class TestCase < ActiveSupport::TestCase
+    class TestCase < ApplicationTestCase
       include Rails::Generators::Testing::Behaviour
       include Rails::Generators::Testing::SetupAndTeardown
       include Rails::Generators::Testing::Assertions


### PR DESCRIPTION
I understand this PR isn't complete; I'd like to see if the idea gets traction.

### Summary

All Rails test classes extend `ActiveSupport::TestCase`. This makes it
very had for applications to customize the test inheritance; they simply
have to reopen/freedom-patch `ActiveSupport::TestCase`.

Having a class implemented by the application would make it much more
straightforward. It's also in line with the way Rails has moved from
`ActiveRecord::Base` to `ApplicationRecord`, `ActiveJob::Base` to
`ApplicationJob`, etc.
