### PR TITLE
Wrap `load_schema` in a Mutex.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Loading model schema from database is now thread-safe. GH#28589
+
+    *Vikrant Chaudhary*
+
 *   Add `ActiveRecord::Base#cache_version` to support recyclable cache keys via the new versioned entries
     in `ActiveSupport::Cache`. This also means that `ActiveRecord::Base#cache_key` will now return a stable key
     that does not include a timestamp any more.

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -149,6 +149,9 @@ module ActiveRecord
       class_attribute :ignored_columns, instance_accessor: false
       self.ignored_columns = [].freeze
 
+      class_attribute :load_schema_monitor, instance_accessor: false
+      self.load_schema_monitor = Monitor.new
+
       self.inheritance_column = "type"
 
       delegate :type_for_attribute, to: :class
@@ -166,8 +169,6 @@ module ActiveRecord
     end
 
     module ClassMethods
-      @@load_schema_mutex = Mutex.new
-
       # Guesses the table name (in forced lower-case) based on the name of the class in the
       # inheritance hierarchy descending directly from ActiveRecord::Base. So if the hierarchy
       # looks like: Reply < Message < ActiveRecord::Base, then Message is used
@@ -449,17 +450,9 @@ module ActiveRecord
           # finished loading, and that may produce unexpected results.
           # For more information, see: https://github.com/rails/rails/issues/28589
 
-          # We can't use `@@load_schema_mutex.synchronize` because `load_schema` may
-          # call `load_schema` again in certain situations, and that will cause a deadlock error.
-          acquired_mutex_lock = false
-          unless @@load_schema_mutex.owned?
-            @@load_schema_mutex.lock
-            acquired_mutex_lock = true
+          load_schema_monitor.synchronize do
+            load_schema! unless schema_loaded?
           end
-
-          load_schema! unless schema_loaded?
-        ensure
-          @@load_schema_mutex.unlock if acquired_mutex_lock
         end
 
         def load_schema!


### PR DESCRIPTION
This PR wraps `ActiveRecord::ModelSchema::ClassMethods#load_schema` in a Mutex to make it thread-safe. Closes https://github.com/rails/rails/issues/28589.

Regarding tests, are there existing tests in Rails that test thread-safety from race-conditions that I can use as examples to write tests for this PR?
