### PR TITLE
Remove useless test case

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2037,11 +2037,6 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal client_association.new.attributes, client_association.send(:new).attributes
   end
 
-  def test_respond_to_private_class_methods
-    client_association = companies(:first_firm).clients
-    assert !client_association.respond_to?(:private_method)
-  end
-
   def test_creating_using_primary_key
     firm = Firm.all.merge!(order: "id").first
     client = firm.clients_using_primary_key.create!(name: "test")

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -170,14 +170,6 @@ class Client < Company
 
   def overwrite_to_raise
   end
-
-  class << self
-    private
-
-    def private_method
-      "darkness"
-    end
-  end
 end
 
 class ExclusivelyDependentFirm < Company


### PR DESCRIPTION
Cannot call private methods in `@klass` against `CollectionProxy`
(inherites `Relation`) because using `public_send` in `method_missing`.