### PR TITLE
Fix the example code for `Rails.groups` [ci skip]

### DIFF
--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -87,8 +87,8 @@ module Rails
     #   groups assets: [:development, :test]
     #
     #   # Returns
-    #   # => [:default, :development, :assets] for Rails.env == "development"
-    #   # => [:default, :production]           for Rails.env == "production"
+    #   # => [:default, "development", :assets] for Rails.env == "development"
+    #   # => [:default, "production"]           for Rails.env == "production"
     def groups(*groups)
       hash = groups.extract_options!
       env = Rails.env


### PR DESCRIPTION
### Summary
`Rails.groups` contains `Rails.env` that is inspected as String.
