### PR TITLE
Sync transaction state when accessing primary key

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -29,9 +29,11 @@ module ActiveRecord
             temp_method = "__temp__#{safe_name}"
 
             ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
+            sync_with_transaction_state = "sync_with_transaction_state" if name == primary_key
 
             generated_attribute_methods.module_eval <<-STR, __FILE__, __LINE__ + 1
               def #{temp_method}
+                #{sync_with_transaction_state}
                 name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
                 _read_attribute(name) { |n| missing_attribute(n, caller) }
               end

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -13,9 +13,11 @@ module ActiveRecord
           def define_method_attribute=(name)
             safe_name = name.unpack("h*".freeze).first
             ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
+            sync_with_transaction_state = "sync_with_transaction_state" if name == primary_key
 
             generated_attribute_methods.module_eval <<-STR, __FILE__, __LINE__ + 1
               def __temp__#{safe_name}=(value)
+                #{sync_with_transaction_state}
                 name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
                 write_attribute(name, value)
               end

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -595,6 +595,52 @@ class TransactionTest < ActiveRecord::TestCase
     assert_not topic.frozen?
   end
 
+  def test_restore_id_after_rollback
+    topic = Topic.new
+
+    Topic.transaction do
+      topic.save!
+      raise ActiveRecord::Rollback
+    end
+
+    assert_nil topic.id
+  end
+
+  def test_restore_custom_primary_key_after_rollback
+    movie = Movie.new(name: "foo")
+
+    Movie.transaction do
+      movie.save!
+      raise ActiveRecord::Rollback
+    end
+
+    assert_nil movie.movieid
+  end
+
+  def test_assign_id_after_rollback
+    topic = Topic.create!
+
+    Topic.transaction do
+      topic.save!
+      raise ActiveRecord::Rollback
+    end
+
+    topic.id = nil
+    assert_nil topic.id
+  end
+
+  def test_assign_custom_primary_key_after_rollback
+    movie = Movie.create(name: "foo")
+
+    Movie.transaction do
+      movie.save!
+      raise ActiveRecord::Rollback
+    end
+
+    movie.movieid = nil
+    assert_nil movie.movieid
+  end
+
   def test_rollback_of_frozen_records
     topic = Topic.create.freeze
     Topic.transaction do


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/28274.

If a record is modified inside a transaction, it must check the outcome of that transaction before accessing any state which would no longer be valid if it was rolled back.

For example, consider a new record that was saved inside a transaction which was later rolled back: it should be restored to its previous state so that saving it again inserts a new row into the database instead of trying to update a row that no longer exists.

The [`id`](https://github.com/rails/rails/blob/097612e8f5bc520bbcdd3c9134a3421eac4d624a/activerecord/lib/active_record/attribute_methods/primary_key.rb#L19) and [`id=`](https://github.com/rails/rails/blob/097612e8f5bc520bbcdd3c9134a3421eac4d624a/activerecord/lib/active_record/attribute_methods/primary_key.rb#L26) methods defined on the PrimaryKey module implement this correctly, but they are almost always overridden by dynamically defined attribute methods. Those attribute methods must also check the transaction state if they are the record's primary key.