### PR TITLE
Fix preload query for through associations with custom scope block

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix incorrect preload query when using `includes` with a through association and a custom scope block. Fixes #28703
+
+    *Chris Fung*
+
 *   Add type caster to `RuntimeReflection#alias_name`
 
     Fixes #28959.

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -82,7 +82,9 @@ module ActiveRecord
               scope.where! reflection.foreign_type => options[:source_type]
             else
               unless reflection_scope.where_clause.empty?
-                scope.includes_values = Array(reflection_scope.values[:includes] || options[:source])
+                include_values = Array(reflection_scope.values[:includes] || options[:source])
+                scope.includes_values = include_values
+                scope.references! include_values
                 scope.where_clause = reflection_scope.where_clause
               end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1252,4 +1252,13 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       )
     end
   end
+
+  def test_through_association_includes
+    member = Member.create!
+    fancy_club = Club.create!(fancy: true)
+    member.memberships << Membership.create!(club: fancy_club)
+    member.save!
+
+    assert_equal Member.includes(:fancy_clubs).flat_map(&:fancy_clubs), [fancy_club]
+  end
 end

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -528,7 +528,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_nested_has_many_through_with_conditions_on_source_associations_preload
-    authors = assert_queries(4) { Author.includes(:misc_post_first_blue_tags_2).to_a.sort_by(&:id) }
+    authors = assert_queries(2) { Author.includes(:misc_post_first_blue_tags_2).to_a.sort_by(&:id) }
     blue = tags(:blue)
 
     assert_no_queries do

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -8,6 +8,8 @@ class Club < ActiveRecord::Base
 
   has_many :favourites, -> { where(memberships: { favourite: true }) }, through: :memberships, source: :member
 
+  scope :fancy, -> { where(fancy: true) }
+
   private
 
     def private_method

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -29,6 +29,12 @@ class Member < ActiveRecord::Base
   has_many :tenant_memberships
   has_many :tenant_clubs, through: :tenant_memberships, class_name: "Club", source: :club
 
+  has_many :memberships
+  has_many :fancy_clubs, -> { fancy },
+    class_name: "Club",
+    through: :memberships,
+    source: :club
+
   has_one :club_through_many, through: :current_memberships, source: :club
 
   belongs_to :admittable, polymorphic: true

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -158,6 +158,7 @@ ActiveRecord::Schema.define do
   create_table :clubs, force: true do |t|
     t.string :name
     t.integer :category_id
+    t.boolean :fancy, default: false
   end
 
   create_table :collections, force: true do |t|


### PR DESCRIPTION
### Summary

Fixes #28703.

Using a through association with `includes` could raise an exception if the association had a custom scope block. This was because the preload query for the through association would not join in the source association's table, but the conditions in the where clause could depend on that table.

This changes `ActiveRecord::Associations::Preload#through_scope` to also spawn references for the reflection_scope's source if there was a where clause on the reflection_scope. This makes the query join in the source association's table so any conditions in the where clause will have the table to reference.

/cc @matthewd 