### PR TITLE
Updates incorrect documentation [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -192,11 +192,10 @@ module ActionDispatch
       # HTTP methods in integration tests. +#process+ is only required when using a
       # request method that doesn't have a method defined in the integration tests.
       #
-      # This method returns a Response object, which one can use to
-      # inspect the details of the response. Furthermore, if this method was
+      # This method returns a response status. Furthermore, if this method was
       # called from an ActionDispatch::IntegrationTest object, then that
-      # object's <tt>@response</tt> instance variable will point to the same
-      # response object.
+      # object's <tt>@response</tt> instance variable will point to Response object
+      # which one can use to inspect the details of the response.
       #
       # Example:
       #   process :get, '/author', params: { since: 201501011400 }


### PR DESCRIPTION
### Summary

Looking on [code for this method](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/testing/integration.rb#L274) it's clear that it's just return `response.status` instead of full `response` object. I wish it would work as documented but it's better to correct docs as probably lots of tests are relying on current behavior.

### Other Information

It's easy to check what is actually returned:
![_357](https://cloud.githubusercontent.com/assets/1160699/23993591/d9e556f8-0a49-11e7-9889-3eb27ad5f05f.png)
