### PR TITLE
Don't highlight code in anchorlink [ci skip]

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -294,10 +294,8 @@ a, a:link, a:visited {
 #mainCol a, #subCol a, #feature a {color: #980905;}
 #mainCol a code, #subCol a code, #feature a code {color: #980905;}
 
-#mainCol a.anchorlink {
-  color: #333;
-  text-decoration: none;
-}
+#mainCol a.anchorlink, #mainCol a.anchorlink code {color: #333;}
+#mainCol a.anchorlink { text-decoration: none; }
 #mainCol a.anchorlink:hover { text-decoration: underline; }
 
 /* Navigation


### PR DESCRIPTION
Minor fix to #28662

Before:
<img width="1552" alt="before" src="https://cloud.githubusercontent.com/assets/10076/24674328/dcff24f0-192f-11e7-83c3-78a723d24cf4.png">


After:
<img width="1552" alt="after" src="https://cloud.githubusercontent.com/assets/10076/24674331/e0f7442a-192f-11e7-9c65-02e841238229.png">

@matthewd 👍 ?