### PR TITLE
Add configuration option to reduce postgresql adapter memory bloat

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -78,6 +78,16 @@ module ActiveRecord
       mattr_accessor :error_on_ignored_order, instance_writer: false
       self.error_on_ignored_order = false
 
+      ##
+      # :singleton-method:
+      # due to in Postgre multi-schema structure, there will be a lot of tables.
+      # PostgreSQL will create a lot of records in the pg_type table.
+      # ActiveRecord doesn't need to be mapped to all these records because
+      # we don't have the type's name is the same as the table's name.
+      # So add excluded_pg_type_names to let user could exclude useless types
+      mattr_accessor :excluded_pg_type_names, instance_writer: false
+      self.excluded_pg_type_names = []
+
       def self.error_on_ignored_order_or_limit
         ActiveSupport::Deprecation.warn(<<-MSG.squish)
           The flag error_on_ignored_order_or_limit is deprecated. Limits are

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -373,6 +373,8 @@ All these configuration options are delegated to the `I18n` library.
   having to send a query to the database to get this information.
   Defaults to `true`.
 
+* `config.active_record.excluded_pg_type_names` lets you add exclusion for useless type. There are a lot of redundant types for active_record in Postgre multiple schemas. Default is: `[]`, the setting could be like: `['useless type1', 'useless type2']`
+
 The MySQL adapter adds one additional configuration option:
 
 * `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans` controls whether Active Record will consider all `tinyint(1)` columns as booleans. Defaults to `true`.


### PR DESCRIPTION
### Summary

The PR is provide the configuration option for my previous PR (https://github.com/rails/rails/pull/28369 500x memory reduction of 10k schemas for postgresql adapter)

Current query_conditions_for_initial_load will consume a lot of memories due to it collects records from multiple schemas and grows when numbers of schemas increase. The memory bloat issue should be fixed.

I use a active_record setting (config.active_record.excluded_pg_type_names) to let user could add exclusion for useless types.

This would allow people who know that every schema is identical to reduce their memory usage while by default using the current behaviour

### Other information

I use benchmark-memory gem to test on my local environments

I create two database environments

1. development (408 schemas)
2. big (10000 schemas)

I exclude all my tables on pg_type, 

```
config.active_record.excluded_pg_type_names = Dir['app/models/*.rb'].map {|f| "_#{File.basename(f, '.*')}s” }
```


```
Benchmark.memory do |x|
 x.report(:normal) do
   y.times do
     ActiveRecord::Base.establish_connection(:big).connection
     ActiveRecord::Base.establish_connection(:development).connection
   end
 end

 x.report(:patch) do
   require 'active_record_postgresql_adapter_ext'
   y.times do
     ActiveRecord::Base.establish_connection(:big).connection
     ActiveRecord::Base.establish_connection(:development).connection
   end
 end
x.compare!
end
```
result:
```
Calculating -------------------------------------
              normal   408.838M memsize (    90.936k retained)
                         3.510M objects (   908.000  retained)
                        50.000  strings (    50.000  retained)
               patch   884.509k memsize (    91.155k retained)
                         7.337k objects (   910.000  retained)
                        50.000  strings (    50.000  retained)

Comparison:
               patch:     884509 allocated
              normal:  408837567 allocated - 462.22x more
```