### PR TITLE
Update `database.yml` when `rails new <new_app> -d oracle` specified

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -280,7 +280,7 @@ module Rails
         case options[:database]
         when "mysql"          then ["mysql2", [">= 0.3.18", "< 0.5"]]
         when "postgresql"     then ["pg", ["~> 0.18"]]
-        when "oracle"         then ["ruby-oci8", nil]
+        when "oracle"         then ["activerecord-oracle_enhanced-adapter", nil]
         when "frontbase"      then ["ruby-frontbase", nil]
         when "sqlserver"      then ["activerecord-sqlserver-adapter", nil]
         when "jdbcmysql"      then ["activerecord-jdbcmysql-adapter", nil]
@@ -296,7 +296,6 @@ module Rails
           case options[:database]
           when "postgresql" then options[:database].replace "jdbcpostgresql"
           when "mysql"      then options[:database].replace "jdbcmysql"
-          when "oracle"     then options[:database].replace "jdbc"
           when "sqlite3"    then options[:database].replace "jdbcsqlite3"
           end
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml
@@ -1,4 +1,4 @@
-# Oracle/OCI 8i, 9, 10g
+# Oracle/OCI 11g or higher recommended
 #
 # Requires Ruby/OCI8:
 #  https://github.com/kubo/ruby-oci8
@@ -17,7 +17,7 @@
 #  cursor_sharing: similar
 #
 default: &default
-  adapter: oracle
+  adapter: oracle_enhanced
   pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= app_name %>
   password:
@@ -45,7 +45,9 @@ test:
 # On Heroku and other platform providers, you may have a full connection URL
 # available as an environment variable. For example:
 #
-#   DATABASE_URL="oracle://myuser:mypass@localhost/somedatabase"
+#   DATABASE_URL="oracle-enhanced://myuser:mypass@localhost/somedatabase"
+#
+# Note that the adapter name uses a dash instead of an underscore.
 #
 # You can use this database configuration with:
 #


### PR DESCRIPTION
### Summary
This pull requests updates `database.yml` for Oracle enhanced adapter users.

  - Install "activerecord-oracle_enhanced-adapter".
  Oracle adapter used to be a bundled one. Now it is a 3rd party one.
  Also "ruby-oci8" is a required gem for CRuby, not for JRuby.

  - Remove oracle entry for JRuby since Oracle enhanced adapter
  supports both CRuby and JRuby with a single gem.

  - Change adapter name from `oracle` to `oracle_enhanced` in the oracle.yml.
  Not changing `-d oracle`

  - Update `DATABASE_URL` entry to use a dash instead of an underscore
  Refer https://github.com/rails/rails/commit/d72a0cbc807a14d3eec02a53317d11b9d9fa5815 for the reason.
