### PR TITLE
Don't cache locally if unless_exist was passed

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -115,7 +115,12 @@ module ActiveSupport
           end
 
           def write_entry(key, entry, options)
-            local_cache.write_entry(key, entry, options) if local_cache
+            if options[:unless_exist]
+              local_cache.delete_entry(key, options) if local_cache
+            else
+              local_cache.write_entry(key, entry, options) if local_cache
+            end
+
             super
           end
 

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -708,6 +708,14 @@ module LocalCacheBehavior
     end
   end
 
+  def test_local_cache_of_write_with_unless_exist
+    @cache.with_local_cache do
+      @cache.write("foo", "bar")
+      @cache.write("foo", "baz", unless_exist: true)
+      assert_equal @peek.read("foo"), @cache.read("foo")
+    end
+  end
+
   def test_local_cache_of_delete
     @cache.with_local_cache do
       @cache.write("foo", "bar")


### PR DESCRIPTION
Some cache backends support the `unless_exist` option, which tells them not to overwrite existing entries. The local cache currently always stores the new value, even though the backend may have rejected it.

Since we can't tell which value will end up in the backend cache, we should delete the key from the local cache, so that the next read for that key will go to the backend and pick up the correct value.

The DalliStore backend hacked around this problem in https://github.com/petergoldstein/dalli/pull/365.