### PR TITLE
Both reference id and type should be `NOT NULL` if `null: false` is specified

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -146,7 +146,7 @@ module ActiveRecord
         end
 
         def polymorphic_options
-          as_options(polymorphic)
+          as_options(polymorphic).merge(null: options[:null])
         end
 
         def index_options

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -50,6 +50,14 @@ module ActiveRecord
         assert column_exists?(table_name, :taggable_type, :string, default: "Photo")
       end
 
+      def test_creates_reference_type_column_with_not_null
+        connection.create_table table_name, force: true do |t|
+          t.references :taggable, null: false, polymorphic: true
+        end
+        assert column_exists?(table_name, :taggable_id, :integer, null: false)
+        assert column_exists?(table_name, :taggable_type, :string, null: false)
+      end
+
       def test_does_not_share_options_with_reference_type_column
         add_reference table_name, :taggable, type: :integer, limit: 2, polymorphic: true
         assert column_exists?(table_name, :taggable_id, :integer, limit: 2)


### PR DESCRIPTION
This is a regression due to #28282.

Fixes #29136.