### PR TITLE
Add type caster to `RuntimeReflection#alias_name`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add type caster to `RuntimeReflection#alias_name`
+
+    Fixes #28959.
+
+    *Jon Moss*
+
 *   Deprecate `supports_statement_cache?`.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1105,7 +1105,7 @@ module ActiveRecord
       end
 
       def alias_name
-        Arel::Table.new(table_name)
+        Arel::Table.new(table_name, type_caster: klass.type_caster)
       end
 
       def all_includes; yield; end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -1,10 +1,12 @@
 require "cases/helper"
+require "models/author"
 require "models/book"
 
 class EnumTest < ActiveRecord::TestCase
-  fixtures :books
+  fixtures :books, :authors
 
   setup do
+    @author = authors(:david)
     @book = books(:awdr)
   end
 
@@ -55,6 +57,7 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_equal @book, Book.where(status: :written).first
     assert_equal @book, Book.where(status: [:published]).first
     assert_not_equal @book, Book.where(status: [:written]).first
+    assert_not @author.unpublished_books.include?(@book)
     assert_not_equal @book, Book.where.not(status: :published).first
     assert_equal @book, Book.where.not(status: :written).first
   end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -106,6 +106,7 @@ class Author < ActiveRecord::Base
   has_many :tags_with_primary_key, through: :posts
 
   has_many :books
+  has_many :unpublished_books, -> { where(status: [:proposed, :written]) }, class_name: "Book"
   has_many :subscriptions,        through: :books
   has_many :subscribers, -> { order("subscribers.nick") }, through: :subscriptions
   has_many :distinct_subscribers, -> { select("DISTINCT subscribers.*").order("subscribers.nick") }, through: :subscriptions, source: :subscriber

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -1,5 +1,5 @@
 class Book < ActiveRecord::Base
-  has_many :authors
+  belongs_to :author
 
   has_many :citations, foreign_key: "book1_id"
   has_many :references, -> { distinct }, through: :citations, source: :reference_of


### PR DESCRIPTION
### Summary

Since we have been using this `Arel::Table` since 111ccc832bc977b15af12c14e7ca078dad2d4373,
in order to properly handle queries, it's important that we properly type cast arguments.

### Other Information

Should fix #28959