### PR TITLE
Handle Timeout.timeout in rails queries

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -240,7 +240,7 @@ module ActiveRecord
                 rollback_transaction if transaction
               else
                 begin
-                  commit_transaction
+                  commit_transaction if transaction
                 rescue Exception
                   rollback_transaction(transaction) unless transaction.state.completed?
                   raise


### PR DESCRIPTION
### TL;DR

If a `Timeout.timeout` is triggered in  `Transaction#within_new_transaction`, an exception is thrown:

```
[NoMethodError]: undefined method `state' for nil:NilClass
  Method:[rescue in block in refresh]
```

### Reproducing Script

[[Script]](https://gist.github.com/kbrock/175a3c7044e3e1f3d6079bd14e6c3cdd) reproduces on rails `5.0.0.1`, `master` with `sqlite3` and `pg`. (did not try mysql)

Since it is a race condition, you sometimes need to run the reproduction script a few times.
Also, I added a `puts "ISSUE" if transaction.nil?` in the code to help me know that I indeed triggered the race condition and that the fix worked.

### Details

When a `SIGINT`, `SIGTERM`, or `Timeout::Error` is thrown inside `within_new_transaction`,
`transaction.nil? == true` and `@stack.empty? == true`

For this reason, the code is currently guarding for `transaction.nil?` in 2 places.

Unfortunately, `commit_transaction` is not guarding against these seemingly impossible cases.

The problem with the method is finally realized in the error checking itself.
it calls `transaction.state` (i.e.: `nil.state`) and that is the final exception
raised.

The solution is to handle `transaction.nil?` and `@stack.empty?`

### Diagram of Details

```ruby
      def within_new_transaction(options = {})
        transaction = begin_transaction options # transaction = nil
        yield
      rescue Exception => error # no exception
        if transaction
          rollback_transaction
          after_failure_actions(transaction, error)
        end
        raise
      ensure
        unless error # no exception
          if Thread.current.status == "aborting" # not aborting
            rollback_transaction if transaction
          else
            begin
              # suggestion: commit_transaction if transaction
              commit_transaction # error
            rescue Exception
              rollback_transaction(transaction) unless transaction.state.completed? # error: transaction == nil
              raise
            end
          end
        end
      end
```
