### PR TITLE
Add missing word 'to' [ci skip]

### DIFF
--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -426,7 +426,7 @@ Fallbacks allow your generators to have a single responsibility, increasing code
 Application Templates
 ---------------------
 
-Now that you've seen how generators can be used _inside_ an application, did you know they can also be used to _generate_ applications too? This kind of generator is referred as a "template". This is a brief overview of the Templates API. For detailed documentation see the [Rails Application Templates guide](rails_application_templates.html).
+Now that you've seen how generators can be used _inside_ an application, did you know they can also be used to _generate_ applications too? This kind of generator is referred to as a "template". This is a brief overview of the Templates API. For detailed documentation see the [Rails Application Templates guide](rails_application_templates.html).
 
 ```ruby
 gem "rspec-rails", group: "test"


### PR DESCRIPTION
While the original sentence is easy to understand, adding the 'to' is
imho a bit more correct.

Sources:
* https://ell.stackexchange.com/q/16964
* https://www.usingenglish.com/forum/threads/127099-It-is-referred-as-or-It-is-referred-to-as