### PR TITLE
Friendly maintain schema error in test runner

### DIFF
--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -12,7 +12,12 @@ require "rails/generators/test_case"
 require "active_support/testing/autorun"
 
 if defined?(ActiveRecord::Base)
-  ActiveRecord::Migration.maintain_test_schema!
+  begin
+    ActiveRecord::Migration.maintain_test_schema!
+  rescue ActiveRecord::PendingMigrationError => e
+    puts e.to_s.strip
+    exit 1
+  end
 
   module ActiveSupport
     class TestCase


### PR DESCRIPTION
When you run a test, the test helper will raise an error if you have a migration pending. This is very helpful check indeed, but with the trace it takes a while to scroll up to the top to see the error:

![](https://d2ppvlu71ri8gs.cloudfront.net/items/0i1l30233b1G0o2q0u05/Screen%20Recording%202017-04-30%20at%2005.56%20PM.gif?v=2af680f6)

It takes even longer to scroll up in case of a large app like Shopify where the trace is large.

My suggestion is to print the error and exit with non-zero status. In this case the error is visible right away:

<img width="642" alt="screen shot 2017-04-30 at 18 04 24" src="https://cloud.githubusercontent.com/assets/522155/25568382/8a8dd13a-2dcf-11e7-8d5d-43733b391c59.png">

review @rafaelfranca 