### PR TITLE
Specify lang attribute in generated app layout

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Specify lang attribute in generated application layout
+
+    W3C recommends the use of the lang attribute on the html tag. This uses
+    the `locale` view helper to specify the current app's language.
+
+    *Edward Loveall*
+
 *   Don't generate unused files in `app:update` task
 
      Skip the assets' initializer when sprockets isn't loaded.

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%%= locale %>">
   <head>
     <title><%= camelized %></title>
     <%%= csrf_meta_tags %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -990,6 +990,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_html_lang_attribute
+    run_generator
+
+    assert_file("app/views/layouts/application.html.erb", /<html lang="<%= locale %>">/)
+  end
+
   private
     def stub_rails_application(root)
       Rails.application.config.root = root


### PR DESCRIPTION
### Summary

This adds the lang attribute to the html tag in the generated application.html.erb layout. The W3C [states][1]:

> Always use a language attribute on the html tag to declare the default language of the text in the page.

Rails exposes the code for the current language with the `locale` helper. This seemed like the obvious choice to set the language properly and automatically.

### Why is this a problem?

First, declaring what language a page is written in is a good web practice.

Second, some browsers such as Google Chrome will ask if a site needs to be translated if it detects there are many non-native words on the page. It's possible to confuse this translation detector if, for
example, you have a quirky company name on a page with little other text like a promo page. Adding the lang attribute puts a stop to this unhelpful suggestion by the browser.

[1]:
https://www.w3.org/International/questions/qa-html-language-declarations