### PR TITLE
Use oracle-enhanced 1.8 branch for Rails 5.1 stable branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,7 +145,7 @@ if ENV["ORACLE_ENHANCED"]
   platforms :ruby do
     gem "ruby-oci8", "~> 2.2"
   end
-  gem "activerecord-oracle_enhanced-adapter", github: "rsim/oracle-enhanced", branch: "master"
+  gem "activerecord-oracle_enhanced-adapter", github: "rsim/oracle-enhanced", branch: "release18"
 end
 
 # A gem necessary for Active Record tests with IBM DB.


### PR DESCRIPTION
### Summary

The currently master branch of activerecord-oracle_enhanced-adapter is for AR 5.2.0.alpha.

https://github.com/rsim/oracle-enhanced/blob/ade8850766bf5a2859364b204ad414ea8ee11950/activerecord-oracle_enhanced-adapter.gemspec#L88

The version of activerecord-oracle_enhanced-adapter for AR 5.1.x is 1.8.x.

Similar issue ... https://github.com/rails/rails/pull/27915
