### PR TITLE
Consider y/n/YES/NO aliases to true/false for cast

### DIFF
--- a/activemodel/lib/active_model/type/boolean.rb
+++ b/activemodel/lib/active_model/type/boolean.rb
@@ -12,7 +12,7 @@ module ActiveModel
     # - Empty strings are coerced to +nil+
     # - All other values will be coerced to +true+
     class Boolean < Value
-      FALSE_VALUES = [false, 0, "0", "f", "F", "false", "FALSE", "off", "OFF"].to_set
+      FALSE_VALUES = [false, 0, "0", "f", "F", "false", "FALSE", "off", "OFF", "n", "N", "no", "NO"].to_set
 
       def type # :nodoc:
         :boolean

--- a/activemodel/test/cases/type/boolean_test.rb
+++ b/activemodel/test/cases/type/boolean_test.rb
@@ -18,6 +18,10 @@ module ActiveModel
         assert type.cast("TRUE")
         assert type.cast("on")
         assert type.cast("ON")
+        assert type.cast("y")
+        assert type.cast("Y")
+        assert type.cast("yes")
+        assert type.cast("YES")
         assert type.cast(" ")
         assert type.cast("\u3000\r\n")
         assert type.cast("\u0000")
@@ -33,6 +37,10 @@ module ActiveModel
         assert_equal false, type.cast("FALSE")
         assert_equal false, type.cast("off")
         assert_equal false, type.cast("OFF")
+        assert_equal false, type.cast("n")
+        assert_equal false, type.cast("N")
+        assert_equal false, type.cast("no")
+        assert_equal false, type.cast("NO")
       end
     end
   end


### PR DESCRIPTION
### Summary

Debatable if this is a bug or an improvement, but I was keen to use cast until I discovered that our business-specified text input of yes/no did not map correctly to booleans via cast.  This should be an easy (hopefully) uncontroversial fix, but happy to hear other opinions or issues.