### PR TITLE
rails-ujs: missing default url for ajax requests.

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
@@ -29,6 +29,7 @@ Rails.ajax = (options) ->
     fire(document, 'ajaxStop') # to be compatible with jQuery.ajax
 
 prepareOptions = (options) ->
+  options.url = options.url or location.href
   options.type = options.type.toUpperCase()
   # append data to url if it's a GET request
   if options.type is 'GET' and options.data

--- a/actionview/test/ujs/public/test/data-remote.js
+++ b/actionview/test/ujs/public/test/data-remote.js
@@ -1,3 +1,17 @@
+(function() {
+
+function buildSelect(attrs) {
+  attrs = $.extend({
+    'name': 'user_data', 'data-remote': 'true', 'data-url': '/echo', 'data-params': 'data1=value1'
+  }, attrs)
+
+  $('#qunit-fixture').append(
+    $('<select />', attrs)
+      .append($('<option />', {value: 'optionValue1', text: 'option1'}))
+      .append($('<option />', {value: 'optionValue2', text: 'option2'}))
+  )
+}
+
 module('data-remote', {
   setup: function() {
     $('#qunit-fixture')
@@ -135,17 +149,7 @@ asyncTest('clicking on a button with data-remote attribute', 5, function() {
 })
 
 asyncTest('changing a select option with data-remote attribute', 5, function() {
-  $('form')
-    .append(
-      $('<select />', {
-        'name': 'user_data',
-        'data-remote': 'true',
-        'data-params': 'data1=value1',
-        'data-url': '/echo'
-      })
-      .append($('<option />', {value: 'optionValue1', text: 'option1'}))
-      .append($('<option />', {value: 'optionValue2', text: 'option2'}))
-    )
+  buildSelect()
 
   $('select[data-remote]')
     .bindNative('ajax:success', function(e, data, status, xhr) {
@@ -350,17 +354,7 @@ asyncTest('submitting a form with falsy "data-remote" attribute', 0, function() 
 })
 
 asyncTest('changing a select option with falsy "data-remote" attribute', 0, function() {
-  $('form')
-    .append(
-      $('<select />', {
-        'name': 'user_data',
-        'data-remote': 'false',
-        'data-params': 'data1=value1',
-        'data-url': '/echo'
-      })
-      .append($('<option />', {value: 'optionValue1', text: 'option1'}))
-      .append($('<option />', {value: 'optionValue2', text: 'option2'}))
-    )
+  buildSelect({'data-remote': 'false'})
 
   $('select[data-remote=false]:first')
     .bindNative('ajax:beforeSend', function() {
@@ -413,3 +407,32 @@ asyncTest('form buttons should only be serialized when clicked', 4, function() {
     })
     .find('[name=submit2]').triggerNative('click')
 })
+
+asyncTest('changing a select option without "data-url" attribute still fires ajax request to current location', 1, function() {
+  var currentLocation, ajaxLocation
+
+  buildSelect({'data-url': ''});
+
+  $('select[data-remote]')
+    .bindNative('ajax:beforeSend', function(e, xhr, settings) {
+      // Get current location (the same way jQuery does)
+      try {
+        currentLocation = location.href
+      } catch(err) {
+        currentLocation = document.createElement( 'a' )
+        currentLocation.href = ''
+        currentLocation = currentLocation.href
+      }
+
+      ajaxLocation = settings.url.replace(settings.data, '').replace(/&$/, '').replace(/\?$/, '')
+      equal(ajaxLocation, currentLocation, 'URL should be current page by default')
+
+      return false
+    })
+    .val('optionValue2')
+    .triggerNative('change')
+
+  setTimeout(function() { start() }, 20)
+})
+
+})()


### PR DESCRIPTION
### Steps to reproduce
Hi!
I'm using rails 5.1.0.rc1 and faced with next unexpected behaviour.

According to documentation I can set `remote: true` on `select` element like next:
```
<%= select_tag( "user_id", some_collection, ..., data: { remote: true, url: users_path } %>
```
And in this case everything will work.

But actually I can remove `url` 

### Expected behavior
When we use `jquery_ujs` and use `$.ajax` function:
This `ajax` function provides [default value]() for `url` if it is not specified.

```
url (default: The current page)
Type: String
A string containing the URL to which the request is sent.
```

### Actual behavior
Currently if I remove `url` option from `select_tag` I will receive an error:

```javascript
rails-ujs.js:189 Uncaught TypeError: Cannot read property 'indexOf' of null
    at prepareOptions (rails-ujs.js:189)
    at Rails.ajax (rails-ujs.js:161)
    at HTMLSelectElement.Rails.handleRemote (rails-ujs.js:536)
    at HTMLDocument.<anonymous> (rails-ujs.js:137)
    at jQuery.fn.init.triggerNative (settings.js:96)
    at Object.<anonymous> (data-remote.js:435)
    at Test.run (qunit.js:1303)
    at qunit.js:1463
    at process (qunit.js:1016)
    at qunit.js:186
```

### System configuration
**Rails version**:
5.1.0.rc1
**Ruby version**:
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin15]


### Other Information
Maybe you had reasons not to do this.

Thanks.