### PR TITLE
Pass request params to ActionMailer::Preview

### DIFF
--- a/actionmailer/lib/action_mailer/preview.rb
+++ b/actionmailer/lib/action_mailer/preview.rb
@@ -52,6 +52,12 @@ module ActionMailer
   class Preview
     extend ActiveSupport::DescendantsTracker
 
+    attr_reader :params
+
+    def initialize(params = {})
+      @params = params
+    end
+
     class << self
       # Returns all mailer preview classes.
       def all
@@ -62,8 +68,8 @@ module ActionMailer
       # Returns the mail object for the given email name. The registered preview
       # interceptors will be informed so that they can transform the message
       # as they would if the mail was actually being delivered.
-      def call(email)
-        preview = new
+      def call(email, params = {})
+        preview = new(params)
         message = preview.public_send(email)
         inform_preview_interceptors(message)
         message

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -968,3 +968,19 @@ class BasePreviewInterceptorsTest < ActiveSupport::TestCase
     end
   end
 end
+
+class BasePreviewTest < ActiveSupport::TestCase
+  class BaseMailerPreview < ActionMailer::Preview
+    def welcome
+      BaseMailer.welcome(params)
+    end
+  end
+
+  test "has access to params" do
+    params = { name: "World" }
+
+    assert_called_with(BaseMailer, :welcome, [params]) do
+      BaseMailerPreview.call(:welcome, params)
+    end
+  end
+end

--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -6,6 +6,8 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
   before_action :require_local!, unless: :show_previews?
   before_action :find_preview, only: :preview
 
+  helper_method :part_query
+
   def index
     @previews = ActionMailer::Preview.all
     @page_title = "Mailer Previews"
@@ -19,7 +21,7 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
       @email_action = File.basename(params[:path])
 
       if @preview.email_exists?(@email_action)
-        @email = @preview.call(@email_action)
+        @email = @preview.call(@email_action, params)
 
         if params[:part]
           part_type = Mime::Type.lookup(params[:part])
@@ -75,5 +77,9 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
       elsif @email.mime_type == format
         @email
       end
+    end
+
+    def part_query(mime_type)
+      request.query_parameters.merge(part: mime_type).to_query
     end
 end

--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -98,8 +98,8 @@
     <% if @email.multipart? %>
       <dd>
         <select onchange="formatChanged(this);">
-          <option <%= request.format == Mime[:html] ? 'selected' : '' %> value="?part=text%2Fhtml">View as HTML email</option>
-          <option <%= request.format == Mime[:text] ? 'selected' : '' %> value="?part=text%2Fplain">View as plain-text email</option>
+          <option <%= request.format == Mime[:html] ? 'selected' : '' %> value="?<%= part_query('text/html') %>">View as HTML email</option>
+          <option <%= request.format == Mime[:text] ? 'selected' : '' %> value="?<%= part_query('text/plain') %>">View as plain-text email</option>
         </select>
       </dd>
     <% end %>
@@ -107,7 +107,7 @@
 </header>
 
 <% if @part && @part.mime_type %>
-  <iframe seamless name="messageBody" src="?part=<%= Rack::Utils.escape(@part.mime_type) %>"></iframe>
+  <iframe seamless name="messageBody" src="?<%= part_query(@part.mime_type) %>"></iframe>
 <% else %>
   <p>
     You are trying to preview an email that does not have any content.


### PR DESCRIPTION
Allows passing query params to email previews:

```
http://localhost:3000/rails/mailers/user_mailer/password_recovery?email=alice@foobar.com
```

Second attempt of #25193