### PR TITLE
Add missing env & config dependency to `rake db:seed`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add environment & load_config dependency to `bin/rake db:seed` to enable
+    seed load in environments without Rails and custom DB configuration
+
+    *Tobias Bielohlawek*
+
 *   Fix default value for mysql time types with specified precision.
 
     *Nikolay Kondratyev*

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -217,7 +217,7 @@ db_namespace = namespace :db do
   task setup: ["db:schema:load_if_ruby", "db:structure:load_if_sql", :seed]
 
   desc "Loads the seed data from db/seeds.rb"
-  task :seed do
+  task seed: :load_config do
     db_namespace["abort_if_pending_migrations"].invoke
     ActiveRecord::Tasks::DatabaseTasks.load_seed
   end


### PR DESCRIPTION
Follow up on #21896, I accidentally deleted my fork so github lost the branch reference :( Commit update on latest master.

----

Fixes loading Seeds in a custom, non-rails environment. This failed due to missing dependencies on `rake db:seed` - added with this PR.

The problem occurs when AR is configured without rails but with custom seed loader. As of the dependency chain in https://github.com/rngtng/rails/blob/add-seed-dependency/activerecord/lib/active_record/railties/databases.rake#L175 `rake db:setup` currently works and loads the seeds via the custom loader correctly. 
Although, due to the missing dependencies on the seed task itself, it fails when `rake db:seed` is executed on its own. See the stacktrace below, problem is that the (overwritten) `environment` and/or `load_config` task isn't executed and therefore the custom seed loader never configured and therefor evoked. The PR add those missing dependencies explicit. 

``` bash
rake aborted!
NameError: uninitialized constant ActiveRecord::Tasks::DatabaseTasks::Rails
./vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.4/lib/active_record/tasks/database_tasks.rb:79:in `seed_loader'
./vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.4/lib/active_record/tasks/database_tasks.rb:249:in `load_seed'
./vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.4/lib/active_record/railties/databases.rake:183:in `block (2 levels) in <top (required)>'
Tasks: TOP => db:seed
(See full trace by running task with --trace)
```


To reproduce, an example `Rakefile` looks sth like  this:

``` ruby
load 'active_record/railties/databases.rake'
Rake::Task['db:load_config'].clear
namespace :db do
  task load_config: :environment do
    ActiveRecord::Tasks::DatabaseTasks.tap do |config|
      config.root = ROOT_PATH
      config.env = ENVIRONMENT
      config.database_configuration = ::ActiveRecord::Base.configurations
      config.db_dir = 'db'
      config.migrations_paths = ['db/migrate', 'other_project/db/migrate']
      config.seed_loader = Object.new
      config.seed_loader.instance_eval do
        def load_seed
          load "#{ActiveRecord::Tasks::DatabaseTasks.db_dir}/seeds.rb"
        end
      end
    end
    ActiveRecord::Migrator.migrations_paths = ActiveRecord::Tasks::DatabaseTasks.migrations_paths
  end
end
```

->  `rake db:setup` works using my custom cfg & seeds, although `rake db:seed` failed 
