### PR TITLE
Update comment in sanitizer helper test [skip ci]

### DIFF
--- a/actionview/test/template/sanitize_helper_test.rb
+++ b/actionview/test/template/sanitize_helper_test.rb
@@ -1,6 +1,6 @@
 require "abstract_unit"
 
-# The exhaustive tests are in test/controller/html/sanitizer_test.rb.
+# The exhaustive tests are in the rails-html-sanitizer gem.
 # This tests that the helpers hook up correctly to the sanitizer classes.
 class SanitizeHelperTest < ActionView::TestCase
   tests ActionView::Helpers::SanitizeHelper


### PR DESCRIPTION
### Summary

Small documentation change to the sanitizer helper test. The previously referenced file appears to pre-date the extraction of sanitization logic to the `rails-html-sanitizer` gem.