### PR TITLE
Add deprecation warning for query attribute methods

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -8,6 +8,15 @@ module ActiveRecord
       end
 
       def query_attribute(attr_name)
+        ActiveSupport::Deprecation.warn(<<-EOW.squish)
+          Query attribute methods(like `attribute?`) will not behave like
+          using `ActiveModel::Type::Boolean` and will be shortcuts
+          for `attribute.present?` in the next version of Rails.
+          If you'd like #{attr_name}? to return false for values defined
+          in `ActiveModel::Type::Boolean::FALSE_VALUES`, use
+          `ActiveModel::Type::Boolean` instead.
+        EOW
+
         value = self[attr_name]
 
         case value


### PR DESCRIPTION
Query attribute methods behave unexpectedly for the majority of developers. Everybody thinks they are just shortcuts for `attribute.present?`. It the reality the logic is more complex and inconsistent. They return `false` for zero values if the attribute's table column is numeric and `false` for values like 0, '0', 'off', etc. if the attribute has no table column. 

Since changing the behavior of these methods can break applications, we should add a deprecation warning and fix the implementation in the next major version.

See issue: https://github.com/rails/rails/issues/28438

And some articles about query attribute methods:
https://rails-bestpractices.com/posts/2010/10/03/use-query-attribute/
http://blog.plataformatec.com.br/2012/05/active-record-attribute-method/
