### PR TITLE
Prevent ujs event propagation if element disabled when event chain begins

### DIFF
--- a/actionview/app/assets/javascripts/features/disable.coffee
+++ b/actionview/app/assets/javascripts/features/disable.coffee
@@ -2,6 +2,10 @@
 
 { matches, getData, setData, stopEverything, formElements } = Rails
 
+Rails.handleDisabledElement = (e) ->
+  element = this
+  stopEverything(e) if element.disabled
+
 # Unified function to enable an element (link, button and form)
 Rails.enableElement = (e) ->
   element = if e instanceof Event then e.target else e

--- a/actionview/app/assets/javascripts/rails-ujs.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs.coffee
@@ -12,7 +12,7 @@
   fire, delegate
   getData, $
   refreshCSRFTokens, CSRFProtection
-  enableElement, disableElement
+  enableElement, disableElement, handleDisabledElement
   handleConfirm
   handleRemote, formSubmitButtonClick, handleMetaClick
   handleMethod
@@ -44,19 +44,23 @@ Rails.start = ->
   delegate document, Rails.buttonDisableSelector, 'ajax:complete', enableElement
   delegate document, Rails.buttonDisableSelector, 'ajax:stopped', enableElement
 
+  delegate document, Rails.linkClickSelector, 'click', handleDisabledElement
   delegate document, Rails.linkClickSelector, 'click', handleConfirm
   delegate document, Rails.linkClickSelector, 'click', handleMetaClick
   delegate document, Rails.linkClickSelector, 'click', disableElement
   delegate document, Rails.linkClickSelector, 'click', handleRemote
   delegate document, Rails.linkClickSelector, 'click', handleMethod
 
+  delegate document, Rails.buttonClickSelector, 'click', handleDisabledElement
   delegate document, Rails.buttonClickSelector, 'click', handleConfirm
   delegate document, Rails.buttonClickSelector, 'click', disableElement
   delegate document, Rails.buttonClickSelector, 'click', handleRemote
 
+  delegate document, Rails.inputChangeSelector, 'change', handleDisabledElement
   delegate document, Rails.inputChangeSelector, 'change', handleConfirm
   delegate document, Rails.inputChangeSelector, 'change', handleRemote
 
+  delegate document, Rails.formSubmitSelector, 'submit', handleDisabledElement
   delegate document, Rails.formSubmitSelector, 'submit', handleConfirm
   delegate document, Rails.formSubmitSelector, 'submit', handleRemote
   # Normal mode submit
@@ -65,6 +69,7 @@ Rails.start = ->
   delegate document, Rails.formSubmitSelector, 'ajax:send', disableElement
   delegate document, Rails.formSubmitSelector, 'ajax:complete', enableElement
 
+  delegate document, Rails.formInputClickSelector, 'click', handleDisabledElement
   delegate document, Rails.formInputClickSelector, 'click', handleConfirm
   delegate document, Rails.formInputClickSelector, 'click', formSubmitButtonClick
 

--- a/actionview/test/ujs/public/test/data-confirm.js
+++ b/actionview/test/ujs/public/test/data-confirm.js
@@ -26,6 +26,13 @@ module('data-confirm', {
       'data-confirm': 'Are you absolutely sure?'
     }))
 
+    $('#qunit-fixture').append($('<button />', {
+      type: 'submit',
+      form: 'confirm',
+      disabled: 'disabled',
+      'data-confirm': 'Are you absolutely sure?'
+    }))
+
     this.windowConfirm = window.confirm
   },
   teardown: function() {
@@ -285,4 +292,25 @@ asyncTest('clicking on the children of a link should also trigger a confirm', 6,
     })
     .find('strong')
     .triggerNative('click')
+})
+
+asyncTest('clicking on the children of a disabled button should not trigger a confirm.', 1, function() {
+  var message
+  // auto-decline:
+  window.confirm = function(msg) { message = msg; return false }
+
+  $('button[data-confirm][disabled]')
+    .html("<strong>Click me</strong>")
+    .bindNative('confirm', function() {
+      App.assertCallbackNotInvoked('confirm')
+    })
+    .find('strong')
+    .bindNative('click', function() {
+      App.assertCallbackInvoked('click')
+    })
+    .triggerNative('click')
+
+  setTimeout(function() {
+    start()
+  }, 50)
 })


### PR DESCRIPTION
### Summary

The existing ujs event behavior relies on browsers not triggering
various events when an element is disabled. For example, imagine the following:

    <button type="submit" disabled="disabled" data-confirm="Confirm">Click me</button>

The above button is disabled, so browsers will not trigger a click event and
all ujs behavior is prevented. However, imagine a button like this:

    <button type="submit" disabled="disabled" data-confirm="Confirm"><strong>Click me</strong></button>

The above is treated differently by browsers such as Chrome/Safari. These
browsers do not consider the strong tag to be disabled, and will trigger click
events (ex. the data confirm prompt will be shown with the second button example). ujs has logic to walk up the DOM to find an associated element subject
to ujs behavior. But, this logic does not take into account the disabled
status of the element.

I originally thought we could simply [change the selectors](https://github.com/rails/rails/blob/c8c1460f7a97c15dff641a30e63914991d407595/actionview/app/assets/javascripts/config.coffee#L9-L10) used to match
elements to ignore disabled elements. However, ujs [disables some elements](https://github.com/rails/rails/blob/c8c1460f7a97c15dff641a30e63914991d407595/actionview/app/assets/javascripts/rails-ujs.coffee#L54) as
part of the event chain. So, an element might match early in the chain and
then fail to match later. Instead of changing the selectors I added a callback
to the chain that calls `stopEverything` if an element is disabled when the
event chain begins.

### Other Information

I'm guessing that, based on the changes I've made, this could use some additional tests. I'm pretty unfamiliar with this bit of the codebase, and would appreciate some guidance.
