### PR TITLE
Fix `automatic_inverse_of` not to be disabled if extension block is given

### DIFF
--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -66,17 +66,5 @@ module ActiveRecord::Associations::Builder # :nodoc:
         end
       CODE
     end
-
-    def self.wrap_scope(scope, mod)
-      if scope
-        if scope.arity > 0
-          proc { |owner| instance_exec(owner, &scope).extending(mod) }
-        else
-          proc { instance_exec(&scope).extending(mod) }
-        end
-      else
-        proc { extending(mod) }
-      end
-    end
   end
 end

--- a/activerecord/test/cases/associations/eager_load_nested_include_test.rb
+++ b/activerecord/test/cases/associations/eager_load_nested_include_test.rb
@@ -110,10 +110,10 @@ class EagerLoadNestedIncludeWithMissingDataTest < ActiveRecord::TestCase
   end
 
   teardown do
-    @davey_mcdave.destroy
-    @first_post.destroy
     @first_comment.destroy
     @first_categorization.destroy
+    @davey_mcdave.destroy
+    @first_post.destroy
   end
 
   def test_missing_data_in_a_nested_include_should_not_cause_errors_when_constructing_objects

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2578,22 +2578,22 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   test "association with extend option" do
     post = posts(:welcome)
-    assert_equal "lifo",  post.comments_with_extend.author
-    assert_equal "hello", post.comments_with_extend.greeting
+    assert_equal "lifo", post.comments_with_extend.author
+    assert_equal "hello :)", post.comments_with_extend.greeting
   end
 
   test "association with extend option with multiple extensions" do
     post = posts(:welcome)
-    assert_equal "lifo",  post.comments_with_extend_2.author
-    assert_equal "hullo", post.comments_with_extend_2.greeting
+    assert_equal "lifo", post.comments_with_extend_2.author
+    assert_equal "hullo :)", post.comments_with_extend_2.greeting
   end
 
   test "extend option affects per association" do
     post = posts(:welcome)
-    assert_equal "lifo",  post.comments_with_extend.author
-    assert_equal "lifo",  post.comments_with_extend_2.author
-    assert_equal "hello", post.comments_with_extend.greeting
-    assert_equal "hullo", post.comments_with_extend_2.greeting
+    assert_equal "lifo", post.comments_with_extend.author
+    assert_equal "lifo", post.comments_with_extend_2.author
+    assert_equal "hello :)", post.comments_with_extend.greeting
+    assert_equal "hullo :)", post.comments_with_extend_2.greeting
   end
 
   test "delete record with complex joins" do

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -8,6 +8,7 @@ require "models/zine"
 require "models/club"
 require "models/sponsor"
 require "models/rating"
+require "models/post"
 require "models/comment"
 require "models/car"
 require "models/bulb"
@@ -60,6 +61,14 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
 
     assert comment_reflection.has_inverse?, "The Comment reflection should have an inverse"
     assert_equal rating_reflection, comment_reflection.inverse_of, "The Comment reflection's inverse should be the Rating reflection"
+  end
+
+  def test_has_many_and_belongs_to_should_find_inverse_automatically_for_extension_block
+    comment_reflection = Comment.reflect_on_association(:post)
+    post_reflection = Post.reflect_on_association(:comments)
+
+    assert_predicate post_reflection, :has_inverse?
+    assert_equal comment_reflection, post_reflection.inverse_of
   end
 
   def test_has_many_and_belongs_to_should_find_inverse_automatically_for_sti

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -11,6 +11,10 @@ class Post < ActiveRecord::Base
     def author
       "lifo"
     end
+
+    def greeting
+      super + " :)"
+    end
   end
 
   module NamedExtension2


### PR DESCRIPTION
If an association has a scope, `automatic_inverse_of` is to be disabled.
But extension block is obviously not a scope. It should not be regarded
as a scope.

Fixes #28806.