### PR TITLE
remove uniqueness validators from ActiveModel examples

### DIFF
--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -18,7 +18,6 @@ module ActiveModel
       #   validates :first_name, length: { maximum: 30 }
       #   validates :age, numericality: true
       #   validates :username, presence: true
-      #   validates :username, uniqueness: true
       #
       # The power of the +validates+ method comes when using custom validators
       # and default validators in one call for a given attribute.
@@ -34,7 +33,7 @@ module ActiveModel
       #     include ActiveModel::Validations
       #     attr_accessor :name, :email
       #
-      #     validates :name, presence: true, uniqueness: true, length: { maximum: 100 }
+      #     validates :name, presence: true, length: { maximum: 100 }
       #     validates :email, presence: true, email: true
       #   end
       #
@@ -94,7 +93,7 @@ module ActiveModel
       # Example:
       #
       #   validates :password, presence: true, confirmation: true, if: :password_required?
-      #   validates :token, uniqueness: true, strict: TokenGenerationException
+      #   validates :token, length: 24, strict: TokenLengthException
       #
       #
       # Finally, the options +:if+, +:unless+, +:on+, +:allow_blank+, +:allow_nil+, +:strict+

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -97,7 +97,7 @@ module ActiveModel
     # Returns the kind of the validator.
     #
     #   PresenceValidator.kind   # => :presence
-    #   UniquenessValidator.kind # => :uniqueness
+    #   AcceptanceValidator.kind # => :acceptance
     def self.kind
       @kind ||= name.split("::").last.underscore.chomp("_validator").to_sym unless anonymous?
     end
@@ -110,7 +110,7 @@ module ActiveModel
     # Returns the kind for this validator.
     #
     #   PresenceValidator.new.kind   # => :presence
-    #   UniquenessValidator.new.kind # => :uniqueness
+    #   AcceptanceValidator.new.kind # => :acceptance
     def kind
       self.class.kind
     end


### PR DESCRIPTION
### Summary

While implementing a class that utilizes `ActiveModel::Validations` I noticed that the documentation includes a number of examples that reference `uniqueness` validations which are not implemented in ActiveModel since there is no persistence layer.

### Other Information

Where possible, I replaced the example with a comparable one that is supported by ActiveModel.

I also noticed that the examples for the `Validator#kind` will raise an exception since they require an `attributes` argument, so instead of:

```ruby
PresenceValidator.new.kind   # => :presence
AcceptanceValidator.new.kind # => :acceptance
```

the examples should look like this:

```ruby
PresenceValidator.new(attributes: [:username]).kind   # => :presence
AcceptanceValidator.new(attributes: [:terms]).kind # => :acceptance
```

I did not update these examples as part of this initial change but would be happy to do so either as part of this PR or a separate one.