### PR TITLE
Make `driven_by` overridable

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -87,7 +87,7 @@ module ActionDispatch
 
     def initialize(*) # :nodoc:
       super
-      self.class.superclass.driver.use
+      self.class.driver.use
     end
 
     def self.start_application # :nodoc:
@@ -99,6 +99,8 @@ module ActionDispatch
 
       SystemTesting::Server.new.run
     end
+
+    class_attribute :driver, instance_accessor: false
 
     # System Test configuration options
     #
@@ -113,13 +115,10 @@ module ActionDispatch
     #
     #   driven_by :selenium, screen_size: [800, 800]
     def self.driven_by(driver, using: :chrome, screen_size: [1400, 1400], options: {})
-      @driver = SystemTesting::Driver.new(driver, using: using, screen_size: screen_size, options: options)
+      self.driver = SystemTesting::Driver.new(driver, using: using, screen_size: screen_size, options: options)
     end
 
-    # Returns the driver object for the initialized system test
-    def self.driver
-      @driver ||= SystemTestCase.driven_by(:selenium)
-    end
+    driven_by :selenium
   end
 
   SystemTestCase.start_application

--- a/actionpack/test/dispatch/system_testing/system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/system_test_case_test.rb
@@ -6,6 +6,14 @@ class SetDriverToRackTestTest < DrivenByRackTest
   end
 end
 
+class OverrideSeleniumSubclassToRackTestTest < DrivenBySeleniumWithChrome
+  driven_by :rack_test
+
+  test "uses rack_test" do
+    assert_equal :rack_test, Capybara.current_driver
+  end
+end
+
 class SetDriverToSeleniumTest < DrivenBySeleniumWithChrome
   test "uses selenium" do
     assert_equal :selenium, Capybara.current_driver


### PR DESCRIPTION
Sometimes we want to use rack_test partially instead of selenium for test speed:

```ruby
class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
  driven_by :selenium, using: :chrome, screen_size: [1400, 1400], options: {url: "http://chrome:4444/wd/hub"}
end

class WithJavascriptTest < ApplicationSystemTestCase
end

class WithoutJavascriptTest < ApplicationSystemTestCase
  driven_by :rack_test
end
```

In the abobe case, `WithoutJavascriptTest` uses selenium because
`SystemTestCase` calls superclass' driver on `#initialize` (`self.class.superclass.driver.use`).

Using `class_attribute` can handle inherited `driven_by`.