### PR TITLE
Remove a duplicate test of inverse_associations_test in AR

### DIFF
--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -651,20 +651,6 @@ class InversePolymorphicBelongsToTests < ActiveRecord::TestCase
     assert_equal face.description, new_man.polymorphic_face.description, "Description of face should be the same after changes to replaced-parent-owned instance"
   end
 
-  def test_child_instance_should_be_shared_with_replaced_via_method_parent
-    face = faces(:confused)
-    new_man = Man.new
-
-    assert_not_nil face.polymorphic_man
-    face.polymorphic_man = new_man
-
-    assert_equal face.description, new_man.polymorphic_face.description, "Description of face should be the same before changes to parent instance"
-    face.description = "Bongo"
-    assert_equal face.description, new_man.polymorphic_face.description, "Description of face should be the same after changes to parent instance"
-    new_man.polymorphic_face.description = "Mungo"
-    assert_equal face.description, new_man.polymorphic_face.description, "Description of face should be the same after changes to replaced-parent-owned instance"
-  end
-
   def test_inversed_instance_should_not_be_reloaded_after_stale_state_changed
     new_man = Man.new
     face = Face.new


### PR DESCRIPTION
I found that the contents of the following two tests are the same.

- https://github.com/rails/rails/blob/97838a5541fb0028b4e96520ae18d1a5d665efc5/activerecord/test/cases/associations/inverse_associations_test.rb#L640-L652
- https://github.com/rails/rails/blob/97838a5541fb0028b4e96520ae18d1a5d665efc5/activerecord/test/cases/associations/inverse_associations_test.rb#L654-L666

Originally, there were the following differences in this tests.

https://github.com/rails/rails/blame/6a74ee7f4deea4a44520d3fcc9120e0bb848823f/activerecord/test/cases/associations/inverse_associations_test.rb#L505

It seems that the contents of these tests have become the same by the following commit.

https://github.com/rails/rails/commit/1644663ba7f678d178deab2bf1629dc05626f85b#diff-826e6f229c4f0c933046ee533b249875L437

I thought about replacing `face.polymorphic_man = new_man` with `face.association(:polymorphic_man).replace(new_man)` at [test_child_instance_should_be_shared_with_replaced_via_method_parent](https://github.com/rails/rails/blob/97838a5541fb0028b4e96520ae18d1a5d665efc5/activerecord/test/cases/associations/inverse_associations_test.rb#L659). However, It has not been tested using `AR::Associations::BelongsToPolymorphicAssociation#replace` in inverse_associations_test.rb.

So this PR removes a duplicate tests.