### PR TITLE
Raise when using a bad symlink

### DIFF
--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -205,7 +205,14 @@ module Rails
 
       # Returns all expanded paths but only if they exist in the filesystem.
       def existent
-        expanded.select { |f| File.exist?(f) }
+        expanded.select do |f|
+          does_exist = File.exist?(f)
+
+          if !does_exist && File.symlink?(f)
+            raise "File #{f.inspect} is a symlink that does not point to a valid file"
+          end
+          does_exist
+        end
       end
 
       def existent_directories

--- a/railties/test/paths_test.rb
+++ b/railties/test/paths_test.rb
@@ -274,3 +274,23 @@ class PathsTest < ActiveSupport::TestCase
     end
   end
 end
+
+class PathsIntegrationTest < ActiveSupport::TestCase
+  test "A failed symlink is still a valid file" do
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        FileUtils.mkdir_p("foo")
+        File.symlink("foo/doesnotexist.rb", "foo/bar.rb")
+        assert_equal true, File.symlink?("foo/bar.rb")
+
+        root = Rails::Paths::Root.new("foo")
+        root.add "bar.rb"
+
+        exception = assert_raises(RuntimeError) do
+          root["bar.rb"].existent
+        end
+        assert_match File.expand_path("foo/bar.rb"), exception.message
+      end
+    end
+  end
+end


### PR DESCRIPTION
There was a case where a dev made a symlink that worked on some machines and not on others. The issue manifested itself on a machine with `RAILS_ENV=staging` as the had their `config/environments/staging.rb` symlinked to another config file. The behavior was very hard to track down.

Current behavior: If you use a bad symlink in a file, you get no warnings or failures or anything. If you have a bad symlink it just ignores the file as if it didn't exist (`File.exist?` returns false for a bad symlink).


Patch behavior: With this patch when a file is not present we check if a symlink exists. If it does, that indicates there is a bad symlink and we should raise 

```
File "config/environments/staging.rb" is a symlink that does not point to a valid file
```
