### PR TITLE
PostgreSQL: Ensure the database time zone matches Ruby's time zone

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -43,6 +43,28 @@ class PostgresqlTimestampTest < ActiveRecord::PostgreSQLTestCase
   ensure
     @connection.reconnect!
   end
+
+  def test_timestamp_with_zone_values_with_local_timezone
+    time = Time.now.utc.change(usec: 0)
+    timestamp = nil
+
+    with_timezone_config default: :local do
+      with_env_tz "America/New_York" do
+        @connection.reconnect!
+
+        timestamp = PostgresqlTimestampWithZone.create!(id: 2, time: time)
+        timestamp.reload
+        assert_equal time, timestamp.time
+      end
+    end
+
+    @connection.reconnect!
+
+    timestamp.reload
+    assert_equal time, timestamp.time
+  ensure
+    @connection.reconnect!
+  end
 end
 
 class PostgresqlTimestampFixtureTest < ActiveRecord::PostgreSQLTestCase


### PR DESCRIPTION
This restores bf6661c5 (reverts 7a7c608a).

If `AR::Base.default_timezone = :local`, incorrect value will be saved
unless the database time zone matches Ruby's time zone.