### PR TITLE
Allow to receive arbitrary arguments in `aggregated_results`

### DIFF
--- a/railties/lib/rails/test_unit/minitest_plugin.rb
+++ b/railties/lib/rails/test_unit/minitest_plugin.rb
@@ -6,7 +6,7 @@ require "shellwords"
 module Minitest
   class SuppressedSummaryReporter < SummaryReporter
     # Disable extra failure output after a run if output is inline.
-    def aggregated_results
+    def aggregated_results(*)
       super unless options[:output_inline]
     end
   end


### PR DESCRIPTION
When run rails test runner with minitest 5.10.2, the following error occurred. 

```
/home/travis/build/y-yagi/wikin/vendor/bundle/ruby/2.4.0/gems/railties-5.1.0/lib/rails/test_unit/minitest_plugin.rb:9:in `aggregated_results': wrong number of arguments (given 1, expected 0) (ArgumentError)
	from /home/travis/build/y-yagi/wikin/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:597:in `report'
	from /home/travis/build/y-yagi/wikin/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:687:in `each'
	from /home/travis/build/y-yagi/wikin/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:687:in `report'
	from /home/travis/build/y-yagi/wikin/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:141:in `run'
	from /home/travis/build/y-yagi/wikin/vendor/bundle/ruby/2.4.0/gems/railties-5.1.0/lib/rails/test_unit/minitest_plugin.rb:77:in `run'
	from /home/travis/build/y-yagi/wikin/vendor/bundle/ruby/2.4.0/gems/minitest-5.10.2/lib/minitest.rb:63:in `block in autorun'
	from /home/travis/build/y-yagi/wikin/vendor/bundle/ruby/2.4.0/gems/spring-2.0.1/lib/spring/application.rb:161:in `fork'
	from /home/travis/build/y-yagi/wikin/vendor/bundle/ruby/2.4.0/gems/spring-2.0.1/lib/spring/application.rb:161:in `serve'
	from /home/travis/build/y-yagi/wikin/vendor/bundle/ruby/2.4.0/gems/spring-2.0.1/lib/spring/application.rb:131:in `block in run'
	from /home/travis/build/y-yagi/wikin/vendor/bundle/ruby/2.4.0/gems/spring-2.0.1/lib/spring/application.rb:125:in `loop'
	from /home/travis/build/y-yagi/wikin/vendor/bundle/ruby/2.4.0/gems/spring-2.0.1/lib/spring/application.rb:125:in `run'
	from /home/travis/build/y-yagi/wikin/vendor/bundle/ruby/2.4.0/gems/spring-2.0.1/lib/spring/application/boot.rb:19:in `<top (required)>'
	from /home/travis/.rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/travis/.rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from -e:1:in `<main>'
``` 

This is because minitest added an argument to `aggregated_results` in minitest 5.10.2 . 
https://github.com/seattlerb/minitest/commit/c6ba2afd90473b76d289562edd24f7d7ca8484f9 

Therefore, fix to `aggregated_results` so that argument can be specified.
