### PR TITLE
Implemented #cache_version conventional method

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -58,9 +58,9 @@ module ActiveRecord
       else
         timestamp = if timestamp_names.any?
           max_updated_column_timestamp(timestamp_names)
-        else
-          max_updated_column_timestamp
-        end
+                    elsif !respond_to?(:cache_version)
+                      max_updated_column_timestamp
+                    end
 
         if timestamp
           timestamp = timestamp.utc.to_s(cache_timestamp_format)

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -167,6 +167,11 @@ class IntegrationTest < ActiveRecord::TestCase
     assert_equal key, dev.reload.cache_key
   end
 
+  def test_cache_key_when_cache_version_defined
+    dev = VersionedCacheDeveloper.first
+    assert_equal "versioned_cache_developers/#{dev.id}", dev.cache_key
+  end
+
   def test_named_timestamps_for_cache_key
     owner = owners(:blackbeard)
     assert_equal "owners/#{owner.id}-#{owner.happy_at.utc.to_s(:usec)}", owner.cache_key(:updated_at, :happy_at)

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -266,3 +266,10 @@ class DeveloperWithIncorrectlyOrderedHasManyThrough < ActiveRecord::Base
   has_many :companies, through: :contracts
   has_many :contracts, foreign_key: :developer_id
 end
+
+class VersionedCacheDeveloper < ActiveRecord::Base
+  self.table_name = "developers"
+  def cache_version
+    updated_at
+  end
+end


### PR DESCRIPTION
Implemented `#cache_version` conventional method for the default cache `version` option value.

Examples:

``` ruby
Rails.cache.fetch(["post_preview", post])
Rails.cache.fetch(["post_preview", post, post.author]) 

class Post
  def cache_key
     "posts/#{id}"
  end
  def cache_version
    updated_at
  end
end
```

