### PR TITLE
Respect 'SchemaDumper.ignore_tables' in databases structure dump

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Respect 'SchemaDumper.ignore_tables' in rake tasks for databases structure dump
+
+    *Rusty Geldmacher*, *Guillermo Iguaran*
+
 *   Add type caster to `RuntimeReflection#alias_name`
 
     Fixes #28959.

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -11,8 +11,8 @@ module ActiveRecord
     ##
     # :singleton-method:
     # A list of tables which should not be dumped to the schema.
-    # Acceptable values are strings as well as regexp.
-    # This setting is only used if ActiveRecord::Base.schema_format == :ruby
+    # Acceptable values are strings as well as regexp if ActiveRecord::Base.schema_format == :ruby.
+    # Only strings are accepted if ActiveRecord::Base.schema_format == :sql.
     cattr_accessor :ignore_tables
     @@ignore_tables = []
 

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -60,6 +60,12 @@ module ActiveRecord
         args.concat(["--routines"])
         args.concat(["--skip-comments"])
         args.concat(Array(extra_flags)) if extra_flags
+
+        ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
+        if ignore_tables.any?
+          args += ignore_tables.map { |table| "--ignore-table=#{configuration['database']}.#{table}" }
+        end
+
         args.concat(["#{configuration['database']}"])
 
         run_cmd("mysqldump", args, "dumping")

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -66,6 +66,12 @@ module ActiveRecord
             "--schema=#{part.strip}"
           end
         end
+
+        ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
+        if ignore_tables.any?
+          args += ignore_tables.flat_map { |table| ["-T", table] }
+        end
+
         args << configuration["database"]
         run_cmd("pg_dump", args, "dumping")
         remove_sql_header_comments(filename)

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -36,18 +36,18 @@ module ActiveRecord
       end
 
       def structure_dump(filename, extra_flags)
-        dbfile = configuration["database"]
-        flags = extra_flags.join(" ") if extra_flags
+        args = []
+        args.concat(Array(extra_flags)) if extra_flags
+        args << configuration["database"]
 
         ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
         if ignore_tables.any?
-          tables = `sqlite3 #{dbfile} .tables`.split - ignore_tables
-          condition = tables.map { |table| "tbl_name = '#{table}'" }.join(" OR ")
-          statement = "SELECT sql FROM sqlite_master WHERE #{condition} ORDER BY tbl_name, type DESC, name"
-          `sqlite3 #{flags} #{dbfile} "#{statement}" > #{filename}`
+          condition = ignore_tables.map { |table| connection.quote_table_name(table) }.join(", ")
+          args << "SELECT sql FROM sqlite_master WHERE tbl_name NOT IN (#{condition}) ORDER BY tbl_name, type DESC, name"
         else
-          `sqlite3 #{flags} #{dbfile} .schema > #{filename}`
+          args << ".schema"
         end
+        run_cmd("sqlite3", args, filename)
       end
 
       def structure_load(filename, extra_flags)
@@ -64,6 +64,17 @@ module ActiveRecord
 
         def root
           @root
+        end
+
+        def run_cmd(cmd, args, out)
+          fail run_cmd_error(cmd, args) unless Kernel.system(cmd, *args, out: out)
+        end
+
+        def run_cmd_error(cmd, args)
+          msg = "failed to execute:\n"
+          msg << "#{cmd} #{args.join(' ')}\n\n"
+          msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"
+          msg
         end
     end
   end

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -294,6 +294,13 @@ if current_adapter?(:Mysql2Adapter)
         ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
       end
 
+      def test_structure_dump
+        filename = "awesome-file.sql"
+        Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db").returns(true)
+
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+      end
+
       def test_structure_dump_with_extra_flags
         filename = "awesome-file.sql"
         expected_command = ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "--noop", "test-db"]
@@ -303,6 +310,15 @@ if current_adapter?(:Mysql2Adapter)
             ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
           end
         end
+      end
+
+      def test_structure_dump_with_ignore_tables
+        filename = "awesome-file.sql"
+        ActiveRecord::SchemaDumper.expects(:ignore_tables).returns(["foo", "bar"])
+
+        Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "--ignore-table=test-db.foo", "--ignore-table=test-db.bar", "test-db").returns(true)
+
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
       end
 
       def test_warn_when_external_structure_dump_command_execution_fails

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -259,6 +259,14 @@ if current_adapter?(:PostgreSQLAdapter)
         end
       end
 
+      def test_structure_dump_with_ignore_tables
+        ActiveRecord::SchemaDumper.expects(:ignore_tables).returns(["foo", "bar"])
+
+        Kernel.expects(:system).with("pg_dump", "-s", "-x", "-O", "-f", @filename, "-T", "foo", "-T", "bar", "my-app-db").returns(true)
+
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
+      end
+
       def test_structure_dump_with_schema_search_path
         @configuration["schema_search_path"] = "foo,bar"
 

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -180,6 +180,9 @@ if current_adapter?(:SQLite3Adapter)
           "adapter"  => "sqlite3",
           "database" => @database
         }
+
+        `sqlite3 #{@database} 'CREATE TABLE bar(id INTEGER)'`
+        `sqlite3 #{@database} 'CREATE TABLE foo(id INTEGER)'`
       end
 
       def test_structure_dump
@@ -189,6 +192,23 @@ if current_adapter?(:SQLite3Adapter)
         ActiveRecord::Tasks::DatabaseTasks.structure_dump @configuration, filename, "/rails/root"
         assert File.exist?(dbfile)
         assert File.exist?(filename)
+        assert_match(/CREATE TABLE foo/, File.read(filename))
+        assert_match(/CREATE TABLE bar/, File.read(filename))
+      ensure
+        FileUtils.rm_f(filename)
+        FileUtils.rm_f(dbfile)
+      end
+
+      def test_structure_dump_with_ignore_tables
+        dbfile   = @database
+        filename = "awesome-file.sql"
+        ActiveRecord::SchemaDumper.expects(:ignore_tables).returns(["foo"])
+
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename, "/rails/root")
+        assert File.exist?(dbfile)
+        assert File.exist?(filename)
+        assert_match(/bar/, File.read(filename))
+        assert_no_match(/foo/, File.read(filename))
       ensure
         FileUtils.rm_f(filename)
         FileUtils.rm_f(dbfile)


### PR DESCRIPTION
This includes changes from #29060, fix a broken test and adds support for MySQL and SQLite3 as well.