### PR TITLE
Add an alias for reverse_merge to with_defaults

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -667,6 +667,7 @@ module ActionController
         other_hash.to_h.merge(@parameters)
       )
     end
+    alias_method :with_defaults, :reverse_merge
 
     # Returns current <tt>ActionController::Parameters</tt> instance with
     # current hash merged into +other_hash+.
@@ -674,6 +675,7 @@ module ActionController
       @parameters.merge!(other_hash.to_h) { |key, left, right| left }
       self
     end
+    alias_method :with_defaults!, :reverse_merge!
 
     # This is required by ActiveModel attribute assignment, so that user can
     # pass +Parameters+ to a mass assignment methods in a model. It should not

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -310,6 +310,14 @@ class ParametersPermitTest < ActiveSupport::TestCase
     refute_predicate merged_params[:person], :empty?
   end
 
+  test "#with_defaults is an alias of reverse_merge" do
+    default_params = ActionController::Parameters.new(id: "1234", person: {}).permit!
+    merged_params = @params.with_defaults(default_params)
+
+    assert_equal "1234", merged_params[:id]
+    refute_predicate merged_params[:person], :empty?
+  end
+
   test "not permitted is sticky beyond reverse_merge" do
     refute_predicate @params.reverse_merge(a: "b"), :permitted?
   end
@@ -322,6 +330,14 @@ class ParametersPermitTest < ActiveSupport::TestCase
   test "#reverse_merge! with parameters" do
     default_params = ActionController::Parameters.new(id: "1234", person: {}).permit!
     @params.reverse_merge!(default_params)
+
+    assert_equal "1234", @params[:id]
+    refute_predicate @params[:person], :empty?
+  end
+
+  test "#with_defaults! is an alias of reverse_merge!" do
+    default_params = ActionController::Parameters.new(id: "1234", person: {}).permit!
+    @params.with_defaults!(default_params)
 
     assert_equal "1234", @params[:id]
     refute_predicate @params[:person], :empty?

--- a/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb
@@ -12,6 +12,7 @@ class Hash
   def reverse_merge(other_hash)
     other_hash.merge(self)
   end
+  alias_method :with_defaults, :reverse_merge
 
   # Destructive +reverse_merge+.
   def reverse_merge!(other_hash)
@@ -19,4 +20,5 @@ class Hash
     merge!(other_hash) { |key, left, right| left }
   end
   alias_method :reverse_update, :reverse_merge!
+  alias_method :with_defaults!, :reverse_merge!
 end

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -225,11 +225,13 @@ module ActiveSupport
     def reverse_merge(other_hash)
       super(self.class.new(other_hash))
     end
+    alias_method :with_defaults, :reverse_merge
 
     # Same semantics as +reverse_merge+ but modifies the receiver in-place.
     def reverse_merge!(other_hash)
       replace(reverse_merge(other_hash))
     end
+    alias_method :with_defaults!, :reverse_merge!
 
     # Replaces the contents of this hash with other_hash.
     #

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -535,6 +535,16 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal "clobber", hash[:another]
   end
 
+  def test_indifferent_with_defaults_aliases_reverse_merge
+    hash = HashWithIndifferentAccess.new key: :old_value
+    actual = hash.with_defaults key: :new_value
+    assert_equal :old_value, actual[:key]
+
+    hash = HashWithIndifferentAccess.new key: :old_value
+    hash.with_defaults! key: :new_value
+    assert_equal :old_value, hash[:key]
+  end
+
   def test_indifferent_deleting
     get_hash = proc { { a: "foo" }.with_indifferent_access }
     hash = get_hash.call
@@ -845,6 +855,21 @@ class HashExtTest < ActiveSupport::TestCase
     # Should be an alias for reverse_merge!
     merged = options.dup
     assert_equal expected, merged.reverse_update(defaults)
+    assert_equal expected, merged
+  end
+
+  def test_with_defaults_aliases_reverse_merge
+    defaults = { a: "x", b: "y", c: 10 }.freeze
+    options  = { a: 1, b: 2 }
+    expected = { a: 1, b: 2, c: 10 }
+
+    # Should be an alias for reverse_merge
+    assert_equal expected, options.with_defaults(defaults)
+    assert_not_equal expected, options
+
+    # Should be an alias for reverse_merge!
+    merged = options.dup
+    assert_equal expected, merged.with_defaults!(defaults)
     assert_equal expected, merged
   end
 


### PR DESCRIPTION
In the context of controller parameters, reverse_merge is commonly used
to provide defaults for user input. Having an alias to reverse_merge
called with_defaults feels more idiomatic for Rails.

Should we add documentation to reverse merge referencing these new aliases?