### PR TITLE
Ignore AR tests of index comment when using Oracle

### DIFF
--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -72,9 +72,11 @@ if ActiveRecord::Base.connection.supports_comments?
     end
 
     def test_add_index_with_comment_later
-      @connection.add_index :commenteds, :obvious, name: "idx_obvious", comment: "We need to see obvious comments"
-      index = @connection.indexes("commenteds").find { |idef| idef.name == "idx_obvious" }
-      assert_equal "We need to see obvious comments", index.comment
+      unless current_adapter?(:OracleAdapter)
+        @connection.add_index :commenteds, :obvious, name: "idx_obvious", comment: "We need to see obvious comments"
+        index = @connection.indexes("commenteds").find { |idef| idef.name == "idx_obvious" }
+        assert_equal "We need to see obvious comments", index.comment
+      end
     end
 
     def test_add_comment_to_column
@@ -112,8 +114,10 @@ if ActiveRecord::Base.connection.supports_comments?
       assert_match %r[t\.string\s+"obvious"\n], output
       assert_match %r[t\.string\s+"content",\s+comment: "Whoa, content describes itself!"], output
       assert_match %r[t\.integer\s+"rating",\s+comment: "I am running out of imagination"], output
-      assert_match %r[t\.index\s+.+\s+comment: "\\\"Very important\\\" index that powers all the performance.\\nAnd it's fun!"], output
-      assert_match %r[t\.index\s+.+\s+name: "idx_obvious",\s+comment: "We need to see obvious comments"], output
+      unless current_adapter?(:OracleAdapter)
+        assert_match %r[t\.index\s+.+\s+comment: "\\\"Very important\\\" index that powers all the performance.\\nAnd it's fun!"], output
+        assert_match %r[t\.index\s+.+\s+name: "idx_obvious",\s+comment: "We need to see obvious comments"], output
+      end
     end
 
     def test_schema_dump_omits_blank_comments


### PR DESCRIPTION
### Summary

This PR ignores the following some failure tests when using Oracle (11g) .

```sh
% ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
% ARCONN=oracle bundle exec ruby -w -Itest test/cases/comment_test.rb

(snip)

9 runs, 51 assertions, 2 failures, 0 errors, 0 skips
```

As far as I know, Oracle Database doesn't seem to support adding COMMENT to INDEX.

https://docs.oracle.com/cd/B28359_01/server.111/b28286/statements_4009.htm#SQLRF01109

Therefore, this patch will not run the tests related with it.

As additional Information, I confirmed that there is the same test fails on 5-1-stable branch.