### PR TITLE
Deserialize a raw value from the database in `changed_in_place?` for `Mutable` helper

### DIFF
--- a/activemodel/lib/active_model/type/helpers/mutable.rb
+++ b/activemodel/lib/active_model/type/helpers/mutable.rb
@@ -12,7 +12,7 @@ module ActiveModel
         # value (likely a string). +new_value+ will be the current, type
         # cast value.
         def changed_in_place?(raw_old_value, new_value)
-          raw_old_value != serialize(new_value)
+          deserialize(raw_old_value) != new_value
         end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -68,10 +68,6 @@ module ActiveRecord
             value.map(&block)
           end
 
-          def changed_in_place?(raw_old_value, new_value)
-            deserialize(raw_old_value) != new_value
-          end
-
           def force_equality?(value)
             value.is_a?(::Array)
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/hstore.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/hstore.rb
@@ -37,14 +37,6 @@ module ActiveRecord
             ActiveRecord::Store::StringKeyedHashAccessor
           end
 
-          # Will compare the Hash equivalents of +raw_old_value+ and +new_value+.
-          # By comparing hashes, this avoids an edge case where the order of
-          # the keys change between the two hashes, and they would not be marked
-          # as equal.
-          def changed_in_place?(raw_old_value, new_value)
-            deserialize(raw_old_value) != new_value
-          end
-
           private
             HstorePair = begin
               quoted_string = /"[^"\\]*(?:\\.[^"\\]*)*"/

--- a/activerecord/lib/active_record/type/json.rb
+++ b/activerecord/lib/active_record/type/json.rb
@@ -18,10 +18,6 @@ module ActiveRecord
         ActiveSupport::JSON.encode(value) unless value.nil?
       end
 
-      def changed_in_place?(raw_old_value, new_value)
-        deserialize(raw_old_value) != new_value
-      end
-
       def accessor
         ActiveRecord::Store::StringKeyedHashAccessor
       end


### PR DESCRIPTION
Structured type values sometimes caused representation problems (keys
sort order, spaces, etc). A raw value from the database should be
deserialized (normalized) to prevent the problems.