### PR TITLE
Added config for ActionDispatch to return first IP from header issue …

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -59,7 +59,7 @@ module ActionDispatch
     # ignore those IP addresses, and return the one that you want.
     #
     # To use the first address that is probably accurate, use the
-    # config.action_dispatch.use_first_ip_from_header option this matches the 
+    # config.action_dispatch.use_first_ip_from_header option this matches the
     # general format (https://en.wikipedia.org/wiki/X-Forwarded-For)
     def initialize(app, ip_spoofing_check = true, custom_proxies = nil, use_first_ip_from_header = false)
       @app = app
@@ -115,14 +115,14 @@ module ActionDispatch
       # the last address left, which was presumably set by one of those proxies.
       #
       # To instead use the first address that is probably accurate, use the
-      # config.action_dispatch.use_first_ip_from_header option this matches the 
+      # config.action_dispatch.use_first_ip_from_header option this matches the
       # general format (https://en.wikipedia.org/wiki/X-Forwarded-For)
       def calculate_ip
         # Set by the Rack web server, this is a single value.
         remote_addr = ips_from(@req.remote_addr).last
 
         # Could be a CSV list and/or repeated headers that were concatenated.
-        client_ips    = ips_from(@req.client_ip).reverse
+        client_ips = ips_from(@req.client_ip).reverse
 
         if @use_first_ip_from_header
           forwarded_ips = ips_from(@req.x_forwarded_for)

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -39,7 +39,7 @@ module ActionDispatch
       "192.168.0.0/16", # private IPv4 range 192.168.x.x
     ].map { |proxy| IPAddr.new(proxy) }
 
-    attr_reader :check_ip, :proxies
+    attr_reader :check_ip, :proxies, :use_first_ip_from_header
 
     # Create a new +RemoteIp+ middleware instance.
     #
@@ -57,9 +57,14 @@ module ActionDispatch
     # with your proxy servers after it. If your proxies aren't removed, pass
     # them in via the +custom_proxies+ parameter. That way, the middleware will
     # ignore those IP addresses, and return the one that you want.
-    def initialize(app, ip_spoofing_check = true, custom_proxies = nil)
+    #
+    # To use the first address that is probably accurate, use the
+    # config.action_dispatch.use_first_ip_from_header option this matches the 
+    # general format (https://en.wikipedia.org/wiki/X-Forwarded-For)
+    def initialize(app, ip_spoofing_check = true, custom_proxies = nil, use_first_ip_from_header = false)
       @app = app
       @check_ip = ip_spoofing_check
+      @use_first_ip_from_header = use_first_ip_from_header
       @proxies = if custom_proxies.blank?
         TRUSTED_PROXIES
       elsif custom_proxies.respond_to?(:any?)
@@ -75,7 +80,7 @@ module ActionDispatch
     # GetIp#calculate_ip method will calculate the memoized client IP address.
     def call(env)
       req = ActionDispatch::Request.new env
-      req.remote_ip = GetIp.new(req, check_ip, proxies)
+      req.remote_ip = GetIp.new(req, check_ip, proxies, use_first_ip_from_header)
       @app.call(req.env)
     end
 
@@ -83,10 +88,11 @@ module ActionDispatch
     # into an actual IP address. If the ActionDispatch::Request#remote_ip method
     # is called, this class will calculate the value and then memoize it.
     class GetIp
-      def initialize(req, check_ip, proxies)
+      def initialize(req, check_ip, proxies, use_first_ip_from_header = false)
         @req      = req
         @check_ip = check_ip
         @proxies  = proxies
+        @use_first_ip_from_header = use_first_ip_from_header
       end
 
       # Sort through the various IP address headers, looking for the IP most
@@ -107,13 +113,22 @@ module ActionDispatch
       # In order to find the first address that is (probably) accurate, we
       # take the list of IPs, remove known and trusted proxies, and then take
       # the last address left, which was presumably set by one of those proxies.
+      #
+      # To instead use the first address that is probably accurate, use the
+      # config.action_dispatch.use_first_ip_from_header option this matches the 
+      # general format (https://en.wikipedia.org/wiki/X-Forwarded-For)
       def calculate_ip
         # Set by the Rack web server, this is a single value.
         remote_addr = ips_from(@req.remote_addr).last
 
         # Could be a CSV list and/or repeated headers that were concatenated.
         client_ips    = ips_from(@req.client_ip).reverse
-        forwarded_ips = ips_from(@req.x_forwarded_for).reverse
+
+        if @use_first_ip_from_header
+          forwarded_ips = ips_from(@req.x_forwarded_for)
+        else
+          forwarded_ips = ips_from(@req.x_forwarded_for).reverse
+        end
 
         # +Client-Ip+ and +X-Forwarded-For+ should not, generally, both be set.
         # If they are both set, it means that either:
@@ -172,8 +187,12 @@ module ActionDispatch
       end
 
       def filter_proxies(ips) # :doc:
-        ips.reject do |ip|
-          @proxies.any? { |proxy| proxy === ip }
+        if @use_first_ip_from_header
+          return ips
+        else
+          ips.reject do |ip|
+            @proxies.any? { |proxy| proxy === ip }
+          end
         end
       end
     end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -105,7 +105,7 @@ class RequestIP < BaseRequestTest
   end
 
   test "use first ip from header" do
-    request = stub_request({:use_first_ip_from_header => true, "HTTP_X_FORWARDED_FOR" => "10.0.0.1, 3.4.5.6"})
+    request = stub_request(:use_first_ip_from_header => true, "HTTP_X_FORWARDED_FOR" => "10.0.0.1, 3.4.5.6")
     assert_equal "10.0.0.1", request.remote_ip
   end
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -20,9 +20,10 @@ class BaseRequestTest < ActiveSupport::TestCase
 
   private
     def stub_request(env = {})
+      use_first_ip_from_header = env.key?(:use_first_ip_from_header) ? env.delete(:use_first_ip_from_header) : false
       ip_spoofing_check = env.key?(:ip_spoofing_check) ? env.delete(:ip_spoofing_check) : true
       @trusted_proxies ||= nil
-      ip_app = ActionDispatch::RemoteIp.new(Proc.new {}, ip_spoofing_check, @trusted_proxies)
+      ip_app = ActionDispatch::RemoteIp.new(Proc.new {}, ip_spoofing_check, @trusted_proxies, use_first_ip_from_header)
       ActionDispatch::Http::URL.tld_length = env.delete(:tld_length) if env.key?(:tld_length)
 
       ip_app.call(env)
@@ -101,6 +102,11 @@ class RequestIP < BaseRequestTest
 
     request = stub_request "HTTP_X_FORWARDED_FOR" => "not_ip_address"
     assert_nil request.remote_ip
+  end
+
+  test "use first ip from header" do
+    request = stub_request({:use_first_ip_from_header => true, "HTTP_X_FORWARDED_FOR" => "10.0.0.1, 3.4.5.6"})
+    assert_equal "10.0.0.1", request.remote_ip
   end
 
   test "remote ip spoof detection" do

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -229,7 +229,7 @@ Every Rails application comes with a standard set of middleware which it uses in
 * `Rails::Rack::Logger` notifies the logs that the request has begun. After request is complete, flushes all the logs.
 * `ActionDispatch::ShowExceptions` rescues any exception returned by the application and renders nice exception pages if the request is local or if `config.consider_all_requests_local` is set to `true`. If `config.action_dispatch.show_exceptions` is set to `false`, exceptions will be raised regardless.
 * `ActionDispatch::RequestId` makes a unique X-Request-Id header available to the response and enables the `ActionDispatch::Request#uuid` method.
-* `ActionDispatch::RemoteIp` checks for IP spoofing attacks and gets valid `client_ip` from request headers. Configurable with the `config.action_dispatch.ip_spoofing_check`, and `config.action_dispatch.trusted_proxies` options.
+* `ActionDispatch::RemoteIp` checks for IP spoofing attacks and gets valid `client_ip` from request headers. Configurable with the `config.action_dispatch.ip_spoofing_check`, and `config.action_dispatch.trusted_proxies` options. Optionally, the first IP address from the X-Forwarded-For header can be used by configuring the config.action_dispatch.use_first_ip_from_header option.
 * `Rack::Sendfile` intercepts responses whose body is being served from a file and replaces it with a server specific X-Sendfile header. Configurable with `config.action_dispatch.x_sendfile_header`.
 * `ActionDispatch::Callbacks` runs the prepare callbacks before serving the request.
 * `ActionDispatch::Cookies` sets cookies for the request.

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -40,7 +40,7 @@ module Rails
           middleware.use ::Rack::Runtime
           middleware.use ::Rack::MethodOverride unless config.api_only
           middleware.use ::ActionDispatch::RequestId
-          middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
+          middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies, config.action_dispatch.use_first_ip_from_header
 
           middleware.use ::Rails::Rack::Logger, config.log_tags
           middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app


### PR DESCRIPTION
…#28436

### Summary
This change adds the configuration option to return the first IP from the X-Forwarded-For header matching the general format (https://en.wikipedia.org/wiki/X-Forwarded-For). This will return the correct client IP in instances where Rails is deployed as an internally available service behind a reverse proxy or load balancer.

