### PR TITLE
Ignore errors while loading db/structure into postgresql

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow PostgreSQL errors to be ignored during the loading of `db/structure.sql`, via the `IGNORE_PG_LOAD_ERRORS` ENV.
+
+    Fixes #29049
+
+    *Dan Collis-Puro*
+
 *   Prevent making bind param if casted value is nil.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -80,7 +80,11 @@ module ActiveRecord
 
       def structure_load(filename, extra_flags)
         set_psql_env
-        args = ["-v", ON_ERROR_STOP_1, "-q", "-f", filename]
+        args = if ENV["IGNORE_PG_LOAD_ERRORS"]
+                 ["-v", "-q", "-f", filename]
+               else
+                 ["-v", ON_ERROR_STOP_1, "-q", "-f", filename]
+               end
         args.concat(Array(extra_flags)) if extra_flags
         args << configuration["database"]
         run_cmd("psql", args, "loading")


### PR DESCRIPTION
### Summary

This will allow the loading of db/structure.sql files with non-fatal
errors (like "set row security" or adding schema COMMENTs) to complete
without failure, similar to the behavior under rails < 5.

To use this, export IGNORE_PG_LOAD_ERRORS=1 when loading your
db/structure.sql, thusly:

    bundle exec rails IGNORE_PG_LOAD_ERRORS=1 db:structure:load

This is necessary because many rails developers work with postgres
connections that have superuser access, and the process of dumping
`structure.sql` will reflect that privilege level. This typically
happens on osx machines. This makes it hard to interoperate with
developers that use postgres connections that aren't configured as the
superuser - for instance, most default linux installs and most CI providers.

This isn't a perfect solution, but it allows us to at least function
similar to pre rails 5, where we'd do a "best effort" loading of the
structure. This generally worked OK.

### Other Information

RE: https://github.com/rails/rails/issues/29049