### PR TITLE
MySQL: Ensure the database time zone matches Ruby's time zone

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -835,6 +835,17 @@ module ActiveRecord
           end
           sql_mode_assignment = "@@SESSION.sql_mode = #{sql_mode}, " if sql_mode
 
+          unless variables["time_zone"]
+            if ActiveRecord::Base.default_timezone == :utc
+              variables["time_zone"] = "+00:00"
+            else
+              offset = Time.now.utc_offset / 3600.0
+              sign = offset >= 0 ? "+" : "-"
+              offset = offset.abs
+              variables["time_zone"] = "%s%d:%d" % [sign, offset, 60 * (offset - offset.to_i)]
+            end
+          end
+
           # NAMES does not have an equals sign, see
           # http://dev.mysql.com/doc/refman/5.7/en/set-statement.html#id944430
           # (trailing comma because variable_assignments will always have content)

--- a/activerecord/test/cases/adapters/mysql2/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/timestamp_test.rb
@@ -1,0 +1,66 @@
+require "cases/helper"
+
+class Mysql2TimestampTest < ActiveRecord::Mysql2TestCase
+  class MysqlTimestamp < ActiveRecord::Base
+  end
+
+  self.use_transactional_tests = false
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table :mysql_timestamps, force: true do |t|
+      t.timestamp :time
+    end
+    @time = Time.now.utc.change(usec: 0)
+    MysqlTimestamp.create!(id: 1, time: @time)
+  end
+
+  def teardown
+    @connection.drop_table :mysql_timestamps, if_exists: true
+  end
+
+  def test_timestamp_with_time_zone_utc
+    with_timezone_config default: :utc do
+      @connection.reconnect!
+
+      timestamp = MysqlTimestamp.find(1)
+      assert_equal @time, timestamp.time
+    end
+  ensure
+    @connection.reconnect!
+  end
+
+  def test_timestamp_with_time_zone_local
+    with_timezone_config default: :local do
+      with_env_tz "America/New_York" do
+        @connection.reconnect!
+
+        timestamp = MysqlTimestamp.find(1)
+        assert_equal @time, timestamp.time
+      end
+    end
+  ensure
+    @connection.reconnect!
+  end
+
+  def test_create_timestamp_with_time_zone_local
+    timestamp = nil
+
+    with_timezone_config default: :local do
+      with_env_tz "America/New_York" do
+        @connection.reconnect!
+
+        timestamp = MysqlTimestamp.create!(id: 2, time: @time)
+        timestamp.reload
+        assert_equal @time, timestamp.time
+      end
+    end
+
+    @connection.reconnect!
+
+    timestamp.reload
+    assert_equal @time, timestamp.time
+  ensure
+    @connection.reconnect!
+  end
+end


### PR DESCRIPTION
Follow up of #23553. Related #28391.

If `AR::Base.default_timezone = :local`, incorrect value will be saved
unless the database time zone matches Ruby's time zone.