### PR TITLE
Make preload query to preparable

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -103,7 +103,7 @@ module ActiveRecord
           end
 
           def records_for(ids, &block)
-            scope.where(association_key_name => ids).load(&block)
+            scope.where(association_key_name => ids.size == 1 ? ids.first : ids).load(&block)
           end
 
           def scope

--- a/activerecord/test/cases/adapters/postgresql/explain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/explain_test.rb
@@ -15,6 +15,6 @@ class PostgreSQLExplainTest < ActiveRecord::PostgreSQLTestCase
     explain = Developer.where(id: 1).includes(:audit_logs).explain
     assert_match %(QUERY PLAN), explain
     assert_match %r(EXPLAIN for: SELECT "developers"\.\* FROM "developers" WHERE "developers"\."id" = (?:\$1 \[\["id", 1\]\]|1)), explain
-    assert_match %(EXPLAIN for: SELECT "audit_logs".* FROM "audit_logs" WHERE "audit_logs"."developer_id" = 1), explain
+    assert_match %r(EXPLAIN for: SELECT "audit_logs"\.\* FROM "audit_logs" WHERE "audit_logs"\."developer_id" = (?:\$1 \[\["developer_id", 1\]\]|1)), explain
   end
 end

--- a/activerecord/test/cases/adapters/sqlite3/explain_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/explain_test.rb
@@ -15,7 +15,7 @@ class SQLite3ExplainTest < ActiveRecord::SQLite3TestCase
     explain = Developer.where(id: 1).includes(:audit_logs).explain
     assert_match %r(EXPLAIN for: SELECT "developers"\.\* FROM "developers" WHERE "developers"\."id" = (?:\? \[\["id", 1\]\]|1)), explain
     assert_match(/(SEARCH )?TABLE developers USING (INTEGER )?PRIMARY KEY/, explain)
-    assert_match %(EXPLAIN for: SELECT "audit_logs".* FROM "audit_logs" WHERE "audit_logs"."developer_id" = 1), explain
+    assert_match %r(EXPLAIN for: SELECT "audit_logs"\.\* FROM "audit_logs" WHERE "audit_logs"\."developer_id" = (?:\? \[\["developer_id", 1\]\]|1)), explain
     assert_match(/(SCAN )?TABLE audit_logs/, explain)
   end
 end

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -418,7 +418,7 @@ class InheritanceTest < ActiveRecord::TestCase
 
   def test_eager_load_belongs_to_primary_key_quoting
     con = Account.connection
-    assert_sql(/#{con.quote_table_name('companies')}\.#{con.quote_column_name('id')} = 1/) do
+    assert_sql(/#{con.quote_table_name('companies')}\.#{con.quote_column_name('id')} = (?:#{Regexp.quote(bind_param.to_sql)}|1)/) do
       Account.all.merge!(includes: :firm).find(1)
     end
   end


### PR DESCRIPTION
Currently preload query cannot be prepared statements even if
`prepared_statements: true` due to array handler in predicate builder
doesn't support making bind params. This makes preload query to
preparable by don't passing array value if possible.