### PR TITLE
Add Puerto Rico support to ActiveSupport::TimeZone

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -6,7 +6,7 @@ module ActiveSupport
   # The TimeZone class serves as a wrapper around TZInfo::Timezone instances.
   # It allows us to do the following:
   #
-  # * Limit the set of zones provided by TZInfo to a meaningful subset of 146
+  # * Limit the set of zones provided by TZInfo to a meaningful subset of 134
   #   zones.
   # * Retrieve and display zones with a friendlier name
   #   (e.g., "Eastern Time (US & Canada)" instead of "America/New_York").

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -59,6 +59,7 @@ module ActiveSupport
       "Buenos Aires"                 => "America/Argentina/Buenos_Aires",
       "Montevideo"                   => "America/Montevideo",
       "Georgetown"                   => "America/Guyana",
+      "Puerto Rico"                  => "America/Puerto_Rico",
       "Greenland"                    => "America/Godthab",
       "Mid-Atlantic"                 => "Atlantic/South_Georgia",
       "Azores"                       => "Atlantic/Azores",


### PR DESCRIPTION
### Summary

This adds Puerto Rico support to ActiveSupport::TimeZone.

### Other Information

Currently, there are no time zones in ActiveSupport that can properly represent Puerto Rico (from what I can understand).  Puerto Rico uses Atlantic Standard Time all year round with no Daylight Savings Time.  This change surfaces TZInfo's "America/Puerto_Rico" which conforms to AST with no DST.

Also, I updated the documentation to reflect the actual number of unique zones represented here. (146 is not accurate by either count right now.)

```ruby
ActiveSupport::TimeZone.all.count
=> 151
ActiveSupport::TimeZone.all.map(&:tzinfo).uniq.count
=> 134
```