### PR TITLE
Add show_first to Array#to_sentence

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Add options `show_first` and `hidden_items_word` to ActiveSupport's
+    `Array#to_sentence`.
+
+    It is sometimes helpful to only show a subset of long lists when using
+    `to_sentence`. Let's say you have a dashboard that displays the names of
+    people who have sent you a message and it's been awhile since your last
+    login.
+
+    Instead of seeing this:
+
+        senders.to_sentence + " left you messages"
+        # => "Paul Smith, Heidi Adler, Anna White, Jacob Winkler, Sam Summers,
+        Emma Jones, Chad Young and Joe Schmoe left you messages."
+
+    You could see this:
+
+        senders.to_sentence(show_first: 2, hidden_items_word: "other person") +
+          " left you messages"
+        # => "Paul Smith, Heidi Adler, and 4 other people left you messages."
+
+    *Paul Smith*
+
 *   Deprecate implicit coercion of `ActiveSupport::Duration`
 
     Currently `ActiveSupport::Duration` implicitly converts to a seconds

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -25,6 +25,14 @@ class ToSentenceTest < ActiveSupport::TestCase
     assert_equal "one, two and three", ["one", "two", "three"].to_sentence(last_word_connector: " and ")
   end
 
+  def test_to_sentence_with_show_first
+    assert_equal "one and 2 others", ["one", "two", "three"].to_sentence(show_first: 1)
+    assert_equal "one and also 2 others", ["one", "two", "three"].to_sentence(two_words_connector: " and also ", show_first: 1)
+    assert_equal "one, two, and 1 other", ["one", "two", "three"].to_sentence(show_first: 2)
+    assert_equal "one, two, and also 1 other", ["one", "two", "three"].to_sentence(last_word_connector: ", and also ", show_first: 2)
+    assert_equal "one, two, and three", ["one", "two", "three"].to_sentence(show_first: 3)
+  end
+
   def test_two_elements
     assert_equal "one and two", ["one", "two"].to_sentence
     assert_equal "one two", ["one", "two"].to_sentence(two_words_connector: " ")
@@ -58,7 +66,7 @@ class ToSentenceTest < ActiveSupport::TestCase
       ["one", "two"].to_sentence(passing: "invalid option")
     end
 
-    assert_equal exception.message, "Unknown key: :passing. Valid keys are: :words_connector, :two_words_connector, :last_word_connector, :locale"
+    assert_equal exception.message, "Unknown key: :passing. Valid keys are: :words_connector, :two_words_connector, :last_word_connector, :locale, :show_first, :hidden_items_word"
   end
 
   def test_always_returns_string

--- a/activesupport/test/i18n_test.rb
+++ b/activesupport/test/i18n_test.rb
@@ -88,14 +88,18 @@ class I18nTest < ActiveSupport::TestCase
   def test_to_sentence
     default_two_words_connector = I18n.translate(:'support.array.two_words_connector')
     default_last_word_connector = I18n.translate(:'support.array.last_word_connector')
+    default_hidden_items_word = I18n.translate(:'support.array.hidden_items_word')
     assert_equal "a, b, and c", %w[a b c].to_sentence
     I18n.backend.store_translations "en", support: { array: { two_words_connector: " & " } }
     assert_equal "a & b", %w[a b].to_sentence
     I18n.backend.store_translations "en", support: { array: { last_word_connector: " and " } }
     assert_equal "a, b and c", %w[a b c].to_sentence
+    I18n.backend.store_translations "en", support: { array: { hidden_items_word: "otro" } }
+    assert_equal "a & 2 otros", %w[a b c].to_sentence(show_first: 1)
   ensure
     I18n.backend.store_translations "en", support: { array: { two_words_connector: default_two_words_connector } }
     I18n.backend.store_translations "en", support: { array: { last_word_connector: default_last_word_connector } }
+    I18n.backend.store_translations "en", support: { array: { hidden_items_word: default_hidden_items_word } }
   end
 
   def test_to_sentence_with_empty_i18n_store


### PR DESCRIPTION
It is helpful to be able to only show a certain portion of long lists
when using `to_sentence`. Let's say you have a dashboard that displays
the names of people who have sent you a message and it's been awhile
since your last login.

Instead of seeing this:

    senders.to_sentence + " left you messages"
    # => "Paul Smith, Heidi Adler, Anna White, Jacob Winkler, Sam
    Bing, Emma Jones, Chad Young and Joe Schmoe left you messages."

You could see this:

    senders.to_sentence(show_first: 2, hidden_items_word: "other person") + " left you messages"
    # => "Paul Smith, Heidi Adler, and 4 other people left you messages."

## Other ideas for the option name

* `to_sentence(hide_after_first: 2)`
* `to_sentence(only_show: 2)`
* `to_sentence(only_show_first: 2)`

Thanks for taking a look ❤️ 