### PR TITLE
Remove useless `Migrator.schema_migrations_table_name`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -996,7 +996,7 @@ module ActiveRecord
       end
 
       def insert_versions_sql(versions) # :nodoc:
-        sm_table = quote_table_name(ActiveRecord::Migrator.schema_migrations_table_name)
+        sm_table = quote_table_name(ActiveRecord::SchemaMigration.table_name)
 
         if versions.is_a?(Array)
           sql = "INSERT INTO #{sm_table} (version) VALUES\n"
@@ -1025,7 +1025,7 @@ module ActiveRecord
       def assume_migrated_upto_version(version, migrations_paths)
         migrations_paths = Array(migrations_paths)
         version = version.to_i
-        sm_table = quote_table_name(ActiveRecord::Migrator.schema_migrations_table_name)
+        sm_table = quote_table_name(ActiveRecord::SchemaMigration.table_name)
 
         migrated = select_values("SELECT version FROM #{sm_table}").map(&:to_i)
         versions = ActiveRecord::Migrator.migration_files(migrations_paths).map do |file|

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1022,12 +1022,8 @@ module ActiveRecord
         new(:up, migrations(migrations_paths), nil)
       end
 
-      def schema_migrations_table_name
-        SchemaMigration.table_name
-      end
-
       def get_all_versions(connection = Base.connection)
-        if connection.table_exists?(schema_migrations_table_name)
+        if SchemaMigration.table_exists?
           SchemaMigration.all.map { |x| x.version.to_i }.sort
         else
           []

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -337,20 +337,20 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_schema_migrations_table_name
-    original_schema_migrations_table_name = ActiveRecord::Migrator.schema_migrations_table_name
+    original_schema_migrations_table_name = ActiveRecord::Base.schema_migrations_table_name
 
-    assert_equal "schema_migrations", ActiveRecord::Migrator.schema_migrations_table_name
+    assert_equal "schema_migrations", ActiveRecord::SchemaMigration.table_name
     ActiveRecord::Base.table_name_prefix = "prefix_"
     ActiveRecord::Base.table_name_suffix = "_suffix"
     Reminder.reset_table_name
-    assert_equal "prefix_schema_migrations_suffix", ActiveRecord::Migrator.schema_migrations_table_name
+    assert_equal "prefix_schema_migrations_suffix", ActiveRecord::SchemaMigration.table_name
     ActiveRecord::Base.schema_migrations_table_name = "changed"
     Reminder.reset_table_name
-    assert_equal "prefix_changed_suffix", ActiveRecord::Migrator.schema_migrations_table_name
+    assert_equal "prefix_changed_suffix", ActiveRecord::SchemaMigration.table_name
     ActiveRecord::Base.table_name_prefix = ""
     ActiveRecord::Base.table_name_suffix = ""
     Reminder.reset_table_name
-    assert_equal "changed", ActiveRecord::Migrator.schema_migrations_table_name
+    assert_equal "changed", ActiveRecord::SchemaMigration.table_name
   ensure
     ActiveRecord::Base.schema_migrations_table_name = original_schema_migrations_table_name
     Reminder.reset_table_name


### PR DESCRIPTION
Simply use `SchemaMigration.table_name` instead.