### PR TITLE
Use assert_nil instead of assert_equal nil

### DIFF
--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -315,7 +315,7 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal(1, scalar <=> 5)
     assert_equal(0, scalar <=> 10)
     assert_equal(-1, scalar <=> 15)
-    assert_equal(nil, scalar <=> "foo")
+    assert_nil(scalar <=> "foo")
   end
 
   def test_scalar_plus


### PR DESCRIPTION
Warning:
```bash
Use assert_nil if expecting nil from test/core_ext/duration_test.rb:318:in `test_scalar_compare'. This will
fail in MT6.
```