### PR TITLE
Update the Gem Bug Report Templates to 5.1.0

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -8,7 +8,7 @@ end
 gemfile(true) do
   source "https://rubygems.org"
   # Activate the gem you are reporting the issue against.
-  gem "rails", "5.1.0.rc1"
+  gem "rails", "5.1.0"
 end
 
 require "rack/test"

--- a/guides/bug_report_templates/active_job_gem.rb
+++ b/guides/bug_report_templates/active_job_gem.rb
@@ -8,7 +8,7 @@ end
 gemfile(true) do
   source "https://rubygems.org"
   # Activate the gem you are reporting the issue against.
-  gem "activejob", "5.1.0.rc1"
+  gem "activejob", "5.1.0"
 end
 
 require "minitest/autorun"

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -8,7 +8,7 @@ end
 gemfile(true) do
   source "https://rubygems.org"
   # Activate the gem you are reporting the issue against.
-  gem "activerecord", "5.1.0.rc1"
+  gem "activerecord", "5.1.0"
   gem "sqlite3"
 end
 

--- a/guides/bug_report_templates/active_record_migrations_gem.rb
+++ b/guides/bug_report_templates/active_record_migrations_gem.rb
@@ -8,7 +8,7 @@ end
 gemfile(true) do
   source "https://rubygems.org"
   # Activate the gem you are reporting the issue against.
-  gem "activerecord", "5.1.0.rc1"
+  gem "activerecord", "5.1.0"
   gem "sqlite3"
 end
 

--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -8,7 +8,7 @@ end
 gemfile(true) do
   source "https://rubygems.org"
   # Activate the gem you are reporting the issue against.
-  gem "activesupport", "5.1.0.rc1"
+  gem "activesupport", "5.1.0"
 end
 
 require "active_support/core_ext/object/blank"


### PR DESCRIPTION
### Summary

5.1.0 has been released, and the gem templates can reflect that now.