### PR TITLE
Preprocess association query handling in predicate builder

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -92,7 +92,14 @@ module ActiveRecord
             attrs, bvs = associated_predicate_builder(column_name).create_binds_for_hash(value)
             result[column_name] = attrs
             binds += bvs
-            next
+          when table.associated_with?(column_name)
+            # Find the foreign key when using queries such as:
+            # Post.where(author: author)
+            #
+            # For polymorphic relationships, find the foreign key and type:
+            # PriceEstimate.where(estimate_of: treasure)
+            result[column_name] = AssociationQueryHandler.value_for(table, column_name, value)
+            binds.concat(value.bound_attributes) if value.is_a?(Relation)
           when value.is_a?(Relation)
             binds += value.bound_attributes
           when value.is_a?(Range) && !table.type(column_name).respond_to?(:subtype)
@@ -113,15 +120,6 @@ module ActiveRecord
               result[column_name] = Arel::Nodes::BindParam.new
               binds << build_bind_param(column_name, value)
             end
-          end
-
-          # Find the foreign key when using queries such as:
-          # Post.where(author: author)
-          #
-          # For polymorphic relationships, find the foreign key and type:
-          # PriceEstimate.where(estimate_of: treasure)
-          if table.associated_with?(column_name)
-            result[column_name] = AssociationQueryHandler.value_for(table, column_name, value)
           end
         end
 
@@ -155,7 +153,6 @@ module ActiveRecord
       end
 
       def can_be_bound?(column_name, value)
-        return if table.associated_with?(column_name)
         case value
         when Array, Range
           table.type(column_name).respond_to?(:subtype)

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -87,6 +87,7 @@ module ActiveRecord
         binds = []
 
         attributes.each do |column_name, value|
+          binds.concat(value.bound_attributes) if value.is_a?(Relation)
           case
           when value.is_a?(Hash) && !table.has_column?(column_name)
             attrs, bvs = associated_predicate_builder(column_name).create_binds_for_hash(value)
@@ -99,9 +100,6 @@ module ActiveRecord
             # For polymorphic relationships, find the foreign key and type:
             # PriceEstimate.where(estimate_of: treasure)
             result[column_name] = AssociationQueryHandler.value_for(table, column_name, value)
-            binds.concat(value.bound_attributes) if value.is_a?(Relation)
-          when value.is_a?(Relation)
-            binds += value.bound_attributes
           when value.is_a?(Range) && !table.type(column_name).respond_to?(:subtype)
             first = value.begin
             last = value.end


### PR DESCRIPTION
Currently association query is handled as a postprocess. This has two
problems.

1. When `value` is a `Hash`, we need to skip the postprocess using
`next`.

2. `can_be_bound?` should return false if
`table.associated_with?(column_name)` is true (pass to the postprocess).

These are unneeded if preprocessing association query handling.