### PR TITLE
Test case for has_many :though unscoping bug

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1234,6 +1234,10 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     TenantMembership.current_member = nil
   end
 
+  def test_has_many_through_able_overwrite_source_association_order
+    assert_equal [], Member.first.unordered_clubs.order_values
+  end
+
   def test_has_many_through_with_scope_should_respect_table_alias
     family = Family.create!
     users = 3.times.map { User.create! }

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -29,6 +29,9 @@ class Member < ActiveRecord::Base
   has_many :tenant_memberships
   has_many :tenant_clubs, through: :tenant_memberships, class_name: "Club", source: :club
 
+  has_many :ordered_memberships, -> { order(:created_at) }, class_name: 'Membership'
+  has_many :unordered_clubs, -> { unscope(:order) }, through: :ordered_memberships, class_name: "Club", source: :club
+
   has_one :club_through_many, through: :current_memberships, source: :club
 
   belongs_to :admittable, polymorphic: true


### PR DESCRIPTION
### Summary

There is no way to un-scope the order in has-many-though association defined in the source reflection.
This PR is a failing test case for the issue.