### PR TITLE
Fix ConnectionPool#active_connection? to return boolean values

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix predicate method `ActiveRecord::ConnectionPool#active_connection?` to actually return boolean values.
+    Starting from 5.0 it returns `nil` or actual active connection object.
+
+    *Andrey Novikov*
+
 *   When calling the dynamic fixture accessor method with no arguments it now returns all fixtures of this type.
     Previously this method always returned an empty array.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -380,7 +380,7 @@ module ActiveRecord
       # #connection or #with_connection methods. Connections obtained through
       # #checkout will not be detected by #active_connection?
       def active_connection?
-        @thread_cached_conns[connection_cache_key(Thread.current)]
+        !!@thread_cached_conns[connection_cache_key(Thread.current)]
       end
 
       # Signal that the thread is finished with the current connection.

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -81,11 +81,11 @@ module ActiveRecord
         assert !pool.active_connection?
         main_thread = pool.connection
 
-        assert pool.active_connection?
+        assert_equal true, pool.active_connection?
 
         main_thread.close
 
-        assert !pool.active_connection?
+        assert_equal false, pool.active_connection?
       end
 
       def test_full_pool_exception


### PR DESCRIPTION
Starting from 5.0 (actually from https://github.com/rails/rails/commit/603fe20c0b8c05bc1cca8d01caadbd7060518141) it returns `nil` or actual active connection object.

It's harmless, but astonishing, as it's have question mark in name. 

This PR returns to 4.x behaviour.