### PR TITLE
Use `blank?` instead of `empty?`

### DIFF
--- a/railties/lib/rails/commands/secrets/secrets_command.rb
+++ b/railties/lib/rails/commands/secrets/secrets_command.rb
@@ -18,7 +18,7 @@ module Rails
       end
 
       def edit
-        if ENV["EDITOR"].empty?
+        if ENV["EDITOR"].to_s.empty?
           say "No $EDITOR to open decrypted secrets in. Assign one like this:"
           say ""
           say %(EDITOR="mate --wait" bin/rails secrets:edit)


### PR DESCRIPTION
Using `empty?` will get an error if `ENV["EDITOR"]` is not set.

```
$ echo $EDITOR

$ bin/rails secrets:edit
rails/railties/lib/rails/commands/secrets/secrets_command.rb:21:in `edit': undefined method `empty?' for nil:NilClass (NoMethodError)
```

Follow up to 82f7dc6178f86e5e2dd82f9e528475a6acee6cd8

