### PR TITLE
Raising an `ArgumentError` when rendering with invalid option:

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -605,6 +605,12 @@ class BaseTest < ActiveSupport::TestCase
     mail.deliver_now
   end
 
+  test "renders raises an ArgumentError when called with invalid option" do
+    assert_raises(ArgumentError) do
+      BaseMailer.invalid_rendering_options.deliver_now
+    end
+  end
+
   # Before and After hooks
 
   class MyObserver

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -133,4 +133,11 @@ class BaseMailer < ActionMailer::Base
   def with_subject_interpolations
     mail(subject: default_i18n_subject(rapper_or_impersonator: "Slim Shady"), body: "")
   end
+
+  def invalid_rendering_options
+    mail do |format|
+      format.text { render text: "TEXT Explicit Multipart" }
+      format.html { render text: "HTML Explicit Multipart" }
+    end
+  end
 end


### PR DESCRIPTION
- `render text: ''` was deprecated a while ago and rails 5.1 removed the ability to call render with the text option
- While people were able to see the deprecation message when rendering a view from the controller, the deprecation didn't show up for mailers. The reason for that is because the deprecation message was added in the `AC::Metal::Rendering` module which ActionMailer doesn't include https://github.com/rails/rails/pull/20917/files
- The current behaviour on master if someone tries to `render text: ''` will throw an error and say the template was not found
- Although a check was added when removing the ability to call `render text: ''` (https://github.com/rails/rails/blob/97bd56e674603529d96c6f6e85d695dd24208afb/actionview/lib/action_view/renderer/template_renderer.rb#L41) it was never called because when `TemplateRenderer#render` gets called, the options contains a `template` key and will try to resolve the template https://github.com/rails/rails/blob/97bd56e674603529d96c6f6e85d695dd24208afb/actionview/lib/action_view/renderer/template_renderer.rb#L34


