### PR TITLE
Fix `where` with relations in an array

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -127,6 +127,8 @@ module ActiveRecord
               else
                 result[column_name] = nil
               end
+            elsif value.is_a?(Array)
+              value.each { |v| binds.concat(v.bound_attributes) if v.is_a?(Relation) }
             end
           end
         end

--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -11,7 +11,7 @@ module ActiveRecord
 
         values = value.map { |x| x.is_a?(Base) ? x.id : x }
         nils, values = values.partition(&:nil?)
-        ranges, values = values.partition { |v| v.is_a?(Range) }
+        ranges, values = values.partition { |v| v.is_a?(Range) || v.is_a?(Relation) }
 
         values_predicate =
           case values.length

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -711,6 +711,11 @@ class RelationTest < ActiveRecord::TestCase
     assert authors.to_a.blank?
   end
 
+  def test_where_with_relations_in_array
+    authors = Author.where(id: [Author.where(id: 1), Author.where(id: 2)])
+    assert_equal Author.where(id: [1, 2]), authors.to_a
+  end
+
   def test_where_with_ar_object
     author = Author.first
     authors = Author.all.where(id: author)


### PR DESCRIPTION
We need to produce binds in `create_binds_for_hash` because handlers
doesn't support to produce binds (related e1533d2).

Fixes #26541.