### PR TITLE
Support string Content-Type key for head

### DIFF
--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -24,7 +24,7 @@ module ActionController
       status ||= :ok
 
       location = options.delete(:location)
-      content_type = options.delete(:content_type)
+      content_type = options.delete(:content_type) || options.delete("Content-Type")
 
       options.each do |key, value|
         headers[key.to_s.dasherize.split("-").each { |v| v[0] = v[0].chr.upcase }.join("-")] = value.to_s

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -177,6 +177,10 @@ class TestController < ActionController::Base
     head :created, content_type: "application/json"
   end
 
+  def head_created_with_application_json_string_content_type
+    head :created, "Content-Type" => "application/json"
+  end
+
   def head_ok_with_image_png_content_type
     head :ok, content_type: "image/png"
   end
@@ -653,6 +657,13 @@ class HeadRenderTest < ActionController::TestCase
 
   def test_head_created_with_application_json_content_type
     post :head_created_with_application_json_content_type
+    assert @response.body.blank?
+    assert_equal "application/json", @response.header["Content-Type"]
+    assert_response :created
+  end
+
+  def test_head_created_with_application_json_string_content_type
+    post :head_created_with_application_json_string_content_type
     assert @response.body.blank?
     assert_equal "application/json", @response.header["Content-Type"]
     assert_response :created


### PR DESCRIPTION
### Summary

Previously, only the Symbol key `:content_type` would have been
respected. Now, both `:content_type` and `Content-Type` will be
respected.

### Other Information

Fixes #28850