### PR TITLE
Move comment to inside the method [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -301,8 +301,8 @@ module ActiveRecord
         true
       end
 
-      # Range datatypes weren't introduced until PostgreSQL 9.2
       def supports_ranges?
+        # Range datatypes weren't introduced until PostgreSQL 9.2
         postgresql_version >= 90200
       end
 


### PR DESCRIPTION
Because this comment is not document for `supports_ranges?`

ref: https://github.com/rails/rails/pull/27636#discussion_r107560081