### PR TITLE
rails server: Allow to explicitly specify whether to output Rails's log to stdout

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -132,13 +132,14 @@ module Rails
         desc: "Specifies whether to perform caching in development."
       class_option :restart, type: :boolean, default: nil, hide: true
       class_option :early_hints, type: :boolean, default: nil, desc: "Enables HTTP/2 early hints."
+      class_option :log_to_stdout, type: :boolean, default: nil, optional: true,
+        desc: "Whether to log to stdout. Enabled by default in development when not daemonized."
 
       def initialize(args, local_options, *)
         super
 
         @original_options = local_options - %w( --restart )
         deprecate_positional_rack_server_and_rewrite_to_option(@original_options)
-        @log_stdout = options[:daemon].blank? && (options[:environment] || Rails.env) == "development"
       end
 
       def perform
@@ -166,7 +167,7 @@ module Rails
           {
             user_supplied_options: user_supplied_options,
             server:                using,
-            log_stdout:            @log_stdout,
+            log_stdout:            log_to_stdout?,
             Port:                  port,
             Host:                  host,
             DoNotReverseLookup:    true,
@@ -254,6 +255,12 @@ module Rails
 
         def early_hints
           options[:early_hints]
+        end
+
+        def log_to_stdout?
+          options.fetch(:log_to_stdout) do
+            options[:daemon].blank? && environment == "development"
+          end
         end
 
         def pid

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -143,9 +143,21 @@ class Rails::Command::ServerCommandTest < ActiveSupport::TestCase
         options = parse_arguments(args)
         assert_equal true, options[:log_stdout]
 
+        args    = ["-e", "development", "-d"]
+        options = parse_arguments(args)
+        assert_equal false, options[:log_stdout]
+
         args    = ["-e", "production"]
         options = parse_arguments(args)
         assert_equal false, options[:log_stdout]
+
+        args    = ["-e", "development", "--no-log-to-stdout"]
+        options = parse_arguments(args)
+        assert_equal false, options[:log_stdout]
+
+        args    = ["-e", "production", "--log-to-stdout"]
+        options = parse_arguments(args)
+        assert_equal true, options[:log_stdout]
 
         with_rack_env "development" do
           args    = []


### PR DESCRIPTION
### Summary

Allow to explicitly specify whether to output Rails's log to stdout

Before Rails' logger output is mirrored to std out if:

	* environment is development and
	* the process is not daemonized

It was not possible to change that behaviour, e.g. to disable log output
in that case or enable it in other cases.

Now you can explicitly disable or enable output with the new command
line switch `-l`, regardless of any other circumstances.

```
// enable output even in production
rails server -e production -l

// disable output in development
rails server -e development -l false
```

Enabling output when daemonized still makes no sense (since tty is
detached), so the flag is ignored then and daemonizing always disables
output.

If the command line flag `-l` is not specified, the old behaviour still
applies, so this change is completely backward compatible.