### PR TITLE
ignore system test gems on Gemfile when execute with --skip-test option

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -413,6 +413,10 @@ module Rails
         !options[:skip_spring] && !options.dev? && Process.respond_to?(:fork) && !RUBY_PLATFORM.include?("cygwin")
       end
 
+      def depends_on_system_test?
+        !(options[:skip_system_test] || options[:skip_test] || options[:api])
+      end
+
       def depend_on_listen?
         !options[:skip_listen] && os_supports_listen_out_of_the_box?
       end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -275,7 +275,7 @@ module Rails
       end
 
       def create_system_test_files
-        build(:system_test) unless options[:skip_system_test] || options[:skip_test] || options[:api]
+        build(:system_test) if depends_on_system_test?
       end
 
       def create_tmp_files

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -32,7 +32,7 @@ end
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  <%- unless options.skip_system_test? || options.api? -%>
+  <%- if depends_on_system_test? -%>
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13.0'
   gem 'selenium-webdriver'

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -436,6 +436,30 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile", /^# gem 'redis'/
   end
 
+  def test_generator_if_skip_test_is_given
+    run_generator [destination_root, "--skip-test"]
+    assert_file "Gemfile" do |content|
+      assert_no_match(/capybara/, content)
+      assert_no_match(/selenium-webdriver/, content)
+    end
+  end
+
+  def test_generator_if_skip_system_test_is_given
+    run_generator [destination_root, "--skip_system_test"]
+    assert_file "Gemfile" do |content|
+      assert_no_match(/capybara/, content)
+      assert_no_match(/selenium-webdriver/, content)
+    end
+  end
+
+  def test_generator_if_api_is_given
+    run_generator [destination_root, "--api"]
+    assert_file "Gemfile" do |content|
+      assert_no_match(/capybara/, content)
+      assert_no_match(/selenium-webdriver/, content)
+    end
+  end
+
   def test_inclusion_of_javascript_runtime
     run_generator
     if defined?(JRUBY_VERSION)


### PR DESCRIPTION
### Summary
`rails new app_name -T` generate rails application without test.
But, generated Gemfile include `capybara` and `selenium-webdriver`.
So I fix don't generate these gems when test skip option add.
