### PR TITLE
Improve Active Record::Enum

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -177,5 +177,7 @@ ActiveSupport.on_load(:active_record) do
 end
 
 ActiveSupport.on_load(:i18n) do
-  I18n.load_path << File.dirname(__FILE__) + "/active_record/locale/en.yml"
+  ["pt", "en"].each do |language|
+    I18n.load_path << File.dirname(__FILE__) + '/active_record' + '/locale' + "/#{language}.yml"
+  end
 end

--- a/activerecord/lib/active_record/locale/en.yml
+++ b/activerecord/lib/active_record/locale/en.yml
@@ -46,3 +46,15 @@ en:
       #   user:
       #     login: "Handle"
       # will translate User attribute "login" as "Handle"
+
+    # use with translable enums
+    attributes:
+        books:
+          status:
+            proposed: 'Proposed'
+            written: 'Written'
+            published: 'Published'
+          read_status:
+            unread: 'Unread'
+            reading: 'Reading'
+            read: 'Read'

--- a/activerecord/lib/active_record/locale/pt.yml
+++ b/activerecord/lib/active_record/locale/pt.yml
@@ -1,0 +1,14 @@
+pt:
+  # Active Record models configuration
+  activerecord:
+    # use with translable enums
+    attributes:
+        books:
+          status:
+            proposed: 'Sugerido'
+            written: 'Escrito'
+            published: 'Publicado'
+          read_status:
+            unread: 'Não lido'
+            reading: 'Lendo'
+            read: 'Lido'

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -8,6 +8,46 @@ class EnumTest < ActiveRecord::TestCase
     @book = books(:awdr)
   end
 
+  test "book respond_to status_translable" do
+    assert @book.respond_to? :status_translable
+  end
+
+  test "book respond_to read_status_translable" do
+    assert @book.respond_to? :read_status_translable
+  end
+
+  test "when not exists enum by name" do
+    assert_not_respond_to @book, :blank_translable
+  end
+
+  test "when I18n.locale in english status Published" do
+    I18n.locale = :en
+    assert_equal "Published", @book.status_translable
+  end
+
+  test "when I18n.locale in portuguese status Publicado" do
+    I18n.locale = :pt
+    assert_equal "Publicado", @book.status_translable
+  end
+
+  test "when I18n.locale in portuguese status Escrito" do
+    I18n.locale = :pt
+    @book.written!
+    assert_equal "Escrito", @book.status_translable
+  end
+
+  test "when I18n.locale in english read_status Reading" do
+    I18n.locale = :en
+    @book.reading!
+    assert_equal "Reading", @book.read_status_translable
+  end
+
+  test "when I18n.locale in portuguese read_status Lido" do
+    I18n.locale = :pt
+    @book.read!
+    assert_equal "Lido", @book.read_status_translable
+  end
+
   test "query state by predicate" do
     assert @book.published?
     assert_not @book.written?


### PR DESCRIPTION
## ActiveRecord::Enum 
Translation Natively our enums

#### Why?
The community needs to be translated natively to your enums, without using other gems. For this reason, I make this Pull Request, requesting that this method be dynamically created when there is a definite enum in a Model. All the tests have been done and I have been working with this code for some time. I hope I can help you more.

Kind Regards,
Thadeu Esteves Jr
tadeuu@gmail.com