### PR TITLE
Fix partial cache logging

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -207,6 +207,7 @@ module ActionView #:nodoc:
         @view_renderer = ActionView::Renderer.new(lookup_context)
       end
 
+      @cache_hit = {}
       assign(assigns)
       assign_controller(controller)
       _prepare_context

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -227,6 +227,8 @@ module ActionView
       end
 
       def fragment_for(name = {}, options = nil, &block)
+        # Some tests might using this helper without initialize actionview object
+        @cache_hit ||= {}
         if content = read_fragment_for(name, options)
           @cache_hit[@virtual_path] = true
           content

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -228,10 +228,10 @@ module ActionView
 
       def fragment_for(name = {}, options = nil, &block)
         if content = read_fragment_for(name, options)
-          @cache_hit = true
+          @cache_hit[@virtual_path] = true
           content
         else
-          @cache_hit = false
+          @cache_hit[@virtual_path] = false
           write_fragment_for(name, options, &block)
         end
       end

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -344,7 +344,7 @@ module ActionView
           end
 
           content = layout.render(view, locals) { content } if layout
-          payload[:cache_hit] = view.cache_hit
+          payload[:cache_hit] = !!view.cache_hit[@template.virtual_path]
           content
         end
       end

--- a/actionview/test/activerecord/relation_cache_test.rb
+++ b/actionview/test/activerecord/relation_cache_test.rb
@@ -4,6 +4,7 @@ class RelationCacheTest < ActionView::TestCase
   tests ActionView::Helpers::CacheHelper
 
   def setup
+    @cache_hit = {}
     @virtual_path = "path"
     controller.cache_store = ActiveSupport::Cache::MemoryStore.new
   end

--- a/actionview/test/fixtures/test/_cached_nested_cached_customer.erb
+++ b/actionview/test/fixtures/test/_cached_nested_cached_customer.erb
@@ -1,0 +1,3 @@
+<% cache cached_customer do %>
+  <%= render partial: "test/cached_customer", locals: { cached_customer: cached_customer } %>
+<% end %>

--- a/actionview/test/fixtures/test/_nested_cached_customer.erb
+++ b/actionview/test/fixtures/test/_nested_cached_customer.erb
@@ -1,0 +1,1 @@
+<%= render partial: "test/cached_customer", locals: { cached_customer: cached_customer } %>


### PR DESCRIPTION
### Summary

This should fix #28529.

One partial's cache hit result might be changed when rendering other partial (e.g. rendering nested partials) if we use a single boolean to track it. So I now use a hash to make cache hit status partial-specific.