### PR TITLE
Fix server-generated JS response processing on IE9

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
@@ -14,7 +14,7 @@ AcceptHeaders =
 Rails.ajax = (options) ->
   options = prepareOptions(options)
   xhr = createXHR options, ->
-    response = processResponse(xhr.response, xhr.getResponseHeader('Content-Type'))
+    response = processResponse(xhr.response ? xhr.responseText, xhr.getResponseHeader('Content-Type'))
     if xhr.status // 100 == 2
       options.success?(response, xhr.statusText, xhr)
     else


### PR DESCRIPTION
### Summary

Fix for #29069, IE9's lack of `xhr.response`. With this in place, server-generated JS responses, Turbolinks redirects etc should now be executed by IE9 when given in response to a rails-ujs `remote: true` request.

### Other Information

This PR is not intended to make the rails-ujs test suite pass in IE9. That might be desirable, but it's more work than I could justify this week to nurse a dying browser. Tested with https://github.com/inopinatus/ujs-test-app instead.

1. Why not simply `xhr.response || xhr.responseText` in the call to `processResponse`? Because falsy values other than `null` are still valid response objects.
2. Why not a ternary operation like `xhrResponseObject = if xhr.response? then xhr.response else xhr.responseText`? I felt this way showed the intent more clearly.

