### PR TITLE
Update puma.rb generator template to reconcile with Puma documentation

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb
@@ -48,7 +48,11 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # cannot share connections between processes.
 #
 # on_worker_boot do
-#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+#   if defined?(ActiveRecord)
+#     ActiveSupport.on_load(:active_record) do
+#       ActiveRecord::Base.establish_connection
+#     end
+#   end
 # end
 #
 


### PR DESCRIPTION
### Summary

I'm attempting to reconcile some documentation on ActiveRecord connections between Puma's README and the default generated Puma config file in Rails.

What's recommended in the Puma [README](https://github.com/puma/puma#clustered-mode):
```ruby
on_worker_boot do
  ActiveSupport.on_load(:active_record) do
    ActiveRecord::Base.establish_connection
  end
end
```

What's in the default puma.rb:
```ruby
on_worker_boot do
  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
end
```


### Other Information

The config was originally added by @schneems here: #23057

Not sure if he had some reasoning behind not using `ActiveSupport.on_load` (perhaps `ActiveRecord` will always already be loaded by this point?)