### PR TITLE
add deep_fetch method to Hash

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash.rb
+++ b/activesupport/lib/active_support/core_ext/hash.rb
@@ -1,5 +1,6 @@
 require "active_support/core_ext/hash/compact"
 require "active_support/core_ext/hash/conversions"
+require "active_support/core_ext/hash/deep_fetch"
 require "active_support/core_ext/hash/deep_merge"
 require "active_support/core_ext/hash/except"
 require "active_support/core_ext/hash/indifferent_access"

--- a/activesupport/lib/active_support/core_ext/hash/deep_fetch.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_fetch.rb
@@ -1,0 +1,14 @@
+class Hash
+  # Returns a value obtained by traversing a hash structure by a given keys.
+  #
+  # hash = { a: { b: 1 } }
+  # hash.deep_fetch(:a, :b) # => 1
+  #
+  # If hash does not have a key a KeyError is raised.
+  # If previously retrieved value is not a Hash a NoMethodError is raised.
+  def deep_fetch(*keys)
+    keys.reduce(self) do |hash, key|
+      hash.fetch(key)
+    end
+  end
+end

--- a/activesupport/test/core_ext/hash/deep_fetch_test.rb
+++ b/activesupport/test/core_ext/hash/deep_fetch_test.rb
@@ -1,0 +1,24 @@
+require "abstract_unit"
+require "active_support/core_ext/hash/deep_fetch"
+
+class DeepFetchTest < ActiveSupport::TestCase
+  test "deep_fetch returns a correct value" do
+    hash = { a: { b: 1 } }
+    assert_equal(1, hash.deep_fetch(:a, :b))
+  end
+
+  test "deep_fetch raises a KeyError if value is missing" do
+    hash = { a: { b: 1 } }
+    assert_raise KeyError do
+      hash.deep_fetch(:a, :c)
+    end
+  end
+
+  test "deep_fetch raises a NoMethodError if previously retrieved value is not a Hash" do
+    hash = { a: "not_a_hash" }
+
+    assert_raise NoMethodError do
+      hash.deep_fetch(:a, :b)
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Using Hash#fetch instead of a bracket notation is a common way to avoid unwanted nil's. When working with deeply nested json api's I find myself writing a lot of code like this:

```
json_data.fetch("user").fetch("profile").fetch("avatar_url")
```
this method allows to simplify it:
```
json_data.deep_fetch("user", "profile", "avatar_url")
```

