### PR TITLE
Use the config value directly when call `secrets`

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -386,7 +386,9 @@ module Rails
     def secrets
       @secrets ||= begin
         secrets = ActiveSupport::OrderedOptions.new
-        secrets.merge! Rails::Secrets.parse(config.paths["config/secrets"].existent, env: Rails.env)
+        files = config.paths["config/secrets"].existent
+        files = files.reject { |path| path.end_with?(".enc") } unless config.read_encrypted_secrets
+        secrets.merge! Rails::Secrets.parse(files, env: Rails.env)
 
         # Fallback to config.secret_key_base if secrets.secret_key_base isn't set
         secrets.secret_key_base ||= config.secret_key_base

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -81,7 +81,6 @@ INFO
 
       initializer :set_secrets_root, group: :all do
         Rails::Secrets.root = root
-        Rails::Secrets.read_encrypted_secrets = config.read_encrypted_secrets
       end
     end
   end

--- a/railties/lib/rails/secrets.rb
+++ b/railties/lib/rails/secrets.rb
@@ -14,12 +14,10 @@ module Rails
     end
 
     @cipher = "aes-128-gcm"
-    @read_encrypted_secrets = false
     @root = File # Wonky, but ensures `join` uses the current directory.
 
     class << self
-      attr_writer   :root
-      attr_accessor :read_encrypted_secrets
+      attr_writer :root
 
       def parse(paths, env:)
         paths.each_with_object(Hash.new) do |path, all_secrets|
@@ -88,11 +86,7 @@ module Rails
 
         def preprocess(path)
           if path.end_with?(".enc")
-            if @read_encrypted_secrets
-              decrypt(IO.binread(path))
-            else
-              ""
-            end
+            decrypt(IO.binread(path))
           else
             IO.read(path)
           end


### PR DESCRIPTION
Currently, `read_encrypted_secrets` is set with initializer.
Therefore if refer to `secrets` in config, `read_encrypted_secrets` is false,
so can not get the value of `secrets.yml.enc`.

In order to be able to refer to secrets in config, modified to refer to
`config.read_encrypted_secrets` when calling `secrets`.

Fixes #28618.

r? @kaspth 