### PR TITLE
Coerce ActiveModel::Type::Boolean values on serialization

### DIFF
--- a/activemodel/lib/active_model/type/boolean.rb
+++ b/activemodel/lib/active_model/type/boolean.rb
@@ -18,6 +18,10 @@ module ActiveModel
         :boolean
       end
 
+      def serialize(value)
+        cast(value)
+      end
+
       private
 
         def cast_value(value)

--- a/activemodel/test/cases/type/boolean_test.rb
+++ b/activemodel/test/cases/type/boolean_test.rb
@@ -9,19 +9,20 @@ module ActiveModel
         assert type.cast("").nil?
         assert type.cast(nil).nil?
 
-        assert type.cast(true)
-        assert type.cast(1)
-        assert type.cast("1")
-        assert type.cast("t")
-        assert type.cast("T")
-        assert type.cast("true")
-        assert type.cast("TRUE")
-        assert type.cast("on")
-        assert type.cast("ON")
-        assert type.cast(" ")
-        assert type.cast("\u3000\r\n")
-        assert type.cast("\u0000")
-        assert type.cast("SOMETHING RANDOM")
+        # explicitly check for true
+        assert_equal true, type.cast(true)
+        assert_equal true, type.cast(1)
+        assert_equal true, type.cast("1")
+        assert_equal true, type.cast("t")
+        assert_equal true, type.cast("T")
+        assert_equal true, type.cast("true")
+        assert_equal true, type.cast("TRUE")
+        assert_equal true, type.cast("on")
+        assert_equal true, type.cast("ON")
+        assert_equal true, type.cast(" ")
+        assert_equal true, type.cast("\u3000\r\n")
+        assert_equal true, type.cast("\u0000")
+        assert_equal true, type.cast("SOMETHING RANDOM")
 
         # explicitly check for false vs nil
         assert_equal false, type.cast(false)
@@ -33,6 +34,38 @@ module ActiveModel
         assert_equal false, type.cast("FALSE")
         assert_equal false, type.cast("off")
         assert_equal false, type.cast("OFF")
+      end
+
+      def test_serialize_boolean
+        type = Type::Boolean.new
+        assert type.serialize("").nil?
+        assert type.serialize(nil).nil?
+
+        # explicitly check for true
+        assert_equal true, type.serialize(true)
+        assert_equal true, type.serialize(1)
+        assert_equal true, type.serialize("1")
+        assert_equal true, type.serialize("t")
+        assert_equal true, type.serialize("T")
+        assert_equal true, type.serialize("true")
+        assert_equal true, type.serialize("TRUE")
+        assert_equal true, type.serialize("on")
+        assert_equal true, type.serialize("ON")
+        assert_equal true, type.serialize(" ")
+        assert_equal true, type.serialize("\u3000\r\n")
+        assert_equal true, type.serialize("\u0000")
+        assert_equal true, type.serialize("SOMETHING RANDOM")
+
+        # explicitly check for false vs nil
+        assert_equal false, type.serialize(false)
+        assert_equal false, type.serialize(0)
+        assert_equal false, type.serialize("0")
+        assert_equal false, type.serialize("f")
+        assert_equal false, type.serialize("F")
+        assert_equal false, type.serialize("false")
+        assert_equal false, type.serialize("FALSE")
+        assert_equal false, type.serialize("off")
+        assert_equal false, type.serialize("OFF")
       end
     end
   end


### PR DESCRIPTION
The activerecord-import gem makes use of the Active Record typecaster API to serialize data as it generates the sql insert statement:

```
type_caster.type_cast_for_database(column_name, value)
```

Unfortunately this currently doesn't cast values like "1" and "0" to boolean values, which is causing an issue. See: https://github.com/zdennis/activerecord-import/issues/389

I've updated `ActiveModel::Type::Boolean` to cast values on serialization. If there is a better approach please let me know.