### PR TITLE
[#28431], Adds mapping for TzInfo zone Identifier "America/El_Salvador"

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -45,6 +45,7 @@ module ActiveSupport
       "Mexico City"                  => "America/Mexico_City",
       "Monterrey"                    => "America/Monterrey",
       "Central America"              => "America/Guatemala",
+      "El Salvador"                  => "America/El_Salvador",
       "Eastern Time (US & Canada)"   => "America/New_York",
       "Indiana (East)"               => "America/Indiana/Indianapolis",
       "Bogota"                       => "America/Bogota",


### PR DESCRIPTION
### Summary

- Under Issue #28431 is was found that time_zone.rb had a mapping missing for officially assigned country code(SV) for El Salvador.

- It was also verified that Tzinfo returns the appropriate zone_identifier ["America/El_Salvador"]

- This pull request adds the Mapping for "America/El_Salvador" zone_identifier.
