### PR TITLE
Set consistent typecast ENV["VERBOSE"]

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -164,7 +164,7 @@ module ActiveRecord
       def migrate
         raise "Empty VERSION provided" if ENV["VERSION"] && ENV["VERSION"].empty?
 
-        verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
+        verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] != "false" : true
         version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
         scope = ENV["SCOPE"]
         verbose_was, Migration.verbose = Migration.verbose, verbose

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -343,8 +343,23 @@ module ActiveRecord
 
       ENV["VERBOSE"] = "false"
       ENV["VERSION"] = "4"
-
       ActiveRecord::Migrator.expects(:migrate).with("custom/path", 4)
+      ActiveRecord::Migration.expects(:verbose=).with(false)
+      ActiveRecord::Migration.expects(:verbose=).with(ActiveRecord::Migration.verbose)
+      ActiveRecord::Tasks::DatabaseTasks.migrate
+
+      ENV.delete("VERBOSE")
+      ENV.delete("VERSION")
+      ActiveRecord::Migrator.expects(:migrate).with("custom/path", nil)
+      ActiveRecord::Migration.expects(:verbose=).with(true)
+      ActiveRecord::Migration.expects(:verbose=).with(ActiveRecord::Migration.verbose)
+      ActiveRecord::Tasks::DatabaseTasks.migrate
+
+      ENV["VERBOSE"] = "yes"
+      ENV["VERSION"] = "unknown"
+      ActiveRecord::Migrator.expects(:migrate).with("custom/path", 0)
+      ActiveRecord::Migration.expects(:verbose=).with(true)
+      ActiveRecord::Migration.expects(:verbose=).with(ActiveRecord::Migration.verbose)
       ActiveRecord::Tasks::DatabaseTasks.migrate
     ensure
       ENV["VERBOSE"], ENV["VERSION"] = verbose, version


### PR DESCRIPTION
- ~~Refactor DatabaseTasksMigrateTest#test_migrate_receives_correct_env_vars~~
  - ~~Remove redundant overriding ENV["VERBOSE"] in the test.~~

- Refactor AR::Tasks::DatabaseTasks::migrate
  - Set consistent type cast ENV["VERBOSE"]:
      ENV["VERBOSE"] is true if it not equal to "false",
   This also more consistent with the documentation
   http://edgeguides.rubyonrails.org/active_record_migrations.html

- Refactor DatabaseTasksMigrateTest#test_migrate_receives_correct_env_vars
  - Add cases to ensure that environment variables VERBOSE and VERSION have correct typecast.