### PR TITLE
More connection locking

### DIFF
--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -36,7 +36,7 @@ module ActiveRecord
       caching_pool.disable_query_cache! unless caching_was_enabled
 
       ActiveRecord::Base.connection_handler.connection_pool_list.each do |pool|
-        pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?
+        pool.release_connection if pool.active_connection? && (pool.connection.owner != Thread.current || !pool.connection.transaction_open?)
       end
     end
 

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -673,7 +673,7 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
       end
     end.new
     connection.pool = Class.new do
-      def lock_thread=(lock_thread); false; end
+      def lock_thread=(enable); false; end
     end.new
     fire_connection_notification(connection)
     teardown_fixtures


### PR DESCRIPTION
Address two failure modes for connection pool thread locking (yay) by making it more complicated (boo).

First, a deadlock between the pool lock and the connection lock, due to inconsistent lock acquisition order: `clear_query_cache` requires the connection lock, and is invoked by a checkin callback while holding the pool lock. (I don't think we should actually be invoking callbacks while holding the pool lock, but that's a matter for another time.)

Second, the less proximate cause of the above failure: the main thread could checkin its connection while another thread was still using it. The second thread would then unexpectedly change connections between two queries -- even while inside a transaction on the first one. 

---

We now keep track of who has borrowed the connection, and don't complete the "unlock" until they have released it. This also means that the lock only applies to connection acquisition: after that (and until it attempts to release it) the borrowing thread treats the connection as its own.