### PR TITLE
Correctly reset ARGV for "rails runner `CODE' arg arg arg..."

### DIFF
--- a/railties/lib/rails/commands/runner/runner_command.rb
+++ b/railties/lib/rails/commands/runner/runner_command.rb
@@ -16,7 +16,7 @@ module Rails
         "#{super} [<'Some.ruby(code)'> | <filename.rb>]"
       end
 
-      def perform(code_or_file = nil, *file_argv)
+      def perform(code_or_file = nil, *command_argv)
         unless code_or_file
           help
           exit 1
@@ -27,9 +27,10 @@ module Rails
         require_application_and_environment!
         Rails.application.load_runner
 
+        ARGV.replace(command_argv)
+
         if File.exist?(code_or_file)
           $0 = code_or_file
-          ARGV.replace(file_argv)
           Kernel.load code_or_file
         else
           begin

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -36,7 +36,7 @@ module ApplicationTests
     end
 
     def test_should_set_argv_when_running_code
-      output = Dir.chdir(app_path) { 
+      output = Dir.chdir(app_path) {
         # Both long and short args, at start and end of ARGV
         `bin/rails runner "puts ARGV.join(',')" --foo a1 -b a2 a3 --moo`
       }

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -35,6 +35,14 @@ module ApplicationTests
       assert_match "42", Dir.chdir(app_path) { `bin/rails runner "puts User.count"` }
     end
 
+    def test_should_set_argv_when_running_code
+      output = Dir.chdir(app_path) { 
+        # Both long and short args, at start and end of ARGV
+        `bin/rails runner "puts ARGV.join(',')" --foo a1 -b a2 a3 --moo`
+      }
+      assert_equal "--foo,a1,-b,a2,a3,--moo", output.chomp
+    end
+
     def test_should_run_file
       app_file "bin/count_users.rb", <<-SCRIPT
       puts User.count


### PR DESCRIPTION
The code itself should not be in the ARGV vector.

Fixes #28515

### Summary

This corrects a regression in 5.1.0.{beta,rc}1 in setting ARGV for the code in `rails runner CODE arg arg arg...`
