### PR TITLE
[ci skip] Fix `scaffold_controller` generator usage

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/USAGE
+++ b/railties/lib/rails/generators/rails/scaffold_controller/USAGE
@@ -12,7 +12,7 @@ Description:
 Example:
     `rails generate scaffold_controller CreditCard`
 
-    Credit card controller with URLs like /credit_card/debit.
+    Credit card controller with URLs like /credit_cards.
         Controller: app/controllers/credit_cards_controller.rb
         Test:       test/controllers/credit_cards_controller_test.rb
         Views:      app/views/credit_cards/index.html.erb [...]


### PR DESCRIPTION
The `/credit_card/debit` part of the current usage example is not correct and seems to be copy-pasted from the `controller` generator. As the `scaffold` generator does not mention anything about URLs I thought rewording the usage example to focus on the RESTful actions would make more sense.