### PR TITLE
Clarify behavior for ActiveSupport's String#first, String#last when limit is negative

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/access.rb
+++ b/activesupport/lib/active_support/core_ext/string/access.rb
@@ -67,7 +67,7 @@ class String
   # Returns the first character. If a limit is supplied, returns a substring
   # from the beginning of the string until it reaches the limit value. If the
   # given limit is greater than or equal to the string length, returns a copy of self.
-  # Returns a blank string when the given limit is negative.
+  # Raises an ArgumentError when the given limit is negative.
   #
   #   str = "hello"
   #   str.first    # => "h"
@@ -75,9 +75,11 @@ class String
   #   str.first(2) # => "he"
   #   str.first(0) # => ""
   #   str.first(6) # => "hello"
-  #   str.first(-1) # => ""
+  #   str.first(-1) # => ArgumentError: invalid limit value
   def first(limit = 1)
-    if limit <= 0
+    if limit < 0
+      raise ArgumentError, "invalid limit value"
+    elsif limit == 0
       ""
     elsif limit >= size
       dup
@@ -89,7 +91,7 @@ class String
   # Returns the last character of the string. If a limit is supplied, returns a substring
   # from the end of the string until it reaches the limit value (counting backwards). If
   # the given limit is greater than or equal to the string length, returns a copy of self.
-  # Returns a blank string when the given limit is negative.
+  # Raises an ArgumentError when the given limit is negative.
   #
   #   str = "hello"
   #   str.last    # => "o"
@@ -97,9 +99,11 @@ class String
   #   str.last(2) # => "lo"
   #   str.last(0) # => ""
   #   str.last(6) # => "hello"
-  #   str.last(-1) # => ""
+  #   str.last(-1) # => ArgumentError: invalid limit value
   def last(limit = 1)
-    if limit <= 0
+    if limit < 0
+      raise ArgumentError, "invalid limit value"
+    elsif limit == 0
       ""
     elsif limit >= size
       dup

--- a/activesupport/lib/active_support/core_ext/string/access.rb
+++ b/activesupport/lib/active_support/core_ext/string/access.rb
@@ -67,6 +67,7 @@ class String
   # Returns the first character. If a limit is supplied, returns a substring
   # from the beginning of the string until it reaches the limit value. If the
   # given limit is greater than or equal to the string length, returns a copy of self.
+  # Returns a blank string when the given limit is negative.
   #
   #   str = "hello"
   #   str.first    # => "h"
@@ -74,8 +75,9 @@ class String
   #   str.first(2) # => "he"
   #   str.first(0) # => ""
   #   str.first(6) # => "hello"
+  #   str.first(-1) # => ""
   def first(limit = 1)
-    if limit == 0
+    if limit <= 0
       ""
     elsif limit >= size
       dup
@@ -87,6 +89,7 @@ class String
   # Returns the last character of the string. If a limit is supplied, returns a substring
   # from the end of the string until it reaches the limit value (counting backwards). If
   # the given limit is greater than or equal to the string length, returns a copy of self.
+  # Returns a blank string when the given limit is negative.
   #
   #   str = "hello"
   #   str.last    # => "o"
@@ -94,8 +97,9 @@ class String
   #   str.last(2) # => "lo"
   #   str.last(0) # => ""
   #   str.last(6) # => "hello"
+  #   str.last(-1) # => ""
   def last(limit = 1)
-    if limit == 0
+    if limit <= 0
       ""
     elsif limit >= size
       dup

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -469,8 +469,10 @@ class StringAccessTest < ActiveSupport::TestCase
     assert_not_same different_string, string
   end
 
-  test "#first with negative Integer returns a blank string" do
-    assert_equal "", "hello".last(-1)
+  test "#first with negative Integer raises an argument error" do
+    assert_raise ArgumentError do
+      "hello".first(-1)
+    end
   end
 
   test "#last returns the last character" do
@@ -491,8 +493,10 @@ class StringAccessTest < ActiveSupport::TestCase
     assert_not_same different_string, string
   end
 
-  test "#last with negative Integer returns a blank string" do
-    assert_equal "", "hello".last(-1)
+  test "#last with negative Integer raises an argument error" do
+    assert_raise ArgumentError do
+      "hello".last(-1)
+    end
   end
 
   test "access returns a real string" do

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -469,6 +469,10 @@ class StringAccessTest < ActiveSupport::TestCase
     assert_not_same different_string, string
   end
 
+  test "#first with negative Integer returns a blank string" do
+    assert_equal "", "hello".last(-1)
+  end
+
   test "#last returns the last character" do
     assert_equal "o", "hello".last
     assert_equal "x", "x".last
@@ -485,6 +489,10 @@ class StringAccessTest < ActiveSupport::TestCase
     string = "hello"
     different_string = string.last(5)
     assert_not_same different_string, string
+  end
+
+  test "#last with negative Integer returns a blank string" do
+    assert_equal "", "hello".last(-1)
   end
 
   test "access returns a real string" do


### PR DESCRIPTION
### Summary

I propose we more clearly define the behavior of ActiveSupport's `String#first` and `String#last` methods when passed a negative limit value.

Here's the current (seemingly untested/documented) behavior:

```ruby
str = "hello"
str.first(-1)
# => "hell"
str.last(-2)
# => "llo"
```
I found this a little surprising, but is this the intended behavior?  If so I feel we should at least add [tests for these cases](https://github.com/rails/rails/blob/master/activesupport/test/core_ext/string_ext_test.rb#L379-L413).

If not, I propose that when passed a negative number we either return a blank string:
```ruby
str.first(-1)
# => ""
str.last(-2)
# => ""
```

or raise an ArgumentError:
```ruby
str.first(-1)
# => ArgumentError: limit must be a positive integer
str.last(-2)
# => ArgumentError: limit must be a positive integer
```

This PR implements **the second strategy** above.  

Any thoughts?
