### PR TITLE
Don't require all frameworks in engine executable

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
@@ -9,5 +9,4 @@ APP_PATH = File.expand_path('../../<%= dummy_path -%>/config/application', __FIL
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 
-require 'rails/all'
 require 'rails/engine/commands'

--- a/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/engine.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/engine.rb
@@ -1,3 +1,6 @@
+require 'rails'
+require 'rails/engine'
+
 <%= wrap_in_modules <<-rb.strip_heredoc
   class Engine < ::Rails::Engine
   #{mountable? ? '  isolate_namespace ' + camelized_modules : ' '}


### PR DESCRIPTION
### Summary

No reason to require all of Rails' components/frameworks in the
`bin/rails` binstub. The binstub now simply loads the commands, just as
the application binstub does.

### Other Information

Fixes #28345