### PR TITLE
Remove mysql2 database adapter default username root

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -10,8 +10,6 @@ module ActiveRecord
     # Establishes a connection to the database that's used by all Active Record objects.
     def mysql2_connection(config)
       config = config.symbolize_keys
-
-      config[:username] = "root" if config[:username].nil?
       config[:flags] ||= 0
 
       if config[:flags].kind_of? Array


### PR DESCRIPTION
A mysql2 bug was opened a while back, that if a user wants to put all of their mysql config into a separate config file, through the `default_file` option, it will conflict with Rails supplying a default value of `"root"` for the database username.

https://github.com/brianmario/mysql2/issues/801

I went back and looked at the history of the mysql2_adapter in Rails, and found that setting the default username to`root` has been there for 6+ years: https://github.com/rails/rails/commit/70b9db173e958944fcf61ac8514408fba9ef0c9a

I don't think that default should be there. In particular, MySQL 5.7 and 8.0 are much more aggressive about setting a random-by-default root password, and distributions are following suit to make the MySQL `root` user no longer a default password-less account.

I wonder if it would be possible to get this into the upcoming Rails 5.1. If not, then at least a test like `config[:username] = "root" if config[:username].nil? && config[:default_file].nil?`. Let me know what we can do to correct this.