### PR TITLE
PostgreSQL 10 does not convert `CURRENT_DATE` into `('now'::text)::date`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -561,7 +561,7 @@ module ActiveRecord
         end
 
         def has_default_function?(default_value, default)
-          !default_value && (%r{\w+\(.*\)|\(.*\)::\w+} === default)
+          !default_value && %r{\w+\(.*\)|\(.*\)::\w+|CURRENT_DATE|CURRENT_TIMESTAMP}.match?(default)
         end
 
         def load_additional_types(type_map, oids = nil)

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -87,9 +87,14 @@ if current_adapter?(:PostgreSQLAdapter)
 
     test "schema dump includes default expression" do
       output = dump_table_schema("defaults")
-      assert_match %r/t\.date\s+"modified_date",\s+default: -> { "\('now'::text\)::date" }/, output
+      if ActiveRecord::Base.connection.postgresql_version >= 100000
+        assert_match %r/t\.date\s+"modified_date",\s+default: -> { "CURRENT_DATE" }/, output
+        assert_match %r/t\.datetime\s+"modified_time",\s+default: -> { "CURRENT_TIMESTAMP" }/, output
+      else
+        assert_match %r/t\.date\s+"modified_date",\s+default: -> { "\('now'::text\)::date" }/, output
+        assert_match %r/t\.datetime\s+"modified_time",\s+default: -> { "now\(\)" }/, output
+      end
       assert_match %r/t\.date\s+"modified_date_function",\s+default: -> { "now\(\)" }/, output
-      assert_match %r/t\.datetime\s+"modified_time",\s+default: -> { "now\(\)" }/, output
       assert_match %r/t\.datetime\s+"modified_time_function",\s+default: -> { "now\(\)" }/, output
     end
   end


### PR DESCRIPTION
### Summary

PostgreSQL 10 allows `CURRENT_DATE` and `CURRENT_TIMESTAMP` as default functions

Address #28797

In the previous versions of PostgreSQL, `CURRENT_DATE` converted to `('now'::text)::date`
and `CURRENT_TIMESTAMP` converted to `now()`.

Refer these discussions and commit at PostgreSQL :
https://www.postgresql.org/message-id/flat/5878.1463098164%40sss.pgh.pa.us#5878.1463098164@sss.pgh.pa.us
postgres/postgres@0bb51aa

### Other Information
This pull request has been tested with these two versions of PostgreSQL.

```sql
activerecord_unittest=# select version();
                                                  version
-----------------------------------------------------------------------------------------------------------
 PostgreSQL 10devel on x86_64-pc-linux-gnu, compiled by gcc (GCC) 6.3.1 20161221 (Red Hat 6.3.1-1), 64-bit
(1 row)
```

```
activerecord_unittest=# select version();
                                                 version
----------------------------------------------------------------------------------------------------------
 PostgreSQL 9.5.6 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 6.2.0-5ubuntu12) 6.2.0 20161005, 64-bit
(1 row)

activerecord_unittest=#
```