### PR TITLE
Let assets:precompile fail if yarn:install fails

### DIFF
--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -1,11 +1,11 @@
 namespace :yarn do
   desc "Install all JavaScript dependencies as specified via Yarn"
   task :install do
-    system("./bin/yarn install --no-progress")
+    system("./bin/yarn install --no-progress") || exit($?.exitstatus)
   end
 end
 
 # Run Yarn prior to Sprockets assets precompilation, so dependencies are available for use.
-if Rake::Task.task_defined?("assets:precompile")
+if Rake::Task.task_defined?("assets:precompile") && File.exist?("./bin/yarn")
   Rake::Task["assets:precompile"].enhance [ "yarn:install" ]
 end


### PR DESCRIPTION
### Summary

When I deploy Rails app, I want to abort the deployment if any process inside `assets:precompile` fails. But `rake assets:precompile` exits successfully even if `bin/yarn` fails.

So I changed yarn:install to exit with failure if it fails. Also, I changed it to skip `yarn:install` if `bin/yarn` doesn't exist for the case that `--skip-yarn` is specified.