### PR TITLE
Reset path_parameters every time a route fails to match

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   ActionDispatch::Routing::RouteSet#recognize_path resets path_parameters every time a route fails to match
+
+    *Hiroyuki Ishii*
+
 *   Fix `NameError` raised in `ActionController::Renderer#with_defaults`
 
     *Hiroyuki Ishii*

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -871,6 +871,8 @@ module ActionDispatch
             end
 
             return req.path_parameters
+          else
+            req.path_parameters = {}
           end
         end
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1601,6 +1601,19 @@ class RouteSetTest < ActiveSupport::TestCase
     assert_equal(name_param, "mypage")
   end
 
+  def test_route_with_constraints_and_defaults_must_receive_params
+    set.draw do
+      scope constraints: lambda { |_| false }, defaults: { subdomain: "subdomain" } do
+        get "/", to: "posts#index"
+      end
+
+      get "/", to: "posts#index"
+    end
+
+    assert_equal({ controller: "posts", action: "index" },
+      set.recognize_path("http://example.org/"))
+  end
+
   def test_route_requirement_recognize_with_ignore_case
     set.draw do
       get "page/:name" => "pages#show",


### PR DESCRIPTION
### Summary

Fixes bug `ActionDispatch::Routing::RouteSet#recognize_path`. 
`request.path_parameters` is always merged with `defaults` even though route is not matched.

```
Rails.application.routes.draw do
  scope constraints: lambda { |_| false }, defaults: { subdomain: 'default_subdomain' } do
    get '/', to: 'posts#index'
  end

  scope constraints: lambda { |_| false }, defaults: { format: 'default_format' } do
    get '/', to: 'posts#index'
  end

  get '/', to: 'posts#index'
end

Rails.application.routes.recognize_path('/')
# expected: {:controller=>"posts", :action=>"index"}
# got: {:subdomain=>"default_subdomain", :controller=>"posts", :action=>"index", :format=>"default_format"}
```