### PR TITLE
[PostgreSQL] Replace deprecated PG constants.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -439,7 +439,7 @@ module ActiveRecord
 
       # Provides access to the underlying database driver for this adapter. For
       # example, this method returns a Mysql2::Client object in case of Mysql2Adapter,
-      # and a PGconn object in case of PostgreSQLAdapter.
+      # and a PG::Connection object in case of PostgreSQLAdapter.
       #
       # This is useful for when you need to call a proprietary method such as
       # PostgreSQL's lo_* methods.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
@@ -6,7 +6,7 @@ module ActiveRecord
           def deserialize(value)
             return if value.nil?
             return value.to_s if value.is_a?(Type::Binary::Data)
-            PGconn.unescape_bytea(super)
+            PG::Connection.unescape_bytea(super)
           end
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -33,7 +33,7 @@ module ActiveRecord
 
         # Quotes schema names for use in SQL queries.
         def quote_schema_name(name)
-          PGconn.quote_ident(name)
+          PG::Connection.quote_ident(name)
         end
 
         def quote_table_name_for_assignment(table, attr)
@@ -42,7 +42,7 @@ module ActiveRecord
 
         # Quotes column names for use in SQL queries.
         def quote_column_name(name) # :nodoc:
-          @quoted_column_names[name] ||= PGconn.quote_ident(super).freeze
+          @quoted_column_names[name] ||= PG::Connection.quote_ident(super).freeze
         end
 
         # Quote date/time values for use in SQL input.
@@ -105,7 +105,7 @@ module ActiveRecord
             case value
             when Type::Binary::Data
               # Return a bind param hash with format as binary.
-              # See http://deveiate.org/code/pg/PGconn.html#method-i-exec_prepared-doc
+              # See https://deveiate.org/code/pg/PG/Connection.html#method-i-exec_prepared-doc
               # for more information
               { value: value.to_s, format: 1 }
             when OID::Xml::Data, OID::Bit::Data

--- a/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
@@ -19,9 +19,9 @@ module ActiveRecord
 
         def quoted
           if schema
-            PGconn.quote_ident(schema) << SEPARATOR << PGconn.quote_ident(identifier)
+            PG::Connection.quote_ident(schema) << SEPARATOR << PG::Connection.quote_ident(identifier)
           else
-            PGconn.quote_ident(identifier)
+            PG::Connection.quote_ident(identifier)
           end
         end
 

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -123,7 +123,7 @@ module ActiveRecord
     #     # statement will cause a PostgreSQL error, even though the unique
     #     # constraint is no longer violated:
     #     Number.create(i: 1)
-    #     # => "PGError: ERROR:  current transaction is aborted, commands
+    #     # => "PG::Error: ERROR:  current transaction is aborted, commands
     #     #     ignored until end of transaction block"
     #   end
     #

--- a/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
@@ -3,13 +3,13 @@ require "cases/helper"
 module ActiveRecord
   module ConnectionAdapters
     class PostgreSQLAdapter < AbstractAdapter
-      class InactivePGconn
+      class InactivePgConnection
         def query(*args)
-          raise PGError
+          raise PG::Error
         end
 
         def status
-          PGconn::CONNECTION_BAD
+          PG::CONNECTION_BAD
         end
       end
 
@@ -31,7 +31,7 @@ module ActiveRecord
         end
 
         def test_dealloc_does_not_raise_on_inactive_connection
-          cache = StatementPool.new InactivePGconn.new, 10
+          cache = StatementPool.new InactivePgConnection.new, 10
           cache["foo"] = "bar"
           assert_nothing_raised { cache.clear }
         end


### PR DESCRIPTION
### Summary

This PR replaces the top level classes PGconn, PGresult and PGError with their counterparts within the PG namespace.

The old top level classes PGconn, PGresult and PGError were deprecated [since pg-0.13.0](https://github.com/ged/ruby-pg/blob/master/History.rdoc#v0130-2012-02-09-michael-granger-gedfaeriemudorg) .

The old classes will probably be removed in pg-1.0.0. See: https://bitbucket.org/ged/ruby-pg/issues/257/release-version-10 . Possibly we'll add another 0.x release cycle which prints deprecation warnings when the old constants are used.


### Other Information

Shall I add an entry to the CHANGELOG?

Shall I open separate PRs for backporting to the stable branches?

