### PR TITLE
Do not show hidden namespaces in destroy commnad help

### DIFF
--- a/railties/lib/rails/commands/destroy/destroy_command.rb
+++ b/railties/lib/rails/commands/destroy/destroy_command.rb
@@ -5,6 +5,9 @@ module Rails
     class DestroyCommand < Base # :nodoc:
       no_commands do
         def help
+          require_application_and_environment!
+          load_generators
+
           Rails::Generators.help self.class.command_name
         end
       end

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -189,6 +189,9 @@ module ApplicationTests
       FileUtils.cd(rails_root) do
         output = `bin/rails generate --help`
         assert_no_match "active_record:migration", output
+
+        output = `bin/rails destroy --help`
+        assert_no_match "active_record:migration", output
       end
     end
   end


### PR DESCRIPTION

**before**

```
./bin/rails destroy --help
Usage: rails destroy GENERATOR [args] [options]

General options:
  -h, [--help]     # Print generator's options and usage
  -p, [--pretend]  # Run but do not make any changes
  -f, [--force]    # Overwrite files that already exist
  -s, [--skip]     # Skip files that already exist
  -q, [--quiet]    # Suppress status output

Please choose a generator below.

Rails:
  assets
  channel
  controller
  generator
  helper
  integration_test
  jbuilder
  job
  mailer
  migration
  model
  resource
  scaffold
  scaffold_controller
  system_test
  task

ActiveRecord:
  active_record:migration
  active_record:model

Coffee:
  coffee:assets

Js:
  js:assets

TestUnit:
  test_unit:controller
  test_unit:generator
  test_unit:helper
  test_unit:integration
  test_unit:job
  test_unit:mailer
  test_unit:model
  test_unit:plugin
  test_unit:scaffold
  test_unit:system
```

**after**

```
./bin/rails destroy --help
Usage: rails destroy GENERATOR [args] [options]

General options:
  -h, [--help]     # Print generator's options and usage
  -p, [--pretend]  # Run but do not make any changes
  -f, [--force]    # Overwrite files that already exist
  -s, [--skip]     # Skip files that already exist
  -q, [--quiet]    # Suppress status output

Please choose a generator below.

Rails:
  assets
  channel
  controller
  generator
  helper
  integration_test
  jbuilder
  job
  mailer
  migration
  model
  resource
  scaffold
  scaffold_controller
  system_test
  task

Coffee:
  coffee:assets

Js:
  js:assets

TestUnit:
  test_unit:generator
  test_unit:plugin 
```
