### PR TITLE
Do not use nonexistent `handleDisabledElement`

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/start.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/start.coffee
@@ -2,7 +2,7 @@
   fire, delegate
   getData, $
   refreshCSRFTokens, CSRFProtection
-  enableElement, disableElement, handleDisabledElement
+  enableElement, disableElement
   handleConfirm
   handleRemote, formSubmitButtonClick, handleMetaClick
   handleMethod
@@ -34,23 +34,19 @@ Rails.start = ->
   delegate document, Rails.buttonDisableSelector, 'ajax:complete', enableElement
   delegate document, Rails.buttonDisableSelector, 'ajax:stopped', enableElement
 
-  delegate document, Rails.linkClickSelector, 'click', handleDisabledElement
   delegate document, Rails.linkClickSelector, 'click', handleConfirm
   delegate document, Rails.linkClickSelector, 'click', handleMetaClick
   delegate document, Rails.linkClickSelector, 'click', disableElement
   delegate document, Rails.linkClickSelector, 'click', handleRemote
   delegate document, Rails.linkClickSelector, 'click', handleMethod
 
-  delegate document, Rails.buttonClickSelector, 'click', handleDisabledElement
   delegate document, Rails.buttonClickSelector, 'click', handleConfirm
   delegate document, Rails.buttonClickSelector, 'click', disableElement
   delegate document, Rails.buttonClickSelector, 'click', handleRemote
 
-  delegate document, Rails.inputChangeSelector, 'change', handleDisabledElement
   delegate document, Rails.inputChangeSelector, 'change', handleConfirm
   delegate document, Rails.inputChangeSelector, 'change', handleRemote
 
-  delegate document, Rails.formSubmitSelector, 'submit', handleDisabledElement
   delegate document, Rails.formSubmitSelector, 'submit', handleConfirm
   delegate document, Rails.formSubmitSelector, 'submit', handleRemote
   # Normal mode submit
@@ -59,7 +55,6 @@ Rails.start = ->
   delegate document, Rails.formSubmitSelector, 'ajax:send', disableElement
   delegate document, Rails.formSubmitSelector, 'ajax:complete', enableElement
 
-  delegate document, Rails.formInputClickSelector, 'click', handleDisabledElement
   delegate document, Rails.formInputClickSelector, 'click', handleConfirm
   delegate document, Rails.formInputClickSelector, 'click', formSubmitButtonClick
 


### PR DESCRIPTION
`handleDisabledElement` was added to master in #28367. 　
The #28367 was not backported to 5-1-stable, but when backporting 154c879e097ba088a8eee1d55f4d9703b70680b7,
only a part of it was mistakenly included.

The test is an error, but it seems that it could not be detected. 
https://travis-ci.org/rails/rails/jobs/224686927 
