### PR TITLE
Remove unused `DelegationTest#call_method`

### DIFF
--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -3,29 +3,7 @@ require "models/post"
 require "models/comment"
 
 module ActiveRecord
-  class DelegationTest < ActiveRecord::TestCase
-    fixtures :posts
-
-    def call_method(target, method)
-      method_arity = target.to_a.method(method).arity
-
-      if method_arity.zero?
-        target.public_send(method)
-      elsif method_arity < 0
-        if method == :shuffle!
-          target.public_send(method)
-        else
-          target.public_send(method, 1)
-        end
-       elsif method_arity == 1
-         target.public_send(method, 1)
-      else
-        raise NotImplementedError
-      end
-    end
-  end
-
-  module DelegationWhitelistBlacklistTests
+  module DelegationWhitelistTests
     ARRAY_DELEGATES = [
       :+, :-, :|, :&, :[], :shuffle,
       :all?, :collect, :compact, :detect, :each, :each_cons, :each_with_index,
@@ -43,16 +21,18 @@ module ActiveRecord
     end
   end
 
-  class DelegationAssociationTest < DelegationTest
-    include DelegationWhitelistBlacklistTests
+  class DelegationAssociationTest < ActiveRecord::TestCase
+    include DelegationWhitelistTests
+
+    fixtures :posts
 
     def target
       Post.first.comments
     end
   end
 
-  class DelegationRelationTest < DelegationTest
-    include DelegationWhitelistBlacklistTests
+  class DelegationRelationTest < ActiveRecord::TestCase
+    include DelegationWhitelistTests
 
     fixtures :comments
 


### PR DESCRIPTION
`DelegationTest#call_method` is no longer used since 9d79334a.