### PR TITLE
Make README's welcome section a bit easier to read

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to Rails
 
-Rails is a web-application framework that includes everything needed to
+**Rails** is a web-application framework that includes everything needed to
 create database-backed web applications according to the
 [Model-View-Controller (MVC)](http://en.wikipedia.org/wiki/Model-view-controller)
 pattern.
@@ -8,39 +8,38 @@ pattern.
 Understanding the MVC pattern is key to understanding Rails. MVC divides your
 application into three layers, each with a specific responsibility.
 
-The _Model layer_ represents your domain model (such as Account, Product,
-Person, Post, etc.) and encapsulates the business logic that is specific to
+The **Model layer** represents your domain model (such as Account, Product,
+or Person) and encapsulates the business logic that is specific to
 your application. In Rails, database-backed model classes are derived from
-`ActiveRecord::Base`. Active Record allows you to present the data from
+`ActiveRecord::Base`.
+[Active Record](activerecord/README.rdoc) allows you to present the data from
 database rows as objects and embellish these data objects with business logic
-methods. You can read more about Active Record in its [README](activerecord/README.rdoc).
+methods.
 Although most Rails models are backed by a database, models can also be ordinary
 Ruby classes, or Ruby classes that implement a set of interfaces as provided by
-the Active Model module. You can read more about Active Model in its [README](activemodel/README.rdoc).
+the [Active Model](activemodel/README.rdoc) module.
 
-The _Controller layer_ is responsible for handling incoming HTTP requests and
+The **Controller layer** is responsible for handling incoming HTTP requests and
 providing a suitable response. Usually this means returning HTML, but Rails controllers
 can also generate XML, JSON, PDFs, mobile-specific views, and more. Controllers load and
 manipulate models, and render view templates in order to generate the appropriate HTTP response.
 In Rails, incoming requests are routed by Action Dispatch to an appropriate controller, and
 controller classes are derived from `ActionController::Base`. Action Dispatch and Action Controller
-are bundled together in Action Pack. You can read more about Action Pack in its
-[README](actionpack/README.rdoc).
+are bundled together in [Action Pack](actionpack/README.rdoc).
 
-The _View layer_ is composed of "templates" that are responsible for providing
+The **View layer** is composed of templates that are responsible for providing
 appropriate representations of your application's resources. Templates can
 come in a variety of formats, but most view templates are HTML with embedded
 Ruby code (ERB files). Views are typically rendered to generate a controller response,
-or to generate the body of an email. In Rails, View generation is handled by Action View.
-You can read more about Action View in its [README](actionview/README.rdoc).
+or to generate the body of an email. In Rails, View generation is handled by [Action View](actionview/README.rdoc).
 
 Active Record, Active Model, Action Pack, and Action View can each be used independently outside Rails.
-In addition to that, Rails also comes with Action Mailer ([README](actionmailer/README.rdoc)), a library
-to generate and send emails; Active Job ([README](activejob/README.md)), a
+In addition to that, Rails also comes with [Action Mailer](actionmailer/README.rdoc), a library
+to generate and send emails; [Active Job](activejob/README.md), a
 framework for declaring jobs and making them run on a variety of queueing
-backends; Action Cable ([README](actioncable/README.md)), a framework to
+backends; [Action Cable](actioncable/README.md), a framework to
 integrate WebSockets with a Rails application;
-and Active Support ([README](activesupport/README.rdoc)), a collection
+and [Active Support](activesupport/README.rdoc), a collection
 of utility classes and standard library extensions that are useful for Rails,
 and may also be used independently outside Rails.
 


### PR DESCRIPTION
I noticed the README file is actually hard to read because of all the, well, README links to the major modules. Instead I linked the modules directly and also highlighted the M, C and V to help the reader jump through the text quicker.