### PR TITLE
passing unique parameter to belongs_to wrongly

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -154,7 +154,7 @@ case, the column definition might look like this:
 
 ```ruby
 create_table :accounts do |t|
-  t.belongs_to :supplier, index: true, unique: true, foreign_key: true
+  t.belongs_to :supplier, index: { unique: true }, foreign_key: true
   # ...
 end
 ```


### PR DESCRIPTION
passing `unique` parameter to belongs_to not right

### Summary

the original code can't generate unique index:

```ruby
create_table :accounts do |t|
  t.belongs_to :supplier, index: true, unique: true, foreign_key: true
  # ...
end
```

the generated `schema.rb` is:

```ruby
create_table "accounts", force: :cascade do |t|
    t.string   "account_number"
    t.integer  "supplier_id"
    t.datetime "created_at",     null: false
    t.datetime "updated_at",     null: false
    t.index ["supplier_id"], name: "index_accounts_on_supplier_id"
 end
```

when change the migration code to:

```ruby
create_table :accounts do |t|
      t.string :account_number
      t.belongs_to :supplier, index: { unique: true }, foreign_key: true

      t.timestamps
end
```

the result is right:
```ruby
create_table "accounts", force: :cascade do |t|
    t.string   "account_number"
    t.integer  "supplier_id"
    t.datetime "created_at",     null: false
    t.datetime "updated_at",     null: false
    t.index ["supplier_id"], name: "index_accounts_on_supplier_id", unique: true
end
```


