### PR TITLE
Fix edge guides for Active Record callbacks

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -254,7 +254,11 @@ Halting Execution
 
 As you start registering new callbacks for your models, they will be queued for execution. This queue will include all your model's validations, the registered callbacks, and the database operation to be executed.
 
-The whole callback chain is wrapped in a transaction. If any _before_ callback method returns exactly `false` or raises an exception, the execution chain gets halted and a ROLLBACK is issued; _after_ callbacks can only accomplish that by raising an exception.
+The whole callback chain is wrapped in a transaction. If any callback raises an exception, the execution chain gets halted and a ROLLBACK is issued. To intentionally stop a chain use:
+
+```ruby
+throw :abort
+```
 
 WARNING. Any exception that is not `ActiveRecord::Rollback` or `ActiveRecord::RecordInvalid` will be re-raised by Rails after the callback chain is halted. Raising an exception other than `ActiveRecord::Rollback` or `ActiveRecord::RecordInvalid` may break code that does not expect methods like `save` and `update_attributes` (which normally try to return `true` or `false`) to raise an exception.
 


### PR DESCRIPTION
### Summary

Fixes #28669. As a reference I checked what the [code in Active Support](https://github.com/rails/rails/blob/60c5d393bb642e9228c07948fd8fb73be2ad1526/activesupport/lib/active_support/callbacks.rb#L597) does, which Active Record itself uses.

The default terminator halts the chain when a callback throws `:abort`. AR doesn't seem to use a custom terminator.

### Other Information

I saw some custom terminators used but only in [tests](https://github.com/rails/rails/blob/7ca4b2a76d69d86e1afa92cb0f201f0168815636/activerecord/test/models/parrot.rb#L13).
