### PR TITLE
Fix where_clause#except with specific where value

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -148,9 +148,9 @@ module ActiveRecord
               (binds_index...(binds_index + binds_contains)).each do |i|
                 except_binds[i] = true
               end
-
-              binds_index += binds_contains
             end
+
+            binds_index += binds_contains if binds_contains
 
             except
           end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1970,6 +1970,14 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal p2.first.comments, comments
   end
 
+  def test_unscope_specific_where_value
+    posts = Post.where(title: "Welcome to the weblog", body: "Such a lovely day")
+
+    assert_equal 1, posts.count
+    assert_equal 1, posts.unscope(where: :title).count
+    assert_equal 1, posts.unscope(where: :body).count
+  end
+
   def test_unscope_removes_binds
     left = Post.where(id: Arel::Nodes::BindParam.new)
     column = Post.columns_hash["id"]


### PR DESCRIPTION
Fixes #28496

Fixes a regression introduced in 22ca710f20c3c656811df006cbf1f4dbc359f7a6 where Relation#unscope with a specific where value (vs unscoping the entire where clause) could result
in the wrong binds being left on the query.

This was caused by an index variable not being incremented properly.


