### PR TITLE
Add comprehensive locking around DB transactions

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -74,7 +74,7 @@ module ActiveRecord
       SIMPLE_INT = /\A\d+\z/
 
       attr_accessor :visitor, :pool
-      attr_reader :schema_cache, :owner, :logger, :prepared_statements
+      attr_reader :schema_cache, :owner, :logger, :prepared_statements, :lock
       alias :in_use? :owner
 
       def self.type_cast_config_to_integer(config)


### PR DESCRIPTION
Transactional-fixture using tests with racing threads and inter-thread synchronisation inside transaction blocks will now deadlock... but without this, they would just crash.

In 5.0, the threads didn't share a connection at all, so it would've worked... but with the main thread inside the fixture transaction, they wouldn't've been able to see each other.

So: as far as I can tell, the set of operations this "breaks" never had a compelling use case. Meanwhile, it provides an increased level of coherency to the operational feel of transactional fixtures.

If this does cause anyone problems, they're probably best off disabling transactional fixtures on the affected tests, and managing transactions themselves.

Fixes #28197 