### PR TITLE
Add missing require in ActionMailer::Base

### DIFF
--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -25,6 +25,7 @@ require "abstract_controller"
 require "action_mailer/version"
 
 # Common Active Support usage in Action Mailer
+require "active_support"
 require "active_support/rails"
 require "active_support/core_ext/class"
 require "active_support/core_ext/module/attr_internal"


### PR DESCRIPTION
Without this, Action Mailer doesn't work like it used to on version 4. The following snippet fails since version 5:

    > require 'action_mailer'
    > ActionMailer::Base
    NameError: uninitialized constant ActiveSupport::Rescuable