### PR TITLE
Set non 0 value to logger not to be affected by Ruby versions

### DIFF
--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -59,19 +59,19 @@ class LogSubscriberTest < ActiveRecord::TestCase
     logger = TestDebugLogSubscriber.new
     assert_equal 0, logger.debugs.length
 
-    logger.sql(Event.new(0, sql: "hi mom!"))
+    logger.sql(Event.new(0.9, sql: "hi mom!"))
     assert_equal 1, logger.debugs.length
 
-    logger.sql(Event.new(0, sql: "hi mom!", name: "foo"))
+    logger.sql(Event.new(0.9, sql: "hi mom!", name: "foo"))
     assert_equal 2, logger.debugs.length
 
-    logger.sql(Event.new(0, sql: "hi mom!", name: "SCHEMA"))
+    logger.sql(Event.new(0.9, sql: "hi mom!", name: "SCHEMA"))
     assert_equal 2, logger.debugs.length
   end
 
   def test_sql_statements_are_not_squeezed
     logger = TestDebugLogSubscriber.new
-    logger.sql(Event.new(0, sql: "ruby   rails"))
+    logger.sql(Event.new(0.9, sql: "ruby   rails"))
     assert_match(/ruby   rails/, logger.debugs.first)
   end
 
@@ -87,7 +87,7 @@ class LogSubscriberTest < ActiveRecord::TestCase
     logger = TestDebugLogSubscriber.new
     logger.colorize_logging = true
     SQL_COLORINGS.each do |verb, color_regex|
-      logger.sql(Event.new(0, sql: verb.to_s))
+      logger.sql(Event.new(0.9, sql: verb.to_s))
       assert_match(/#{REGEXP_BOLD}#{color_regex}#{verb}#{REGEXP_CLEAR}/i, logger.debugs.last)
     end
   end
@@ -96,11 +96,11 @@ class LogSubscriberTest < ActiveRecord::TestCase
     logger = TestDebugLogSubscriber.new
     logger.colorize_logging = true
     SQL_COLORINGS.each do |verb, _|
-      logger.sql(Event.new(0, sql: verb.to_s))
-      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.0ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
+      logger.sql(Event.new(0.9, sql: verb.to_s))
+      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.9ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
 
-      logger.sql(Event.new(0, sql: verb.to_s, name: "SQL"))
-      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA}SQL \(0.0ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
+      logger.sql(Event.new(0.9, sql: verb.to_s, name: "SQL"))
+      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA}SQL \(0\.9ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
     end
   end
 
@@ -108,14 +108,14 @@ class LogSubscriberTest < ActiveRecord::TestCase
     logger = TestDebugLogSubscriber.new
     logger.colorize_logging = true
     SQL_COLORINGS.each do |verb, _|
-      logger.sql(Event.new(0, sql: verb.to_s, name: "Model Load"))
-      assert_match(/#{REGEXP_BOLD}#{REGEXP_CYAN}Model Load \(0\.0ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
+      logger.sql(Event.new(0.9, sql: verb.to_s, name: "Model Load"))
+      assert_match(/#{REGEXP_BOLD}#{REGEXP_CYAN}Model Load \(0\.9ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
 
-      logger.sql(Event.new(0, sql: verb.to_s, name: "Model Exists"))
-      assert_match(/#{REGEXP_BOLD}#{REGEXP_CYAN}Model Exists \(0\.0ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
+      logger.sql(Event.new(0.9, sql: verb.to_s, name: "Model Exists"))
+      assert_match(/#{REGEXP_BOLD}#{REGEXP_CYAN}Model Exists \(0\.9ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
 
-      logger.sql(Event.new(0, sql: verb.to_s, name: "ANY SPECIFIC NAME"))
-      assert_match(/#{REGEXP_BOLD}#{REGEXP_CYAN}ANY SPECIFIC NAME \(0\.0ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
+      logger.sql(Event.new(0.9, sql: verb.to_s, name: "ANY SPECIFIC NAME"))
+      assert_match(/#{REGEXP_BOLD}#{REGEXP_CYAN}ANY SPECIFIC NAME \(0\.9ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
     end
   end
 
@@ -123,8 +123,8 @@ class LogSubscriberTest < ActiveRecord::TestCase
     logger = TestDebugLogSubscriber.new
     logger.colorize_logging = true
     SQL_COLORINGS.slice(:SELECT, :INSERT, :UPDATE, :DELETE).each do |verb, color_regex|
-      logger.sql(Event.new(0, sql: "#{verb} WHERE ID IN SELECT"))
-      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.0ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{color_regex}#{verb} WHERE ID IN SELECT#{REGEXP_CLEAR}/i, logger.debugs.last)
+      logger.sql(Event.new(0.9, sql: "#{verb} WHERE ID IN SELECT"))
+      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.9ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{color_regex}#{verb} WHERE ID IN SELECT#{REGEXP_CLEAR}/i, logger.debugs.last)
     end
   end
 
@@ -138,8 +138,8 @@ class LogSubscriberTest < ActiveRecord::TestCase
           SELECT ID FROM THINGS
         )
       EOS
-      logger.sql(Event.new(0, sql: sql))
-      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.0ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{color_regex}.*#{verb}.*#{REGEXP_CLEAR}/mi, logger.debugs.last)
+      logger.sql(Event.new(0.9, sql: sql))
+      assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.9ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{color_regex}.*#{verb}.*#{REGEXP_CLEAR}/mi, logger.debugs.last)
     end
   end
 
@@ -151,14 +151,14 @@ class LogSubscriberTest < ActiveRecord::TestCase
         (SELECT * FROM mytable FOR UPDATE) ss
       WHERE col1 = 5;
     EOS
-    logger.sql(Event.new(0, sql: sql))
-    assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.0ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{SQL_COLORINGS[:LOCK]}.*FOR UPDATE.*#{REGEXP_CLEAR}/mi, logger.debugs.last)
+    logger.sql(Event.new(0.9, sql: sql))
+    assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.9ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{SQL_COLORINGS[:LOCK]}.*FOR UPDATE.*#{REGEXP_CLEAR}/mi, logger.debugs.last)
 
     sql = <<-EOS
       LOCK TABLE films IN SHARE MODE;
     EOS
-    logger.sql(Event.new(0, sql: sql))
-    assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.0ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{SQL_COLORINGS[:LOCK]}.*LOCK TABLE.*#{REGEXP_CLEAR}/mi, logger.debugs.last)
+    logger.sql(Event.new(0.9, sql: sql))
+    assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.9ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{SQL_COLORINGS[:LOCK]}.*LOCK TABLE.*#{REGEXP_CLEAR}/mi, logger.debugs.last)
   end
 
   def test_exists_query_logging


### PR DESCRIPTION
### Summary

Addresses #29021

There was another pull request #29089 which intends to handle 0ms and 0.0ms differences using regular expressions. This pull request sets non 0 value to logger, 0.9ms so that there will be no need to implement regular expressions in tests.

