### PR TITLE
Add missing require

### DIFF
--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -5,6 +5,7 @@ require "jobs/hello_job"
 require "jobs/logging_job"
 require "jobs/overridden_logging_job"
 require "jobs/nested_job"
+require "jobs/rescue_job"
 require "models/person"
 
 class LoggingTest < ActiveSupport::TestCase


### PR DESCRIPTION
Without this, unit test fails.

```
bundle exec ruby -w -Ilib:lib:test test/cases/logging_test.rb
Using inline
Run options: --seed 41246

# Running:

SE......S....

Finished in 0.052938s, 245.5696 runs/s, 831.1585 assertions/s.

  1) Error:
LoggingTest#test_job_error_logging:
NameError: uninitialized constant LoggingTest::RescueJob
    test/cases/logging_test.rb:130:in `rescue in test_job_error_logging'
    test/cases/logging_test.rb:129:in `test_job_error_logging'

13 runs, 44 assertions, 0 failures, 1 errors, 2 skips

You have skipped tests. Run with --verbose for details.
```

