### PR TITLE
Change AD::ParamsParser::ParseError deprecation so it can be rescued

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -115,6 +115,7 @@ module ActionDispatch
   end
 
   module ParamsParser
-    ParseError = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("ActionDispatch::ParamsParser::ParseError", "ActionDispatch::Http::Parameters::ParseError")
+    include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+    deprecate_constant "ParseError", "ActionDispatch::Http::Parameters::ParseError"
   end
 end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,1 +1,13 @@
+* Add ActiveSupport::Deprecation::DeprecatedConstantAccessor
+
+  Provides transparent deprecation of constants, compatible with exceptions.
+  Example usage:
+
+      module Example
+        include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+        deprecate_constant 'OldException', 'Elsewhere::NewException'
+      end
+
+  *Dominic Cleal*
+
 Please check [5-1-stable](https://github.com/rails/rails/blob/5-1-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/deprecation.rb
+++ b/activesupport/lib/active_support/deprecation.rb
@@ -15,6 +15,7 @@ module ActiveSupport
     require "active_support/deprecation/instance_delegator"
     require "active_support/deprecation/behaviors"
     require "active_support/deprecation/reporting"
+    require "active_support/deprecation/constant_accessor"
     require "active_support/deprecation/method_wrappers"
     require "active_support/deprecation/proxy_wrappers"
     require "active_support/core_ext/module/deprecation"

--- a/activesupport/lib/active_support/deprecation/constant_accessor.rb
+++ b/activesupport/lib/active_support/deprecation/constant_accessor.rb
@@ -1,0 +1,50 @@
+require "active_support/inflector/methods"
+
+module ActiveSupport
+  class Deprecation
+    # DeprecatedConstantAccessor transforms a constant into a deprecated one by
+    # hooking +const_missing+.
+    #
+    # It takes the names of an old (deprecated) constant and of a new constant
+    # (both in string form) and optionally a deprecator. The deprecator defaults
+    # to +ActiveSupport::Deprecator+ if none is specified.
+    #
+    # The deprecated constant now returns the same object as the new one rather
+    # than a proxy object, so it can be used transparently in +rescue+ blocks
+    # etc.
+    #
+    #   PLANETS = %w(mercury venus earth mars jupiter saturn uranus neptune pluto)
+    #
+    #   (In a later update, the original implementation of `PLANETS` has been removed.)
+    #
+    #   PLANETS_POST_2006 = %w(mercury venus earth mars jupiter saturn uranus neptune)
+    #   include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+    #   deprecate_constant 'PLANETS', 'PLANETS_POST_2006'
+    #
+    #   PLANETS.map { |planet| planet.capitalize }
+    #   # => DEPRECATION WARNING: PLANETS is deprecated! Use PLANETS_POST_2006 instead.
+    #        (Backtrace information…)
+    #        ["Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune"]
+    module DeprecatedConstantAccessor
+      def self.included(base)
+        extension = Module.new do
+          def const_missing(missing_const_name)
+            if class_variable_defined?(:@@_deprecated_constants)
+              if (replacement = class_variable_get(:@@_deprecated_constants)[missing_const_name.to_s])
+                replacement[:deprecator].warn(replacement[:message] || "#{name}::#{missing_const_name} is deprecated! Use #{replacement[:new]} instead.", caller_locations)
+                return ActiveSupport::Inflector.constantize(replacement[:new].to_s)
+              end
+            end
+            super
+          end
+
+          def deprecate_constant(const_name, new_constant, message: nil, deprecator: ActiveSupport::Deprecation.instance)
+            class_variable_set(:@@_deprecated_constants, {}) unless class_variable_defined?(:@@_deprecated_constants)
+            class_variable_get(:@@_deprecated_constants)[const_name.to_s] = { new: new_constant, message: message, deprecator: deprecator }
+          end
+        end
+        base.singleton_class.prepend extension
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Adds a new deprecation tool, `ActiveSupport::Deprecation::DeprecatedConstantAccessor` to help deprecation exceptions in particular, and changes the deprecated constant `ActionDispatch::ParamsParser::ParseException` to use it. This allows the old constant to be used in a `begin..rescue` block without errors.

Fixes #28525.