### PR TITLE
CI against Ruby 2.2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ env:
     - "GEM=ac:integration"
 
 rvm:
-  - 2.2.6
+  - 2.2.7
   - 2.3.3
   - 2.4.1
   - ruby-head
@@ -64,7 +64,7 @@ matrix:
   include:
     - rvm: 2.4.1
       env: "GEM=av:ujs"
-    - rvm: 2.2.6
+    - rvm: 2.2.7
       env: "GEM=aj:integration"
       services:
         - memcached


### PR DESCRIPTION
### Summary
https://www.ruby-lang.org/en/news/2017/03/28/ruby-2-2-7-released/