### PR TITLE
Avoid running system tests by default

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -730,6 +730,9 @@ Run the system tests.
 bin/rails test:system
 ```
 
+NOTE: By default, running `bin/rails test` won't run your system tests.
+Make sure to run `bin/rails test:system` to actually run them.
+
 #### Creating articles system test
 
 Now let's test the flow for creating a new article in our blog.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Avoid running system tests by default with the `bin/rails test`
+    and `bin/rake test` commands since they may be expansive.
+
+    *Robin Dupret* (#28286)
+
 *   Improve encryption for encrypted secrets.
 
     Switch to aes-128-gcm authenticated encryption. Also generate a random

--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -62,9 +62,9 @@ module Minitest
     options[:patterns] = opts.order! unless run_via.rake?
   end
 
-  def self.rake_run(patterns) # :nodoc:
+  def self.rake_run(patterns, exclude_patterns = []) # :nodoc:
     self.run_via = :rake unless run_via.set?
-    ::Rails::TestRequirer.require_files(patterns)
+    ::Rails::TestRequirer.require_files(patterns, exclude_patterns)
     autorun
   end
 
@@ -88,7 +88,13 @@ module Minitest
     # If run via `ruby` we've been passed the files to run directly, or if run
     # via `rake` then they have already been eagerly required.
     unless run_via.ruby? || run_via.rake?
-      ::Rails::TestRequirer.require_files(options[:patterns])
+      # If there are no given patterns, we can assume that the user
+      # simply runs the `bin/rails test` command without extra arguments.
+      if options[:patterns].empty?
+        ::Rails::TestRequirer.require_files(options[:patterns], ["test/system/**/*"])
+      else
+        ::Rails::TestRequirer.require_files(options[:patterns])
+      end
     end
 
     unless options[:full_backtrace] || ENV["BACKTRACE"]

--- a/railties/lib/rails/test_unit/test_requirer.rb
+++ b/railties/lib/rails/test_unit/test_requirer.rb
@@ -4,10 +4,13 @@ require "rake/file_list"
 module Rails
   class TestRequirer # :nodoc:
     class << self
-      def require_files(patterns)
+      def require_files(patterns, exclude_patterns = [])
         patterns = expand_patterns(patterns)
 
-        Rake::FileList[patterns.compact.presence || "test/**/*_test.rb"].to_a.each do |file|
+        file_list = Rake::FileList[patterns.compact.presence || "test/**/*_test.rb"]
+        file_list.exclude(exclude_patterns)
+
+        file_list.to_a.each do |file|
           require File.expand_path(file)
         end
       end

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -4,15 +4,15 @@ require "rails/test_unit/minitest_plugin"
 
 task default: :test
 
-desc "Runs all tests in test folder"
+desc "Runs all tests in test folder except system ones"
 task :test do
   $: << "test"
-  pattern = if ENV.key?("TEST")
-    ENV["TEST"]
+
+  if ENV.key?("TEST")
+    Minitest.rake_run([ENV["TEST"]])
   else
-    "test"
+    Minitest.rake_run(["test"], ["test/system/**/*"])
   end
-  Minitest.rake_run([pattern])
 end
 
 namespace :test do

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -604,6 +604,52 @@ module ApplicationTests
       end
     end
 
+    def test_system_tests_are_not_run_with_the_default_test_command
+      app_file "test/system/dummy_test.rb", <<-RUBY
+        require "application_system_test_case"
+
+        class DummyTest < ApplicationSystemTestCase
+          test "something" do
+            assert true
+          end
+        end
+      RUBY
+
+      run_test_command("").tap do |output|
+        assert_match "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips", output
+      end
+    end
+
+    def test_system_tests_are_not_run_through_rake_test
+      app_file "test/system/dummy_test.rb", <<-RUBY
+        require "application_system_test_case"
+
+        class DummyTest < ApplicationSystemTestCase
+          test "something" do
+            assert true
+          end
+        end
+      RUBY
+
+      output = Dir.chdir(app_path) { `bin/rake test` }
+      assert_match "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips", output
+    end
+
+    def test_system_tests_are_run_through_rake_test_when_given_in_TEST
+      app_file "test/system/dummy_test.rb", <<-RUBY
+        require "application_system_test_case"
+
+        class DummyTest < ApplicationSystemTestCase
+          test "something" do
+            assert true
+          end
+        end
+      RUBY
+
+      output = Dir.chdir(app_path) { `bin/rake test TEST=test/system/dummy_test.rb` }
+      assert_match "1 runs, 1 assertions, 0 failures, 0 errors, 0 skips", output
+    end
+
     private
       def run_test_command(arguments = "test/unit/test_test.rb")
         Dir.chdir(app_path) { `bin/rails t #{arguments}` }


### PR DESCRIPTION
Hello,

This is a follow-up to #28283 to address Eileen's comment in #28109:

> system tests aren't supposed to run with the whole suite

These tests may be expansive so let's only allow users to run them through `bin/rails test:system` or by passing a path to the `test` command.

Have a nice day ! :-)