### PR TITLE
Add class option timestamps to migration generator

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow generated create_table migrations to include or skip timestamps
+
+    *Michael Duchemin*
+
 *   Fix `relation.create` to avoid leaking scope to initialization block and callbacks.
 
     Fixes #9894, #17577.

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -7,6 +7,7 @@ module ActiveRecord
     class MigrationGenerator < Base # :nodoc:
       argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
 
+      class_option :timestamps, type: :boolean
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
       class_option :database, type: :string, aliases: %i(db), desc: "The database for your migration. By default, the current environment's primary database is used."
 

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -225,6 +225,8 @@ class CreateProducts < ActiveRecord::Migration[5.0]
     create_table :products do |t|
       t.string :name
       t.string :part_number
+
+      t.timestamps
     end
   end
 end

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -245,6 +245,21 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_create_table_migration_with_timestamps
+    run_generator ["create_books", "title:string", "content:text"]
+    assert_migration "db/migrate/create_books.rb", /t.timestamps/
+  end
+
+  def test_create_table_timestamps_are_skipped
+    run_generator ["create_books", "title:string", "content:text", "--no-timestamps"]
+
+    assert_migration "db/migrate/create_books.rb" do |m|
+      assert_method :change, m do |change|
+        assert_no_match(/t.timestamps/, change)
+      end
+    end
+  end
+
   def test_add_uuid_to_create_table_migration
     run_generator ["create_books", "--primary_key_type=uuid"]
     assert_migration "db/migrate/create_books.rb" do |content|


### PR DESCRIPTION
Fixes GH#28706. Now rails g migration create_foo and rails g model Foo have the same behavior for timestamps since they implement the same migration template. The expected behavior is that this create table migration will create the table with timestamps unless you pass --no-timestamps or --skip-timestamps to the generator. The expected migration should match what you get when you use the model generator. Using the migration generator, which doesn't have a class_option for timestamps would cause them to not be added to the migration file. Now the migration behavior of the migration generator, create_table only, is aligned with the migration behavior of the model generator.

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
