### PR TITLE
Give clients a way to refer to ActionDispatch middleware classes without triggering an early load of ActionDispatch

### DIFF
--- a/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
+++ b/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
@@ -25,12 +25,6 @@ module ActionController
 
     included do
       class_attribute :etag_with_template_digest, default: true
-
-      ActiveSupport.on_load :action_view, yield: true do
-        etag do |options|
-          determine_template_etag(options) if etag_with_template_digest
-        end
-      end
     end
 
     private

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -4,9 +4,6 @@ require "action_dispatch/http/request"
 require "action_dispatch/middleware/exception_wrapper"
 require "action_dispatch/routing/inspector"
 require "action_view"
-require "action_view/base"
-
-require "pp"
 
 module ActionDispatch
   # This middleware is responsible for logging exceptions and
@@ -14,41 +11,7 @@ module ActionDispatch
   class DebugExceptions
     RESCUES_TEMPLATE_PATH = File.expand_path("templates", __dir__)
 
-    class DebugView < ActionView::Base
-      def debug_params(params)
-        clean_params = params.clone
-        clean_params.delete("action")
-        clean_params.delete("controller")
-
-        if clean_params.empty?
-          "None"
-        else
-          PP.pp(clean_params, +"", 200)
-        end
-      end
-
-      def debug_headers(headers)
-        if headers.present?
-          headers.inspect.gsub(",", ",\n")
-        else
-          "None"
-        end
-      end
-
-      def debug_hash(object)
-        object.to_hash.sort_by { |k, _| k.to_s }.map { |k, v| "#{k}: #{v.inspect rescue $!.message}" }.join("\n")
-      end
-
-      def render(*)
-        logger = ActionView::Base.logger
-
-        if logger && logger.respond_to?(:silence)
-          logger.silence { super }
-        else
-          super
-        end
-      end
-    end
+    autoload :DebugView, "action_dispatch/middleware/debug_exceptions/debug_view"
 
     cattr_reader :interceptors, instance_accessor: false, default: []
 
@@ -200,7 +163,7 @@ module ActionDispatch
       end
 
       def logger(request)
-        request.logger || ActionView::Base.logger || stderr_logger
+        request.logger || DebugView.logger || stderr_logger
       end
 
       def stderr_logger

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions/debug_view.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions/debug_view.rb
@@ -1,0 +1,43 @@
+require "action_view"
+
+require "pp"
+
+module ActionDispatch
+  class DebugExceptions
+    class DebugView < ActionView::Base
+      def debug_params(params)
+        clean_params = params.clone
+        clean_params.delete("action")
+        clean_params.delete("controller")
+
+        if clean_params.empty?
+          "None"
+        else
+          PP.pp(clean_params, "", 200)
+        end
+      end
+
+      def debug_headers(headers)
+        if headers.present?
+          headers.inspect.gsub(",", ",\n")
+        else
+          "None"
+        end
+      end
+
+      def debug_hash(object)
+        object.to_hash.sort_by { |k, _| k.to_s }.map { |k, v| "#{k}: #{v.inspect rescue $!.message}" }.join("\n")
+      end
+
+      def render(*)
+        logger = ActionView::Base.logger
+
+        if logger && logger.respond_to?(:silence)
+          logger.silence { super }
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions/debug_view.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions/debug_view.rb
@@ -30,8 +30,6 @@ module ActionDispatch
       end
 
       def render(*)
-        logger = ActionView::Base.logger
-
         if logger && logger.respond_to?(:silence)
           logger.silence { super }
         else

--- a/actionpack/test/fixtures/namespaced/implicit_render_test/hello_world.erb
+++ b/actionpack/test/fixtures/namespaced/implicit_render_test/hello_world.erb
@@ -1,1 +1,0 @@
-Hello world!

--- a/actionpack/test/fixtures/test/with_implicit_template.erb
+++ b/actionpack/test/fixtures/test/with_implicit_template.erb
@@ -1,1 +1,0 @@
-Hello explicitly!

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -74,10 +74,8 @@ module ActionView
     end
 
     initializer "action_view.per_request_digest_cache" do |app|
-      ActiveSupport.on_load(:action_view) do
-        unless ActionView::Resolver.caching?
-          app.executor.to_run ActionView::Digestor::PerExecutionDigestCacheExpiry
-        end
+      unless ActionView::Resolver.caching?
+        app.executor.to_run ActionView::Digestor::PerExecutionDigestCacheExpiry
       end
     end
 

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -87,6 +87,14 @@ module ActionView
       end
     end
 
+    initializer "action_view.setup_etag_with_template_digest" do |app|
+      ActiveSupport.on_load(:action_controller_base) do
+        etag do |options|
+          determine_template_etag(options) if etag_with_template_digest
+        end
+      end
+    end
+
     initializer "action_view.collection_caching", after: "action_controller.set_configs" do |app|
       PartialRenderer.collection_cache = app.config.action_controller.cache_store
     end

--- a/railties/test/application/etag_with_template_digest_test.rb
+++ b/railties/test/application/etag_with_template_digest_test.rb
@@ -1,0 +1,115 @@
+require "isolation/abstract_unit"
+require "rack/test"
+require "minitest/mock"
+
+require "action_view"
+require "active_support/testing/method_call_assertions"
+
+class PerRequestDigestCacheTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+  include ActiveSupport::Testing::MethodCallAssertions
+  include Rack::Test::Methods
+
+  setup do
+    build_app
+
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        get "with_template" => "customers#with_template"
+        get "with_implicit_template" => "customers#with_implicit_template"
+        get "namespaced_implicit_template" => "namespaced/customers#with_implicit_template"
+      end
+    RUBY
+
+    app_file "app/controllers/customers_controller.rb", <<-RUBY
+      class CustomersController < ApplicationController
+        def with_template
+          if stale? template: "test/hello_world"
+            render plain: "stale"
+          end
+        end
+
+        def with_implicit_template
+          fresh_when(etag: "123")
+        end
+      end
+    RUBY
+
+    app_file "app/controllers/namespaced/customers_controller.rb", <<-RUBY
+      module Namespaced
+        class CustomersController < ApplicationController
+          def with_implicit_template
+            fresh_when(etag: "abc")
+          end
+        end
+      end
+    RUBY
+
+    app_file "app/views/test/hello_world.erb", <<-RUBY
+      Hello World!
+    RUBY
+
+    app_file "app/views/customers/with_implicit_template.erb", <<-RUBY
+      Hello explicitly!
+    RUBY
+
+    app_file "app/views/namespaced/customers/with_implicit_template.erb", <<-RUBY
+      Hello explicitly and namespaced!
+    RUBY
+
+    require "#{app_path}/config/environment"
+  end
+
+  teardown :teardown_app
+
+  test "etag reflects template digest" do
+    get "/with_template"
+    assert_equal 200, last_response.status
+    assert_not_nil etag = last_response.etag
+
+    get "/with_template", {}, "HTTP_IF_NONE_MATCH" => etag
+    assert_equal 304, last_response.status
+
+    app_file "app/views/test/hello_world.erb", <<-RUBY
+      Hello World moddified!
+    RUBY
+
+    get "/with_template", {}, "HTTP_IF_NONE_MATCH" => etag
+    assert_equal 200, last_response.status
+    assert_not_equal etag, last_response.etag
+  end
+
+  test "etag reflects implicit template digest" do
+    get "/with_implicit_template"
+    assert_equal 200, last_response.status
+    assert_not_nil etag = last_response.etag
+
+    get "/with_implicit_template", {}, "HTTP_IF_NONE_MATCH" => etag
+    assert_equal 304, last_response.status
+
+    app_file "app/views/customers/with_implicit_template.erb", <<-RUBY
+      Hello explicitly modified!
+    RUBY
+
+    get "/with_implicit_template", {}, "HTTP_IF_NONE_MATCH" => etag
+    assert_equal 200, last_response.status
+    assert_not_equal etag, last_response.etag
+  end
+
+  test "etag reflects namespacd template digest" do
+    get "/namespaced_implicit_template"
+    assert_equal 200, last_response.status
+    assert_not_nil etag = last_response.etag
+
+    get "/namespaced_implicit_template", {}, "HTTP_IF_NONE_MATCH" => etag
+    assert_equal 304, last_response.status
+
+    app_file "app/views/namespaced/customers/with_implicit_template.erb", <<-RUBY
+      Hello explicitly and namespaced modified!
+    RUBY
+
+    get "/namespaced_implicit_template", {}, "HTTP_IF_NONE_MATCH" => etag
+    assert_equal 200, last_response.status
+    assert_not_equal etag, last_response.etag
+  end
+end


### PR DESCRIPTION
### Summary

There is a bug in web-console, which is that it forces a load of ActionDispatch, and therefore ActionView, before all initializers have run.

The reason is because it needs to prepend its own middleware using `insert_before ActionDispatch::DebugExceptions` [here](https://github.com/rails/web-console/blob/v3.4.0/lib/web_console/railtie.rb#L36).

Historically, the workaround would have been to refer to `ActionDispatch::DebugExceptions` there using a String instead of the class, so that it's not eager-loaded.  However, that was deprecated in 83b767cef90abfc4c2ee9f4b451b0215501fae9a and is no longer supported as of 1b975e6a696655f476b10a4567b537cc92077563.

This commit resolves that, and enables us to fix web-console by making the following change (and I have a PR in progress for web-console, though I have not opened a ticket there yet):

```
# before
initializer 'web_console.insert_middleware' do |app|
  app.middleware.insert_before ActionDispatch::DebugExceptions, Middleware
end

# after
initializer 'web_console.insert_middleware' do |app|
  ActiveSupport.on_load(:action_dispatch_middleware) do
    app.middleware.insert_before ActionDispatch::DebugExceptions, Middleware
  end
end
```

This postpones the autoload of ActionDispatch until the latest possible moment, as the middleware stack is built.

### Other Information

Please give me some guidance about what docs and CHANGELOGs to update.

### How to reproduce

1. Generate a fresh rails app
2. Add the following to `config/initializers/action_view.rb`

```
Rails.application.configure do
  config.action_view.debug_missing_translation = false
end
```

3. Run `bin/rails console` and enter the following:
```
ActionView::Base.debug_missing_translation
```

Notice that it is set to true.

4. Comment out web-console in the Gemfile, bundle install, and run the same command in the console.  This time, it is set to false as expected.
