### PR TITLE
Make test less brittle

### DIFF
--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -40,20 +40,14 @@ module ApplicationTests
         output = `bin/setup 2>&1`
 
         # Ignore line that's only output by Bundler < 1.14
-        output.sub!(/^Resolving dependencies\.\.\.\n/, "")
-
-        assert_equal(<<-OUTPUT, output)
-== Installing dependencies ==
-The Gemfile's dependencies are satisfied
-
-== Preparing database ==
-Created database 'db/development.sqlite3'
-Created database 'db/test.sqlite3'
-
-== Removing old logs and tempfiles ==
-
-== Restarting application server ==
-        OUTPUT
+        assert_match("== Installing dependencies ==", output)
+        assert_match("The Gemfile's dependencies are satisfied", output)
+        assert_match("== Preparing database ==", output)
+        assert_match("Created database 'db/development.sqlite3'", output)
+        assert_match("Created database 'db/test.sqlite3'", output)
+        assert_match("== Preparing database ==", output)
+        assert_match("== Removing old logs and tempfiles ==", output)
+        assert_match("== Restarting application server ==", output)
       end
     end
   end


### PR DESCRIPTION
Instead of relying on the __exact__ output of the command we can instead assert matches of the individual components we expect.

This was failing on my machine due to running a different version of bundler:

```
+Warning: the running version of Bundler (1.14.3) is older than the version that created the lockfile (1.14.4). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
```
