### PR TITLE
Document AC::Connection::Authorization#reject_unauthorized_connection

### DIFF
--- a/actioncable/lib/action_cable/connection/authorization.rb
+++ b/actioncable/lib/action_cable/connection/authorization.rb
@@ -3,11 +3,11 @@ module ActionCable
     module Authorization
       class UnauthorizedError < StandardError; end
 
-      private
-        def reject_unauthorized_connection
-          logger.error "An unauthorized connection attempt was rejected"
-          raise UnauthorizedError
-        end
+      # Closes the \WebSocket connection if it is open and returns a 404 "File not Found" response.
+      def reject_unauthorized_connection
+        logger.error "An unauthorized connection attempt was rejected"
+        raise UnauthorizedError
+      end
     end
   end
 end


### PR DESCRIPTION
This method is repeatedly used throughout the docs (in the [AC::Connection docs](https://github.com/rails/rails/blob/12b684985837bc8ee9ad15c174cf4e07ca82d7c4/actioncable/lib/action_cable/connection/base.rb#L28), the [AC README](https://github.com/rails/rails/blob/12b684985837bc8ee9ad15c174cf4e07ca82d7c4/actioncable/README.md#a-full-stack-example), the [AC Guides](https://github.com/rails/rails/blob/12b684985837bc8ee9ad15c174cf4e07ca82d7c4/guides/source/action_cable_overview.md#connection-setup)), but not actually documented itself and seemingly not supported for public use based on its current `private` status.

This actually makes the method public and documents it.  The actual behavior that’s documented here is implemented [here](https://github.com/rails/rails/blob/12b684985837bc8ee9ad15c174cf4e07ca82d7c4/actioncable/lib/action_cable/connection/base.rb#L213-L219), via [this rescuing of the UnauthorizedError](https://github.com/rails/rails/blob/3dd1de8ba4d5862b01e7f5dd3878b21fd98b443b/actioncable/lib/action_cable/connection/base.rb#L172).

The method is [already tested here](https://github.com/rails/rails/blob/25473baf409185638073fe2f016f4b9dda284e50/actioncable/test/connection/authorization_test.rb#L17-L29).