### PR TITLE
Fix ambigious error message of select query method [ci skip]

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -248,7 +248,7 @@ module ActiveRecord
         return super()
       end
 
-      raise ArgumentError, "Call this with at least one field" if fields.empty?
+      raise ArgumentError, "Call `select' with at least one field" if fields.empty?
       spawn._select!(*fields)
     end
 


### PR DESCRIPTION
I saw this while working on different issue, the error message for `select` method is not clear and should be more descriptive like the error message in case passing argument with block case.
Also I've added ci skip because the test which is checking this case does not look the message of the exception.