### PR TITLE
WIP: Clone attributes passed to #new

### DIFF
--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -43,9 +43,16 @@ module ActiveModel
 
       def _assign_attribute(k, v)
         if respond_to?("#{k}=")
-          public_send("#{k}=", v)
+          public_send("#{k}=", clone_value(v))
         else
           raise UnknownAttributeError.new(self, k)
+        end
+      end
+
+      def clone_value(value)
+        case value
+        when String then value.clone
+        else value
         end
       end
   end


### PR DESCRIPTION
### Summary

**_Note: I am opening this to get feedback on it for being a potential solution to issue #28718_**.

Say we have a model Car and a car object, **car_1**.
When Car is passed **car_1's** attributes in **_#new_**( `car_2 = Car.new(car_1.attributes)` ), **car_2** will save **car_1's** attributes as its `@value_before_type_cast` values for FromUser.

A method like  `car_2.inspect` can affect `@value_before_type_cast` values for **car_2** which can in turn affect **car_1's** attributes. See issue #28718 and [its reproducable script]( https://gist.github.com/rafaelfranca/dd0a2d32397fd9c3a596a349e6601309) for an example.

This commit starts an attempt to clone values(allocate a separate object) for a new object. My reasoning behind this is that each object should have its own allocated values even if the contents of the value are the same for the two objects. While *car_1* and *car_2* may share the same name, they should not share the same String object for name.

This is a crude attempt at solving the issue by showing that the attributes passed in could be cloned before they are saved to the new object. It's minimal to allow for feedback before moving forward.