### PR TITLE
Prevent after_commit callback with on: :create option runs when record not actually committed

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -448,7 +448,7 @@ module ActiveRecord
         actions.any? do |action|
           case action
           when :create
-            transaction_record_state(:new_record)
+            transaction_record_state(:new_record) && !destroyed?
           when :destroy
             defined?(@_trigger_destroy_callback) && @_trigger_destroy_callback
           when :update

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -137,6 +137,21 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
     assert_equal false, callback_ran
   end
 
+  def test_still_call_after_commit_on_destroy_when_record_is_create_and_destroyed_in_transaction_block
+    callback_ran = false
+    record = TopicWithCallbacks.new
+    record.after_commit_block(:destroy) { callback_ran = true }
+
+    TopicWithCallbacks.transaction do
+      record.title = "New topic"
+      record.written_on = Date.today
+      record.save
+      record.destroy
+    end
+
+    assert_equal true, callback_ran
+  end
+
   def test_only_call_after_commit_on_create_after_transaction_commits_for_new_record
     new_record = TopicWithCallbacks.new(title: "New topic", written_on: Date.today)
     add_transaction_execution_blocks new_record

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -122,6 +122,21 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
     assert_equal [:commit_on_destroy], @first.history
   end
 
+  def test_only_call_after_commit_on_create_when_record_is_actually_created
+    callback_ran = false
+    record = TopicWithCallbacks.new
+    record.after_commit_block(:create) { callback_ran = true }
+
+    TopicWithCallbacks.transaction do
+      record.title = "New topic"
+      record.written_on = Date.today
+      record.save
+      record.destroy
+    end
+
+    assert_equal false, callback_ran
+  end
+
   def test_only_call_after_commit_on_create_after_transaction_commits_for_new_record
     new_record = TopicWithCallbacks.new(title: "New topic", written_on: Date.today)
     add_transaction_execution_blocks new_record


### PR DESCRIPTION
### Summary

This is related to #28667 .
`after_commit` callback with `on: :create` option should not run in transactions that record is not technically committed (which means the record has both `new_record` and `destroyed` states).

For example:

```ruby
Post.transaction do
  post = Post.create(title: 'Foo')
  post.destroy
end
```