### PR TITLE
rake -T should load development env by default, not test

### DIFF
--- a/railties/lib/rails/test_unit/railtie.rb
+++ b/railties/lib/rails/test_unit/railtie.rb
@@ -1,7 +1,7 @@
 require "rails/test_unit/line_filtering"
 
 if defined?(Rake.application) && Rake.application.top_level_tasks.grep(/^(default$|test(:|$))/).any?
-  ENV["RAILS_ENV"] ||= "test"
+  ENV["RAILS_ENV"] ||= Rake.application.options.show_tasks ? "development" : "test"
 end
 
 module Rails


### PR DESCRIPTION
### Summary

`rake -T` loads test env by default. This is quite unexpected and not good because maybe you installed some gems that provide rake tasks just for development env because you don't need them in tests. Now these won't be shown. Or maybe you have a nasty gem that need some envs to work and crashes rake -T because you haven't set up test env.

### Other Information

See issue: https://github.com/rails/rails/issues/29028