### PR TITLE
Deprecate #where with blank condition

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `ActiveRecord::QueryMethods#where` with blank condition.
+
+    *bogdanvlviv*
+
 *   Fix `rake db:schema:load` with subdirectories.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -591,15 +591,15 @@ module ActiveRecord
     #    # SELECT * FROM users WHERE name != 'Jon'
     #
     # See WhereChain for more details on #not.
-    #
-    # === blank condition
-    #
-    # If the condition is any blank-ish object, then #where is a no-op and returns
-    # the current relation.
     def where(opts = :chain, *rest)
       if :chain == opts
         WhereChain.new(spawn)
       elsif opts.blank?
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          Query with blank condition is deprecated and will raise an
+          exception in Rails 5.3.
+        MSG
+
         self
       else
         spawn.where!(opts, *rest)

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -219,8 +219,10 @@ module ActiveRecord
     end
 
     def test_where_with_blank_conditions
-      [[], {}, nil, ""].each do |blank|
-        assert_equal 4, Edge.where(blank).order("sink_id").to_a.size
+      [[], {}, nil, false, ""].each do |blank|
+        assert_deprecated do
+          assert_equal Edge.count, Edge.where(blank).to_a.size
+        end
       end
     end
 


### PR DESCRIPTION
Before:
```ruby
Post.where(false) # Returns all posts records
Post.where(nil) # Returns all records

Post.find_by(false) # Returns one post record
Post.find_by(nil) # Returns one post record
```

After:
```ruby
Post.where(false) # => ArgumentError: Unsupported argument type: false (FalseClass)
Post.where(nil) # => ArgumentError: Unsupported argument type:  (NilClass)

Post.find_by(false) # => ArgumentError: Unsupported argument type: false (FalseClass)
Post.find_by(nil) # => ArgumentError: Unsupported argument type:  (NilClass)
```