### PR TITLE
Add `:compose` option to `has_many`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add `:compose` option to `has_many`.
+
+    Generates additionnal has_many for each given association scope.
+
+        # Before
+        has_many :posts
+        has_many :published_posts, -> { published }, class_name: "Post"
+
+        # After
+        has_many :posts, compose: :published
+
+    *Julien Grillot*
+
 *   Load only needed records on `ActiveRecord::Relation#inspect`.
 
     Instead of loading all records and returning only a subset of those, just

--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -5,7 +5,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_options(options)
-      super + [:primary_key, :dependent, :as, :through, :source, :source_type, :inverse_of, :counter_cache, :join_table, :foreign_type, :index_errors]
+      super + [:primary_key, :dependent, :as, :through, :source, :source_type, :inverse_of, :counter_cache, :join_table, :foreign_type, :index_errors, :compose]
     end
 
     def self.valid_dependent_options

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2260,6 +2260,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal "hello", post.comments_with_extend_2.greeting
   end
 
+  test "has_many association with compose option" do
+    author = Author.create!(name: "Scope lover")
+    author.posts.create!([
+      { title: "' apostrophe", body: "'b'..'z' letters" },
+      { title: "no apostrophe", body: "'a' letter" },
+      { title: "' apostrophe", body: "'a' letter" },
+      { title: "no apostrophe", body: "'b'..'z' letters" }
+    ])
+    assert_equal 2, author.containing_the_letter_a_posts.count
+    assert_equal 1, author.containing_the_letter_a_titled_with_an_apostrophe_posts.count
+  end
+
   test "delete record with complex joins" do
     david = authors(:david)
 

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -1,5 +1,7 @@
 class Author < ActiveRecord::Base
-  has_many :posts
+  has_many :posts, compose: [:containing_the_letter_a]
+  has_many :titled_with_an_apostrophe_posts, -> { titled_with_an_apostrophe }, class_name: "Post", compose: :containing_the_letter_a
+
   has_many :serialized_posts
   has_one :post
   has_many :very_special_comments, through: :posts


### PR DESCRIPTION
### Summary

Generates additionnal has_many for each given association scope.

    # Before
    has_many :posts
    has_many :published_posts, -> { published }, class_name: "Post"

    # After
    has_many :posts, compose: :published

### Other Information

In my rails projects, I write a lot of `has_many` variations to be able to use fine-grained preload. Eg: `Author.all.preload(:published_post)…`. So I wrote this feature to have syntaxic sugar to shorten all theses `has_many`.

Here is an unpublished post I wrote about this feature:

https://medium.com/octoly-tech/activerecord-has-many-compose-option-4f2cbdb524a3

Perhaps a better name for this option may be `preloadable_scopes`—it does not cover all things one can do with this feature, but it is a quite self-explained option name since preloading theses generated has_many would be (I think) its main usage. I am not a native english and this is my first contribution, do not hesitate suggesting other option names.