### PR TITLE
Fixed Frozen string error in actionpack

### DIFF
--- a/actionpack/lib/action_dispatch/http/upload.rb
+++ b/actionpack/lib/action_dispatch/http/upload.rb
@@ -27,14 +27,18 @@ module ActionDispatch
         @tempfile = hash[:tempfile]
         raise(ArgumentError, ":tempfile is required") unless @tempfile
 
-        @original_filename = hash[:filename]
-        if @original_filename
+        if hash[:filename]
+          @original_filename = hash[:filename].dup
+
           begin
             @original_filename.encode!(Encoding::UTF_8)
           rescue EncodingError
             @original_filename.force_encoding(Encoding::UTF_8)
           end
+        else
+          @original_filename = nil
         end
+
         @content_type      = hash[:type]
         @headers           = hash[:head]
       end

--- a/actionpack/test/dispatch/uploaded_file_test.rb
+++ b/actionpack/test/dispatch/uploaded_file_test.rb
@@ -13,6 +13,12 @@ module ActionDispatch
       assert_equal "foo", uf.original_filename
     end
 
+    def test_filename_is_different_object
+      file_str = "foo"
+      uf = Http::UploadedFile.new(filename: file_str, tempfile: Object.new)
+      assert_not_equal file_str.object_id , uf.original_filename.object_id
+    end
+
     def test_filename_should_be_in_utf_8
       uf = Http::UploadedFile.new(filename: "foo", tempfile: Object.new)
       assert_equal "UTF-8", uf.original_filename.encoding.to_s


### PR DESCRIPTION
Fixed string being modified in place during `encode` causing frozen string errors in Ruby 3.0.