### PR TITLE
CLI arg `--port` has precedence over env `PORT`

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -95,10 +95,11 @@ module Rails
 
   module Command
     class ServerCommand < Base # :nodoc:
+      DEFAULT_PORT = 3000
       DEFAULT_PID_PATH = "tmp/pids/server.pid".freeze
 
       class_option :port, aliases: "-p", type: :numeric,
-        desc: "Runs Rails on the specified port.", banner: :port, default: 3000
+        desc: "Runs Rails on the specified port - defaults to 3000.", banner: :port
       class_option :binding, aliases: "-b", type: :string,
         desc: "Binds Rails to the specified IP - defaults to 'localhost' in development and '0.0.0.0' in other environments'.",
         banner: :IP
@@ -184,7 +185,7 @@ module Rails
         end
 
         def port
-          ENV.fetch("PORT", options[:port]).to_i
+          options[:port] || ENV.fetch("PORT", DEFAULT_PORT).to_i
         end
 
         def host

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -140,6 +140,18 @@ class Rails::ServerTest < ActiveSupport::TestCase
   end
 
   def test_argument_precedence_over_environment_variable
+    switch_env "PORT", "1234" do
+      args = ["-p", "5678"]
+      options = parse_arguments(args)
+      assert_equal 5678, options[:Port]
+    end
+
+    switch_env "PORT", "1234" do
+      args = ["-p", "3000"]
+      options = parse_arguments(args)
+      assert_equal 3000, options[:Port]
+    end
+
     switch_env "HOST", "1.2.3.4" do
       args = ["-b", "127.0.0.1"]
       options = parse_arguments(args)


### PR DESCRIPTION
### Summary

In Rails 5.0.2, the option `-p` for command `rails server` has precedence over environment variable `PORT`.
But in Rails 5.1.0, environment variable `PORT` has precedence.

Is it expected behavior?

See also: [CLI arg "host" has precedence over ENV var "host" by maclover7 · Pull Request #28513 · rails/rails](https://github.com/rails/rails/pull/28513)

### current behavior

#### Rails 5.1.0

```
$ rails --version
Rails 5.1.0
$ export PORT=3456
$ echo $PORT
3456
$ rails s -p 3333
=> Booting WEBrick
=> Rails 5.1.0 application starting in development on http://localhost:3456
=> Run `rails server -h` for more startup options
[2017-05-01 16:09:44] INFO  WEBrick 1.3.1
[2017-05-01 16:09:44] INFO  ruby 2.4.1 (2017-03-22) [x86_64-darwin16]
[2017-05-01 16:09:44] INFO  WEBrick::HTTPServer#start: pid=37581 port=3456
```

#### Rails 5.0.2

```
$ rails --version
Rails 5.0.2
$ echo $PORT
3456
$ rails s -p 3333
=> Booting WEBrick
=> Rails 5.0.2 application starting in development on http://localhost:3333
=> Run `rails server -h` for more startup options
[2017-05-01 16:11:24] INFO  WEBrick 1.3.1
[2017-05-01 16:11:24] INFO  ruby 2.4.1 (2017-03-22) [x86_64-darwin16]
[2017-05-01 16:11:24] INFO  WEBrick::HTTPServer#start: pid=43415 port=3333
$ rails s
=> Booting WEBrick
=> Rails 5.0.2 application starting in development on http://localhost:3456
=> Run `rails server -h` for more startup options
[2017-05-01 16:11:40] INFO  WEBrick 1.3.1
[2017-05-01 16:11:40] INFO  ruby 2.4.1 (2017-03-22) [x86_64-darwin16]
[2017-05-01 16:11:40] INFO  WEBrick::HTTPServer#start: pid=44602 port=3456
```