### PR TITLE
Move `package.json` creation to `create_root_files`

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -67,6 +67,10 @@ module Rails
       end
     end
 
+    def package_json
+      template "package.json"
+    end
+
     def app
       directory "app"
 
@@ -198,10 +202,6 @@ module Rails
 
     def vendor
       empty_directory_with_keep_file "vendor"
-
-      unless options[:skip_yarn]
-        template "package.json"
-      end
     end
   end
 
@@ -248,6 +248,7 @@ module Rails
         build(:gitignore)   unless options[:skip_git]
         build(:gemfile)     unless options[:skip_gemfile]
         build(:version_control)
+        build(:package_json) unless options[:skip_yarn]
       end
 
       def create_app_files


### PR DESCRIPTION
Since `package.json` is created in root directory, it is appropriate to create it in `create_root_files`.

