### PR TITLE
Introduce ActiveSupport::TestCase.describe for grouping related tests

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,35 @@
+*   Introduce `ActiveSupport::TestCase.describe`
+
+    Groups relevant tests together. Turns the code below...
+
+        class ParentsControllerTest < ActionDispatch::IntegrationTest
+          test 'POST /v1/parents registers a new parent'
+          test 'POST /v1/parents allows empty email for the kid'
+          test 'POST /v1/parents ...'
+
+          test 'PUT /v1/parents/:id updates a parent'
+          test 'PUT /v1/parents/:id can set a card'
+          test 'PUT /v1/parents/:id ...'
+        end
+
+    Into the following... 👇
+
+        class ParentsControllerTest < ActionDispatch::IntegrationTest
+          describe 'POST /v1/parents' do
+            test 'registers a new parent'
+            test 'allows empty email for the kid'
+            # ...
+          end
+
+          describe 'PUT /v1/parents/:id' do
+            test 'updates a parent'
+            test 'can set a card'
+            # ...
+          end
+        end
+
+    *Genadi Samokovarov*
+
 *   Update `titleize` regex to allow apostrophes
 
     In 4b685aa the regex in `titleize` was updated to not match apostrophes to

--- a/activesupport/lib/active_support/testing/declarative.rb
+++ b/activesupport/lib/active_support/testing/declarative.rb
@@ -9,7 +9,8 @@ module ActiveSupport
         #     ...
         #   end
         def test(name, &block)
-          test_name = "test_#{name.gsub(/\s+/, '_')}".to_sym
+          prefix = ("#{@__context__} " if defined? @__context__).to_s
+          test_name = "test_#{(prefix + name).gsub(/\s+/, '_')}".to_sym
           defined = method_defined? test_name
           raise "#{test_name} is already defined in #{self}" if defined
           if block_given?
@@ -18,6 +19,25 @@ module ActiveSupport
             define_method(test_name) do
               flunk "No implementation provided for #{name}"
             end
+          end
+        end
+
+        # Helper to group related tests together.
+        #
+        #   describe "attributes not backed by database columns" do
+        #     test "not dirty when unchanged" do
+        #     test "always initialized"
+        #     test "return the default on models loaded from database"
+        #   end
+        #
+        # Multiple descriptions cannot be nested.
+        def describe(context)
+          raise "#{@__context__} already defined" if defined? @__context__
+          @__context__ = context.to_s
+          begin
+            yield
+          ensure
+            remove_instance_variable(:@__context__)
           end
         end
       end

--- a/activesupport/test/testing/declarative_test.rb
+++ b/activesupport/test/testing/declarative_test.rb
@@ -1,0 +1,46 @@
+require "abstract_unit"
+
+class DescribeTest < ActiveSupport::TestCase
+  test "prefixes declarative test names for show" do
+    cls = Class.new(ActiveSupport::TestCase) do
+      describe "context" do
+        test "something"
+
+        # Non-declarative test names are untouched.
+        def test_something_else
+        end
+      end
+    end
+
+    assert_includes cls.instance_methods, :test_context_something
+    assert_includes cls.instance_methods, :test_something_else
+  end
+
+  test "the context can be anything we can show" do
+    cls = Class.new(ActiveSupport::TestCase) do
+      Inner = Class.new do
+        def self.to_s
+          "Inner"
+        end
+      end
+
+      describe Inner do
+        test "internal_work"
+      end
+    end
+
+    assert_includes cls.instance_methods, :"test_Inner_internal_work"
+  end
+
+  test "cannot be nested" do
+    assert_raises RuntimeError do
+      Class.new(ActiveSupport::TestCase) do
+        describe "context" do
+          describe "we do not encourage nested contexts" do
+            test "something"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We in the Ruby world, write lot's of tests. And this is awesome! 🙌

Now writing lot's of tests means we do have to manage them somehow. See
my controller tests, taken right from an app I've been working on.

This is RESTful controller here, that is something a bit more specified:

```ruby
class ParentsControllerTest < ActionDispatch::IntegrationTest
  test 'POST /v1/parents registers a new parent'
  test 'POST /v1/parents allows empty email for the kid'
  test 'POST /v1/parents validates timezone a new parent'
  test 'POST /v1/parents respond with errors'
  test 'POST /v1/parents does not allow duplicate email addresses'

  test 'PUT /v1/parents/:id updates a parent'
  test 'PUT /v1/parents/:id can set a card'
  test 'PUT /v1/parents/:id can update card expiry through :credit_card'
  test 'PUT /v1/parents/:id can update card expiry through :card'
  test 'PUT /v1/parents/:id card_token takes priority over {credit_,}card'
  test 'PUT /v1/parents/:id can set a new email'
  test 'PUT /v1/parents/:id can set a new password'
  test 'PUT /v1/parents/:id returns a new token'
  test 'PUT /v1/parents/:id errors out on empty password'
  test 'PUT /v1/parents/:id can set a new password and change email at the same time'
  test 'PUT /v1/parents/:id works only for the parent in the token'
  test 'PUT /v1/parents/:id can error out with invalid stripe token'

  test 'GET /v1/parents returns the partners of a parent'
end
```

And this is a PORO test, which can represent something a bit more
generalized:

```ruby
class AuthorizableTest < ActiveSupport::TestCase
  test '#confirm does not confirm a nil input'
  test '#confirm proper token and flags confirmed_at'
  test '#password? is falsy on for blank password_digest'
  test '#password? is truthy on for present password_digest'
  test '#initial_password sets the initial password with confirmation token'
  test '#initial_password with wrong confirmation token'
  test '#initial_password does nothing for already set password'
  test '#reset_password resets a password with correct code'
  test '#reset_password with wrong code'
  test '#reset_password with unconfirmed auth'
  test '#reset_password with blank code'
  test '#reset_password attack for blank password_reset_code'
  test '#new_password_reset_code generates a random 6 digit code'
  test '#new_password_reset_code works for nil passwords'
  test '#change_password can change the password if old_password matches'
  test '#change_password cannot change empty password'
  test '#change_password cannot change empty short passwords'
  test 'password cannot be set or kept to nil after creation'
end
```

When you unroll the tests, it doesn't get that hard to navigate
through , but still, it's a bit noisy. We may argue that this way
structuring tests is not the optimal one. I think, I'm quite the average
testing guy here and lot's of folks tend to converge to this
organizational style. Again, or so I think. 😅

Now, if we had a way to group those tests by something, even just
organizationally, it would be a bit easier for me to navigate, know
where to put another `#reset_password` test or fold the tests I don't
need to focus on right now in my editor.

Here is the controller:

```ruby
class ParentsControllerTest < ActionDispatch::IntegrationTest
  describe 'POST /v1/parents' do
    test 'registers a new parent'
    test 'allows empty email for the kid'
    test 'validates timezone a new parent'
    test 'respond with errors'
    test 'does not allow duplicate email addresses'
  end

  describe 'PUT /v1/parents/:id' do
    test 'updates a parent'
    test 'can set a card'
    test 'can update card expiry through :credit_card'
    test 'can update card expiry through :card'
    test 'card_token takes priority over {credit_,}card'
    test 'can set a new email'
    test 'can set a new password'
    test 'returns a new token'
    test 'errors out on empty password'
    test 'can set a new password and change email at the same time'
    test 'works only for the parent in the token'
    test 'can error out with invalid stripe token'
  end

  describe 'GET /v1/parents' do
    test 'returns the partners of a parent'
  end
end
```

And here is the PORO:

```ruby
class AuthorizableTest < ActiveSupport::TestCase
  describe '#confirm' do
    test 'does not confirm a nil input'
    test 'sets proper token and flags confirmed_at'
  end

  describe '#password?' do
    test 'falsy on for blank password_digest'
    test 'truthy on for present password_digest'
  end

  describe '#initial_password' do
    test 'sets the initial password with confirmation token'
    test 'wrong confirmation token'
    test 'does nothing for already set password'
  end

  describe '#reset_password' do
    test 'resets a password with correct code'
    test 'with wrong code'
    test 'with unconfirmed auth'
    test 'with blank code'
    test 'attack for blank password_reset_code'
  end

  describe '#new_password_reset_code' do
    test 'generates a random 6 digit code'
    test 'works for nil passwords'
  end

  describe '#change_password' do
    test 'can change the password if old_password matches'
    test 'cannot change empty password'
    test 'cannot change empty short passwords'
  end

  test 'password cannot be set or kept to nil after creation'
end
```

I know David doesn't prefer the BDD DSL, but I wanna make a case for
`.describe` here. It doesn't create hidden test-cases or special
environments. It cannot be nested by design, so we don't promote those
levels into levels into levels kind of tests. It's used purely for
organizational work.

@dhh would you be interested in such change?