### PR TITLE
[ci_skip] Fix typo in Rails 5.1 upgrade notes

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -87,7 +87,7 @@ the right constant and that loading them won't break in the future.
 ### `config.secrets` now load with all keys as symbols
 
 If you application stores nested configuration in `secrets.yml` now all keys are being
-laded as symbols so access using strings should be changed.
+loaded as symbols so access using strings should be changed.
 
 From:
 


### PR DESCRIPTION
Change `laded` to `loaded` in the Rails 5.1 upgrade section
