### PR TITLE
Check for jQuery ajax

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/start.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/start.coffee
@@ -9,7 +9,7 @@
 } = Rails
 
 # For backward compatibility
-if jQuery? and not jQuery.rails
+if jQuery? and jQuery.ajax? and not jQuery.rails
   jQuery.rails = Rails
   jQuery.ajaxPrefilter (options, originalOptions, xhr) ->
     CSRFProtection(xhr) unless options.crossDomain


### PR DESCRIPTION
### Summary

jQuery slim version doesn't have ajax, so if a person include this version ajaxFilter raises error.
http://blog.jquery.com/2017/03/20/jquery-3-2-1-now-available/