### PR TITLE
Don't share `options` with a reference type column

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -116,16 +116,12 @@ module ActiveRecord
 
       private
 
-        def as_options(value, default = {})
-          if value.is_a?(Hash)
-            value
-          else
-            default
-          end
+        def as_options(value)
+          value.is_a?(Hash) ? value : {}
         end
 
         def polymorphic_options
-          as_options(polymorphic, options)
+          as_options(polymorphic)
         end
 
         def index_options

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -50,6 +50,13 @@ module ActiveRecord
         assert column_exists?(table_name, :taggable_type, :string, default: "Photo")
       end
 
+      def test_does_not_share_options_with_reference_type_column
+        add_reference table_name, :taggable, type: :integer, limit: 2, polymorphic: true
+        assert column_exists?(table_name, :taggable_id, :integer, limit: 2)
+        assert column_exists?(table_name, :taggable_type, :string)
+        assert_not column_exists?(table_name, :taggable_type, :string, limit: 2)
+      end
+
       def test_creates_named_index
         add_reference table_name, :tag, index: { name: "index_taggings_on_tag_id" }
         assert index_exists?(table_name, :tag_id, name: "index_taggings_on_tag_id")


### PR DESCRIPTION
Sharing `options` causes some unexpected behavior. If `limit: 2` is
specified, this means that 2 bytes integer for a reference id column and
2 chars string for a reference type column. Another example, if
`unsigned: true` is specified, this means that unsigned integer for a
reference id column, but a invalid option for a reference type column.
So `options` should not be shared with a reference type column.