### PR TITLE
Adding documentation concerning enum with strings

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -92,6 +92,17 @@ module ActiveRecord
   #
   #   conversation.comments_inactive!
   #   conversation.comments_active? # => false
+  #
+  # Note that you may use a non-integer column to persist the enumerated value.
+  #
+  #   create_table :conversations do |t|
+  #     t.column :status, :string, default: 'active'
+  #   end
+  #
+  #   class Conversation < ActiveRecord::Base
+  #     enum status: { active: 'active', archived: 'archived' }
+  #   end
+  #
 
   module Enum
     def self.extended(base) # :nodoc:

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -19,6 +19,7 @@ class EnumTest < ActiveRecord::TestCase
     assert @book.illustrator_visibility_visible?
     assert @book.with_medium_font_size?
     assert @book.medium_to_read?
+    assert @book.soft?
   end
 
   test "query state with strings" do
@@ -28,6 +29,7 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal "visible", @book.author_visibility
     assert_equal "visible", @book.illustrator_visibility
     assert_equal "medium", @book.difficulty
+    assert_equal "soft", @book.cover
   end
 
   test "find via scope" do
@@ -37,6 +39,7 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal @book, Book.author_visibility_visible.first
     assert_equal @book, Book.illustrator_visibility_visible.first
     assert_equal @book, Book.medium_to_read.first
+    assert_equal @book, Book.soft.first
   end
 
   test "find via where with values" do
@@ -89,6 +92,8 @@ class EnumTest < ActiveRecord::TestCase
     assert @book.in_english?
     @book.author_visibility_visible!
     assert @book.author_visibility_visible?
+    @book.hard!
+    assert @book.hard?
   end
 
   test "update by setter" do

--- a/activerecord/test/fixtures/books.yml
+++ b/activerecord/test/fixtures/books.yml
@@ -10,6 +10,7 @@ awdr:
   illustrator_visibility: :visible
   font_size: :medium
   difficulty: :medium
+  cover: :soft
 
 rfr:
   author_id: 1


### PR DESCRIPTION
I am updating the documentation to include how to do non-integer based enums in ActiveRecord::Base.

Used in book model for tests:

```ruby
class Book < ActiveRecord::Base
  #...
  enum cover: { hard: "hard", soft: "soft" }
```

https://github.com/rails/rails/blob/master/activerecord/test/models/book.rb#L18

Tested:

```ruby
test "uses default value from database on initialization when using custom mapping" do
  book = Book.new
  assert book.hard?
end
```

https://github.com/rails/rails/blob/master/activerecord/test/cases/enum_test.rb#L476-L479
