### PR TITLE
Add documentation to use with_options anywhere in the same class [ci

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/with_options.rb
+++ b/activesupport/lib/active_support/core_ext/object/with_options.rb
@@ -62,6 +62,17 @@ class Object
   #
   # Hence the inherited default for `if` key is ignored.
   #
+  # NOTE: You cannot call class methods implicitly inside of with_options,
+  # refer the methods using the class name instead, like so:
+  #
+  #   class Phone < ActiveRecord::Base
+  #     enum phone_number_type: [home: 0, office: 1, mobile: 2]
+  #
+  #     with_options presence: true do
+  #       validates :phone_number_type, inclusion: { in: Phone.phone_number_types.keys }
+  #     end
+  #   end
+  #
   def with_options(options, &block)
     option_merger = ActiveSupport::OptionMerger.new(self, options)
     block.arity.zero? ? option_merger.instance_eval(&block) : block.call(option_merger)


### PR DESCRIPTION
skip]

Add documentation for issue #27897 Specifying an enum and then using with_options anywhere in the same class raises an ArgumentError  