### PR TITLE
Remove unnecessary `package.json` deletion

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -317,10 +317,6 @@ module Rails
 
       def create_vendor_files
         build(:vendor)
-
-        if options[:skip_yarn]
-          remove_file "package.json"
-        end
       end
 
       def delete_app_assets_if_api_option


### PR DESCRIPTION
The `package.json` is created only if `skip_yarn` is not specified.
https://github.com/rails/rails/blob/a4c1282854795d1f0d7696ce1ccbabf94b3d9098/railties/lib/rails/generators/rails/app/app_generator.rb#L202..L204

