### PR TITLE
Add missing requires for depedencies of strong_parameters.rb

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -3,6 +3,8 @@ require "active_support/core_ext/hash/transform_values"
 require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/string/filters"
 require "active_support/core_ext/object/to_query"
+require 'active_support/core_ext/module/attribute_accessors'
+require 'active_support/core_ext/module/delegation'
 require "active_support/rescuable"
 require "action_dispatch/http/upload"
 require "rack/test"


### PR DESCRIPTION
## Problem

If strong_parameters is the first `require`, then it gets the following error.

```
irb(main):001:0> require 'action_controller/metal/strong_parameters'
NoMethodError: undefined method `cattr_accessor' for ActionController::Parameters:Class
Did you mean?  attr_accessor
	from /Users/dylansmith/.gem/ruby/2.3.3/gems/actionpack-5.1.0.rc1/lib/action_controller/metal/strong_parameters.rb:110:in `<class:Parameters>'
	from /Users/dylansmith/.gem/ruby/2.3.3/gems/actionpack-5.1.0.rc1/lib/action_controller/metal/strong_parameters.rb:109:in `<module:ActionController>'
	from /Users/dylansmith/.gem/ruby/2.3.3/gems/actionpack-5.1.0.rc1/lib/action_controller/metal/strong_parameters.rb:13:in `<top (required)>'
	from /opt/rubies/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:133:in `require'
	from /opt/rubies/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:133:in `rescue in require'
	from /opt/rubies/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:40:in `require'
	from (irb):1
	from /opt/rubies/2.3.3/bin/irb:11:in `<main>'
```

The problem is that it is using extensions of Module (`cattr_accessor` and `delegate`) without requiring them.

## Solution

Add the missing `require` statements in strong_parameters.rb for its core extension dependencies