### PR TITLE
Remove unused `@txn` variable

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -559,7 +559,6 @@ module ActiveRecord
         @marked_for_destruction   = false
         @destroyed_by_association = nil
         @new_record               = true
-        @txn                      = nil
         @_start_transaction_state = {}
         @transaction_state        = nil
       end

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -606,7 +606,6 @@ You can also inspect for an object method this way:
 @new_record = true
 @readonly = false
 @transaction_state = nil
-@txn = nil
 ```
 
 You can also use `display` to start watching variables. This is a good way of


### PR DESCRIPTION
This was added in c24c885209ac2334dc6f798c394a821ee270bec6, removed in b89ffe7f0047eb614e42232a21201b317b880755, and then (unintentionally?) reintroduced in 2d7ae1b08ee2a10b12cbfeef3a6cc6da55b57df6.