### PR TITLE
Fix `direct` with params example [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -2054,7 +2054,7 @@ module ActionDispatch
         # your url helper definition, e.g:
         #
         #   direct :browse, page: 1, size: 10 do |options|
-        #     [ :products, options.merge(params.permit(:page, :size)) ]
+        #     [ :products, options.merge(params.permit(:page, :size).to_h.symbolize_keys) ]
         #   end
         #
         # In this instance the `params` object comes from the context in which the the


### PR DESCRIPTION
Since `ActionController:Parameters` does not inherit `Hash`, need to explicitly convert it to `Hash`.
Also, `Parameters#to_h` returns `Hash` whose key is `String`. Therefore, if merge as it is, the value will not be overwritten as expected.
