### PR TITLE
Add test cases for optimistic locking

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -62,8 +62,8 @@ module ActiveRecord
 
         def increment_lock
           lock_col = self.class.locking_column
-          previous_lock_value = send(lock_col).to_i
-          send(lock_col + "=", previous_lock_value + 1)
+          previous_lock_value = send(lock_col)
+          send("#{lock_col}=", previous_lock_value + 1)
         end
 
         def _create_record(attribute_names = self.attribute_names, *)
@@ -107,7 +107,8 @@ module ActiveRecord
 
           # If something went wrong, revert the locking_column value.
           rescue Exception
-            send(lock_col + "=", previous_lock_value.to_i)
+            send("#{lock_col}=", previous_lock_value.to_i)
+
             raise
           end
         end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -167,6 +167,12 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     assert_equal 0, p1.lock_version
   end
 
+  def test_lock_new_when_explicitly_passing_value
+    p1 = Person.new(first_name: "Douglas Adams", lock_version: 42)
+    p1.save!
+    assert_equal 42, p1.lock_version
+  end
+
   def test_touch_existing_lock
     p1 = Person.find(1)
     assert_equal 0, p1.lock_version
@@ -183,6 +189,19 @@ class OptimisticLockingTest < ActiveRecord::TestCase
 
     assert_raises(ActiveRecord::StaleObjectError) do
       stale_person.touch
+    end
+  end
+
+  def test_explicit_update_lock_column_raise_error
+    person = Person.find(1)
+
+    assert_raises(ActiveRecord::StaleObjectError) do
+      person.first_name = "Douglas Adams"
+      person.lock_version = 42
+
+      assert person.lock_version_changed?
+
+      person.save
     end
   end
 


### PR DESCRIPTION
Add test to ensure that locking_column cannot be updated explicitly.

Add test to prevent regression on creating new object with
explicit value locking_column.

Related to #28318

<hr/>

Clean up 'Optimistic Locking' implementation


<hr/>

/cc @rafaelfranca