### PR TITLE
fix ActiveModel::Validator#kind code examples

### DIFF
--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -109,8 +109,8 @@ module ActiveModel
 
     # Returns the kind for this validator.
     #
-    #   PresenceValidator.new.kind   # => :presence
-    #   AcceptanceValidator.new.kind # => :acceptance
+    #   PresenceValidator.new(attributes: [:username]).kind # => :presence
+    #   AcceptanceValidator.new(attributes: [:terms]).kind  # => :acceptance
     def kind
       self.class.kind
     end


### PR DESCRIPTION
### Summary

This is a follow up to #28966 which was previously merged. The code examples for `ActiveModel::Validators#kind` raise exceptions in their current state as they use validators that inherit from `EachValidator` and require an `attributes` argument.

### Other Information

Alternatively, would it make sense for the default `attributes` to be an empty array?