### PR TITLE
Remove `node` parameter to `join_constraints`

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -171,7 +171,7 @@ module ActiveRecord
           chain         = child.reflection.chain
           foreign_table = parent.table
           foreign_klass = parent.base_klass
-          child.join_constraints(foreign_table, foreign_klass, child, join_type, tables, chain)
+          child.join_constraints(foreign_table, foreign_klass, join_type, tables, chain)
         end
 
         def make_outer_joins(parent, child)

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -23,7 +23,7 @@ module ActiveRecord
 
         JoinInformation = Struct.new :joins, :binds
 
-        def join_constraints(foreign_table, foreign_klass, node, join_type, tables, chain)
+        def join_constraints(foreign_table, foreign_klass, join_type, tables, chain)
           joins         = []
           binds         = []
           tables        = tables.reverse
@@ -46,7 +46,7 @@ module ActiveRecord
                 item
               else
                 ActiveRecord::Relation.create(klass, table, predicate_builder)
-                  .instance_exec(node, &item)
+                  .instance_exec(&item)
               end
             end
 


### PR DESCRIPTION
I don't think we actually need this parameter anymore.  Nobody seems to
be using it.