### PR TITLE
Fix association with extension issues

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -133,6 +133,16 @@ module ActiveRecord
         AssociationRelation.create(klass, klass.arel_table, klass.predicate_builder, self).merge!(klass.all)
       end
 
+      def extensions
+        extensions = klass.all.extensions | reflection.extensions
+
+        if scope = reflection.scope
+          extensions |= klass.unscoped.instance_exec(owner, &scope).extensions
+        end
+
+        extensions
+      end
+
       # Loads the \target if needed and returns it.
       #
       # This method is abstract in the sense that it relies on +find_target+,

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -134,7 +134,7 @@ module ActiveRecord
       end
 
       def extensions
-        extensions = klass.all.extensions | reflection.extensions
+        extensions = klass.default_extensions | reflection.extensions
 
         if scope = reflection.scope
           extensions |= klass.unscoped.instance_exec(owner, &scope).extensions

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -24,7 +24,7 @@ module ActiveRecord
         alias_tracker = AliasTracker.create connection, association.klass.table_name, klass.type_caster
         chain_head, chain_tail = get_chain(reflection, association, alias_tracker)
 
-        scope.extending! Array(reflection.options[:extend])
+        scope.extending! reflection.extensions
         add_constraints(scope, owner, reflection, chain_head, chain_tail)
       end
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -30,7 +30,8 @@ module ActiveRecord
           reload
         end
 
-        CollectionProxy.create(klass, self)
+        @proxy ||= CollectionProxy.create(klass, self)
+        @proxy.reset_scope
       end
 
       # Implements the writer method, e.g. foo.items= for Foo.has_many :items

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1087,9 +1087,8 @@ module ActiveRecord
       #   person.pets(true)  # fetches pets from the database
       #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
       def reload
-        @scope = nil
         proxy_association.reload
-        self
+        reset_scope
       end
 
       # Unloads the association. Returns +self+.
@@ -1109,9 +1108,13 @@ module ActiveRecord
       #   person.pets  # fetches pets from the database
       #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
       def reset
-        @scope = nil
         proxy_association.reset
         proxy_association.reset_scope
+        reset_scope
+      end
+
+      def reset_scope # :nodoc:
+        @scope = nil
         self
       end
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -581,6 +581,10 @@ module ActiveRecord
         seed + [self]
       end
 
+      def extensions
+        Array(options[:extend])
+      end
+
       protected
 
         def actual_source_reflection # FIXME: this is a horrible name

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -25,8 +25,6 @@ module ActiveRecord
 
       def inherited(child_class)
         child_class.initialize_relation_delegate_cache
-        delegate = child_class.relation_delegate_class(ActiveRecord::Associations::CollectionProxy)
-        delegate.include ActiveRecord::Associations::CollectionProxy::DelegateExtending
         super
       end
     end

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -30,13 +30,8 @@ module ActiveRecord
         end
 
         def default_scoped # :nodoc:
-          scope = build_default_scope
-
-          if scope
-            relation.spawn.merge!(scope)
-          else
-            relation
-          end
+          scope = relation
+          build_default_scope(scope) || scope
         end
 
         # Adds a class method for retrieving and querying objects.

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -34,6 +34,14 @@ module ActiveRecord
           build_default_scope(scope) || scope
         end
 
+        def default_extensions # :nodoc:
+          if scope = current_scope || build_default_scope
+            scope.extensions
+          else
+            []
+          end
+        end
+
         # Adds a class method for retrieving and querying objects.
         # The method is intended to return an ActiveRecord::Relation
         # object, which is composable with other scopes.

--- a/activerecord/test/cases/associations/extension_test.rb
+++ b/activerecord/test/cases/associations/extension_test.rb
@@ -78,6 +78,12 @@ class AssociationsExtensionsTest < ActiveRecord::TestCase
     assert_equal post.association(:comments), post.comments.where("1=1").the_association
   end
 
+  def test_association_with_default_scope
+    assert_raises OopsError do
+      posts(:welcome).comments.destroy_all
+    end
+  end
+
   private
 
     def extend!(model)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2251,7 +2251,15 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   test "association with extend option with multiple extensions" do
     post = posts(:welcome)
     assert_equal "lifo",  post.comments_with_extend_2.author
-    assert_equal "hello", post.comments_with_extend_2.greeting
+    assert_equal "hullo", post.comments_with_extend_2.greeting
+  end
+
+  test "extend option affects per association" do
+    post = posts(:welcome)
+    assert_equal "lifo",  post.comments_with_extend.author
+    assert_equal "lifo",  post.comments_with_extend_2.author
+    assert_equal "hello", post.comments_with_extend.greeting
+    assert_equal "hullo", post.comments_with_extend_2.greeting
   end
 
   test "delete record with complex joins" do

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -220,6 +220,11 @@ class AssociationProxyTest < ActiveRecord::TestCase
     assert_equal david.projects, david.projects.scope
   end
 
+  test "proxy object is cached" do
+    david = developers(:david)
+    assert_same david.projects, david.projects
+  end
+
   test "inverses get set of subsets of the association" do
     man = Man.create
     man.interests.create

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -19,6 +19,16 @@ class Comment < ActiveRecord::Base
   has_many :children, class_name: "Comment", foreign_key: :parent_id
   belongs_to :parent, class_name: "Comment", counter_cache: :children_count
 
+  class ::OopsError < RuntimeError; end
+
+  module OopsExtension
+    def destroy_all(*)
+      raise OopsError
+    end
+  end
+
+  default_scope { extending OopsExtension }
+
   # Should not be called if extending modules that having the method exists on an association.
   def self.greeting
     raise

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -13,7 +13,7 @@ class Post < ActiveRecord::Base
 
   module NamedExtension2
     def greeting
-      "hello"
+      "hullo"
     end
   end
 


### PR DESCRIPTION
This fixes the following issues.

* `association_scope` doesn't include `default_scope`. Should use `scope` instead.
* We can't use `method_missing` for customizing existing method.
* We can't use `relation_delegate_class` for sharing extensions. Should extend per association.