### PR TITLE
Correctly set user_supplied_options when there is no whitespace in option specification

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -155,9 +155,16 @@ module Rails
         def user_supplied_options
           @user_supplied_options ||= begin
             # Convert incoming options array to a hash of flags
-            #   ["-p", "3001", "-c", "foo"] # => {"-p" => true, "-c" => true}
+            #   ["-p3001", "-C", "--binding", "127.0.0.1"] # => {"-p"=>true, "-C"=>true, "--binding"=>true}
             user_flag = {}
-            @original_options.each_with_index { |command, i| user_flag[command] = true if i.even? }
+            @original_options.each do |command|
+              if command.to_s.start_with?("--")
+                option = command.split("=")[0]
+                user_flag[option] = true
+              elsif command =~ /\A(-.)/
+                user_flag[Regexp.last_match[0]] = true
+              end
+            end
 
             # Collect all options that the user has explicitly defined so we can
             # differentiate them from defaults

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -165,6 +165,12 @@ class Rails::ServerTest < ActiveSupport::TestCase
 
     server_options = parse_arguments(["--port", 3001])
     assert_equal [:Port], server_options[:user_supplied_options]
+
+    server_options = parse_arguments(["-p3001", "-C", "--binding", "127.0.0.1"])
+    assert_equal [:Port, :Host, :caching], server_options[:user_supplied_options]
+
+    server_options = parse_arguments(["--port=3001"])
+    assert_equal [:Port], server_options[:user_supplied_options]
   end
 
   def test_default_options


### PR DESCRIPTION
Current `user_supplied_options` method can not set the value correctly
if there is no space between option and value (e.g., `-p9000`).
This makes it possible to set the value correctly in the case like the above.

Fixes #29138

