### PR TITLE
Keep "test types" info in one location

### DIFF
--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -2,18 +2,11 @@ require "rails/code_statistics_calculator"
 require "active_support/core_ext/enumerable"
 
 class CodeStatistics #:nodoc:
-  TEST_TYPES = ["Controller tests",
-                "Helper tests",
-                "Model tests",
-                "Mailer tests",
-                "Job tests",
-                "Integration tests",
-                "System tests"]
-
   HEADERS = { lines: " Lines", code_lines: "   LOC", classes: "Classes", methods: "Methods" }
 
-  def initialize(*pairs)
+  def initialize(*pairs, test_types)
     @pairs      = pairs
+    @test_types = test_types
     @statistics = calculate_statistics
     @total      = calculate_total if pairs.length > 1
   end
@@ -60,13 +53,13 @@ class CodeStatistics #:nodoc:
 
     def calculate_code
       code_loc = 0
-      @statistics.each { |k, v| code_loc += v.code_lines unless TEST_TYPES.include? k }
+      @statistics.each { |k, v| code_loc += v.code_lines unless @test_types.include? k }
       code_loc
     end
 
     def calculate_tests
       test_loc = 0
-      @statistics.each { |k, v| test_loc += v.code_lines if TEST_TYPES.include? k }
+      @statistics.each { |k, v| test_loc += v.code_lines if @test_types.include? k }
       test_loc
     end
 

--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -1,7 +1,18 @@
 # While global constants are bad, many 3rd party tools depend on this one (e.g
 # rspec-rails & cucumber-rails). So a deprecation warning is needed if we want
 # to remove it.
-STATS_DIRECTORIES = [
+
+TEST_STATS_DIRECTORIES = [
+  %w(Controller\ tests  test/controllers),
+  %w(Helper\ tests      test/helpers),
+  %w(Model\ tests       test/models),
+  %w(Mailer\ tests      test/mailers),
+  %w(Job\ tests         test/jobs),
+  %w(Integration\ tests test/integration),
+  %w(System\ tests      test/system)
+]
+
+STATS_DIRECTORIES = ([
   %w(Controllers        app/controllers),
   %w(Helpers            app/helpers),
   %w(Jobs               app/jobs),
@@ -10,20 +21,13 @@ STATS_DIRECTORIES = [
   %w(Channels           app/channels),
   %w(JavaScripts        app/assets/javascripts),
   %w(Libraries          lib/),
-  %w(APIs               app/apis),
-  %w(Controller\ tests  test/controllers),
-  %w(Helper\ tests      test/helpers),
-  %w(Model\ tests       test/models),
-  %w(Mailer\ tests      test/mailers),
-  %w(Job\ tests         test/jobs),
-  %w(Integration\ tests test/integration),
-  %w(System\ tests      test/system),
-].collect do |name, dir|
+  %w(APIs               app/apis)
+] + TEST_STATS_DIRECTORIES).collect do |name, dir|
   [ name, "#{File.dirname(Rake.application.rakefile_location)}/#{dir}" ]
 end.select { |name, dir| File.directory?(dir) }
 
 desc "Report code statistics (KLOCs, etc) from the application or engine"
 task :stats do
   require "rails/code_statistics"
-  CodeStatistics.new(*STATS_DIRECTORIES).to_s
+  CodeStatistics.new(*STATS_DIRECTORIES, TEST_STATS_DIRECTORIES.map { |d| d[0] }).to_s
 end

--- a/railties/test/code_statistics_test.rb
+++ b/railties/test/code_statistics_test.rb
@@ -14,7 +14,7 @@ class CodeStatisticsTest < ActiveSupport::TestCase
 
   test "ignores directories that happen to have source files extensions" do
     assert_nothing_raised do
-      @code_statistics = CodeStatistics.new(["tmp dir", @tmp_path])
+      @code_statistics = CodeStatistics.new(["tmp dir", @tmp_path], [])
     end
   end
 
@@ -26,7 +26,7 @@ class CodeStatisticsTest < ActiveSupport::TestCase
     CODE
 
     assert_nothing_raised do
-      CodeStatistics.new(["hidden file", @tmp_path])
+      CodeStatistics.new(["hidden file", @tmp_path], [])
     end
   end
 end


### PR DESCRIPTION
### Summary

This commit aims to centralize the "test types" constant used by
`CodeStatistics`. Previously, if one wanted to add a test type, you
would have to update two different constants. Now, you only have to
update one, and the changes will be properly propogated.

### Other Information

Sidenote: `CodeStatistics` is a nodoc'ed class, so external users should
not be using it.

Inspired by #28744.