### PR TITLE
fix docs for show_detailed_exceptions?

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -75,7 +75,7 @@ application. Accepts a valid week day symbol (e.g. `:monday`).
 
 * `config.colorize_logging` specifies whether or not to use ANSI color codes when logging information. Defaults to `true`.
 
-* `config.consider_all_requests_local` is a flag. If `true` then any error will cause detailed debugging information to be dumped in the HTTP response, and the `Rails::Info` controller will show the application runtime context in `/rails/info/properties`. `true` by default in development and test environments, and `false` in production mode. For finer-grained control, set this to `false` and implement `local_request?` in controllers to specify which requests should provide debugging information on errors.
+* `config.consider_all_requests_local` is a flag. If `true` then any error will cause detailed debugging information to be dumped in the HTTP response, and the `Rails::Info` controller will show the application runtime context in `/rails/info/properties`. `true` by default in development and test environments, and `false` in production mode. For finer-grained control, set this to `false` and implement `show_detailed_exceptions?` in controllers to specify which requests should provide debugging information on errors.
 
 * `config.console` allows you to set class that will be used as console you run `rails console`. It's best to run it in `console` block:
 


### PR DESCRIPTION
I followed the instructions in the existing guides and overrode `local_request?`, but it didn't do anything. On [closer inspection](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/rescue.rb#L14) it seems that this docs are out of date and the actual method to override is `show_detailed_exceptions?`. (Right?)

