### PR TITLE
if you set default_url_options[:trailing_slash], url_string becomes s…

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -553,8 +553,7 @@ module ActionView
         request_uri = URI.parser.unescape(request_uri).force_encoding(Encoding::BINARY)
 
         # if you set default_url_options[:trailing_slash], url_string becomes same as request_uri
-        if Rails.application.config.action_controller.default_url_options.is_a?(Hash) &&
-          Rails.application.config.action_controller.default_url_options.key?(:trailing_slash)
+        if url_options[:trailing_slash]
           request_uri.chomp!("/") if request_uri.start_with?("/") && request_uri != "/"
         end
 

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -553,7 +553,10 @@ module ActionView
         request_uri = URI.parser.unescape(request_uri).force_encoding(Encoding::BINARY)
 
         # if you set default_url_options[:trailing_slash], url_string becomes same as request_uri
-        request_uri.chomp!("/") if request_uri.start_with?("/") && request_uri != "/" && Rails.application.config.action_controller.default_url_options[:trailing_slash]
+        if Rails.application.config.action_controller.default_url_options.is_a?(Hash) &&
+          Rails.application.config.action_controller.default_url_options.key?(:trailing_slash)
+          request_uri.chomp!("/") if request_uri.start_with?("/") && request_uri != "/"
+        end
 
         url_string.chomp!("/") if url_string.start_with?("/") && url_string != "/"
 

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -552,6 +552,9 @@ module ActionView
         request_uri = url_string.index("?") || check_parameters ? request.fullpath : request.path
         request_uri = URI.parser.unescape(request_uri).force_encoding(Encoding::BINARY)
 
+        # if you set default_url_options[:trailing_slash], url_string becomes same as request_uri
+        request_uri.chomp!("/") if request_uri.start_with?("/") && request_uri != "/" && Rails.application.config.action_controller.default_url_options[:trailing_slash]
+
         url_string.chomp!("/") if url_string.start_with?("/") && url_string != "/"
 
         if %r{^\w+://}.match?(url_string)

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -553,9 +553,7 @@ module ActionView
         request_uri = URI.parser.unescape(request_uri).force_encoding(Encoding::BINARY)
 
         # if you set default_url_options[:trailing_slash], url_string becomes same as request_uri
-        if url_options[:trailing_slash]
-          request_uri.chomp!("/") if request_uri.start_with?("/") && request_uri != "/"
-        end
+        request_uri.chomp!("/") if request_uri.start_with?("/") && request_uri != "/" && url_options[:trailing_slash]
 
         url_string.chomp!("/") if url_string.start_with?("/") && url_string != "/"
 


### PR DESCRIPTION
I set Rails.application.config.action_controller.default_url_options[:trailing_slash], but `current_page?` method works wrong.
So, I fixed `actionview/lib/action_view/helpers/url_helper.rb`.

Please check it.

Thank you.