### PR TITLE
Fix to use correct path with language on guide

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -73,7 +73,7 @@ module RailsGuides
 
         @output_dir  = "#{@guides_dir}/output"
         @output_dir += "/kindle"       if @kindle
-        @source_dir += "/#{@language}" if @language
+        @output_dir += "/#{@language}" if @language
       end
 
       def create_output_dir_if_needed


### PR DESCRIPTION
### Summary

i.e. let `@language = "ko"`

Before:
- source_dir: "source/ko/ko"
- output_dir: "output"

After:
- source_dir: "source/ko"
- output_dir: "output/ko"
