### PR TITLE
Fix preloading has_many through with STI association

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -89,6 +89,8 @@ module ActiveRecord
                 scope.where_clause = reflection_scope.where_clause
                 if joins = values[:joins]
                   scope.joins!(source_reflection.name => joins)
+                elsif klass.finder_needs_type_condition?
+                  scope.joins!(source_reflection.name)
                 end
                 if left_outer_joins = values[:left_outer_joins]
                   scope.left_outer_joins!(source_reflection.name => left_outer_joins)

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -522,6 +522,14 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal [comments(:does_it_hurt)], assert_no_queries { author.special_post_comments }
   end
 
+  def test_preloading_has_many_through_with_association_inheritance
+    authors = Author.includes(:very_special_comments).load
+    assert_no_queries do
+      special_comment_authors = authors.map { |author| [author.name, author.very_special_comments.size] }
+      assert_equal [["David", 1], ["Mary", 0], ["Bob", 0]], special_comment_authors
+    end
+  end
+
   def test_eager_with_has_many_through_an_sti_join_model_with_conditions_on_both
     author = Author.all.merge!(includes: :special_nonexistent_post_comments, order: "authors.id").first
     assert_equal [], author.special_nonexistent_post_comments


### PR DESCRIPTION
If `source_reflection` is a STI association, `through_scope` should be
joined that.

Fixes #11078, #26129.