### PR TITLE
Do not try to encoding the parameters when the controller is not defined

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -85,12 +85,18 @@ module ActionDispatch
 
         def set_binary_encoding(params)
           action = params[:action]
-          if controller_class.binary_params_for?(action)
+          if binary_params_for?(action)
             ActionDispatch::Request::Utils.each_param_value(params) do |param|
               param.force_encoding ::Encoding::ASCII_8BIT
             end
           end
           params
+        end
+
+        def binary_params_for?(action)
+          controller_class.binary_params_for?(action)
+        rescue NameError
+          false
         end
 
         def parse_formatted_parameters(parsers)

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -100,6 +100,20 @@ module ApplicationTests
       end
     end
 
+    test "routing to an nonexistent controller when action_dispatch.show_exceptions and consider_all_requests_local are set shows diagnostics" do
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          resources :articles
+        end
+      RUBY
+
+      app.config.action_dispatch.show_exceptions = true
+      app.config.consider_all_requests_local = true
+
+      get "/articles"
+      assert_match "<title>Action Controller: Exception caught</title>", last_response.body
+    end
+
     test "displays diagnostics message when exception raised in template that contains UTF-8" do
       controller :foo, <<-RUBY
         class FooController < ActionController::Base


### PR DESCRIPTION
When you have a route that points to an nonexistent controller we raise an exception.

This exception was being caught by the DebugExceptions middleware in development, but when trying to render the error page, we are reading the request format[[1][]]. To determine the request format we are reading the format parameters[[2][]], and to be able to read the parameters we need
to encode them[[3][]]. This was raising another exception because, to encode the parameter, we try to load the controller to determine if we need to encode the parameters are binary[[4][]]. This new exception inside the DebugExceptions middleware makes Rails to render a generic error page.

To avoid this new exception now we only encode the parameters when the controller can be loaded.

Fixes #28892

[1]: https://github.com/rails/rails/blob/f52cdaac6336f99d13622ff9bda556a3124a4121/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb#L80
[2]: https://github.com/rails/rails/blob/f52cdaac6336f99d13622ff9bda556a3124a4121/actionpack/lib/action_dispatch/http/mime_negotiation.rb#L63
[3]: https://github.com/rails/rails/blob/f52cdaac6336f99d13622ff9bda556a3124a4121/actionpack/lib/action_dispatch/http/parameters.rb#L58
[4]: https://github.com/rails/rails/blob/f52cdaac6336f99d13622ff9bda556a3124a4121/actionpack/lib/action_dispatch/http/parameters.rb#L88