### PR TITLE
Allow Rails apps to create their own Thor commands

### DIFF
--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -66,15 +66,6 @@ module Rails
         namespaces[(lookups & namespaces.keys).first]
       end
 
-      # Returns the root of the Rails engine or app running the command.
-      def root
-        if defined?(ENGINE_ROOT)
-          Pathname.new(ENGINE_ROOT)
-        elsif defined?(APP_PATH)
-          Pathname.new(File.expand_path("../..", APP_PATH))
-        end
-      end
-
       def print_commands # :nodoc:
         sorted_groups.each { |b, n| print_list(b, n) }
       end

--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -28,18 +28,13 @@ module Rails
 
       # Receives a namespace, arguments and the behavior to invoke the command.
       def invoke(full_namespace, args = [], **config)
-        namespace = full_namespace = full_namespace.to_s
+        full_namespace = String(full_namespace)
 
-        if char = namespace =~ /:(\w+)$/
-          command_name, namespace = $1, namespace.slice(0, char)
-        else
-          command_name = namespace
-        end
-
-        command_name, namespace = "help", "help" if command_name.blank? || HELP_MAPPINGS.include?(command_name)
-        command_name, namespace = "version", "version" if %w( -v --version ).include?(command_name)
+        namespace, command_name = full_namespace.split(/:(\w+)$/)
+        command_name = namespace if command_name.blank?
 
         command = find_by_namespace(namespace, command_name)
+
         if command && command.all_commands[command_name]
           command.perform(command_name, args, config)
         else

--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -1,16 +1,22 @@
 require "rails/command"
 
 aliases = {
-  "g"  => "generate",
-  "d"  => "destroy",
-  "c"  => "console",
-  "s"  => "server",
-  "db" => "dbconsole",
-  "r"  => "runner",
-  "t"  => "test"
+  "g"         => "generate",
+  "d"         => "destroy",
+  "c"         => "console",
+  "s"         => "server",
+  "db"        => "dbconsole",
+  "r"         => "runner",
+  "t"         => "test",
+  ""          => "help",
+  "-h"        => "help",
+  "-?"        => "help",
+  "-help"     => "help",
+  "--version" => "version",
+  "-v"        => "version"
 }
 
-command = ARGV.shift
+command = String(ARGV.shift)
 command = aliases[command] || command
 
 Rails::Command.invoke command, ARGV

--- a/railties/test/command_test.rb
+++ b/railties/test/command_test.rb
@@ -1,0 +1,46 @@
+require "isolation/abstract_unit"
+
+class Rails::CommandTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  def setup
+    build_app
+    create_command
+  end
+
+  def teardown
+    teardown_app
+  end
+
+  test "Rails Help Command prints user created commands in apps" do
+    assert_match "Foo:", Dir.chdir(app_path) { `bin/rails help` }
+  end
+
+  test "user created command can be executed" do
+    assert_match "FooBarFoo!", Dir.chdir(app_path) { `bin/rails foo` }
+  end
+
+  private
+
+    def create_command
+      Dir.chdir("#{app_path}/app") do
+        Dir.mkdir("commands")
+        Dir.mkdir("commands/foo")
+        Dir.chdir("commands/foo") do
+          File.open("foo_command.rb", "w") do |f|
+            f.write %q(
+              module Foo
+                module Command
+                  class FooCommand < Rails::Command::Base
+                    def foo
+                      puts "FooBarFoo!"
+                    end
+                  end
+                end
+              end
+            )
+          end
+        end
+      end
+    end
+end


### PR DESCRIPTION
### Summary

This modification takes the first step and adds Rails apps to the `$LOAD_PATH` giving applications the ability to add their own commands. 

### Other Information

While Rails has great support for adding Rake tasks there is currently no support for adding Thor commands, despite Thor playing an active role internally. I find Thor commands to be better for handling more sophisticated interaction from the user and they're great for testing. There already seems to be solid conventions in place for Rails/Thor commands for either engines or applications however, this is currently undocumented and impossible to use because the `rails` command does not search Rails applications for commands. 

If this looks plausible, I'll further document the process of adding commands, explaining naming conventions and lookup directories. I would also be happy to create generators that follow these conventions.