### PR TITLE
Support PostgreSQL 10 `pg_sequence`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -290,9 +290,17 @@ module ActiveRecord
 
           if pk && sequence
             quoted_sequence = quote_table_name(sequence)
+            max_pk = select_value("select MAX(#{quote_column_name pk}) from #{quote_table_name(table)}")
+            if max_pk.nil?
+              if postgresql_version >= 100000
+                minvalue = select_value("SELECT seqmin from pg_sequence where seqrelid = '#{quoted_sequence}'::regclass")
+              else
+                minvalue = select_value("SELECT min_value FROM #{quoted_sequence}")
+              end
+            end
 
             select_value(<<-end_sql, "SCHEMA")
-              SELECT setval('#{quoted_sequence}', (SELECT COALESCE(MAX(#{quote_column_name pk})+(SELECT increment_by FROM #{quoted_sequence}), (SELECT min_value FROM #{quoted_sequence})) FROM #{quote_table_name(table)}), false)
+              SELECT setval('#{quoted_sequence}', #{max_pk ? max_pk : minvalue}, #{max_pk ? true : false})
             end_sql
           end
         end


### PR DESCRIPTION
Another fix for #28780 based on discussions at #28789

- In PostgreSQL 10 each sequence does not know  `increment_by` or `min_value`.
A new system catalog `pg_sequences` knows both. https://github.com/postgres/postgres/commit/1753b1b027035029c2a2a1649065762fafbf63f3

- `pg_sequence` has `schemaname` and `sequencename` columns to identify the sequence.
When `sequence` is a `ActiveRecord::ConnectionAdapters::PostgreSQL::Name`,
it is easy to find it by using `sequence.schema` and `sequence.identifier`.
However, when `sequence` is a String it needs to find sequence schema name
and sequence name by splitting it by `.`. Also it needs to consider
when sequence does not have `.` to separate sequence schema name and sequence name.

- `setval` 3rd argument needs to set to `false` only when the table has no rows
to avoid `nextval(<sequence_name>)` returns `2` where `1` is expected.

- `min_value` is only necessary when the table has no rows. It used to be necessary
since the 3rd argument of `setval` is always `false`.
