### PR TITLE
Fix `rake db:schema:load` with subdirectories

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `rake db:schema:load` with subdirectories.
+
+    *Ryuta Kamizono*
+
 *   Fix `rake db:migrate:status` with subdirectories.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1022,15 +1022,14 @@ module ActiveRecord
         { primary_key: true }
       end
 
-      def assume_migrated_upto_version(version, migrations_paths)
-        migrations_paths = Array(migrations_paths)
+      def assume_migrated_upto_version(version, paths) # :nodoc:
+        paths = Array(paths)
         version = version.to_i
         sm_table = quote_table_name(ActiveRecord::Migrator.schema_migrations_table_name)
 
         migrated = select_values("SELECT version FROM #{sm_table}").map(&:to_i)
-        paths = migrations_paths.map { |p| "#{p}/[0-9]*_*.rb" }
-        versions = Dir[*paths].map do |filename|
-          filename.split("/").last.split("_").first.to_i
+        versions = ActiveRecord::Migrator.migration_files(paths).map do |file|
+          ActiveRecord::Migrator.parse_migration_filename(file).first.to_i
         end
 
         unless migrated.include?(version)

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -152,6 +152,23 @@ class MigratorTest < ActiveRecord::TestCase
     ], ActiveRecord::Migrator.migrations_status(path)
   end
 
+  def test_migrations_status_with_schema_define_in_subdirectories
+    path = MIGRATIONS_ROOT + "/valid_with_subdirectories"
+    prev_paths = ActiveRecord::Migrator.migrations_paths
+    ActiveRecord::Migrator.migrations_paths = path
+
+    ActiveRecord::Schema.define(version: 3) do
+    end
+
+    assert_equal [
+      ["up", "001", "Valid people have last names"],
+      ["up", "002", "We need reminders"],
+      ["up", "003", "Innocent jointable"],
+    ], ActiveRecord::Migrator.migrations_status(path)
+  ensure
+    ActiveRecord::Migrator.migrations_paths = prev_paths
+  end
+
   def test_migrations_status_from_two_directories
     paths = [MIGRATIONS_ROOT + "/valid_with_timestamps", MIGRATIONS_ROOT + "/to_copy_with_timestamps"]
 


### PR DESCRIPTION
Related #25174.

`db:schema:load` doesn't work with subdirectories like previous
`db:migrate:status`. `Migrator.migration_files` should be used in
`assume_migrated_upto_version` to fix the issue.

@pixeltrix Could you also review this?