### PR TITLE
Use target language's document.yaml [ci skip]

### DIFF
--- a/guides/rails_guides/helpers.rb
+++ b/guides/rails_guides/helpers.rb
@@ -15,7 +15,7 @@ module RailsGuides
     end
 
     def documents_by_section
-      @documents_by_section ||= YAML.load_file(File.expand_path("../../source/#{@lang ? @lang + '/' : ''}documents.yaml", __FILE__))
+      @documents_by_section ||= YAML.load_file(File.expand_path("../../source/#{@language ? @language + '/' : ''}documents.yaml", __FILE__))
     end
 
     def documents_flat


### PR DESCRIPTION
Ref: [generator code](https://github.com/rails/rails/blob/master/guides/rails_guides/generator.rb#L24)

this bug force to use origin documents.yaml although we specify LANGUAGE option.

Let me build guide with "ko" language, It try to use,
    
    Before:
    - `guides/source/documents.yaml`
    
    After:
    - `guides/source/ko/documents.yaml`

/r @rafaelfranca could you check this?

Related #28337