### PR TITLE
Improving docs for callbacks execution order [ci skip]

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -1,4 +1,24 @@
 module AbstractController
+  # = Abstract Controller Callbacks
+  #
+  # Abstract Controller provides hooks during the life cycle of a controller action.
+  # Callbacks allow you to trigger logic during this cycle. Available callbacks are:
+  #
+  # * <tt>after_action</tt>
+  # * <tt>append_after_action</tt>
+  # * <tt>append_around_action</tt>
+  # * <tt>append_before_action</tt>
+  # * <tt>around_action</tt>
+  # * <tt>before_action</tt>
+  # * <tt>prepend_after_action</tt>
+  # * <tt>prepend_around_action</tt>
+  # * <tt>prepend_before_action</tt>
+  # * <tt>skip_after_action</tt>
+  # * <tt>skip_around_action</tt>
+  # * <tt>skip_before_action</tt>
+  #
+  # NOTE: Calling the same callback multiple times will overwrite previous callback definitions.
+  #
   module Callbacks
     extend ActiveSupport::Concern
 

--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -4,7 +4,7 @@ module ActiveJob
   # = Active Job Callbacks
   #
   # Active Job provides hooks during the life cycle of a job. Callbacks allow you
-  # to trigger logic during the life cycle of a job. Available callbacks are:
+  # to trigger logic during this cycle. Available callbacks are:
   #
   # * <tt>before_enqueue</tt>
   # * <tt>around_enqueue</tt>
@@ -12,6 +12,8 @@ module ActiveJob
   # * <tt>before_perform</tt>
   # * <tt>around_perform</tt>
   # * <tt>after_perform</tt>
+  #
+  # NOTE: Calling the same callback multiple times will overwrite previous callback definitions.
   #
   module Callbacks
     extend  ActiveSupport::Concern

--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -56,6 +56,9 @@ module ActiveModel
   #
   # Would only create the +after_create+ and +before_create+ callback methods in
   # your class.
+  #
+  # NOTE: Calling the same callback multiple times will overwrite previous callback definitions.
+  #
   module Callbacks
     def self.extended(base) #:nodoc:
       base.class_eval do

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -147,6 +147,9 @@ module ActiveModel
       #   or <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>). The
       #   method, proc or string should return or evaluate to a +true+ or +false+
       #   value.
+      #
+      # NOTE: Calling +validate+ multiple times on the same method will overwrite previous definitions.
+      #
       def validate(*args, &block)
         options = args.extract_options!
 

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -715,6 +715,9 @@ end
 
 Now, the `LoginsController`'s `new` and `create` actions will work as before without requiring the user to be logged in. The `:only` option is used to skip this filter only for these actions, and there is also an `:except` option which works the other way. These options can be used when adding filters too, so you can add a filter which only runs for selected actions in the first place.
 
+NOTE: Calling the same filter multiple times with different options will not work,
+since the last filter definition will overwrite the previous ones.
+
 ### After Filters and Around Filters
 
 In addition to "before" filters, you can also run filters after an action has been executed, or both before and after.


### PR DESCRIPTION
When define controller callbacks or `ActiveModel::Validations#validate` validators in your class, latest definition on the same callback/method overwrites previous ones. As noted here  #29048 this should be documented