### PR TITLE
Mixin `CollectionProxy::DelegateExtending` after `ClassSpecificRelation`

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -25,6 +25,8 @@ module ActiveRecord
 
       def inherited(child_class)
         child_class.initialize_relation_delegate_cache
+        delegate = child_class.relation_delegate_class(ActiveRecord::Associations::CollectionProxy)
+        delegate.include ActiveRecord::Associations::CollectionProxy::DelegateExtending
         super
       end
     end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -19,6 +19,11 @@ class Comment < ActiveRecord::Base
   has_many :children, class_name: "Comment", foreign_key: :parent_id
   belongs_to :parent, class_name: "Comment", counter_cache: :children_count
 
+  # Should not be called if extending modules that having the method exists on an association.
+  def self.greeting
+    raise
+  end
+
   def self.what_are_you
     "a comment..."
   end


### PR DESCRIPTION
`ClassSpecificRelation` has `method_missing` and the `method_missing` is
called first. if an associated class has the missing method in a
relation, never reach to the `method_missing` in the `CollectionProxy`.
I extracted `DelegateExtending` and included it to the delegate class
that including `ClassSpecificRelation` to fix the issue.

Fixes https://github.com/rails/rails/pull/28246#issuecomment-296033784.