### PR TITLE
Fail hard if incompatible options are supplied with --webpack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,11 +8,11 @@ GIT
 
 GIT
   remote: https://github.com/matthewd/rb-inotify.git
-  revision: 90553518d1fb79aedc98a3036c59bd2b6731ac40
+  revision: 856730aad4b285969e8dd621e44808a7c5af4242
   branch: close-handling
   specs:
-    rb-inotify (0.9.7)
-      ffi (>= 0.5.0)
+    rb-inotify (0.9.9)
+      ffi (~> 1.0)
 
 GIT
   remote: https://github.com/matthewd/websocket-client-simple.git

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -13,7 +13,7 @@ module Rails
       DATABASES = %w( mysql postgresql sqlite3 oracle frontbase ibm_db sqlserver )
       JDBC_DATABASES = %w( jdbcmysql jdbcsqlite3 jdbcpostgresql jdbc )
       DATABASES.concat(JDBC_DATABASES)
-      WEBPACKS = %w( react vue angular )
+      WEBPACKS = %w( react vue angular elm )
 
       attr_accessor :rails_template
       add_shebang_option!

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -224,6 +224,18 @@ module Rails
           raise Error, "Invalid value for --database option. Supported for preconfiguration are: #{DATABASES.join(", ")}."
         end
 
+        # --webpack uses webpacker, which uses action view helpers
+        # --api skips action view
+        if options[:webpack] && options[:api]
+          raise Error, "Incompatible options --api and --webpack supplied. Please use either --api or --webpack"
+        end
+
+        # --webpack requires webpacker gem to be pre-bundled
+        # --skip-bundle skips bundle install
+        if options[:webpack] && options[:skip_bundle]
+          raise Error, "Incompatible options --webpack and --skip-bundle supplied. Please use either --skip-bundle or --webpack"
+        end
+
         # Force sprockets and yarn to be skipped when generating API only apps.
         # Can't modify options hash as it's frozen by default.
         if options[:api]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -384,6 +384,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_directory "test/mailers"
   end
 
+  def test_generator_if_skip_bundle_and_webpack_is_given
+    stderr_output = capture(:stderr) { run_generator [destination_root, "--skip-bundle", "--webpack"] }
+    assert_equal(stderr_output, "Incompatible options --webpack and --skip-bundle supplied. Please use either --skip-bundle or --webpack\n")
+  end
+
+  def test_generator_if_api_and_webpack_is_given
+    stderr_output = capture(:stderr) { run_generator [destination_root, "--api", "--webpack"] }
+    assert_equal(stderr_output, "Incompatible options --api and --webpack supplied. Please use either --api or --webpack\n")
+  end
+
   def test_generator_has_assets_gems
     run_generator
 


### PR DESCRIPTION
### Summary
* Fail hard if using `--webpack` and `--api` option together, they simple aren't made for each other 😄 . Addresses this - https://github.com/rails/webpacker/issues/276
* Fail hard if using `--webpack` and `--skip-bundle` option together, chicken and egg situation apparently 😄 . Addresses this - https://github.com/rails/rails/issues/28916 
* Add elm to installer list

// cc @rafaelfranca @dhh 
