### PR TITLE
Add secrets edit test

### DIFF
--- a/railties/test/commands/secrets_test.rb
+++ b/railties/test/commands/secrets_test.rb
@@ -17,8 +17,21 @@ class Rails::Command::SecretsCommandTest < ActiveSupport::TestCase
     assert_match "No $EDITOR to open decrypted secrets in", run_edit_command(editor: "")
   end
 
+  test "edit secrets" do
+    run_setup_command
+
+    # Run twice to ensure encrypted secrets can be reread after first edit pass.
+    2.times do
+      assert_match(/external_api_key: 1466aac22e6a869134be3d09b9e89232fc2c2289…/, run_edit_command)
+    end
+  end
+
   private
     def run_edit_command(editor: "cat")
       Dir.chdir(app_path) { `EDITOR="#{editor}" bin/rails secrets:edit` }
+    end
+
+    def run_setup_command
+      Dir.chdir(app_path) { `bin/rails secrets:setup` }
     end
 end


### PR DESCRIPTION
### Summary

This add a test that actually executes the secrets command. 
I use the ex command in test to avoid starting the editor. Therefore, it makes me feel a bit strange. @kaspth What do you think? 

r? @kaspth 
