### PR TITLE
Clarify deprecation message for #quoted_id

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -10,8 +10,15 @@ module ActiveRecord
         value = id_value_for_database(value) if value.is_a?(Base)
 
         if value.respond_to?(:quoted_id)
+          at = value.method(:quoted_id).source_location
+          at &&= " at %s:%d" % at
+
+          owner = value.method(:quoted_id).owner.to_s
+          klass = value.class.to_s
+          klass += "(#{owner})" unless owner == klass
+
           ActiveSupport::Deprecation.warn \
-            "Using #quoted_id is deprecated and will be removed in Rails 5.2."
+            "Defining #quoted_id is deprecated and will be ignored in Rails 5.2. (defined on #{klass}#{at})"
           return value.quoted_id
         end
 

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -81,8 +81,21 @@ module ActiveRecord
         end
       end
 
+      class QuotedOne
+        def quoted_id
+          1
+        end
+      end
+      class SubQuotedOne < QuotedOne
+      end
       def test_quote_with_quoted_id
-        assert_deprecated { assert_equal 1, @quoter.quote(Struct.new(:quoted_id).new(1)) }
+        assert_deprecated /defined on \S+::QuotedOne at .*quoting_test\.rb:[0-9]/ do
+          assert_equal 1, @quoter.quote(QuotedOne.new)
+        end
+
+        assert_deprecated /defined on \S+::SubQuotedOne\(\S+::QuotedOne\) at .*quoting_test\.rb:[0-9]/ do
+          assert_equal 1, @quoter.quote(SubQuotedOne.new)
+        end
       end
 
       def test_quote_nil


### PR DESCRIPTION
In this case, it's the method definition that's more at fault, rather than the current caller.

Addresses https://github.com/rails/rails/pull/27962#issuecomment-298492481

cc @grosser @kamipo 


I've only checked this within our tests; @grosser, are you able to confirm that this better indicates what's up when it encounters your ActiveHash example?