### PR TITLE
Fix extension method with dirty target in has_many associations

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1154,8 +1154,9 @@ module ActiveRecord
         end
 
         def method_missing(method, *args, &block)
-          if scope.respond_to?(method)
-            scope.public_send(method, *args, &block)
+          if scope.respond_to?(method) && scope.extending_values.any?
+            extend(*scope.extending_values)
+            public_send(method, *args, &block)
           else
             super
           end

--- a/activerecord/test/cases/associations/extension_test.rb
+++ b/activerecord/test/cases/associations/extension_test.rb
@@ -36,6 +36,11 @@ class AssociationsExtensionsTest < ActiveRecord::TestCase
     assert_equal comments(:greetings), posts(:welcome).comments.not_again.find_most_recent
   end
 
+  def test_extension_with_dirty_target
+    comment = posts(:welcome).comments.build(body: "New comment")
+    assert_equal comment, posts(:welcome).comments.with_content("New comment")
+  end
+
   def test_marshalling_extensions
     david = developers(:david)
     assert_equal projects(:action_controller), david.projects.find_most_recent

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -59,6 +59,10 @@ class Post < ActiveRecord::Base
     def the_association
       proxy_association
     end
+
+    def with_content(content)
+      self.detect { |comment| comment.body == content }
+    end
   end
 
   has_many :comments_with_extend, extend: NamedExtension, class_name: "Comment", foreign_key: "post_id" do


### PR DESCRIPTION
Extension methods should not delegate to `scope` to respect dirty
target on `CollectionProxy`.

Fixes #28419.