### PR TITLE
`abstract_class?' returns false when instance variable @abstract_class does not defined.

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -123,7 +123,7 @@ module ActiveRecord
 
       # Returns whether this class is an abstract class or not.
       def abstract_class?
-        defined?(@abstract_class) && @abstract_class == true
+        instance_variable_defined?(:@abstract_class) && @abstract_class == true
       end
 
       def sti_name


### PR DESCRIPTION
### Summary

`abstract_class?` returns `nil` when `@abstract_class` was not defined.
For example:

```ruby
class ApplicationRecord < ActiveRecord::Base
  self.abstract_class = true
end

class User < ApplicationRecord
end
```
I got following results:
```
[1] pry(main)> ApplicationRecord.abstract_class?
=> true
[2] pry(main)> User.abstract_class?
=> nil
```

I suppose that `User.abstract_class?` could be better to return `false` not `nil`.