### PR TITLE
Backport Send user_supplied_options to server

### DIFF
--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -11,9 +11,13 @@ module Rails
 
       def parse!(args)
         args, options = args.dup, {}
+        options[:user_supplied_options] = []
+        options[:user_supplied_options] << :Host if ENV["Host"]
+        options[:user_supplied_options] << :Port if ENV["PORT"]
 
         option_parser(options).parse! args
 
+        options[:user_supplied_options].uniq!
         options[:log_stdout] = options[:daemonize].blank? && (options[:environment] || Rails.env) == "development"
         options[:server]     = args.shift
         options
@@ -25,21 +29,42 @@ module Rails
         OptionParser.new do |opts|
           opts.banner = "Usage: rails server [mongrel, thin etc] [options]"
           opts.on("-p", "--port=port", Integer,
-                  "Runs Rails on the specified port.", "Default: 3000") { |v| options[:Port] = v }
+                  "Runs Rails on the specified port.", "Default: 3000") { |v|
+            options[:user_supplied_options] << :Port
+            options[:Port] = v
+          }
           opts.on("-b", "--binding=IP", String,
-                  "Binds Rails to the specified IP.", "Default: localhost") { |v| options[:Host] = v }
+                  "Binds Rails to the specified IP.", "Default: localhost") { |v|
+            options[:user_supplied_options] << :Host
+            options[:Host] = v
+          }
           opts.on("-c", "--config=file", String,
-                  "Uses a custom rackup configuration.") { |v| options[:config] = v }
-          opts.on("-d", "--daemon", "Runs server as a Daemon.") { options[:daemonize] = true }
+                  "Uses a custom rackup configuration.") { |v|
+            options[:user_supplied_options] << :config
+            options[:config] = v
+          }
+          opts.on("-d", "--daemon", "Runs server as a Daemon.") {
+            options[:user_supplied_options] << :daemonize
+            options[:daemonize] = true
+          }
           opts.on("-e", "--environment=name", String,
                   "Specifies the environment to run this server under (test/development/production).",
-                  "Default: development") { |v| options[:environment] = v }
+                  "Default: development") { |v|
+            options[:user_supplied_options] << :environment
+            options[:environment] = v
+          }
           opts.on("-P", "--pid=pid", String,
                   "Specifies the PID file.",
-                  "Default: tmp/pids/server.pid") { |v| options[:pid] = v }
+                  "Default: tmp/pids/server.pid") { |v|
+            options[:user_supplied_options] << :pid
+            options[:pid] = v
+          }
           opts.on("-C", "--[no-]dev-caching",
                   "Specifies whether to perform caching in development.",
-                  "true or false") { |v| options[:caching] = v }
+                  "true or false") { |v|
+            options[:user_supplied_options] << :caching
+            options[:caching] = v
+          }
 
           opts.separator ""
 
@@ -100,7 +125,6 @@ module Rails
     end
 
     private
-
       def setup_dev_caching
         if options[:environment] == "development"
           Rails::DevCaching.enable_by_argument(options[:caching])

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -110,6 +110,14 @@ class Rails::ServerTest < ActiveSupport::TestCase
     end
   end
 
+  def test_records_user_supplied_options
+    server_options = Rails::Server::Options.new.parse!(["-p", "3001"])
+    assert_equal [:Port], server_options[:user_supplied_options]
+
+    server_options = Rails::Server::Options.new.parse!(["--port", "3001"])
+    assert_equal [:Port], server_options[:user_supplied_options]
+  end
+
   def test_default_options
     server = Rails::Server.new
     old_default_options = server.default_options


### PR DESCRIPTION
Currently when Puma gets a `:Port` it doesn't know if it is Rails' default port or if it is one that is specified by a user. Because of this it assumes that the port passed in is always a user defined port and therefor 3000 always "wins" even if you specify `port` inside of the `config/puma.rb` file when booting your server with `rails s`.

The fix is to record the options that are explicitly passed in from the user and pass those to the Puma server (or all servers really). Puma then has enough information to know when `:Port` is the default and when it is user defined. I went ahead and did this for all values rails server exposes as server side options for completeness.

The hardest thing was converting the input say `-p` or `--port` into the appropriate "name", in this case `Port`. There may be a more straightforward way to do this with Thor, but I'm not an expert here.

Move logic for parsing user options to method

Better variable name for iteration

Explicitly test `--port` user input

✂️

Update array if environment variables are used
