### PR TITLE
Don't freeze input strings

### DIFF
--- a/activemodel/lib/active_model/type/string.rb
+++ b/activemodel/lib/active_model/type/string.rb
@@ -12,7 +12,12 @@ module ActiveModel
       private
 
         def cast_value(value)
-          ::String.new(super)
+          case value
+          when ::String then ::String.new(value)
+          when true then "t".freeze
+          when false then "f".freeze
+          else value.to_s
+          end
         end
     end
   end

--- a/activemodel/test/cases/type/string_test.rb
+++ b/activemodel/test/cases/type/string_test.rb
@@ -12,16 +12,25 @@ module ActiveModel
       end
 
       test "cast strings are mutable" do
-        s = "foo"
         type = Type::String.new
+
+        s = "foo"
         assert_equal false, type.cast(s).frozen?
+        assert_equal false, s.frozen?
+
+        f = "foo".freeze
+        assert_equal false, type.cast(f).frozen?
+        assert_equal true, f.frozen?
       end
 
       test "values are duped coming out" do
-        s = "foo"
         type = Type::String.new
+
+        s = "foo"
         assert_not_same s, type.cast(s)
+        assert_equal s, type.cast(s)
         assert_not_same s, type.deserialize(s)
+        assert_equal s, type.deserialize(s)
       end
     end
   end


### PR DESCRIPTION
See 34321e4a433bb7eef48fd743286601403f8f7d82 for background on ImmutableString vs String.

Our String type cannot delegate typecasting to ImmutableString, because the latter freezes its input: duplicating the value after that gives us an unfrozen result, but still mutates the originally passed object.

Fixes #24185
Fixes #28718