### PR TITLE
Deprecate passing a connection to `Migration.check_pending!`

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -552,17 +552,11 @@ module ActiveRecord
       def call(env)
         mtime = ActiveRecord::Migrator.last_migration.mtime.to_i
         if @last_check < mtime
-          ActiveRecord::Migration.check_pending!(connection)
+          ActiveRecord::Migration.check_pending!
           @last_check = mtime
         end
         @app.call(env)
       end
-
-      private
-
-        def connection
-          ActiveRecord::Base.connection
-        end
     end
 
     class << self
@@ -574,8 +568,12 @@ module ActiveRecord
       end
 
       # Raises <tt>ActiveRecord::PendingMigrationError</tt> error if any migrations are pending.
-      def check_pending!(connection = Base.connection)
-        raise ActiveRecord::PendingMigrationError if ActiveRecord::Migrator.needs_migration?(connection)
+      def check_pending!(connection = nil)
+        if connection
+          ActiveSupport::Deprecation.warn \
+            "Passing a connection is deprecated and will be removed in Rails 6.0."
+        end
+        raise ActiveRecord::PendingMigrationError if ActiveRecord::Migrator.needs_migration?
       end
 
       def load_schema_if_pending!
@@ -1053,12 +1051,12 @@ module ActiveRecord
         end
       end
 
-      def current_version(connection = nil)
+      def current_version
         get_all_versions.max || 0
       rescue ActiveRecord::NoDatabaseError
       end
 
-      def needs_migration?(connection = nil)
+      def needs_migration?
         (migrations(migrations_paths).collect(&:version) - get_all_versions).size > 0
       end
 


### PR DESCRIPTION
Propagating a connection was to do
`connection.table_exists?(schema_migrations_table_name)`.
Simply use `SchemaMigration.table_exists?` instead.