### PR TITLE
Fix `warning: extra states are no longer copied`

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -172,8 +172,8 @@ module ActiveModel
     #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
     #   person.errors.values   # => [["cannot be nil", "must be specified"]]
     def values
-      messages.reject do |key, value|
-        value.empty?
+      messages.select do |key, value|
+        !value.empty?
       end.values
     end
 
@@ -182,8 +182,8 @@ module ActiveModel
     #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
     #   person.errors.keys     # => [:name]
     def keys
-      messages.reject do |key, value|
-        value.empty?
+      messages.select do |key, value|
+        !value.empty?
       end.keys
     end
 


### PR DESCRIPTION
`messages` has `default_proc` so calling `reject` causes the warning.

https://github.com/ruby/ruby/blob/v2_4_1/hash.c#L1335-L1337