### PR TITLE
Keep frozen records frozen on save

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -63,6 +63,7 @@ module ActiveRecord
       end
 
       def changes_internally_applied # :nodoc:
+        return if frozen?
         @mutations_before_last_save = mutation_tracker
         forget_attribute_assignments
         @mutations_from_database = AttributeMutationTracker.new(@attributes)

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -87,6 +87,16 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::StaleObjectError) { p2.save! }
   end
 
+  def test_frozen_save
+    p1 = Person.find(1)
+    p1.freeze
+    assert p1.frozen?
+
+    p1.save!
+
+    assert p1.frozen?
+  end
+
   # See Lighthouse ticket #1966
   def test_lock_destroy
     p1 = Person.find(1)


### PR DESCRIPTION
### Summary

In Rails 4.2.6, if you called `save` on a frozen record, it would keep its frozen state. Between 4.2.6 and 5.0.0, 07723c23a7dc570beae73c074ad37227e3e8a06e introduced a regression where `save` will mutate a record and unfreeze it.

I pinpointed it to ActiveRecord::AttributeMethods::Dirty's `changes_internally_applied` that replaces a record's `@mutations_before_last_save` and `@mutations_from_database` ivars.

Returning if the record is frozen bypasses the changes and keeps the records frozen.

[Here is a test case ](https://gist.github.com/alexcameron89/11b77a2d2da66757062cfcf9d52eb490)showing the regression.

### Other Information

This is related to #28563.

There may be other solutions to this problem that I'm open to pursuing.