### PR TITLE
Delegate `ast` and `locked` to `arel` explicitly

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -18,6 +18,7 @@ module ActiveRecord
     attr_reader :table, :klass, :loaded, :predicate_builder
     alias :model :klass
     alias :loaded? :loaded
+    alias :locked? :locked
 
     def initialize(klass, table, predicate_builder, values = {})
       @klass  = klass

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -46,6 +46,8 @@ module ActiveRecord
     delegate :table_name, :quoted_table_name, :primary_key, :quoted_primary_key,
              :connection, :columns_hash, to: :klass
 
+    delegate :ast, :locked, to: :arel
+
     module ClassSpecificRelation # :nodoc:
       extend ActiveSupport::Concern
 

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -56,7 +56,7 @@ class RelationMergingTest < ActiveRecord::TestCase
 
   def test_relation_merging_with_locks
     devs = Developer.lock.where("salary >= 80000").order("id DESC").merge(Developer.limit(2))
-    assert devs.locked.present?
+    assert devs.locked?
   end
 
   def test_relation_merging_with_preload

--- a/activerecord/test/models/category.rb
+++ b/activerecord/test/models/category.rb
@@ -29,6 +29,15 @@ class Category < ActiveRecord::Base
   has_many :authors_with_select, -> { select "authors.*, categorizations.post_id" }, through: :categorizations, source: :author
 
   scope :general, -> { where(name: "General") }
+
+  # Should be delegated `ast` and `locked` to `arel`.
+  def self.ast
+    raise
+  end
+
+  def self.locked
+    raise
+  end
 end
 
 class SpecialCategory < Category


### PR DESCRIPTION
Currently `ast` and `locked` are used in the internal but delegating to
`arel` is depend on `method_missing`. If a model class is defined these
methods, `select_all` will be broken.

It should be delegated to `arel` explicitly.