### PR TITLE
Evaluate belongs_to :default option against the owner, not the association

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -22,7 +22,7 @@ module ActiveRecord
       end
 
       def default(&block)
-        writer(instance_exec(&block)) if reader.nil?
+        writer(owner.instance_exec(&block)) if reader.nil?
       end
 
       def reset

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -136,6 +136,24 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal david, ship.developer
   end
 
+  def test_default_with_lambda
+    model = Class.new(ActiveRecord::Base) do
+      self.table_name = "ships"
+      def self.name; "Temp"; end
+      belongs_to :developer, default: -> { default_developer }
+
+      def default_developer
+        Developer.first
+      end
+    end
+
+    ship = model.create!
+    assert_equal developers(:david), ship.developer
+
+    ship = model.create!(developer: developers(:jamis))
+    assert_equal developers(:jamis), ship.developer
+  end
+
   def test_default_scope_on_relations_is_not_cached
     counter = 0
 


### PR DESCRIPTION
Before:

```ruby
# app/models/ship.rb
class Ship < ApplicationRecord
  belongs_to :developer, default: -> { default_developer }

  def default_developer
    Developer.first
  end
end
```

```
> ship = Ship.create!
NameError: undefined local variable or method `default_developer' for #<ActiveRecord::Associations::BelongsToAssociation:0x0056312d94b8d0>
```

After:

```rib
> ship = Ship.create!
# => #<Ship id: 1, developer_id: 1>
```

/cc @dhh