### PR TITLE
[ci skip] explain async queue and rake tasks

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -310,6 +310,12 @@ UserMailer.welcome(@user).deliver_now
 UserMailer.welcome(@user).deliver_later
 ```
 
+NOTE: Using the asynchronous queue from a rake task (for example, to
+send an email using `.deliver_later`) will generally not work because rake will
+likely end, causing the in-process thread pool to be deleted, before any/all
+of the `.deliver_later` emails are processed. To avoid this problem, use
+`.deliver_now` or run a persistent queue in development as well.
+
 
 Internationalization
 --------------------

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -310,8 +310,8 @@ UserMailer.welcome(@user).deliver_now
 UserMailer.welcome(@user).deliver_later
 ```
 
-NOTE: Using the asynchronous queue from a rake task (for example, to
-send an email using `.deliver_later`) will generally not work because rake will
+NOTE: Using the asynchronous queue from a Rake task (for example, to
+send an email using `.deliver_later`) will generally not work because Rake will
 likely end, causing the in-process thread pool to be deleted, before any/all
 of the `.deliver_later` emails are processed. To avoid this problem, use
 `.deliver_now` or run a persistent queue in development as well.

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -314,7 +314,7 @@ NOTE: Using the asynchronous queue from a Rake task (for example, to
 send an email using `.deliver_later`) will generally not work because Rake will
 likely end, causing the in-process thread pool to be deleted, before any/all
 of the `.deliver_later` emails are processed. To avoid this problem, use
-`.deliver_now` or run a persistent queue in development as well.
+`.deliver_now` or run a persistent queue in development.
 
 
 Internationalization


### PR DESCRIPTION
[ci skip]
Small update to the guide for ActiveJob to point out a problem that might commonly occur in development when using the Async  Queue with rake tasks. Includes advice on how to solve it.