### PR TITLE
Remove obsolete warning about regular expression

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -490,9 +490,6 @@ If you set `:only_integer` to `true`, then it will use the
 regular expression to validate the attribute's value. Otherwise, it will try to
 convert the value to a number using `Float`.
 
-WARNING. Note that the regular expression above allows a trailing newline
-character.
-
 ```ruby
 class Player < ApplicationRecord
   validates :points, numericality: true


### PR DESCRIPTION
This warning became obsolete when the regular expression was changed to use `\z` instead of `\Z` in fce9c4e5e1ecb31cff2ca43a04fbe332816c3c45.

```ruby
"-1234\n" =~ /\A[+-]?\d+\Z/ => 0
"-1234\n" =~ /\A[+-]?\d+\z/ => nil
```