### PR TITLE
Additional explanation about cache implementations

### DIFF
--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -387,6 +387,11 @@ store is not appropriate for large application deployments. However, it can
 work well for small, low traffic sites with only a couple of server processes,
 as well as development and test environments.
 
+New Rails projects will be configured to use this implementation in the
+development environment by default. (Note that, because processes will not share
+cache data, if using `:memory_store` it will not be possible to manually read,
+write or expire the cache via the Rails console.)
+
 ### ActiveSupport::Cache::FileStore
 
 This cache store uses the file system to store entries. The path to the directory where the store files will be stored must be specified when initializing the cache.
@@ -403,7 +408,8 @@ share a cache by using a shared file system, but that setup is not recommended.
 As the cache will grow until the disk is full, it is recommended to
 periodically clear out old entries.
 
-This is the default cache store implementation.
+This is the default cache store implementation (at `"#{root}/tmp/cache/"`) if
+no explicit `config.cache_store` is supplied.
 
 ### ActiveSupport::Cache::MemCacheStore
 


### PR DESCRIPTION
As discussed in https://github.com/rails/rails/issues/28535, Rails uses the `:file_store` cache implementation by default when no config is supplied, however new Rails projects will initially be configured for the `:memory_store` implementation (in the dev environment).

This PR adds some language to the Rails guide to clear up any possible confusion about these two "defaults."

It also makes explicit that commands like `Rails.cache.read` and `Rails.cache.clear` from the Rails console will not work using `:memory_store`, which might prevent some gotchas for new Rails users following caching tutorials (for instance http://railscasts.com/episodes/90-fragment-caching-revised) that emphasize use of the console for debugging purposes.