### PR TITLE
Fixes Marshalling With Autoload

### DIFF
--- a/activesupport/lib/active_support/core_ext/marshal.rb
+++ b/activesupport/lib/active_support/core_ext/marshal.rb
@@ -1,7 +1,7 @@
 module ActiveSupport
   module MarshalWithAutoloading # :nodoc:
-    def load(source, proc = nil)
-      super(source, proc)
+    def load(source, *proc)
+      super(source, *proc)
     rescue ArgumentError, NameError => exc
       if exc.message.match(%r|undefined class/module (.+?)(?:::)?\z|)
         # try loading the class/module


### PR DESCRIPTION
### Summary

Active Support's `Marshal.load` prepend does not match the signature for the overridden method. This triggers crashing on the JRuby engine, though not on MRI. This fixes marshalling with autoload for both.

### Other Information

Only tested on JRuby and MRI.
