### PR TITLE
Don't add a dummy API key to every new Rails app

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/secrets.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/secrets.yml
@@ -12,8 +12,8 @@
 
 # Shared secrets are available across all environments.
 
-shared:
-  api_key: 123
+# shared:
+#   api_key: a1B2c3D4e5F6
 
 # Environmental secrets are only available for that specific environment.
 


### PR DESCRIPTION
Every new Rails app is currently generated with `Rails.application.secrets[:api_key]` set to `123`.

This comes from a line in `config/secrets.yml` that, in my opinion, should be left commented out to only serve as a syntax example, rather than being actually set in every Rails app.

Additionally, we might want to give a better example than `123`, since in the same file we are suggesting to:

> Make sure the secret is at least 30 characters and all random,
> no regular words or you'll be exposed to dictionary attacks.

The result of this commit is that `config/secrets.yml` will include something like:

```yaml
# Shared secrets are available across all environments.

# shared:
#   api_key: f56930851993982510d5bd9236f4108f6fe7c15448f1c6923a51872e0dbae1a24d274b318abb6518b540dfb51079c61640885f607467e5ed1053849be7587d61
```

rather than:

```yaml
# Shared secrets are available across all environments.

shared:
  api_key: 123
```