### PR TITLE
Do not take screenshot if driver does not support screenshot

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -22,7 +22,7 @@ module ActionDispatch
         # fails add +take_failed_screenshot+ to the teardown block before clearing
         # sessions.
         def take_failed_screenshot
-          take_screenshot if failed?
+          take_screenshot if failed? && supports_screenshot?
         end
 
         private
@@ -54,6 +54,10 @@ module ActionDispatch
 
           def failed?
             !passed? && !skipped?
+          end
+
+          def supports_screenshot?
+            page.driver.public_methods(false).include?(:save_screenshot)
           end
       end
     end

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -1,5 +1,6 @@
 require "abstract_unit"
 require "action_dispatch/system_testing/test_helpers/screenshot_helper"
+require "capybara/dsl"
 
 class ScreenshotHelperTest < ActiveSupport::TestCase
   test "image path is saved in tmp directory" do
@@ -23,6 +24,30 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
       new_test.stub :skipped?, true do
         assert_equal "tmp/screenshots/x.png", new_test.send(:image_path)
       end
+    end
+  end
+
+  test "rack_test driver does not support screenshot" do
+    begin
+      original_driver = Capybara.current_driver
+      Capybara.current_driver = :rack_test
+
+      new_test = ActionDispatch::SystemTestCase.new("x")
+      assert_not new_test.send(:supports_screenshot?)
+    ensure
+      Capybara.current_driver = original_driver
+    end
+  end
+
+  test "selenium driver supports screenshot" do
+    begin
+      original_driver = Capybara.current_driver
+      Capybara.current_driver = :selenium
+
+      new_test = ActionDispatch::SystemTestCase.new("x")
+      assert new_test.send(:supports_screenshot?)
+    ensure
+      Capybara.current_driver = original_driver
     end
   end
 end


### PR DESCRIPTION
`Capybara::RackTest::Driver` does not support taking screenshots. If call
`#save_screenshot` on `Capybara::RackTest::Driver` will raise the error.

```ruby
Error:
UsersTest#test_visiting_the_index:
Capybara::NotSupportedByDriverError: Capybara::Driver::Base#save_screenshot
```

To prevent errors, if driver does not support screenshot, do not call it.

