### PR TITLE
Fix a failed AR test when running with OracleAdapter

### DIFF
--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -462,6 +462,8 @@ class DefaultScopingTest < ActiveRecord::TestCase
   def test_with_abstract_class_scope_should_be_executed_in_correct_context
     vegetarian_pattern, gender_pattern = if current_adapter?(:Mysql2Adapter)
       [/`lions`.`is_vegetarian`/, /`lions`.`gender`/]
+    elsif current_adapter?(:OracleAdapter)
+      [/"LIONS"."IS_VEGETARIAN"/, /"LIONS"."GENDER"/]
     else
       [/"lions"."is_vegetarian"/, /"lions"."gender"/]
     end


### PR DESCRIPTION
### Summary

This PR fixes the following failure when using Oracle (11g) .

```sh
% ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]

% ARCONN=oracle bundle exec ruby -w -Itest test/cases/scoping/default_scoping_test.rb -n test_with_abstract_class_scope_should_be_executed_in_correct_context

(snip)

Run options: -n test_with_abstract_class_scope_should_be_executed_in_correct_context --seed 45783

# Running:

F

Finished in 0.331497s, 3.0166 runs/s, 6.0332 assertions/s.

  1) Failure:
DefaultScopingTest#test_with_abstract_class_scope_should_be_executed_in_correct_context [test/cases/scoping/default_scoping_test.rb:471]:
Expected /"lions"."is_vegetarian"/ to match "SELECT \"LIONS\".* FROM \"LIONS\" WHERE \"LIONS\".\"IS_VEGETARIAN\" = 0".

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

It matched the SQL string returned by OracleAdapter.
