### PR TITLE
Fix `current_page?` regression:

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -542,7 +542,7 @@ module ActionView
 
         return false unless request.get? || request.head?
 
-        check_parameters ||= !options.is_a?(String) && options.try(:delete, :check_parameters)
+        check_parameters ||= options.is_a?(Hash) && options.delete(:check_parameters)
         url_string = URI.parser.unescape(url_for(options)).force_encoding(Encoding::BINARY)
 
         # We ignore any extra parameters in the request_uri if the

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -509,6 +509,12 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert !current_page?("http://www.example.com/", check_parameters: true)
   end
 
+  def test_current_page_considering_params_when_options_does_not_respond_to_to_hash
+    @request = request_for_url("/?order=desc&page=1")
+
+    assert !current_page?(:back, check_parameters: false)
+  end
+
   def test_current_page_with_params_that_match
     @request = request_for_url("/?order=desc&page=1")
 
@@ -880,6 +886,11 @@ class WorkshopsController < ActionController::Base
     @workshop = Workshop.new(params[:id])
     render inline: "<%= url_for(@workshop) %>\n<%= link_to('Workshop', @workshop) %>"
   end
+
+  def edit
+    @workshop = Workshop.new(params[:id])
+    render inline: "<%= current_page?(@workshop) %>"
+  end
 end
 
 class SessionsController < ActionController::Base
@@ -943,5 +954,12 @@ class PolymorphicControllerTest < ActionController::TestCase
 
     get :edit, params: { workshop_id: 1, id: 1, format: "json"  }
     assert_equal %{/workshops/1/sessions/1.json\n<a href="/workshops/1/sessions/1.json">Session</a>}, @response.body
+  end
+
+  def test_current_page_when_options_does_not_respond_to_to_hash
+    @controller = WorkshopsController.new
+
+    get :edit, params: { id: 1 }
+    assert_equal "false", @response.body
   end
 end


### PR DESCRIPTION
Hey guys 👋 

- `check_parameters` kwargs was added to the `current_page?` method, the implementation was assuming only hashes responds to `delete`. This was causing issues when `current_page?` was called with a Active Model object
- `current_page?` should work with any kind of options that are accepted by [url_for](https://github.com/rails/rails/blob/master/actionview/lib/action_view/routing_url_for.rb#L77)
- ref https://github.com/rails/rails/pull/27549
- Fixes #28846
