### PR TITLE
Add `app:update` task to engines

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `app:update` task to engines.
+
+    *Yuji Yaginuma*
+
 *   Avoid running system tests by default with the `bin/rails test`
     and `bin/rake test` commands since they may be expensive.
 

--- a/railties/lib/rails/engine/updater.rb
+++ b/railties/lib/rails/engine/updater.rb
@@ -1,0 +1,19 @@
+require "rails/generators"
+require "rails/generators/rails/plugin/plugin_generator"
+
+module Rails
+  class Engine
+    class Updater
+      class << self
+        def generator
+          @generator ||= Rails::Generators::PluginGenerator.new ["plugin"],
+            { engine: true }, destination_root: ENGINE_ROOT
+        end
+
+        def run(action)
+          generator.send(action)
+        end
+      end
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -301,7 +301,7 @@ task default: :test
       end
 
       def engine?
-        full? || mountable?
+        full? || mountable? || options[:engine]
       end
 
       def full?

--- a/railties/lib/rails/tasks/engine.rake
+++ b/railties/lib/rails/tasks/engine.rake
@@ -1,6 +1,17 @@
 task "load_app" do
   namespace :app do
     load APP_RAKEFILE
+
+    desc "Update some initially generated files"
+    task update: [ "update:bin" ]
+
+    namespace :update do
+      require "rails/engine/updater"
+      # desc "Adds new executables to the engine bin/ directory"
+      task :bin do
+        Rails::Engine::Updater.run(:create_bin_files)
+      end
+    end
   end
   task environment: "app:environment"
 


### PR DESCRIPTION
Occasionally we update the file generated by engine.
Therefore, I think that there is a task for updating as well as
application in the engine, it is convenient for updating.

