### PR TITLE
Keyword arguments to `class_attributes, mattr_accessor` 's args

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -68,11 +68,9 @@ class Class
   #   object.setting = false  # => NoMethodError
   #
   # To opt out of both instance methods, pass <tt>instance_accessor: false</tt>.
-  def class_attribute(*attrs)
-    options = attrs.extract_options!
-    instance_reader = options.fetch(:instance_accessor, true) && options.fetch(:instance_reader, true)
-    instance_writer = options.fetch(:instance_accessor, true) && options.fetch(:instance_writer, true)
-    instance_predicate = options.fetch(:instance_predicate, true)
+  def class_attribute(*attrs, instance_accessor: true, instance_reader: true, instance_writer: true, instance_predicate: true)
+    instance_reader = instance_accessor && instance_reader
+    instance_writer = instance_accessor && instance_writer
 
     attrs.each do |name|
       remove_possible_singleton_method(name)

--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
@@ -52,8 +52,7 @@ class Module
   #   end
   #
   #   Person.new.hair_colors # => [:brown, :black, :blonde, :red]
-  def mattr_reader(*syms)
-    options = syms.extract_options!
+  def mattr_reader(*syms, instance_reader: true, instance_accessor: true)
     syms.each do |sym|
       raise NameError.new("invalid attribute name: #{sym}") unless /\A[_A-Za-z]\w*\z/.match?(sym)
       class_eval(<<-EOS, __FILE__, __LINE__ + 1)
@@ -64,7 +63,7 @@ class Module
         end
       EOS
 
-      unless options[:instance_reader] == false || options[:instance_accessor] == false
+      unless (instance_reader == false) || (instance_accessor == false)
         class_eval(<<-EOS, __FILE__, __LINE__ + 1)
           def #{sym}
             @@#{sym}
@@ -120,8 +119,7 @@ class Module
   #   end
   #
   #   Person.class_variable_get("@@hair_colors") # => [:brown, :black, :blonde, :red]
-  def mattr_writer(*syms)
-    options = syms.extract_options!
+  def mattr_writer(*syms, instance_writer: true, instance_accessor: true)
     syms.each do |sym|
       raise NameError.new("invalid attribute name: #{sym}") unless /\A[_A-Za-z]\w*\z/.match?(sym)
       class_eval(<<-EOS, __FILE__, __LINE__ + 1)
@@ -132,7 +130,7 @@ class Module
         end
       EOS
 
-      unless options[:instance_writer] == false || options[:instance_accessor] == false
+      unless (instance_writer == false) || (instance_accessor == false)
         class_eval(<<-EOS, __FILE__, __LINE__ + 1)
           def #{sym}=(obj)
             @@#{sym} = obj
@@ -210,9 +208,9 @@ class Module
   #   end
   #
   #   Person.class_variable_get("@@hair_colors") # => [:brown, :black, :blonde, :red]
-  def mattr_accessor(*syms, &blk)
-    mattr_reader(*syms, &blk)
-    mattr_writer(*syms)
+  def mattr_accessor(*syms, instance_accessor: true, instance_reader: true, instance_writer: true, &blk)
+    mattr_reader(*syms, instance_accessor: instance_accessor, instance_reader: instance_reader, &blk)
+    mattr_writer(*syms, instance_accessor: instance_accessor, instance_writer: instance_writer)
   end
   alias :cattr_accessor :mattr_accessor
 end

--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
@@ -34,9 +34,7 @@ class Module
   #   end
   #
   #   Current.new.user # => NoMethodError
-  def thread_mattr_reader(*syms) # :nodoc:
-    options = syms.extract_options!
-
+  def thread_mattr_reader(*syms, instance_reader: true, instance_accessor: true) # :nodoc:
     syms.each do |sym|
       raise NameError.new("invalid attribute name: #{sym}") unless /^[_A-Za-z]\w*$/.match?(sym)
 
@@ -48,7 +46,7 @@ class Module
         end
       EOS
 
-      unless options[:instance_reader] == false || options[:instance_accessor] == false
+      unless (instance_reader == false) || (instance_accessor == false)
         class_eval(<<-EOS, __FILE__, __LINE__ + 1)
           def #{sym}
             self.class.#{sym}
@@ -77,8 +75,7 @@ class Module
   #   end
   #
   #   Current.new.user = "DHH" # => NoMethodError
-  def thread_mattr_writer(*syms) # :nodoc:
-    options = syms.extract_options!
+  def thread_mattr_writer(*syms, instance_writer: true, instance_accessor: true) # :nodoc:
     syms.each do |sym|
       raise NameError.new("invalid attribute name: #{sym}") unless /^[_A-Za-z]\w*$/.match?(sym)
 
@@ -90,7 +87,7 @@ class Module
         end
       EOS
 
-      unless options[:instance_writer] == false || options[:instance_accessor] == false
+      unless (instance_writer == false) || (instance_accessor == false)
         class_eval(<<-EOS, __FILE__, __LINE__ + 1)
           def #{sym}=(obj)
             self.class.#{sym} = obj
@@ -140,9 +137,9 @@ class Module
   #
   #   Current.new.user = "DHH"  # => NoMethodError
   #   Current.new.user          # => NoMethodError
-  def thread_mattr_accessor(*syms)
-    thread_mattr_reader(*syms)
-    thread_mattr_writer(*syms)
+  def thread_mattr_accessor(*syms, instance_accessor: true, instance_reader: true, instance_writer: true)
+    thread_mattr_reader(*syms, instance_accessor: instance_accessor, instance_reader: instance_reader)
+    thread_mattr_writer(*syms, instance_accessor: instance_accessor, instance_writer: instance_writer)
   end
   alias :thread_cattr_accessor :thread_mattr_accessor
 end


### PR DESCRIPTION
### Summary

Separating determined args from variable length args.
ex: `instance_accessor`, `instance_reader`, `instance_writer` args from `*syms`

### Other Information

This is related to @amatsuda https://github.com/amatsuda/rails/commit/ee6776f5f5067d63394ada06394afb191f0a184d

