### PR TITLE
Make `nil.to_query(key)` return `key`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Make `nil.to_query` return `key`.
+
+    Fixes #28322 so that:
+
+        >> {key: nil}.to_query
+        => "key"
+        >> Rack::Utils.parse_nested_query("key")
+        => {key: nil}
+
 *   Update `titleize` regex to allow apostrophes
 
     In 4b685aa the regex in `titleize` was updated to not match apostrophes to

--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -14,6 +14,11 @@ class Object
 end
 
 class NilClass
+  # Returns a CGI-escaped +key+.
+  def to_query(key)
+    "#{CGI.escape(key.to_param)}"
+  end
+
   # Returns +self+.
   def to_param
     self
@@ -49,7 +54,7 @@ class Array
     prefix = "#{key}[]"
 
     if empty?
-      nil.to_query(prefix)
+      "".to_query(prefix)
     else
       collect { |value| value.to_query(prefix) }.join "&"
     end

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -20,10 +20,8 @@ class ToQueryTest < ActiveSupport::TestCase
     assert_query_equal "a=%5B10%5D", "a" => "[10]".html_safe
   end
 
-  def test_nil_parameter_value
-    empty = Object.new
-    def empty.to_param; nil end
-    assert_query_equal "a=", "a" => empty
+  def test_nil_to_parameter_value
+    assert_equal "a", nil.to_query("a")
   end
 
   def test_nested_conversion
@@ -57,7 +55,7 @@ class ToQueryTest < ActiveSupport::TestCase
       a: 1, b: { c: 3, d: {} }
     assert_query_equal "",
       a: { b: { c: {} } }
-    assert_query_equal "b%5Bc%5D=false&b%5Be%5D=&b%5Bf%5D=&p=12",
+    assert_query_equal "b%5Bc%5D=false&b%5Be%5D&b%5Bf%5D=&p=12",
       p: 12, b: { c: false, e: nil, f: "" }
     assert_query_equal "b%5Bc%5D=3&b%5Bf%5D=",
       b: { c: 3, k: {}, f: "" }


### PR DESCRIPTION
### Summary

Fixes #28322 so that:

```ruby
>> {key: nil}.to_query
=> "key"
>> Rack::Utils.parse_nested_query("key")
=> {key: nil}
```