### PR TITLE
Add check for nil in parameter sanitization

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -87,6 +87,7 @@ module ActiveRecord
         def expand_hash_conditions_for_aggregates(attrs) # :doc:
           expanded_attrs = {}
           attrs.each do |attr, value|
+            next if attr.nil?
             if aggregation = reflect_on_aggregation(attr.to_sym)
               mapping = aggregation.mapping
               mapping.each do |field_attr, aggregate_attr|


### PR DESCRIPTION
I will start by appologizing for what will surely be a
not-super-well-done job of investigating a bug that I was having.

So, for some reason today, a process that had been working stopped
working. When I attempted to call `.save` or `.save!` on a model, I got
an error `No method 'to_sym` for NilClass`, even though I'm just trying
to do a very simple update of a very simple model (no Attributes API
stuff, or even any aggregate attributes to speak of).

All I know, is that somehow in the attributes being passed into
this method, a key of `nil` has snuck in there somehow, causing the
error when we try and call `to_sym` on that. My solution was to just
skip that key-value pair if the attribute is `nil`. I figured this
would be a good thing to do anyway.

So, long story short, I don't know how this is possible or why it's
happening, but I know this patch fixes my code in production, and it
seems like a reasonable defensive coding thing to do. Maybe it'll help
others as well!