### PR TITLE
assert_differences - for testing mutiple values that change at different rates

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `assert_differences` to `ActiveSupport::Testing::Assertions`
+
+    The method allows allows testing of multiple changing values.
+
+    *Kieran Eglin*
+    
 *   Pass gem name and deprecation horizon to deprecation notifications.
 
     *Willem van Bergen*

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -56,7 +56,7 @@ module ActiveSupport
       #     post :create, params: { article: {...} }
       #   end
       #
-      # A lambda or a list of lambdas can be passed in and evaluated:
+      # A lambda or a list of lambdas can be passed in and evaluated.
       #
       #   assert_differences [->{ Article.count }, 2] do
       #     post :create, params: { article: {...} }

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -30,6 +30,71 @@ module ActiveSupport
         yield
       end
 
+      # Test varying numeric difference between the return value of an expression as a
+      # result of what is evaluated in the yielded block.
+      #
+      #   assert_differences ['Article.count'] do
+      #     post :create, params: { article: {...} }
+      #   end
+      #
+      # An arbitrary expression is passed in and evaluated.
+      #
+      #   assert_differences ['Article.last.comments(:reload).size'] do
+      #     post :create, params: { comment: {...} }
+      #   end
+      #
+      # An arbitrary positive or negative difference can be specified.
+      # The default is <tt>1</tt>.
+      #
+      #   assert_differences ['Article.count', -1] do
+      #     post :delete, params: { id: ... }
+      #   end
+      #
+      # An array of expressions and the predicted change can also be passed in and evaluated.
+      #
+      #   assert_differences [ ['Article.count', 2], ['Post.count', 1] ] do
+      #     post :create, params: { article: {...} }
+      #   end
+      #
+      # A lambda or a list of lambdas can be passed in and evaluated:
+      #
+      #   assert_differences [->{ Article.count }, 2] do
+      #     post :create, params: { article: {...} }
+      #   end
+      #
+      #   assert_differences [ [->{ Article.count }, 2], [->{ Post.count }, 1] ] do
+      #     post :create, params: { article: {...} }
+      #   end
+      #
+      # An error message can be specified.
+      #
+      #   assert_differences ['Article.count', -1], 'An Article should be destroyed' do
+      #     post :delete, params: { id: ... }
+      #   end
+      def assert_differences(expression_array, message = nil, &block)
+        expressions = Array(expression_array)
+        expressions = [expressions] unless expressions.all? { |e| e.kind_of? Array }
+
+        exps = expressions.map do |e|
+          callable = e.first.respond_to?(:call) ? e.first : lambda { eval(e.first, block.binding) }
+          {
+            callable: callable,
+            before: callable.call
+          }
+        end
+
+        retval = yield
+
+        expressions.zip(exps).each do |code, e|
+          difference = code[1] || 1
+          error      = "#{code.first.inspect} didn't change by #{difference}"
+          error      = "#{message}.\n#{error}" if message
+          assert_equal(e[:before] + difference, e[:callable].call, error)
+        end
+
+        retval
+      end
+
       # Test numeric difference between the return value of an expression as a
       # result of what is evaluated in the yielded block.
       #
@@ -72,22 +137,8 @@ module ActiveSupport
       #     post :delete, params: { id: ... }
       #   end
       def assert_difference(expression, difference = 1, message = nil, &block)
-        expressions = Array(expression)
-
-        exps = expressions.map { |e|
-          e.respond_to?(:call) ? e : lambda { eval(e, block.binding) }
-        }
-        before = exps.map(&:call)
-
-        retval = yield
-
-        expressions.zip(exps).each_with_index do |(code, e), i|
-          error  = "#{code.inspect} didn't change by #{difference}"
-          error  = "#{message}.\n#{error}" if message
-          assert_equal(before[i] + difference, e.call, error)
-        end
-
-        retval
+        expressions = Array(expression).map { |e| [e, difference] }
+        assert_differences expressions, message, &block
       end
 
       # Assertion that the numeric result of evaluating an expression is not

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -56,6 +56,12 @@ class AssertDifferenceTest < ActiveSupport::TestCase
     end
   end
 
+  def test_assert_difference_array_of_expressions
+    assert_difference ["@object.num", "@object.num + 1"] do
+      @object.increment
+    end
+  end
+
   def test_assert_difference_fail
     error = assert_raises(Minitest::Assertion) do
       assert_difference "@object.num" do

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -50,35 +50,59 @@ class AssertDifferenceTest < ActiveSupport::TestCase
     assert_equal "Object Changed.\n\"@object.num\" didn't change by 0.\nExpected: 0\n  Actual: 1", error.message
   end
 
-  def test_assert_difference
-    assert_difference "@object.num", +1 do
+  def test_assert_difference_pass
+    assert_difference "@object.num" do
       @object.increment
     end
   end
 
-  def test_assert_difference_retval
-    incremented = assert_difference "@object.num", +1 do
+  def test_assert_difference_fail
+    error = assert_raises(Minitest::Assertion) do
+      assert_difference "@object.num" do
+        # ...
+      end
+    end
+    assert_equal "\"@object.num\" didn't change by 1.\nExpected: 1\n  Actual: 0", error.message
+  end
+
+  def test_assert_difference_with_message_fail
+    error = assert_raises(Minitest::Assertion) do
+      assert_difference "@object.num", 1, "Object Changed" do
+        # ...
+      end
+    end
+    assert_equal "Object Changed.\n\"@object.num\" didn't change by 1.\nExpected: 1\n  Actual: 0", error.message
+  end
+
+  def test_assert_differences
+    assert_differences ["@object.num", +1] do
+      @object.increment
+    end
+  end
+
+  def test_assert_differences_retval
+    incremented = assert_differences ["@object.num", +1] do
       @object.increment
     end
 
     assert_equal incremented, 1
   end
 
-  def test_assert_difference_with_implicit_difference
-    assert_difference "@object.num" do
+  def test_assert_differences_with_implicit_difference
+    assert_differences ["@object.num"] do
       @object.increment
     end
   end
 
   def test_arbitrary_expression
-    assert_difference "@object.num + 1", +2 do
+    assert_differences ["@object.num + 1", +2] do
       @object.increment
       @object.increment
     end
   end
 
   def test_negative_differences
-    assert_difference "@object.num", -1 do
+    assert_differences ["@object.num", -1] do
       @object.decrement
     end
   end
@@ -86,19 +110,21 @@ class AssertDifferenceTest < ActiveSupport::TestCase
   def test_expression_is_evaluated_in_the_appropriate_scope
     silence_warnings do
       local_scope = local_scope = "foo"
-      assert_difference("local_scope; @object.num") { @object.increment }
+      assert_differences(["local_scope; @object.num"]) { @object.increment }
     end
   end
 
   def test_array_of_expressions
-    assert_difference [ "@object.num", "@object.num + 1" ], +1 do
+    @object2 = @object.dup
+    assert_differences [ ["@object.num", +1], ["@object2.num", -1] ] do
       @object.increment
+      @object2.decrement
     end
   end
 
   def test_array_of_expressions_identify_failure
     assert_raises(Minitest::Assertion) do
-      assert_difference ["@object.num", "1 + 1"] do
+      assert_differences [ ["@object.num"], ["1 + 1"] ] do
         @object.increment
       end
     end
@@ -106,10 +132,18 @@ class AssertDifferenceTest < ActiveSupport::TestCase
 
   def test_array_of_expressions_identify_failure_when_message_provided
     assert_raises(Minitest::Assertion) do
-      assert_difference ["@object.num", "1 + 1"], 1, "something went wrong" do
+      assert_differences [ ["@object.num", 1], ["1 + 1", 1] ], "something went wrong" do
         @object.increment
       end
     end
+  end
+
+  def test_assert_differences_with_message_fail
+    error = assert_raises(Minitest::Assertion) do
+      assert_differences ["@object.num"], "Object Didn't Change" do
+      end
+    end
+    assert_equal "Object Didn't Change.\n\"@object.num\" didn't change by 1.\nExpected: 1\n  Actual: 0", error.message
   end
 
   def test_assert_changes_pass


### PR DESCRIPTION
### Summary

(This is my first PR to a big project, so let me know if I missed anything!)

Several times, I've wanted to test that 2+ values are changed by an action.  But what if we expect `model_1` to change by +1, while `model_2` changes by -1?  You can nest calls to `assert_difference`, but what if you need to check 3 values?  That would get ugly fairly quickly.

That is why I worked on `assert_differences`.  Influenced *heavily* by [Malcolm at wholemeal](http://wholemeal.co.nz/blog/2011/04/06/assert-difference-with-multiple-count-values/), you can use it like so:

```ruby
assert_differences [ ['Foo.count', +1], ['Bar.count', -1], ['Baz.count', +2] ] do
  #...
end
```

I tried my best to emulate the code style of the existing `assert_difference`.  Furthermore, `assert_difference` now calls the new `assert_differences`.  

The API for `assert_difference` has not changed at all and should be 100% back-compatible.

### Other Information

#### The name

I've tested the waters on StackOverflow and /r/rails.  Devs really seem to like the idea of this, but some don't love the name, stating it's too close the the existing `assert_difference`.

While I'm not sold on the idea that having a similar name is an issue, I'm very open to a name change!

___

If there's anything I missed, please let me know :) 
