### PR TITLE
Add support for calling nested direct routes

### DIFF
--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -40,7 +40,7 @@ module ActionDispatch
     #
     # Example usage:
     #
-    #   edit_polymorphic_path(@post)              # => "/posts/1/edit"
+    #   edit_polymorphic_path(@post)           # => "/posts/1/edit"
     #   polymorphic_path(@post, format: :pdf)  # => "/posts/1.pdf"
     #
     # == Usage with mounted engines
@@ -104,7 +104,7 @@ module ActionDispatch
         end
 
         if mapping = polymorphic_mapping(record_or_hash_or_array)
-          return mapping.call(self, [record_or_hash_or_array, options])
+          return mapping.call(self, [record_or_hash_or_array, options], false)
         end
 
         opts   = options.dup
@@ -128,7 +128,7 @@ module ActionDispatch
         end
 
         if mapping = polymorphic_mapping(record_or_hash_or_array)
-          return mapping.call(self, [record_or_hash_or_array, options], only_path: true)
+          return mapping.call(self, [record_or_hash_or_array, options], true)
         end
 
         opts   = options.dup
@@ -273,7 +273,7 @@ module ActionDispatch
 
           def handle_model_call(target, record)
             if mapping = polymorphic_mapping(target, record)
-              mapping.call(target, [record], only_path: suffix == "path")
+              mapping.call(target, [record], suffix == "path")
             else
               method, args = handle_model(record)
               target.send(method, *args)

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -192,6 +192,10 @@ module ActionDispatch
         end
       end
 
+      def route_for(name, *args) # :nodoc:
+        public_send(:"#{name}_url", *args)
+      end
+
       protected
 
         def optimize_routes_generation?


### PR DESCRIPTION
Not all requirements can be expressed in terms of polymorphic url options so add a `route_for` method that allows calling another direct route (or regular named route) which a set of arguments, e.g:

``` ruby
resources :buckets

direct :recordable do |recording|
  route_for(:bucket, recording.bucket)
end

direct :threadable do |threadable|
  route_for(:recordable, threadable.parent)
end
```

This maintains the context of the original caller, e.g.

``` ruby
threadable_path(threadable) # => /buckets/1
threadable_url(threadable)  # => http://example.com/buckets/1
```
