### PR TITLE
Add documentation about signature_key for MessageEncryptor.new [ci skip]

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -50,6 +50,11 @@ module ActiveSupport
     # key by using <tt>ActiveSupport::KeyGenerator</tt> or a similar key
     # derivation function.
     #
+    # First additional parameter is used as the signature key for +MessageVerifier+.
+    # This allows you to specify keys to encrypt and sign data.
+    #
+    #    ActiveSupport::MessageEncryptor.new('secret', 'signature_key')
+    #
     # Options:
     # * <tt>:cipher</tt>     - Cipher to use. Can be any cipher returned by
     #   <tt>OpenSSL::Cipher.ciphers</tt>. Default is 'aes-256-cbc'.


### PR DESCRIPTION
### Summary

I spent some times trying [make a migration from ruby 2.3 to 2.4 with wrong signature_key for ActiveSupport::MessageVerifier.new](https://github.com/rails/rails/issues/28401). I think `ActiveSupport::MessageEncryptor` lacks of documentation about the `sign_secret` parameter.
