### PR TITLE
[ci skip] Fix ParameterMissing exception name in docs

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -862,7 +862,7 @@ module ActionController
   #     end
   #
   #     # This will pass with flying colors as long as there's a person key in the
-  #     # parameters, otherwise it'll raise an ActionController::MissingParameter
+  #     # parameters, otherwise it'll raise an ActionController::ParameterMissing
   #     # exception, which will get caught by ActionController::Base and turned
   #     # into a 400 Bad Request reply.
   #     def update


### PR DESCRIPTION
### Summary

Should be `ActionController::ParameterMissing` and not `ActionController::MissingParameter`.

### Other Information

Corresponding change was done in guides in https://github.com/rails/rails/pull/9816.
