### PR TITLE
Namespace CSS selectors on error pages

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,1 +1,8 @@
+*   Namespace error pages' CSS selectors to stop the styles from bleeding into other pages
+    when using Turbolinks. 
+    
+    *Jan Krutisch*
+
+    
+
 Please check [5-1-stable](https://github.com/rails/rails/blob/5-1-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/generators/rails/app/templates/public/404.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/404.html
@@ -4,7 +4,7 @@
   <title>The page you were looking for doesn't exist (404)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
-  body {
+  .rails-default-error-page {
     background-color: #EFEFEF;
     color: #2E2F30;
     text-align: center;
@@ -12,13 +12,13 @@
     margin: 0;
   }
 
-  div.dialog {
+  .rails-default-error-page div.dialog {
     width: 95%;
     max-width: 33em;
     margin: 4em auto 0;
   }
 
-  div.dialog > div {
+  .rails-default-error-page div.dialog > div {
     border: 1px solid #CCC;
     border-right-color: #999;
     border-left-color: #999;
@@ -31,13 +31,13 @@
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
-  h1 {
+  .rails-default-error-page h1 {
     font-size: 100%;
     color: #730E15;
     line-height: 1.5em;
   }
 
-  div.dialog > p {
+  .rails-default-error-page div.dialog > p {
     margin: 0 0 1em;
     padding: 1em;
     background-color: #F7F7F7;
@@ -54,7 +54,7 @@
   </style>
 </head>
 
-<body>
+<body class="rails-default-error-page">
   <!-- This file lives in public/404.html -->
   <div class="dialog">
     <div>

--- a/railties/lib/rails/generators/rails/app/templates/public/422.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/422.html
@@ -4,7 +4,7 @@
   <title>The change you wanted was rejected (422)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
-  body {
+  .rails-default-error-page {
     background-color: #EFEFEF;
     color: #2E2F30;
     text-align: center;
@@ -12,13 +12,13 @@
     margin: 0;
   }
 
-  div.dialog {
+  .rails-default-error-page div.dialog {
     width: 95%;
     max-width: 33em;
     margin: 4em auto 0;
   }
 
-  div.dialog > div {
+  .rails-default-error-page div.dialog > div {
     border: 1px solid #CCC;
     border-right-color: #999;
     border-left-color: #999;
@@ -31,13 +31,13 @@
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
-  h1 {
+  .rails-default-error-page h1 {
     font-size: 100%;
     color: #730E15;
     line-height: 1.5em;
   }
 
-  div.dialog > p {
+  .rails-default-error-page div.dialog > p {
     margin: 0 0 1em;
     padding: 1em;
     background-color: #F7F7F7;
@@ -54,7 +54,7 @@
   </style>
 </head>
 
-<body>
+<body class="rails-default-error-page">
   <!-- This file lives in public/422.html -->
   <div class="dialog">
     <div>

--- a/railties/lib/rails/generators/rails/app/templates/public/500.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/500.html
@@ -4,7 +4,7 @@
   <title>We're sorry, but something went wrong (500)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
-  body {
+  .rails-default-error-page {
     background-color: #EFEFEF;
     color: #2E2F30;
     text-align: center;
@@ -12,13 +12,13 @@
     margin: 0;
   }
 
-  div.dialog {
+  .rails-default-error-page div.dialog {
     width: 95%;
     max-width: 33em;
     margin: 4em auto 0;
   }
 
-  div.dialog > div {
+  .rails-default-error-page div.dialog > div {
     border: 1px solid #CCC;
     border-right-color: #999;
     border-left-color: #999;
@@ -31,13 +31,13 @@
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
-  h1 {
+  .rails-default-error-page h1 {
     font-size: 100%;
     color: #730E15;
     line-height: 1.5em;
   }
 
-  div.dialog > p {
+  .rails-default-error-page div.dialog > p {
     margin: 0 0 1em;
     padding: 1em;
     background-color: #F7F7F7;
@@ -54,7 +54,7 @@
   </style>
 </head>
 
-<body>
+<body class="rails-default-error-page">
   <!-- This file lives in public/500.html -->
   <div class="dialog">
     <div>


### PR DESCRIPTION
### Summary

The css selectors on the generated error pages are too broad (for example `text-align: center` on `body` and thus bleed out to the following pages (say, by pressing the back button) when using Turbolinks. The commit namespaces all the selectors.

This would fix #28813

