### PR TITLE
Fix typo on edgeguides

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -53,7 +53,7 @@ module ApplicationCable
 
     private
       def find_verified_user
-        if current_user = User.find_by(id: cookies.signed[:user_id])
+        if current_user == User.find_by(id: cookies.signed[:user_id])
           current_user
         else
           reject_unauthorized_connection

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -64,7 +64,7 @@ module ApplicationCable
 
     private
       def find_verified_user
-        if current_user = User.find_by(id: cookies.signed[:user_id])
+        if current_user == User.find_by(id: cookies.signed[:user_id])
           current_user
         else
           reject_unauthorized_connection


### PR DESCRIPTION
* Use comparison operator instead of assignment operator.
