### PR TITLE
Various refactoring to association scopes and joins

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -61,7 +61,7 @@ module ActiveRecord
         end
 
         def last_chain_scope(scope, table, reflection, owner, association_klass)
-          join_keys = reflection.join_keys(association_klass)
+          join_keys = reflection.join_keys
           key = join_keys.key
           foreign_key = join_keys.foreign_key
 
@@ -81,7 +81,7 @@ module ActiveRecord
         end
 
         def next_chain_scope(scope, table, reflection, association_klass, foreign_table, next_reflection)
-          join_keys = reflection.join_keys(association_klass)
+          join_keys = reflection.join_keys
           key = join_keys.key
           foreign_key = join_keys.foreign_key
 

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         chain_head, chain_tail = get_chain(reflection, association, alias_tracker)
 
         scope.extending! Array(reflection.options[:extend])
-        add_constraints(scope, owner, klass, reflection, chain_head, chain_tail)
+        add_constraints(scope, owner, reflection, chain_head, chain_tail)
       end
 
       def join_type
@@ -60,7 +60,7 @@ module ActiveRecord
           table.create_join(table, table.create_on(constraint), join_type)
         end
 
-        def last_chain_scope(scope, table, reflection, owner, association_klass)
+        def last_chain_scope(scope, table, reflection, owner)
           join_keys = reflection.join_keys
           key = join_keys.key
           foreign_key = join_keys.foreign_key
@@ -80,7 +80,7 @@ module ActiveRecord
           value_transformation.call(value)
         end
 
-        def next_chain_scope(scope, table, reflection, association_klass, foreign_table, next_reflection)
+        def next_chain_scope(scope, table, reflection, foreign_table, next_reflection)
           join_keys = reflection.join_keys
           key = join_keys.key
           foreign_key = join_keys.foreign_key
@@ -120,10 +120,10 @@ module ActiveRecord
           [runtime_reflection, previous_reflection]
         end
 
-        def add_constraints(scope, owner, association_klass, refl, chain_head, chain_tail)
+        def add_constraints(scope, owner, refl, chain_head, chain_tail)
           owner_reflection = chain_tail
           table = owner_reflection.alias_name
-          scope = last_chain_scope(scope, table, owner_reflection, owner, association_klass)
+          scope = last_chain_scope(scope, table, owner_reflection, owner)
 
           reflection = chain_head
           while reflection
@@ -132,7 +132,7 @@ module ActiveRecord
 
             unless reflection == chain_tail
               foreign_table = next_reflection.alias_name
-              scope = next_chain_scope(scope, table, reflection, association_klass, foreign_table, next_reflection)
+              scope = next_chain_scope(scope, table, reflection, foreign_table, next_reflection)
             end
 
             # Exclude the scope of the association itself, because that

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -42,20 +42,8 @@ module ActiveRecord
 
             predicate_builder = PredicateBuilder.new(TableMetadata.new(klass, table))
             scope_chain_items = reflection.join_scopes(table, predicate_builder)
+            klass_scope       = reflection.klass_join_scope(table, predicate_builder)
 
-            klass_scope =
-              if klass.current_scope
-                klass.current_scope.clone.tap { |scope|
-                  scope.joins_values = []
-                }
-              else
-                relation = ActiveRecord::Relation.create(
-                  klass,
-                  table,
-                  predicate_builder,
-                )
-                klass.send(:build_default_scope, relation)
-              end
             scope_chain_items.concat [klass_scope].compact
 
             rel = scope_chain_items.inject(scope_chain_items.shift) do |left, right|

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -34,7 +34,7 @@ module ActiveRecord
             table = tables.shift
             klass = reflection.klass
 
-            join_keys   = reflection.join_keys(klass)
+            join_keys   = reflection.join_keys
             key         = join_keys.key
             foreign_key = join_keys.foreign_key
 

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -41,14 +41,7 @@ module ActiveRecord
             constraint = build_constraint(klass, table, key, foreign_table, foreign_key)
 
             predicate_builder = PredicateBuilder.new(TableMetadata.new(klass, table))
-            scope_chain_items = reflection.scopes.map do |item|
-              if item.is_a?(Relation)
-                item
-              else
-                ActiveRecord::Relation.create(klass, table, predicate_builder)
-                  .instance_exec(&item)
-              end
-            end
+            scope_chain_items = reflection.join_scopes(table, predicate_builder)
 
             klass_scope =
               if klass.current_scope

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -173,7 +173,15 @@ module ActiveRecord
       JoinKeys = Struct.new(:key, :foreign_key) # :nodoc:
 
       def join_keys(association_klass)
-        JoinKeys.new(foreign_key, active_record_primary_key)
+        JoinKeys.new(join_pk(association_klass), join_fk)
+      end
+
+      def join_pk(klass)
+        foreign_key
+      end
+
+      def join_fk
+        active_record_primary_key
       end
 
       # Returns a list of scopes that should be applied for this Reflection
@@ -711,9 +719,12 @@ module ActiveRecord
         end
       end
 
-      def join_keys(association_klass)
-        key = polymorphic? ? association_primary_key(association_klass) : association_primary_key
-        JoinKeys.new(key, foreign_key)
+      def join_fk
+        foreign_key
+      end
+
+      def join_pk(klass)
+        polymorphic? ? association_primary_key(klass) : association_primary_key
       end
 
       def join_id_for(owner) # :nodoc:

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -196,6 +196,21 @@ module ActiveRecord
         end
       end
 
+      def klass_join_scope(table, predicate_builder) # :nodoc:
+        if klass.current_scope
+          klass.current_scope.clone.tap { |scope|
+            scope.joins_values = []
+          }
+        else
+          relation = ActiveRecord::Relation.create(
+            klass,
+            table,
+            predicate_builder,
+          )
+          klass.send(:build_default_scope, relation)
+        end
+      end
+
       def constraints
         chain.map(&:scopes).flatten
       end


### PR DESCRIPTION
The two main changes are:

1. Introduce `join_scopes` that returns a homogeneous array of `Relation` objects.  This means we can skip doing an `is_a?` check and building an intermediate array.
2. Remove the parameter to `join_keys`.  This means we can call `join_keys` on a reflection without context, so we don't have to pass a "klass" object everywhere.