### PR TITLE
Pass block in ActionController::Parameters#delete

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -666,8 +666,8 @@ module ActionController
     # to key. If the key is not found, returns the default value. If the
     # optional code block is given and the key is not found, pass in the key
     # and return the result of block.
-    def delete(key)
-      convert_value_to_parameters(@parameters.delete(key))
+    def delete(key, &block)
+      convert_value_to_parameters(@parameters.delete(key, &block))
     end
 
     # Returns a new instance of <tt>ActionController::Parameters</tt> with only

--- a/actionpack/test/controller/parameters/mutators_test.rb
+++ b/actionpack/test/controller/parameters/mutators_test.rb
@@ -25,6 +25,27 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
     assert_not @params.delete(:person).permitted?
   end
 
+  test "delete returns the value when the key is present" do
+    assert_equal "32", @params[:person].delete(:age)
+  end
+
+  test "delete removes the entry when the key present" do
+    @params[:person].delete(:age)
+    assert_not @params[:person].key?(:age)
+  end
+
+  test "delete returns nil when the key is not present" do
+    assert_equal nil, @params[:person].delete(:first_name)
+  end
+
+  test "delete returns the value of the given block when the key is not present" do
+    assert_equal "David", @params[:person].delete(:first_name) { "David" }
+  end
+
+  test "delete yields the key to the given block when the key is not present" do
+    assert_equal "first_name: David", @params[:person].delete(:first_name) { |k| "#{k}: David" }
+  end
+
   test "delete_if retains permitted status" do
     @params.permit!
     assert @params.delete_if { |k| k == "person" }.permitted?


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/29037.

In order to fully support the same interface as `Hash#delete`, we need to pass the block through to the underlying method, not just the key.

This used to work correctly, but it regressed when `ActionController::Parameters` stopped inheriting from `Hash` in https://github.com/rails/rails/pull/20868.