### PR TITLE
Fix guide incorrectly refers to public/assets/images 

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -335,7 +335,7 @@ an asset has been updated and if so loads it into the page:
 <%= javascript_include_tag "application", "data-turbolinks-track" => "reload" %>
 ```
 
-In regular views you can access images in the `public/assets/images` directory
+In regular views you can access images in the `app/assets/images` directory
 like this:
 
 ```erb


### PR DESCRIPTION
Fix for  [asset pipeline guide](https://github.com/rails/rails/blob/master/guides/source/asset_pipeline.md#coding-links-to-assets) in this line:

> In regular views you can access images in the `public/assets/images` directory like this:

Relates to issue [#28387](https://github.com/rails/rails/issues/28387)