### PR TITLE
Fix automatic inverse for polymorphic interfaces

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -567,7 +567,7 @@ module ActiveRecord
       end
 
       VALID_AUTOMATIC_INVERSE_MACROS = [:has_many, :has_one, :belongs_to]
-      INVALID_AUTOMATIC_INVERSE_OPTIONS = [:conditions, :through, :polymorphic, :foreign_key]
+      INVALID_AUTOMATIC_INVERSE_OPTIONS = [:conditions, :through, :foreign_key]
 
       def add_as_source(seed)
         seed
@@ -640,9 +640,8 @@ module ActiveRecord
         # us from being able to guess the inverse automatically. First, the
         # <tt>inverse_of</tt> option cannot be set to false. Second, we must
         # have <tt>has_many</tt>, <tt>has_one</tt>, <tt>belongs_to</tt> associations.
-        # Third, we must not have options such as <tt>:polymorphic</tt> or
-        # <tt>:foreign_key</tt> which prevent us from correctly guessing the
-        # inverse association.
+        # Third, we must not have options such as <tt>:foreign_key</tt>
+        # which prevent us from correctly guessing the inverse association.
         #
         # Anything with a scope can additionally ruin our attempt at finding an
         # inverse, so we exclude reflections with scopes.

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -241,6 +241,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal "defaulty", bulb.name
   end
 
+  def test_build_from_association_sets_inverse_instance
+    car = Car.new(name: "honda")
+
+    bulb = car.bulbs.build
+    assert_equal car, bulb.car
+  end
+
   def test_do_not_call_callbacks_for_delete_all
     car = Car.create(name: "honda")
     car.funky_bulbs.create!
@@ -2144,6 +2151,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal welcome.id, tagging.taggable_id
     assert_equal "Post", tagging.taggable_type
+  end
+
+  def test_build_from_polymorphic_association_sets_inverse_instance
+    post = Post.new
+    tagging = post.taggings.build
+
+    assert_equal post, tagging.taggable
   end
 
   def test_dont_call_save_callbacks_twice_on_has_many

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -116,15 +116,11 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     assert !club_reflection.has_inverse?, "A has_many_through association should not find an inverse automatically"
   end
 
-  def test_polymorphic_relationships_should_still_not_have_inverses_when_non_polymorphic_relationship_has_the_same_name
+  def test_polymorphic_has_one_should_find_inverse_automatically
     man_reflection = Man.reflect_on_association(:polymorphic_face_without_inverse)
-    face_reflection = Face.reflect_on_association(:man)
-
-    assert_respond_to face_reflection, :has_inverse?
-    assert face_reflection.has_inverse?, "For this test, the non-polymorphic association must have an inverse"
 
     assert_respond_to man_reflection, :has_inverse?
-    assert !man_reflection.has_inverse?, "The target of a polymorphic association should not find an inverse automatically"
+    assert man_reflection.has_inverse?
   end
 end
 


### PR DESCRIPTION
### Summary

This is a fix for an issue I encountered (#21843) with polymorphic relationships, but also solves another issue with `touch: true` not working for polymorphic relationships (#16446). This PR solves the same problem as #16448, albeit a bit differently.

These issues can be solved by manually setting the `inverse_of`-option, however it is quite confusing that it works for 'normal' relationships, but not for polymorphic ones. It's also not really documented that you need to set `inverse_of` for these things to work (I checked docs & guides for the :touch option). 

This PR solves these problems by removing `:polymorphic` from the `INVALID_AUTOMATIC_INVERSE_OPTIONS`-array. The logic behind this is: `belongs_to ..., polymorhic: true` will still fail the `automatic_inverse_of` lookup because it would fail later when doing the klass or reflection lookup. However, `can_find_inverse_of_automatically?` will not return false for polymorphic relationships, thus `valid_inverse_reflection?` will return true for polymorphic interfaces, which leads to a successful automatic inverse_of lookup. Which will fix the above issues.

### Other Information
A drawback is that more exceptions will be raised / rescued when trying to do the automatic lookup for polymorphic relationships, which is slow. But I honestly don't think that this has any measureable effect. Also, we could cache the value of `automatic_inverse_of` for falsey cases if this is a concern.

Also the name of the method `can_find_inverse_of_automatically?` is a bit confusing, because it implies that the inverse lookup can be looked up if this returns true, while it only means that the inverse lookup will be attempted if it returns true. This is now even more true because we removed :polymorphic from the list of checks carried out in this method.

While writing this issue I noticed that for polymorphic interfaces, the `:as` option must always be passed, and always indicates the reverse relationship (if I'm not missing something). Maybe it is possible to short-circuit `automatic_inverse_of`-method to return `options[:as]` early in case it is specified? That's maybe an even simpler fix for this problem.