### PR TITLE
CLI arg "host" has precedence over ENV var "host"

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -188,10 +188,12 @@ module Rails
         end
 
         def host
-          unless (default_host = options[:binding])
+          if options[:binding]
+            options[:binding]
+          else
             default_host = environment == "development" ? "localhost" : "0.0.0.0"
+            ENV.fetch("HOST", default_host)
           end
-          ENV.fetch("HOST", default_host)
         end
 
         def environment

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -139,6 +139,14 @@ class Rails::ServerTest < ActiveSupport::TestCase
     end
   end
 
+  def test_argument_precedence_over_environment_variable
+    switch_env "HOST", "1.2.3.4" do
+      args = ["-b", "127.0.0.1"]
+      options = parse_arguments(args)
+      assert_equal "127.0.0.1", options[:Host]
+    end
+  end
+
   def test_records_user_supplied_options
     server_options = parse_arguments(["-p", 3001])
     assert_equal [:Port], server_options[:user_supplied_options]


### PR DESCRIPTION
### Summary

This is a regression from when the server command switched to its own
argument parser, as opposed to Rack's. Rack's argument parser, when
provided with a "host" argument, gives that value precedence over
environment variables.

### Other Information

- Fixes #28500 
- cc @kaspth 
- Rack's argument parser option for host: https://github.com/rack/rack/blob/master/lib/rack/server.rb#L54-L56