### PR TITLE
Use a query that's compatible with PostgreSQL 9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,9 +93,14 @@ matrix:
         - "GEM=ar:mysql2 MYSQL=mariadb"
       addons:
         mariadb: 10.0
-    - rvm: 2.4.1
+    - rvm: 2.3.4
       env:
         - "GEM=ar:sqlite3_mem"
+    - rvm: 2.3.4
+      env:
+        - "GEM=ar:postgresql POSTGRES=9.2"
+      addons:
+        postgresql: "9.2"
     - rvm: jruby-9.1.8.0
       jdk: oraclejdk8
       env:
@@ -104,12 +109,6 @@ matrix:
       jdk: oraclejdk8
       env:
         - "GEM=am,amo,aj"
-    # Test with old (< 9.4.2) postgresql
-    - rvm: 2.4.1
-      env:
-        - "GEM=ar:postgresql"
-      addons:
-        postgresql: "9.4"
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-9.1.8.0

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -13,6 +13,10 @@ module PostgresqlUUIDHelper
   def uuid_function
     connection.supports_pgcrypto_uuid? ? "gen_random_uuid()" : "uuid_generate_v4()"
   end
+
+  def uuid_default
+    connection.supports_pgcrypto_uuid? ? {} : { default: uuid_function }
+  end
 end
 
 class PostgresqlUUIDTest < ActiveRecord::PostgreSQLTestCase
@@ -178,7 +182,7 @@ class PostgresqlUUIDGenerationTest < ActiveRecord::PostgreSQLTestCase
       t.uuid "other_uuid_2", default: "my_uuid_generator()"
     end
 
-    connection.create_table("pg_uuids_3", id: :uuid) do |t|
+    connection.create_table("pg_uuids_3", id: :uuid, **uuid_default) do |t|
       t.string "name"
     end
   end
@@ -320,10 +324,10 @@ class PostgresqlUUIDTestInverseOf < ActiveRecord::PostgreSQLTestCase
 
   setup do
     connection.transaction do
-      connection.create_table("pg_uuid_posts", id: :uuid) do |t|
+      connection.create_table("pg_uuid_posts", id: :uuid, **uuid_default) do |t|
         t.string "title"
       end
-      connection.create_table("pg_uuid_comments", id: :uuid) do |t|
+      connection.create_table("pg_uuid_comments", id: :uuid, **uuid_default) do |t|
         t.references :uuid_post, type: :uuid
         t.string "content"
       end

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -80,7 +80,7 @@ module ActiveRecord
         end
 
         def test_renaming_table_doesnt_attempt_to_rename_non_existent_sequences
-          connection.create_table :cats, id: :uuid
+          connection.create_table :cats, id: :uuid, default: "uuid_generate_v4()"
           assert_nothing_raised { rename_table :cats, :felines }
           assert connection.table_exists? :felines
         ensure

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -154,7 +154,9 @@ if ActiveRecord::Base.connection.supports_views?
   end
 
   # sqlite dose not support CREATE, INSERT, and DELETE for VIEW
-  if current_adapter?(:Mysql2Adapter, :PostgreSQLAdapter, :SQLServerAdapter)
+  if current_adapter?(:Mysql2Adapter, :SQLServerAdapter) ||
+      current_adapter?(:PostgreSQLAdapter) && ActiveRecord::Base.connection.postgresql_version >= 90300
+
     class UpdateableViewTest < ActiveRecord::TestCase
       self.use_transactional_tests = false
       fixtures :books

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -3,11 +3,13 @@ ActiveRecord::Schema.define do
   enable_extension!("uuid-ossp", ActiveRecord::Base.connection)
   enable_extension!("pgcrypto",  ActiveRecord::Base.connection) if ActiveRecord::Base.connection.supports_pgcrypto_uuid?
 
-  create_table :uuid_parents, id: :uuid, force: true do |t|
+  uuid_default = connection.supports_pgcrypto_uuid? ? {} : { default: "uuid_generate_v4()" }
+
+  create_table :uuid_parents, id: :uuid, force: true, **uuid_default do |t|
     t.string :name
   end
 
-  create_table :uuid_children, id: :uuid, force: true do |t|
+  create_table :uuid_children, id: :uuid, force: true, **uuid_default do |t|
     t.string :name
     t.uuid :uuid_parent_id
   end
@@ -102,7 +104,7 @@ _SQL
   end
 
   create_table :uuid_items, force: true, id: false do |t|
-    t.uuid :uuid, primary_key: true
+    t.uuid :uuid, primary_key: true, **uuid_default
     t.string :title
   end
 end


### PR DESCRIPTION
Also, explicitly apply the order: generate_subscripts is unlikely to start returning values out of order, but we should still be clear about what we want.

---

I've changed the Travis config to run against 9.2, instead of specifically testing the 9.4.0 special case. And unified the special-DB-config tests to use ruby 2.3, which does less work because of 22deb92216d83f64fa8e948abe305309b327b33a.