### PR TITLE
Include FormErrorsHelper in FormHelper

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -113,6 +113,7 @@ module ActionView
       include UrlHelper
       include ModelNaming
       include RecordIdentifier
+      include FormErrorsHelper
 
       attr_internal :default_form_builder
 


### PR DESCRIPTION
### Summary

Using error_span with twitter-bootstrap-rails can cause an "undefined method error_span" error.

See https://github.com/seyhunak/twitter-bootstrap-rails/issues/913
and http://stackoverflow.com/questions/26245222/undefined-method-error-span-rails-project/36120983#36120983

This patch includes the module which contains the error_span code so that this error won't happen.

Thanks for contributing to Rails!
