### PR TITLE
Support for URI objects in link_to method

### DIFF
--- a/actionview/lib/action_view/routing_url_for.rb
+++ b/actionview/lib/action_view/routing_url_for.rb
@@ -78,6 +78,8 @@ module ActionView
       case options
       when String
         options
+      when URI
+        options.to_s
       when nil
         super(only_path: _generate_paths_by_default)
       when Hash

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -266,6 +266,10 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_dom_equal %{<a href="http://www.example.com">Hello</a>}, link_to("Hello", "http://www.example.com")
   end
 
+  def test_link_tag_with_uri_instance
+    assert_dom_equal %{<a href="http://www.example.com">Hello</a>}, link_to("Hello", URI("http://www.example.com"))
+  end
+
   def test_link_tag_without_host_option
     assert_dom_equal(%{<a href="/">Test Link</a>}, link_to("Test Link", url_hash))
   end


### PR DESCRIPTION
### Summary

Adds URI object support to `link_to` view method. 

For example, I have a lot of helpers in my application that use the URI object to ensure well-formed URLs like:

```ruby
def download_url(platform = "win")
  URI(ENV.fetch("APP_URL")).tap { |u| u.path = u.path.join(platform) }
end
```

Today the `link_to` helper doesn't know how to handle URI objects, thus the following template code would have to be written as follows to not result in an exception:

```erb
<%=link_to "Windows download", download_url("win").to_s %>
```

This patch makes it possible for `link_to` to accept URI objects. The resulting template code would look like:

```erb
<%=link_to "Windows download", download_url("win") %>
```

Which feels more intuitive and looks better.

### Other Information

N/A