### PR TITLE
Allow capybara minor releases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "rake", ">= 11.1"
 # be loaded after loading the test library.
 gem "mocha", "~> 0.14", require: false
 
-gem "capybara", "~> 2.13.0"
+gem "capybara", "~> 2.13"
 
 gem "rack-cache", "~> 1.2"
 gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.0)
+    addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     amq-protocol (2.1.0)
     ast (2.3.0)
@@ -125,7 +125,7 @@ GEM
     bunny (2.6.2)
       amq-protocol (>= 2.0.1)
     byebug (9.0.6)
-    capybara (2.13.0)
+    capybara (2.14.0)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -226,11 +226,11 @@ GEM
     mysql2 (0.4.6-x64-mingw32)
     mysql2 (0.4.6-x86-mingw32)
     nio4r (2.0.0)
-    nokogiri (1.7.0.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
-    nokogiri (1.7.0.1-x64-mingw32)
+    nokogiri (1.7.1-x64-mingw32)
       mini_portile2 (~> 2.1.0)
-    nokogiri (1.7.0.1-x86-mingw32)
+    nokogiri (1.7.1-x86-mingw32)
       mini_portile2 (~> 2.1.0)
     parser (2.4.0.0)
       ast (~> 2.2)
@@ -383,7 +383,7 @@ DEPENDENCIES
   blade
   blade-sauce_labs_plugin
   byebug
-  capybara (~> 2.13.0)
+  capybara (~> 2.13)
   coffee-rails
   dalli (>= 2.2.1)
   delayed_job

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -34,7 +34,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   <%- if depends_on_system_test? -%>
   # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '~> 2.13.0'
+  gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
   <%- end -%>
 end


### PR DESCRIPTION
Capybara 2.14.0 was released. Loosen the tight constraint in the
generated Gemfile, so that Rails applications can take advantage of the
new version