### PR TITLE
[Backport] Freeze and convert `to_time`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fixed bug in `DateAndTime::Compatibility#to_time` that caused it to
+    raise `RuntimeError: can't modify frozen Time` when called on any frozen `Time`.
+    Properly pass through the frozen `Time` or `ActiveSupport::TimeWithZone` object
+    when calling `#to_time`.
+
+    *Kevin McPhillips* & *Andrew White*
+
 *   Restore the return type of `DateTime#utc`
 
     In Rails 5.0 the return type of `DateTime#utc` was changed to `Time` to be

--- a/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
@@ -11,9 +11,5 @@ module DateAndTime
     # this behavior, but new apps will have an initializer that sets
     # this to true, because the new behavior is preferred.
     mattr_accessor(:preserve_timezone, instance_writer: false) { false }
-
-    def to_time
-      preserve_timezone ? getlocal(utc_offset) : getlocal
-    end
   end
 end

--- a/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
@@ -12,18 +12,8 @@ module DateAndTime
     # this to true, because the new behavior is preferred.
     mattr_accessor(:preserve_timezone, instance_writer: false) { false }
 
-    def self.included(base)
-      base.class_eval do
-        remove_possible_method :to_time
-
-        def to_time
-          if preserve_timezone
-            @_to_time_with_instance_offset ||= getlocal(utc_offset)
-          else
-            @_to_time_with_system_offset ||= getlocal
-          end
-        end
-      end
+    def to_time
+      preserve_timezone ? getlocal(utc_offset) : getlocal
     end
   end
 end

--- a/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
@@ -2,4 +2,14 @@ require 'active_support/core_ext/date_and_time/compatibility'
 
 class DateTime
   include DateAndTime::Compatibility
+
+  remove_possible_method :to_time
+
+  # Either return an instance of `Time` with the same UTC offset
+  # as +self+ or an instance of `Time` representing the same time
+  # in the the local system timezone depending on the setting of
+  # on the setting of +ActiveSupport.to_time_preserves_timezone+.
+  def to_time
+    preserve_timezone ? getlocal(utc_offset) : getlocal
+  end
 end

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -257,7 +257,9 @@ class Time
   # can be chronologically compared with a Time
   def compare_with_coercion(other)
     # we're avoiding Time#to_datetime cause it's expensive
-    if other.is_a?(Time)
+    if other.class == Time
+      compare_without_coercion(other)
+    elsif other.is_a?(Time)
       compare_without_coercion(other.to_time)
     else
       to_datetime <=> other

--- a/activesupport/lib/active_support/core_ext/time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/time/compatibility.rb
@@ -6,6 +6,8 @@ class Time
 
   remove_possible_method :to_time
 
+  # Either return +self+ or the time in the local system timezone depending
+  # on the setting of +ActiveSupport.to_time_preserves_timezone+.
   def to_time
     preserve_timezone ? self : getlocal
   end

--- a/activesupport/lib/active_support/core_ext/time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/time/compatibility.rb
@@ -1,5 +1,12 @@
-require 'active_support/core_ext/date_and_time/compatibility'
+require "active_support/core_ext/date_and_time/compatibility"
+require "active_support/core_ext/module/remove_method"
 
 class Time
   include DateAndTime::Compatibility
+
+  remove_possible_method :to_time
+
+  def to_time
+    preserve_timezone ? self : getlocal
+  end
 end

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -326,6 +326,15 @@ module ActiveSupport
       @to_datetime ||= utc.to_datetime.new_offset(Rational(utc_offset, 86_400))
     end
 
+    # Returns an instance of <tt>Time</tt>
+    def to_time
+      if preserve_timezone
+        @to_time_with_instance_offset ||= getlocal(utc_offset)
+      else
+        @to_time_with_system_offset ||= getlocal
+      end
+    end
+
     # So that +self+ <tt>acts_like?(:time)</tt>.
     def acts_like_time?
       true
@@ -339,7 +348,7 @@ module ActiveSupport
 
     def freeze
       # preload instance variables before freezing
-      period; utc; time; to_datetime
+      period; utc; time; to_datetime; to_time
       super
     end
 

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -326,7 +326,9 @@ module ActiveSupport
       @to_datetime ||= utc.to_datetime.new_offset(Rational(utc_offset, 86_400))
     end
 
-    # Returns an instance of <tt>Time</tt>
+    # Returns an instance of +Time+, either with the same UTC offset
+    # as +self+ or in the local system timezone depending on the setting
+    # of +ActiveSupport.to_time_preserves_timezone+.
     def to_time
       if preserve_timezone
         @to_time_with_instance_offset ||= getlocal(utc_offset)

--- a/activesupport/test/core_ext/date_and_time_compatibility_test.rb
+++ b/activesupport/test/core_ext/date_and_time_compatibility_test.rb
@@ -15,32 +15,67 @@ class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
 
   def test_time_to_time_preserves_timezone
     with_preserve_timezone(true) do
-      with_env_tz 'US/Eastern' do
-        time = Time.new(2016, 4, 23, 15, 11, 12, 3600).to_time
+      with_env_tz "US/Eastern" do
+        source = Time.new(2016, 4, 23, 15, 11, 12, 3600)
+        time = source.to_time
 
         assert_instance_of Time, time
         assert_equal @utc_time, time.getutc
         assert_equal @utc_offset, time.utc_offset
+        assert_equal source.object_id, time.object_id
       end
     end
   end
 
   def test_time_to_time_does_not_preserve_time_zone
     with_preserve_timezone(false) do
-      with_env_tz 'US/Eastern' do
-        time = Time.new(2016, 4, 23, 15, 11, 12, 3600).to_time
+      with_env_tz "US/Eastern" do
+        source = Time.new(2016, 4, 23, 15, 11, 12, 3600)
+        time = source.to_time
 
         assert_instance_of Time, time
         assert_equal @utc_time, time.getutc
         assert_equal @system_offset, time.utc_offset
+        assert_not_equal source.object_id, time.object_id
+      end
+    end
+  end
+
+  def test_time_to_time_frozen_preserves_timezone
+    with_preserve_timezone(true) do
+      with_env_tz "US/Eastern" do
+        source = Time.new(2016, 4, 23, 15, 11, 12, 3600).freeze
+        time = source.to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_equal @utc_offset, time.utc_offset
+        assert_equal source.object_id, time.object_id
+        assert_predicate time, :frozen?
+      end
+    end
+  end
+
+  def test_time_to_time_frozen_does_not_preserve_time_zone
+    with_preserve_timezone(false) do
+      with_env_tz "US/Eastern" do
+        source = Time.new(2016, 4, 23, 15, 11, 12, 3600).freeze
+        time = source.to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_equal @system_offset, time.utc_offset
+        assert_not_equal source.object_id, time.object_id
+        assert_not_predicate time, :frozen?
       end
     end
   end
 
   def test_datetime_to_time_preserves_timezone
     with_preserve_timezone(true) do
-      with_env_tz 'US/Eastern' do
-        time = DateTime.new(2016, 4, 23, 15, 11, 12, Rational(1,24)).to_time
+      with_env_tz "US/Eastern" do
+        source = DateTime.new(2016, 4, 23, 15, 11, 12, Rational(1, 24))
+        time = source.to_time
 
         assert_instance_of Time, time
         assert_equal @utc_time, time.getutc
@@ -51,8 +86,9 @@ class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
 
   def test_datetime_to_time_does_not_preserve_time_zone
     with_preserve_timezone(false) do
-      with_env_tz 'US/Eastern' do
-        time = DateTime.new(2016, 4, 23, 15, 11, 12, Rational(1,24)).to_time
+      with_env_tz "US/Eastern" do
+        source = DateTime.new(2016, 4, 23, 15, 11, 12, Rational(1, 24))
+        time = source.to_time
 
         assert_instance_of Time, time
         assert_equal @utc_time, time.getutc
@@ -61,17 +97,47 @@ class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
     end
   end
 
+  def test_datetime_to_time_frozen_preserves_timezone
+    with_preserve_timezone(true) do
+      with_env_tz "US/Eastern" do
+        source = DateTime.new(2016, 4, 23, 15, 11, 12, Rational(1, 24)).freeze
+        time = source.to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_equal @utc_offset, time.utc_offset
+        assert_not_predicate time, :frozen?
+      end
+    end
+  end
+
+  def test_datetime_to_time_frozen_does_not_preserve_time_zone
+    with_preserve_timezone(false) do
+      with_env_tz "US/Eastern" do
+        source = DateTime.new(2016, 4, 23, 15, 11, 12, Rational(1, 24)).freeze
+        time = source.to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_equal @system_offset, time.utc_offset
+        assert_not_predicate time, :frozen?
+      end
+    end
+  end
+
   def test_twz_to_time_preserves_timezone
     with_preserve_timezone(true) do
-      with_env_tz 'US/Eastern' do
-        time = ActiveSupport::TimeWithZone.new(@utc_time, @zone).to_time
+      with_env_tz "US/Eastern" do
+        source = ActiveSupport::TimeWithZone.new(@utc_time, @zone)
+        time = source.to_time
 
         assert_instance_of Time, time
         assert_equal @utc_time, time.getutc
         assert_instance_of Time, time.getutc
         assert_equal @utc_offset, time.utc_offset
 
-        time = ActiveSupport::TimeWithZone.new(@date_time, @zone).to_time
+        source = ActiveSupport::TimeWithZone.new(@date_time, @zone)
+        time = source.to_time
 
         assert_instance_of Time, time
         assert_equal @date_time, time.getutc
@@ -83,15 +149,17 @@ class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
 
   def test_twz_to_time_does_not_preserve_time_zone
     with_preserve_timezone(false) do
-      with_env_tz 'US/Eastern' do
-        time = ActiveSupport::TimeWithZone.new(@utc_time, @zone).to_time
+      with_env_tz "US/Eastern" do
+        source = ActiveSupport::TimeWithZone.new(@utc_time, @zone)
+        time = source.to_time
 
         assert_instance_of Time, time
         assert_equal @utc_time, time.getutc
         assert_instance_of Time, time.getutc
         assert_equal @system_offset, time.utc_offset
 
-        time = ActiveSupport::TimeWithZone.new(@date_time, @zone).to_time
+        source = ActiveSupport::TimeWithZone.new(@date_time, @zone)
+        time = source.to_time
 
         assert_instance_of Time, time
         assert_equal @date_time, time.getutc
@@ -101,10 +169,59 @@ class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
     end
   end
 
+  def test_twz_to_time_frozen_preserves_timezone
+    with_preserve_timezone(true) do
+      with_env_tz "US/Eastern" do
+        source = ActiveSupport::TimeWithZone.new(@utc_time, @zone).freeze
+        time = source.to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_instance_of Time, time.getutc
+        assert_equal @utc_offset, time.utc_offset
+        assert_not_predicate time, :frozen?
+
+        source = ActiveSupport::TimeWithZone.new(@date_time, @zone).freeze
+        time = source.to_time
+
+        assert_instance_of Time, time
+        assert_equal @date_time, time.getutc
+        assert_instance_of Time, time.getutc
+        assert_equal @utc_offset, time.utc_offset
+        assert_not_predicate time, :frozen?
+      end
+    end
+  end
+
+  def test_twz_to_time_frozen_does_not_preserve_time_zone
+    with_preserve_timezone(false) do
+      with_env_tz "US/Eastern" do
+        source = ActiveSupport::TimeWithZone.new(@utc_time, @zone).freeze
+        time = source.to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_instance_of Time, time.getutc
+        assert_equal @system_offset, time.utc_offset
+        assert_not_predicate time, :frozen?
+
+        source = ActiveSupport::TimeWithZone.new(@date_time, @zone).freeze
+        time = source.to_time
+
+        assert_instance_of Time, time
+        assert_equal @date_time, time.getutc
+        assert_instance_of Time, time.getutc
+        assert_equal @system_offset, time.utc_offset
+        assert_not_predicate time, :frozen?
+      end
+    end
+  end
+
   def test_string_to_time_preserves_timezone
     with_preserve_timezone(true) do
-      with_env_tz 'US/Eastern' do
-        time = "2016-04-23T15:11:12+01:00".to_time
+      with_env_tz "US/Eastern" do
+        source = "2016-04-23T15:11:12+01:00"
+        time = source.to_time
 
         assert_instance_of Time, time
         assert_equal @utc_time, time.getutc
@@ -115,12 +232,41 @@ class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
 
   def test_string_to_time_does_not_preserve_time_zone
     with_preserve_timezone(false) do
-      with_env_tz 'US/Eastern' do
-        time = "2016-04-23T15:11:12+01:00".to_time
+      with_env_tz "US/Eastern" do
+        source = "2016-04-23T15:11:12+01:00"
+        time = source.to_time
 
         assert_instance_of Time, time
         assert_equal @utc_time, time.getutc
         assert_equal @system_offset, time.utc_offset
+      end
+    end
+  end
+
+  def test_string_to_time_frozen_preserves_timezone
+    with_preserve_timezone(true) do
+      with_env_tz "US/Eastern" do
+        source = "2016-04-23T15:11:12+01:00".freeze
+        time = source.to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_equal @utc_offset, time.utc_offset
+        assert_not_predicate time, :frozen?
+      end
+    end
+  end
+
+  def test_string_to_time_frozen_does_not_preserve_time_zone
+    with_preserve_timezone(false) do
+      with_env_tz "US/Eastern" do
+        source = "2016-04-23T15:11:12+01:00".freeze
+        time = source.to_time
+
+        assert_instance_of Time, time
+        assert_equal @utc_time, time.getutc
+        assert_equal @system_offset, time.utc_offset
+        assert_not_predicate time, :frozen?
       end
     end
   end

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -385,11 +385,29 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal time, Time.at(time)
   end
 
-  def test_to_time
-    with_env_tz 'US/Eastern' do
-      assert_equal Time, @twz.to_time.class
-      assert_equal Time.local(1999, 12, 31, 19), @twz.to_time
-      assert_equal Time.local(1999, 12, 31, 19).utc_offset, @twz.to_time.utc_offset
+  def test_to_time_with_preserve_timezone
+    with_preserve_timezone(true) do
+      with_env_tz "US/Eastern" do
+        time = @twz.to_time
+
+        assert_equal Time, time.class
+        assert_equal time.object_id, @twz.to_time.object_id
+        assert_equal Time.local(1999, 12, 31, 19), time
+        assert_equal Time.local(1999, 12, 31, 19).utc_offset, time.utc_offset
+      end
+    end
+  end
+
+  def test_to_time_without_preserve_timezone
+    with_preserve_timezone(false) do
+      with_env_tz "US/Eastern" do
+        time = @twz.to_time
+
+        assert_equal Time, time.class
+        assert_equal time.object_id, @twz.to_time.object_id
+        assert_equal Time.local(1999, 12, 31, 19), time
+        assert_equal Time.local(1999, 12, 31, 19).utc_offset, time.utc_offset
+      end
     end
   end
 
@@ -468,6 +486,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
       @twz.period
       @twz.time
       @twz.to_datetime
+      @twz.to_time
     end
   end
 


### PR DESCRIPTION
Backport of #28147 which also includes 505537082849d912e8e29819655b80a573e93c0c by @pixeltrix 

## Summary

Properly handles `#to_time` calls on date/time/TWZ objects, including memoziation for speed and dealing with frozen objects. Fixes the `RuntimeError: can't modify frozen Time` when comparing against a frozen time in some cases.

**Also**, includes the small change to prevent coersion with `to_time` unnecessarily if the object is already a `Time`. It is on `master` and `5-0-stable` but was lost on `4-2-stable` due to some reverts that were not backported. This specific omission is what makes this time freeze bug so much easier to encounter on `4.2.8`.

https://github.com/rails/rails/blob/bac40b9cc8bae5a88743dba01bdee24ef8a2d579/activesupport/lib/active_support/core_ext/time/calculations.rb#L287-L288

