### PR TITLE
Default content type for `head` is `text/html`

### DIFF
--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -36,7 +36,7 @@ module ActionController
       self.response_body = ""
 
       if include_content?(response_code)
-        self.content_type = content_type || (Mime[formats.first] if formats)
+        self.content_type = content_type || (Mime[formats.first] if formats) || Mime[:html]
         response.charset = false
       end
 

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -227,6 +227,15 @@ class TestController < ActionController::Base
     head 204
   end
 
+  def head_default_content_type
+    # simulating path like "/1.foobar"
+    request.formats = []
+
+    respond_to do |format|
+      format.any { head 200 }
+    end
+  end
+
   private
 
     def set_variable_for_layout
@@ -758,6 +767,11 @@ class HeadRenderTest < ActionController::TestCase
     assert_nothing_raised do
       get :head_and_return
     end
+  end
+
+  def test_head_default_content_type
+    post :head_default_content_type
+    assert_equal "text/html", @response.header["Content-Type"]
   end
 end
 


### PR DESCRIPTION
### Summary

Otherwise an instance of `Mime::NullType` will be returned as the `Content-Type` header.

### Other Information

Fixes #28927