### PR TITLE
Fixes ActionController::Rendering#with_defaults

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `ActionController::Renderer#with_defaults` does not work
+
+    Fixes `NameError: undefined local variable or method `env'`.
+
+    *Hiroyuki Ishii*
+
 *   Added `#reverse_merge` and `#reverse_merge!` methods to `ActionController::Parameters`
 
     *Edouard Chin*, *Mitsutaka Mimura*

--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -56,7 +56,7 @@ module ActionController
 
     # Create a new renderer for the same controller but with new defaults.
     def with_defaults(defaults)
-      self.class.new controller, env, self.defaults.merge(defaults)
+      self.class.new controller, @env, self.defaults.merge(defaults)
     end
 
     # Accepts a custom Rack environment to render templates in.

--- a/actionpack/test/controller/renderer_test.rb
+++ b/actionpack/test/controller/renderer_test.rb
@@ -19,6 +19,16 @@ class RendererTest < ActiveSupport::TestCase
     assert_equal controller, renderer.controller
   end
 
+  test "creating with new defaults" do
+    renderer = ApplicationController.renderer
+
+    new_defaults = { https: true }
+    new_renderer = renderer.with_defaults(new_defaults).new
+    content = new_renderer.render(inline: "<%= request.ssl? %>")
+
+    assert_equal "true", content
+  end
+
   test "rendering with a class renderer" do
     renderer = ApplicationController.renderer
     content  = renderer.render template: "ruby_template"


### PR DESCRIPTION
`ActionController::Renderer#with_defaults` raises `NameError: undefined local variable or method`.
Use instance variable instead of local variable.