### PR TITLE
Specify `table.name` only when `scope.table` and `table` are different

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -66,11 +66,11 @@ module ActiveRecord
           foreign_key = join_keys.foreign_key
 
           value = transform_value(owner[foreign_key])
-          scope = scope.where(table.name => { key => value })
+          scope = apply_scope(scope, table, key, value)
 
           if reflection.type
             polymorphic_type = transform_value(owner.class.base_class.name)
-            scope = scope.where(table.name => { reflection.type => polymorphic_type })
+            scope = apply_scope(scope, table, reflection.type, polymorphic_type)
           end
 
           scope
@@ -89,10 +89,10 @@ module ActiveRecord
 
           if reflection.type
             value = transform_value(next_reflection.klass.base_class.name)
-            scope = scope.where(table.name => { reflection.type => value })
+            scope = apply_scope(scope, table, reflection.type, value)
           end
 
-          scope = scope.joins(join(foreign_table, constraint))
+          scope.joins!(join(foreign_table, constraint))
         end
 
         class ReflectionProxy < SimpleDelegator # :nodoc:
@@ -161,6 +161,14 @@ module ActiveRecord
           end
 
           scope
+        end
+
+        def apply_scope(scope, table, key, value)
+          if scope.table == table
+            scope.where!(key => value)
+          else
+            scope.where!(table.name => { key => value })
+          end
         end
 
         def eval_scope(reflection, table, scope, owner)

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -190,6 +190,7 @@ ActiveRecord::Schema.define do
     t.string :resource_type
     t.integer :developer_id
     t.datetime :deleted_at
+    t.integer :comments
   end
 
   create_table :companies, force: true do |t|


### PR DESCRIPTION
Fixes #29045.