### PR TITLE
Remove implicit fallback to :html for JS requests

### DIFF
--- a/actionpack/test/controller/mime/accept_format_test.rb
+++ b/actionpack/test/controller/mime/accept_format_test.rb
@@ -85,8 +85,9 @@ class MimeControllerLayoutsTest < ActionController::TestCase
     assert_equal '<html><div id="super_iphone">Super iPhone</div></html>', @response.body
   end
 
-  def test_non_navigational_format_with_no_template_fallbacks_to_html_template_with_no_layout
-    get :index, format: :js
-    assert_equal "Hello Firefox", @response.body
+  def test_no_html_fallback_for_javascript_format
+    assert_raise ActionController::UnknownFormat do
+      get :index, format: :js
+    end
   end
 end

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -241,13 +241,11 @@ module ActionView
     end
     private :initialize_details
 
-    # Override formats= to expand ["*/*"] values and automatically
-    # add :html as fallback to :js.
+    # Override formats= to expand ["*/*"] values.
     def formats=(values)
       if values
         values.concat(default_formats) if values.delete "*/*".freeze
         if values == [:js]
-          values << :html
           @html_fallback_for_js = true
         end
       end

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -56,11 +56,6 @@ class LookupContextTest < ActiveSupport::TestCase
     assert_equal [:js, *Mime::SET.symbols], @lookup_context.formats
   end
 
-  test "adds :html fallback to :js formats" do
-    @lookup_context.formats = [:js]
-    assert_equal [:js, :html], @lookup_context.formats
-  end
-
   test "provides getters and setters for locale" do
     @lookup_context.locale = :pt
     assert_equal :pt, @lookup_context.locale


### PR DESCRIPTION
For now Rails app renders HTML templates for JS request when `.js` template is missing. There is also known issue, that js errors are suppressed while evaluating response for `remote: true` request. So they both produces errors which are silent in production and can be detected in tests only either with complex browser tests, or with explicit format checks (I mean there is no exception at all when running `post(path, params: params, xhr: true)`, in browser console too).

I've found first appearance of this fallback: https://github.com/rails/rails/commit/56fb60ebfe9a20ced1366f3e35b2f9bd0bac8e45, it was almost 7 years ago.

I've also opened issue in rails-ujs: https://github.com/rails/rails-ujs/issues/21 about using `*/*` in `Accept` header, which also leads to this behaviour.