### PR TITLE
Switch to LIFO for the connection pool

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -80,7 +80,7 @@ module ActiveRecord
     # * private methods that require being called in a +synchronize+ blocks
     #   are now explicitly documented
     class ConnectionPool
-      # Threadsafe, fair, FIFO queue.  Meant to be used by ConnectionPool
+      # Threadsafe, fair, LIFO queue.  Meant to be used by ConnectionPool
       # with which it shares a Monitor.  But could be a generic Queue.
       #
       # The Queue in stdlib's 'thread' could replace this class except
@@ -111,7 +111,7 @@ module ActiveRecord
         # Add +element+ to the queue.  Never blocks.
         def add(element)
           synchronize do
-            @queue.push element
+            @queue.unshift element
             @cond.signal
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -80,11 +80,8 @@ module ActiveRecord
     # * private methods that require being called in a +synchronize+ blocks
     #   are now explicitly documented
     class ConnectionPool
-      # Threadsafe, fair, LIFO queue.  Meant to be used by ConnectionPool
-      # with which it shares a Monitor.  But could be a generic Queue.
-      #
-      # The Queue in stdlib's 'thread' could replace this class except
-      # stdlib's doesn't support waiting with a timeout.
+      # Threadsafe, fair, FIFO queue.  Meant to be used by ConnectionPool
+      # with which it shares a Monitor.
       class Queue
         def initialize(lock = Monitor.new)
           @lock = lock
@@ -111,7 +108,7 @@ module ActiveRecord
         # Add +element+ to the queue.  Never blocks.
         def add(element)
           synchronize do
-            @queue.unshift element
+            @queue.push element
             @cond.signal
           end
         end
@@ -173,7 +170,7 @@ module ActiveRecord
 
           # Removes and returns the head of the queue if possible, or +nil+.
           def remove
-            @queue.shift
+            @queue.pop
           end
 
           # Remove and return the head the queue if the number of

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -80,7 +80,7 @@ module ActiveRecord
     # * private methods that require being called in a +synchronize+ blocks
     #   are now explicitly documented
     class ConnectionPool
-      # Threadsafe, fair, FIFO queue.  Meant to be used by ConnectionPool
+      # Threadsafe, fair, LIFO queue.  Meant to be used by ConnectionPool
       # with which it shares a Monitor.
       class Queue
         def initialize(lock = Monitor.new)

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -203,7 +203,7 @@ module ActiveRecord
         end.join
       end
 
-      def test_checkout_order_is_fifo
+      def test_checkout_order_is_lifo
         conn1 = @pool.checkout
         conn2 = @pool.checkout
         @pool.checkin conn1

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -203,6 +203,14 @@ module ActiveRecord
         end.join
       end
 
+      def test_checkout_order_is_fifo
+        conn1 = @pool.checkout
+        conn2 = @pool.checkout
+        @pool.checkin conn1
+        @pool.checkin conn2
+        assert_equal [conn2, conn1], 2.times.map { @pool.checkout }
+      end
+
       # The connection pool is "fair" if threads waiting for
       # connections receive them in the order in which they began
       # waiting.  This ensures that we don't timeout one HTTP request


### PR DESCRIPTION
### Summary

Using a FIFO for the connection pool can lead to issues when there are
upstream components (pgbouncer, haproxy, etc.) that terminate
connections that are idle after a period of time. Switching to a LIFO
reduces the probability that a thread will checkout a connection that is
about to be closed by an idle timeout in an upstream component.

### Other Information

I would also be interested in adding an idle timeout and a max lifetime into the connection pool itself. Putting the idle timeout in the connection pool will eliminate the possibility that an upstream closes a connection as its being checked out by a thread. Adding the max lifetime would create a way to drain connections from an upstream component. I wanted to start with this small change to start the discussion and gauge the receptiveness to changes in this part of the code base.
