### PR TITLE
Remove -j (--javascript) option from `rails new`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,1 +1,6 @@
+*   Remove -j (--javascript) option from `rails new` command
+
+	  *claudiob*
+
+
 Please check [5-1-stable](https://github.com/rails/rails/blob/5-1-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -31,9 +31,6 @@ module Rails
         class_option :database,           type: :string, aliases: "-d", default: "sqlite3",
                                           desc: "Preconfigure for selected database (options: #{DATABASES.join('/')})"
 
-        class_option :javascript,         type: :string, aliases: "-j",
-                                          desc: "Preconfigure for selected JavaScript library"
-
         class_option :webpack,            type: :string, default: nil,
                                           desc: "Preconfigure for app-like JavaScript with Webpack (options: #{WEBPACKS.join('/')})"
 
@@ -341,11 +338,6 @@ module Rails
         else
           gems = [javascript_runtime_gemfile_entry]
           gems << coffee_gemfile_entry unless options[:skip_coffee]
-
-          if options[:javascript]
-            gems << GemfileEntry.version("#{options[:javascript]}-rails", nil,
-              "Use #{options[:javascript]} as the JavaScript library")
-          end
 
           unless options[:skip_turbolinks]
             gems << GemfileEntry.version("turbolinks", "~> 5",

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -452,14 +452,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_inclusion_of_javascript_libraries_if_required
-    run_generator [destination_root, "-j", "jquery"]
-    assert_file "app/assets/javascripts/application.js" do |contents|
-      assert_match %r{^//= require jquery}, contents
-    end
-    assert_gem "jquery-rails"
-  end
-
   def test_javascript_is_skipped_if_required
     run_generator [destination_root, "--skip-javascript"]
 


### PR DESCRIPTION
The "-j" option was added 5 years ago (https://github.com/rails/rails/commit/d9c39c3a)
when we wanted to support prototype-rails and jquery-rails.
Prototype is not as popular and jQuery is not a requirement anymore.
Still the "-j" option can be used to install *any* gem that ends in "-rails".

This "might" open security issues and does not bring great benefits anymore.

If you know which "-rails"-ending gem you want to install, you can manually
add it to the Gemfile just like any other gem.
