### PR TITLE
Suppress `warning: assigned but unused variable - stdout`

### DIFF
--- a/actioncable/Rakefile
+++ b/actioncable/Rakefile
@@ -65,7 +65,7 @@ namespace :assets do
     end
 
     print "[verify] #{dir} can be required as a module "
-    stdout, stderr, status = Open3.capture3("node", "--print", "window = {}; require('#{dir}');")
+    _, stderr, status = Open3.capture3("node", "--print", "window = {}; require('#{dir}');")
     if status.success?
       puts "[OK]"
     else

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -119,7 +119,7 @@ namespace :assets do
       class Element {}
       require('#{dir}')
     JS
-    stdout, stderr, status = Open3.capture3("node", "--print", js)
+    _, stderr, status = Open3.capture3("node", "--print", js)
     if status.success?
       puts "[OK]"
     else


### PR DESCRIPTION
This PR suppresses the following warning at rails/actioncable and rails/actionview.

```sh
% RUBYOPT=-w bundle exec rake 
/Users/koic/src/github.com/rails/rails/actioncable/Rakefile:68: warning: assigned but unused variable - stdout
```