### PR TITLE
Correctly check whether key is defined in configuration

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -58,14 +58,14 @@ module Rails
       def load_defaults(target_version)
         case target_version.to_s
         when "5.0"
-          if defined?(action_controller)
+          if respond_to?(:action_controller)
             action_controller.per_form_csrf_tokens = true
             action_controller.forgery_protection_origin_check = true
           end
 
           ActiveSupport.to_time_preserves_timezone = true
 
-          if defined?(active_record)
+          if respond_to?(:active_record)
             active_record.belongs_to_required_by_default = true
           end
 
@@ -74,7 +74,7 @@ module Rails
         when "5.1"
           load_defaults "5.0"
 
-          if defined?(assets)
+          if respond_to?(:assets)
             assets.unknown_asset_fallback = false
           end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -160,6 +160,18 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "config/initializers/new_framework_defaults_5_1.rb"
   end
 
+  def test_new_application_load_defaults
+    app_root = File.join(destination_root, "myfirstapp")
+    run_generator [app_root]
+    output = nil
+
+    Dir.chdir(app_root) do
+      output = `./bin/rails r "puts Rails.application.config.assets.unknown_asset_fallback"`
+    end
+
+    assert_equal "false\n", output
+  end
+
   def test_app_update_keep_the_cookie_serializer_if_it_is_already_configured
     app_root = File.join(destination_root, "myapp")
     run_generator [app_root]

--- a/railties/test/railties/mounted_engine_test.rb
+++ b/railties/test/railties/mounted_engine_test.rb
@@ -141,7 +141,7 @@ module ApplicationTests
             end
 
             def engine_asset_path
-              render inline: "<%= asset_path 'images/foo.png' %>"
+              render inline: "<%= asset_path 'images/foo.png', skip_pipeline: true %>"
             end
           end
         end


### PR DESCRIPTION
It can not check correctly with `defined?`

```ruby
irb(main):001:0> Rails.application.config.active_record
=> {:maintain_test_schema=>true, :belongs_to_required_by_default=>true}
irb(main):002:0> defined?(Rails.application.config.active_record)
=> nil
```

Follow up to #28469
