### PR TITLE
5-0-stable changelog new fix

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -65,6 +65,11 @@
 
     *Nicholas Firth-McCoy*
 
+*   Default `config.assets.quiet = true` in the development environment. Suppress
+    logging of assets requests by default.
+
+    *Kevin McPhillips*
+
 *   Add `config/initializers/to_time_preserves_timezone.rb`, which tells
     Active Support to preserve the receiver's timezone when calling `to_time`.
     This matches the new behavior that will be part of Ruby 2.4.


### PR DESCRIPTION
The entry in the CHANGELOG refers to #25351 which was merged into
Rails 5.0. The behavior did not change in Rails 5.1.

See discussion at https://github.com/rails/rails/commit/2ffa001faa3e9d0295358dfe716b17c54623a086#commitcomment-21410869
