### PR TITLE
Return boolean from `ConnectionHandler#connected?`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -937,7 +937,7 @@ module ActiveRecord
       # already been opened.
       def connected?(spec_name)
         conn = retrieve_connection_pool(spec_name)
-        conn && conn.connected?
+        !!(conn && conn.connected?)
       end
 
       # Remove the connection for this class. This will close the active

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -92,6 +92,13 @@ module ActiveRecord
         assert !@handler.active_connections?
       end
 
+      def test_connected?
+        assert @handler.retrieve_connection(@spec_name)
+        assert_equal true, @handler.connected?(@spec_name)
+        @handler.remove_connection(@spec_name)
+        assert_equal false, @handler.connected?(@spec_name)
+      end
+
       def test_retrieve_connection_pool
         assert_not_nil @handler.retrieve_connection_pool(@spec_name)
       end


### PR DESCRIPTION
### Summary

If the connection is disconnected, this method will now return `false` instead
of `nil`.