### PR TITLE
Use appropriate type to `header` option

### DIFF
--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -140,7 +140,7 @@ module Rails
       class_option :mode, enum: %w( html list line column ), type: :string,
         desc: "Automatically put the sqlite3 database in the specified mode (html, list, line, column)."
 
-      class_option :header, type: :string
+      class_option :header, type: :boolean
 
       class_option :environment, aliases: "-e", type: :string,
         desc: "Specifies the environment to run this console under (test/development/production)."


### PR DESCRIPTION
The `header` option checks only whether it is specified or not.
https://github.com/rails/rails/blob/e8c33349bfabca28996ac74d344d69c7aaffec50/railties/lib/rails/commands/dbconsole/dbconsole_command.rb#L52

Also, if string is used, the behavior difference will occur if the following option is specified.  


``` 
# In Rails 5.0.2 
./bin/rails db --header test 
# => Connect to test environment DB 

# In Rails 5.1.0.rc1
./bin/rails db --header test 
# => Connect to development environment DB  
```
