### PR TITLE
Mention Time.zone.parse possibly throwing ArgumentError

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -358,7 +358,7 @@ module ActiveSupport
     #   Time.zone.iso8601('1999-12-31') # => Fri, 31 Dec 1999 00:00:00 HST -10:00
     #
     # If the string is invalid then an +ArgumentError+ will be raised unlike +parse+
-    # which returns +nil+ when given an invalid date string.
+    # which usually returns +nil+ when given an invalid date string.
     def iso8601(str)
       parts = Date._iso8601(str)
 
@@ -397,6 +397,8 @@ module ActiveSupport
     # components are supplied, then the day of the month defaults to 1:
     #
     #   Time.zone.parse('Mar 2000') # => Wed, 01 Mar 2000 00:00:00 HST -10:00
+    #
+    # If the string is invalid then an +ArgumentError+ could be raised.
     def parse(str, now = now())
       parts_to_time(Date._parse(str, false), now)
     end

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -403,6 +403,16 @@ class TimeZoneTest < ActiveSupport::TestCase
     end
   end
 
+  def test_parse_with_invalid_date
+    zone = ActiveSupport::TimeZone["UTC"]
+
+    exception = assert_raises(ArgumentError) do
+      zone.parse("9000")
+    end
+
+    assert_equal "argument out of range", exception.message
+  end
+
   def test_rfc3339
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
     twz = zone.rfc3339("1999-12-31T14:00:00-10:00")


### PR DESCRIPTION
`Time.zone.parse("9000")` can fail for instance, and it's not mentioned in the docs.

----

- Running the time zone tests: `bundle exec ruby -w -I test/ test/time_zone_test.rb` (in `activesupport/`)