### PR TITLE
use formatted number as schema version

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -47,8 +47,16 @@ module ActiveRecord
         @options = options
       end
 
+      # turns 20170404131909 into "2017_04_04131909"
+      def formatted_version
+        return "" unless @version
+        stringified = @version.to_s
+        return stringified unless stringified.length == 14
+        stringified.insert(4, "_").insert(7, "_").insert(10, "_")
+      end
+
       def header(stream)
-        define_params = @version ? "version: #{@version}" : ""
+        define_params = @version ? "version: #{formatted_version}" : ""
 
         stream.puts <<HEADER
 # This file is auto-generated from the current state of the database. Instead


### PR DESCRIPTION
In short, this PR turns this line in `schema.rb`:

```ruby
ActiveRecord::Schema.define(version: 20170404131909)
```

into this:

```ruby
ActiveRecord::Schema.define(version: 2017_04_04_131909)
```

From my point of view, being able to recognize version timestamp at a glance might be very helpful when resolving merge conflicts (which are frequent in `schema.rb`). 

This change is possible because Ruby perfectly understands integers with underscores as delimiters:

```ruby
2017_04_04_131909 == 20170404131909 # => true
```

This PR doesn't affect migration naming, only schema dumper.