### PR TITLE
Fix an AR test of schema dump when using Oracle

### DIFF
--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -113,7 +113,11 @@ if ActiveRecord::Base.connection.supports_comments?
       assert_match %r[t\.string\s+"name",\s+comment: "Comment should help clarify the column purpose"], output
       assert_match %r[t\.string\s+"obvious"\n], output
       assert_match %r[t\.string\s+"content",\s+comment: "Whoa, content describes itself!"], output
-      assert_match %r[t\.integer\s+"rating",\s+comment: "I am running out of imagination"], output
+      if current_adapter?(:OracleAdapter)
+        assert_match %r[t\.integer\s+"rating",\s+precision: 38,\s+comment: "I am running out of imagination"], output
+      else
+        assert_match %r[t\.integer\s+"rating",\s+comment: "I am running out of imagination"], output
+      end
       unless current_adapter?(:OracleAdapter)
         assert_match %r[t\.index\s+.+\s+comment: "\\\"Very important\\\" index that powers all the performance.\\nAnd it's fun!"], output
         assert_match %r[t\.index\s+.+\s+name: "idx_obvious",\s+comment: "We need to see obvious comments"], output


### PR DESCRIPTION
### Summary

This PR fixes the following failure test when using Oracle (11g) .

```sh
% ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
% ARCONN=oracle bundle exec ruby -w -Itest test/cases/comment_test.rb -n test_schema_dump_with_comments
/home/vagrant/src/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using oracle
Run options: -n test_schema_dump_with_comments --seed 2699

# Running:

F

Finished in 7.428140s, 0.1346 runs/s, 1.3462 assertions/s.

  1) Failure:
CommentTest#test_schema_dump_with_comments [test/cases/comment_test.rb:116]:
Expected /t\.integer\s+"rating",\s+comment: "I am running out of imagination"/ to match "# This file is auto-generated from the current state of the database. Instead\n# of editing this file, please use the migrations feature of Active Record to\n# incrementally modify your database, and then regenerate this schema definition.\n#\n# Note that this schema.rb definition is the authoritative source for your\n# database schema. If you need to create the application database on another\n# system, you should be using db:schema:load, not running all the migrations\n# from scratch. The latter is a flawed and unsustainable approach (the more migrations\n# you'll amass, the slower it'll run and the greater likelihood for issues).\n#\n# It's strongly recommended that you check this file into your version control system.\n\nActiveRecord::Schema.define(version: 0) do\n\n  create_table \"commenteds\", force: :cascade, comment: \"A table with comment\" do |t|\n    t.string \"name\", comment: \"Comment should help clarify the column purpose\"\n    t.string \"obvious\"\n    t.string \"content\", comment: \"Whoa, content describes itself!\"\n    t.integer \"rating\", precision: 38, comment: \"I am running out of imagination\"\n    t.index [\"name\"], name: \"index_commenteds_on_name\"\n    t.index [\"obvious\"], name: \"idx_obvious\"\n  end\n\nend\n".

1 runs, 10 assertions, 1 failures, 0 errors, 0 skips
```

Schema dump of Oracle Adapter shows `precision: 38` explicitly for integer type as below.

```ruby
t.integer \"rating\", precision: 38, comment: \"I am running out of imagination\"
```

This PR fixes a test to accept `precision: 38` for integer type of schema dump in Oracle Adapter.
These discussions are following URL.

rsim/oracle-enhanced#1289

### Other Information

I confirmed that there is the same test fails on 5-1-stable branch.
