### PR TITLE
Enable query cache on all connection pools

### DIFF
--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -24,16 +24,19 @@ module ActiveRecord
     end
 
     def self.run
-      caching_pool = ActiveRecord::Base.connection_pool
-      caching_was_enabled = caching_pool.query_cache_enabled
+      ActiveRecord::Base.connection_handler.connection_pool_list.map do |pool|
+        caching_was_enabled = pool.query_cache_enabled
 
-      caching_pool.enable_query_cache!
+        pool.enable_query_cache!
 
-      [caching_pool, caching_was_enabled]
+        [pool, caching_was_enabled]
+      end
     end
 
-    def self.complete((caching_pool, caching_was_enabled))
-      caching_pool.disable_query_cache! unless caching_was_enabled
+    def self.complete(caching_pools)
+      caching_pools.each do |pool, caching_was_enabled|
+        pool.disable_query_cache! unless caching_was_enabled
+      end
 
       ActiveRecord::Base.connection_handler.connection_pool_list.each do |pool|
         pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -426,6 +426,15 @@ class QueryCacheTest < ActiveRecord::TestCase
     end
   end
 
+  def test_query_cache_is_enabled_on_all_connection_pools
+    middleware {
+      ActiveRecord::Base.connection_handler.connection_pool_list.each do |pool|
+        assert pool.query_cache_enabled
+        assert pool.connection.query_cache_enabled
+      end
+    }.call({})
+  end
+
   private
     def middleware(&app)
       executor = Class.new(ActiveSupport::Executor)


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/26978.

Since the query cache no longer eagerly checks out a connection, we can enable it on all connection pools at the start of every request, and it will only take effect for requests that actually use those pools.

r? @matthewd 