### PR TITLE
Remove duplicated `test_merging_reorders_bind_params`

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2007,15 +2007,6 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal binds, merged.bound_attributes
   end
 
-  def test_merging_reorders_bind_params
-    post  = Post.first
-    right = Post.where(id: post.id)
-    left  = Post.where(title: post.title)
-
-    merged = left.merge(right)
-    assert_equal post, merged.first
-  end
-
   def test_relation_join_method
     assert_equal "Thank you for the welcome,Thank you again for the welcome", Post.first.comments.join(",")
   end


### PR DESCRIPTION
The same test exists in `test/cases/relation/merging_test.rb`.

https://github.com/rails/rails/blob/v5.1.0/activerecord/test/cases/relation/merging_test.rb#L94-L101