### PR TITLE
Support password in ActionCable redis configuration

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -10,7 +10,7 @@ module ActionCable
 
       # Overwrite this factory method for redis connections if you want to use a different Redis library than Redis.
       # This is needed, for example, when using Makara proxies for distributed Redis.
-      cattr_accessor(:redis_connector) { ->(config) { ::Redis.new(url: config[:url]) } }
+      cattr_accessor(:redis_connector) { ->(config) { ::Redis.new(url: config[:url], password: config[:password]) } }
 
       def initialize(*)
         super


### PR DESCRIPTION
### Summary

Redis supports being configured to require a password. Redis-rb supports this parameter. All that remains is passing it through.

### Other Information

This is one of my first patches, so please let me know how I can improve it. It looks like there are no Redis specific tests, so I'm not sure how you would like me to proceed on that front.

Thanks!