### PR TITLE
List options for `rails new --webpack=WEBPACK`

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -13,6 +13,7 @@ module Rails
       DATABASES = %w( mysql postgresql sqlite3 oracle frontbase ibm_db sqlserver )
       JDBC_DATABASES = %w( jdbcmysql jdbcsqlite3 jdbcpostgresql jdbc )
       DATABASES.concat(JDBC_DATABASES)
+      WEBPACKS = %w( react vue angular )
 
       attr_accessor :rails_template
       add_shebang_option!
@@ -34,7 +35,7 @@ module Rails
                                           desc: "Preconfigure for selected JavaScript library"
 
         class_option :webpack,            type: :string, default: nil,
-                                          desc: "Preconfigure for app-like JavaScript with Webpack"
+                                          desc: "Preconfigure for app-like JavaScript with Webpack (options: #{WEBPACKS.join('/')})"
 
         class_option :skip_yarn,          type: :boolean, default: false,
                                           desc: "Don't use Yarn for managing JavaScript dependencies"


### PR DESCRIPTION
When you type `rails new -h`, the `--database=DATABASE` options display this useful message:

> Preconfigure for selected database (options: mysql/postgresql/sqlite3/oracle/frontbase/ibm_db/sqlserver/jdbcmysql/jdbcsqlite3/jdbcpostgresql/jdbc)

However, the `--webpack=WEBPACK` option only displays this:

> Preconfigure for app-like JavaScript with Webpack

so it's hard to know *which* values are valid for `WEBPACK`.

This commit improves the help message to display:

> Preconfigure for app-like JavaScript with Webpack (options: react/vue/angular)

The implication of this commit is that the list needs to be manually updated whenever rails/webpacker adds support for a new framework.

However, I don't imagine this list to change very frequently, and I think that the benefit of display the list to the users is greater than the hustle of updating the list when needed.