### PR TITLE
Remove unneeded `association.respond_to?(:reset_scope)`

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -389,7 +389,7 @@ module ActiveRecord
           autosave = reflection.options[:autosave]
 
           # reconstruct the scope now that we know the owner's id
-          association.reset_scope if association.respond_to?(:reset_scope)
+          association.reset_scope
 
           if records = associated_records_to_validate_or_save(association, @new_record_before_save, autosave)
             if autosave


### PR DESCRIPTION
Since 86390c3 all associations have `reset_scope` so `respond_to?` is
unneeded.