### PR TITLE
Check for existence of multiple HashWithIndifferentAccess keys

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -158,6 +158,21 @@ module ActiveSupport
     alias_method :has_key?, :key?
     alias_method :member?, :key?
 
+    # Checks the hash for keys matching the arguments passed in:
+    #
+    #   hash = ActiveSupport::HashWithIndifferentAccess.new
+    #   hash['key1'] = 'value1'
+    #   hash['key2'] = 'value2'
+    #   hash.keys?(:key1, :key2)   # => true
+    #   hash.keys?('key1', 'key2') # => true
+    def keys?(*keys)
+      !keys.inject([]) do |results, key|
+        results << key?(key)
+      end.include?(false)
+    end
+
+    alias_method :has_keys?, :keys?
+
     # Same as <tt>Hash#[]</tt> where the key passed as argument can be
     # either a string or a symbol:
     #

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1810,4 +1810,13 @@ class HashToXmlTest < ActiveSupport::TestCase
       Hash.from_xml(attack_xml)
     end
   end
+
+  def test_has_keys
+    hash = HashWithIndifferentAccess.new(a: 1, b: 2)
+    assert_equal true, hash.keys?("a", "b")
+    assert_equal true, hash.keys?(:a, :b)
+
+    assert_equal false, hash.keys?("a", "b", "c")
+    assert_equal false, hash.keys?(:a, :b, :c)
+  end
 end


### PR DESCRIPTION
### Summary

This pull request adds a method to `HashWithIndifferentAccess` named `#keys?` (aliased as `#has_keys?`). It simply checks if every key passed into the method exists in the hash.

One common use case I have for this is checking the existence of multiple params in a controller. Instead of writing:
````ruby
params.has_key?(:password) && params.has_key?(:password_confirmation)
````
We can now write:
````ruby
params.has_keys?(:password, :password_confirmation)
````
