### PR TITLE
Add missing require for `remove_possible_method`

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/date_and_time/compatibility"
+require "active_support/core_ext/module/remove_method"
 
 class DateTime
   include DateAndTime::Compatibility


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/28918.

https://github.com/rails/rails/commit/505537082849d912e8e29819655b80a573e93c0c added a call to `remove_possible_method`, but didn't require the file that defines it.

r? @pixeltrix