### PR TITLE
Replace \Z to \z

### DIFF
--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -107,7 +107,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_format_of_with_lambda
-    Topic.validates_format_of :content, with: lambda { |topic| topic.title == "digit" ? /\A\d+\Z/ : /\A\S+\Z/ }
+    Topic.validates_format_of :content, with: lambda { |topic| topic.title == "digit" ? /\A\d+\z/ : /\A\S+\z/ }
 
     t = Topic.new
     t.title = "digit"
@@ -119,7 +119,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_format_of_without_lambda
-    Topic.validates_format_of :content, without: lambda { |topic| topic.title == "characters" ? /\A\d+\Z/ : /\A\S+\Z/ }
+    Topic.validates_format_of :content, without: lambda { |topic| topic.title == "characters" ? /\A\d+\z/ : /\A\S+\z/ }
 
     t = Topic.new
     t.title = "characters"
@@ -131,7 +131,7 @@ class PresenceValidationTest < ActiveModel::TestCase
   end
 
   def test_validates_format_of_for_ruby_class
-    Person.validates_format_of :karma, with: /\A\d+\Z/
+    Person.validates_format_of :karma, with: /\A\d+\z/
 
     p = Person.new
     p.karma = "Pixies"

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -11,16 +11,16 @@ module ActiveRecord
     fixtures :developers, :projects, :developers_projects, :topics, :comments, :posts
 
     test "collection_cache_key on model" do
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/, Developer.collection_cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, Developer.collection_cache_key)
     end
 
     test "cache_key for relation" do
       developers = Developer.where(salary: 100000).order(updated_at: :desc)
       last_developer_timestamp = developers.first.updated_at
 
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
 
-      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/ =~ developers.cache_key
+      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/ =~ developers.cache_key
 
       assert_equal Digest::MD5.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
@@ -31,9 +31,9 @@ module ActiveRecord
       developers = Developer.where(salary: 100000).order(updated_at: :desc).limit(5)
       last_developer_timestamp = developers.first.updated_at
 
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
 
-      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/ =~ developers.cache_key
+      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/ =~ developers.cache_key
 
       assert_equal Digest::MD5.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
@@ -44,9 +44,9 @@ module ActiveRecord
       developers = Developer.where(salary: 100000).order(updated_at: :desc).limit(5).load
       last_developer_timestamp = developers.first.updated_at
 
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
 
-      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/ =~ developers.cache_key
+      /\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/ =~ developers.cache_key
 
       assert_equal Digest::MD5.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
@@ -74,7 +74,7 @@ module ActiveRecord
 
     test "cache_key for empty relation" do
       developers = Developer.where(name: "Non Existent Developer")
-      assert_match(/\Adevelopers\/query-(\h+)-0\Z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-0\z/, developers.cache_key)
     end
 
     test "cache_key with custom timestamp column" do
@@ -90,7 +90,7 @@ module ActiveRecord
 
     test "collection proxy provides a cache_key" do
       developers = projects(:active_record).developers
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
     end
 
     test "cache_key for loaded collection with zero size" do
@@ -98,18 +98,18 @@ module ActiveRecord
       posts = Post.includes(:comments)
       empty_loaded_collection = posts.first.comments
 
-      assert_match(/\Acomments\/query-(\h+)-0\Z/, empty_loaded_collection.cache_key)
+      assert_match(/\Acomments\/query-(\h+)-0\z/, empty_loaded_collection.cache_key)
     end
 
     test "cache_key for queries with offset which return 0 rows" do
       developers = Developer.offset(20)
-      assert_match(/\Adevelopers\/query-(\h+)-0\Z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-0\z/, developers.cache_key)
     end
 
     test "cache_key with a relation having selected columns" do
       developers = Developer.select(:salary)
 
-      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\Z/, developers.cache_key)
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
     end
   end
 end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -49,7 +49,7 @@ class PersistenceTest < ActiveRecord::TestCase
         assert !test_update_with_order_succeeds.call("id ASC") # test that this wasn't a fluke and using an incorrect order results in an exception
       else
         # test that we're failing because the current Arel's engine doesn't support UPDATE ORDER BY queries is using subselects instead
-        assert_sql(/\AUPDATE .+ \(SELECT .* ORDER BY id DESC\)\Z/i) do
+        assert_sql(/\AUPDATE .+ \(SELECT .* ORDER BY id DESC\)\z/i) do
           test_update_with_order_succeeds.call("id DESC")
         end
       end

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -21,7 +21,7 @@ class RelationMergingTest < ActiveRecord::TestCase
   def test_relation_to_sql
     post = Post.first
     sql = post.comments.to_sql
-    assert_match(/.?post_id.? = #{post.id}\Z/i, sql)
+    assert_match(/.?post_id.? = #{post.id}\z/i, sql)
   end
 
   def test_relation_merging_with_arel_equalities_keeps_last_equality

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -119,7 +119,7 @@ module TestHelpers
       end
 
       routes = File.read("#{app_path}/config/routes.rb")
-      if routes =~ /(\n\s*end\s*)\Z/
+      if routes =~ /(\n\s*end\s*)\z/
         File.open("#{app_path}/config/routes.rb", "w") do |f|
           f.puts $` + "\nActiveSupport::Deprecation.silence { match ':controller(/:action(/:id))(.:format)', via: :all }\n" + $1
         end
@@ -251,7 +251,7 @@ module TestHelpers
 
     def add_to_config(str)
       environment = File.read("#{app_path}/config/application.rb")
-      if environment =~ /(\n\s*end\s*end\s*)\Z/
+      if environment =~ /(\n\s*end\s*end\s*)\z/
         File.open("#{app_path}/config/application.rb", "w") do |f|
           f.puts $` + "\n#{str}\n" + $1
         end
@@ -260,7 +260,7 @@ module TestHelpers
 
     def add_to_env_config(env, str)
       environment = File.read("#{app_path}/config/environments/#{env}.rb")
-      if environment =~ /(\n\s*end\s*)\Z/
+      if environment =~ /(\n\s*end\s*)\z/
         File.open("#{app_path}/config/environments/#{env}.rb", "w") do |f|
           f.puts $` + "\n#{str}\n" + $1
         end


### PR DESCRIPTION
\Z was a mistake of \z. Replace \Z to \z to prevent newly \Z added.