### PR TITLE
Load :author_addresses fixture to keep data integrity with :authors

### DIFF
--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -15,7 +15,7 @@ require "models/post"
 
 class HasOneAssociationsTest < ActiveRecord::TestCase
   self.use_transactional_tests = false unless supports_savepoints?
-  fixtures :accounts, :companies, :developers, :projects, :developers_projects, :ships, :pirates, :authors
+  fixtures :accounts, :companies, :developers, :projects, :developers_projects, :ships, :pirates, :authors, :author_addresses
 
   def setup
     Account.destroyed_account_ids.clear

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -283,7 +283,7 @@ class InverseHasOneTests < ActiveRecord::TestCase
 end
 
 class InverseHasManyTests < ActiveRecord::TestCase
-  fixtures :men, :interests, :posts, :authors
+  fixtures :men, :interests, :posts, :authors, :author_addresses
 
   def test_parent_instance_should_be_shared_with_every_child_on_find
     m = men(:gordon)

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -5,7 +5,7 @@ require "models/author"
 require "models/book"
 
 class EnumTest < ActiveRecord::TestCase
-  fixtures :books, :authors
+  fixtures :books, :authors, :author_addresses
 
   setup do
     @book = books(:awdr)

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -8,7 +8,7 @@ require "models/post"
 module ActiveRecord
   class OrTest < ActiveRecord::TestCase
     fixtures :posts
-    fixtures :authors
+    fixtures :authors, :author_addresses
 
     def test_or_with_relation
       expected = Post.where("id = 1 or id = 2").to_a


### PR DESCRIPTION
### Summary

This pull request addresses the following failure with Oracle database.

```ruby
$ ARCONN=oracle bundle exec ruby -w -Itest test/cases/enum_test.rb -n test_NULL_values_from_database_should_be_casted_to_nil
Using oracle
Run options: -n test_NULL_values_from_database_should_be_casted_to_nil --seed 11245

# Running:

E

Finished in 0.296445s, 3.3733 runs/s, 0.0000 assertions/s.

  1) Error:
EnumTest#test_NULL_values_from_database_should_be_casted_to_nil:
ActiveRecord::StatementInvalid: OCIError: ORA-02298: cannot validate (ARUNIT.FK_RAILS_94423A17A3) - parent keys not found: ALTER TABLE "AUTHORS" ENABLE CONSTRAINT "FK_RAILS_94423A17A3"
    stmt.c:243:in oci8lib_250.so
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/ruby-oci8-2.2.3/lib/oci8/cursor.rb:129:in `exec'
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/ruby-oci8-2.2.3/lib/oci8/oci8.rb:276:in `exec_internal'
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/ruby-oci8-2.2.3/lib/oci8/oci8.rb:267:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:429:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:90:in `exec'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:580:in `block (2 levels) in log'
    /home/yahonda/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/monitor.rb:214:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:579:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:571:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb:999:in `log'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb:11:in `execute'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:421:in `block in disable_referential_integrity'
    /home/yahonda/git/rails/activerecord/lib/active_record/result.rb:55:in `block in each'
    /home/yahonda/git/rails/activerecord/lib/active_record/result.rb:55:in `each'
    /home/yahonda/git/rails/activerecord/lib/active_record/result.rb:55:in `each'
    /home/yahonda/git/oracle-enhanced/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb:420:in `disable_referential_integrity'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:542:in `create_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:1049:in `load_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:986:in `setup_fixtures'
    /home/yahonda/git/rails/activerecord/lib/active_record/fixtures.rb:870:in `before_setup'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

### Other Information

Databases and/or database adapters which validate existing data when enabling foreign keys like Oracle database Both `:authors` and `:author_addresses` need to load.  Details are explained in #25328

