### PR TITLE
Prevent negative IDs in output of #inspect.

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -56,7 +56,7 @@ module ActionView
       end
 
       def inspect
-        "#<#{self.class.name}:0x#{(object_id << 1).to_s(16)} keys=#{@data.size} queries=#{@query_cache.size}>"
+        "#{to_s[0..-2]} keys=#{@data.size} queries=#{@query_cache.size}>"
       end
 
       # Cache the templates returned by the block


### PR DESCRIPTION
### Summary

object_id might be negative, since Ruby tries to avoid Bignums:

https://bugs.ruby-lang.org/issues/13397

### Other Information

The associated test case fails from time to time in Fedora's CI infrastructure:

https://kojipkgs.fedoraproject.org/work/tasks/6269/19116269/build.log
https://apps.fedoraproject.org/koschei/package/rubygem-actionview?collection=f27