### PR TITLE
Include gem name and deprecation horizon when calling the deprecation behaviors

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Pass gem name and deprecation horizon to deprecation notifications.
+
+    *Willem van Bergen*
+
 *   Add support for `:offset` and `:zone` to `ActiveSupport::TimeWithZone#change`
 
     *Andrew White*

--- a/activesupport/lib/active_support/deprecation.rb
+++ b/activesupport/lib/active_support/deprecation.rb
@@ -30,7 +30,7 @@ module ActiveSupport
     attr_accessor :deprecation_horizon
 
     # It accepts two parameters on initialization. The first is a version of library
-    # and the second is a library name
+    # and the second is a library name.
     #
     #   ActiveSupport::Deprecation.new('2.0', 'MyLibrary')
     def initialize(deprecation_horizon = "5.3", gem_name = "Rails")

--- a/activesupport/lib/active_support/deprecation/behaviors.rb
+++ b/activesupport/lib/active_support/deprecation/behaviors.rb
@@ -9,18 +9,18 @@ module ActiveSupport
   class Deprecation
     # Default warning behaviors per Rails.env.
     DEFAULT_BEHAVIORS = {
-      raise: ->(message, callstack) {
+      raise: ->(message, callstack, deprecation_horizon, gem_name) {
         e = DeprecationException.new(message)
         e.set_backtrace(callstack.map(&:to_s))
         raise e
       },
 
-      stderr: ->(message, callstack) {
+      stderr: ->(message, callstack, deprecation_horizon, gem_name) {
         $stderr.puts(message)
         $stderr.puts callstack.join("\n  ") if debug
       },
 
-      log: ->(message, callstack) {
+      log: ->(message, callstack, deprecation_horizon, gem_name) {
         logger =
             if defined?(Rails.logger) && Rails.logger
               Rails.logger
@@ -32,12 +32,16 @@ module ActiveSupport
         logger.debug callstack.join("\n  ") if debug
       },
 
-      notify: ->(message, callstack) {
-        ActiveSupport::Notifications.instrument("deprecation.rails",
-                                                message: message, callstack: callstack)
+      notify: ->(message, callstack, deprecation_horizon, gem_name) {
+        notification_name = "deprecation.#{gem_name.underscore.tr('/', '_')}"
+        ActiveSupport::Notifications.instrument(notification_name,
+                                                message: message,
+                                                callstack: callstack,
+                                                gem_name: gem_name,
+                                                deprecation_horizon: deprecation_horizon)
       },
 
-      silence: ->(message, callstack) {},
+      silence: ->(message, callstack, deprecation_horizon, gem_name) {},
     }
 
     # Behavior module allows to determine how to display deprecation messages.
@@ -83,8 +87,17 @@ module ActiveSupport
       #     # custom stuff
       #   }
       def behavior=(behavior)
-        @behavior = Array(behavior).map { |b| DEFAULT_BEHAVIORS[b] || b }
+        @behavior = Array(behavior).map { |b| DEFAULT_BEHAVIORS[b] || arity_coerce(b) }
       end
+
+      private
+        def arity_coerce(behavior)
+          if behavior.arity == 4 || behavior.arity == -1
+            behavior
+          else
+            -> message, callstack, _, _ { behavior.call(message, callstack) }
+          end
+        end
     end
   end
 end

--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -18,7 +18,7 @@ module ActiveSupport
 
         callstack ||= caller_locations(2)
         deprecation_message(callstack, message).tap do |m|
-          behavior.each { |b| b.call(m, callstack) }
+          behavior.each { |b| b.call(m, callstack, deprecation_horizon, gem_name) }
         end
       end
 


### PR DESCRIPTION
### Summary

We are planning to use `ActiveSupport::Deprecation` in our own code base to mark deprecated behavior. We have some tooling subscribing to the `ActiveSupport::Notifications` that are generated by the deprecations. 

However, for our tooling we would like to be able to make sure we can differentiate between the source of the deprecation. ActiveSupport::Deprecation already has useful context for this: gem name, and deprecation horizon. Unfortunately, these pieces of metadata are not made available to the behavior lambdas. 

This PR exposes them as extra arguments, and makes sure those arguments are passed on to the `ActiveSupport::Notification` we create. As part of this, we also dynamically generate the notification name based on the gem name. It was hardcoded to `deprecations.rails` before. All the other predefined behaviors are unaffected by this.

cc @rafaelfranca @casperisfine
