### PR TITLE
`changes` should not be a HWIA

### DIFF
--- a/activerecord/lib/active_record/attribute_mutation_tracker.rb
+++ b/activerecord/lib/active_record/attribute_mutation_tracker.rb
@@ -17,7 +17,7 @@ module ActiveRecord
     end
 
     def changes
-      attr_names.each_with_object({}.with_indifferent_access) do |attr_name, result|
+      attr_names.each_with_object({}) do |attr_name, result|
         change = change_to_attribute(attr_name)
         if change
           result[attr_name] = change

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -858,6 +858,17 @@ class DirtyTest < ActiveRecord::TestCase
     refute person.changed?
   end
 
+  test "Hash is not turned into HWIA" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "people"
+
+      serialize :first_name, Array
+    end
+
+    person = klass.create!(first_name: [{ first_letter: 'S', second_letter: 'e' }])
+    assert_equal Hash, person.first_name.first.class
+  end
+
   private
     def with_partial_writes(klass, on = true)
       old = klass.partial_writes?


### PR DESCRIPTION
### Summary

To make a long story as short as possible, if an attribute is an Array
of Hashes (I believe just a normal Hash as the value should also cause
this behavior), it will be converted to a HWIA through this method. This
is because when you pass the above value to `HWIA[]=`, it will convert
all nested Hashes to be HWIA's.

The easiest way to solve this is to have
`changes` not be a HWIA anymore, but that breaks the "indifferent
access" part of the API contract and the tests that watch over that
behavior. Maybe we need to create a mini-class for only indifferent
access, and not worry about setting values, since that's not intended
behavior here?

### Other Information

This commit fixes a regression between Rails 5.0 and 5.1, which was
introduced by way of 16ae3db5a5c6a08383b974ae6c96faac5b4a3c81. That
commit technically didn't introduce the truly regression causing behavior --
it was the "light switch" commit that directed users toward the bad
behavior.

Fixes #29013