### PR TITLE
PostgreSQL 10 converts unknown type to text type

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -324,13 +324,13 @@ module ActiveRecord
         reset_connection
       end
 
-      def test_only_reload_type_map_once_for_every_unknown_type
+      def test_only_reload_type_map_once_for_every_unrecognized_type
         silence_warnings do
           assert_queries 2, ignore_none: true do
-            @connection.select_all "SELECT NULL::anyelement"
+            @connection.select_all "select 'pg_catalog.pg_class'::regclass"
           end
           assert_queries 1, ignore_none: true do
-            @connection.select_all "SELECT NULL::anyelement"
+            @connection.select_all "select 'pg_catalog.pg_class'::regclass"
           end
           assert_queries 2, ignore_none: true do
             @connection.select_all "SELECT NULL::anyarray"
@@ -340,13 +340,13 @@ module ActiveRecord
         reset_connection
       end
 
-      def test_only_warn_on_first_encounter_of_unknown_oid
+      def test_only_warn_on_first_encounter_of_unrecognized_oid
         warning = capture(:stderr) {
-          @connection.select_all "SELECT NULL::anyelement"
-          @connection.select_all "SELECT NULL::anyelement"
-          @connection.select_all "SELECT NULL::anyelement"
+          @connection.select_all "select 'pg_catalog.pg_class'::regclass"
+          @connection.select_all "select 'pg_catalog.pg_class'::regclass"
+          @connection.select_all "select 'pg_catalog.pg_class'::regclass"
         }
-        assert_match(/\Aunknown OID \d+: failed to recognize type of 'anyelement'\. It will be treated as String\.\n\z/, warning)
+        assert_match(/\Aunknown OID \d+: failed to recognize type of 'regclass'\. It will be treated as String\.\n\z/, warning)
       ensure
         reset_connection
       end


### PR DESCRIPTION
### Summary

Address #28799

* Refer these discussion and commit:
https://www.postgresql.org/message-id/28163.1486478547%40sss.pgh.pa.us
https://git.postgresql.org/gitweb/?p=postgresql.git&a=commitdiff&h=1e7c4bb0049732ece651d993d03bb6772e5d281a

* Skip 2 specs which expect `select_all` returns unknown type if PostgreSQL 10 or higher
There was a suggestion to remove these warning spec but this behavior is true
as long as PostgreSQL 9.6 or lower version, then just skip them.

* Add 1 spec to validate unknown type is converted to text type if PostgreSQl 10 or higher

### Other Information
This pull request has been tested with these two versions of PostgreSQL.

```sql
activerecord_unittest=# select version();
                                                  version
-----------------------------------------------------------------------------------------------------------
 PostgreSQL 10devel on x86_64-pc-linux-gnu, compiled by gcc (GCC) 6.3.1 20161221 (Red Hat 6.3.1-1), 64-bit
(1 row)
```

```
activerecord_unittest=# select version();
                                                 version
----------------------------------------------------------------------------------------------------------
 PostgreSQL 9.5.6 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 6.2.0-5ubuntu12) 6.2.0 20161005, 64-bit
(1 row)

activerecord_unittest=#
```