### PR TITLE
Delegate `uniq` to `records`

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -36,7 +36,7 @@ module ActiveRecord
     # may vary depending on the klass of a relation, so we create a subclass of Relation
     # for each different klass, and the delegations are compiled into that subclass only.
 
-    delegate :to_xml, :encode_with, :length, :collect, :map, :each, :all?, :include?, :to_ary, :join,
+    delegate :to_xml, :encode_with, :length, :collect, :uniq, :each, :all?, :include?, :to_ary, :join,
              :[], :&, :|, :+, :-, :sample, :reverse, :compact, :in_groups, :in_groups_of,
              :to_sentence, :to_formatted_s, :as_json,
              :shuffle, :split, :index, to: :records

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -36,7 +36,7 @@ module ActiveRecord
     # may vary depending on the klass of a relation, so we create a subclass of Relation
     # for each different klass, and the delegations are compiled into that subclass only.
 
-    delegate :to_xml, :encode_with, :length, :collect, :uniq, :each, :all?, :include?, :to_ary, :join,
+    delegate :to_xml, :encode_with, :length, :each, :uniq, :to_ary, :join,
              :[], :&, :|, :+, :-, :sample, :reverse, :compact, :in_groups, :in_groups_of,
              :to_sentence, :to_formatted_s, :as_json,
              :shuffle, :split, :index, to: :records

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1903,7 +1903,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_calling_many_on_loaded_association_should_not_use_query
     firm = companies(:first_firm)
-    firm.clients.collect  # force load
+    firm.clients.load  # force load
     assert_no_queries { assert firm.clients.many? }
   end
 
@@ -1942,7 +1942,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_calling_none_on_loaded_association_should_not_use_query
     firm = companies(:first_firm)
-    firm.clients.collect  # force load
+    firm.clients.load  # force load
     assert_no_queries { assert ! firm.clients.none? }
   end
 
@@ -1977,7 +1977,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_calling_one_on_loaded_association_should_not_use_query
     firm = companies(:first_firm)
-    firm.clients.collect  # force load
+    firm.clients.load  # force load
     assert_no_queries { assert ! firm.clients.one? }
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -112,7 +112,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_loaded_first
     topics = Topic.all.order("id ASC")
-    topics.to_a # force load
+    topics.load # force load
 
     assert_no_queries do
       assert_equal "The First Topic", topics.first.title
@@ -123,7 +123,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_loaded_first_with_limit
     topics = Topic.all.order("id ASC")
-    topics.to_a # force load
+    topics.load # force load
 
     assert_no_queries do
       assert_equal ["The First Topic",
@@ -136,7 +136,7 @@ class RelationTest < ActiveRecord::TestCase
   def test_first_get_more_than_available
     topics = Topic.all.order("id ASC")
     unloaded_first = topics.first(10)
-    topics.to_a # force load
+    topics.load # force load
 
     assert_no_queries do
       loaded_first = topics.first(10)
@@ -1155,7 +1155,7 @@ class RelationTest < ActiveRecord::TestCase
     assert ! posts.loaded?
 
     best_posts = posts.where(comments_count: 0)
-    best_posts.to_a # force load
+    best_posts.load # force load
     assert_no_queries { assert_equal 9, best_posts.size }
   end
 
@@ -1166,7 +1166,7 @@ class RelationTest < ActiveRecord::TestCase
     assert ! posts.loaded?
 
     best_posts = posts.where(comments_count: 0)
-    best_posts.to_a # force load
+    best_posts.load # force load
     assert_no_queries { assert_equal 9, best_posts.size }
   end
 
@@ -1176,7 +1176,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_no_queries { assert_equal 0, posts.size }
     assert ! posts.loaded?
 
-    posts.to_a # force load
+    posts.load # force load
     assert_no_queries { assert_equal 0, posts.size }
   end
 
@@ -1205,7 +1205,7 @@ class RelationTest < ActiveRecord::TestCase
     assert ! no_posts.loaded?
 
     best_posts = posts.where(comments_count: 0)
-    best_posts.to_a # force load
+    best_posts.load # force load
     assert_no_queries { assert_equal false, best_posts.empty? }
   end
 

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -23,8 +23,8 @@ class NamedScopingTest < ActiveRecord::TestCase
     all_posts = Topic.base
 
     assert_queries(1) do
-      all_posts.collect
-      all_posts.collect
+      all_posts.collect { true }
+      all_posts.collect { true }
     end
   end
 
@@ -167,7 +167,7 @@ class NamedScopingTest < ActiveRecord::TestCase
 
   def test_first_and_last_should_not_use_query_when_results_are_loaded
     topics = Topic.base
-    topics.reload # force load
+    topics.load # force load
     assert_no_queries do
       topics.first
       topics.last
@@ -178,7 +178,7 @@ class NamedScopingTest < ActiveRecord::TestCase
     topics = Topic.base
     assert_queries(2) do
       topics.empty?  # use count query
-      topics.collect # force load
+      topics.load    # force load
       topics.empty?  # use loaded (no query)
     end
   end
@@ -187,7 +187,7 @@ class NamedScopingTest < ActiveRecord::TestCase
     topics = Topic.base
     assert_queries(2) do
       topics.any?    # use count query
-      topics.collect # force load
+      topics.load    # force load
       topics.any?    # use loaded (no query)
     end
   end
@@ -203,7 +203,7 @@ class NamedScopingTest < ActiveRecord::TestCase
 
   def test_any_should_not_fire_query_if_scope_loaded
     topics = Topic.base
-    topics.collect # force load
+    topics.load # force load
     assert_no_queries { assert topics.any? }
   end
 
@@ -217,7 +217,7 @@ class NamedScopingTest < ActiveRecord::TestCase
     topics = Topic.base
     assert_queries(2) do
       topics.many?   # use count query
-      topics.collect # force load
+      topics.load    # force load
       topics.many?   # use loaded (no query)
     end
   end
@@ -233,7 +233,7 @@ class NamedScopingTest < ActiveRecord::TestCase
 
   def test_many_should_not_fire_query_if_scope_loaded
     topics = Topic.base
-    topics.collect # force load
+    topics.load # force load
     assert_no_queries { assert topics.many? }
   end
 
@@ -384,7 +384,7 @@ class NamedScopingTest < ActiveRecord::TestCase
 
   def test_size_should_use_length_when_results_are_loaded
     topics = Topic.base
-    topics.reload # force load
+    topics.load # force load
     assert_no_queries do
       topics.size # use loaded (no query)
     end


### PR DESCRIPTION
This fixes CI failure due to 48f3be8c.

`Enumerable#uniq` was introduced since Ruby 2.4. We should delegate
`uniq` to `records` explicitly.

And since b644964b `ActiveRecord::Relation` includes `Enumerable` so
delegating `map` is unneeded.