### PR TITLE
Add lazy loading to #keys and #values methods in Session

### DIFF
--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -101,11 +101,13 @@ module ActionDispatch
 
       # Returns keys of the session as Array.
       def keys
+        load_for_read!
         @delegate.keys
       end
 
       # Returns values of the session as Array.
       def values
+        load_for_read!
         @delegate.values
       end
 

--- a/actionpack/test/dispatch/request/session_test.rb
+++ b/actionpack/test/dispatch/request/session_test.rb
@@ -54,11 +54,21 @@ module ActionDispatch
         assert_equal %w[rails adequate], s.keys
       end
 
+      def test_keys_with_deferred_loading
+        s = Session.create(store_with_data, req, {})
+        assert_equal %w[sample_key], s.keys
+      end
+
       def test_values
         s = Session.create(store, req, {})
         s["rails"] = "ftw"
         s["adequate"] = "awesome"
         assert_equal %w[ftw awesome], s.values
+      end
+
+      def test_values_with_deferred_loading
+        s = Session.create(store_with_data, req, {})
+        assert_equal %w[sample_value], s.values
       end
 
       def test_clear
@@ -109,6 +119,14 @@ module ActionDispatch
         def store
           Class.new {
             def load_session(env); [1, {}]; end
+            def session_exists?(env); true; end
+            def delete_session(env, id, options); 123; end
+          }.new
+        end
+
+        def store_with_data
+          Class.new {
+            def load_session(env); [1, { "sample_key" => "sample_value" }]; end
             def session_exists?(env); true; end
             def delete_session(env, id, options); 123; end
           }.new


### PR DESCRIPTION
This fixes a bug where session.keys and session.values return an empty
array unless one of the other methods that does lazy loading from the
underlying store is called first. #keys and #values should also
call #load_for_read!
