### PR TITLE
Fix example usage of ActiveRecord::Base.establish_connection [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -825,7 +825,7 @@ module ActiveRecord
     #   end
     #
     #   class Book < ActiveRecord::Base
-    #     establish_connection "library_db"
+    #     establish_connection :library_db
     #   end
     #
     #   class ScaryBook < Book


### PR DESCRIPTION
### Summary

`ActiveRecord::Base.establish_connection` accepts a single symbol argument to specify a named connection; a single string argument appears to be interpreted as a connection URI
