### PR TITLE
Update 'Building Complex Forms' with `inverse_of`

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -877,7 +877,7 @@ Active Record provides model level support via the `accepts_nested_attributes_fo
 
 ```ruby
 class Person < ApplicationRecord
-  has_many :addresses
+  has_many :addresses, inverse_of: :person
   accepts_nested_attributes_for :addresses
 end
 


### PR DESCRIPTION
Documentation only update.

### Summary

If the example for complex forms is implemented, ActiveRecord will prevent saving unless `inverse_of: :person` is added to the `has_many :addresses` association.
