### PR TITLE
Add default_scope note to ActiveRecord guide

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1381,8 +1381,9 @@ class Client < ApplicationRecord
 end
 ```
 
-NOTE: The `default_scope` is also applied while creating/building a record.
-It is not applied while updating a record. E.g.:
+NOTE: The `default_scope` is also applied while creating/building a record
+when the scope arguments are given as a `Hash`. It is not applied while 
+updating a record. E.g.:
 
 ```ruby
 class Client < ApplicationRecord
@@ -1391,6 +1392,17 @@ end
 
 Client.new          # => #<Client id: nil, active: true>
 Client.unscoped.new # => #<Client id: nil, active: nil>
+```
+
+Be aware that, when given in the `Array` format, `default_scope` query arguments
+cannot be converted to a `Hash` for default attribute assignment. E.g.:
+
+```ruby
+class Client < ApplicationRecord
+  default_scope { where("active = ?", true) }
+end
+
+Client.new # => #<Client id: nil, active: nil>
 ```
 
 ### Merging of scopes


### PR DESCRIPTION
Adds note to explain unexpected behavior described in issue #28561.

Developers may be surprised that the internal representation of similar query conditions in Hash and Array formats in default_scope will yield  different results for model initialization.
