### PR TITLE
Fix `after_commit, on: :update`

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -101,7 +101,9 @@ module ActiveRecord
               end.to_h
             )
 
-            unless affected_rows == 1
+            if affected_rows == 1
+              @_trigger_update_callback = true
+            else
               raise ActiveRecord::StaleObjectError.new(self, "update")
             end
 


### PR DESCRIPTION
The `after_commit on: :update` callbacks do not be fired when optimistic
locking enabled.