### PR TITLE
Extract `SchemaMigration.all_versions`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -991,7 +991,7 @@ module ActiveRecord
       end
 
       def dump_schema_information #:nodoc:
-        versions = ActiveRecord::SchemaMigration.order("version").pluck(:version)
+        versions = ActiveRecord::SchemaMigration.all_versions
         insert_versions_sql(versions)
       end
 
@@ -1027,7 +1027,7 @@ module ActiveRecord
         version = version.to_i
         sm_table = quote_table_name(ActiveRecord::SchemaMigration.table_name)
 
-        migrated = select_values("SELECT version FROM #{sm_table}").map(&:to_i)
+        migrated = ActiveRecord::SchemaMigration.all_versions.map(&:to_i)
         versions = ActiveRecord::Migrator.migration_files(migrations_paths).map do |file|
           ActiveRecord::Migrator.parse_migration_filename(file).first.to_i
         end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1024,7 +1024,7 @@ module ActiveRecord
 
       def get_all_versions(connection = Base.connection)
         if SchemaMigration.table_exists?
-          SchemaMigration.all.map { |x| x.version.to_i }.sort
+          SchemaMigration.all_versions.map(&:to_i)
         else
           []
         end

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -39,7 +39,11 @@ module ActiveRecord
       end
 
       def normalized_versions
-        pluck(:version).map { |v| normalize_migration_number v }
+        all_versions.map { |v| normalize_migration_number v }
+      end
+
+      def all_versions
+        order(:version).pluck(:version)
       end
     end
 


### PR DESCRIPTION
Use `SchemaMigration.all_versions` instead of
`SchemaMigration.all.map(&:version)` to avoid to instantiate AR objects.