### PR TITLE
Assorted delegate_missing_to doc fixes

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -219,48 +219,43 @@ class Module
   # When building decorators, a common pattern may emerge:
   #
   #   class Partition
-  #     def initialize(first_event)
-  #       @events = [ first_event ]
+  #     def initialize(event)
+  #       @event = event
   #     end
   #
-  #     def people
-  #       if @events.first.detail.people.any?
-  #         @events.collect { |e| Array(e.detail.people) }.flatten.uniq
-  #       else
-  #         @events.collect(&:creator).uniq
-  #       end
+  #     def person
+  #       @event.detail.person || @event.creator
   #     end
   #
   #     private
   #       def respond_to_missing?(name, include_private = false)
-  #         @events.respond_to?(name, include_private)
+  #         @event.respond_to?(name, include_private)
   #       end
   #
   #       def method_missing(method, *args, &block)
-  #         @events.send(method, *args, &block)
+  #         @event.send(method, *args, &block)
   #       end
   #   end
   #
-  # With `Module#delegate_missing_to`, the above is condensed to:
+  # With <tt>Module#delegate_missing_to</tt>, the above is condensed to:
   #
   #   class Partition
-  #     delegate_missing_to :@events
+  #     delegate_missing_to :@event
   #
-  #     def initialize(first_event)
-  #       @events = [ first_event ]
+  #     def initialize(event)
+  #       @event = event
   #     end
   #
-  #     def people
-  #       if @events.first.detail.people.any?
-  #         @events.collect { |e| Array(e.detail.people) }.flatten.uniq
-  #       else
-  #         @events.collect(&:creator).uniq
-  #       end
+  #     def person
+  #       @event.detail.person || @event.creator
   #     end
   #   end
   #
-  # The target can be anything callable within the object. E.g. instance
-  # variables, methods, constants and the likes.
+  # The target can be anything callable within the object, e.g. instance
+  # variables, methods, constants, etc.
+  #
+  # The delegated method must be public on the target, otherwise it will
+  # raise +NoMethodError+.
   def delegate_missing_to(target)
     target = target.to_s
     target = "self.#{target}" if DELEGATION_RESERVED_METHOD_NAMES.include?(target)

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -348,15 +348,15 @@ class ModuleTest < ActiveSupport::TestCase
     assert has_block.hello?
   end
 
-  def test_delegate_to_missing_with_method
+  def test_delegate_missing_to_with_method
     assert_equal "David", DecoratedTester.new(@david).name
   end
 
-  def test_delegate_to_missing_with_reserved_methods
+  def test_delegate_missing_to_with_reserved_methods
     assert_equal "David", DecoratedReserved.new(@david).name
   end
 
-  def test_delegate_to_missing_does_not_delegate_to_private_methods
+  def test_delegate_missing_to_does_not_delegate_to_private_methods
     e = assert_raises(NoMethodError) do
       DecoratedReserved.new(@david).private_name
     end
@@ -364,7 +364,7 @@ class ModuleTest < ActiveSupport::TestCase
     assert_match(/undefined method `private_name' for/, e.message)
   end
 
-  def test_delegate_to_missing_does_not_delegate_to_fake_methods
+  def test_delegate_missing_to_does_not_delegate_to_fake_methods
     e = assert_raises(NoMethodError) do
       DecoratedReserved.new(@david).my_fake_method
     end
@@ -372,7 +372,7 @@ class ModuleTest < ActiveSupport::TestCase
     assert_match(/undefined method `my_fake_method' for/, e.message)
   end
 
-  def test_delegate_to_missing_affects_respond_to
+  def test_delegate_missing_to_affects_respond_to
     assert DecoratedTester.new(@david).respond_to?(:name)
     assert_not DecoratedTester.new(@david).respond_to?(:private_name)
     assert_not DecoratedTester.new(@david).respond_to?(:my_fake_method)
@@ -382,7 +382,7 @@ class ModuleTest < ActiveSupport::TestCase
     assert_not DecoratedTester.new(@david).respond_to?(:my_fake_method, true)
   end
 
-  def test_delegate_to_missing_respects_superclass_missing
+  def test_delegate_missing_to_respects_superclass_missing
     assert_equal 42, DecoratedTester.new(@david).extra_missing
 
     assert_respond_to DecoratedTester.new(@david), :extra_missing


### PR DESCRIPTION
Probably easier to consider commit-by-commit, but all pretty simple:

* Rdoc code formatting mistake — `<tt>` instead of backticks

* Grammar tweak: should at least just be “and the **like**”, not “likes”, but this is just general tightening up.

* Extra documentation that the delegated methods must be public ([tested here](https://github.com/rails/rails/blob/7ff5ccae94ce2aff76b5f8a31a28e305a047d642/activesupport/test/core_ext/module_test.rb#L359-L365)).

* The hardest to see in the diff, but the example code was needlessly complex.  This just removes a bunch of extraneous code that was unneeded for actually demonstrating the feature itself and made the example less obvious.

* The test names were using the wrong name for the method: `delegate_to_missing` instead of `delegate_missing_to`.