### PR TITLE
Implement ActiveRecord::Result#cast_values! method.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ActiveRecord::Result#cast_values!` method to overwrite result rows with their cast values.
+
+    *Brad Nauta*
+
 *   Quote database name in db:create grant statement (when database_user does not have access to create the database).
 
     *Rune Philosof*

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -95,12 +95,14 @@ module ActiveRecord
     end
 
     def cast_values(type_overrides = {}) # :nodoc:
-      types = columns.map { |name| column_type(name, type_overrides) }
-      result = rows.map do |values|
-        types.zip(values).map { |type, value| type.deserialize(value) }
-      end
-
+      result = cast_rows(type_overrides)
       columns.one? ? result.map!(&:first) : result
+    end
+
+    def cast_values!(type_overrides = {}) # :nodoc:
+      @hash_rows = nil
+      @rows = cast_rows(type_overrides)
+      columns.one? ? @rows.map!(&:first) : @rows
     end
 
     def initialize_copy(other)
@@ -115,6 +117,13 @@ module ActiveRecord
       def column_type(name, type_overrides = {})
         type_overrides.fetch(name) do
           column_types.fetch(name, Type.default_value)
+        end
+      end
+
+      def cast_rows(type_overrides)
+        types = columns.map { |name| column_type(name, type_overrides) }
+        rows.map do |values|
+          types.zip(values).map { |type, value| type.deserialize(value) }
         end
       end
 

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -86,41 +86,41 @@ module ActiveRecord
     end
 
     test "cast_values! returns rows after type casting" do
-       values = [["1.1", "2.2"], ["3.3", "4.4"]]
-       columns = ["col1", "col2"]
-       types = { "col1" => Type::Integer.new, "col2" => Type::Float.new }
-       result = Result.new(columns, values, types)
+      values = [["1.1", "2.2"], ["3.3", "4.4"]]
+      columns = ["col1", "col2"]
+      types = { "col1" => Type::Integer.new, "col2" => Type::Float.new }
+      result = Result.new(columns, values, types)
 
-       assert_equal [[1, 2.2], [3, 4.4]], result.cast_values!
-     end
+      assert_equal [[1, 2.2], [3, 4.4]], result.cast_values!
+    end
 
-     test "cast_values! can receive types to use instead" do
-       values = [["1.1", "2.2"], ["3.3", "4.4"]]
-       columns = ["col1", "col2"]
-       types = { "col1" => Type::Integer.new, "col2" => Type::Float.new }
-       result = Result.new(columns, values, types)
+    test "cast_values! can receive types to use instead" do
+      values = [["1.1", "2.2"], ["3.3", "4.4"]]
+      columns = ["col1", "col2"]
+      types = { "col1" => Type::Integer.new, "col2" => Type::Float.new }
+      result = Result.new(columns, values, types)
 
-       assert_equal [[1.1, 2.2], [3.3, 4.4]], result.cast_values!("col1" => Type::Float.new)
-     end
+      assert_equal [[1.1, 2.2], [3.3, 4.4]], result.cast_values!("col1" => Type::Float.new)
+    end
 
-     test "cast_values! overwrites rows attribute" do
-       values = [["1.1", "2.2"], ["3.3", "4.4"]]
-       columns = ["col1", "col2"]
-       types = { "col1" => Type::Integer.new, "col2" => Type::Float.new }
-       result = Result.new(columns, values, types)
-       result.cast_values!
+    test "cast_values! overwrites rows attribute" do
+      values = [["1.1", "2.2"], ["3.3", "4.4"]]
+      columns = ["col1", "col2"]
+      types = { "col1" => Type::Integer.new, "col2" => Type::Float.new }
+      result = Result.new(columns, values, types)
+      result.cast_values!
 
-       assert_equal [[1, 2.2], [3, 4.4]], result.rows
-     end
+      assert_equal [[1, 2.2], [3, 4.4]], result.rows
+    end
 
-     test "cast_values! clears hash_rows memoziation cache" do
-       columns = ["col1"]
-       values = [["row_1 col_1"]]
-       result = Result.new(columns, values)
-       result.to_hash
-       result.cast_values!
+    test "cast_values! clears hash_rows memoziation cache" do
+      columns = ["col1"]
+      values = [["row_1 col_1"]]
+      result = Result.new(columns, values)
+      result.to_hash
+      result.cast_values!
 
-       assert_nil result.instance_variable_get("@hash_rows")
-     end
+      assert_nil result.instance_variable_get("@hash_rows")
+    end
   end
 end

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -84,5 +84,43 @@ module ActiveRecord
 
       assert_equal [[1.1, 2.2], [3.3, 4.4]], result.cast_values("col1" => Type::Float.new)
     end
+
+    test "cast_values! returns rows after type casting" do
+       values = [["1.1", "2.2"], ["3.3", "4.4"]]
+       columns = ["col1", "col2"]
+       types = { "col1" => Type::Integer.new, "col2" => Type::Float.new }
+       result = Result.new(columns, values, types)
+
+       assert_equal [[1, 2.2], [3, 4.4]], result.cast_values!
+     end
+
+     test "cast_values! can receive types to use instead" do
+       values = [["1.1", "2.2"], ["3.3", "4.4"]]
+       columns = ["col1", "col2"]
+       types = { "col1" => Type::Integer.new, "col2" => Type::Float.new }
+       result = Result.new(columns, values, types)
+
+       assert_equal [[1.1, 2.2], [3.3, 4.4]], result.cast_values!("col1" => Type::Float.new)
+     end
+
+     test "cast_values! overwrites rows attribute" do
+       values = [["1.1", "2.2"], ["3.3", "4.4"]]
+       columns = ["col1", "col2"]
+       types = { "col1" => Type::Integer.new, "col2" => Type::Float.new }
+       result = Result.new(columns, values, types)
+       result.cast_values!
+
+       assert_equal [[1, 2.2], [3, 4.4]], result.rows
+     end
+
+     test "cast_values! clears hash_rows memoziation cache" do
+       columns = ["col1"]
+       values = [["row_1 col_1"]]
+       result = Result.new(columns, values)
+       result.to_hash
+       result.cast_values!
+
+       assert_nil result.instance_variable_get("@hash_rows")
+     end
   end
 end


### PR DESCRIPTION
### Summary

Add `ActiveRecord::Result#cast_values!` method to overwrite result rows with their cast values.

Uses much of the same code as `#cast_values`, so refactored by implementing a shared method as well.

### Other Information

ActiveRecord::Result has a `cast_values` instance method which casts row values to implicit (or explicit, via options) types. Calling this method returns the _cast_ version of AR::Result#rows, not mutating the parent AR::Result object.

This is sometimes undesirable as other instance methods such as `#to_hash`, `#first` and `#last` use the _uncast_ row values, forcing the developer to re-implement the method logic elsewhere in an application.

Calling `cast_values!` replaces the default `rows` attribute with cast values,  maintaining caller access to other instance methods.

Ex (using PostgreSQLAdapter):

```
> result = ActiveRecord::Base::connection.exec_query("SELECT ARRAY[1,2,3] AS col")
=> #<ActiveRecord::Result:...>

> result.rows
=> [["{1,2,3}"]]

> result.cast_values
=> [[1, 2, 3]]
# note `#cast_values` intentionally returns only the first column if only one
# column is projected. In this case, a one-dimensional array containing our
# [1, 2, 3] cast value is correct.

> result.to_hash
=> [{"col"=>"{1,2,3}"}]

> result.cast_values!
=> [[1, 2, 3]]
# like `#cast_values`, also returns one-dimensional array containing our [1, 2, 3]
# cast value to maintain the principle of least surprise.

> result.rows
=> [[[1, 2, 3]]]

> result.to_hash
=> [{"col"=>[1, 2, 3]}]
```
