### PR TITLE
Limit stale checks to issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -24,3 +24,5 @@ markComment: >
   Thank you for all your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
@rafaelfranca, https://github.com/probot/stale/pull/8 adds support for marking Pull Requests as stale in addition to Issues. The default will be to check both Issues and PRs, so I updated the config here to limit stale checking to issues.

Feel free to just close this PR If you want stale checks on PRs as well, but I will wait to hear from you either way before I deploy https://github.com/probot/stale/pull/8.