### PR TITLE
Add keep id suffix option to humanize new

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -100,12 +100,17 @@ class String
   # a nicer looking title. +titleize+ is meant for creating pretty output. It is not
   # used in the Rails internals.
   #
+  # The trailing '_id','Id'.. can be kept and capitalized by setting the
+  # optional parameter +keep_id_suffix+ to true.
+  # By default, this parameter is false.
+  #
   # +titleize+ is also aliased as +titlecase+.
   #
-  #   'man from the boondocks'.titleize # => "Man From The Boondocks"
-  #   'x-men: the last stand'.titleize  # => "X Men: The Last Stand"
-  def titleize
-    ActiveSupport::Inflector.titleize(self)
+  #   'man from the boondocks'.titleize                       # => "Man From The Boondocks"
+  #   'x-men: the last stand'.titleize                        # => "X Men: The Last Stand"
+  #   'string_ending_with_id'.titleize(keep_id_suffix: true)  # => "String Ending With Id"
+  def titleize(options = {})
+    ActiveSupport::Inflector.titleize(self, options)
   end
   alias_method :titlecase, :titleize
 
@@ -202,7 +207,7 @@ class String
     ActiveSupport::Inflector.classify(self)
   end
 
-  # Capitalizes the first word, turns underscores into spaces, and strips a
+  # Capitalizes the first word, turns underscores into spaces, and (by default)strips a
   # trailing '_id' if present.
   # Like +titleize+, this is meant for creating pretty output.
   #
@@ -210,10 +215,15 @@ class String
   # optional parameter +capitalize+ to false.
   # By default, this parameter is true.
   #
-  #   'employee_salary'.humanize              # => "Employee salary"
-  #   'author_id'.humanize                    # => "Author"
-  #   'author_id'.humanize(capitalize: false) # => "author"
-  #   '_id'.humanize                          # => "Id"
+  # The trailing '_id' can be kept and capitalized by setting the
+  # optional parameter +keep_id_suffix+ to true.
+  # By default, this parameter is false.
+  #
+  #   'employee_salary'.humanize                    # => "Employee salary"
+  #   'author_id'.humanize                          # => "Author"
+  #   'author_id'.humanize(capitalize: false)       # => "author"
+  #   '_id'.humanize                                # => "Id"
+  #   'author_id'.humanize(keep_id_suffix: true)    # => "Author Id"
   def humanize(options = {})
     ActiveSupport::Inflector.humanize(self, options)
   end

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -108,14 +108,17 @@ module ActiveSupport
     # * Replaces underscores with spaces, if any.
     # * Downcases all words except acronyms.
     # * Capitalizes the first word.
-    #
     # The capitalization of the first word can be turned off by setting the
     # +:capitalize+ option to false (default is true).
     #
-    #   humanize('employee_salary')              # => "Employee salary"
-    #   humanize('author_id')                    # => "Author"
-    #   humanize('author_id', capitalize: false) # => "author"
-    #   humanize('_id')                          # => "Id"
+    # The trailing '_id' can be kept and capitalized by setting the
+    # optional parameter +keep_id_suffix+ to true (default is false).
+    #
+    #   humanize('employee_salary')                  # => "Employee salary"
+    #   humanize('author_id')                        # => "Author"
+    #   humanize('author_id', capitalize: false)     # => "author"
+    #   humanize('_id')                              # => "Id"
+    #   humanize('author_id', keep_id_suffix: true)  # => "Author Id"
     #
     # If "SSL" was defined to be an acronym:
     #
@@ -127,7 +130,9 @@ module ActiveSupport
       inflections.humans.each { |(rule, replacement)| break if result.sub!(rule, replacement) }
 
       result.sub!(/\A_+/, "".freeze)
-      result.sub!(/_id\z/, "".freeze)
+      unless options.fetch(:keep_id_suffix, false)
+        result.sub!(/_id\z/, "".freeze)
+      end
       result.tr!("_".freeze, " ".freeze)
 
       result.gsub!(/([a-z\d]*)/i) do |match|
@@ -154,14 +159,19 @@ module ActiveSupport
     # create a nicer looking title. +titleize+ is meant for creating pretty
     # output. It is not used in the Rails internals.
     #
+    # The trailing '_id','Id'.. can be kept and capitalized by setting the
+    # optional parameter +keep_id_suffix+ to true.
+    # By default, this parameter is false.
+    #
     # +titleize+ is also aliased as +titlecase+.
     #
-    #   titleize('man from the boondocks')   # => "Man From The Boondocks"
-    #   titleize('x-men: the last stand')    # => "X Men: The Last Stand"
-    #   titleize('TheManWithoutAPast')       # => "The Man Without A Past"
-    #   titleize('raiders_of_the_lost_ark')  # => "Raiders Of The Lost Ark"
-    def titleize(word)
-      humanize(underscore(word)).gsub(/\b(?<!['’`])[a-z]/) { |match| match.capitalize }
+    #   titleize('man from the boondocks')                       # => "Man From The Boondocks"
+    #   titleize('x-men: the last stand')                        # => "X Men: The Last Stand"
+    #   titleize('TheManWithoutAPast')                           # => "The Man Without A Past"
+    #   titleize('raiders_of_the_lost_ark')                      # => "Raiders Of The Lost Ark"
+    #   titleize('string_ending_with_id', keep_id_suffix: true)  # => "String Ending With Id"
+    def titleize(word, options = {})
+      humanize(underscore(word), options).gsub(/\b(?<!['’`])[a-z]/) { |match| match.capitalize }
     end
 
     # Creates the name of a table like Rails does for models to table names.

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -77,6 +77,12 @@ class StringInflectionsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_titleize_with_keep_id_suffix
+    MixtureToTitleCaseWithKeepIdSuffix.each do |before, titleized|
+      assert_equal(titleized, before.titleize(keep_id_suffix: true))
+    end
+  end
+
   def test_upcase_first
     assert_equal "What a Lovely Day", "what a Lovely Day".upcase_first
   end
@@ -195,6 +201,12 @@ class StringInflectionsTest < ActiveSupport::TestCase
   def test_humanize_without_capitalize
     UnderscoreToHumanWithoutCapitalize.each do |underscore, human|
       assert_equal(human, underscore.humanize(capitalize: false))
+    end
+  end
+
+  def test_humanize_with_keep_id_suffix
+    UnderscoreToHumanWithKeepIdSuffix.each do |underscore, human|
+      assert_equal(human, underscore.humanize(keep_id_suffix: true))
     end
   end
 

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -93,6 +93,13 @@ class InflectorTest < ActiveSupport::TestCase
     end
   end
 
+  MixtureToTitleCaseWithKeepIdSuffix.each_with_index do |(before, titleized), index|
+    define_method "test_titleize_with_keep_id_suffix_mixture_to_title_case_#{index}" do
+      assert_equal(titleized, ActiveSupport::Inflector.titleize(before, keep_id_suffix: true),
+        "mixture to TitleCase with keep_id_suffix failed for #{before}")
+    end
+  end
+
   def test_camelize
     CamelToUnderscore.each do |camel, underscore|
       assert_equal(camel, ActiveSupport::Inflector.camelize(underscore))
@@ -305,6 +312,12 @@ class InflectorTest < ActiveSupport::TestCase
   def test_humanize_without_capitalize
     UnderscoreToHumanWithoutCapitalize.each do |underscore, human|
       assert_equal(human, ActiveSupport::Inflector.humanize(underscore, capitalize: false))
+    end
+  end
+
+  def test_humanize_with_keep_id_suffix
+    UnderscoreToHumanWithKeepIdSuffix.each do |underscore, human|
+      assert_equal(human, ActiveSupport::Inflector.humanize(underscore, keep_id_suffix: true))
     end
   end
 

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -248,10 +248,25 @@ module InflectorTestCases
     "_external_id"    => "External"
   }
 
+  UnderscoreToHumanWithKeepIdSuffix = {
+    "this_is_a_string_ending_with_id" => "This is a string ending with id",
+    "employee_id"                => "Employee id",
+    "employee_id_something_else" => "Employee id something else",
+    "underground"               => "Underground",
+    "_id"                       => "Id",
+    "_external_id"              => "External id"
+  }
+
   UnderscoreToHumanWithoutCapitalize = {
     "employee_salary" => "employee salary",
     "employee_id"     => "employee",
     "underground"     => "underground"
+  }
+
+  MixtureToTitleCaseWithKeepIdSuffix = {
+    "this_is_a_string_ending_with_id" => "This Is A String Ending With Id",
+    "EmployeeId"                      => "Employee Id",
+    "Author Id"                       => "Author Id"
   }
 
   MixtureToTitleCase = {


### PR DESCRIPTION
Refer [Issue#26011](https://github.com/rails/rails/issues/26011) also refer [PR#26078](https://github.com/rails/rails/pull/26078).

***Note: The previous [PR#26078](https://github.com/rails/rails/pull/26078) had got a lot dirty and resolving conflicts was taking me ages.***


The following changes were made based on the discussion.
## Changes:
1. Added `keep_id_suffix` check to [humanize](https://github.com/rails/rails/blob/f2489f493b794ee83a86e746b6240031acb8994e/activesupport/lib/active_support/inflector/methods.rb#L129).
2. Added `options` hash to [titleize](https://github.com/rails/rails/blob/f2489f493b794ee83a86e746b6240031acb8994e/activesupport/lib/active_support/inflector/methods.rb#L162) to utilize `keep_id_suffix` flag and keep the trailing '_id' in a string.
3. Added additional tests for both `humanize` and `titleize` with the `keep_id_suffix` set to `true`.
