### PR TITLE
Remove duplicated `delivery_method` definition

### DIFF
--- a/actionmailer/test/parameterized_test.rb
+++ b/actionmailer/test/parameterized_test.rb
@@ -14,7 +14,6 @@ class ParameterizedTest < ActiveSupport::TestCase
 
     @previous_deliver_later_queue_name = ActionMailer::Base.deliver_later_queue_name
     ActionMailer::Base.deliver_later_queue_name = :test_queue
-    ActionMailer::Base.delivery_method = :test
 
     @mail = ParamsMailer.with(inviter: "david@basecamp.com", invitee: "jason@basecamp.com").invitation
   end


### PR DESCRIPTION
`ActionMailer::Base.delivery_method` is already defined in
https://github.com/rails/rails/blob/master/actionmailer/test/parameterized_test.rb#L13

