### PR TITLE
add documentation for bind parameters to find_by_sql [ci skip]

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -35,6 +35,8 @@ module ActiveRecord
     #
     #   Post.find_by_sql ["SELECT title FROM posts WHERE author = ? AND created > ?", author_id, start_date]
     #   Post.find_by_sql ["SELECT body FROM comments WHERE author = :user_id OR approved_by = :user_id", { :user_id => user_id }]
+    #   Post.find_by_sql ["SELECT title FROM posts WHERE author_id = $1 AND status = $2", [[nil, 42],[nil, 'active']]
+    #
     def find_by_sql(sql, binds = [])
       result_set = connection.select_all(sanitize_sql(sql), "#{name} Load", binds)
       column_types = result_set.column_types.dup


### PR DESCRIPTION
### Summary

The change documents the parameter format to use for the ```binds``` parameter when calling ```find_by_sql``` when the sql text contains substitution values from a prepared statement ($1)