### PR TITLE
Honour content type headers when assigning content type in head, instead of always trying to determine it. Fixes #28850

### DIFF
--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -36,7 +36,7 @@ module ActionController
       self.response_body = ""
 
       if include_content?(response_code)
-        self.content_type = content_type || (Mime[formats.first] if formats)
+        self.content_type ||= content_type || (Mime[formats.first] if formats)
         response.charset = false
       end
 


### PR DESCRIPTION
Honour content type headers when assigning content type in head, instead of always trying to determine it. Fixes #28850