### PR TITLE
exclude ORDER BY clause for exists?

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -383,7 +383,7 @@ module ActiveRecord
       end
 
       def construct_relation_for_exists(relation, conditions)
-        relation = relation.except(:select, :distinct)._select!(ONE_AS_ONE).limit!(1)
+        relation = relation.except(:select, :distinct, :order)._select!(ONE_AS_ONE).limit!(1)
 
         case conditions
         when Array, Hash

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -202,15 +202,15 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal true, Topic.first.replies.exists?
   end
 
-  # Ensure +exists?+ runs without an error by excluding distinct value.
+  # ensures +exists?+ runs without an error by excluding distinct value
   # See https://github.com/rails/rails/pull/26981.
-  def test_exists_with_order_and_distinct
-    assert_equal true, Topic.order(:id).distinct.exists?
+  def test_exists_with_distinct
+    assert_equal true, Topic.distinct.exists?
   end
 
-  # ensures +exists?+ runs valid SQL by excluding order value
+  # ensures +exists?+ runs without an error by excluding order value
   def test_exists_with_order
-    assert_equal true, Topic.order("invalid sql here").distinct.exists?
+    assert_equal true, Topic.order("invalid sql here").exists?
   end
 
   def test_exists_with_joins

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -204,8 +204,8 @@ class FinderTest < ActiveRecord::TestCase
 
   # ensures +exists?+ runs without an error by excluding distinct value
   # See https://github.com/rails/rails/pull/26981.
-  def test_exists_with_distinct
-    assert_equal true, Topic.distinct.exists?
+  def test_exists_with_order_and_distinct
+    assert_equal true, Topic.order(:id).distinct.exists?
   end
 
   # ensures +exists?+ runs without an error by excluding order value

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -202,13 +202,13 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal true, Topic.first.replies.exists?
   end
 
-  # ensures +exists?+ runs without an error by excluding distinct value
+  # Ensure +exists?+ runs without an error by excluding distinct value.
   # See https://github.com/rails/rails/pull/26981.
   def test_exists_with_order_and_distinct
     assert_equal true, Topic.order(:id).distinct.exists?
   end
 
-  # ensures +exists?+ runs without an error by excluding order value
+  # Ensure +exists?+ runs without an error by excluding order value.
   def test_exists_with_order
     assert_equal true, Topic.order("invalid sql here").exists?
   end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -208,6 +208,11 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal true, Topic.order(:id).distinct.exists?
   end
 
+  # ensures +exists?+ runs valid SQL by excluding order value
+  def test_exists_with_order
+    assert_equal true, Topic.order("invalid sql here").distinct.exists?
+  end
+
   def test_exists_with_joins
     assert_equal true, Topic.joins(:replies).where(replies_topics: { approved: true }).order("replies_topics.created_at DESC").exists?
   end


### PR DESCRIPTION
### Summary

Noticed the following regression when testing our app on 5.1.0rc1,

#### 5.0.2
```
[1] pry(main)> Model.order(status: :desc).any?
  SELECT COUNT(*) FROM `models`
=> false
```

#### 5.1.0rc1
```
[1] pry(main)> Model.order(status: :desc).any?
 SELECT  1 AS one FROM `models` ORDER BY `models`.`status` DESC LIMIT 1
=> false
```

The test originally added by https://github.com/rails/rails/pull/3572 wasn't specific enough to catch regressions, it appears, so this PR addresses that going forward, as well as fixes the underlying issue.