### PR TITLE
Fix quoting in db:create grant all statement.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,1 +1,5 @@
+*   Quote database name in db:create grant statement (when database_user does not have access to create the database).
+
+    *Rune Philosof*
+
 Please check [5-1-stable](https://github.com/rails/rails/blob/5-1-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -104,7 +104,7 @@ module ActiveRecord
 
         def grant_statement
           <<-SQL
-GRANT ALL PRIVILEGES ON #{configuration['database']}.*
+GRANT ALL PRIVILEGES ON `#{configuration['database']}`.*
   TO '#{configuration['username']}'@'localhost'
 IDENTIFIED BY '#{configuration['password']}' WITH GRANT OPTION;
           SQL

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -167,7 +167,7 @@ if current_adapter?(:Mysql2Adapter)
         def assert_permissions_granted_for(db_user)
           db_name = @configuration["database"]
           db_password = @configuration["password"]
-          @connection.expects(:execute).with("GRANT ALL PRIVILEGES ON #{db_name}.* TO '#{db_user}'@'localhost' IDENTIFIED BY '#{db_password}' WITH GRANT OPTION;")
+          @connection.expects(:execute).with("GRANT ALL PRIVILEGES ON `#{db_name}`.* TO '#{db_user}'@'localhost' IDENTIFIED BY '#{db_password}' WITH GRANT OPTION;")
         end
     end
 


### PR DESCRIPTION
The database name used in the test would have actually shown this if it
had tried to execute on a real Mysql instead of being stubbed out
(dashes in database names needs quotes).

### Other Information

Which CHANGELOG should I update?
The activerecord/CHANGELOG.md in master is almost empty.