### PR TITLE
FinderMethods#fourty_two docs cite proper source

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -224,7 +224,7 @@ module ActiveRecord
       fifth || raise_record_not_found_exception!
     end
 
-    # Find the forty-second record. Also known as accessing "the reddit".
+    # Find the forty-second record. Also known as accessing "the answer to life the universe and everything".
     # If no order is defined it will order by primary key.
     #
     #   Person.forty_two # returns the forty-second object fetched by SELECT * FROM people


### PR DESCRIPTION
Silly method gets a silly doc fix, 
or I'm missing an even sillier joke and I'm about to get schooled.

BUT I'm pretty sure this is some serious Beaudrillard simulacrum, though.
I'm just doing my part to spread the gospel of Douglas Adams.

Note: I dug [back as far as it seemed reasonable](https://github.com/rails/rails/blame/0405d5a7e95776f9adf5b8ff064300898d89b43a/activerecord/lib/active_record/relation/finder_methods.rb) to make sure I wasn't missing something here, but it seems an innocuous-but-still-somewhat-important misunderstanding to correct.