### PR TITLE
Accept requests sent with no-referrer in Chrome

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -398,7 +398,9 @@ module ActionController #:nodoc:
       def valid_request_origin?
         if forgery_protection_origin_check
           # We accept blank origin headers because some user agents don't send it.
-          request.origin.nil? || request.origin == request.base_url
+          # Chrome sends "null" instead of not sending the Origin header when the folling is set in head:
+          # <meta name="referrer" content="no-referrer">
+          request.origin.nil? || request.origin == "null" || request.origin == request.base_url
         else
           true
         end


### PR DESCRIPTION
### Summary
Fixes https://github.com/rails/rails/issues/28299

When a meta tag is set for referrer=no-referrer, Firefox omits the Origin header while Chrome sets it to a string containing "null."  This change ensures Rails behaves consistently across browsers.
