### PR TITLE
Use link instead of link_directory in manifest

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/assets/config/manifest.js.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/config/manifest.js.tt
@@ -1,5 +1,5 @@
 //= link_tree ../images
 <% unless options.skip_javascript -%>
-//= link_directory ../javascripts .js
+//= link application.js
 <% end -%>
-//= link_directory ../stylesheets .css
+//= link application.css

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/dummy_manifest.js
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/dummy_manifest.js
@@ -3,9 +3,9 @@
 //= link_tree ../images
 <% end -%>
 <% unless options.skip_javascript -%>
-//= link_directory ../javascripts .js
+//= link application.js
 <% end -%>
-//= link_directory ../stylesheets .css
+//= link application.css
 <% if mountable? && !api? -%>
 //= link <%= underscored_name %>_manifest.js
 <% end -%>


### PR DESCRIPTION
The `link_directory` directive will link all assets in the target directory. Instead we should only default to rendering application.css and application.js

Related PR: https://github.com/rails/sprockets-rails/pull/395