### PR TITLE
Calling fixture accessor method with no arguments returns all fixtures rather than empty array

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,1 +1,7 @@
+*   When calling the dynamic fixture accessor method with no arguments it now returns all fixtures of this type.
+    Previously this method always returned an empty array.
+
+    *Kevin McPhillips*
+
+
 Please check [5-1-stable](https://github.com/rails/rails/blob/5-1-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -70,11 +70,30 @@ module ActiveRecord
   # test. To ensure consistent data, the environment deletes the fixtures before running the load.
   #
   # In addition to being available in the database, the fixture's data may also be accessed by
-  # using a special dynamic method, which has the same name as the model, and accepts the
-  # name of the fixture to instantiate:
+  # using a special dynamic method, which has the same name as the model.
   #
-  #   test "find" do
+  # Passing in a fixture name to this dynamic method returns the fixture matching this name:
+  #
+  #   test "find one" do
   #     assert_equal "Ruby on Rails", web_sites(:rubyonrails).name
+  #   end
+  #
+  # Passing in multiple fixture names returns all fixtures matching these names:
+  #
+  #   test "find all by name" do
+  #     assert_equal 2, web_sites(:rubyonrails, :google).length
+  #   end
+  #
+  # Passing in no arguments returns all fixtures:
+  #
+  #   test "find all" do
+  #     assert_equal 2, web_sites.length
+  #   end
+  #
+  # Passing in any fixture name that does not exist will raise <tt>StandardError</tt>:
+  #
+  #   test "find by name that does not exist" do
+  #     assert_raise(StandardError) { web_sites(:reddit) }
   #   end
   #
   # Alternatively, you may enable auto-instantiation of the fixture data. For instance, take the
@@ -909,6 +928,8 @@ module ActiveRecord
 
             define_method(accessor_name) do |*fixture_names|
               force_reload = fixture_names.pop if fixture_names.last == true || fixture_names.last == :reload
+              return_single_record = fixture_names.size == 1
+              fixture_names = @loaded_fixtures[fs_name].fixtures.keys if fixture_names.empty?
 
               @fixture_cache[fs_name] ||= {}
 
@@ -923,7 +944,7 @@ module ActiveRecord
                 end
               end
 
-              instances.size == 1 ? instances.first : instances
+              return_single_record ? instances.first : instances
             end
             private accessor_name
           end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -95,6 +95,24 @@ class FixturesTest < ActiveRecord::TestCase
     assert_nil(topics["second"]["author_email_address"])
   end
 
+  def test_no_args_returns_all
+    all_topics = topics
+    assert_equal 5, all_topics.length
+    assert_equal "The First Topic", all_topics.first["title"]
+    assert_equal 5, all_topics.last.id
+  end
+
+  def test_no_args_record_returns_all_without_array
+    all_binaries = binaries
+    assert_kind_of(Array, all_binaries)
+    assert_equal 1, binaries.length
+  end
+
+  def test_nil_raises
+    assert_raise(StandardError) { topics(nil) }
+    assert_raise(StandardError) { topics([nil]) }
+  end
+
   def test_inserts
     create_fixtures("topics")
     first_row = ActiveRecord::Base.connection.select_one("SELECT * FROM topics WHERE author_name = 'David'")


### PR DESCRIPTION
## Problem

Fixtures provide a convenience method to access fixtures by name. So given:

```yaml
# fixtures/things.yml
one:
  name: The first
two:
  name: The second
```
You can access the `Thing`s using `things()`:
```ruby
things(:two)
# #<Thing:0x007f821b6346c0 name: "The second">
things(:one, :two)
# [#<Thing:0x007f821b6346c8 name: "The first">, #<Thing:0x007f821b6346c0 name: "The second">]
```
The inconsistent behaviour is that passing no arguments to this method _always_ returns an empty array:

```ruby
things
# []
```

The reason this happens is that it initializes an empty array of results, then iterates over all names passed in and pushes them into that array. Any names that do not match raise `StandardError`, but we don't check for empty arguments.

## Solution

We now return _all_ records for this fixture if none are passed in:
```ruby
things
# [#<Thing:0x007f821b6346c8 name: "The first">, #<Thing:0x007f821b6346c0 name: "The second">]
```

There is a special case for if there is only a single fixture that exists, and was call with no arguments, we still return the array with one element. Where as if we ask for a single fixture by name we return it without wrapping it in an array.

## Alternative solution

A simpler solution would be:

```ruby
raise StandardError, "Must pass in a name" if fixture_names.blank?
```

But the "return all" solution exposes a nice iteration functionality that could be useful.

@rafaelfranca 