### PR TITLE
Fix decimal typecaster ArgumentError safe [4.2-stable]

### DIFF
--- a/activerecord/lib/active_record/type/decimal.rb
+++ b/activerecord/lib/active_record/type/decimal.rb
@@ -17,8 +17,14 @@ module ActiveRecord
         casted_value = case value
         when ::Float
           convert_float_to_big_decimal(value)
-        when ::Numeric, ::String
+        when ::Numeric
           BigDecimal(value, precision.to_i)
+        when ::String
+          begin
+            BigDecimal(value, precision.to_i)
+          rescue ArgumentError
+            BigDecimal(0)
+          end
         else
           if value.respond_to?(:to_d)
             value.to_d


### PR DESCRIPTION
### Summary
In ruby-2.4, `BigDecimal()` raise `ArgumentError` when it is given invalid String argument,
and in previous version, it returns `BigDecimal(0)`.

In current master branch, this probrem is fixed.
But in rails-4.2.8, this probrem still exists.

I think that it is better to fix this probrem because rails-4.2.8 supports ruby-2.4.