### PR TITLE
Update routing doc on the `get` `to:` option [ci skip]

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -142,10 +142,10 @@ Sometimes, you have a resource that clients always look up without referencing a
 get 'profile', to: 'users#show'
 ```
 
-Passing a `String` to `get` will expect a `controller#action` format, while passing a `Symbol` will map directly to an action but you must also specify the `controller:` to use:
+Passing a `String` to `to:` will expect a `controller#action` format. When using a `Symbol`, the `to:` option should be replaced with `action:`. When using a `String` without a `#`, the `to:` option should be replaced with `controller:`:
 
 ```ruby
-get 'profile', to: :show, controller: 'users'
+get 'profile', action: :show, controller: 'users'
 ```
 
 This resourceful route:


### PR DESCRIPTION
### Summary

While following the Rails guides on the routing chapter and having `get 'profile', to: :show, controller: 'users'` in place in a Rails 5.1.0.rc1 application raised an `AbstractController::ActionNotFound` exception with the `The action 'profile' could not be found for UsersController` message. As it turns out, this usage of the `to:` option [was deprecated 3 years ago](https://github.com/rails/rails/commit/cc26b6b7bccf0eea2e2c1a9ebdcc9d30ca7390d9). So, this PR updates the section in question.