### PR TITLE
PostgreSQL: Ensure to configurable `SET time zone`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -637,6 +637,10 @@ module ActiveRecord
           columns(table_name).detect { |c| c.name == column_name } ||
             raise(ActiveRecordError, "No such column: #{table_name}.#{column_name}")
         end
+
+        def default_variable?(v)
+          v == ":default".freeze || v == :default
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -816,14 +816,12 @@ module ActiveRecord
           wait_timeout = 2147483 unless wait_timeout.is_a?(Integer)
           variables["wait_timeout"] = wait_timeout
 
-          defaults = [":default", :default].to_set
-
           # Make MySQL reject illegal values rather than truncating or blanking them, see
           # http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_strict_all_tables
           # If the user has provided another value for sql_mode, don't replace it.
           if sql_mode = variables.delete("sql_mode")
             sql_mode = quote(sql_mode)
-          elsif !defaults.include?(strict_mode?)
+          elsif !default_variable?(strict_mode?)
             if strict_mode?
               sql_mode = "CONCAT(@@sql_mode, ',STRICT_ALL_TABLES')"
             else
@@ -846,7 +844,7 @@ module ActiveRecord
 
           # Gather up all of the SET variables...
           variable_assignments = variables.map do |k, v|
-            if defaults.include?(v)
+            if default_variable?(v)
               "@@SESSION.#{k} = DEFAULT" # Sets the value to the global or compile default
             elsif !v.nil?
               "@@SESSION.#{k} = #{quote(v)}"

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -712,20 +712,25 @@ module ActiveRecord
           # Use standard-conforming strings so we don't have to do the E'...' dance.
           set_standard_conforming_strings
 
+          variables = @config.fetch(:variables, {}).stringify_keys
+
           # If using Active Record's time zone support configure the connection to return
           # TIMESTAMP WITH ZONE types in UTC.
           # (SET TIME ZONE does not use an equals sign like other SET variables)
-          if ActiveRecord::Base.default_timezone == :utc
-            execute("SET time zone 'UTC'", "SCHEMA")
-          elsif @local_tz
-            execute("SET time zone '#{@local_tz}'", "SCHEMA")
+          unless time_zone = variables.delete("time_zone")
+            if ActiveRecord::Base.default_timezone == :utc
+              time_zone = "UTC"
+            elsif @local_tz
+              time_zone = @local_tz
+            end
           end
+          time_zone = default_variable?(time_zone) ? "DEFAULT" : quote(time_zone)
+          execute("SET time zone #{time_zone}", "SCHEMA")
 
           # SET statements from :variables config hash
           # http://www.postgresql.org/docs/current/static/sql-set.html
-          variables = @config[:variables] || {}
           variables.map do |k, v|
-            if v == ":default" || v == :default
+            if default_variable?(v)
               # Sets the value to the global or compile default
               execute("SET SESSION #{k} TO DEFAULT", "SCHEMA")
             elsif !v.nil?

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -212,6 +212,21 @@ module ActiveRecord
       end
     end
 
+    def test_set_session_time_zone
+      run_without_connection do |orig_connection|
+        ActiveRecord::Base.establish_connection(orig_connection.deep_merge(variables: { time_zone: "America/New_York" }))
+        time_zone = ActiveRecord::Base.connection.select_value("SHOW TIME ZONE")
+        assert_equal "America/New_York", time_zone
+      end
+    end
+
+    def test_set_session_time_zone_default
+      run_without_connection do |orig_connection|
+        # This should execute a query that does not raise an error
+        ActiveRecord::Base.establish_connection(orig_connection.deep_merge(variables: { time_zone: :default }))
+      end
+    end
+
     def test_get_and_release_advisory_lock
       lock_id = 5295901941911233559
       list_advisory_locks = <<-SQL


### PR DESCRIPTION
PostgreSQL doesn't support `SET time zone TO` syntax.

https://www.postgresql.org/docs/current/static/sql-set.html