### PR TITLE
Suppress `WARNING:  nonstandard use of \\ in a string literal` warning

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -89,6 +89,7 @@ class PostgresqlByteaTest < ActiveRecord::PostgreSQLTestCase
     Thread.new do
       other_conn = ActiveRecord::Base.connection
       other_conn.execute("SET standard_conforming_strings = off")
+      other_conn.execute("SET escape_string_warning = off")
     end.join
 
     test_via_to_sql


### PR DESCRIPTION
### Summary
This pull request suppresses WARNING:  nonstandard use of \\ in a string literal` warning by setting `escape_string_warning = off`.

```ruby
$ ARCONN=postgresql bundle exec ruby -w -Itest test/cases/adapters/postgresql/bytea_test.rb -n test_via_to_sql_with_complicating_connection
/home/yahonda/git/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using postgresql
Run options: -n test_via_to_sql_with_complicating_connection --seed 15566

# Running:

WARNING:  nonstandard use of \\ in a string literal
LINE 1: ...ea_data_type" WHERE "bytea_data_type"."payload" = '\\x271f5c...
                                                             ^
HINT:  Use the escape string syntax for backslashes, e.g., E'\\'.
.

Finished in 0.038166s, 26.2015 runs/s, 26.2015 assertions/s.

1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
$
```

### Other Information
* PostgreSQL 9.6.2 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 6.3.1 20161221 (Red Hat 6.3.1-1), 64-bit
* ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
* Rails master branch


[escape_string_warning (boolean)](https://www.postgresql.org/docs/9.6/static/runtime-config-compatible.html)

> escape_string_warning (boolean)
> When on, a warning is issued if a backslash (\) appears in an ordinary string literal ('...' syntax) and standard_conforming_strings is off. The default is on.
> 
> Applications that wish to use backslash as escape should be modified to use escape string syntax (E'...'), because the default behavior of ordinary strings is now to treat backslash as an ordinary character, per SQL standard. This variable can be enabled to help locate code that needs to be changed.
