### PR TITLE
Make code statistics task handle system tests properly

### DIFF
--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -7,7 +7,8 @@ class CodeStatistics #:nodoc:
                 "Model tests",
                 "Mailer tests",
                 "Job tests",
-                "Integration tests"]
+                "Integration tests",
+                "System tests"]
 
   HEADERS = { lines: " Lines", code_lines: "   LOC", classes: "Classes", methods: "Methods" }
 


### PR DESCRIPTION
If it is not added to `TEST_TYPES`, it is not regarded as a test when counting the total count.

**before** 

```
 ./bin/rails stats  
....

| System tests         |      9 |      7 |       1 |       1 |   1 |     5 |
+----------------------+--------+--------+---------+---------+-----+-------+
| Total                |    208 |    137 |      13 |      19 |   1 |     5 |
+----------------------+--------+--------+---------+---------+-----+-------+
  Code LOC: 93     Test LOC: 44     Code to Test Ratio: 1:0.5


```

**after**

```
 ./bin/rails stats  
....

| System tests         |      9 |      7 |       1 |       1 |   1 |     5 |
+----------------------+--------+--------+---------+---------+-----+-------+
| Total                |    208 |    137 |      13 |      19 |   1 |     5 |
+----------------------+--------+--------+---------+---------+-----+-------+
  Code LOC: 86     Test LOC: 51     Code to Test Ratio: 1:0.6
```
