### PR TITLE
Remove returning true in internal callbacks

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -62,7 +62,6 @@ module ActiveRecord
           super(attribute_names)
           @attribute_methods_generated = true
         end
-        true
       end
 
       def undefine_attribute_methods # :nodoc:

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -216,13 +216,7 @@ module ActiveRecord
               method = :validate_single_association
             end
 
-            define_non_cyclic_method(validation_method) do
-              send(method, reflection)
-              # TODO: remove the following line as soon as the return value of
-              # callbacks is ignored, that is, returning `false` does not
-              # display a deprecation warning or halts the callback chain.
-              true
-            end
+            define_non_cyclic_method(validation_method) { send(method, reflection) }
             validate validation_method
             after_validation :_ensure_no_duplicate_errors
           end
@@ -369,7 +363,6 @@ module ActiveRecord
       # association whether or not the parent was a new record before saving.
       def before_save_collection_association
         @new_record_before_save = new_record?
-        true
       end
 
       def after_save_collection_association

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -66,10 +66,6 @@ module I18n
       app.reloaders << reloader
       app.reloader.to_run do
         reloader.execute_if_updated { require_unload_lock! }
-        # TODO: remove the following line as soon as the return value of
-        # callbacks is ignored, that is, returning `false` does not
-        # display a deprecation warning or halts the callback chain.
-        true
       end
       reloader.execute
 


### PR DESCRIPTION
`display_deprecation_warning_for_false_terminator` was removed since
3a25cdc.