### PR TITLE
Don't fallback to utf8mb3 after MySQL 8.0.0

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -64,14 +64,6 @@ module ActiveRecord
         end
       end
 
-      CHARSETS_OF_4BYTES_MAXLEN = ["utf8mb4", "utf16", "utf16le", "utf32"]
-
-      def internal_string_options_for_primary_key # :nodoc:
-        super.tap { |options|
-          options[:collation] = collation.sub(/\A[^_]+/, "utf8") if CHARSETS_OF_4BYTES_MAXLEN.include?(charset)
-        }
-      end
-
       def version #:nodoc:
         @version ||= Version.new(full_version.match(/^\d+\.\d+\.\d+/)[0])
       end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -45,7 +45,17 @@ module ActiveRecord
           indexes
         end
 
+        def internal_string_options_for_primary_key
+          super.tap do |options|
+            if CHARSETS_OF_4BYTES_MAXLEN.include?(charset) && (mariadb? || version < "8.0.0")
+              options[:collation] = collation.sub(/\A[^_]+/, "utf8")
+            end
+          end
+        end
+
         private
+          CHARSETS_OF_4BYTES_MAXLEN = ["utf8mb4", "utf16", "utf16le", "utf32"]
+
           def schema_creation
             MySQL::SchemaCreation.new(self)
           end

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -18,7 +18,7 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
 
       ActiveRecord::SchemaMigration.create_table
 
-      assert connection.column_exists?(table_name, :version, :string, collation: "utf8_general_ci")
+      assert connection.column_exists?(table_name, :version, :string)
     end
   end
 
@@ -29,7 +29,7 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
 
       ActiveRecord::InternalMetadata.create_table
 
-      assert connection.column_exists?(table_name, :key, :string, collation: "utf8_general_ci")
+      assert connection.column_exists?(table_name, :key, :string)
     end
   end
 


### PR DESCRIPTION
`internal_string_options_for_primary_key` is used for creating internal
tables in newly apps. But it is no longer needed after MySQL 8.0.0.

MySQL 5.7 has introduced `innodb_default_row_format` (default `DYNAMIC`)
and has deprecated `innodb_large_prefix` and `innodb_file_format`.

The purpose of the deprecated options was for compatibility with earlier
versions of InnoDB.

https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_large_prefix

> innodb_large_prefix is deprecated and will be removed in a future
release. innodb_large_prefix was introduced in MySQL 5.5 to disable
large index key prefixes for compatibility with earlier versions of
InnoDB that do not support large index key prefixes.

https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_file_format

> The innodb_file_format option is deprecated and will be removed in a
future release. The purpose of the innodb_file_format option was to
allow users to downgrade to the built-in version of InnoDB in MySQL 5.1.
Now that MySQL 5.1 has reached the end of its product lifecycle,
downgrade support provided by this option is no longer necessary.

The deprecated options has removed in MySQL 8.0.0. It is no longer
needed to take care newly created internal tables as a legacy format
after MySQL 8.0.0.

Fixes #28730.

cc @yahonda