### PR TITLE
Added fixed links to code for Rails Guides ActiveSupport

### DIFF
--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -93,7 +93,7 @@ HTML
         def github_file_url(file_path)
           tree = version || edge
 
-          root = file_path[%r{(.+)/}, 1]
+          root = file_path[%r{(\w+)/}, 1]
           path = \
             case root
             when "abstract_controller", "action_controller", "action_dispatch"


### PR DESCRIPTION
# Fixed #29055 
       
The links in the [Rails Guide for ActiveSupport](http://guides.rubyonrails.org/active_support_core_extensions.html) were fixed to actually lead to the codebase as they were originally linking to a 404 Github page.

Most were like this
```markdown
`active_support/core_ext/object/blank.rb.`
```
and they were changed to 
```markdown
[`active_support/core_ext/object/blank.rb.`](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/object/blank.rb)