### PR TITLE
Remove checks for Enumerator#size method

### DIFF
--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -35,12 +35,10 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
-  if Enumerator.method_defined? :size
-    def test_each_should_return_a_sized_enumerator
-      assert_equal 11, Post.find_each(batch_size: 1).size
-      assert_equal 5, Post.find_each(batch_size:  2, start: 7).size
-      assert_equal 11, Post.find_each(batch_size: 10_000).size
-    end
+  def test_each_should_return_a_sized_enumerator
+    assert_equal 11, Post.find_each(batch_size: 1).size
+    assert_equal 5, Post.find_each(batch_size:  2, start: 7).size
+    assert_equal 11, Post.find_each(batch_size: 10_000).size
   end
 
   def test_each_enumerator_should_execute_one_query_per_batch
@@ -515,14 +513,12 @@ class EachTest < ActiveRecord::TestCase
     assert_equal 2, person.reload.author_id # incremented only once
   end
 
-  if Enumerator.method_defined? :size
-    def test_find_in_batches_should_return_a_sized_enumerator
-      assert_equal 11, Post.find_in_batches(batch_size: 1).size
-      assert_equal 6, Post.find_in_batches(batch_size: 2).size
-      assert_equal 4, Post.find_in_batches(batch_size: 2, start: 4).size
-      assert_equal 4, Post.find_in_batches(batch_size: 3).size
-      assert_equal 1, Post.find_in_batches(batch_size: 10_000).size
-    end
+  def test_find_in_batches_should_return_a_sized_enumerator
+    assert_equal 11, Post.find_in_batches(batch_size: 1).size
+    assert_equal 6, Post.find_in_batches(batch_size: 2).size
+    assert_equal 4, Post.find_in_batches(batch_size: 2, start: 4).size
+    assert_equal 4, Post.find_in_batches(batch_size: 3).size
+    assert_equal 1, Post.find_in_batches(batch_size: 10_000).size
   end
 
   [true, false].each do |load|

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -45,10 +45,8 @@ module ActiveRecord
       end
     end
 
-    if Enumerator.method_defined? :size
-      test "each without block returns a sized enumerator" do
-        assert_equal 3, result.each.size
-      end
+    test "each without block returns a sized enumerator" do
+      assert_equal 3, result.each.size
     end
 
     test "cast_values returns rows after type casting" do

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -171,10 +171,8 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal({ 5 => Payment.new(5), 15 => Payment.new(15), 10 => Payment.new(10) },
                  payments.index_by(&:price))
     assert_equal Enumerator, payments.index_by.class
-    if Enumerator.method_defined? :size
-      assert_nil payments.index_by.size
-      assert_equal 42, (1..42).index_by.size
-    end
+    assert_nil payments.index_by.size
+    assert_equal 42, (1..42).index_by.size
     assert_equal({ 5 => Payment.new(5), 15 => Payment.new(15), 10 => Payment.new(10) },
                  payments.index_by.each(&:price))
   end


### PR DESCRIPTION
The [Enumerator#size](http://ruby-doc.org/core-2.0.0/Enumerator.html#method-i-size) method was introduced in Ruby 2.0.

These tests were added when Rails 4.1 was current (https://github.com/rails/rails/pull/13938), and Ruby 1.9.3 was still supported. Since Rails 5 only Ruby >= 2.2.2 is supported, so the checks are no longer necessary.