### PR TITLE
Add anchor links to all headers

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -294,6 +294,9 @@ a, a:link, a:visited {
 #mainCol a, #subCol a, #feature a {color: #980905;}
 #mainCol a code, #subCol a code, #feature a code {color: #980905;}
 
+#mainCol a.anchorlink { text-decoration: none; }
+#mainCol a.anchorlink:hover { text-decoration: underline; }
+
 /* Navigation
 --------------------------------------- */
 

--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -105,6 +105,10 @@ module RailsGuides
                 node.inner_html = "#{node_index(hierarchy)} #{node.inner_html}"
               end
             end
+
+            doc.css('h3, h4, h5, h6').each do |node|
+              node.inner_html = "<a class='anchorlink' href='##{node[:id]}'>#{node.inner_html}</a>"
+            end
           end.to_html
         end
       end


### PR DESCRIPTION
To allow easy linking at all levels and not just from index

### Summary

Updated the markdown renderer for the guides to wrap all headers (h3-h6) in an anchor tag to allow easy linking within the guide and not just from the sidebar index.

### Other Information

Updated the main.css as to maintain existing look and feel, making the headings only underline when hovered on.
