### PR TITLE
Fix regression caused by collection_singular_ids= ignoring different …

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -67,10 +67,14 @@ module ActiveRecord
           pk_type.type_cast_from_user(i)
         end
 
-        if (objs = klass.where(pk_column => ids)).size == ids.size
+        objs = klass.where(pk_column => ids).index_by do |r|
+          r.send(pk_column)
+        end.values_at(*ids).compact
+
+        if objs.size == ids.size
           replace(objs.index_by { |r| r.send(pk_column) }.values_at(*ids))
         else
-          objs.raise_record_not_found_exception!(ids, objs.size, ids.size)
+          klass.all.raise_record_not_found_exception!(ids, objs.size, ids.size)
         end
       end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1211,4 +1211,16 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     @user.business_ids = [businesses(:walmart).uuid]
     assert @user.businesses.include?(businesses(:walmart))
   end
+
+  def test_singular_collection_ids_are_added_correctly
+    user     = users(:one)
+    business = businesses(:walmart)
+    assert user.businesses.empty?
+    user.business_ids = [business.uuid]
+
+    assert_equal user.business_ids, [business.uuid]
+    assert_nothing_raised(ActiveRecord::RecordNotFound) do
+      user.business_ids += [business.uuid]
+    end
+  end
 end


### PR DESCRIPTION
…primary key on relationship

There was a regression caused by my commit here #27566. Calling`model.association_ids += [1, 2]` if `1` or `2` is already in the `association_ids` caused ActiveRecord::RecordNotFound to be raised when it should not be. I used what was already on master [here](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/collection_association.rb#L58).

An executable gist that shows this is [here](https://gist.github.com/madwork/94bcaa528fe0ea68e510b9feda549cb4)

P.S. Thanks to @madwork for pointing this out. 