### PR TITLE
Explicitly require AS::Notifications in AS::Cache

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -6,6 +6,7 @@ require "active_support/core_ext/numeric/bytes"
 require "active_support/core_ext/numeric/time"
 require "active_support/core_ext/object/to_param"
 require "active_support/core_ext/string/inflections"
+require "active_support/notifications"
 
 module ActiveSupport
   # See ActiveSupport::Cache::Store for documentation.


### PR DESCRIPTION
Right now, if you install the current release version of Active Support (5.0.2) and try to use its cache implementation standalone by requiring `active_support/cache`, it crashes with `NameError: uninitialized constant ActiveSupport::Notifications`.  (`AS::Notifications` is used in `cache.rb` down around [line 555](https://github.com/rails/rails/blob/8776a7139757d0b264785c774d4e7f37d4bc1ac7/activesupport/lib/active_support/cache.rb#L555).)

Here's a quick repro script:

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "activesupport", "5.0.2"
end

require "active_support/cache"

cache_store = ActiveSupport::Cache::MemoryStore.new

cache_store.write('test', 'okay')
puts cache_store.read('test')
```

`5.1.0.beta1` also fails.  However, any version _newer_ than `5.1.0.beta1` passes (including `master`).

This is because [this commit](https://github.com/rails/rails/commit/75924c4517c8f87712d3f59c11f10152ed57b9d8) inadvertently included `AS::Notifications` into `AS::Cache` (thus fixing the issue) by mixing [`AS::Deprecation` into `AS::Duration`](https://github.com/rails/rails/blob/75924c4517c8f87712d3f59c11f10152ed57b9d8/activesupport/lib/active_support/duration.rb#L4), giving you a nice require chain of [`Cache` including `Time`][1] [including `Duration`][2] [including `Deprecation`][3] [including `Behaviors`][4] [including `Notifications`][5].  Phew.

Aside from being not very explicit, the fact that the fixing is specifically done by `AS::Deprecation` means that this fix is probably only temporary (until the deprecation is removed).

This PR just makes the inclusion explicit to future-proof against this breakage.

(Ideally, this would also be backported to `5-0-stable` to get picked up in any subsequent point release.)

See also: https://github.com/rails/rails/pull/14667

[1]: https://github.com/rails/rails/blob/75924c4517c8f87712d3f59c11f10152ed57b9d8/activesupport/lib/active_support/cache.rb#L6
[2]: https://github.com/rails/rails/blob/75924c4517c8f87712d3f59c11f10152ed57b9d8/activesupport/lib/active_support/time.rb#L2
[3]: https://github.com/rails/rails/blob/75924c4517c8f87712d3f59c11f10152ed57b9d8/activesupport/lib/active_support/duration.rb#L4
[4]: https://github.com/rails/rails/blob/75924c4517c8f87712d3f59c11f10152ed57b9d8/activesupport/lib/active_support/deprecation.rb#L16
[5]: https://github.com/rails/rails/blob/75924c4517c8f87712d3f59c11f10152ed57b9d8/activesupport/lib/active_support/deprecation/behaviors.rb#L1