### PR TITLE
user form with instead of form for in scaffold generator

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
@@ -1,4 +1,4 @@
-<%%= form_for(<%= singular_table_name %>) do |f| %>
+<%%= form_with(model: <%= singular_table_name %>) do |f| %>
   <%% if <%= singular_table_name %>.errors.any? %>
     <div id="error_explanation">
       <h2><%%= pluralize(<%= singular_table_name %>.errors.count, "error") %> prohibited this <%= singular_table_name %> from being saved:</h2>

--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb
@@ -1,4 +1,4 @@
-<%%= form_with(model: <%= singular_table_name %>) do |f| %>
+<%%= form_with(model: <%= singular_table_name %>, local: true) do |f| %>
   <%% if <%= singular_table_name %>.errors.any? %>
     <div id="error_explanation">
       <h2><%%= pluralize(<%= singular_table_name %>.errors.count, "error") %> prohibited this <%= singular_table_name %> from being saved:</h2>


### PR DESCRIPTION
According to this http://weblog.rubyonrails.org/releases/#unify-form_tagform_for-with-form_with form_tag & form_for were unified in form_with, but the scaffold generator is still using form_for so I modified the template to use form_with 😬  