### PR TITLE
Remove any `nil` attribute values from CSS/JS tag helpers

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove any attributes from `javascript_include_tag` and `stylesheet_link_tag` that have `nil` values.
+
+    *Jacob Bednarz*
+
 *   Update `distance_of_time_in_words` helper to display better error messages
     for bad input.
 

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -1,5 +1,6 @@
 require "active_support/core_ext/array/extract_options"
 require "active_support/core_ext/hash/keys"
+require "active_support/core_ext/hash/compact"
 require "action_view/helpers/asset_url_helper"
 require "action_view/helpers/tag_helper"
 
@@ -73,7 +74,7 @@ module ActionView
       #   javascript_include_tag "http://www.example.com/xmlhr.js"
       #   # => <script src="http://www.example.com/xmlhr.js"></script>
       def javascript_include_tag(*sources)
-        options = sources.extract_options!.stringify_keys
+        options = sources.extract_options!.stringify_keys.compact
         path_options = options.extract!("protocol", "extname", "host", "skip_pipeline").symbolize_keys
         sources.uniq.map { |source|
           tag_options = {
@@ -109,7 +110,7 @@ module ActionView
       #   # => <link href="/assets/random.styles" media="screen" rel="stylesheet" />
       #   #    <link href="/css/stylish.css" media="screen" rel="stylesheet" />
       def stylesheet_link_tag(*sources)
-        options = sources.extract_options!.stringify_keys
+        options = sources.extract_options!.stringify_keys.compact
         path_options = options.extract!("protocol", "host", "skip_pipeline").symbolize_keys
         sources.uniq.map { |source|
           tag_options = {

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -100,6 +100,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(javascript_include_tag("bank.js")) => %(<script src="/javascripts/bank.js" ></script>),
     %(javascript_include_tag("bank", :lang => "vbscript")) => %(<script lang="vbscript" src="/javascripts/bank.js" ></script>),
     %(javascript_include_tag("bank", :host => "assets.example.com")) => %(<script src="http://assets.example.com/javascripts/bank.js"></script>),
+    %(javascript_include_tag("sample", :crossorigin => nil)) => %(<script src="/javascripts/sample.js" ></script>),
 
     %(javascript_include_tag("http://example.com/all")) => %(<script src="http://example.com/all"></script>),
     %(javascript_include_tag("http://example.com/all.js")) => %(<script src="http://example.com/all.js"></script>),
@@ -145,6 +146,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(stylesheet_link_tag("subdir/subdir")) => %(<link href="/stylesheets/subdir/subdir.css" media="screen" rel="stylesheet" />),
     %(stylesheet_link_tag("bank", :media => "all")) => %(<link href="/stylesheets/bank.css" media="all" rel="stylesheet" />),
     %(stylesheet_link_tag("bank", :host => "assets.example.com")) => %(<link href="http://assets.example.com/stylesheets/bank.css" media="screen" rel="stylesheet" />),
+    %(stylesheet_link_tag("example", :something => nil)) => %(<link rel="stylesheet" media="screen" href="/stylesheets/example.css" />),
 
     %(stylesheet_link_tag("http://www.example.com/styles/style")) => %(<link href="http://www.example.com/styles/style" media="screen" rel="stylesheet" />),
     %(stylesheet_link_tag("http://www.example.com/styles/style.css")) => %(<link href="http://www.example.com/styles/style.css" media="screen" rel="stylesheet" />),


### PR DESCRIPTION
When options are passed into the `javascript_include_tag` and
`stylesheet_link_tag` the data is stringified and should the value of
the options ever be `nil` it is outputted which is unexpected. To fix
this, I've updated the helpers to drop any `nil` key/value pairs using
`compact`.

@rafaelfranca correctly denied this in #28950 because it was against 
`4-2-stable`. I've double checked this in `master` and found that the
issue is still present so opening here instead.