### PR TITLE
Don't accidentally lose includes in serialization

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,6 @@
+*   Don't only take the first hash key in serialization :includes. Doing so silently loses options in `includes: [:account, {address: {only: id}, user: {only: id}]`
+
+    *Mike Mangino*
 ## Rails 5.1.0.beta1 (February 23, 2017) ##
 
 *   Remove deprecated behavior that halts callbacks when the return is false.

--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -177,7 +177,7 @@ module ActiveModel
         return unless includes = options[:include]
 
         unless includes.is_a?(Hash)
-          includes = Hash[Array(includes).map { |n| n.is_a?(Hash) ? n.to_a.first : [n, {}] }]
+          includes = Hash[Array(includes).flat_map { |n| n.is_a?(Hash) ? n.to_a : [[n, {}]] }]
         end
 
         includes.each do |association, opts|

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -144,6 +144,12 @@ class SerializationTest < ActiveModel::TestCase
     assert_equal expected, @user.serializable_hash(include: { address: { only: "street" } })
   end
 
+  def test_multiple_includes_with_options
+    expected = { "email" => "david@example.com", "gender" => "male", "name" => "David",
+                "address" => { "street" => "123 Lane" } }
+    assert_equal expected, @user.serializable_hash(include: { address: { only: "street" } })
+  end
+
   def test_nested_include
     @user.friends.first.friends = [@user]
     expected = { "email" => "david@example.com", "gender" => "male", "name" => "David",
@@ -168,8 +174,8 @@ class SerializationTest < ActiveModel::TestCase
   def test_multiple_includes_with_options
     expected = { "email" => "david@example.com", "gender" => "male", "name" => "David",
                 "address" => { "street" => "123 Lane" },
-                "friends" => [{ "name" => "Joe", "email" => "joe@example.com", "gender" => "male" },
-                           { "name" => "Sue", "email" => "sue@example.com", "gender" => "female" }] }
-    assert_equal expected, @user.serializable_hash(include: [{ address: { only: "street" } }, :friends])
+                "friends" => [{ "name" => "Joe" },
+                           { "name" => "Sue" }] }
+    assert_equal expected, @user.serializable_hash(include: [ address: { only: "street" } , friends: {only: "name"}])
   end
 end

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -176,6 +176,6 @@ class SerializationTest < ActiveModel::TestCase
                 "address" => { "street" => "123 Lane" },
                 "friends" => [{ "name" => "Joe" },
                            { "name" => "Sue" }] }
-    assert_equal expected, @user.serializable_hash(include: [ address: { only: "street" } , friends: {only: "name"}])
+    assert_equal expected, @user.serializable_hash(include: [ address: { only: "street" } , friends: { only: "name" }])
   end
 end


### PR DESCRIPTION
### Summary

We had a major production bug caused by an includes change that looks like this:

```
  includes: [:user,
                   :account,
                   templates: {only: :id},
                   addresses: {only: id}]
```

In this case, the last include is a single hash with two keys instead of two hashes with a single value. ActiveModel throws away all but the first key in this case, silently ignoring a passed option. This was tricky to find since it looks like addresses is provided, but you don't get addresses back.

This change will include all keys from a passed hash.

