### PR TITLE
fix the dirty tracking code's save hook overwriting missing attribute…

### DIFF
--- a/activerecord/lib/active_record/attribute.rb
+++ b/activerecord/lib/active_record/attribute.rb
@@ -231,6 +231,10 @@ module ActiveRecord
           false
         end
 
+        def forgetting_assignment
+          dup
+        end
+
         def with_type(type)
           self.class.new(name, type)
         end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -775,6 +775,13 @@ class DirtyTest < ActiveRecord::TestCase
     assert person.changed?
   end
 
+  test "attributes not selected are still missing after save" do
+    person = Person.select(:id).first
+    assert_raises(ActiveModel::MissingAttributeError) { person.first_name }
+    assert person.save # calls forget_attribute_assignments
+    assert_raises(ActiveModel::MissingAttributeError) { person.first_name }
+  end
+
   test "saved_change_to_attribute? returns whether a change occurred in the last save" do
     person = Person.create!(first_name: "Sean")
 


### PR DESCRIPTION
### Summary

Fixes issue #29017

This was causing subtle errors where an attribute appeared to be loaded on a record that was actually loaded without selecting those columns - but only after the record was saved again.