### PR TITLE
Document using `default_url_options` in an ActionMailer class.

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -133,6 +133,9 @@ module ActionMailer
   #
   #   config.action_mailer.default_url_options = { host: "example.com" }
   #
+  # You can also define a <tt>default_url_options</tt> method on individual mailers to override these
+  # default settings per-mailer.
+  #
   # By default when <tt>config.force_ssl</tt> is true, URLs generated for hosts will use the HTTPS protocol.
   #
   # = Sending mail


### PR DESCRIPTION
### Summary

It's possible to have a `default_url_options` method in your mailer classes. It will be used instead of the global defaults. This is useful if you have your app sitting on many domains, and need to have some outgoing e-mails link to one domain, and others to another domain.

This works because `ActionMailer::Base` inherits all relevant plumbing from `AbstractController::Base`, but is not documented anywhere. Is it considered private behavior then?

This commit adds a single sentence to `ActionMailer::Base`'s doc explaining that usage.
