### PR TITLE
Clarify Strong Parameters documentation

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -198,9 +198,10 @@ which attributes to allow for mass update. This is a better security
 practice to help prevent accidentally allowing users to update sensitive
 model attributes.
 
-In addition, parameters can be marked as required and will flow through a
-predefined raise/rescue flow that will result in a 400 Bad Request being
-returned if not all required parameters are passed in.
+In addition, parameters can be marked as required and an `ActionController::ParameterMissing`
+exception will be raised if not all required parameters are passed. If this
+is the case the log will show the request completing as a 400 Bad Request
+even though the exception is not caught.
 
 ```ruby
 class PeopleController < ActionController::Base
@@ -211,11 +212,11 @@ class PeopleController < ActionController::Base
     Person.create(params[:person])
   end
 
-  # This will pass with flying colors as long as there's a person key
-  # in the parameters, otherwise it'll raise a
-  # ActionController::ParameterMissing exception, which will get
-  # caught by ActionController::Base and turned into a 400 Bad
-  # Request error.
+  # This will pass with flying colors as long as there's a person
+  # key in the parameters, otherwise it'll raise an
+  # ActionController::ParameterMissing exception. 
+  # In this case the log will show the request completing as a
+  # 400 Bad Request.
   def update
     person = current_account.people.find(params[:id])
     person.update!(person_params)

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -205,9 +205,9 @@ even though the exception is not caught.
 
 ```ruby
 class PeopleController < ActionController::Base
-  # This will raise an ActiveModel::ForbiddenAttributesError exception
-  # because it's using mass assignment without an explicit permit
-  # step.
+  # This will raise an ActiveModel::ForbiddenAttributesError 
+  # exception because it's using mass assignment without an 
+  # explicit permit step.
   def create
     Person.create(params[:person])
   end
@@ -224,10 +224,11 @@ class PeopleController < ActionController::Base
   end
 
   private
-    # Using a private method to encapsulate the permissible parameters
-    # is just a good pattern since you'll be able to reuse the same
-    # permit list between create and update. Also, you can specialize
-    # this method with per-user checking of permissible attributes.
+    # Using a private method to encapsulate the permissible 
+    # parameters is just a good pattern since you'll be able 
+    # to reuse the same permit list between create and
+    # update. Also, you can specialize this method with
+    # per-user checking of permissible attributes.
     def person_params
       params.require(:person).permit(:name, :age)
     end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -465,7 +465,7 @@ encrypted cookies salt value. Defaults to `'signed encrypted cookie'`.
   method should be performed on the parameters. See [Security Guide](security.html#unsafe-query-generation)
   for more information. It defaults to `true`.
 
-* `config.action_dispatch.rescue_responses` configures what exceptions are assigned to an HTTP status. It accepts a hash and you can specify pairs of exception/status. By default, this is defined as:
+* `config.action_dispatch.rescue_responses` configures what exceptions are assigned to an HTTP status. It accepts a hash and you can specify pairs of exception/status. Please note that this is only for the purposes of logging. No exceptions are actually rescued. By default, this is defined as:
 
   ```ruby
   config.action_dispatch.rescue_responses = {


### PR DESCRIPTION
### Summary

The Rails Guides contain some misleading statements with regard to the way strong parameters are handled in the case where a required parameter is missing. This has [caused confusion](https://github.com/rails/rails/issues/27128).

This change aims to clarify the Rails Guides, specifically the _Action Controller Overview_ and _Configuring Rails Application_ guides. 

Hopefully, as a result, Rails users will understand that the `ActionController::MissingParameter` exception is not actually rescued so that a 400 Bad Request response can be sent. The `rescue_responses` hash is actually used by `ActionDispatch::ExceptionWrapper` to map exceptions to status codes for `ActionController::LogSubscriber`. As a result the mapped status codes appear in the log.
