### PR TITLE
feat(ActiveRecord::Relation) support Sets in `where` values

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -3,6 +3,7 @@ require "active_record/relation/predicate_builder/base_handler"
 require "active_record/relation/predicate_builder/basic_object_handler"
 require "active_record/relation/predicate_builder/range_handler"
 require "active_record/relation/predicate_builder/relation_handler"
+require "active_record/relation/predicate_builder/set_handler"
 
 require "active_record/relation/predicate_builder/association_query_value"
 require "active_record/relation/predicate_builder/polymorphic_array_value"
@@ -21,6 +22,7 @@ module ActiveRecord
       register_handler(RangeHandler::RangeWithBinds, RangeHandler.new)
       register_handler(Relation, RelationHandler.new)
       register_handler(Array, ArrayHandler.new(self))
+      register_handler(Set, SetHandler.new(self))
     end
 
     def build_from_hash(attributes)

--- a/activerecord/lib/active_record/relation/predicate_builder/set_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/set_handler.rb
@@ -1,0 +1,9 @@
+module ActiveRecord
+  class PredicateBuilder
+    class SetHandler < ArrayHandler# :nodoc:
+      def call(attribute, value)
+        super(attribute, value.to_a)
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -524,6 +524,11 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal Topic.where(id: "1-meowmeow".."2-hello"), Topic.where(id: 1..2)
   end
 
+  def test_find_by_set
+    assert_equal Topic.where(id: Set.new([1, 2])), Topic.find([1, 2])
+    assert_equal 2, Topic.where(id: Set.new(["1-meowmeow", "2-hello"])).count
+  end
+
   def test_equality_of_new_records
     assert_not_equal Topic.new, Topic.new
     assert_equal false, Topic.new == Topic.new


### PR DESCRIPTION
Thanks for all your hard work making Rails awesome! 

I'm working with some external services that return arrays of IDs. To deduplicate these arrays, I join them in a Set. I discovered that Sets _don't_ become `IN` clauses, but instead, become `NULL`. Is this desirable behavior? 

In fact, it was a design flaw in my code: it return an Array in some cases and Set in others, but I expected both of them to become `IN` clauses!

In any case, I thought I'd try a fix in case you think it's helpful. Thanks for your review!

### Summary

Previously, querying by a Set turned it into NULL:

    Event.where(id: [1,2,3].to_set).to_sql
    # => "SELECT `events`.* FROM `events` WHERE `events`.`id` = NULL"

Now, it's turned into an IN condition:

    Event.where(id: [1,2,3].to_set).to_sql
    # => "SELECT `events`.* FROM `events` WHERE `events`.`id` IN (1, 2, 3)"

This way, you can use a Set to specify a collection values you want to match.

I couldn't find any previous mention of this issue, but did I miss it? 
