### PR TITLE
Support PostgreSQL 10 whose sequences do not know  `increment_by`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -281,9 +281,10 @@ module ActiveRecord
 
           if pk && sequence
             quoted_sequence = quote_table_name(sequence)
+            max_pk = select_value("select MAX(#{quote_column_name pk}) from #{quote_table_name(table)}")
 
             select_value(<<-end_sql, "SCHEMA")
-              SELECT setval('#{quoted_sequence}', (SELECT COALESCE(MAX(#{quote_column_name pk})+(SELECT increment_by FROM #{quoted_sequence}), (SELECT min_value FROM #{quoted_sequence})) FROM #{quote_table_name(table)}), false)
+              SELECT setval('#{quoted_sequence}', #{max_pk ? max_pk : 1}, #{max_pk ? true : false})
             end_sql
           end
         end


### PR DESCRIPTION
### Summary

Addresses #28780

- Each sequence does not know  `increment_by` or `min_value` since
PostgreSQL 10. A new system catalog `pg_sequences` knows both. https://github.com/postgres/postgres/commit/1753b1b027035029c2a2a1649065762fafbf63f3

- Since `pg_sequences` does not exist PostgreSQL 9.6 or earlier version
This commit addresses by removing `increment_by` or `min_value`

- `setval` 3rd argument needs to set to `false` only when the table has
no rows to avoid `nextval(<sequence_name>)` returns 2 where 1 is
expected.

- Replaced `min_value` with `1` since it is necessary only when
the table has no rows. If someone wants to reset sequence to non 1 when table has no rows new pull requests/commits required.
