### PR TITLE
Restore action_cable.js UMD module support. Fixes #28366

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ group :cable do
 
   gem "blade", require: false, platforms: [:ruby]
   gem "blade-sauce_labs_plugin", require: false, platforms: [:ruby]
+  gem "sprockets-export", require: false
 end
 
 # Add your own local bundler stuff.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,6 +319,7 @@ GEM
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
+    sprockets-export (0.9.1)
     sprockets-rails (3.2.0)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
@@ -414,6 +415,7 @@ DEPENDENCIES
   sequel
   sidekiq
   sneakers
+  sprockets-export
   sqlite3 (~> 1.3.6)
   stackprof
   sucker_punch

--- a/actioncable/Rakefile
+++ b/actioncable/Rakefile
@@ -1,12 +1,13 @@
 require "rake/testtask"
 require "pathname"
+require "open3"
 require "action_cable"
 
 dir = File.dirname(__FILE__)
 
 task default: :test
 
-task package: "assets:compile"
+task package: %w( assets:compile assets:verify )
 
 Rake::TestTask.new do |t|
   t.libs << "test"
@@ -37,6 +38,39 @@ namespace :assets do
   desc "Compile Action Cable assets"
   task :compile do
     require "blade"
+    require "sprockets"
+    require "sprockets/export"
     Blade.build
+  end
+
+  desc "Verify compiled Action Cable assets"
+  task :verify do
+    file = "lib/assets/compiled/action_cable.js"
+    pathname = Pathname.new("#{dir}/#{file}")
+
+    print "[verify] #{file} exists "
+    if pathname.exist?
+      puts "[OK]"
+    else
+      $stderr.puts "[FAIL]"
+      fail
+    end
+
+    print "[verify] #{file} is a UMD module "
+    if pathname.read =~ /module\.exports.*define\.amd/m
+      puts "[OK]"
+    else
+      $stderr.puts "[FAIL]"
+      fail
+    end
+
+    print "[verify] #{dir} can be required as a module "
+    stdout, stderr, status = Open3.capture3("node", "--print", "window = {}; require('#{dir}');")
+    if status.success?
+      puts "[OK]"
+    else
+      $stderr.puts "[FAIL]\n#{stderr}"
+      fail
+    end
   end
 end


### PR DESCRIPTION
Fix for #28366

774be3ea3b9d25ab69daf11c5071deaf053d7d5b bumped Blade from 0.6.1 to 0.7.0, which dropped [sprockets-export](https://github.com/javan/sprockets-export) from `Gemfile.lock` (Blade 0.7.0 no longer includes sprockets-export as a dependency). Doing so silently dropped `action_cable.js`'s UMD module support, essentially breaking it as an npm package.

This change restores sprockets-export and adds a new rake task that validates `action_cable.js` to help ensure this doesn't happen again.

/cc @matthewd 