### PR TITLE
Add useful links to the welcome page

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add useful links to the welcome page
+
+    *Dino Maric*
+
 *   Specify form field ids when generating a scaffold.
 
     This makes sure that the labels are linked up with the fields. The

--- a/railties/lib/rails/templates/rails/welcome/index.html.erb
+++ b/railties/lib/rails/templates/rails/welcome/index.html.erb
@@ -38,6 +38,10 @@
       width: 700px;
       text-align: center;
     }
+
+    .useful-resources > a {
+      padding-right: 0.3em;
+    }
   </style>
 </head>
 
@@ -58,6 +62,14 @@
         <strong>Rails version:</strong> <%= Rails.version %><br />
         <strong>Ruby version:</strong> <%= RUBY_VERSION %> (<%= RUBY_PLATFORM %>)
       </p>
+
+      <div class="useful-resources">
+        <%= link_to "Blog", "http://weblog.rubyonrails.org/", target: "_blank" %>
+        <%= link_to "Guides", "http://guides.rubyonrails.org/", target: "_blank" %>
+        <%= link_to "API", "http://api.rubyonrails.org/", target: "_blank" %>
+        <%= link_to "Ask for help", "http://stackoverflow.com/questions/tagged/ruby-on-rails", target: "_blank" %>
+        <%= link_to "Contribute on GitHub", "https://github.com/rails/rails", target: "_blank" %>
+      </div>
     </section>
   </div>
 </body>


### PR DESCRIPTION
When someone opens rails welcome page now she/he can see useful links
from community on the page
* Blog
* Guides
* API
* Ask for help
* Contibute on GitHub

<img width="1275" alt="screen shot 2017-03-26 at 15 55 41" src="https://cloud.githubusercontent.com/assets/7427365/24331863/f79a1954-123c-11e7-813c-d4a32c12368e.png">

