### PR TITLE
video_tag should accept a fallback option

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -343,7 +343,7 @@ module ActionView
 
           if sources.size > 1
             content_tag(type, options) do
-              safe_join sources.map { |source| tag("source", src: send("path_to_#{type}", source, skip_pipeline: skip_pipeline)) }, fallback
+              safe_join sources.map { |source| tag("source", src: send("path_to_#{type}", source, skip_pipeline: skip_pipeline)) } << fallback
             end
           else
             options[:src] = send("path_to_#{type}", sources.first, skip_pipeline: skip_pipeline)

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -531,9 +531,14 @@ class AssetTagHelperTest < ActionView::TestCase
     FontPathToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
 
-  def test_video_tag_with_block
+  def test_video_tag_with_fallback
     options = { fallback: "Video not supported" }
     assert_equal '<video src="/videos/video">Video not supported</video>', video_tag("video", options)
+  end
+
+  def test_video_tag_with_multiple_sources_and_fallback
+    options = { fallback: "Video not supported" }
+    assert_equal '<video><source src="/videos/video1" /><source src="/videos/video2" />Video not supported</video>', video_tag(["video1", "video2"], options)
   end
 
   def test_video_audio_tag_does_not_modify_options

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -531,6 +531,11 @@ class AssetTagHelperTest < ActionView::TestCase
     FontPathToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
 
+  def test_video_tag_with_block
+    options = { fallback: "Video not supported" }
+    assert_equal '<video src="/videos/video">Video not supported</video>', video_tag("video", options)
+  end
+
   def test_video_audio_tag_does_not_modify_options
     options = { autoplay: true }
     video_tag("video", options)


### PR DESCRIPTION
### Summary

Here is a common implementation of the `<video>` tag that accounts for browsers that do not support it.
````html
<video src="/videos/trailer.avi">
  Video not supported.
</video>
````
The `video_tag` helper does not provide a way to insert text inside of a `<video>` tag. This pull request adds a `fallback` option to the `video_tag` helper. The markup passed to this option is displayed in the `<video>` tag after any `<source>` tags.
