### PR TITLE
Fix Minitest 5.10.2 test incompatibility

### DIFF
--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -489,7 +489,7 @@ module ApplicationTests
       create_test_file :models, "post", pass: false
 
       output = run_test_command("test/models/post_test.rb")
-      assert_match %r{Finished in.*\n\n1 runs, 1 assertions}, output
+      assert_match %r{Finished in.*\n1 runs, 1 assertions}, output
     end
 
     def test_fail_fast

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -71,7 +71,7 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
     create_test_file "post", pass: false
 
     output = run_test_command("test/post_test.rb")
-    assert_match %r{Finished in.*\n\n1 runs, 1 assertions}, output
+    assert_match %r{Finished in.*\n1 runs, 1 assertions}, output
   end
 
   def test_fail_fast


### PR DESCRIPTION
### Summary

Minitest output has changed in 5.10.2. This commit affects 

`TestRunnerTest#test_only_inline_failure_output`
and
`PluginTestRunnerTest#test_only_inline_failure_output`

tests which verified the output.

### Other Information

I've just removed one empty line from regexp in two test instances.