### PR TITLE
Remove unnecessary `skip_default_ids` and `allow_method_names_outside_object` attributes of select tag in `form_with`

### DIFF
--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -149,7 +149,7 @@ module ActionView
             end
 
             value = options.fetch(:selected) { value(object) }
-            select = content_tag("select", add_options(option_tags, options, value), html_options)
+            select = content_tag("select", add_options(option_tags, options, value), html_options.except!("skip_default_ids", "allow_method_names_outside_object"))
 
             if html_options["multiple"] && options.fetch(:include_hidden, true)
               tag("input", disabled: html_options["disabled"], name: html_options["name"], type: "hidden", value: "") + select

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -302,6 +302,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
+      concat f.select(:category, %w( animal economy sports ))
       concat f.submit("Create post")
       concat f.button("Create post")
       concat f.button {
@@ -315,6 +316,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<textarea name='post[body]'>\nBack to the hill and over it again!</textarea>" \
       "<input name='post[secret]' type='hidden' value='0' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' />" \
+      "<select name='post[category]'><option value='animal'>animal</option>\n<option value='economy'>economy</option>\n<option value='sports'>sports</option></select>" \
       "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />" \
       "<button name='button' type='submit'>Create post</button>" \
       "<button name='button' type='submit'><span>Create post</span></button>"


### PR DESCRIPTION
Currently, `form_with` add `skip_default_ids` and `allow_method_names_outside_object` attributes to select tag created by `f.select` in `form_with`. But it doesn't add these attributes to the other tags apart from select tag.

```
<%= form_with model: Post.new do |f| %>
  <%= f.select :category, {comedy: 1, anime: 2} %>
...

# =>

<form action="/posts" accept-charset="UTF-8" data-remote="true" method="post">
....
  <select skip_default_ids="true" allow_method_names_outside_object="true" name="post[category]">
....
```


`skip_default_ids` and `allow_method_names_outside_object` are internal option for `form_with`. So it should not output these as html.

Related https://github.com/rails/rails/commit/a6d065e39f9285119d75a05ee46c659f8b3c0db8