### PR TITLE
Update guide to reflect browser compatibility for HTTP verbs

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -212,7 +212,7 @@ CSRF appears very rarely in CVE (Common Vulnerabilities and Exposures) - less th
 
 NOTE: _First, as is required by the W3C, use GET and POST appropriately. Secondly, a security token in non-GET requests will protect your application from CSRF._
 
-The HTTP protocol basically provides two main types of requests - GET and POST (and more, but they are not supported by most browsers). The World Wide Web Consortium (W3C) provides a checklist for choosing HTTP GET or POST:
+The HTTP protocol basically provides two main types of requests - GET and POST (DELETE, PUT, and PATCH should be used like POST). The World Wide Web Consortium (W3C) provides a checklist for choosing HTTP GET or POST:
 
 **Use GET if:**
 
@@ -224,7 +224,7 @@ The HTTP protocol basically provides two main types of requests - GET and POST (
 * The interaction _changes the state_ of the resource in a way that the user would perceive (e.g., a subscription to a service), or
 * The user is _held accountable for the results_ of the interaction.
 
-If your web application is RESTful, you might be used to additional HTTP verbs, such as PATCH, PUT or DELETE. Most of today's web browsers, however, do not support them - only GET and POST. Rails uses a hidden `_method` field to handle this barrier.
+If your web application is RESTful, you might be used to additional HTTP verbs, such as PATCH, PUT or DELETE. Some legacy web browsers, however, do not support them - only GET and POST. Rails uses a hidden `_method` field to handle these cases.
 
 _POST requests can be sent automatically, too_. In this example, the link www.harmless.com is shown as the destination in the browser's status bar. But it has actually dynamically created a new form that sends a POST request.
 


### PR DESCRIPTION
### Summary

This updates the security guide to reflect how most browsers now _do_ support all restful HTTP verbs.

### Other Information

I was reading up on CSRF because I have an API controller that didn't pass `brakeman` validation for not having `protect_from_forgery`.

I ended up on Rails Guides for how to handle CSRF and it says this (my emphasis):
> The HTTP protocol basically provides two main types of requests - GET and POST (**and more, but they are not supported by most browsers**)

Which I thought weird because it seemed to me that most browsers _do currently_ support all RESTful methods. And [MDN confirmed](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods#Browser_compatibility) what I thought.

So I decided to update the text to say that _Some legacy web browsers_ don't support the other methods.

I appreciate any improvements on the wording, especially because I'm not a native English speaker.
