### PR TITLE
better docs for ActiveRecord::PredicateBuilder::BaseHandler#initialize

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/base_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/base_handler.rb
@@ -1,6 +1,7 @@
 module ActiveRecord
   class PredicateBuilder
     class BaseHandler # :nodoc:
+      #:notnew: stops RDoc from seeing the initialize method as the new method
       def initialize(predicate_builder)
         @predicate_builder = predicate_builder
       end


### PR DESCRIPTION
### Summary

Added a Rdoc to ignore the initialize method from seeing


