### PR TITLE
Remove datetime fields from helper list [ci skip]

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -164,7 +164,7 @@ make it easier for users to click the inputs.
 
 Other form controls worth mentioning are textareas, password fields,
 hidden fields, search fields, telephone fields, date fields, time fields,
-color fields, datetime fields, datetime-local fields, month fields, week fields,
+color fields, datetime-local fields, month fields, week fields,
 URL fields, email fields, number fields and range fields:
 
 ```erb


### PR DESCRIPTION
The `datetime_field` is an alias of the `datetime_local_field`, there isno helper to generate datetime fields.
Ref: #25469
