### PR TITLE
Rails 28466

### DIFF
--- a/actionpack/test/dispatch/system_testing/db_conn_test.rb
+++ b/actionpack/test/dispatch/system_testing/db_conn_test.rb
@@ -1,0 +1,69 @@
+require "abstract_unit"
+
+# We're trying to test that threads are shared between the test-runner
+# thread and the server thread, when appropriate.  But we don't have the
+# "real" ActiveRecord.  So, we mock up the per-thread behavior of
+# ActiveRecord's connection pools, using "connections" which are
+# just random objects.
+
+# But to do this, we have to have mock ActiveRecord::Base.connection
+# and .connection_pool in place while 'setup' is running, so they
+# can't just be stubbed within the tests themselves.  Hence the
+# following, admittedly dodgy hack:
+
+module ActiveRecord
+  class Base
+    def self.connection; MockConnectionPool::connection; end
+    def self.connection_pool; MockConnectionPool; end
+  end
+end
+
+module MockConnectionPool
+
+  def self.connection
+    Thread.current['db_connection'] ||= Object.new
+  end
+
+  def self.using_connection(conn)
+    saved_conn = Thread.current['db_connection']
+    begin
+      Thread.current['db_connection'] = conn
+      yield
+    ensure
+      Thread.current['db_connection'] = saved_conn
+    end
+  end
+
+end
+
+class TestTransactionalSharing < DrivenByRackTest
+
+  cattr_accessor :use_transactional_tests
+
+  test "setup happens properly" do
+    # Tests function of the Setup hook on SystemTest itself
+    assert_equal self, self.class.currently_running_test
+    assert_equal ActiveRecord::Base.connection, self.class.cached_db_connection
+  end
+
+  test "shares DB connection when transactional" do
+    self.class.use_transactional_tests = true
+    test_runner_connection = ActiveRecord::Base.connection
+    Thread.new do
+      ActionDispatch::SystemTestCase.with_db_connection_for_web_service do
+        assert_equal test_runner_connection, ActiveRecord::Base.connection
+      end
+    end.join
+  end
+
+  test "doesn't share DB connection when not transactional" do
+    self.class.use_transactional_tests = false
+    test_runner_connection = ActiveRecord::Base.connection
+    Thread.new do
+      ActionDispatch::SystemTestCase.with_db_connection_for_web_service do
+        assert_not_equal test_runner_connection, ActiveRecord::Base.connection
+      end
+    end.join
+  end
+  
+end

--- a/actionpack/test/dispatch/system_testing/db_conn_test.rb
+++ b/actionpack/test/dispatch/system_testing/db_conn_test.rb
@@ -19,7 +19,6 @@ module ActiveRecord
 end
 
 module MockConnectionPool
-
   def self.connection
     Thread.current['db_connection'] ||= Object.new
   end
@@ -27,17 +26,15 @@ module MockConnectionPool
   def self.using_connection(conn)
     saved_conn = Thread.current['db_connection']
     begin
-      Thread.current['db_connection'] = conn
+      Thread.current["db_connection"] = conn
       yield
     ensure
-      Thread.current['db_connection'] = saved_conn
+      Thread.current["db_connection"] = saved_conn
     end
   end
-
 end
 
 class TestTransactionalSharing < DrivenByRackTest
-
   cattr_accessor :use_transactional_tests
 
   test "setup happens properly" do
@@ -65,5 +62,4 @@ class TestTransactionalSharing < DrivenByRackTest
       end
     end.join
   end
-  
 end

--- a/actionpack/test/dispatch/system_testing/db_conn_test.rb
+++ b/actionpack/test/dispatch/system_testing/db_conn_test.rb
@@ -20,11 +20,11 @@ end
 
 module MockConnectionPool
   def self.connection
-    Thread.current['db_connection'] ||= Object.new
+    Thread.current["db_connection"] ||= Object.new
   end
 
   def self.using_connection(conn)
-    saved_conn = Thread.current['db_connection']
+    saved_conn = Thread.current["db_connection"]
     begin
       Thread.current["db_connection"] = conn
       yield

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -364,6 +364,26 @@ module ActiveRecord
         @thread_cached_conns[connection_cache_key(Thread.current)] ||= checkout
       end
 
+      # Force a particular connection to be used on this thread, while
+      # running the block passed to the method.  Cleans up afterward,
+      # to avoid leaving dangling references if the thread that "loaned"
+      # the connection terminates.
+      #
+      # This can be used, e.g., to ensure that the webservice thread
+      # in a transactional system test is using the same connection as
+      # the thread that sets up the fixtures.
+
+      def using_connection(other_connection)
+        conn_key = connection_cache_key(Thread.current)
+        old_connection = @thread_cached_conns[conn_key]
+        begin
+          @thread_cached_conns[conn_key] = other_connection
+          yield
+        ensure
+          @thread_cached_conns[conn_key] = old_connection
+        end
+      end
+
       # Returns true if there is an open connection being used for the current thread.
       #
       # This method only works for connections that have been obtained through

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -353,16 +353,6 @@ module ActiveRecord
         @threads_blocking_new_connections = 0
 
         @available = ConnectionLeasingQueue.new self
-
-        @lock_thread = false
-      end
-
-      def lock_thread=(lock_thread)
-        if lock_thread
-          @lock_thread = Thread.current
-        else
-          @lock_thread = nil
-        end
       end
 
       # Retrieve the connection associated with the current thread, or call
@@ -371,7 +361,7 @@ module ActiveRecord
       # #connection can be called any number of times; the connection is
       # held in a cache keyed by a thread.
       def connection
-        @thread_cached_conns[connection_cache_key(@lock_thread || Thread.current)] ||= checkout
+        @thread_cached_conns[connection_cache_key(Thread.current)] ||= checkout
       end
 
       # Returns true if there is an open connection being used for the current thread.

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -970,7 +970,6 @@ module ActiveRecord
         @fixture_connections = enlist_fixture_connections
         @fixture_connections.each do |connection|
           connection.begin_transaction joinable: false
-          connection.pool.lock_thread = true
         end
 
         # When connections are established in the future, begin a transaction too
@@ -986,7 +985,6 @@ module ActiveRecord
 
             if connection && !@fixture_connections.include?(connection)
               connection.begin_transaction joinable: false
-              connection.pool.lock_thread = true
               @fixture_connections << connection
             end
           end
@@ -1009,7 +1007,6 @@ module ActiveRecord
         ActiveSupport::Notifications.unsubscribe(@connection_subscriber) if @connection_subscriber
         @fixture_connections.each do |connection|
           connection.rollback_transaction if connection.transaction_open?
-          connection.pool.lock_thread = false
         end
         @fixture_connections.clear
       else

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -638,8 +638,6 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
   def test_transaction_created_on_connection_notification
     connection = stub(transaction_open?: false)
     connection.expects(:begin_transaction).with(joinable: false)
-    pool = connection.stubs(:pool).returns(ActiveRecord::ConnectionAdapters::ConnectionPool.new(ActiveRecord::Base.connection_pool.spec))
-    pool.stubs(:lock_thread=).with(false)
     fire_connection_notification(connection)
   end
 
@@ -647,15 +645,11 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
     # Mocha is not thread-safe so define our own stub to test
     connection = Class.new do
       attr_accessor :rollback_transaction_called
-      attr_accessor :pool
       def transaction_open?; true; end
       def begin_transaction(*args); end
       def rollback_transaction(*args)
         @rollback_transaction_called = true
       end
-    end.new
-    connection.pool = Class.new do
-      def lock_thread=(lock_thread); false; end
     end.new
     fire_connection_notification(connection)
     teardown_fixtures

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -532,16 +532,4 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
       end
     end
   end
-
-  test "threads use the same connection" do
-    @connection_1 = ActiveRecord::Base.connection.object_id
-
-    thread_a = Thread.new do
-      @connection_2 = ActiveRecord::Base.connection.object_id
-    end
-
-    thread_a.join
-
-    assert_equal @connection_1, @connection_2
-  end
 end


### PR DESCRIPTION
### Summary

The transactional system tests introduced in Rails 5.1 change the way DB connections
are managed while running _all_ transactional tests, not just system tests.
As described in #28466 this has the unfortunate effect of breaking, e.g., pre-existing 
transactional model tests.  This PR provides an alternative approach, which allows 
transactional system tests to work as they do in 5.1.0rc1, while leaving behavior
of other tests unchanged.

In a bit more detail:

In releases before 5.1, it was possible for transactional tests to start threads which
would have their own DB connections, as normal.  In Rails 5.1 rc1 (and beta1), all
threads share a single connection while running a transactional test, including not
only system tests, but transactional controller, model, and integration tests as well.
This breaks tests which, for example, started up a thread on the side (with its own
connection) to verify that code under test was properly doing a rollback.

The new behavior was introduced so that Capybara-based transactional system 
tests could have the test-runner code and the server share a database connection,
even though most Capybara drivers put the server on a thread of its own.

This PR allows those two threads to share the connection more discreetly, using
a mechanism that doesn't affect anything else.  In particular, it leaves the behavior
of pre-existing model and controller tests unchanged.

### Other Information

The PR replaces the `lock_thread` machinery introduced for the system tests with
a `ConnectionPool#using_connection` method, which allows one thread to
selectively borrow another's.  It then alters `SystemTest` to use the new machinery.
Specifically, at the start of every test, a `setup` hook puts references to the currently
running test suite, and the test-runner threads DB connection, someplace that the
web-service thread can find it.  (I used class attributes on `SystemTest` itself for
the purpose.)  It lastly makes `Capybara.app` be a Rack app that wraps a
`using_connection` around the invocation of `Rails.application`, if the currently
running `SystemTest` is transactional.

Unfortunately, tests for the thread-sharing logic in `SystemTest` itself require support
that fits awkwardly within the rest of the `ActionDispatch` test suite.  In particular, it
needs mocks for `ActiveRecord::Base.connection` and `connection_pool` to be in place
while the `setup` hook is running, so they can't just be stubbed within the test itself.
The results are not consistent with framework mocks elsewhere in the test suite, and
I'd be happy to replace the result with something a little more stylish.

(It would also be nice to have tests which ensure that `with_db_connection_for_web_service`
is actually called on the thread that's serving web requests.  But that requires a Capybara
driver which actually does web service on a separate thread.  The `:rack_test` driver doesn't
do that, and all the other standard ones require a heavyweight mock browser which isn't
otherwise needed for running `ActionPack` tests.)