### PR TITLE
Fix `TestInvalidUrls` with rack 2.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,7 +249,7 @@ GEM
       simple_uuid
     que (0.12.0)
     racc (1.4.14)
-    rack (2.0.1)
+    rack (2.0.3)
     rack-cache (1.6.1)
       rack (>= 0.4)
     rack-protection (1.5.3)

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4419,7 +4419,7 @@ class TestInvalidUrls < ActionDispatch::IntegrationTest
     end
   end
 
-  test "invalid UTF-8 encoding returns a 400 Bad Request" do
+  test "invalid UTF-8 encoding is treated as ASCII 8BIT encode" do
     with_routing do |set|
       set.draw do
         get "/bar/:id", to: redirect("/foo/show/%{id}")
@@ -4435,19 +4435,19 @@ class TestInvalidUrls < ActionDispatch::IntegrationTest
       end
 
       get "/%E2%EF%BF%BD%A6"
-      assert_response :bad_request
+      assert_response :not_found
 
       get "/foo/%E2%EF%BF%BD%A6"
-      assert_response :bad_request
+      assert_response :not_found
 
       get "/foo/show/%E2%EF%BF%BD%A6"
-      assert_response :bad_request
+      assert_response :ok
 
       get "/bar/%E2%EF%BF%BD%A6"
-      assert_response :bad_request
+      assert_response :redirect
 
       get "/foobar/%E2%EF%BF%BD%A6"
-      assert_response :bad_request
+      assert_response :ok
     end
   end
 end


### PR DESCRIPTION
Currently, raise `BadRequest` if params encoding is invalid.
https://github.com/rails/rails/blob/5-1-stable/actionpack/lib/action_dispatch/http/parameters.rb#L64..L74
https://github.com/rails/rails/blob/5-1-stable/actionpack/lib/action_dispatch/request/utils.rb#L26..L39

However, env values are ensure encoded in ASCII 8 BIT at rack 2.0.3.
rack/rack@68db9aa

Therefore, even if specify an invalid urls, it will not cause an error.