### PR TITLE
Explicitly require AS::Time in AS::Testing::TimeHelpers

### DIFF
--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/string/strip" # for strip_heredoc
+require "active_support/core_ext/time/calculations"
 require "concurrent/map"
 
 module ActiveSupport


### PR DESCRIPTION
If you just try to use `ActiveSupport::Testing::TimeHelpers` standalone by requiring `active_support/testing/time_helpers`, you currently get an error: ``NoMethodError: undefined method `change' for 2017-12-14 01:04:44 -0500:Time``.

9f6e82ee4783e491c20f5244a613fdeb4024beb5 added a dependency on `AS::Time` by using `AS::Time#change`.

Here's a script to reproduce the error:

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "activesupport", github: "rails/rails"
end

require "active_support/testing/time_helpers"

require "minitest/autorun"

class BugTest < Minitest::Test
  include ActiveSupport::Testing::TimeHelpers

  def test_stuff
    travel_to Time.new(2017, 12, 14, 01, 04, 44) do
      assert true
    end
  end
end
```

It currently fails for all 5.x.x versions and master.  Ideally, this would be backported to `5-0-stable` and `5-1-stable` as well.

Thanks!