### PR TITLE
Move AS::Duration::ISO8601Parser::ParsingError

### DIFF
--- a/activesupport/lib/active_support/duration/iso8601_parser.rb
+++ b/activesupport/lib/active_support/duration/iso8601_parser.rb
@@ -9,8 +9,6 @@ module ActiveSupport
     #
     # This parser allows negative parts to be present in pattern.
     class ISO8601Parser # :nodoc:
-      class ParsingError < ::ArgumentError; end
-
       PERIOD_OR_COMMA = /\.|,/
       PERIOD = ".".freeze
       COMMA = ",".freeze
@@ -94,7 +92,7 @@ module ActiveSupport
         end
 
         def raise_parsing_error(reason = nil)
-          raise ParsingError, "Invalid ISO 8601 duration: #{scanner.string.inspect} #{reason}".strip
+          raise ArgumentError, "Invalid ISO 8601 duration: #{scanner.string.inspect} #{reason}".strip
         end
 
         # Checks for various semantic errors as stated in ISO 8601 standard.

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -446,7 +446,7 @@ class DurationTest < ActiveSupport::TestCase
   def test_iso8601_parsing_wrong_patterns_with_raise
     invalid_patterns = ["", "P", "PT", "P1YT", "T", "PW", "P1Y1W", "~P1Y", ".P1Y", "P1.5Y0.5M", "P1.5Y1M", "P1.5MT10.5S"]
     invalid_patterns.each do |pattern|
-      assert_raise ActiveSupport::Duration::ISO8601Parser::ParsingError, pattern.inspect do
+      assert_raise ArgumentError, pattern.inspect do
         ActiveSupport::Duration.parse(pattern)
       end
     end


### PR DESCRIPTION
`ActiveSupport::Duration::ISO8601Parser` is an internal class (the public API is `AS::Duration.parse`). This moves the error under the public `AS::Duration` class so that it could be documented. Keeping the parser class private would also allow us to change the parsing implementation strategy in the future.

cc @pixeltrix 