### PR TITLE
Record environment in AR metadata before running migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Record environment in database before running migrations
+
+    The environment is now set in the database before running DB migrations,
+    so in the event of a migration error on a new database, destructive rake
+    tasks can be run.
+
+    Fixes #28001.
+
+    *Dominic Cleal*
+
 *   Load only needed records on `ActiveRecord::Relation#inspect`.
 
     Instead of loading all records and returning only a subset of those, just

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1185,10 +1185,10 @@ module ActiveRecord
       def run_without_lock
         migration = migrations.detect { |m| m.version == @target_version }
         raise UnknownMigrationVersionError.new(@target_version) if migration.nil?
-        result = execute_migration_in_transaction(migration, @direction)
 
         record_environment
-        result
+
+        execute_migration_in_transaction(migration, @direction)
       end
 
       # Used for running multiple migrations up to or down to a certain value.
@@ -1197,12 +1197,11 @@ module ActiveRecord
           raise UnknownMigrationVersionError.new(@target_version)
         end
 
-        result = runnable.each do |migration|
+        record_environment
+
+        runnable.each do |migration|
           execute_migration_in_transaction(migration, @direction)
         end
-
-        record_environment
-        result
       end
 
       # Stores the current environment in the database.


### PR DESCRIPTION
When migrating a new database, errors or cancellations in the migration
process could leave the database without the environment recorded in the
AR metadata. This would prevent db:drop and other destructive commands
from being run.

Setting the database's environment prior to running migrations ensures
that partially migrated databases can be destroyed later.

Fixes #28001

(an alternative to #28051, which allows dropping of the DB without the environment stored)