### PR TITLE
Log subscriber - avoid rescuing certain exceptions

### DIFF
--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -81,7 +81,7 @@ module ActiveSupport
 
     def finish(name, id, payload)
       super if logger
-    rescue Exception => e
+    rescue => e
       logger.error "Could not log #{name.inspect} event. #{e.class}: #{e.message} #{e.backtrace}"
     end
 

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -82,7 +82,9 @@ module ActiveSupport
     def finish(name, id, payload)
       super if logger
     rescue => e
-      logger.error "Could not log #{name.inspect} event. #{e.class}: #{e.message} #{e.backtrace}"
+      if logger
+        logger.error "Could not log #{name.inspect} event. #{e.class}: #{e.message} #{e.backtrace}"
+      end
     end
 
   private


### PR DESCRIPTION
### Summary

I've encountered an issue with ctrl+c failing to have the intended interrupt effect, due to over-broad rescuing and insufficient checking. this is the error when I hit ctrl+c:

```
NoMethodError: undefined method `error' for nil:NilClass
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.2/lib/active_support/log_subscriber.rb:85:in `rescue in finish'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.2/lib/active_support/log_subscriber.rb:83:in `finish'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.2/lib/active_support/notifications/fanout.rb:102:in `finish'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.2/lib/active_support/notifications/fanout.rb:46:in `block in finish'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.2/lib/active_support/notifications/fanout.rb:46:in `each'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.2/lib/active_support/notifications/fanout.rb:46:in `finish'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.2/lib/active_support/notifications/instrumenter.rb:42:in `finish_with_state'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activesupport-5.0.2/lib/active_support/notifications/instrumenter.rb:27:in `instrument'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.2/lib/active_record/connection_adapters/postgresql/database_statements.rb:97:in `execute'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.2/lib/active_record/connection_adapters/postgresql/database_statements.rb:162:in `commit_db_transaction'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract/transaction.rb:143:in `commit'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract/transaction.rb:177:in `commit_transaction'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract/transaction.rb:202:in `within_new_transaction'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.2/lib/active_record/transactions.rb:211:in `transaction'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.2/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.2/lib/active_record/transactions.rb:319:in `block in save'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.2/lib/active_record/transactions.rb:334:in `rollback_active_record_state!'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.2/lib/active_record/transactions.rb:318:in `save'
  /Users/ethan/.rvm/gems/ruby-2.3.3/gems/activerecord-5.0.2/lib/active_record/suppressor.rb:41:in `save'
```

to address this I have added the check `if logger` around the `logger.error` call in the rescue. it's not quite clear to me how this happens given that `if logger` is already checked before anything happens, but apparently `logger` is somehow getting unset during that call, before the Interrupt is raised.

that is insufficient, however, since the Interrupt should not actually be rescued in the first place. so I have added a module (derived from - that is to say identical to - one from rspec) which avoids rescuing exceptions that should not be rescued.

I think that this module should probably replace nearly all instances of `rescue Exception` in the codebase, actually. the number of `rescue Exception` instances I see around the code is rather surprising. but I will start with this one and see what feedback I get before looking more broadly.
