### PR TITLE
Convert association queries to PORO queries

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -10,6 +10,7 @@ module ActiveRecord
         nils, values = values.partition(&:nil?)
 
         return attribute.in([]) if values.empty? && nils.empty?
+        return queries_predicates(values) if nils.empty? && values.all? { |v| v.is_a?(Hash) }
 
         ranges, values = values.partition { |v| v.is_a?(Range) }
 
@@ -26,7 +27,7 @@ module ActiveRecord
 
         array_predicates = ranges.map { |range| predicate_builder.build(attribute, range) }
         array_predicates.unshift(values_predicate)
-        array_predicates.inject { |composite, predicate| composite.or(predicate) }
+        array_predicates.inject(&:or)
       end
 
       # TODO Change this to private once we've dropped Ruby 2.2 support.
@@ -38,6 +39,17 @@ module ActiveRecord
         module NullPredicate # :nodoc:
           def self.or(other)
             other
+          end
+        end
+
+      private
+        def queries_predicates(queries)
+          if queries.size > 1
+            queries.map do |query|
+              Arel::Nodes::And.new(predicate_builder.build_from_hash(query))
+            end.inject(&:or)
+          else
+            predicate_builder.build_from_hash(queries.first)
           end
         end
     end

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
@@ -9,7 +9,7 @@ module ActiveRecord
       end
 
       def queries
-        { associated_table.association_foreign_key.to_s => ids }
+        [associated_table.association_foreign_key.to_s => ids]
       end
 
       private

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb
@@ -1,35 +1,5 @@
 module ActiveRecord
   class PredicateBuilder
-    class AssociationQueryHandler # :nodoc:
-      def self.value_for(table, column, value)
-        associated_table = table.associated_table(column)
-        if associated_table.polymorphic_association?
-          case value.is_a?(Array) ? value.first : value
-          when Base, Relation
-            value = [value] unless value.is_a?(Array)
-            klass = PolymorphicArrayValue
-          end
-        end
-
-        klass ||= AssociationQueryValue
-        klass.new(associated_table, value)
-      end
-
-      def initialize(predicate_builder)
-        @predicate_builder = predicate_builder
-      end
-
-      def call(attribute, value)
-        predicate_builder.build_from_hash(value.queries)
-      end
-
-      # TODO Change this to private once we've dropped Ruby 2.2 support.
-      # Workaround for Ruby 2.2 "private attribute?" warning.
-      protected
-
-        attr_reader :predicate_builder
-    end
-
     class AssociationQueryValue # :nodoc:
       attr_reader :associated_table, :value
 

--- a/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_handler.rb
@@ -1,28 +1,5 @@
 module ActiveRecord
   class PredicateBuilder
-    class PolymorphicArrayHandler # :nodoc:
-      def initialize(predicate_builder)
-        @predicate_builder = predicate_builder
-      end
-
-      def call(attribute, value)
-        predicates = value.queries.map { |query| predicate_builder.build_from_hash(query) }
-
-        if predicates.size > 1
-          type_and_ids_predicates = predicates.map { |type_predicate, id_predicate| Arel::Nodes::Grouping.new(type_predicate.and(id_predicate)) }
-          type_and_ids_predicates.inject(&:or)
-        else
-          predicates.first
-        end
-      end
-
-      # TODO Change this to private once we've dropped Ruby 2.2 support.
-      # Workaround for Ruby 2.2 "private attribute?" warning.
-      protected
-
-        attr_reader :predicate_builder
-    end
-
     class PolymorphicArrayValue # :nodoc:
       attr_reader :associated_table, :values
 
@@ -35,7 +12,7 @@ module ActiveRecord
         type_to_ids_mapping.map do |type, ids|
           {
             associated_table.association_foreign_type.to_s => type,
-            associated_table.association_foreign_key.to_s => ids
+            associated_table.association_foreign_key.to_s => ids.size > 1 ? ids : ids.first
           }
         end
       end


### PR DESCRIPTION
This is a second part of #28713.

This change makes preparable association queries by handling queries as PORO.