### PR TITLE
`respond_to_missing?` should be private

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -326,11 +326,11 @@ module Mime
 
     def ref; end
 
-    def respond_to_missing?(method, include_private = false)
-      method.to_s.ends_with? "?"
-    end
-
     private
+      def respond_to_missing?(method, _)
+        method.to_s.ends_with? "?"
+      end
+
       def method_missing(method, *args)
         false if method.to_s.ends_with? "?"
       end

--- a/actionpack/lib/action_dispatch/routing/routes_proxy.rb
+++ b/actionpack/lib/action_dispatch/routing/routes_proxy.rb
@@ -19,7 +19,8 @@ module ActionDispatch
         end
       end
 
-      def respond_to_missing?(method, include_private = false)
+    private
+      def respond_to_missing?(method, _)
         super || @helpers.respond_to?(method)
       end
 
@@ -32,7 +33,7 @@ module ActionDispatch
               @helpers.#{method}(*args)
             end
           RUBY
-          send(method, *args)
+          public_send(method, *args)
         else
           super
         end

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -385,14 +385,15 @@ module ActionDispatch
         integration_session.default_url_options = options
       end
 
-      def respond_to_missing?(method, include_private = false)
-        integration_session.respond_to?(method, include_private) || super
+    private
+      def respond_to_missing?(method, _)
+        integration_session.respond_to?(method) || super
       end
 
       # Delegate unhandled messages to the current session instance.
-      def method_missing(sym, *args, &block)
-        if integration_session.respond_to?(sym)
-          integration_session.__send__(sym, *args, &block).tap do
+      def method_missing(method, *args, &block)
+        if integration_session.respond_to?(method)
+          integration_session.public_send(method, *args, &block).tap do
             copy_session_variables!
           end
         else

--- a/activerecord/lib/active_record/dynamic_matchers.rb
+++ b/activerecord/lib/active_record/dynamic_matchers.rb
@@ -1,15 +1,14 @@
 module ActiveRecord
   module DynamicMatchers #:nodoc:
-    def respond_to_missing?(name, include_private = false)
-      if self == Base
-        super
-      else
-        match = Method.match(self, name)
-        match && match.valid? || super
-      end
-    end
-
     private
+      def respond_to_missing?(name, _)
+        if self == Base
+          super
+        else
+          match = Method.match(self, name)
+          match && match.valid? || super
+        end
+      end
 
       def method_missing(name, *arguments, &block)
         match = Method.match(self, name)

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -92,10 +92,6 @@ module ActiveRecord
         send(method, args, &block)
       end
 
-      def respond_to_missing?(*args) # :nodoc:
-        super || delegate.respond_to?(*args)
-      end
-
       ReversibleAndIrreversibleMethods.each do |method|
         class_eval <<-EOV, __FILE__, __LINE__ + 1
           def #{method}(*args, &block)          # def create_table(*args, &block)
@@ -225,10 +221,14 @@ module ActiveRecord
           [:add_foreign_key, reversed_args]
         end
 
+        def respond_to_missing?(method, _)
+          super || delegate.respond_to?(method)
+        end
+
         # Forwards any missing method call to the \target.
         def method_missing(method, *args, &block)
-          if @delegate.respond_to?(method)
-            @delegate.send(method, *args, &block)
+          if delegate.respond_to?(method)
+            delegate.public_send(method, *args, &block)
           else
             super
           end

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -109,12 +109,10 @@ module ActiveRecord
         end
     end
 
-    def respond_to_missing?(method, include_private = false)
-      super || @klass.respond_to?(method, include_private) ||
-        arel.respond_to?(method, include_private)
-    end
-
     private
+      def respond_to_missing?(method, _)
+        super || @klass.respond_to?(method) || arel.respond_to?(method)
+      end
 
       def method_missing(method, *args, &block)
         if @klass.respond_to?(method)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2040,7 +2040,6 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_respond_to_private_class_methods
     client_association = companies(:first_firm).clients
     assert !client_association.respond_to?(:private_method)
-    assert client_association.respond_to?(:private_method, true)
   end
 
   def test_creating_using_primary_key

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -594,7 +594,7 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
-  def test_respond_to_delegates_to_relation
+  def test_respond_to_delegates_to_arel
     relation = Topic.all
     fake_arel = Struct.new(:responds) {
       def respond_to?(method, access = false)
@@ -607,10 +607,6 @@ class RelationTest < ActiveRecord::TestCase
 
     relation.respond_to?(:matching_attributes)
     assert_equal [:matching_attributes, false], fake_arel.responds.first
-
-    fake_arel.responds = []
-    relation.respond_to?(:matching_attributes, true)
-    assert_equal [:matching_attributes, true], fake_arel.responds.first
   end
 
   def test_respond_to_dynamic_finders

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -305,10 +305,6 @@ module ActiveSupport
       to_i
     end
 
-    def respond_to_missing?(method, include_private = false) #:nodoc:
-      @value.respond_to?(method, include_private)
-    end
-
     # Build ISO 8601 Duration string for this duration.
     # The +precision+ parameter can be used to limit seconds' precision of duration.
     def iso8601(precision: nil)
@@ -335,8 +331,12 @@ module ActiveSupport
         end
       end
 
+      def respond_to_missing?(method, _)
+        value.respond_to?(method)
+      end
+
       def method_missing(method, *args, &block)
-        value.send(method, *args, &block)
+        value.public_send(method, *args, &block)
       end
 
       def raise_type_error(other)

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -162,10 +162,6 @@ module Rails
         @instance ||= new
       end
 
-      def respond_to_missing?(*args)
-        instance.respond_to?(*args) || super
-      end
-
       # Allows you to configure the railtie. This is the same method seen in
       # Railtie::Configurable, but this module is no longer required for all
       # subclasses of Railtie so we provide the class method here.
@@ -176,6 +172,10 @@ module Rails
       private
         def generate_railtie_name(string)
           ActiveSupport::Inflector.underscore(string).tr("/", "_")
+        end
+
+        def respond_to_missing?(name, _)
+          instance.respond_to?(name) || super
         end
 
         # If the class method does not have a method, then send the method call


### PR DESCRIPTION
Follow up of 03d3f036.

Some of `respond_to?` were replaced to `respond_to_missing?` in 03d3f036.
But the visibility is still public. It should be private.