### PR TITLE
Fix store accessors in parameters test

### DIFF
--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -32,13 +32,13 @@ class ParamsWrapperTest < ActionController::TestCase
     def self.attribute_names
       []
     end
+
+    def self.stored_attributes
+      { settings: [:color, :size] }
+    end
   end
 
   class Person
-    def self.stores_attributes
-      { settings: [:color, :size] }
-    end
-
     def self.attribute_names
       []
     end
@@ -67,11 +67,13 @@ class ParamsWrapperTest < ActionController::TestCase
   end
 
   def test_store_accessors_wrapped
-    with_default_wrapper_options do
-      @request.env["CONTENT_TYPE"] = "application/json"
-      post :parse, params: { "username" => "sikachu", "color" => "blue", "size" => "large" }
-      assert_parameters("username" => "sikachu", "color" => "blue", "size" => "large",
-                         "user" => { "username" => "sikachu", "color" => "blue", "size" => "large" })
+    assert_called(User, :attribute_names, times: 2, returns: ["username"]) do
+      with_default_wrapper_options do
+        @request.env["CONTENT_TYPE"] = "application/json"
+        post :parse, params: { "username" => "sikachu", "color" => "blue", "size" => "large" }
+        assert_parameters("username" => "sikachu", "color" => "blue", "size" => "large",
+                           "user" => { "username" => "sikachu", "color" => "blue", "size" => "large" })
+      end
     end
   end
 


### PR DESCRIPTION
* The method name must be `stored_attributes`, not `stores_attributes`.
* `attribute_names` must return a non-empty value. Because
  `stored_attributes` is not checked if `attribute_names` is empty.

Follow up to #28056
