### PR TITLE
Add documentation to accessors in AbstractController::Base

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -15,15 +15,15 @@ module AbstractController
   # different things depending on the context.
   class Base
     ##
-    # Returns the body of the HTTP response sent by the controller
+    # Returns the body of the HTTP response sent by the controller.
     attr_internal :response_body
 
     ##
-    # Returns the name of the action this controller is processing
+    # Returns the name of the action this controller is processing.
     attr_internal :action_name
 
     ##
-    # Returns the formats processed by the controller
+    # Returns the formats processed by the controller.
     attr_internal :formats
 
     include ActiveSupport::Configurable

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -15,7 +15,7 @@ module AbstractController
   # different things depending on the context.
   class Base
     ##
-    # Returns the HTTP response sent by the controller
+    # Returns the body of the HTTP response sent by the controller
     attr_internal :response_body
 
     ##

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -14,8 +14,16 @@ module AbstractController
   # expected to provide their own +render+ method, since rendering means
   # different things depending on the context.
   class Base
+    ##
+    # Returns the HTTP response sent by the controller
     attr_internal :response_body
+
+    ##
+    # Returns the name of the action this controller is processing
     attr_internal :action_name
+
+    ##
+    # Returns the formats processed by the controller
     attr_internal :formats
 
     include ActiveSupport::Configurable

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -23,7 +23,7 @@ module AbstractController
     attr_internal :action_name
 
     ##
-    # Returns the formats processed by the controller.
+    # Returns the formats that can be processed by the controller.
     attr_internal :formats
 
     include ActiveSupport::Configurable


### PR DESCRIPTION
### Summary

Adds missing documentation to the three accessors in AbstractController::Base. Fixes #29084.

### Other Information

This is my first Rails patch.
