### PR TITLE
Specify encoding for Rails Plugin's gemspec

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
@@ -1,3 +1,4 @@
+# coding: utf-8
 $:.push File.expand_path("../lib", __FILE__)
 
 # Maintain your gem's version:


### PR DESCRIPTION
### Summary

In some cases (e.g. when the system default encoding is `Encoding:US-ASCII`), using no-ascii character in Rails Plugin's `gemspec` causes an error when `bundle` command is used:

```
Error details
 
ArgumentError: invalid byte sequence in US-ASCII
```

Specifying `coding: utf-8` fixes this issue.

### Other Information

[bundler gem](https://github.com/bundler/bundler) specifies encoding in the same way:

https://github.com/bundler/bundler/blob/master/lib/bundler/templates/newgem/newgem.gemspec.tt#L1
