### PR TITLE
Remove `CollectionProxy#uniq`

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -743,10 +743,6 @@ module ActiveRecord
       #   #    ]
 
       #--
-      def uniq
-        load_target.uniq
-      end
-
       def calculate(operation, column_name)
         null_scope? ? scope.calculate(operation, column_name) : super
       end


### PR DESCRIPTION
Since #28473 `uniq` is delegated to `records`, so `CollectionProxy#uniq`
is unnecessary.