### PR TITLE
Maintain original encoding from path

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -13,11 +13,13 @@ module ActionDispatch
         #   normalize_path("")      # => "/"
         #   normalize_path("/%ab")  # => "/%AB"
         def self.normalize_path(path)
+          encoding = path.encoding
           path = "/#{path}"
           path.squeeze!("/".freeze)
           path.sub!(%r{/+\Z}, "".freeze)
           path.gsub!(/(%[a-f0-9]{2})/) { $1.upcase }
           path = "/" if path == "".freeze
+          path.force_encoding(encoding)
           path
         end
 

--- a/actionpack/test/journey/router/utils_test.rb
+++ b/actionpack/test/journey/router/utils_test.rb
@@ -31,6 +31,11 @@ module ActionDispatch
         def test_normalize_path_uppercase
           assert_equal "/foo%AAbar%AAbaz", Utils.normalize_path("/foo%aabar%aabaz")
         end
+
+        def test_normalize_path_maintains_string_encoding
+          path = "/foo%AAbar%AAbaz".b
+          assert_equal Encoding::ASCII_8BIT, Utils.normalize_path(path).encoding
+        end
       end
     end
   end


### PR DESCRIPTION
When the path info is read from the socket it's encoded as ASCII 8BIT.
The unescape method changes the encoding to UTF8 but it should maintain
the encoding of the string that's passed in.

This causes parameters to be force encoded to UTF8 when we don't
actually know what the encoding of the parameter should be.

Opening a PR to see if CI breaks.

cc/ @tenderlove 