### PR TITLE
Raise if value for `enum` is nil

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -156,6 +156,8 @@ module ActiveRecord
         enum_values = ActiveSupport::HashWithIndifferentAccess.new
         name        = name.to_sym
 
+        detect_nil_enum!(name, values)
+
         # def self.statuses() statuses end
         detect_enum_conflict!(name, name.to_s.pluralize, true)
         klass.singleton_class.send(:define_method, name.to_s.pluralize) { enum_values }
@@ -223,6 +225,20 @@ module ActiveRecord
           raise_conflict_error(enum_name, method_name)
         elsif !klass_method && method_defined_within?(method_name, _enum_methods_module, Module)
           raise_conflict_error(enum_name, method_name, source: "another enum")
+        end
+      end
+
+      ENUM_NIL_MESSAGE = \
+        "You tried to define an enum named \"%{enum}\" on the model \"%{klass}\", but " \
+        "nil values for enums are not supported."
+
+      def detect_nil_enum!(enum_name, values)
+        # Check if values is a Hash, and if any of the values are nil.
+        if values.respond_to?(:each_pair) && values.any? { |k, v| v.nil? }
+          raise ArgumentError, ENUM_NIL_MESSAGE % {
+            enum: enum_name,
+            klass: name,
+          }
         end
       end
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -481,4 +481,15 @@ class EnumTest < ActiveRecord::TestCase
   test "data type of Enum type" do
     assert_equal :integer, Book.type_for_attribute("status").type
   end
+
+  test "nil enum values raise an error" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+    end
+
+    e = assert_raises(ArgumentError, "enum value `#{nil}` should not be allowed") do
+      klass.class_eval { enum "status" => { a: nil } }
+    end
+    assert_match(/You tried to define an enum named .* on the model/, e.message)
+  end
 end


### PR DESCRIPTION
### Summary

Per @sgrif, this is unsupported behavior. Purposefully raising very
early, because we want to blow up before any methods are defined on the
class.

### Other Information

Fixes part of #28945, but the core Attributes API issue still needs to be addressed