### PR TITLE
Pass options to `driven_by`

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -110,8 +110,8 @@ module ActionDispatch
     #   driven_by :selenium, using: :firefox
     #
     #   driven_by :selenium, screen_size: [800, 800]
-    def self.driven_by(driver, using: :chrome, screen_size: [1400, 1400])
-      @driver = SystemTesting::Driver.new(driver, using: using, screen_size: screen_size)
+    def self.driven_by(driver, using: :chrome, screen_size: [1400, 1400], options: {})
+      @driver = SystemTesting::Driver.new(driver, using: using, screen_size: screen_size, options: options)
     end
 
     # Returns the driver object for the initialized system test

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -5,6 +5,7 @@ module ActionDispatch
         @name = name
         @browser = options[:using]
         @screen_size = options[:screen_size]
+        @options = options[:options]
       end
 
       def use
@@ -19,7 +20,7 @@ module ActionDispatch
 
         def register
           Capybara.register_driver @name do |app|
-            Capybara::Selenium::Driver.new(app, browser: @browser).tap do |driver|
+            Capybara::Selenium::Driver.new(app, { browser: @browser }.merge(@options)).tap do |driver|
               driver.browser.manage.window.size = Selenium::WebDriver::Dimension.new(*@screen_size)
             end
           end

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -8,10 +8,11 @@ class DriverTest < ActiveSupport::TestCase
   end
 
   test "initializing the driver with a browser" do
-    driver = ActionDispatch::SystemTesting::Driver.new(:selenium, using: :chrome, screen_size: [1400, 1400])
+    driver = ActionDispatch::SystemTesting::Driver.new(:selenium, using: :chrome, screen_size: [1400, 1400], options: { url: "http://example.com/wd/hub" })
     assert_equal :selenium, driver.instance_variable_get(:@name)
     assert_equal :chrome, driver.instance_variable_get(:@browser)
     assert_equal [1400, 1400], driver.instance_variable_get(:@screen_size)
+    assert_equal ({ url: "http://example.com/wd/hub" }), driver.instance_variable_get(:@options)
   end
 
   test "selenium? returns false if driver is poltergeist" do


### PR DESCRIPTION
Capybara drivers can handle some options such like `url`.

### before

```
# test/test_helper.rb
Capybara.register_driver :remote_chrome do |app|
  Capybara::Selenium::Driver.new(app, browser: :chrome, url: "http://example.com/wd/hub")
end

# test/application_system_test_case.rb
class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
  driven_by :remote_chrome
end
```

### after

```
# test/application_system_test_case.rb
class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
  driven_by :selenium, using: :chrome, screen_size: [1400, 1400], options: {url: "http://chrome:4444/wd/hub"}
end
```

## Other information

I tried this change on my example repo and it works well:

https://github.com/mtsmfm/rails-system-test-example/commit/a889d734073680db8c1841723d0399d5aafa6094
(In my case, I want to use [docker-selenium](https://github.com/SeleniumHQ/docker-selenium) for testing)