### PR TITLE
Remove unused protected accessor

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -571,9 +571,6 @@ module ActiveSupport
           callbacks.each { |c| prepend_one(c) }
         end
 
-        protected
-          def chain; @chain; end
-
         private
 
           def append_one(callback)


### PR DESCRIPTION
This method was added in 3aee912 but never used so far.