### PR TITLE
Handle loops in the cause chain in Rescuable#rescue_with_handler

### DIFF
--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -84,12 +84,18 @@ module ActiveSupport
       #     end
       #
       # Returns the exception if it was handled and +nil+ if it was not.
-      def rescue_with_handler(exception, object: self)
+      def rescue_with_handler(exception, object: self, visited_exceptions: [])
+        visited_exceptions << exception
+
         if handler = handler_for_rescue(exception, object: object)
           handler.call exception
           exception
         elsif exception
-          rescue_with_handler(exception.cause, object: object)
+          if visited_exceptions.include?(exception.cause)
+            nil
+          else
+            rescue_with_handler(exception.cause, object: object, visited_exceptions: visited_exceptions)
+          end
         end
       end
 

--- a/activesupport/test/rescuable_test.rb
+++ b/activesupport/test/rescuable_test.rb
@@ -43,7 +43,9 @@ class Stargate
   def dispatch(method)
     send(method)
   rescue Exception => e
-    rescue_with_handler(e)
+    unless rescue_with_handler(e)
+      @result = "unhandled"
+    end
   end
 
   def attack
@@ -56,6 +58,26 @@ class Stargate
 
   def ronanize
     raise MadRonon.new("dex")
+  end
+
+  def crash
+    raise "unhandled RuntimeError"
+  end
+
+  def looped_crash
+    ex1 = StandardError.new("error 1")
+    ex2 = StandardError.new("error 2")
+    begin
+      begin
+        raise ex1
+      rescue
+        # sets the cause on ex2 to be ex1
+        raise ex2
+      end
+    rescue
+      # sets the cause on ex1 to be ex2
+      raise ex1
+    end
   end
 
   def fall_back_to_cause
@@ -138,5 +160,15 @@ class RescuableTest < ActiveSupport::TestCase
   def test_rescue_falls_back_to_exception_cause
     @stargate.dispatch :fall_back_to_cause
     assert_equal "dex", @stargate.result
+  end
+
+  def test_unhandled_exceptions
+    @stargate.dispatch(:crash)
+    assert_equal "unhandled", @stargate.result
+  end
+
+  def test_rescue_handles_loops_in_exception_cause_chain
+    @stargate.dispatch :looped_crash
+    assert_equal "unhandled", @stargate.result
   end
 end


### PR DESCRIPTION
### Summary

This fixes a `SystemStackError` that can be caused in the unlikely, but possible, scenario there is a loop in the exception cause chain.

### Other Information

Note that the test I've included *does* produce a loop in the exception cause chain in Ruby 2.3.4, but doesn't in Ruby 2.4.1. I haven't found another way to create an exception loop in Ruby 2.4.1