### PR TITLE
Silence puma startup messages in system test

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/server.rb
+++ b/actionpack/lib/action_dispatch/system_testing/server.rb
@@ -11,7 +11,7 @@ module ActionDispatch
       private
         def register
           Capybara.register_server :rails_puma do |app, port, host|
-            Rack::Handler::Puma.run(app, Port: port, Threads: "0:1")
+            Rack::Handler::Puma.run(app, Port: port, Threads: "0:1", Silent: true)
           end
         end
 


### PR DESCRIPTION
Fixes #28109

#
### Before 

```  
./bin/rails t test/system/users_test.rb
Run options: --seed 47104

# Running:

Puma starting in single mode...
* Version 3.7.1 (ruby 2.4.0-p0), codename: Snowy Sagebrush
* Min threads: 0, max threads: 1
* Environment: test
* Listening on tcp://0.0.0.0:38533
Use Ctrl-C to stop
.

Finished in 0.860479s, 1.1621 runs/s, 0.0000 assertions/s.

1 runs, 0 assertions, 0 failures, 0 errors, 0 skips 
```

### After 

```
./bin/rails t test/system/users_test.rb
Run options: --seed 4543

# Running:

.

Finished in 0.824712s, 1.2125 runs/s, 0.0000 assertions/s.

1 runs, 0 assertions, 0 failures, 0 errors, 0 skips 
```
