### PR TITLE
Allow irb options to be passed from `rails console` command

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow irb options to be passed from `rails console` command.
+
+    Fixes #28988.
+
+    *Yuji Yaginuma*
+
 *   Added a shared section to config/database.yml that will be loaded for all environments.
 
     *Pierre Schambacher*

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -73,13 +73,25 @@ module Rails
       class_option :environment, aliases: "-e", type: :string,
         desc: "Specifies the environment to run this console under (test/development/production)."
 
+      def initialize(args = [], local_options = {}, config = {})
+        console_options = []
+
+        # For the same behavior as OptionParser, leave only options after "--" in ARGV.
+        termination = local_options.find_index("--")
+        if termination
+          console_options = local_options[termination + 1..-1]
+          local_options = local_options[0...termination]
+        end
+
+        ARGV.replace(console_options)
+        super(args, local_options, config)
+      end
+
       def perform
         extract_environment_option_from_argument
 
         # RAILS_ENV needs to be set before config/application is required.
         ENV["RAILS_ENV"] = options[:environment]
-
-        ARGV.clear # Clear ARGV so IRB doesn't freak.
 
         require_application_and_environment!
         Rails::Console.start(Rails.application, options)

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -136,9 +136,9 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     assert_output "> "
   end
 
-  def spawn_console
+  def spawn_console(options)
     Process.spawn(
-      "#{app_path}/bin/rails console --sandbox",
+      "#{app_path}/bin/rails console #{options}",
       in: @slave, out: @slave, err: @slave
     )
 
@@ -146,18 +146,26 @@ class FullStackConsoleTest < ActiveSupport::TestCase
   end
 
   def test_sandbox
-    spawn_console
+    spawn_console("--sandbox")
 
     write_prompt "Post.count", "=> 0"
     write_prompt "Post.create"
     write_prompt "Post.count", "=> 1"
     @master.puts "quit"
 
-    spawn_console
+    spawn_console("--sandbox")
 
     write_prompt "Post.count", "=> 0"
     write_prompt "Post.transaction { Post.create; raise }"
     write_prompt "Post.count", "=> 0"
+    @master.puts "quit"
+  end
+
+  def test_environment_option_and_irb_option
+    spawn_console("test -- --verbose")
+
+    write_prompt "a = 1", "a = 1"
+    write_prompt "puts Rails.env", "puts Rails.env\r\ntest"
     @master.puts "quit"
   end
 end


### PR DESCRIPTION
I'm not sure that this behavior is guaranteed. However, up to Rails 5.0, it was possible to specify the irb option from the rails console. 

```
$ ./bin/rails -v
Rails 5.0.2
$ bin/rails c --sandbox test -- --simple-prompt --verbose
Running via Spring preloader in process 15586
Loading test environment in sandbox (Rails 5.0.2)
Any modifications you make will be rolled back on exit
Switch to inspect mode.
>> a = "1"
a = "1"
=> "1"
>>  
``` 

This makes it possible to specify irb options as well as Rails 5.0.

Fixes #28988
