### PR TITLE
Add more explanation to to_time about timezones

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -79,6 +79,9 @@ class Date
   #   date.to_time(:local)           # => 2007-11-10 00:00:00 0800
   #
   #   date.to_time(:utc)             # => 2007-11-10 00:00:00 UTC
+  #
+  # NOTE: The :local timezone is Ruby's *process* timezone, i.e. ENV['TZ']
+  #       If the *application's* timezone is needed, then use +in_time_zone+ instead
   def to_time(form = :local)
     raise ArgumentError, "Expected :local or :utc, got #{form.inspect}." unless [:local, :utc].include?(form)
     ::Time.send(form, year, month, day)


### PR DESCRIPTION
There's a difference in the results between `Date#to_time(:local)` and `Date#in_time_zone` but it is subtle and can confuse users (like me :-).

`Date#to_time(:local)` will convert the date to Ruby's process timezone, i.e. `ENV['TZ']` but when working in a Rails application, you generally want to use the *application's* timezone, i.e. `Time.zone`. There's a method for that: `Date#in_time_zone`, but it's off in another file (https://github.com/rails/rails/blob/92703a9ea5d8b96f30e0b706b801c9185ef14f0e/activesupport/lib/active_support/core_ext/date_and_time/zones.rb)
