### PR TITLE
500x memory reduction of 10k schemas for postgresql adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -568,13 +568,13 @@ module ActiveRecord
 
           if supports_ranges?
             query = <<-SQL
-              SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput, r.rngsubtype, t.typtype, t.typbasetype
+              SELECT DISTINCT on (t.typname) t.oid, t.typname, t.typelem, t.typdelim, t.typinput, r.rngsubtype, t.typtype, t.typbasetype
               FROM pg_type as t
               LEFT JOIN pg_range as r ON oid = rngtypid
             SQL
           else
             query = <<-SQL
-              SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput, t.typtype, t.typbasetype
+              SELECT DISTINCT on (t.typname) t.oid, t.typname, t.typelem, t.typdelim, t.typinput, t.typtype, t.typbasetype
               FROM pg_type as t
             SQL
           end


### PR DESCRIPTION
### Summary

### What is the improvement

- on my local database (10k schemas) test: memory usage  408.838M -> 884.509k (I use benchmark-memory gem, I put the detail data on other information)

- on our production server (80k schemas):  save our production real memory usage from about **8GB to 300mb**

### why I do this
#### background 

Our production structure is multi-schema, we use apartment gem.
currently we have about 80000 schemas.

I found our server will consume a lot of memory (about 3G per puma worker) while using active_record to connect to the database

#### code 
I modified the SQL statements inside the load_additional_types method because I found the current SQL statement is loading too much PostgreSQL type data from pg_type.

But, there are a lot of redundant types for active_record

About pg_type table

(A composite type is automatically created for each table in the database, to represent the row structure of the table),
so if there are a lot of tables in the database (especially for multi-schema structure database), PostgreSQL will create a lot of records in the pg_type table.

### how to do it

I use "select distinct" to filter them in order to reduce memory bloat.

I think active_record doesn't need to be mapped to all these records because we don't have the type's name is the same as the table's name.

I have two solutions

- use "select distinct" (because in multi-schema structure, there are a lot of redundant data on pg_type)

- use "t.typname not in (select distinct on (table_name) '_'|| table_name from information_schema.tables)"

for performance considerations, I choose to use "select distinct"

I test this patch on our production environments, it reduce a lot of memory usage.

Before this patch, one worker consumed memory about 3GB
(because 2389860 records selected from the current SQL statement, we have about 50000 schemas in our database)

After this patch, one worker just consumed memory about 300MB
(only 163 records selected from the amended SQL statement)

### Other Information

I also use benchmark-memory gem to test on my local environments

I create two database environments

1. development (408 schemas)
2. big (10000 schemas)

```
Benchmark.memory do |x|
 x.report(:normal) do
   y.times do
     ActiveRecord::Base.establish_connection(:big).connection
     ActiveRecord::Base.establish_connection(:development).connection
   end
 end

 x.report(:patch) do
   require 'active_record_postgresql_adapter_ext'
   y.times do
     ActiveRecord::Base.establish_connection(:big).connection
     ActiveRecord::Base.establish_connection(:development).connection
   end
 end
x.compare!
end
```
result:
```
Calculating -------------------------------------
              normal   408.838M memsize (    90.936k retained)
                         3.510M objects (   908.000  retained)
                        50.000  strings (    50.000  retained)
               patch   884.509k memsize (    91.155k retained)
                         7.337k objects (   910.000  retained)
                        50.000  strings (    50.000  retained)

Comparison:
               patch:     884509 allocated
              normal:  408837567 allocated - 462.22x more
```

It is about **500 times difference** 