### PR TITLE
Downplay links in Guides headers

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -294,7 +294,10 @@ a, a:link, a:visited {
 #mainCol a, #subCol a, #feature a {color: #980905;}
 #mainCol a code, #subCol a code, #feature a code {color: #980905;}
 
-#mainCol a.anchorlink { text-decoration: none; }
+#mainCol a.anchorlink {
+  color: #333;
+  text-decoration: none;
+}
 #mainCol a.anchorlink:hover { text-decoration: underline; }
 
 /* Navigation


### PR DESCRIPTION
[ci skip]

### Summary

Change color of anchored headings to downplay their importance (see https://github.com/rails/rails/pull/28641#issuecomment-291565328)

