### PR TITLE
[ci skip] Correcting operator '=' to '>' in WHERE condition

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1547,7 +1547,7 @@ SELECT people.id, people.name, comments.text
 FROM people
 INNER JOIN comments
   ON comments.person_id = people.id
-WHERE comments.created_at = '2015-01-01'
+WHERE (comments.created_at > '2014-12-25')
 ```
 
 ### Retrieving specific data from multiple tables


### PR DESCRIPTION
I changed the operator `=` to `>`   and `'2015-01-01'` to the date a week ago, `'2014-12-25'`  in WHERE condition. Regards 