### PR TITLE
Support non-relations custom preloading

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -115,7 +115,16 @@ module ActiveRecord
             # Make several smaller queries if necessary or make one query if the adapter supports it
             slices = owner_keys.each_slice(klass.connection.in_clause_length || owner_keys.size)
             @preloaded_records = slices.flat_map do |slice|
-              records_for(slice).load(&block)
+              records = records_for(slice)
+              if records.respond_to?(:load)
+                # Prefer using #load to set owner association before callbacks when possible
+                # (block supplied to internal #find_by_sql which runs before callbacks).
+                records.load(&block)
+              else
+                # Non-relation supplied by preloader, using #each.
+                records.each(&block)
+              end
+              records
             end
             @preloaded_records.group_by do |record|
               convert_key(record[association_key_name])

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1487,6 +1487,21 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal posts(:welcome), post
   end
 
+  test "preloading of non-relations" do
+    class SpecialPostPreloader < ActiveRecord::Associations::Preloader::HasMany
+      def initialize(authors)
+        super(Post, authors, Author.reflect_on_association(:posts), ActiveRecord::Relation.new(nil, nil, nil))
+      end
+
+      def records_for(author_ids)
+        # to_a on an actual relation is called to simulate a real case
+        Post.where(author_id: author_ids).to_a
+      end
+    end
+
+    SpecialPostPreloader.new(Author.first(10)).run(nil)
+  end
+
   # CollectionProxy#reader is expensive, so the preloader avoids calling it.
   test "preloading has_many_through association avoids calling association.reader" do
     ActiveRecord::Associations::HasManyAssociation.any_instance.expects(:reader).never


### PR DESCRIPTION
I have a use case where I'm implementing custom preloaders which can return an `Array` rather than an `ActiveRecord::Relation`. They used to work until a recent change where suddenly `#load` is called on the result of `#records_for`.

I see no reason to force using `ActiveRecord::Relation` in this occasion, and not allow any `Enumerable`.