### PR TITLE
Fix select tag helper used with Enumerable choices

### DIFF
--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -33,7 +33,7 @@ module ActionView
           #   [nil, []]
           #   { nil => [] }
           def grouped_choices?
-            !@choices.empty? && @choices.first.respond_to?(:last) && Array === @choices.first.last
+            !@choices.blank? && @choices.first.respond_to?(:last) && Array === @choices.first.last
           end
       end
     end

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -6,6 +6,15 @@ class Map < Hash
   end
 end
 
+class CustomEnumerable
+  include Enumerable
+
+  def each
+    yield "one"
+    yield "two"
+  end
+end
+
 class FormOptionsHelperTest < ActionView::TestCase
   tests ActionView::Helpers::FormOptionsHelper
 
@@ -901,6 +910,14 @@ class FormOptionsHelperTest < ActionView::TestCase
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"1\">1</option>\n<option value=\"2\">2</option>\n<option value=\"3\">3</option></select>",
       select("post", "category", 1..3)
+    )
+  end
+
+  def test_select_with_enumerable
+    @post = Post.new
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"><option value=\"one\">one</option>\n<option value=\"two\">two</option></select>",
+      select("post", "category", CustomEnumerable.new)
     )
   end
 


### PR DESCRIPTION
Allows a custom object implementing Enumerable to be used as the choices parameter for a select tag, which previously wasn't possible (despite the documentation suggesting it was) due to the call to `empty?` on the choices (which isn't implemented on Enumerable).