### PR TITLE
Reduce .travis.yml duplication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
 services:
   - memcached
   - redis
+  - rabbitmq
 
 addons:
   postgresql: "9.4"
@@ -53,6 +54,7 @@ env:
     - "GEM=ar:postgresql"
     - "GEM=guides"
     - "GEM=ac:integration"
+    - "GEM=aj:integration"
 
 rvm:
   - 2.2.7
@@ -64,30 +66,6 @@ matrix:
   include:
     - rvm: 2.4.1
       env: "GEM=av:ujs"
-    - rvm: 2.2.7
-      env: "GEM=aj:integration"
-      services:
-        - memcached
-        - redis
-        - rabbitmq
-    - rvm: 2.3.4
-      env: "GEM=aj:integration"
-      services:
-        - memcached
-        - redis
-        - rabbitmq
-    - rvm: 2.4.1
-      env: "GEM=aj:integration"
-      services:
-        - memcached
-        - redis
-        - rabbitmq
-    - rvm: ruby-head
-      env: "GEM=aj:integration"
-      services:
-        - memcached
-        - redis
-        - rabbitmq
     - rvm: 2.3.4
       env:
         - "GEM=ar:mysql2 MYSQL=mariadb"


### PR DESCRIPTION
### Summary

We already have 2 of the 3 required services loaded on every build, so
may as well have the third required one also be loaded. Because of this,
we can add `aj:integration` to the main matrix list.