### PR TITLE
Fix ActiveModel::Errors #keys, #values

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,33 @@
+*   Fix methods `#keys`, `#values` in `ActiveModel::Errors`.
+
+    Change `#keys` to only return the keys that don't have empty messages.
+
+    Change `#values` to only return the not empty values.
+
+     Example:
+
+         # Before
+         person = Person.new
+         person.errors.keys     # => []
+         person.errors.values   # => []
+         person.errors.messages # => {}
+         person.errors[:name]   # => []
+         person.errors.messages # => {:name => []}
+         person.errors.keys     # => [:name]
+         person.errors.values   # => [[]]
+
+         # After
+         person = Person.new
+         person.errors.keys     # => []
+         person.errors.values   # => []
+         person.errors.messages # => {}
+         person.errors[:name]   # => []
+         person.errors.messages # => {:name => []}
+         person.errors.keys     # => []
+         person.errors.values   # => []
+
+    *bogdanvlviv*
+
 *   Avoid converting integer as a string into float.
 
     *namusyaka*

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -132,15 +132,6 @@ module ActiveModel
     #
     #   person.errors[:name]  # => ["cannot be nil"]
     #   person.errors['name'] # => ["cannot be nil"]
-    #
-    # Note that, if you try to get errors of an attribute which has
-    # no errors associated with it, this method will instantiate
-    # an empty error list for it and +keys+ will return an array
-    # of error keys which includes this attribute.
-    #
-    #   person.errors.keys    # => []
-    #   person.errors[:name]  # => []
-    #   person.errors.keys    # => [:name]
     def [](attribute)
       messages[attribute.to_sym]
     end
@@ -181,7 +172,9 @@ module ActiveModel
     #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
     #   person.errors.values   # => [["cannot be nil", "must be specified"]]
     def values
-      messages.values
+      messages.reject do |key, value|
+        value.empty?
+      end.values
     end
 
     # Returns all message keys.
@@ -189,7 +182,9 @@ module ActiveModel
     #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
     #   person.errors.keys     # => [:name]
     def keys
-      messages.keys
+      messages.reject do |key, value|
+        value.empty?
+      end.keys
     end
 
     # Returns +true+ if no errors are found, +false+ otherwise.

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -99,12 +99,28 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["omg", "zomg"], errors.values
   end
 
+  test "values returns an empty array after try to get a message only" do
+    errors = ActiveModel::Errors.new(self)
+    errors.messages[:foo]
+    errors.messages[:baz]
+
+    assert_equal [], errors.values
+  end
+
   test "keys returns the error keys" do
     errors = ActiveModel::Errors.new(self)
     errors.messages[:foo] << "omg"
     errors.messages[:baz] << "zomg"
 
     assert_equal [:foo, :baz], errors.keys
+  end
+
+  test "keys returns an empty array after try to get a message only" do
+    errors = ActiveModel::Errors.new(self)
+    errors.messages[:foo]
+    errors.messages[:baz]
+
+    assert_equal [], errors.keys
   end
 
   test "detecting whether there are errors with empty?, blank?, include?" do


### PR DESCRIPTION
Before:
```ruby
  person.errors.keys    # => []
  person.errors.values  # => []
  person.errors[:name]  # => []
  person.errors.keys    # => [:name]
  person.errors.values  # => [[]]
```

After:
```ruby
  person.errors.keys   # => []
  person.errors.values # => []
  person.errors[:name] # => []
  person.errors.keys   # => []
  person.errors.values # => []
```

Related to #23468