### PR TITLE
Log any write errors originating from the socket

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,1 +1,7 @@
+*   ActionCable socket errors are now logged to the console
+
+    Previously any socket errors were ignored and this made it hard to diagnose socket issues (e.g. as discussed in #28362).
+
+    *Edward Poot*
+    
 Please check [5-1-stable](https://github.com/rails/rails/blob/5-1-stable/actioncable/CHANGELOG.md) for previous changes.

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -126,7 +126,8 @@ module ActionCable
       end
 
       def on_error(message) # :nodoc:
-        # ignore
+        # log errors to make diagnosing socket errors easier
+        logger.error "WebSocket error occurred: #{message}"
       end
 
       def on_close(reason, code) # :nodoc:


### PR DESCRIPTION
In Rails 5.0.1 changes were made to ActionCable to call a non-blocking write method on the socket. Most sockets used in combination with Rails support this method, but Puma does not implement it. This leads to ActionCable being unusable on Rails 5.0.1 or later.

In @maclover7's own words ([source](https://github.com/rails/rails/issues/28362#issuecomment-285903720)):
> Starting with this commit, on this line, Action Cable calls @rack_hijack_io.write_nonblock to write data out to the socket. However, this code depends on the 99% case where @rack_hijack_io is a TCPSocket / IO. When using Puma, @rack_hijack_io is actually an instance of Puma::MiniSSL::Socket, which does not implement the write_nonblock method (it does implement the read_nonblock method...). My take on how to fix this would be for Puma to conform to TCPSocket's API, and to implement the write_nonblock method.

In addition, ActionCable's connection stream event loop also calls `read_nonblock` on the socket (https://github.com/rails/rails/blob/3a11c5b626fcd781e3bacd4a59003465e9aafb5f/actioncable/lib/action_cable/connection/stream_event_loop.rb#L108), another method Puma does not implement.

The folks at Puma have now devised a workaround for this issue by stubbing out these methods and calling the blocking equivalents in turn.
While this is not a proper fix, this can be used to fix this issue for a lot of people using Rails 5.0.1 or later in combination with Puma.

What made this issue troublesome to diagnose is the fact that any errors inside `ActionCable::Connection::Stream#write` may be silently swallowed, because any socket write errors are emitted over a non-working socket. This PR addresses this and logs any such socket write errors.

In this specific issue, the following would have been logged had this been implemented:
`An NoMethodError error occurred while writing to the ActionCable socket: undefined method write_nonblock for #<Puma::MiniSSL::Socket:0x007fe441e7ddd0>`

Related issues: #28362, https://github.com/puma/puma/issues/1189