### PR TITLE
Fix `warning: ambiguous first argument`

### DIFF
--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -89,11 +89,11 @@ module ActiveRecord
       class SubQuotedOne < QuotedOne
       end
       def test_quote_with_quoted_id
-        assert_deprecated /defined on \S+::QuotedOne at .*quoting_test\.rb:[0-9]/ do
+        assert_deprecated(/defined on \S+::QuotedOne at .*quoting_test\.rb:[0-9]/) do
           assert_equal 1, @quoter.quote(QuotedOne.new)
         end
 
-        assert_deprecated /defined on \S+::SubQuotedOne\(\S+::QuotedOne\) at .*quoting_test\.rb:[0-9]/ do
+        assert_deprecated(/defined on \S+::SubQuotedOne\(\S+::QuotedOne\) at .*quoting_test\.rb:[0-9]/) do
           assert_equal 1, @quoter.quote(SubQuotedOne.new)
         end
       end


### PR DESCRIPTION
```
% ARCONN=sqlite3 be ruby -w -Itest test/cases/quoting_test.rb
test/cases/quoting_test.rb:92: warning: ambiguous first argument; put parentheses or a space even after `/' operator
test/cases/quoting_test.rb:96: warning: ambiguous first argument; put parentheses or a space even after `/' operator
Using sqlite3
Run options: --seed 9495

# Running:

.....................................

Finished in 0.046403s, 797.3622 runs/s, 1120.6172 assertions/s.

37 runs, 52 assertions, 0 failures, 0 errors, 0 skips
```