### PR TITLE
Fix ArgumentError in ActiveSupport::Cache::Store#cleanup when local cache enabled

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -87,7 +87,7 @@ module ActiveSupport
 
         def cleanup(options = nil) # :nodoc:
           return super unless cache = local_cache
-          cache.clear(options)
+          cache.clear
           super
         end
 

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -17,6 +17,21 @@ module LocalCacheBehavior
     assert_nil @cache.read("foo")
   end
 
+  def test_cleanup_clears_local_cache_but_not_remote_cache
+    skip unless @cache.class.instance_methods(false).include?(:cleanup)
+
+    @cache.with_local_cache do
+      @cache.write("foo", "bar")
+      assert_equal "bar", @cache.read("foo")
+
+      @cache.send(:bypass_local_cache) { @cache.write("foo", "baz") }
+      assert_equal "bar", @cache.read("foo")
+
+      @cache.cleanup
+      assert_equal "baz", @cache.read("foo")
+    end
+  end
+
   def test_local_cache_of_write
     @cache.with_local_cache do
       @cache.write("foo", "bar")


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/29067.

The `options` argument was removed from the `clear` method in https://github.com/rails/rails/pull/25628, but it was still being passed here, causing an `ArgumentError`.