### PR TITLE
Remove duplicate entries for #25430 [ci skip]

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -58,16 +58,8 @@
 
     *Rafael Mendonça França*
 
-*   Ensure `/rails/info` routes match in development for apps with a catch-all globbing route.
-
-    *Nicholas Firth-McCoy*
-
 
 ## Rails 5.0.0 (June 30, 2016) ##
-
-*   Ensure `/rails/info` routes match in development for apps with a catch-all globbing route.
-
-    *Nicholas Firth-McCoy*
 
 *   Ensure `/rails/info` routes match in development for apps with a catch-all globbing route.
 


### PR DESCRIPTION
The CHANGELOG for 5-0-stable includes the same change three times:

https://github.com/rails/rails/blame/9d3a352777c2594123583b0bc02d0dd80f1e385b/railties/CHANGELOG.md#L61-L75

Indeed, the change was merged into 5.0 as part of e57b9e56 so it belongs
to the "Rails 5.0.0" section.

---

@rafaelfranca I'm opening a PR because this commit is not against master so I'd like another set of eyes to make sure I'm changing the correct file on the correct branch. Thanks!