### PR TITLE
Deprecate `Migrator.schema_migrations_table_name`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `Migrator.schema_migrations_table_name`.
+
+    *Ryuta Kamizono*
+
 *   Check whether `Rails.application` defined before calling it
 
     In #27674 we changed the migration generator to generate migrations at the

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1022,6 +1022,11 @@ module ActiveRecord
         new(:up, migrations(migrations_paths), nil)
       end
 
+      def schema_migrations_table_name
+        SchemaMigration.table_name
+      end
+      deprecate :schema_migrations_table_name
+
       def get_all_versions(connection = Base.connection)
         if SchemaMigration.table_exists?
           SchemaMigration.all_versions.map(&:to_i)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1146,4 +1146,8 @@ class CopyMigrationsTest < ActiveRecord::TestCase
   def test_deprecate_supports_migrations
     assert_deprecated { ActiveRecord::Base.connection.supports_migrations? }
   end
+
+  def test_deprecate_schema_migrations_table_name
+    assert_deprecated { ActiveRecord::Migrator.schema_migrations_table_name }
+  end
 end


### PR DESCRIPTION
Follow up of #28293.

Since 67fba0cf `SchemaMigration` model was extracted.
Use `SchemaMigration.table_name` instead.

r? @rafaelfranca 