### PR TITLE
Moved the `render text: ''` deprecation warning:

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -601,6 +601,12 @@ class BaseTest < ActiveSupport::TestCase
     mail.deliver_now
   end
 
+  test 'rendering text output deprecation message' do
+    assert_deprecated do
+      BaseMailer.rendering_text_output_deprecation_warning.body.to_s
+    end
+  end
+
   # Before and After hooks
 
   class MyObserver

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -133,4 +133,11 @@ class BaseMailer < ActionMailer::Base
   def with_subject_interpolations
     mail(subject: default_i18n_subject(rapper_or_impersonator: 'Slim Shady'), body: '')
   end
+
+  def rendering_text_output_deprecation_warning
+    mail(to: 'john@example.com') do |format|
+      format.html { render text: 'Example' }
+      format.text { render text: 'Example' }
+    end
+  end
 end

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -97,6 +97,17 @@ module AbstractController
     # Normalize options.
     # :api: plugin
     def _normalize_options(options)
+      if options[:text]
+        ActiveSupport::Deprecation.warn <<-WARNING.squish
+          `render :text` is deprecated because it does not actually render a
+          `text/plain` response. Switch to `render plain: 'plain text'` to
+          render as `text/plain`, `render html: '<strong>HTML</strong>'` to
+          render as `text/html`, or `render body: 'raw'` to match the deprecated
+          behavior and render with the default Content-Type, which is
+          `text/html`.
+        WARNING
+      end
+
       options
     end
 

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -83,17 +83,6 @@ module ActionController
     def _normalize_options(options) #:nodoc:
       _normalize_text(options)
 
-      if options[:text]
-        ActiveSupport::Deprecation.warn <<-WARNING.squish
-          `render :text` is deprecated because it does not actually render a
-          `text/plain` response. Switch to `render plain: 'plain text'` to
-          render as `text/plain`, `render html: '<strong>HTML</strong>'` to
-          render as `text/html`, or `render body: 'raw'` to match the deprecated
-          behavior and render with the default Content-Type, which is
-          `text/html`.
-        WARNING
-      end
-
       if options[:html]
         options[:html] = ERB::Util.html_escape(options[:html])
       end


### PR DESCRIPTION
- The deprecation warning was not picked up by ActionMailer as ActionController::Metal::Rendering is not included within ActionMailer
- Added the deprecation in the AbstractController::Rendering module instead

