### PR TITLE
Add require "active_support/testing/declarative"

### DIFF
--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -1,4 +1,5 @@
 require "fileutils"
+require "active_support/testing/declarative"
 
 module FileUpdateCheckerSharedTests
   extend ActiveSupport::Testing::Declarative


### PR DESCRIPTION
Add `require "active_support/testing/declarative"` because of
`ActiveSupport::Testing::Declarative` is used in the file `activesupport/test/file_update_checker_shared_tests.rb`

```bash
bundle exec ruby -Iactivesupport/test activesupport/test/file_update_checker_shared_tests.rb

activesupport/test/file_update_checker_shared_tests.rb:4:in `<module:FileUpdateCheckerSharedTests>': uninitialized constant FileUpdateCheckerSharedTests::ActiveSupport (NameError)
        from activesupport/test/file_update_checker_shared_tests.rb:3:in `<main>
```