### PR TITLE
Fix changelog entry about transaction error classes [ci skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -749,7 +749,7 @@
 
     *Johannes Opper*
 
-*   Introduce `ActiveRecord::TransactionSerializationError` for catching
+*   Introduce new Active Record transaction error classes for catching
     transaction serialization failures or deadlocks.
 
     *Erol Fornoles*


### PR DESCRIPTION
`ActiveRecord::TransactionSerializationError` was introduces in #25093.
However, refactored in #25107, `TransactionSerializationError` is gone.
