### PR TITLE
Deprecate `supports_statement_cache?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `supports_statement_cache?`.
+
+    *Ryuta Kamizono*
+
 *   Quote database name in `db:create` grant statement (when database user does not have access to create the database).
 
     *Rune Philosof*

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -137,9 +137,10 @@ module ActiveRecord
 
       # Returns +true+ when the connection adapter supports prepared statement
       # caching, otherwise returns +false+
-      def supports_statement_cache?
-        false
+      def supports_statement_cache? # :nodoc:
+        true
       end
+      deprecate :supports_statement_cache?
 
       # Runs the given block in a database transaction, and returns the result
       # of the block.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -76,12 +76,6 @@ module ActiveRecord
         true
       end
 
-      # Returns true, since this connection adapter supports prepared statement
-      # caching.
-      def supports_statement_cache?
-        true
-      end
-
       def supports_index_sort_order?
         !mariadb? && version >= "8.0.1"
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -121,12 +121,6 @@ module ActiveRecord
       include PostgreSQL::DatabaseStatements
       include PostgreSQL::ColumnDumper
 
-      # Returns true, since this connection adapter supports prepared statement
-      # caching.
-      def supports_statement_cache?
-        true
-      end
-
       def supports_index_sort_order?
         true
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -105,12 +105,6 @@ module ActiveRecord
         sqlite_version >= "3.8.0"
       end
 
-      # Returns true, since this connection adapter supports prepared statement
-      # caching.
-      def supports_statement_cache?
-        true
-      end
-
       def requires_reloading?
         true
       end

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -3,8 +3,7 @@ require "models/topic"
 require "models/author"
 require "models/post"
 
-if ActiveRecord::Base.connection.supports_statement_cache? &&
-   ActiveRecord::Base.connection.prepared_statements
+if ActiveRecord::Base.connection.prepared_statements
   module ActiveRecord
     class BindParameterTest < ActiveRecord::TestCase
       fixtures :topics, :authors, :author_addresses, :posts
@@ -64,6 +63,10 @@ if ActiveRecord::Base.connection.supports_statement_cache? &&
       def test_logs_legacy_binds_after_type_cast
         binds = [[@pk, "10"]]
         assert_logs_binds(binds)
+      end
+
+      def test_deprecate_supports_statement_cache
+        assert_deprecated { ActiveRecord::Base.connection.supports_statement_cache? }
       end
 
       private


### PR DESCRIPTION
`supports_statement_cache?` was introduced in 3.1.0.beta1 (104d0b2) for
bind parameter substitution, but it is no longer used in 3.1.0.rc1
(73ff679). Originally it should respect `prepared_statements` rather
than `supports_statement_cache?` (fd39847).
One more thing, named `supports_statement_cache?` is pretty misreading.
We have `StatementCache` and `StatementPool`. However,
`supports_statement_cache?` doesn't mean `StatementCache`, but
`StatementPool` unlike its name.

https://github.com/rails/rails/blob/v5.1.0/activerecord/lib/active_record/statement_cache.rb
https://github.com/rails/rails/blob/v5.1.0/activerecord/lib/active_record/connection_adapters/statement_pool.rb