### PR TITLE
Enable Rails config overrides of action view sanitizer classes

### DIFF
--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -121,13 +121,12 @@ module ActionView
       end
 
       module ClassMethods #:nodoc:
-        attr_writer :full_sanitizer, :link_sanitizer, :white_list_sanitizer
-
         # Vendors the full, link and white list sanitizers.
         # Provided strictly for compatibility and can be removed in Rails 5.1.
         def sanitizer_vendor
           Rails::Html::Sanitizer
         end
+        module_function :sanitizer_vendor
 
         def sanitized_allowed_tags
           sanitizer_vendor.white_list_sanitizer.allowed_tags
@@ -144,8 +143,8 @@ module ActionView
         #     config.action_view.full_sanitizer = MySpecialSanitizer.new
         #   end
         #
-        def full_sanitizer
-          @full_sanitizer ||= sanitizer_vendor.full_sanitizer.new
+        cattr_accessor :full_sanitizer do
+          sanitizer_vendor.full_sanitizer.new
         end
 
         # Gets the Rails::Html::LinkSanitizer instance used by +strip_links+.
@@ -155,8 +154,8 @@ module ActionView
         #     config.action_view.link_sanitizer = MySpecialSanitizer.new
         #   end
         #
-        def link_sanitizer
-          @link_sanitizer ||= sanitizer_vendor.link_sanitizer.new
+        cattr_accessor :link_sanitizer do
+          sanitizer_vendor.link_sanitizer.new
         end
 
         # Gets the Rails::Html::WhiteListSanitizer instance used by sanitize and +sanitize_css+.
@@ -166,8 +165,8 @@ module ActionView
         #     config.action_view.white_list_sanitizer = MySpecialSanitizer.new
         #   end
         #
-        def white_list_sanitizer
-          @white_list_sanitizer ||= sanitizer_vendor.white_list_sanitizer.new
+        cattr_accessor :white_list_sanitizer do
+          sanitizer_vendor.white_list_sanitizer.new
         end
       end
     end

--- a/actionview/test/template/sanitize_helper_test.rb
+++ b/actionview/test/template/sanitize_helper_test.rb
@@ -38,4 +38,30 @@ class SanitizeHelperTest < ActionView::TestCase
   def test_sanitize_is_marked_safe
     assert sanitize("<html><script></script></html>").html_safe?
   end
+
+  def test_custom_sanitizer
+    custom_sanitizer = Class.new do
+      def sanitize(html, options = {})
+        "foobar"
+      end
+    end
+
+    default_full_sanitizer = ActionView::Base.full_sanitizer
+    default_link_sanitizer = ActionView::Base.link_sanitizer
+    default_white_list_sanitizer = ActionView::Base.white_list_sanitizer
+
+    ActionView::Base.full_sanitizer = custom_sanitizer.new
+    ActionView::Base.link_sanitizer = custom_sanitizer.new
+    ActionView::Base.white_list_sanitizer = custom_sanitizer.new
+
+    view_context_class = Class.new(ActionView::Base)
+
+    assert_equal "foobar", view_context_class.new.strip_links("<a>test</a>")
+    assert_equal "foobar", view_context_class.new.strip_tags("<a>test</a>")
+    assert_equal "foobar", view_context_class.new.sanitize("<a>test</a>")
+
+    ActionView::Base.full_sanitizer = default_full_sanitizer
+    ActionView::Base.link_sanitizer = default_link_sanitizer
+    ActionView::Base.white_list_sanitizer = default_white_list_sanitizer
+  end
 end


### PR DESCRIPTION
### Summary

Fixes #28587 

These changes ensure that configured `ActionView::Base` sanitizer instances are properly inherited in view contexts used by `sanitize` and other `SanitizeHelper` methods by changing sanitizer class instance variables to use `cattr_accessor`.

### Other Information

It would be nice to get this fix into both Rails 5.x and 4.2 versions.