### PR TITLE
Load rake tasks before run test

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,1 +1,10 @@
+*   Load rake tasks before run test.
+
+    This makes it possible to test rake tasks using `rails test` command just
+    like `rake test`.
+
+    Fixes #28506.
+
+    *Yuji Yaginuma*
+
 Please check [5-1-stable](https://github.com/rails/rails/blob/5-1-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -44,3 +44,7 @@ class ActionDispatch::IntegrationTest
     super
   end
 end
+
+if !Minitest.run_via.rake? && defined?(Rails.application) && Rails.application
+  Rails.application.load_tasks
+end


### PR DESCRIPTION
This makes it possible to test rake tasks using `rails test` command just like `rake test`.

Fixes #28506

r? @kaspth 