### PR TITLE
Improve the upgrade path of Strong Parameters in 5-0-stable

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,41 @@
+*   Raise exception when calling `to_h` in an unfiltered Parameters.
+
+    This method will raise on unfiltered Parameters if
+    `config.action_controller.raise_on_unfiltered_parameters` is true.
+
+    Before we returned either an empty hash or only the always permitted parameters
+    (`:controller` and `:action` by default).
+
+    The previous behavior was dangerous because in order to get the attributes users
+    usually fallback to use `to_unsafe_h` that could potentially introduce security issues.
+
+    *Rafael Mendonça França*
+
+*   Add `ActionController::Parameters#to_hash` to implicit conversion.
+
+    Now methods that implicit convert objects to a hash will be able to work without
+    requiring the users to change their implementation.
+
+    This method will return a `Hash` instead of a `ActiveSupport::HashWithIndefirentAccess`
+    to mimic the same implementation of `ActiveSupport::HashWithIndefirentAccess#to_hash`.
+
+    This method will raise on unfiltered Parameters if
+    `config.action_controller.raise_on_unfiltered_parameters` is true.
+
+    *Rafael Mendonça França*
+
+*   Undeprecate `ActionController::Parameters#to_query` and `#to_param`.
+
+    Previously it was raising a deprecation because it may be unsafe to use those methods
+    in an unfiltered parameter. Now we delegate to `#to_h` that already raise an error when
+    the Parameters instance is not permitted.
+
+    This also fix a bug when using `#to_query` in a hash that contains a
+    `ActionController::Parameters` instance and was returning the name of the class in the
+    string.
+
+    *Rafael Mendonça França*
+
 *   Use more specific check for :format in route path
 
     The current check for whether to add an optional format to the path is very lax

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -27,6 +27,7 @@ module ActionController
         ActionController::Parameters.always_permitted_parameters =
           app.config.action_controller.delete(:always_permitted_parameters)
       end
+      ActionController::Parameters.raise_on_unfiltered_parameters = options.delete(:raise_on_unfiltered_parameters) { false }
       ActionController::Parameters.action_on_unpermitted_parameters = options.delete(:action_on_unpermitted_parameters) do
         (Rails.env.test? || Rails.env.development?) ? :log : false
       end

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -296,16 +296,29 @@ class ParametersPermitTest < ActiveSupport::TestCase
   end
 
   test "to_h returns empty hash on unpermitted params" do
-    assert @params.to_h.is_a? ActiveSupport::HashWithIndifferentAccess
-    assert_not @params.to_h.is_a? ActionController::Parameters
-    assert @params.to_h.empty?
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, @params.to_h
+    assert_not_kind_of ActionController::Parameters, @params.to_h
+    assert_empty @params.to_h
+  end
+
+  test "to_h raises UnfilteredParameters on unfiltered params if raise_on_unfiltered_parameters is true" do
+    begin
+      old_value = ActionController::Parameters.raise_on_unfiltered_parameters
+      ActionController::Parameters.raise_on_unfiltered_parameters = true
+
+      assert_raises(ActionController::UnfilteredParameters) do
+        @params.to_h
+      end
+    ensure
+      ActionController::Parameters.raise_on_unfiltered_parameters = old_value
+    end
   end
 
   test "to_h returns converted hash on permitted params" do
     @params.permit!
 
-    assert @params.to_h.is_a? ActiveSupport::HashWithIndifferentAccess
-    assert_not @params.to_h.is_a? ActionController::Parameters
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, @params.to_h
+    assert_not_kind_of ActionController::Parameters, @params.to_h
   end
 
   test "to_h returns converted hash when .permit_all_parameters is set" do
@@ -313,37 +326,108 @@ class ParametersPermitTest < ActiveSupport::TestCase
       ActionController::Parameters.permit_all_parameters = true
       params = ActionController::Parameters.new(crab: "Senjougahara Hitagi")
 
-      assert params.to_h.is_a? ActiveSupport::HashWithIndifferentAccess
-      assert_not @params.to_h.is_a? ActionController::Parameters
+      assert_instance_of ActiveSupport::HashWithIndifferentAccess, params.to_h
+      assert_not_kind_of ActionController::Parameters, params.to_h
       assert_equal({ "crab" => "Senjougahara Hitagi" }, params.to_h)
     ensure
       ActionController::Parameters.permit_all_parameters = false
     end
   end
 
-  test "to_h returns always permitted parameter on unpermitted params" do
-    params = ActionController::Parameters.new(
-      controller: "users",
-      action: "create",
-      user: {
-        name: "Sengoku Nadeko"
-      }
-    )
+  test "to_hash returns unfiltered params" do
+    assert_not_respond_to @params, :to_hash
 
-    assert_equal({ "controller" => "users", "action" => "create" }, params.to_h)
+    assert_deprecated do
+      assert_instance_of Hash, @params.to_hash
+    end
+    assert_deprecated do
+      assert_not_kind_of ActionController::Parameters, @params.to_hash
+    end
+    assert_deprecated do
+      assert_equal({
+        "person" => {
+          "age" => "32",
+          "name" => {
+            "first" => "David",
+            "last" => "Heinemeier Hansson"
+          },
+          "addresses" => [
+            {
+              "city" => "Chicago",
+              "state" => "Illinois"
+            }
+          ]
+        }
+      }, @params.to_hash)
+    end
+  end
+
+  test "to_hash raises UnfilteredParameters on unfiltered params if raise_on_unfiltered_parameters is true" do
+    begin
+      old_value = ActionController::Parameters.raise_on_unfiltered_parameters
+      ActionController::Parameters.raise_on_unfiltered_parameters = true
+
+      assert_respond_to @params, :to_hash
+
+      assert_raises(ActionController::UnfilteredParameters) do
+        @params.to_hash
+      end
+    ensure
+      ActionController::Parameters.raise_on_unfiltered_parameters = old_value
+    end
+  end
+
+  test "to_hash returns converted hash on permitted params" do
+    @params.permit!
+
+    assert_deprecated do
+      assert_instance_of Hash, @params.to_hash
+    end
+    assert_deprecated do
+      assert_not_kind_of ActionController::Parameters, @params.to_hash
+    end
+  end
+
+  test "to_hash returns converted hash when .permit_all_parameters is set" do
+    begin
+      ActionController::Parameters.permit_all_parameters = true
+      params = ActionController::Parameters.new(crab: "Senjougahara Hitagi")
+
+      assert_deprecated do
+        assert_instance_of Hash, params.to_hash
+      end
+      assert_deprecated do
+        assert_not_kind_of ActionController::Parameters, params.to_hash
+      end
+      assert_deprecated do
+        assert_equal({ "crab" => "Senjougahara Hitagi" }, params.to_hash)
+      end
+    ensure
+      ActionController::Parameters.permit_all_parameters = false
+    end
   end
 
   test "to_unsafe_h returns unfiltered params" do
-    assert @params.to_unsafe_h.is_a? ActiveSupport::HashWithIndifferentAccess
-    assert_not @params.to_unsafe_h.is_a? ActionController::Parameters
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, @params.to_unsafe_h
+    assert_not_kind_of ActionController::Parameters, @params.to_unsafe_h
   end
 
   test "to_unsafe_h returns unfiltered params even after accessing few keys" do
     params = ActionController::Parameters.new("f"=>{"language_facet"=>["Tibetan"]})
     expected = {"f"=>{"language_facet"=>["Tibetan"]}}
 
-    assert params['f'].is_a? ActionController::Parameters
+    assert_instance_of ActionController::Parameters, params["f"]
     assert_equal expected, params.to_unsafe_h
+  end
+
+  test "to_unsafe_h does not mutate the parameters" do
+    params = ActionController::Parameters.new("f" => { "language_facet" => ["Tibetan"] })
+    params[:f]
+
+    params.to_unsafe_h
+
+    assert_not_predicate params, :permitted?
+    assert_not_predicate params[:f], :permitted?
   end
 
   test "to_h only deep dups Ruby collections" do

--- a/actionpack/test/controller/required_params_test.rb
+++ b/actionpack/test/controller/required_params_test.rb
@@ -79,9 +79,41 @@ class ParametersRequireTest < ActiveSupport::TestCase
     end
   end
 
-  test "to_query is not supported" do
-    assert_deprecated do
-      ActionController::Parameters.new(foo: "bar").to_param
+  test "to_param works like in a Hash" do
+    params = ActionController::Parameters.new(nested: { key: "value" }).permit!
+    assert_equal({ nested: { key: "value" } }.to_param, params.to_param)
+
+    params = { root: ActionController::Parameters.new(nested: { key: "value" }).permit! }
+    assert_equal({ root: { nested: { key: "value" } } }.to_param, params.to_param)
+
+    begin
+      old_value = ActionController::Parameters.raise_on_unfiltered_parameters
+      ActionController::Parameters.raise_on_unfiltered_parameters = true
+
+      assert_raise(ActionController::UnfilteredParameters) do
+        ActionController::Parameters.new(nested: { key: "value" }).to_param
+      end
+    ensure
+      ActionController::Parameters.raise_on_unfiltered_parameters = old_value
+    end
+  end
+
+  test "to_query works like in a Hash" do
+    params = ActionController::Parameters.new(nested: { key: "value" }).permit!
+    assert_equal({ nested: { key: "value" } }.to_query, params.to_query)
+
+    params = { root: ActionController::Parameters.new(nested: { key: "value" }).permit! }
+    assert_equal({ root: { nested: { key: "value" } } }.to_query, params.to_query)
+
+    begin
+      old_value = ActionController::Parameters.raise_on_unfiltered_parameters
+      ActionController::Parameters.raise_on_unfiltered_parameters = true
+
+      assert_raise(ActionController::UnfilteredParameters) do
+        ActionController::Parameters.new(nested: { key: "value" }).to_query
+      end
+    ensure
+      ActionController::Parameters.raise_on_unfiltered_parameters = old_value
     end
   end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -372,6 +372,8 @@ The schema dumper adds one additional configuration option:
 
 * `config.action_controller.action_on_unpermitted_parameters` enables logging or raising an exception if parameters that are not explicitly permitted are found. Set to `:log` or `:raise` to enable. The default value is `:log` in development and test environments, and `false` in all other environments.
 
+* `config.action_controller.raise_on_unfiltered_parameters` make hash conversion of the parameters raise an error if they are not permitted.
+
 * `config.action_controller.always_permitted_parameters` sets a list of whitelisted parameters that are permitted by default. The default values are `['controller', 'action']`.
 
 ### Configuring Action Dispatch

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
@@ -7,6 +7,8 @@
 #
 <%- end -%>
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
+
+Rails.application.config.raise_on_unfiltered_parameters = true
 <%- unless options[:api] -%>
 
 # Enable per-form CSRF tokens. Previous versions had false.


### PR DESCRIPTION
Similar to https://github.com/rails/rails/pull/28734. The differences are:

* `to_h` and `to_hash` only raises when `config.action_controller.raise_on_unpermitted_parameters` is true (default to false in existing application and true in new applications).

* The places where it was already raising are not reusing the `to_h` implementation.