### PR TITLE
Prevent extra `spawn` to make `klass.all` faster

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -289,7 +289,8 @@ module ActiveRecord
           relation = Relation.create(self, arel_table, predicate_builder)
 
           if finder_needs_type_condition? && !ignore_default_scope?
-            relation.where(type_condition).create_with(inheritance_column.to_s => sti_name)
+            relation.where!(type_condition)
+            relation.create_with!(inheritance_column.to_s => sti_name)
           else
             relation
           end

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -111,7 +111,7 @@ module ActiveRecord
               # The user has defined their own default scope method, so call that
               evaluate_default_scope do
                 if scope = default_scope
-                  (base_rel ||= relation).merge(scope)
+                  (base_rel ||= relation).merge!(scope)
                 end
               end
             elsif default_scopes.any?
@@ -119,7 +119,7 @@ module ActiveRecord
               evaluate_default_scope do
                 default_scopes.inject(base_rel) do |default_scope, scope|
                   scope = scope.respond_to?(:to_proc) ? scope : scope.method(:call)
-                  default_scope.merge(base_rel.instance_exec(&scope))
+                  default_scope.merge!(base_rel.instance_exec(&scope))
                 end
               end
             end


### PR DESCRIPTION
These extra `spawn` are called via `klass.all` and `klass.all` is called
everywhere in the internal. Avoiding the extra `spawn` makes` klass.all`
30% faster for STI classes.

https://gist.github.com/kamipo/684d03817a8115848cec8e8b079560b7

```
Warming up --------------------------------------
       fast relation     4.410k i/100ms
       slow relation     3.334k i/100ms
Calculating -------------------------------------
       fast relation     47.373k (± 5.2%) i/s -    238.140k in   5.041836s
       slow relation     35.757k (±15.9%) i/s -    176.702k in   5.104625s

Comparison:
       fast relation:    47373.2 i/s
       slow relation:    35756.7 i/s - 1.32x  slower
```