### PR TITLE
Respect `ignore_tables` in Postgres structure dump

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -69,7 +69,7 @@ module ActiveRecord
 
         ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
         if ignore_tables.any?
-          args += ignore_tables.flat_map { |table| ['-T', table] }
+          args += ignore_tables.flat_map { |table| ["-T", table] }
         end
 
         args << configuration["database"]

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -66,6 +66,12 @@ module ActiveRecord
             "--schema=#{part.strip}"
           end
         end
+
+        ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
+        if ignore_tables.any?
+          args += ignore_tables.flat_map { |table| ['-T', table] }
+        end
+
         args << configuration["database"]
         run_cmd("pg_dump", args, "dumping")
         remove_sql_header_comments(filename)

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -1,4 +1,4 @@
-any "cases/helper"
+require "cases/helper"
 require "active_record/tasks/database_tasks"
 
 if current_adapter?(:PostgreSQLAdapter)

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -1,4 +1,4 @@
-require "cases/helper"
+any "cases/helper"
 require "active_record/tasks/database_tasks"
 
 if current_adapter?(:PostgreSQLAdapter)
@@ -257,6 +257,14 @@ if current_adapter?(:PostgreSQLAdapter)
             ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
           end
         end
+      end
+
+      def test_structure_dump_with_ignore_tables
+        ActiveRecord::SchemaDump.expects(:ignore_tables).returns([:foo, "bar"])
+
+        Kernel.expects(:system).with("pg_dump", "-s", "-x", "-O", "-f", @filename, "-T", "foo", "-T", "bar", "my-app-db").returns(true)
+
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
       end
 
       def test_structure_dump_with_schema_search_path


### PR DESCRIPTION
When using `sql` as the schema format, or even just doing `rake
db:structure:dump`, it would be good to respect the list of ignored
tables that has been configured.

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
