### PR TITLE
Don't pass `arel.engine` to `Arel::SelectManager.new`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/arel.git
-  revision: 437aa3a4bb8ad4f3f4eba299dbb1112852f9c7ac
+  revision: 5db56a513286814991c27000af2c0243cc19d1e2
   specs:
     arel (8.0.0)
 

--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -20,7 +20,7 @@ module ActiveRecord
           subquery_alias = "subquery_for_cache_key"
           subquery_column = "#{subquery_alias}.#{timestamp_column}"
           subquery = query.arel.as(subquery_alias)
-          arel = Arel::SelectManager.new(query.engine).project(select_values % subquery_column).from(subquery)
+          arel = Arel::SelectManager.new(subquery).project(select_values % subquery_column)
         else
           query = collection.unscope(:order)
           query.select_values = [select_values % column]

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -714,16 +714,14 @@ module ActiveRecord
         # MySQL is too stupid to create a temporary table for use subquery, so we have
         # to give it some prompting in the form of a subsubquery. Ugh!
         def subquery_for(key, select)
-          subsubselect = select.clone
-          subsubselect.projections = [key]
+          subselect = select.clone
+          subselect.projections = [key]
 
           # Materialize subquery by adding distinct
           # to work with MySQL 5.7.6 which sets optimizer_switch='derived_merge=on'
-          subsubselect.distinct unless select.limit || select.offset || select.orders.any?
+          subselect.distinct unless select.limit || select.offset || select.orders.any?
 
-          subselect = Arel::SelectManager.new(select.engine)
-          subselect.project Arel.sql(key.name)
-          subselect.from subsubselect.as("__active_record_temp")
+          Arel::SelectManager.new(subselect.as("__active_record_temp")).project(Arel.sql(key.name))
         end
 
         def supports_rename_index?

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -368,9 +368,8 @@ module ActiveRecord
         relation.select_values = [aliased_column]
         subquery = relation.arel.as(subquery_alias)
 
-        sm = Arel::SelectManager.new relation.engine
         select_value = operation_over_aggregate_column(column_alias, "count", distinct)
-        sm.project(select_value).from(subquery)
+        Arel::SelectManager.new(subquery).project(select_value)
       end
   end
 end


### PR DESCRIPTION
The argument of `Arel::SelectManager.new` is `table`, not `engine`.

https://github.com/rails/arel/blob/v8.0.0/lib/arel/select_manager.rb#L10