### PR TITLE
`sort_query_string_params` method is no more used

### DIFF
--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -676,13 +676,6 @@ class UrlHelperTest < ActiveSupport::TestCase
   def request_forgery_protection_token
     "form_token"
   end
-
-  private
-    def sort_query_string_params(uri)
-      path, qs = uri.split("?")
-      qs = qs.split("&amp;").sort.join("&amp;") if qs
-      qs ? "#{path}?#{qs}" : path
-    end
 end
 
 class UrlHelperControllerTest < ActionController::TestCase


### PR DESCRIPTION
- This method was added in this commit https://github.com/rails/rails/commit/33258d713a4bc20b71e92fd656c923a7b189cd33
- The last caller got removed there https://github.com/rails/rails/commit/0b6ce3422370647cad3e91263a291f69b313d65b

Found this relic while working on #28847, not too sure if I should have added it directly.

