### PR TITLE
Backport "Delegate to `scope` rather than `merge!` for collection proxy"

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -83,7 +83,7 @@ module ActiveRecord
       end
 
       def scope
-        target_scope.merge(association_scope)
+        target_scope.merge!(association_scope)
       end
 
       # The scope for this association.

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -455,9 +455,9 @@ module ActiveRecord
         record
       end
 
-      def scope(opts = {})
-        scope = super()
-        scope.none! if opts.fetch(:nullify, true) && null_scope?
+      def scope
+        scope = super
+        scope.none! if null_scope?
         scope
       end
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -39,13 +39,7 @@ module ActiveRecord
           reload
         end
 
-        if null_scope?
-          # Cache the proxy separately before the owner has an id
-          # or else a post-save proxy will still lack the id
-          @null_proxy ||= CollectionProxy.create(klass, self)
-        else
-          @proxy ||= CollectionProxy.create(klass, self)
-        end
+        CollectionProxy.create(klass, self)
       end
 
       # Implements the writer method, e.g. foo.items= for Foo.has_many :items

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -901,9 +901,8 @@ module ActiveRecord
 
       # Returns a <tt>Relation</tt> object for the records in this association
       def scope
-        @association.scope
+        @scope ||= @association.scope
       end
-      alias spawn scope
 
       # Equivalent to <tt>Array#==</tt>. Returns +true+ if the two arrays
       # contain the same number of elements and if each element is equal
@@ -1035,6 +1034,7 @@ module ActiveRecord
       #   person.pets(true)  # fetches pets from the database
       #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
       def reload
+        @scope = nil
         proxy_association.reload
         self
       end
@@ -1056,6 +1056,7 @@ module ActiveRecord
       #   person.pets  # fetches pets from the database
       #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
       def reset
+        @scope = nil
         proxy_association.reset
         proxy_association.reset_scope
         self

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -28,12 +28,9 @@ module ActiveRecord
     # is computed directly through SQL and does not trigger by itself the
     # instantiation of the actual post records.
     class CollectionProxy < Relation
-      delegate :exists?, :update_all, :arel, to: :scope
-
       def initialize(klass, association) #:nodoc:
         @association = association
         super klass, klass.arel_table, klass.predicate_builder
-        merge! association.scope(nullify: false)
       end
 
       def target
@@ -902,14 +899,6 @@ module ActiveRecord
         @association
       end
 
-      # We don't want this object to be put on the scoping stack, because
-      # that could create an infinite loop where we call an @association
-      # method, which gets the current scope, which is this object, which
-      # delegates to @association, and so on.
-      def scoping
-        @association.scope.scoping { yield }
-      end
-
       # Returns a <tt>Relation</tt> object for the records in this association
       def scope
         @association.scope
@@ -1072,6 +1061,19 @@ module ActiveRecord
         self
       end
 
+      def respond_to?(name, include_private = false)
+        super || scope.respond_to?(name, include_private)
+      end
+
+      delegate_methods = [
+        QueryMethods,
+        SpawnMethods,
+      ].flat_map { |klass|
+        klass.public_instance_methods(false)
+      } - self.public_instance_methods(false) + [:scoping]
+
+      delegate(*delegate_methods, to: :scope)
+
       private
 
         def null_scope?
@@ -1080,6 +1082,14 @@ module ActiveRecord
 
         def exec_queries
           load_target
+        end
+
+        def method_missing(method, *args, &block)
+          if scope.respond_to?(method)
+            scope.public_send(method, *args, &block)
+          else
+            super
+          end
         end
     end
   end

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1062,10 +1062,6 @@ module ActiveRecord
         self
       end
 
-      def respond_to?(name, include_private = false)
-        super || scope.respond_to?(name, include_private)
-      end
-
       delegate_methods = [
         QueryMethods,
         SpawnMethods,
@@ -1083,6 +1079,10 @@ module ActiveRecord
 
         def exec_queries
           load_target
+        end
+
+        def respond_to_missing?(method, _)
+          scope.respond_to?(method) || super
         end
 
         def method_missing(method, *args, &block)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -594,6 +594,17 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     firm.save!
     assert_equal firm.clients.count, firm.clients.update_all(description: 'Great!')
     assert_equal clients_proxy_id, firm.clients.object_id
+    firm = Firm.new(name: "Firm")
+    firm.clients << Client.first
+    firm.save!
+    assert_equal firm.clients.count, firm.clients.update_all(description: "Great!")
+  end
+
+  def test_update_all_on_association_accessed_before_save_with_explicit_foreign_key
+    firm = Firm.new(name: "Firm", id: 100)
+    firm.clients << Client.first
+    firm.save!
+    assert_equal firm.clients.count, firm.clients.update_all(description: "Great!")
   end
 
   def test_belongs_to_sanity

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -237,11 +237,6 @@ class AssociationProxyTest < ActiveRecord::TestCase
     assert_equal david.projects, david.projects.scope
   end
 
-  test "proxy object is cached" do
-    david = developers(:david)
-    assert david.projects.equal?(david.projects)
-  end
-
   test "inverses get set of subsets of the association" do
     man = Man.create
     man.interests.create


### PR DESCRIPTION
Rails 5.0.1 introduced a bug (#27582), which was fixed by #25877. However, the fix was only merged to master. There doesn't appear to be an easy way for me to workaround this bug, so it would be great if it could be merged into 5-0-stable as well.