### PR TITLE
Copy AR association errors to foreign key

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Active Record models that are converted to Active Model compliant objects
+    (by calling `to_model` on an instance) now return association errors when
+    querying for the association's foreign key. This is particularly useful in the
+    context of Action View where validation errors on the association itself can
+    now be assigned to a foreign key field in a form.
+
+     Solves #28772. 
+ 
+    *Edward Poot*
+
 *   Quote database name in db:create grant statement (when database_user does not have access to create the database).
 
     *Rune Philosof*

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -21,6 +21,7 @@ require "active_record/explain_subscriber"
 require "active_record/relation/delegation"
 require "active_record/attributes"
 require "active_record/type_caster"
+require "active_record/conversion"
 
 module ActiveRecord #:nodoc:
   # = Active Record
@@ -296,7 +297,7 @@ module ActiveRecord #:nodoc:
     include Scoping
     include Sanitization
     include AttributeAssignment
-    include ActiveModel::Conversion
+    include Conversion
     include Integration
     include Validations
     include CounterCache

--- a/activerecord/lib/active_record/conversion.rb
+++ b/activerecord/lib/active_record/conversion.rb
@@ -1,0 +1,16 @@
+module ActiveRecord
+  module Conversion # :nodoc:
+    include ActiveModel::Conversion
+
+    # Wrapper around <tt>ActiveModel::Conversion#to_model</tt> to return an
+    # instance of the <tt>ActiveRecord::Errors</tt> class for the model's
+    # errors.
+    def to_model
+      @errors = Errors.new(self)
+      # fill validation errors
+      validate
+
+      super.dup
+    end
+  end
+end

--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -6,6 +6,7 @@ require "models/developer"
 require "models/computer"
 require "models/parrot"
 require "models/company"
+require "models/hamster"
 
 class ValidationsTest < ActiveRecord::TestCase
   fixtures :topics, :developers
@@ -176,5 +177,20 @@ class ValidationsTest < ActiveRecord::TestCase
     assert_no_queries do
       klass.validates_acceptance_of(:foo)
     end
+  end
+
+  def test_association_errors_copied_to_foreign_key
+    h = Hamster.new
+
+    assert_not h.valid?
+
+    assert h.errors[:breeder].any?
+    assert_not h.errors[:breeder_id].any?, "Without to_model called on the model association errors should not be copied to foreign key"
+
+    # call to_model so that ActiveRecord::Errors is used instead of ActiveModel::Errors
+    h.to_model
+
+    assert h.errors[:breeder].any?
+    assert h.errors[:breeder_id].any?, "The association error should have been copied to the foreign key"
   end
 end

--- a/activerecord/test/models/hamster.rb
+++ b/activerecord/test/models/hamster.rb
@@ -1,0 +1,4 @@
+class Hamster < ActiveRecord::Base
+  belongs_to :breeder
+  validates :breeder, presence: true
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -356,6 +356,10 @@ ActiveRecord::Schema.define do
     t.string :info
   end
 
+  create_table :hamsters, force: true do |t|
+    t.integer :breeder_id
+  end
+
   create_table :having, force: true do |t|
     t.string :where
   end


### PR DESCRIPTION
### Summary

Before this change, association foreign key fields in forms are not marked as having errors when the ActiveModel validation is on the association itself, as opposed to validating on the association's foreign key (which is considered bad practice). This change accounts for this by including errors for the association itself when errors for a specific foreign key field are accessed.

### Other Information

We do have to be careful to prevent adding some errors multiple times, i.e. when there are validators on the association itself and the foreign key. This is currently solved by not including the association's errors when there are explicit validators defined on the foreign key. Alternatively one could just call `uniq` on the resulting error array, but that seems to be a tad more inefficient.

Related issue: #28772 
