### PR TITLE
Load only needed records on ActiveRecord::Relation#inspect

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,1 +1,10 @@
+*   Load only needed records on `ActiveRecord::Relation#inspect`.
+
+    Instead of loading all records and returning only a subset of those, just
+    load the records as needed.
+
+    Fixes #25537.
+
+    *Hendy Tanata*
+
 Please check [5-1-stable](https://github.com/rails/rails/blob/5-1-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -635,7 +635,9 @@ module ActiveRecord
     end
 
     def inspect
-      entries = records.take([limit_value, 11].compact.min).map!(&:inspect)
+      subject = loaded? ? records : self
+      entries = subject.take([limit_value, 11].compact.min).map!(&:inspect)
+
       entries[10] = "..." if entries.size == 11
 
       "#<#{self.class.name} [#{entries.join(', ')}]>"

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1901,6 +1901,12 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal "#<ActiveRecord::Relation [#{Post.limit(10).map(&:inspect).join(', ')}, ...]>", relation.inspect
   end
 
+  test "relations don't load all records in #inspect" do
+    assert_sql(/LIMIT/) do
+      Post.all.inspect
+    end
+  end
+
   test "already-loaded relations don't perform a new query in #inspect" do
     relation = Post.limit(2)
     relation.to_a


### PR DESCRIPTION
Instead of loading all records and returning only a subset of those, just load the records as needed.

The original behavior could be bad when someone types `User.where(...)` on console and accidentally presses enter before they finish, causing a lot of records to be queried and loaded, although only 10 is shown.

To query and inspect all, we can use `to_a` instead, e.g. `User.all.to_a.inspect`.

Fixes #25537.