### PR TITLE
Fix polymorphic association with scope

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix preloading polymorphic association with scope.
+
+    Fixes #27724.
+
+    *Ryuta Kamizono*
+
 *   Merging two relations representing nested joins no longer transforms the joins of
     the merged relation into LEFT OUTER JOIN. Example to clarify:
 

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -54,8 +54,6 @@ module ActiveRecord
         autoload :BelongsTo,           "active_record/associations/preloader/belongs_to"
       end
 
-      NULL_RELATION = Struct.new(:values, :where_clause, :joins_values).new({}, Relation::WhereClause.empty, [])
-
       # Eager loads the named associations for the given Active Record record(s).
       #
       # In this description, 'association name' shall refer to the name passed
@@ -93,7 +91,6 @@ module ActiveRecord
       def preload(records, associations, preload_scope = nil)
         records       = Array.wrap(records).compact.uniq
         associations  = Array.wrap(associations)
-        preload_scope = preload_scope || NULL_RELATION
 
         if records.empty?
           []

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -31,19 +31,9 @@ module ActiveRecord
           scope.where(association_key_name => ids)
         end
 
-        def table
-          klass.arel_table
-        end
-
         # The name of the key on the associated records
         def association_key_name
           raise NotImplementedError
-        end
-
-        # This is overridden by HABTM as the condition should be on the foreign_key column in
-        # the join table
-        def association_key
-          klass.arel_attribute(association_key_name, table)
         end
 
         # The name of the key on the model which declares the association

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -935,6 +935,13 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_has_many_through_polymorphic_with_scope_should_work_properly
+    post = TaggedPost.create!(title: "Tagged", body: "Post")
+    tag = post.tags.create!(name: "Tag")
+    assert_equal [tag], TaggedPost.preload(:tags).last.tags
+    assert_equal [tag], TaggedPost.eager_load(:tags).last.tags
+  end
+
   def test_has_many_through_polymorphic_with_primary_key_option
     assert_equal [categories(:general)], authors(:david).essay_categories
 

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -198,6 +198,11 @@ class FirstPost < ActiveRecord::Base
   has_one  :comment,  foreign_key: :post_id
 end
 
+class TaggedPost < Post
+  has_many :taggings, -> { rewhere(taggable_type: "TaggedPost") }, as: :taggable
+  has_many :tags, through: :taggings
+end
+
 class PostWithDefaultInclude < ActiveRecord::Base
   self.inheritance_column = :disabled
   self.table_name = "posts"


### PR DESCRIPTION
`:as` option should be regard as like a default scope.

Fixes #27724.