### PR TITLE
Tell users where to put time zone aware types changes

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -98,7 +98,7 @@ module ActiveRecord
               still causes `String`s to be parsed as if they were in `Time.zone`,
               and `Time`s to be converted to `Time.zone`.
 
-              To keep the old behavior, you must add the following to your initializer:
+              To keep the old behavior, you must add the following to `config/application.rb`:
 
                   config.active_record.time_zone_aware_types = [:datetime]
 

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -98,7 +98,7 @@ module ActiveRecord
               still causes `String`s to be parsed as if they were in `Time.zone`,
               and `Time`s to be converted to `Time.zone`.
 
-              To keep the old behavior, you must add the following to `config/application.rb`:
+              To keep the old behavior, you must add the following in your initializer or in `config/application.rb`:
 
                   config.active_record.time_zone_aware_types = [:datetime]
 


### PR DESCRIPTION
In a new Rails 5.0.1 application, if you add `config.active_record.time_zone_aware_types = [:datetime]` to an initializer as per the deprecation message, it does not get picked up. However, if you add it to `config/application.rb`, it does. This just changes the wording in the deprecation message.
