### PR TITLE
Message encryptor auth tag check

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -110,7 +110,7 @@ module ActiveSupport
         # Currently the OpenSSL bindings do not raise an error if auth_tag is
         # truncated, which would allow an attacker to easily forge it. See
         # https://github.com/ruby/openssl/issues/63
-        raise InvalidMessage if aead_mode? && auth_tag.bytes.length != 16
+        raise InvalidMessage if aead_mode? && (auth_tag.nil? || auth_tag.bytes.length != 16)
 
         cipher.decrypt
         cipher.key = @secret

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -86,6 +86,14 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     assert_equal @data, encryptor.decrypt_and_verify(message)
   end
 
+  def test_aead_mode_with_hmac_cbc_cipher_text
+    encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: "aes-256-gcm")
+
+    assert_raise ActiveSupport::MessageEncryptor::InvalidMessage do
+      encryptor.decrypt_and_verify "eHdGeExnZEwvMSt3U3dKaFl1WFo0TjVvYzA0eGpjbm5WSkt5MXlsNzhpZ0ZnbWhBWFlQZTRwaXE1bVJCS2oxMDZhYVp2dVN3V0lNZUlWQ3c2eVhQbnhnVjFmeVVubmhRKzF3WnZyWHVNMDg9LS1HSisyakJVSFlPb05ISzRMaXRzcFdBPT0=--831a1d54a3cda8a0658dc668a03dedcbce13b5ca"
+    end
+  end
+
   def test_messing_with_aead_values_causes_failures
     encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: "aes-256-gcm")
     text, iv, auth_tag = encryptor.encrypt_and_sign(@data).split("--")

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -89,24 +89,28 @@ class MessageEncryptorTest < ActiveSupport::TestCase
   def test_aead_mode_with_hmac_cbc_cipher_text
     encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: "aes-256-gcm")
 
-    assert_raise ActiveSupport::MessageEncryptor::InvalidMessage do
-      encryptor.decrypt_and_verify "eHdGeExnZEwvMSt3U3dKaFl1WFo0TjVvYzA0eGpjbm5WSkt5MXlsNzhpZ0ZnbWhBWFlQZTRwaXE1bVJCS2oxMDZhYVp2dVN3V0lNZUlWQ3c2eVhQbnhnVjFmeVVubmhRKzF3WnZyWHVNMDg9LS1HSisyakJVSFlPb05ISzRMaXRzcFdBPT0=--831a1d54a3cda8a0658dc668a03dedcbce13b5ca"
-    end
+    assert_aead_not_decrypted(encryptor, "eHdGeExnZEwvMSt3U3dKaFl1WFo0TjVvYzA0eGpjbm5WSkt5MXlsNzhpZ0ZnbWhBWFlQZTRwaXE1bVJCS2oxMDZhYVp2dVN3V0lNZUlWQ3c2eVhQbnhnVjFmeVVubmhRKzF3WnZyWHVNMDg9LS1HSisyakJVSFlPb05ISzRMaXRzcFdBPT0=--831a1d54a3cda8a0658dc668a03dedcbce13b5ca")
   end
 
   def test_messing_with_aead_values_causes_failures
     encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: "aes-256-gcm")
     text, iv, auth_tag = encryptor.encrypt_and_sign(@data).split("--")
-    assert_not_decrypted([iv, text, auth_tag] * "--")
-    assert_not_decrypted([munge(text), iv, auth_tag] * "--")
-    assert_not_decrypted([text, munge(iv), auth_tag] * "--")
-    assert_not_decrypted([text, iv, munge(auth_tag)] * "--")
-    assert_not_decrypted([munge(text), munge(iv), munge(auth_tag)] * "--")
-    assert_not_decrypted([text, iv] * "--")
-    assert_not_decrypted([text, iv, auth_tag[0..-2]] * "--")
+    assert_aead_not_decrypted(encryptor, [iv, text, auth_tag] * "--")
+    assert_aead_not_decrypted(encryptor, [munge(text), iv, auth_tag] * "--")
+    assert_aead_not_decrypted(encryptor, [text, munge(iv), auth_tag] * "--")
+    assert_aead_not_decrypted(encryptor, [text, iv, munge(auth_tag)] * "--")
+    assert_aead_not_decrypted(encryptor, [munge(text), munge(iv), munge(auth_tag)] * "--")
+    assert_aead_not_decrypted(encryptor, [text, iv] * "--")
+    assert_aead_not_decrypted(encryptor, [text, iv, auth_tag[0..-2]] * "--")
   end
 
   private
+
+    def assert_aead_not_decrypted(encryptor, value)
+      assert_raise(ActiveSupport::MessageEncryptor::InvalidMessage) do
+        encryptor.decrypt_and_verify(value)
+      end
+    end
 
     def assert_not_decrypted(value)
       assert_raise(ActiveSupport::MessageEncryptor::InvalidMessage) do


### PR DESCRIPTION
### Summary

This PR is meant to introduce a small fix to MessageEncryptor when used in AEAD mode. Specifically, we need to check if the `auth_tag` is `nil`. This may arise when an AEAD encryptor is used to decrypt a ciphertext generated from a different mode, such as CBC-HMAC. Basically, the number of double dashes will differ and `auth_tag` may be `nil` in this case.

### Other Information

This PR is in reference to the discussion here: https://github.com/rails/rails/pull/28132#discussion_r116388462

It also contains a second commit which fixes an existing AEAD related test. I think an incorrect `MessageEncryptor` was being used in a AEAD test and thus was giving false positives. 
