### PR TITLE
Remove implicit coercion deprecation of durations

### DIFF
--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -76,8 +76,8 @@ class MessageDeliveryTest < ActiveSupport::TestCase
 
   test "should enqueue a delivery with a delay" do
     travel_to Time.new(2004, 11, 24, 01, 04, 44) do
-      assert_performed_with(job: ActionMailer::DeliveryJob, at: Time.current + 600.seconds, args: ["DelayedMailer", "test_message", "deliver_now", 1, 2, 3]) do
-        @mail.deliver_later wait: 600.seconds
+      assert_performed_with(job: ActionMailer::DeliveryJob, at: Time.current + 10.minutes, args: ["DelayedMailer", "test_message", "deliver_now", 1, 2, 3]) do
+        @mail.deliver_later wait: 10.minutes
       end
     end
   end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Remove implicit coercion deprecation of durations
+
+    In #28204 we deprecated implicit conversion of durations to a numeric which
+    represented the number of seconds in the duration because of unwanted side
+    effects with calculations on durations and dates. This unfortunately had
+    the side effect of forcing a explicit cast when configuring third-party
+    libraries like expiration in Redis, e.g:
+
+        redis.expire("foo", 5.minutes)
+
+    To work around this we've removed the deprecation and added a private class
+    that wraps the numeric and can perform calculation involving durations and
+    ensure that they remain a duration irrespective of the order of operations.
+
+    *Andrew White*
+
 *   Update `titleize` regex to allow apostrophes
 
     In 4b685aa the regex in `titleize` was updated to not match apostrophes to

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -156,7 +156,7 @@ module ActiveSupport
           expires_in = options[:expires_in].to_i
           if expires_in > 0 && !options[:raw]
             # Set the memcache expire a few minutes in the future to support race condition ttls on read
-            expires_in += 300
+            expires_in += 5.minutes
           end
           rescue_error_with false do
             @data.send(method, key, value, expires_in, options)


### PR DESCRIPTION
In #28204 we deprecated implicit conversion of durations to a numeric which represented the number of seconds in the duration because of unwanted side effects with calculations on durations and dates. This unfortunately had the side effect of forcing a explicit cast when configuring third-party libraries like expiration in Redis, e.g:

    redis.expire("foo", 5.minutes)

To work around this we've removed the deprecation and added a private class that wraps the numeric and can perform calculation involving durations and ensure that they remain a duration irrespective of the order of operations.