### PR TITLE
Set `Capybara.app_host` through `host!`

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb
@@ -2,7 +2,12 @@ module ActionDispatch
   module SystemTesting
     module TestHelpers
       module SetupAndTeardown # :nodoc:
-        DEFAULT_HOST = "127.0.0.1"
+        DEFAULT_HOST = "http://127.0.0.1"
+
+        def host!(host)
+          super
+          Capybara.app_host = host
+        end
 
         def before_setup
           host! DEFAULT_HOST

--- a/actionpack/test/dispatch/system_testing/system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/system_test_case_test.rb
@@ -19,3 +19,15 @@ class SetDriverToSeleniumTest < DrivenBySeleniumWithChrome
     assert_equal :selenium, Capybara.current_driver
   end
 end
+
+class SetHostTest < DrivenByRackTest
+  test "sets default host" do
+    assert_equal "http://127.0.0.1", Capybara.app_host
+  end
+
+  test "overrides host" do
+    host! "http://example.com"
+
+    assert_equal "http://example.com", Capybara.app_host
+  end
+end


### PR DESCRIPTION
`visit "/"` will visit always "http://127.0.0.1" even when we call `host!`:

```ruby
class SomeTest < ApplicationSystemTest
  def setup
    host! "http://example.com"
  end

  def test_visit
    visit root_url # => visit "http://example.com/"

    visit "/" # => visit "http://127.0.0.1/"
  end
end
```

Because Capybara assumes that host is same as the server if we don't set `Capybara.app_host`:
https://github.com/teamcapybara/capybara/blob/866c975076f92b5d064ee8998be638dd213f0724/lib/capybara/session.rb#L239