### PR TITLE
Return correct exit status of ujs test

### DIFF
--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -49,7 +49,7 @@ namespace :test do
       status = $?.exitstatus
     ensure
       Process.kill("KILL", pid) if pid
-      FileUtils.rm_f("log")
+      FileUtils.rm_rf("log")
     end
 
     exit status

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -46,7 +46,7 @@ namespace :test do
       end
 
       system("npm run lint && phantomjs ../ci/phantomjs.js http://localhost:4567/")
-      status = $?.to_i
+      status = $?.exitstatus
     ensure
       Process.kill("KILL", pid) if pid
       FileUtils.rm_f("log")


### PR DESCRIPTION
The `Process::Status#to_i` returns the bits in stat. If need exit status, we need to use `#exitstatus`.
Ref: https://ruby-doc.org/core-2.4.0/Process/Status.html#method-i-to_i
