### PR TITLE
DATABASE_URL updates development and test config

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -61,7 +61,13 @@ module ActiveRecord
     class MergeAndResolveDefaultUrlConfig # :nodoc:
       def initialize(raw_configurations)
         @raw_config = raw_configurations.dup
-        @env = DEFAULT_ENV.call.to_s
+
+        env = DEFAULT_ENV.call.to_s
+        if env == "development"
+          @env = [env, "test"]
+        else
+          @env = [env]
+        end
       end
 
       # Returns fully resolved connection hashes.
@@ -74,8 +80,10 @@ module ActiveRecord
         def config
           @raw_config.dup.tap do |cfg|
             if url = ENV["DATABASE_URL"]
-              cfg[@env] ||= {}
-              cfg[@env]["url"] ||= url
+              @env.each do |env|
+                cfg[env] ||= {}
+                cfg[env]["url"] ||= url
+              end
             end
           end
         end

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -250,6 +250,24 @@ module ActiveRecord
                     }
         assert_equal expected, actual
       end
+
+      def test_database_url_updates_development_and_test
+        ENV["DATABASE_URL"] = "postgres://localhost"
+        ENV["RAILS_ENV"]    = "development"
+
+        config = {
+          "development" => { "adapter" => "postgresql", "database" => "foo", "host" => "NOT-LOCALHOST" },
+          "test" => { "adapter" => "postgresql", "database" => "foo2", "host" => "NOT-LOCALHOST" }
+        }
+
+        actual   = resolve_config(config)
+        expected = {
+          "development" => config["development"].merge("host" => "localhost"),
+          "test" => config["test"].merge("host" => "localhost")
+        }
+
+        assert_equal expected, actual
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

development and test usually travel in a pair when it comes to database
configuration, so it makes sense to update the development and test
config if DATABASE_URL is set.

### Other Information

Fixes #28827 