### PR TITLE
Fix mistake in JS response parser

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
@@ -64,10 +64,10 @@ processResponse = (response, type) ->
   if typeof response is 'string' and typeof type is 'string'
     if type.match(/\bjson\b/)
       try response = JSON.parse(response)
-    else if type.match(/\bjavascript\b/)
+    else if type.match(/\b(?:java|ecma)script\b/)
       script = document.createElement('script')
-      script.innerHTML = response
-      document.body.appendChild(script)
+      script.text = response
+      document.head.appendChild(script).parentNode.removeChild(script)
     else if type.match(/\b(xml|html|svg)\b/)
       parser = new DOMParser()
       type = type.replace(/;.+/, '') # remove something like ';charset=utf-8'

--- a/actionview/test/ujs/public/test/call-remote.js
+++ b/actionview/test/ujs/public/test/call-remote.js
@@ -100,6 +100,34 @@ asyncTest('JS code should be executed', 1, function() {
   submit()
 })
 
+asyncTest('ecmascript code should be executed', 1, function() {
+  buildForm({ method: 'post', 'data-type': 'script' })
+
+  $('form').append('<input type="text" name="content_type" value="application/ecmascript">')
+  $('form').append('<input type="text" name="content" value="ok(true, \'remote code should be run\')">')
+
+  submit()
+})
+
+asyncTest('execution of JS code does not modify current DOM', 1, function() {
+  var docLength, newDocLength
+  function getDocLength() {
+    return document.documentElement.outerHTML.length
+  }
+
+  buildForm({ method: 'post', 'data-type': 'script' })
+
+  $('form').append('<input type="text" name="content_type" value="text/javascript">')
+  $('form').append('<input type="text" name="content" value="\'remote code should be run\'">')
+
+  docLength = getDocLength()
+
+  submit(function() {
+    newDocLength = getDocLength()
+    ok(docLength === newDocLength, 'executed JS should not present in the document')
+  })
+})
+
 asyncTest('XML document should be parsed', 1, function() {
   buildForm({ method: 'post', 'data-type': 'html' })
 


### PR DESCRIPTION
### Summary

Restore ability to accept ecmascript
JS response should not modify DOM.

### Steps to reproduce
```
<%= form_with(url: '/test') do %>
  <%= submit_tag 'submit' %>
<% end %>
```
```
# test.js.erb
console.log('bang')
```

### Expected behavior

When we use `jquery` and `jquery_ujs` we actually perform string via [globalEval](https://github.com/jquery/jquery/blob/master/src/ajax/script.js#L27) and [DOMeval](https://github.com/jquery/jquery/blob/master/src/core/DOMEval.js), after execution that string is removed

### Actual behavior
Actually after evaluating string we can see it at the end of the `body` tag.

As a side effect of that behavior, we can see that body tag is updated every time when we click submit.

![screen shot](https://cloud.githubusercontent.com/assets/1914001/25008725/3a731d5a-206d-11e7-8864-8d50b0a0d564.png)

### System configuration

Rails version:
5.1.0.rc1
Ruby version:
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin15]

