### PR TITLE
Allow unscoping of left_outer_joins

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -348,7 +348,7 @@ module ActiveRecord
 
     VALID_UNSCOPING_VALUES = Set.new([:where, :select, :group, :order, :lock,
                                      :limit, :offset, :joins, :includes, :from,
-                                     :readonly, :having])
+                                     :readonly, :having, :left_outer_joins])
 
     # Removes an unwanted relation that is already defined on a chain of relations.
     # This is useful when passing around chains of relations and would like to


### PR DESCRIPTION
### Summary

This one is simple.

The new `left_outer_joins` method can be unscoped with `unscope` method pretty well if it's just white-listed in Relation::QueryMethods.
