### PR TITLE
Fix an AR test of relations_test when using Oracle

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1902,7 +1902,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   test "relations don't load all records in #inspect" do
-    assert_sql(/LIMIT/) do
+    assert_sql(/LIMIT|ROWNUM <=|FETCH FIRST/) do
       Post.all.inspect
     end
   end


### PR DESCRIPTION
### Summary

This PR fixes the following failure test when using Oracle (11g) .

```sh
%  ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
% ARCONN=oracle bundle exec ruby -w -Itest test/cases/relations_test.rb -n "test_relations_don't_load_all_records_in_#inspect"
/home/vagrant/src/rails/activesupport/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
Using oracle
Run options: -n test_relations_don't_load_all_records_in_#inspect --seed 24645

# Running:

F

Finished in 0.994688s, 1.0053 runs/s, 1.0053 assertions/s.

  1) Failure:
RelationTest#test_relations_don't_load_all_records_in_#inspect [test/cases/relations_test.rb:1907]:
Query pattern(s) /LIMIT/ not found.
Queries:
SELECT  "POSTS".* FROM "POSTS" WHERE ROWNUM <= :a1

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

Oracle does not support `LIMIT` clause. Oracle Adapter uses `ROWNUM` instead of that.

### Other Information

I confirmed that there is the same test fails on 5-1-stable branch.
