### PR TITLE
Remove non-exists method delegation

### DIFF
--- a/activemodel/lib/active_model/type.rb
+++ b/activemodel/lib/active_model/type.rb
@@ -21,16 +21,8 @@ module ActiveModel
 
     class << self
       attr_accessor :registry # :nodoc:
-      delegate :add_modifier, to: :registry
 
-      # Add a new type to the registry, allowing it to be referenced as a
-      # symbol by ActiveRecord::Attributes::ClassMethods#attribute.  If your
-      # type is only meant to be used with a specific database adapter, you can
-      # do so by passing +adapter: :postgresql+. If your type has the same
-      # name as a native type for the current adapter, an exception will be
-      # raised unless you specify an +:override+ option. +override: true+ will
-      # cause your type to be used instead of the native type. +override:
-      # false+ will cause the native type to be used over yours if one exists.
+      # Add a new type to the registry, allowing it to be get through ActiveModel::Type#lookup
       def register(type_name, klass = nil, **options, &block)
         registry.register(type_name, klass, **options, &block)
       end


### PR DESCRIPTION
### Summary

The `ActiveModel::Type::Registry#add_modifier` has been removed since commit [4590d77](https://github.com/rails/rails/commit/4590d7729e241cb7f66e018a2a9759cb3baa36e5) but the delegation still there, so I remove it.
