### PR TITLE
Address LogSubscriberTest failures to support Rails 2.5.0-dev

### DIFF
--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -97,10 +97,10 @@ class LogSubscriberTest < ActiveRecord::TestCase
     logger.colorize_logging = true
     SQL_COLORINGS.each do |verb, _|
       logger.sql(Event.new(0, sql: verb.to_s))
-      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.0ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
+      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0(?:\.0)?ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
 
       logger.sql(Event.new(0, sql: verb.to_s, name: "SQL"))
-      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA}SQL \(0.0ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
+      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA}SQL \(0(?:\.0)?ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
     end
   end
 
@@ -109,13 +109,13 @@ class LogSubscriberTest < ActiveRecord::TestCase
     logger.colorize_logging = true
     SQL_COLORINGS.each do |verb, _|
       logger.sql(Event.new(0, sql: verb.to_s, name: "Model Load"))
-      assert_match(/#{REGEXP_BOLD}#{REGEXP_CYAN}Model Load \(0\.0ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
+      assert_match(/#{REGEXP_BOLD}#{REGEXP_CYAN}Model Load \(0(?:\.0)?ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
 
       logger.sql(Event.new(0, sql: verb.to_s, name: "Model Exists"))
-      assert_match(/#{REGEXP_BOLD}#{REGEXP_CYAN}Model Exists \(0\.0ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
+      assert_match(/#{REGEXP_BOLD}#{REGEXP_CYAN}Model Exists \(0(?:\.0)?ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
 
       logger.sql(Event.new(0, sql: verb.to_s, name: "ANY SPECIFIC NAME"))
-      assert_match(/#{REGEXP_BOLD}#{REGEXP_CYAN}ANY SPECIFIC NAME \(0\.0ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
+      assert_match(/#{REGEXP_BOLD}#{REGEXP_CYAN}ANY SPECIFIC NAME \(0(?:\.0)?ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
     end
   end
 
@@ -124,7 +124,7 @@ class LogSubscriberTest < ActiveRecord::TestCase
     logger.colorize_logging = true
     SQL_COLORINGS.slice(:SELECT, :INSERT, :UPDATE, :DELETE).each do |verb, color_regex|
       logger.sql(Event.new(0, sql: "#{verb} WHERE ID IN SELECT"))
-      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.0ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{color_regex}#{verb} WHERE ID IN SELECT#{REGEXP_CLEAR}/i, logger.debugs.last)
+      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0(?:\.0)?ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{color_regex}#{verb} WHERE ID IN SELECT#{REGEXP_CLEAR}/i, logger.debugs.last)
     end
   end
 
@@ -139,7 +139,7 @@ class LogSubscriberTest < ActiveRecord::TestCase
         )
       EOS
       logger.sql(Event.new(0, sql: sql))
-      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.0ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{color_regex}.*#{verb}.*#{REGEXP_CLEAR}/mi, logger.debugs.last)
+      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0(?:\.0)?ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{color_regex}.*#{verb}.*#{REGEXP_CLEAR}/mi, logger.debugs.last)
     end
   end
 
@@ -152,13 +152,13 @@ class LogSubscriberTest < ActiveRecord::TestCase
       WHERE col1 = 5;
     EOS
     logger.sql(Event.new(0, sql: sql))
-    assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.0ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{SQL_COLORINGS[:LOCK]}.*FOR UPDATE.*#{REGEXP_CLEAR}/mi, logger.debugs.last)
+    assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0(?:\.0)?ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{SQL_COLORINGS[:LOCK]}.*FOR UPDATE.*#{REGEXP_CLEAR}/mi, logger.debugs.last)
 
     sql = <<-EOS
       LOCK TABLE films IN SHARE MODE;
     EOS
     logger.sql(Event.new(0, sql: sql))
-    assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.0ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{SQL_COLORINGS[:LOCK]}.*LOCK TABLE.*#{REGEXP_CLEAR}/mi, logger.debugs.last)
+    assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0(?:\.0)?ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{SQL_COLORINGS[:LOCK]}.*LOCK TABLE.*#{REGEXP_CLEAR}/mi, logger.debugs.last)
   end
 
   def test_exists_query_logging


### PR DESCRIPTION
### Summary

This pull request address #29021

Since Ruby 2.5.0-dev does not return decimal value when it is 0.
This change has been made at Ruby 2.5.0-dev between `(2017-05-05 trunk 58572)`
and `(2017-05-07 trunk 58586)`, likely Revision 58586.

This fix has been tested with these Ruby versions:

* ruby 2.5.0dev (2017-05-15 trunk 58733) [x86_64-linux]
* ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
* ruby 2.3.4p301 (2017-03-30 revision 58214) [x86_64-linux]
* ruby 2.2.7p470 (2017-03-28 revision 58194) [x86_64-linux]

