### PR TITLE
Add :default option to belongs_to

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add `:default` option to `belongs_to`.
+
+    Use it to specify that an association should be initialized with a particular
+    record before validation. For example:
+
+        # Before
+        belongs_to :account
+        before_validation -> { self.account ||= Current.account }
+
+        # After
+        belongs_to :account, default: -> { Current.account }
+
+    *George Claghorn*
+
 *   Deprecate `Migrator.schema_migrations_table_name`.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1647,6 +1647,9 @@ module ActiveRecord
         #   +:inverse_of+ to avoid an extra query during validation.
         #   NOTE: <tt>required</tt> is set to <tt>true</tt> by default and is deprecated. If
         #   you don't want to have association presence validated, use <tt>optional: true</tt>.
+        # [:default]
+        #   Provide a callable (i.e. proc or lambda) to specify that the association should
+        #   be initialized with a particular record before validation. 
         #
         # Option examples:
         #   belongs_to :firm, foreign_key: "client_of"
@@ -1660,6 +1663,7 @@ module ActiveRecord
         #   belongs_to :comment, touch: true
         #   belongs_to :company, touch: :employees_last_updated_at
         #   belongs_to :user, optional: true
+        #   belongs_to :account, default: -> { company.account }
         def belongs_to(name, scope = nil, options = {})
           reflection = Builder::BelongsTo.build(self, name, scope, options)
           Reflection.add_reflection self, name, reflection

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -21,6 +21,10 @@ module ActiveRecord
         self.target = record
       end
 
+      def default(record)
+        writer(record) if reader.nil?
+      end
+
       def reset
         super
         @updated = false

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -5,7 +5,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_options(options)
-      super + [:polymorphic, :touch, :counter_cache, :optional]
+      super + [:polymorphic, :touch, :counter_cache, :optional, :default]
     end
 
     def self.valid_dependent_options
@@ -16,6 +16,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
       super
       add_counter_cache_callbacks(model, reflection) if reflection.options[:counter_cache]
       add_touch_callbacks(model, reflection)         if reflection.options[:touch]
+      add_default_callbacks(model, reflection)       if reflection.options[:default]
     end
 
     def self.define_accessors(mixin, reflection)
@@ -116,6 +117,12 @@ module ActiveRecord::Associations::Builder # :nodoc:
       model.after_save    callback.(:saved_changes), if: :saved_changes?
       model.after_touch   callback.(:changes_to_save)
       model.after_destroy callback.(:changes_to_save)
+    end
+
+    def self.add_default_callbacks(model, reflection)
+      model.before_validation lambda { |o|
+        o.association(reflection.name).default o.instance_exec(&reflection.options[:default])
+      }
     end
 
     def self.add_destroy_callbacks(model, reflection)

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -116,6 +116,26 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     ActiveRecord::Base.belongs_to_required_by_default = original_value
   end
 
+  def test_default
+    david = developers(:david)
+    jamis = developers(:jamis)
+
+    model = Class.new(ActiveRecord::Base) do
+      self.table_name = "ships"
+      def self.name; "Temp"; end
+      belongs_to :developer, default: -> { david }
+    end
+
+    ship = model.create!
+    assert_equal david, ship.developer
+
+    ship = model.create!(developer: jamis)
+    assert_equal jamis, ship.developer
+
+    ship.update!(developer: nil)
+    assert_equal david, ship.developer
+  end
+
   def test_default_scope_on_relations_is_not_cached
     counter = 0
 


### PR DESCRIPTION
In Basecamp, we often use `before_validation` callbacks to initialize `belongs_to` associations like so:

```ruby
belongs_to :person
before_validation -> { self.person ||= Current.person }

belongs_to :account
before_validation -> { self.account = person.account }
```

This PR adds a `:default` option to the `belongs_to` macro to formalize and simplify that pattern. The `:default` option adds a `before_validation` callback that initializes the association with the given lambda’s return value. It’s used like this:

```ruby
belongs_to :person, default: -> { Current.person }
belongs_to :account, default: -> { person.account }
```

/cc @dhh 