### PR TITLE
Fixes Hash.from_xml with frozen strings for all engines

### DIFF
--- a/activesupport/lib/active_support/xml_mini/libxml.rb
+++ b/activesupport/lib/active_support/xml_mini/libxml.rb
@@ -14,11 +14,9 @@ module ActiveSupport
         data = StringIO.new(data || "")
       end
 
-      char = data.getc
-      if char.nil?
+      if data.eof?
         {}
       else
-        data.ungetc(char)
         LibXML::XML::Parser.io(data).parse.to_hash
       end
     end

--- a/activesupport/lib/active_support/xml_mini/libxmlsax.rb
+++ b/activesupport/lib/active_support/xml_mini/libxmlsax.rb
@@ -65,12 +65,9 @@ module ActiveSupport
         data = StringIO.new(data || "")
       end
 
-      char = data.getc
-      if char.nil?
+      if data.eof?
         {}
       else
-        data.ungetc(char)
-
         LibXML::XML::Error.set_handler(&LibXML::XML::Error::QUIET_HANDLER)
         parser = LibXML::XML::SaxParser.io(data)
         document = document_class.new

--- a/activesupport/lib/active_support/xml_mini/nokogiri.rb
+++ b/activesupport/lib/active_support/xml_mini/nokogiri.rb
@@ -19,11 +19,9 @@ module ActiveSupport
         data = StringIO.new(data || "")
       end
 
-      char = data.getc
-      if char.nil?
+      if data.eof?
         {}
       else
-        data.ungetc(char)
         doc = Nokogiri::XML(data)
         raise doc.errors.first if doc.errors.length > 0
         doc.to_hash

--- a/activesupport/lib/active_support/xml_mini/nokogirisax.rb
+++ b/activesupport/lib/active_support/xml_mini/nokogirisax.rb
@@ -71,11 +71,9 @@ module ActiveSupport
         data = StringIO.new(data || "")
       end
 
-      char = data.getc
-      if char.nil?
+      if data.eof?
         {}
       else
-        data.ungetc(char)
         document = document_class.new
         parser = Nokogiri::XML::SAX::Parser.new(document)
         parser.parse(data)

--- a/activesupport/test/xml_mini/xml_mini_engine_test.rb
+++ b/activesupport/test/xml_mini/xml_mini_engine_test.rb
@@ -75,6 +75,11 @@ class XMLMiniEngineTest < ActiveSupport::TestCase
       assert_equal({}, ActiveSupport::XmlMini.parse(""))
     end
 
+    def test_parse_from_frozen_string
+      xml_string = "<root/>".freeze
+      assert_equal({ "root" => {} }, ActiveSupport::XmlMini.parse(xml_string))
+    end
+
     def test_array_type_makes_an_array
       assert_equal_rexml(<<-eoxml)
         <blog>


### PR DESCRIPTION
Using frozen strings with `Hash.from_xml` results in an error due to use of `IO#ungetc` (which is a mutating function).

This issue was discovered in https://github.com/rails/rails/pull/24718, this PR ports that fix to other engines.
