### PR TITLE
Set to `form_with_generates_remote_forms` only when config is explicitly specified

### DIFF
--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -19,8 +19,10 @@ module ActionView
 
     initializer "action_view.form_with_generates_remote_forms" do |app|
       ActiveSupport.on_load(:action_view) do
-        ActionView::Helpers::FormHelper.form_with_generates_remote_forms =
-          app.config.action_view.delete(:form_with_generates_remote_forms)
+        form_with_generates_remote_forms = app.config.action_view.delete(:form_with_generates_remote_forms)
+        unless form_with_generates_remote_forms.nil?
+          ActionView::Helpers::FormHelper.form_with_generates_remote_forms = form_with_generates_remote_forms
+        end
       end
     end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -725,6 +725,34 @@ module ApplicationTests
       assert_no_match(/data-remote/, last_response.body)
     end
 
+    test "form_with generates remote forms by default" do
+      app_file "app/models/post.rb", <<-RUBY
+      class Post
+        include ActiveModel::Model
+        attr_accessor :name
+      end
+      RUBY
+
+      app_file "app/controllers/posts_controller.rb", <<-RUBY
+      class PostsController < ApplicationController
+        def index
+          render inline: "<%= begin; form_with(model: Post.new) {|f| f.text_field(:name)}; rescue => e; e.to_s; end %>"
+        end
+      end
+      RUBY
+
+      add_to_config <<-RUBY
+        routes.prepend do
+          resources :posts
+        end
+      RUBY
+
+      app "development"
+
+      get "/posts"
+      assert_match(/data-remote/, last_response.body)
+    end
+
     test "default method for update can be changed" do
       app_file "app/models/post.rb", <<-RUBY
       class Post


### PR DESCRIPTION
Without this check, even if config is not specified, `ActionView::Helpers::FormHelper.form_with_generates_remote_forms` always be set to nil and remote form not be generated.

Follow up to 128b804c6ce40fcbde744f294f8cb98654f6efec
