### PR TITLE
5-0-stable: Fix `select_all` with legacy `binds`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -157,6 +157,10 @@ module ActiveRecord
 
       private
 
+      def type_casted_binds(binds)
+        binds.map { |attr| type_cast(attr.value_for_database) }
+      end
+
       def types_which_need_no_typecasting
         [nil, Numeric, String]
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -158,7 +158,11 @@ module ActiveRecord
       private
 
       def type_casted_binds(binds)
-        binds.map { |attr| type_cast(attr.value_for_database) }
+        if binds.first.is_a?(Array)
+          binds.map { |column, value| type_cast(value, column) }
+        else
+          binds.map { |attr| type_cast(attr.value_for_database) }
+        end
       end
 
       def types_which_need_no_typecasting

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -155,15 +155,15 @@ module ActiveRecord
         binds.map(&:value_for_database)
       end
 
-      private
-
-      def type_casted_binds(binds)
+      def type_casted_binds(binds) # :nodoc:
         if binds.first.is_a?(Array)
           binds.map { |column, value| type_cast(value, column) }
         else
           binds.map { |attr| type_cast(attr.value_for_database) }
         end
       end
+
+      private
 
       def types_which_need_no_typecasting
         [nil, Numeric, String]

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -579,14 +579,15 @@ module ActiveRecord
         exception
       end
 
-      def log(sql, name = "SQL", binds = [], statement_name = nil)
+      def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil)
         @instrumenter.instrument(
           "sql.active_record",
-          :sql            => sql,
-          :name           => name,
-          :connection_id  => object_id,
-          :statement_name => statement_name,
-          :binds          => binds) { yield }
+          sql:               sql,
+          name:              name,
+          binds:             binds,
+          type_casted_binds: type_casted_binds,
+          statement_name:    statement_name,
+          connection_id:     object_id) { yield }
       rescue => e
         raise translate_exception_class(e, sql)
       end

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -75,7 +75,7 @@ module ActiveRecord
 
           type_casted_binds = type_casted_binds(binds)
 
-          log(sql, name, binds) do
+          log(sql, name, binds, type_casted_binds) do
             if cache_stmt
               cache = @statements[sql] ||= {
                 stmt: @connection.prepare(sql)

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -73,7 +73,7 @@ module ActiveRecord
           # made since we established the connection
           @connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
 
-          type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
+          type_casted_binds = type_casted_binds(binds)
 
           log(sql, name, binds) do
             if cache_stmt

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -594,13 +594,13 @@ module ActiveRecord
         end
 
         def exec_no_cache(sql, name, binds)
-          type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
+          type_casted_binds = type_casted_binds(binds)
           log(sql, name, binds) { @connection.async_exec(sql, type_casted_binds) }
         end
 
         def exec_cache(sql, name, binds)
           stmt_key = prepare_statement(sql)
-          type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
+          type_casted_binds = type_casted_binds(binds)
 
           log(sql, name, binds, stmt_key) do
             @connection.exec_prepared(stmt_key, type_casted_binds)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -595,14 +595,14 @@ module ActiveRecord
 
         def exec_no_cache(sql, name, binds)
           type_casted_binds = type_casted_binds(binds)
-          log(sql, name, binds) { @connection.async_exec(sql, type_casted_binds) }
+          log(sql, name, binds, type_casted_binds) { @connection.async_exec(sql, type_casted_binds) }
         end
 
         def exec_cache(sql, name, binds)
           stmt_key = prepare_statement(sql)
           type_casted_binds = type_casted_binds(binds)
 
-          log(sql, name, binds, stmt_key) do
+          log(sql, name, binds, type_casted_binds, stmt_key) do
             @connection.exec_prepared(stmt_key, type_casted_binds)
           end
         rescue ActiveRecord::StatementInvalid => e

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -190,7 +190,7 @@ module ActiveRecord
       def exec_query(sql, name = nil, binds = [], prepare: false)
         type_casted_binds = type_casted_binds(binds)
 
-        log(sql, name, binds) do
+        log(sql, name, binds, type_casted_binds) do
           # Don't cache statements if they are not prepared
           unless prepare
             stmt    = @connection.prepare(sql)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -188,7 +188,7 @@ module ActiveRecord
       end
 
       def exec_query(sql, name = nil, binds = [], prepare: false)
-        type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
+        type_casted_binds = type_casted_binds(binds)
 
         log(sql, name, binds) do
           # Don't cache statements if they are not prepared
@@ -203,7 +203,6 @@ module ActiveRecord
             ensure
               stmt.close
             end
-            stmt = records
           else
             cache = @statements[sql] ||= {
               :stmt => @connection.prepare(sql)
@@ -212,9 +211,10 @@ module ActiveRecord
             cols = cache[:cols] ||= stmt.columns
             stmt.reset!
             stmt.bind_params(type_casted_binds)
+            records = stmt.to_a
           end
 
-          ActiveRecord::Result.new(cols, stmt.to_a)
+          ActiveRecord::Result.new(cols, records)
         end
       end
 

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -20,18 +20,14 @@ module ActiveRecord
       @odd = false
     end
 
-    def render_bind(attribute)
-      value = if attribute.type.binary? && attribute.value
-        if attribute.value.is_a?(Hash)
-          "<#{attribute.value_for_database.to_s.bytesize} bytes of binary data>"
-        else
-          "<#{attribute.value.bytesize} bytes of binary data>"
-        end
+    def render_bind(attr, type_casted_value)
+      value = if attr.type.binary? && attr.value
+        "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"
       else
-        attribute.value_for_database
+        type_casted_value
       end
 
-      [attribute.name, value]
+      [attr.name, value]
     end
 
     def sql(event)
@@ -47,7 +43,9 @@ module ActiveRecord
       binds = nil
 
       unless (payload[:binds] || []).empty?
-        binds = "  " + payload[:binds].map { |attr| render_bind(attr) }.inspect
+        binds = "  " + payload[:binds].zip(payload[:type_casted_binds]).map { |attr, value|
+          render_bind(attr, value)
+        }.inspect
       end
 
       name = colorize_payload_name(name, payload[:name])

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -244,6 +244,15 @@ module ActiveRecord
       assert result.is_a?(ActiveRecord::Result)
     end
 
+    if ActiveRecord::Base.connection.prepared_statements
+      def test_select_all_with_legacy_binds
+        post = Post.create!(title: "foo", body: "bar")
+        expected = @connection.select_all("SELECT * FROM posts WHERE id = #{post.id}")
+        result = @connection.select_all("SELECT * FROM posts WHERE id = #{Arel::Nodes::BindParam.new.to_sql}", nil, [[nil, post.id]])
+        assert_equal expected.to_hash, result.to_hash
+      end
+    end
+
     def test_select_methods_passing_a_association_relation
       author = Author.create!(name: 'john')
       Post.create!(author: author, title: 'foo', body: 'bar')

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -3,36 +3,36 @@ require 'models/topic'
 require 'models/author'
 require 'models/post'
 
-module ActiveRecord
-  class BindParameterTest < ActiveRecord::TestCase
-    fixtures :topics, :authors, :posts
+if ActiveRecord::Base.connection.supports_statement_cache? &&
+   ActiveRecord::Base.connection.prepared_statements
+  module ActiveRecord
+    class BindParameterTest < ActiveRecord::TestCase
+      fixtures :topics, :authors, :posts
 
-    class LogListener
-      attr_accessor :calls
+      class LogListener
+        attr_accessor :calls
 
-      def initialize
-        @calls = []
+        def initialize
+          @calls = []
+        end
+
+        def call(*args)
+          calls << args
+        end
       end
 
-      def call(*args)
-        calls << args
+      def setup
+        super
+        @connection = ActiveRecord::Base.connection
+        @subscriber = LogListener.new
+        @pk = Topic.columns_hash[Topic.primary_key]
+        @subscription = ActiveSupport::Notifications.subscribe("sql.active_record", @subscriber)
       end
-    end
 
-    def setup
-      super
-      @connection = ActiveRecord::Base.connection
-      @subscriber = LogListener.new
-      @pk = Topic.columns_hash[Topic.primary_key]
-      @subscription = ActiveSupport::Notifications.subscribe('sql.active_record', @subscriber)
-    end
+      def teardown
+        ActiveSupport::Notifications.unsubscribe(@subscription)
+      end
 
-    teardown do
-      ActiveSupport::Notifications.unsubscribe(@subscription)
-    end
-
-    if ActiveRecord::Base.connection.supports_statement_cache? &&
-       ActiveRecord::Base.connection.prepared_statements
       def test_bind_from_join_in_subquery
         subquery = Author.joins(:thinking_posts).where(name: 'David')
         scope = Author.from(subquery, 'authors').where(id: 1)
@@ -56,43 +56,48 @@ module ActiveRecord
         assert message, 'expected a message with binds'
       end
 
-      def test_logs_bind_vars_after_type_cast
+      def test_logs_binds_after_type_cast
         binds = [Relation::QueryAttribute.new("id", "10", Type::Integer.new)]
-        type_casted_binds = binds.map { |attr| type_cast(attr.value_for_database) }
-        payload = {
-          :name  => 'SQL',
-          :sql   => 'select * from topics where id = ?',
-          :binds => binds,
-          :type_casted_binds => type_casted_binds
-        }
-        event  = ActiveSupport::Notifications::Event.new(
-          'foo',
-          Time.now,
-          Time.now,
-          123,
-          payload)
+        assert_logs_binds(binds)
+      end
 
-        logger = Class.new(ActiveRecord::LogSubscriber) {
-          attr_reader :debugs
-          def initialize
-            super
-            @debugs = []
-          end
-
-          def debug str
-            @debugs << str
-          end
-        }.new
-
-        logger.sql event
-        assert_match([[@pk.name, 10]].inspect, logger.debugs.first)
+      def test_logs_legacy_binds_after_type_cast
+        binds = [[@pk, "10"]]
+        assert_logs_binds(binds)
       end
 
       private
+        def assert_logs_binds(binds)
+          payload = {
+            name: "SQL",
+            sql: "select * from topics where id = ?",
+            binds: binds,
+            type_casted_binds: @connection.type_casted_binds(binds)
+          }
 
-      def type_cast(value)
-        ActiveRecord::Base.connection.type_cast(value)
-      end
+          event = ActiveSupport::Notifications::Event.new(
+            "foo",
+            Time.now,
+            Time.now,
+            123,
+            payload)
+
+          logger = Class.new(ActiveRecord::LogSubscriber) {
+            attr_reader :debugs
+
+            def initialize
+              super
+              @debugs = []
+            end
+
+            def debug(str)
+              @debugs << str
+            end
+          }.new
+
+          logger.sql(event)
+          assert_match([[@pk.name, 10]].inspect, logger.debugs.first)
+        end
     end
   end
 end


### PR DESCRIPTION
Backport #27939.

r? @rafaelfranca 