### PR TITLE
Define path with __dir__

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ group :cable do
 end
 
 # Add your own local bundler stuff.
-local_gemfile = File.dirname(__FILE__) + "/.Gemfile"
+local_gemfile = File.expand_path(".Gemfile", __dir__)
 instance_eval File.read local_gemfile if File.exist? local_gemfile
 
 group :test do

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "net/http"
 
-$:.unshift File.expand_path("..", __FILE__)
+$:.unshift __dir__
 require "tasks/release"
 require "railties/lib/rails/api/task"
 

--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -409,7 +409,7 @@ application. The recommended basic setup is as follows:
 
 ```ruby
 # cable/config.ru
-require ::File.expand_path('../../config/environment', __FILE__)
+require ::File.expand_path('../config/environment', __dir__)
 Rails.application.eager_load!
 
 run ActionCable.server

--- a/actioncable/Rakefile
+++ b/actioncable/Rakefile
@@ -3,15 +3,13 @@ require "pathname"
 require "open3"
 require "action_cable"
 
-dir = File.dirname(__FILE__)
-
 task default: :test
 
 task package: %w( assets:compile assets:verify )
 
 Rake::TestTask.new do |t|
   t.libs << "test"
-  t.test_files = Dir.glob("#{dir}/test/**/*_test.rb")
+  t.test_files = Dir.glob("#{__dir__}/test/**/*_test.rb")
   t.warning = true
   t.verbose = true
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
@@ -46,7 +44,7 @@ namespace :assets do
   desc "Verify compiled Action Cable assets"
   task :verify do
     file = "lib/assets/compiled/action_cable.js"
-    pathname = Pathname.new("#{dir}/#{file}")
+    pathname = Pathname.new("#{__dir__}/#{file}")
 
     print "[verify] #{file} exists "
     if pathname.exist?
@@ -64,8 +62,8 @@ namespace :assets do
       fail
     end
 
-    print "[verify] #{dir} can be required as a module "
-    _, stderr, status = Open3.capture3("node", "--print", "window = {}; require('#{dir}');")
+    print "[verify] #{__dir__} can be required as a module "
+    _, stderr, status = Open3.capture3("node", "--print", "window = {}; require('#{__dir__}');")
     if status.success?
       puts "[OK]"
     else

--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY

--- a/actioncable/lib/rails/generators/channel/channel_generator.rb
+++ b/actioncable/lib/rails/generators/channel/channel_generator.rb
@@ -1,7 +1,7 @@
 module Rails
   module Generators
     class ChannelGenerator < NamedBase
-      source_root File.expand_path("../templates", __FILE__)
+      source_root File.expand_path("templates", __dir__)
 
       argument :actions, type: :array, default: [], banner: "method method"
 

--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -11,7 +11,7 @@ rescue LoadError
 end
 
 # Require all the stubs and models
-Dir[File.dirname(__FILE__) + "/stubs/*.rb"].each { |file| require file }
+Dir[File.expand_path("stubs/*.rb", __dir__)].each { |file| require file }
 
 class ActionCable::TestCase < ActiveSupport::TestCase
   def wait_for_async

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY

--- a/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
+++ b/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
@@ -1,7 +1,7 @@
 module Rails
   module Generators
     class MailerGenerator < NamedBase
-      source_root File.expand_path("../templates", __FILE__)
+      source_root File.expand_path("templates", __dir__)
 
       argument :actions, type: :array, default: [], banner: "method method"
 

--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -9,7 +9,7 @@ end
 
 module Rails
   def self.root
-    File.expand_path("../", File.dirname(__FILE__))
+    File.expand_path("..", __dir__)
   end
 end
 
@@ -28,7 +28,7 @@ ActiveSupport::Deprecation.debug = true
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false
 
-FIXTURE_LOAD_PATH = File.expand_path("fixtures", File.dirname(__FILE__))
+FIXTURE_LOAD_PATH = File.expand_path("fixtures", __dir__)
 ActionMailer::Base.view_paths = FIXTURE_LOAD_PATH
 
 class ActiveSupport::TestCase

--- a/actionmailer/test/caching_test.rb
+++ b/actionmailer/test/caching_test.rb
@@ -5,7 +5,7 @@ require "mailers/caching_mailer"
 
 CACHE_DIR = "test_cache"
 # Don't change '/../temp/' cavalierly or you might hose something you don't want hosed
-FILE_STORE_PATH = File.join(File.dirname(__FILE__), "/../temp/", CACHE_DIR)
+FILE_STORE_PATH = File.join(__dir__, "/../temp/", CACHE_DIR)
 
 class FragmentCachingMailer < ActionMailer::Base
   abstract!

--- a/actionmailer/test/log_subscriber_test.rb
+++ b/actionmailer/test/log_subscriber_test.rb
@@ -36,7 +36,7 @@ class AMLogSubscriberTest < ActionMailer::TestCase
   end
 
   def test_receive_is_notified
-    fixture = File.read(File.dirname(__FILE__) + "/fixtures/raw_email")
+    fixture = File.read(File.expand_path("fixtures/raw_email", __dir__))
     TestMailer.receive(fixture)
     wait
     assert_equal(1, @logger.logged(:info).size)

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -26,7 +26,7 @@ namespace :test do
 end
 
 task :lines do
-  load File.expand_path("..", File.dirname(__FILE__)) + "/tools/line_statistics"
+  load File.expand_path("..", __dir__) + "/tools/line_statistics"
   files = FileList["lib/**/*.rb"]
   CodeTools::LineStatistics.new(files).print_loc
 end

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY

--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -82,7 +82,7 @@ module ActionDispatch
         end
 
         def visualizer(paths, title = "FSM")
-          viz_dir   = File.join File.dirname(__FILE__), "..", "visualizer"
+          viz_dir   = File.join __dir__, "..", "visualizer"
           fsm_js    = File.read File.join(viz_dir, "fsm.js")
           fsm_css   = File.read File.join(viz_dir, "fsm.css")
           erb       = File.read File.join(viz_dir, "index.html.erb")

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -10,7 +10,7 @@ module ActionDispatch
   # This middleware is responsible for logging exceptions and
   # showing a debugging page in case the request is local.
   class DebugExceptions
-    RESCUES_TEMPLATE_PATH = File.expand_path("../templates", __FILE__)
+    RESCUES_TEMPLATE_PATH = File.expand_path("templates", __dir__)
 
     class DebugView < ActionView::Base
       def debug_params(params)

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -1,6 +1,6 @@
-$:.unshift(File.dirname(__FILE__) + "/lib")
-$:.unshift(File.dirname(__FILE__) + "/fixtures/helpers")
-$:.unshift(File.dirname(__FILE__) + "/fixtures/alternate_helpers")
+$:.unshift File.expand_path("lib", __dir__)
+$:.unshift File.expand_path("fixtures/helpers", __dir__)
+$:.unshift File.expand_path("fixtures/alternate_helpers", __dir__)
 
 require "active_support/core_ext/kernel/reporting"
 
@@ -56,7 +56,7 @@ ActiveSupport::Deprecation.debug = true
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false
 
-FIXTURE_LOAD_PATH = File.join(File.dirname(__FILE__), "fixtures")
+FIXTURE_LOAD_PATH = File.join(__dir__, "fixtures")
 
 SharedTestRoutes = ActionDispatch::Routing::RouteSet.new
 
@@ -156,7 +156,7 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
   end
 
   def with_autoload_path(path)
-    path = File.join(File.dirname(__FILE__), "fixtures", path)
+    path = File.join(__dir__, "fixtures", path)
     if ActiveSupport::Dependencies.autoload_paths.include?(path)
       yield
     else

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -83,7 +83,7 @@ class ActionPackAssertionsController < ActionController::Base
   end
 
   def render_file_absolute_path
-    render file: File.expand_path("../../../README.rdoc", __FILE__)
+    render file: File.expand_path("../../README.rdoc", __dir__)
   end
 
   def render_file_relative_path

--- a/actionpack/test/controller/api/data_streaming_test.rb
+++ b/actionpack/test/controller/api/data_streaming_test.rb
@@ -1,7 +1,7 @@
 require "abstract_unit"
 
 module TestApiFileUtils
-  def file_path() File.expand_path(__FILE__) end
+  def file_path() __FILE__ end
   def file_data() @data ||= File.open(file_path, "rb") { |f| f.read } end
 end
 

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -4,7 +4,7 @@ require "lib/controller/fake_models"
 
 CACHE_DIR = "test_cache"
 # Don't change '/../temp/' cavalierly or you might hose something you don't want hosed
-FILE_STORE_PATH = File.join(File.dirname(__FILE__), "/../temp/", CACHE_DIR)
+FILE_STORE_PATH = File.join(__dir__, "../temp/", CACHE_DIR)
 
 class FragmentCachingMetalTestController < ActionController::Metal
   abstract!

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -1,6 +1,6 @@
 require "abstract_unit"
 
-ActionController::Base.helpers_path = File.expand_path("../../fixtures/helpers", __FILE__)
+ActionController::Base.helpers_path = File.expand_path("../fixtures/helpers", __dir__)
 
 module Fun
   class GamesController < ActionController::Base
@@ -48,7 +48,7 @@ end
 
 class HelpersPathsController < ActionController::Base
   paths = ["helpers2_pack", "helpers1_pack"].map do |path|
-    File.join(File.expand_path("../../fixtures", __FILE__), path)
+    File.join(File.expand_path("../fixtures", __dir__), path)
   end
   $:.unshift(*paths)
 
@@ -61,7 +61,7 @@ class HelpersPathsController < ActionController::Base
 end
 
 class HelpersTypoController < ActionController::Base
-  path = File.expand_path("../../fixtures/helpers_typo", __FILE__)
+  path = File.expand_path("../fixtures/helpers_typo", __dir__)
   $:.unshift(path)
   self.helpers_path = path
 end
@@ -178,7 +178,7 @@ class HelperTest < ActiveSupport::TestCase
   end
 
   def test_all_helpers_with_alternate_helper_dir
-    @controller_class.helpers_path = File.expand_path("../../fixtures/alternate_helpers", __FILE__)
+    @controller_class.helpers_path = File.expand_path("../fixtures/alternate_helpers", __dir__)
 
     # Reload helpers
     @controller_class._helpers = Module.new

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -1091,7 +1091,7 @@ class IntegrationFileUploadTest < ActionDispatch::IntegrationTest
   end
 
   def self.fixture_path
-    File.dirname(__FILE__) + "/../fixtures/multipart"
+    File.expand_path("../fixtures/multipart", __dir__)
   end
 
   routes.draw do

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -152,7 +152,7 @@ module ActionController
       end
 
       def write_sleep_autoload
-        path = File.join(File.dirname(__FILE__), "../fixtures")
+        path = File.expand_path("../fixtures", __dir__)
         ActiveSupport::Dependencies.autoload_paths << path
 
         response.headers["Content-Type"] = "text/event-stream"

--- a/actionpack/test/controller/mime/accept_format_test.rb
+++ b/actionpack/test/controller/mime/accept_format_test.rb
@@ -29,7 +29,7 @@ class StarStarMimeControllerTest < ActionController::TestCase
 end
 
 class AbstractPostController < ActionController::Base
-  self.view_paths = File.dirname(__FILE__) + "/../../fixtures/post_test/"
+  self.view_paths = File.expand_path("../../fixtures/post_test", __dir__)
 end
 
 # For testing layouts which are set automatically

--- a/actionpack/test/controller/new_base/render_file_test.rb
+++ b/actionpack/test/controller/new_base/render_file_test.rb
@@ -2,15 +2,15 @@ require "abstract_unit"
 
 module RenderFile
   class BasicController < ActionController::Base
-    self.view_paths = File.dirname(__FILE__)
+    self.view_paths = __dir__
 
     def index
-      render file: File.join(File.dirname(__FILE__), *%w[.. .. fixtures test hello_world])
+      render file: File.expand_path("../../fixtures/test/hello_world", __dir__)
     end
 
     def with_instance_variables
       @secret = "in the sauce"
-      render file: File.join(File.dirname(__FILE__), "../../fixtures/test/render_file_with_ivar")
+      render file: File.expand_path("../../fixtures/test/render_file_with_ivar", __dir__)
     end
 
     def relative_path
@@ -25,11 +25,11 @@ module RenderFile
 
     def pathname
       @secret = "in the sauce"
-      render file: Pathname.new(File.dirname(__FILE__)).join(*%w[.. .. fixtures test dot.directory render_file_with_ivar])
+      render file: Pathname.new(__dir__).join(*%w[.. .. fixtures test dot.directory render_file_with_ivar])
     end
 
     def with_locals
-      path = File.join(File.dirname(__FILE__), "../../fixtures/test/render_file_with_locals")
+      path = File.expand_path("../../fixtures/test/render_file_with_locals", __dir__)
       render file: path, locals: { secret: "in the sauce" }
     end
   end

--- a/actionpack/test/controller/new_base/render_implicit_action_test.rb
+++ b/actionpack/test/controller/new_base/render_implicit_action_test.rb
@@ -6,7 +6,7 @@ module RenderImplicitAction
       "render_implicit_action/simple/hello_world.html.erb"     => "Hello world!",
       "render_implicit_action/simple/hyphen-ated.html.erb"     => "Hello hyphen-ated!",
       "render_implicit_action/simple/not_implemented.html.erb" => "Not Implemented"
-    ), ActionView::FileSystemResolver.new(File.expand_path("../../../controller", __FILE__))]
+    ), ActionView::FileSystemResolver.new(File.expand_path("../../controller", __dir__))]
 
     def hello_world() end
   end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -257,7 +257,7 @@ end
 module TemplateModificationHelper
   private
     def modify_template(name)
-      path = File.expand_path("../../fixtures/#{name}.erb", __FILE__)
+      path = File.expand_path("../fixtures/#{name}.erb", __dir__)
       original = File.read(path)
       File.write(path, "#{original} Modified!")
       ActionView::LookupContext::DetailsKey.clear
@@ -287,9 +287,9 @@ class ExpiresInRenderTest < ActionController::TestCase
 
   def test_dynamic_render_with_file
     # This is extremely bad, but should be possible to do.
-    assert File.exist?(File.join(File.dirname(__FILE__), "../../test/abstract_unit.rb"))
+    assert File.exist?(File.expand_path("../../test/abstract_unit.rb", __dir__))
     response = get :dynamic_render_with_file, params: { id: '../\\../test/abstract_unit.rb' }
-    assert_equal File.read(File.join(File.dirname(__FILE__), "../../test/abstract_unit.rb")),
+    assert_equal File.read(File.expand_path("../../test/abstract_unit.rb", __dir__)),
       response.body
   end
 
@@ -306,16 +306,16 @@ class ExpiresInRenderTest < ActionController::TestCase
   end
 
   def test_dynamic_render
-    assert File.exist?(File.join(File.dirname(__FILE__), "../../test/abstract_unit.rb"))
+    assert File.exist?(File.expand_path("../../test/abstract_unit.rb", __dir__))
     assert_raises ActionView::MissingTemplate do
       get :dynamic_render, params: { id: '../\\../test/abstract_unit.rb' }
     end
   end
 
   def test_permitted_dynamic_render_file_hash
-    assert File.exist?(File.join(File.dirname(__FILE__), "../../test/abstract_unit.rb"))
+    assert File.exist?(File.expand_path("../../test/abstract_unit.rb", __dir__))
     response = get :dynamic_render_permit, params: { id: { file: '../\\../test/abstract_unit.rb' } }
-    assert_equal File.read(File.join(File.dirname(__FILE__), "../../test/abstract_unit.rb")),
+    assert_equal File.read(File.expand_path("../../test/abstract_unit.rb", __dir__)),
       response.body
   end
 

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -2,7 +2,7 @@ require "abstract_unit"
 
 module TestFileUtils
   def file_name() File.basename(__FILE__) end
-  def file_path() File.expand_path(__FILE__) end
+  def file_path() __FILE__ end
   def file_data() @data ||= File.open(file_path, "rb") { |f| f.read } end
 end
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -122,7 +122,7 @@ XML
     end
 
     def test_send_file
-      send_file(File.expand_path(__FILE__))
+      send_file(__FILE__)
     end
 
     def redirect_to_same_controller
@@ -780,7 +780,7 @@ XML
     end
   end
 
-  FILES_DIR = File.dirname(__FILE__) + "/../fixtures/multipart"
+  FILES_DIR = File.expand_path("../fixtures/multipart", __dir__)
 
   READ_BINARY = "rb:binary"
   READ_PLAIN = "r:binary"
@@ -855,7 +855,7 @@ XML
   end
 
   def test_fixture_file_upload_ignores_fixture_path_given_full_path
-    TestCaseTest.stub :fixture_path, File.dirname(__FILE__) do
+    TestCaseTest.stub :fixture_path, __dir__ do
       uploaded_file = fixture_file_upload("#{FILES_DIR}/ruby_on_rails.jpg", "image/jpg")
       assert_equal File.open("#{FILES_DIR}/ruby_on_rails.jpg", READ_PLAIN).read, uploaded_file.read
     end

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -21,7 +21,7 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
     end
   end
 
-  FIXTURE_PATH = File.dirname(__FILE__) + "/../../fixtures/multipart"
+  FIXTURE_PATH = File.expand_path("../../fixtures/multipart", __dir__)
 
   def teardown
     TestController.last_request_parameters = nil

--- a/actionpack/test/dispatch/request/url_encoded_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/url_encoded_params_parsing_test.rb
@@ -107,7 +107,7 @@ class UrlEncodedParamsParsingTest < ActionDispatch::IntegrationTest
     query = [
       "customers[boston][first][name]=David",
       "something_else=blah",
-      "logo=#{File.expand_path(__FILE__)}"
+      "logo=#{__FILE__}"
     ].join("&")
     expected = {
       "customers" => {
@@ -118,7 +118,7 @@ class UrlEncodedParamsParsingTest < ActionDispatch::IntegrationTest
         }
       },
       "something_else" => "blah",
-      "logo" => File.expand_path(__FILE__),
+      "logo" => __FILE__,
     }
     assert_parses expected, query
   end

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -2,8 +2,6 @@ require "rake/testtask"
 require "fileutils"
 require "open3"
 
-dir = File.dirname(__FILE__)
-
 desc "Default Task"
 task default: :test
 
@@ -95,7 +93,7 @@ namespace :assets do
   desc "Verify compiled Action View assets"
   task :verify do
     file = "lib/assets/compiled/rails-ujs.js"
-    pathname = Pathname.new("#{dir}/#{file}")
+    pathname = Pathname.new("#{__dir__}/#{file}")
 
     print "[verify] #{file} exists "
     if pathname.exist?
@@ -113,11 +111,11 @@ namespace :assets do
       fail
     end
 
-    print "[verify] #{dir} can be required as a module "
+    print "[verify] #{__dir__} can be required as a module "
     js = <<-JS
       window = { Event: class {} }
       class Element {}
-      require('#{dir}')
+      require('#{__dir__}')
     JS
     _, stderr, status = Open3.capture3("node", "--print", js)
     if status.success?
@@ -130,7 +128,7 @@ namespace :assets do
 end
 
 task :lines do
-  load File.expand_path("..", File.dirname(__FILE__)) + "/tools/line_statistics"
+  load File.join(File.expand_path("..", __dir__), "/tools/line_statistics")
   files = FileList["lib/**/*.rb"]
   CodeTools::LineStatistics.new(files).print_loc
 end

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -92,5 +92,5 @@ end
 require "active_support/core_ext/string/output_safety"
 
 ActiveSupport.on_load(:i18n) do
-  I18n.load_path << "#{File.dirname(__FILE__)}/action_view/locale/en.yml"
+  I18n.load_path << File.expand_path("action_view/locale/en.yml", __dir__)
 end

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -1,8 +1,8 @@
-$:.unshift(File.dirname(__FILE__) + "/lib")
-$:.unshift(File.dirname(__FILE__) + "/fixtures/helpers")
-$:.unshift(File.dirname(__FILE__) + "/fixtures/alternate_helpers")
+$:.unshift File.expand_path("lib", __dir__)
+$:.unshift File.expand_path("fixtures/helpers", __dir__)
+$:.unshift File.expand_path("fixtures/alternate_helpers", __dir__)
 
-ENV["TMPDIR"] = File.join(File.dirname(__FILE__), "tmp")
+ENV["TMPDIR"] = File.expand_path("tmp", __dir__)
 
 require "active_support/core_ext/kernel/reporting"
 
@@ -47,7 +47,7 @@ I18n.backend.store_translations "da", {}
 I18n.backend.store_translations "pt-BR", {}
 ORIGINAL_LOCALES = I18n.available_locales.map(&:to_s).sort
 
-FIXTURE_LOAD_PATH = File.join(File.dirname(__FILE__), "fixtures")
+FIXTURE_LOAD_PATH = File.expand_path("fixtures", __dir__)
 
 module RenderERBUtils
   def view
@@ -133,7 +133,7 @@ class BasicController
   def config
     @config ||= ActiveSupport::InheritableOptions.new(ActionController::Base.config).tap do |config|
       # VIEW TODO: View tests should not require a controller
-      public_dir = File.expand_path("../fixtures/public", __FILE__)
+      public_dir = File.expand_path("fixtures/public", __dir__)
       config.assets_dir = public_dir
       config.javascripts_dir = "#{public_dir}/javascripts"
       config.stylesheets_dir = "#{public_dir}/stylesheets"
@@ -196,7 +196,7 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
   end
 
   def with_autoload_path(path)
-    path = File.join(File.dirname(__FILE__), "fixtures", path)
+    path = File.join(File.expand_path("fixtures", __dir__), path)
     if ActiveSupport::Dependencies.autoload_paths.include?(path)
       yield
     else

--- a/actionview/test/actionpack/abstract/abstract_controller_test.rb
+++ b/actionview/test/actionpack/abstract/abstract_controller_test.rb
@@ -42,7 +42,7 @@ module AbstractController
         super
       end
 
-      append_view_path File.expand_path(File.join(File.dirname(__FILE__), "views"))
+      append_view_path File.expand_path("views", __dir__)
     end
 
     class Me2 < RenderingController
@@ -152,7 +152,7 @@ module AbstractController
     class OverridingLocalPrefixes < AbstractController::Base
       include AbstractController::Rendering
       include ActionView::Rendering
-      append_view_path File.expand_path(File.join(File.dirname(__FILE__), "views"))
+      append_view_path File.expand_path("views", __dir__)
 
       def index
         render

--- a/actionview/test/actionpack/abstract/helper_test.rb
+++ b/actionview/test/actionpack/abstract/helper_test.rb
@@ -1,6 +1,6 @@
 require "abstract_unit"
 
-ActionController::Base.helpers_path = File.expand_path("../../../fixtures/helpers", __FILE__)
+ActionController::Base.helpers_path = File.expand_path("../../fixtures/helpers", __dir__)
 
 module AbstractController
   module Testing
@@ -51,7 +51,7 @@ module AbstractController
     class AbstractInvalidHelpers < AbstractHelpers
       include ActionController::Helpers
 
-      path = File.expand_path("../../../fixtures/helpers_missing", __FILE__)
+      path = File.expand_path("../../fixtures/helpers_missing", __dir__)
       $:.unshift(path)
       self.helpers_path = path
     end

--- a/actionview/test/actionpack/controller/capture_test.rb
+++ b/actionview/test/actionpack/controller/capture_test.rb
@@ -2,7 +2,7 @@ require "abstract_unit"
 require "active_support/logger"
 
 class CaptureController < ActionController::Base
-  self.view_paths = [ File.dirname(__FILE__) + "/../../fixtures/actionpack" ]
+  self.view_paths = [ File.expand_path("../../fixtures/actionpack", __dir__) ]
 
   def self.controller_name; "test"; end
   def self.controller_path; "test"; end

--- a/actionview/test/actionpack/controller/layout_test.rb
+++ b/actionview/test/actionpack/controller/layout_test.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/array/extract_options"
 # method has access to the view_paths array when looking for a layout to automatically assign.
 old_load_paths = ActionController::Base.view_paths
 
-ActionController::Base.view_paths = [ File.dirname(__FILE__) + "/../../fixtures/actionpack/layout_tests/" ]
+ActionController::Base.view_paths = [ File.expand_path("../../fixtures/actionpack/layout_tests", __dir__) ]
 
 class LayoutTest < ActionController::Base
   def self.controller_path; "views" end
@@ -96,7 +96,7 @@ class StreamingLayoutController < LayoutTest
 end
 
 class AbsolutePathLayoutController < LayoutTest
-  layout File.expand_path(File.expand_path(__FILE__) + "/../../../fixtures/actionpack/layout_tests/layouts/layout_test")
+  layout File.expand_path("../../fixtures/actionpack/layout_tests/layouts/layout_test", __dir__)
 end
 
 class HasOwnLayoutController < LayoutTest
@@ -117,7 +117,7 @@ end
 
 class PrependsViewPathController < LayoutTest
   def hello
-    prepend_view_path File.dirname(__FILE__) + "/../../fixtures/actionpack/layout_tests/alt/"
+    prepend_view_path File.expand_path("../../fixtures/actionpack/layout_tests/alt", __dir__)
     render layout: "alt"
   end
 end

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -56,7 +56,7 @@ class TestController < ApplicationController
   end
 
   def hello_world_file
-    render file: File.expand_path("../../../fixtures/actionpack/hello", __FILE__), formats: [:html]
+    render file: File.expand_path("../../fixtures/actionpack/hello", __dir__), formats: [:html]
   end
 
   # :ported:
@@ -125,7 +125,7 @@ class TestController < ApplicationController
   # :ported:
   def render_file_with_instance_variables
     @secret = "in the sauce"
-    path = File.join(File.dirname(__FILE__), "../../fixtures/test/render_file_with_ivar")
+    path = File.expand_path("../../fixtures/test/render_file_with_ivar", __dir__)
     render file: path
   end
 
@@ -142,21 +142,21 @@ class TestController < ApplicationController
 
   def render_file_using_pathname
     @secret = "in the sauce"
-    render file: Pathname.new(File.dirname(__FILE__)).join("..", "..", "fixtures", "test", "dot.directory", "render_file_with_ivar")
+    render file: Pathname.new(__dir__).join("..", "..", "fixtures", "test", "dot.directory", "render_file_with_ivar")
   end
 
   def render_file_from_template
     @secret = "in the sauce"
-    @path = File.expand_path(File.join(File.dirname(__FILE__), "../../fixtures/test/render_file_with_ivar"))
+    @path = File.expand_path("../../fixtures/test/render_file_with_ivar", __dir__)
   end
 
   def render_file_with_locals
-    path = File.join(File.dirname(__FILE__), "../../fixtures/test/render_file_with_locals")
+    path = File.expand_path("../../fixtures/test/render_file_with_locals", __dir__)
     render file: path, locals: { secret: "in the sauce" }
   end
 
   def render_file_as_string_with_locals
-    path = File.expand_path(File.join(File.dirname(__FILE__), "../../fixtures/test/render_file_with_locals"))
+    path = File.expand_path("../../fixtures/test/render_file_with_locals", __dir__)
     render file: path, locals: { secret: "in the sauce" }
   end
 

--- a/actionview/test/active_record_unit.rb
+++ b/actionview/test/active_record_unit.rb
@@ -13,7 +13,7 @@ end
 # Try to grab AR
 unless defined?(ActiveRecord) && defined?(FixtureSet)
   begin
-    PATH_TO_AR = "#{File.dirname(__FILE__)}/../../activerecord/lib"
+    PATH_TO_AR = File.expand_path("../../activerecord/lib", __dir__)
     raise LoadError, "#{PATH_TO_AR} doesn't exist" unless File.directory?(PATH_TO_AR)
     $LOAD_PATH.unshift PATH_TO_AR
     require "active_record"
@@ -58,13 +58,13 @@ class ActiveRecordTestConnector
 
       # Load actionpack sqlite3 tables
       def load_schema
-        File.read(File.dirname(__FILE__) + "/fixtures/db_definitions/sqlite.sql").split(";").each do |sql|
+        File.read(File.expand_path("fixtures/db_definitions/sqlite.sql", __dir__)).split(";").each do |sql|
           ActiveRecord::Base.connection.execute(sql) unless sql.blank?
         end
       end
 
       def require_fixture_models
-        Dir.glob(File.dirname(__FILE__) + "/fixtures/*.rb").each { |f| require f }
+        Dir.glob(File.expand_path("fixtures/*.rb", __dir__)).each { |f| require f }
       end
   end
 end

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -14,7 +14,7 @@ class FixtureTemplate
 end
 
 class FixtureFinder < ActionView::LookupContext
-  FIXTURES_DIR = "#{File.dirname(__FILE__)}/../fixtures/digestor"
+  FIXTURES_DIR = File.expand_path("../fixtures/digestor", __dir__)
 
   def initialize(details = {})
     super(ActionView::PathSet.new(["digestor", "digestor/api"]), details, [])

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -138,7 +138,7 @@ module RenderTestCases
   end
 
   def test_render_file_with_full_path
-    template_path = File.join(File.dirname(__FILE__), "../fixtures/test/hello_world")
+    template_path = File.expand_path("../fixtures/test/hello_world", __dir__)
     assert_equal "Hello world!", @view.render(file: template_path)
   end
 
@@ -160,7 +160,7 @@ module RenderTestCases
   end
 
   def test_render_outside_path
-    assert File.exist?(File.join(File.dirname(__FILE__), "../../test/abstract_unit.rb"))
+    assert File.exist?(File.expand_path("../../test/abstract_unit.rb", __dir__))
     assert_raises ActionView::MissingTemplate do
       @view.render(template: "../\\../test/abstract_unit.rb")
     end

--- a/actionview/test/template/resolver_patterns_test.rb
+++ b/actionview/test/template/resolver_patterns_test.rb
@@ -2,7 +2,7 @@ require "abstract_unit"
 
 class ResolverPatternsTest < ActiveSupport::TestCase
   def setup
-    path = File.expand_path("../../fixtures/", __FILE__)
+    path = File.expand_path("../fixtures", __dir__)
     pattern = ":prefix/{:formats/,}:action{.:formats,}{+:variants,}{.:handlers,}"
     @resolver = ActionView::FileSystemResolver.new(path, pattern)
   end

--- a/actionview/test/ujs/config.ru
+++ b/actionview/test/ujs/config.ru
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path("..", __FILE__)
+$LOAD_PATH.unshift __dir__
 require "server"
 
 run UJS::Server

--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -44,9 +44,8 @@ namespace :test do
 
     namespace :isolated do
       task adapter => "test:env:#{adapter}" do
-        dir = File.dirname(__FILE__)
-        Dir.glob("#{dir}/test/cases/**/*_test.rb").all? do |file|
-          sh(Gem.ruby, "-w", "-I#{dir}/lib", "-I#{dir}/test", file)
+        Dir.glob("#{__dir__}/test/cases/**/*_test.rb").all? do |file|
+          sh(Gem.ruby, "-w", "-I#{__dir__}/lib", "-I#{__dir__}/test", file)
         end || raise("Failures")
       end
     end

--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY

--- a/activejob/lib/rails/generators/job/job_generator.rb
+++ b/activejob/lib/rails/generators/job/job_generator.rb
@@ -12,7 +12,7 @@ module Rails # :nodoc:
       hook_for :test_framework
 
       def self.default_generator_root
-        File.dirname(__FILE__)
+        __dir__
       end
 
       def create_job_file

--- a/activejob/test/adapters/delayed_job.rb
+++ b/activejob/test/adapters/delayed_job.rb
@@ -1,6 +1,6 @@
 ActiveJob::Base.queue_adapter = :delayed_job
 
-$LOAD_PATH << File.dirname(__FILE__) + "/../support/delayed_job"
+$LOAD_PATH << File.expand_path("../support/delayed_job", __dir__)
 
 Delayed::Worker.delay_jobs = false
 Delayed::Worker.backend    = :test

--- a/activejob/test/support/integration/dummy_app_template.rb
+++ b/activejob/test/support/integration/dummy_app_template.rb
@@ -5,7 +5,7 @@ end
 rails_command("db:migrate")
 
 initializer "activejob.rb", <<-CODE
-require "#{File.expand_path("../jobs_manager.rb",  __FILE__)}"
+require "#{File.expand_path("jobs_manager.rb",  __dir__)}"
 JobsManager.current_manager.setup
 CODE
 

--- a/activejob/test/support/integration/helper.rb
+++ b/activejob/test/support/integration/helper.rb
@@ -7,7 +7,7 @@ require "rails/generators/rails/app/app_generator"
 
 require "tmpdir"
 dummy_app_path     = Dir.mktmpdir + "/dummy"
-dummy_app_template = File.expand_path("../dummy_app_template.rb",  __FILE__)
+dummy_app_template = File.expand_path("dummy_app_template.rb",  __dir__)
 args = Rails::Generators::ARGVScrubber.new(["new", dummy_app_path, "--skip-gemfile", "--skip-bundle",
   "--skip-git", "--skip-spring", "-d", "sqlite3", "--skip-javascript", "--force", "--quiet",
   "--template", dummy_app_template]).prepare!

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -1,14 +1,12 @@
 require "rake/testtask"
 
-dir = File.dirname(__FILE__)
-
 task default: :test
 
 task :package
 
 Rake::TestTask.new do |t|
   t.libs << "test"
-  t.test_files = Dir.glob("#{dir}/test/cases/**/*_test.rb")
+  t.test_files = Dir.glob("#{__dir__}/test/cases/**/*_test.rb")
   t.warning = true
   t.verbose = true
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
@@ -16,8 +14,8 @@ end
 
 namespace :test do
   task :isolated do
-    Dir.glob("#{dir}/test/**/*_test.rb").all? do |file|
-      sh(Gem.ruby, "-w", "-I#{dir}/lib", "-I#{dir}/test", file)
+    Dir.glob("#{__dir__}/test/**/*_test.rb").all? do |file|
+      sh(Gem.ruby, "-w", "-I#{__dir__}/lib", "-I#{__dir__}/test", file)
     end || raise("Failures")
   end
 end

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -68,5 +68,5 @@ module ActiveModel
 end
 
 ActiveSupport.on_load(:i18n) do
-  I18n.load_path << File.dirname(__FILE__) + "/active_model/locale/en.yml"
+  I18n.load_path << File.expand_path("active_model/locale/en.yml", __dir__)
 end

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -435,4 +435,4 @@ module ActiveModel
   end
 end
 
-Dir[File.dirname(__FILE__) + "/validations/*.rb"].each { |file| require file }
+Dir[File.expand_path("validations/*.rb", __dir__)].each { |file| require file }

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -1,7 +1,7 @@
 require "rake/testtask"
 
-require File.expand_path(File.dirname(__FILE__)) + "/test/config"
-require File.expand_path(File.dirname(__FILE__)) + "/test/support/config"
+require File.expand_path("test/config", __dir__)
+require File.expand_path("test/support/config", __dir__)
 
 def run_without_aborting(*tasks)
   errors = []
@@ -134,7 +134,7 @@ task drop_postgresql_databases: "db:postgresql:drop"
 task rebuild_postgresql_databases: "db:postgresql:rebuild"
 
 task :lines do
-  load File.expand_path("..", File.dirname(__FILE__)) + "/tools/line_statistics"
+  load File.expand_path("../tools/line_statistics", __dir__)
   files = FileList["lib/active_record/**/*.rb"]
   CodeTools::LineStatistics.new(files).print_loc
 end

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -177,5 +177,5 @@ ActiveSupport.on_load(:active_record) do
 end
 
 ActiveSupport.on_load(:i18n) do
-  I18n.load_path << File.dirname(__FILE__) + "/active_record/locale/en.yml"
+  I18n.load_path << File.expand_path("active_record/locale/en.yml", __dir__)
 end

--- a/activerecord/lib/rails/generators/active_record.rb
+++ b/activerecord/lib/rails/generators/active_record.rb
@@ -10,7 +10,7 @@ module ActiveRecord
 
       # Set the current directory as base for the inherited generators.
       def self.base_root
-        File.dirname(__FILE__)
+        __dir__
       end
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -96,7 +96,7 @@ class PostgresqlByteaTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_write_binary
-    data = File.read(File.join(File.dirname(__FILE__), "..", "..", "..", "assets", "example.log"))
+    data = File.read(File.join(__dir__, "..", "..", "..", "assets", "example.log"))
     assert(data.size > 1)
     record = ByteaDataType.create(payload: data)
     assert_not record.new_record?

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -954,7 +954,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_not_nil Developer._reflections["shared_computers"]
     # Checking the fixture for named association is important here, because it's the only way
     # we've been able to reproduce this bug
-    assert_not_nil File.read(File.expand_path("../../../fixtures/developers.yml", __FILE__)).index("shared_computers")
+    assert_not_nil File.read(File.expand_path("../../fixtures/developers.yml", __dir__)).index("shared_computers")
     assert_equal developers(:david).shared_computers.first, computers(:laptop)
   end
 

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -316,7 +316,7 @@ class InheritanceTest < ActiveRecord::TestCase
   end
 
   def test_new_with_autoload_paths
-    path = File.expand_path("../../models/autoloadable", __FILE__)
+    path = File.expand_path("../models/autoloadable", __dir__)
     ActiveSupport::Dependencies.autoload_paths << path
 
     firm = Company.new(type: "ExtraFirm")

--- a/activerecord/test/cases/reload_models_test.rb
+++ b/activerecord/test/cases/reload_models_test.rb
@@ -13,7 +13,7 @@ class ReloadModelsTest < ActiveRecord::TestCase
     # development environment. Note that meanwhile the class Pet is not
     # reloaded, simulating a class that is present in a plugin.
     Object.class_eval { remove_const :Owner }
-    Kernel.load(File.expand_path(File.join(File.dirname(__FILE__), "../models/owner.rb")))
+    Kernel.load(File.expand_path("../models/owner.rb", __dir__))
 
     pet = Pet.find_by_name("parrot")
     pet.owner = Owner.find_by_name("ashley")

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -123,8 +123,8 @@ class YamlSerializationTest < ActiveRecord::TestCase
 
     def yaml_fixture(file_name)
       path = File.expand_path(
-        "../../support/yaml_compatibility_fixtures/#{file_name}.yml",
-        __FILE__
+        "../support/yaml_compatibility_fixtures/#{file_name}.yml",
+        __dir__
       )
       File.read(path)
     end

--- a/activerecord/test/config.rb
+++ b/activerecord/test/config.rb
@@ -1,4 +1,4 @@
-TEST_ROOT       = File.expand_path(File.dirname(__FILE__))
+TEST_ROOT       = __dir__
 ASSETS_ROOT     = TEST_ROOT + "/assets"
 FIXTURES_ROOT   = TEST_ROOT + "/fixtures"
 MIGRATIONS_ROOT = TEST_ROOT + "/migrations"

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY

--- a/activesupport/bin/generate_tables
+++ b/activesupport/bin/generate_tables
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 begin
-  $:.unshift(File.expand_path(File.dirname(__FILE__) + "/../lib"))
+  $:.unshift(File.expand_path("../lib", __dir__))
   require "active_support"
 rescue IOError
 end

--- a/activesupport/lib/active_support/core_ext.rb
+++ b/activesupport/lib/active_support/core_ext.rb
@@ -1,3 +1,3 @@
-(Dir["#{File.dirname(__FILE__)}/core_ext/*.rb"]).each do |path|
+Dir.glob(File.expand_path("core_ext/*.rb", __dir__)).each do |path|
   require path
 end

--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -102,7 +102,7 @@ module ActiveSupport
           end
         end
 
-        RAILS_GEM_ROOT = File.expand_path("../../../../..", __FILE__) + "/"
+        RAILS_GEM_ROOT = File.expand_path("../../../..", __dir__)
 
         def ignored_callstack(path)
           path.start_with?(RAILS_GEM_ROOT) || path.start_with?(RbConfig::CONFIG["rubylibdir"])

--- a/activesupport/lib/active_support/i18n.rb
+++ b/activesupport/lib/active_support/i18n.rb
@@ -10,4 +10,4 @@ end
 require "active_support/lazy_load_hooks"
 
 ActiveSupport.run_load_hooks(:i18n)
-I18n.load_path << "#{File.dirname(__FILE__)}/locale/en.yml"
+I18n.load_path << File.expand_path("locale/en.yml", __dir__)

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -357,7 +357,7 @@ module ActiveSupport
 
         # Returns the directory in which the data files are stored.
         def self.dirname
-          File.dirname(__FILE__) + "/../values/"
+          File.expand_path("../values", __dir__)
         end
 
         # Returns the filename for the data file for this version.

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -104,7 +104,7 @@ class DependenciesTest < ActiveSupport::TestCase
     with_loading "dependencies" do
       old_warnings, ActiveSupport::Dependencies.warnings_on_first_load = ActiveSupport::Dependencies.warnings_on_first_load, true
       filename = "check_warnings"
-      expanded = File.expand_path("#{File.dirname(__FILE__)}/dependencies/#{filename}")
+      expanded = File.expand_path("dependencies/#{filename}", __dir__)
       $check_warnings_load_count = 0
 
       assert_not ActiveSupport::Dependencies.loaded.include?(expanded)
@@ -293,7 +293,7 @@ class DependenciesTest < ActiveSupport::TestCase
   end
 
   def test_doesnt_break_normal_require
-    path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
+    path = File.expand_path("autoloading_fixtures/load_path", __dir__)
     original_path = $:.dup
     $:.push(path)
     with_autoloading_fixtures do
@@ -312,7 +312,7 @@ class DependenciesTest < ActiveSupport::TestCase
   end
 
   def test_doesnt_break_normal_require_nested
-    path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
+    path = File.expand_path("autoloading_fixtures/load_path", __dir__)
     original_path = $:.dup
     $:.push(path)
 
@@ -332,7 +332,7 @@ class DependenciesTest < ActiveSupport::TestCase
   end
 
   def test_require_returns_true_when_file_not_yet_required
-    path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
+    path = File.expand_path("autoloading_fixtures/load_path", __dir__)
     original_path = $:.dup
     $:.push(path)
 
@@ -345,7 +345,7 @@ class DependenciesTest < ActiveSupport::TestCase
   end
 
   def test_require_returns_true_when_file_not_yet_required_even_when_no_new_constants_added
-    path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
+    path = File.expand_path("autoloading_fixtures/load_path", __dir__)
     original_path = $:.dup
     $:.push(path)
 
@@ -359,7 +359,7 @@ class DependenciesTest < ActiveSupport::TestCase
   end
 
   def test_require_returns_false_when_file_already_required
-    path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
+    path = File.expand_path("autoloading_fixtures/load_path", __dir__)
     original_path = $:.dup
     $:.push(path)
 
@@ -379,7 +379,7 @@ class DependenciesTest < ActiveSupport::TestCase
   end
 
   def test_load_returns_true_when_file_found
-    path = File.expand_path("../autoloading_fixtures/load_path", __FILE__)
+    path = File.expand_path("autoloading_fixtures/load_path", __dir__)
     original_path = $:.dup
     $:.push(path)
 
@@ -438,7 +438,7 @@ class DependenciesTest < ActiveSupport::TestCase
 
   def test_loadable_constants_for_path_should_handle_relative_paths
     fake_root = "dependencies"
-    relative_root = File.dirname(__FILE__) + "/dependencies"
+    relative_root = File.expand_path("dependencies", __dir__)
     ["", "/"].each do |suffix|
       with_loading fake_root + suffix do
         assert_equal ["A::B"], ActiveSupport::Dependencies.loadable_constants_for_path(relative_root + "/a/b")
@@ -463,7 +463,7 @@ class DependenciesTest < ActiveSupport::TestCase
   end
 
   def test_loadable_constants_with_load_path_without_trailing_slash
-    path = File.dirname(__FILE__) + "/autoloading_fixtures/class_folder/inline_class.rb"
+    path = File.expand_path("autoloading_fixtures/class_folder/inline_class.rb", __dir__)
     with_loading "autoloading_fixtures/class/" do
       assert_equal [], ActiveSupport::Dependencies.loadable_constants_for_path(path)
     end
@@ -991,7 +991,7 @@ class DependenciesTest < ActiveSupport::TestCase
   def test_remove_constant_does_not_trigger_loading_autoloads
     constant = "ShouldNotBeAutoloaded"
     Object.class_eval do
-      autoload constant, File.expand_path("../autoloading_fixtures/should_not_be_required", __FILE__)
+      autoload constant, File.expand_path("autoloading_fixtures/should_not_be_required", __dir__)
     end
 
     assert_nil ActiveSupport::Dependencies.remove_constant(constant), "Kernel#autoload has been triggered by remove_constant"

--- a/activesupport/test/dependencies_test_helpers.rb
+++ b/activesupport/test/dependencies_test_helpers.rb
@@ -1,7 +1,7 @@
 module DependenciesTestHelpers
   def with_loading(*from)
     old_mechanism, ActiveSupport::Dependencies.mechanism = ActiveSupport::Dependencies.mechanism, :load
-    this_dir = File.dirname(__FILE__)
+    this_dir = __dir__
     parent_dir = File.dirname(this_dir)
     path_copy = $LOAD_PATH.dup
     $LOAD_PATH.unshift(parent_dir) unless $LOAD_PATH.include?(parent_dir)

--- a/activesupport/test/testing/file_fixtures_test.rb
+++ b/activesupport/test/testing/file_fixtures_test.rb
@@ -3,7 +3,7 @@ require "abstract_unit"
 require "pathname"
 
 class FileFixturesTest < ActiveSupport::TestCase
-  self.file_fixture_path = File.expand_path("../../file_fixtures", __FILE__)
+  self.file_fixture_path = File.expand_path("../file_fixtures", __dir__)
 
   test "#file_fixture returns Pathname to file fixture" do
     path = file_fixture("sample.txt")
@@ -20,7 +20,7 @@ class FileFixturesTest < ActiveSupport::TestCase
 end
 
 class FileFixturesPathnameDirectoryTest < ActiveSupport::TestCase
-  self.file_fixture_path = Pathname.new(File.expand_path("../../file_fixtures", __FILE__))
+  self.file_fixture_path = Pathname.new(File.expand_path("../file_fixtures", __dir__))
 
   test "#file_fixture_path returns Pathname to file fixture" do
     path = file_fixture("sample.txt")

--- a/activesupport/test/xml_mini/jdom_engine_test.rb
+++ b/activesupport/test/xml_mini/jdom_engine_test.rb
@@ -2,7 +2,7 @@ require_relative "xml_mini_engine_test"
 
 XMLMiniEngineTest.run_with_platform("java") do
   class JDOMEngineTest < XMLMiniEngineTest
-    FILES_DIR = File.dirname(__FILE__) + "/../fixtures/xml"
+    FILES_DIR = File.expand_path("../fixtures/xml", __dir__)
 
     def test_not_allowed_to_expand_entities_to_files
       attack_xml = <<-EOT

--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -15,7 +15,7 @@ require "rack/test"
 require "action_controller/railtie"
 
 class TestApp < Rails::Application
-  config.root = File.dirname(__FILE__)
+  config.root = __dir__
   config.session_store :cookie_store, key: "cookie_store_key"
   secrets.secret_token    = "secret_token"
   secrets.secret_key_base = "secret_key_base"

--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -14,7 +14,7 @@ end
 require "action_controller/railtie"
 
 class TestApp < Rails::Application
-  config.root = File.dirname(__FILE__)
+  config.root = __dir__
   secrets.secret_token    = "secret_token"
   secrets.secret_key_base = "secret_key_base"
 

--- a/guides/rails_guides/helpers.rb
+++ b/guides/rails_guides/helpers.rb
@@ -15,7 +15,7 @@ module RailsGuides
     end
 
     def documents_by_section
-      @documents_by_section ||= YAML.load_file(File.expand_path("../../source/#{@language ? @language + '/' : ''}documents.yaml", __FILE__))
+      @documents_by_section ||= YAML.load_file(File.expand_path("../source/#{@language ? @language + '/' : ''}documents.yaml", __dir__))
     end
 
     def documents_flat

--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -96,7 +96,7 @@ This is the generator just created:
 
 ```ruby
 class InitializerGenerator < Rails::Generators::NamedBase
-  source_root File.expand_path("../templates", __FILE__)
+  source_root File.expand_path("templates", __dir__)
 end
 ```
 
@@ -122,7 +122,7 @@ And now let's change the generator to copy this template when invoked:
 
 ```ruby
 class InitializerGenerator < Rails::Generators::NamedBase
-  source_root File.expand_path("../templates", __FILE__)
+  source_root File.expand_path("templates", __dir__)
 
   def copy_initializer_file
     copy_file "initializer.rb", "config/initializers/#{file_name}.rb"

--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -277,6 +277,6 @@ relative paths to your template's location.
 
 ```ruby
 def source_paths
-  [File.expand_path(File.dirname(__FILE__))]
+  [__dir__]
 end
 ```

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -356,7 +356,7 @@ send_file('/var/www/uploads/' + params[:filename])
 Simply pass a file name like "../../../etc/passwd" to download the server's login information. A simple solution against this, is to _check that the requested file is in the expected directory_:
 
 ```ruby
-basename = File.expand_path(File.join(File.dirname(__FILE__), '../../files'))
+basename = File.expand_path('../../files', __dir__)
 filename = File.expand_path(File.join(basename, @file.public_filename))
 raise if basename !=
      File.expand_path(File.join(File.dirname(filename), '../../../'))

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path("RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -16,10 +16,10 @@ namespace :test do
       dash_i = [
         "test",
         "lib",
-        "#{File.dirname(__FILE__)}/../activesupport/lib",
-        "#{File.dirname(__FILE__)}/../actionpack/lib",
-        "#{File.dirname(__FILE__)}/../actionview/lib",
-        "#{File.dirname(__FILE__)}/../activemodel/lib"
+        "#{__dir__}/../activesupport/lib",
+        "#{__dir__}/../actionpack/lib",
+        "#{__dir__}/../actionview/lib",
+        "#{__dir__}/../activemodel/lib"
       ]
       ruby "-w", "-I#{dash_i.join ':'}", file
     end
@@ -27,7 +27,7 @@ namespace :test do
 end
 
 Rake::TestTask.new("test:regular") do |t|
-  t.libs << "test" << "#{File.dirname(__FILE__)}/../activesupport/lib"
+  t.libs << "test" << "#{__dir__}/../activesupport/lib"
   t.pattern = "test/**/*_test.rb"
   t.warning = false
   t.verbose = true

--- a/railties/exe/rails
+++ b/railties/exe/rails
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 
-git_path = File.expand_path("../../../.git", __FILE__)
+git_path = File.expand_path("../../.git", __dir__)
 
 if File.exist?(git_path)
-  railties_path = File.expand_path("../../lib", __FILE__)
+  railties_path = File.expand_path("../lib", __dir__)
   $:.unshift(railties_path)
 end
 require "rails/cli"

--- a/railties/lib/rails/application_controller.rb
+++ b/railties/lib/rails/application_controller.rb
@@ -1,5 +1,5 @@
 class Rails::ApplicationController < ActionController::Base # :nodoc:
-  self.view_paths = File.expand_path("../templates", __FILE__)
+  self.view_paths = File.expand_path("templates", __dir__)
   layout "application"
 
   private

--- a/railties/lib/rails/command/actions.rb
+++ b/railties/lib/rails/command/actions.rb
@@ -5,7 +5,7 @@ module Rails
       # This allows us to run `rails server` from other directories, but still get
       # the main config.ru and properly set the tmp directory.
       def set_application_directory!
-        Dir.chdir(File.expand_path("../../", APP_PATH)) unless File.exist?(File.expand_path("config.ru"))
+        Dir.chdir(File.expand_path("../..", APP_PATH)) unless File.exist?(File.expand_path("config.ru"))
       end
 
       def require_application_and_environment!

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -40,7 +40,7 @@ module Rails
   #
   #   class MyEngine < Rails::Engine
   #     # Add a load path for this specific Engine
-  #     config.autoload_paths << File.expand_path("../lib/some/path", __FILE__)
+  #     config.autoload_paths << File.expand_path("lib/some/path", __dir__)
   #
   #     initializer "my_engine.add_middleware" do |app|
   #       app.middleware.use MyEngine::Middleware

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -1,4 +1,4 @@
-activesupport_path = File.expand_path("../../../../activesupport/lib", __FILE__)
+activesupport_path = File.expand_path("../../../activesupport/lib", __dir__)
 $:.unshift(activesupport_path) if File.directory?(activesupport_path) && !$:.include?(activesupport_path)
 
 require "thor/group"

--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -215,7 +215,7 @@ module Rails
       # Returns the base root for a common set of generators. This is used to dynamically
       # guess the default source root.
       def self.base_root
-        File.dirname(__FILE__)
+        __dir__
       end
 
       # Cache source root and add lib/generators/base/generator/templates to

--- a/railties/lib/rails/generators/css/assets/assets_generator.rb
+++ b/railties/lib/rails/generators/css/assets/assets_generator.rb
@@ -3,7 +3,7 @@ require "rails/generators/named_base"
 module Css # :nodoc:
   module Generators # :nodoc:
     class AssetsGenerator < Rails::Generators::NamedBase # :nodoc:
-      source_root File.expand_path("../templates", __FILE__)
+      source_root File.expand_path("templates", __dir__)
 
       def copy_stylesheet
         copy_file "stylesheet.css", File.join("app/assets/stylesheets", class_path, "#{file_name}.css")

--- a/railties/lib/rails/generators/js/assets/assets_generator.rb
+++ b/railties/lib/rails/generators/js/assets/assets_generator.rb
@@ -3,7 +3,7 @@ require "rails/generators/named_base"
 module Js # :nodoc:
   module Generators # :nodoc:
     class AssetsGenerator < Rails::Generators::NamedBase # :nodoc:
-      source_root File.expand_path("../templates", __FILE__)
+      source_root File.expand_path("templates", __dir__)
 
       def copy_javascript
         copy_file "javascript.js", File.join("app/assets/javascripts", class_path, "#{file_name}.js")

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -201,7 +201,7 @@ module Rails
   module Generators
     # We need to store the RAILS_DEV_PATH in a constant, otherwise the path
     # can change in Ruby 1.8.7 when we FileUtils.cd.
-    RAILS_DEV_PATH = File.expand_path("../../../../../..", File.dirname(__FILE__))
+    RAILS_DEV_PATH = File.expand_path("../../../../../..", __dir__)
     RESERVED_NAMES = %w[application destroy plugin runner test]
 
     class AppGenerator < AppBase # :nodoc:

--- a/railties/lib/rails/generators/rails/app/templates/bin/bundle
+++ b/railties/lib/rails/generators/rails/app/templates/bin/bundle
@@ -1,2 +1,2 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 load Gem.bin_path('bundler', 'bundle')

--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -3,7 +3,7 @@ require 'fileutils'
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/railties/lib/rails/generators/rails/app/templates/bin/update.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/update.tt
@@ -3,7 +3,7 @@ require 'fileutils'
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../config/environment', __dir__)
 require 'rails/test_help'
 
 class ActiveSupport::TestCase

--- a/railties/lib/rails/generators/rails/generator/templates/%file_name%_generator.rb.tt
+++ b/railties/lib/rails/generators/rails/generator/templates/%file_name%_generator.rb.tt
@@ -1,3 +1,3 @@
 class <%= class_name %>Generator < Rails::Generators::NamedBase
-  source_root File.expand_path('../templates', __FILE__)
+  source_root File.expand_path('templates', __dir__)
 end

--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
@@ -1,4 +1,4 @@
-$:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("lib", __dir__)
 
 # Maintain your gem's version:
 require "<%= namespaced_name %>/version"

--- a/railties/lib/rails/generators/rails/plugin/templates/Rakefile
+++ b/railties/lib/rails/generators/rails/plugin/templates/Rakefile
@@ -15,7 +15,7 @@ RDoc::Task.new(:rdoc) do |rdoc|
 end
 
 <% if engine? && !options[:skip_active_record] && with_dummy_app? -%>
-APP_RAKEFILE = File.expand_path("../<%= dummy_path -%>/Rakefile", __FILE__)
+APP_RAKEFILE = File.expand_path("<%= dummy_path -%>/Rakefile", __dir__)
 load 'rails/tasks/engine.rake'
 <% end %>
 

--- a/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
@@ -1,12 +1,12 @@
 # This command will automatically be run when you run "rails" with Rails gems
 # installed from the root of your application.
 
-ENGINE_ROOT = File.expand_path('../..', __FILE__)
-ENGINE_PATH = File.expand_path('../../lib/<%= namespaced_name -%>/engine', __FILE__)
-APP_PATH = File.expand_path('../../<%= dummy_path -%>/config/application', __FILE__)
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/<%= namespaced_name -%>/engine', __dir__)
+APP_PATH = File.expand_path('../<%= dummy_path -%>/config/application', __dir__)
 
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 
 require 'rails/all'

--- a/railties/lib/rails/generators/rails/plugin/templates/bin/test.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/test.tt
@@ -1,4 +1,4 @@
-$: << File.expand_path(File.expand_path("../../test", __FILE__))
+$: << File.expand_path("../test", __dir__)
 
 require "bundler/setup"
 require "rails/plugin/test"

--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
@@ -1,8 +1,8 @@
-require File.expand_path("../../<%= options[:dummy_path] -%>/config/environment.rb", __FILE__)
+require File.expand_path("../<%= options[:dummy_path] -%>/config/environment.rb", __dir__)
 <% unless options[:skip_active_record] -%>
-ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../<%= options[:dummy_path] -%>/db/migrate", __FILE__)]
+ActiveRecord::Migrator.migrations_paths = [File.expand_path("../<%= options[:dummy_path] -%>/db/migrate", __dir__)]
 <% if options[:mountable] -%>
-ActiveRecord::Migrator.migrations_paths << File.expand_path('../../db/migrate', __FILE__)
+ActiveRecord::Migrator.migrations_paths << File.expand_path('../db/migrate', __dir__)
 <% end -%>
 <% end -%>
 require "rails/test_help"
@@ -17,7 +17,7 @@ Rails::TestUnitReporter.executable = 'bin/test'
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)
-  ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
+  ActiveSupport::TestCase.fixture_path = File.expand_path("fixtures", __dir__)
   ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
   ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
   ActiveSupport::TestCase.fixtures :all

--- a/railties/lib/rails/generators/test_case.rb
+++ b/railties/lib/rails/generators/test_case.rb
@@ -14,7 +14,7 @@ module Rails
     #
     #   class AppGeneratorTest < Rails::Generators::TestCase
     #     tests AppGenerator
-    #     destination File.expand_path("../tmp", File.dirname(__FILE__))
+    #     destination File.expand_path("../tmp", __dir__)
     #   end
     #
     # If you want to ensure your destination root is clean before running each test,
@@ -22,7 +22,7 @@ module Rails
     #
     #   class AppGeneratorTest < Rails::Generators::TestCase
     #     tests AppGenerator
-    #     destination File.expand_path("../tmp", File.dirname(__FILE__))
+    #     destination File.expand_path("../tmp", __dir__)
     #     setup :prepare_destination
     #   end
     class TestCase < ActiveSupport::TestCase

--- a/railties/lib/rails/generators/testing/behaviour.rb
+++ b/railties/lib/rails/generators/testing/behaviour.rb
@@ -40,7 +40,7 @@ module Rails
 
           # Sets the destination of generator files:
           #
-          #   destination File.expand_path("../tmp", File.dirname(__FILE__))
+          #   destination File.expand_path("../tmp", __dir__)
           def destination(path)
             self.destination_root = path
           end
@@ -51,7 +51,7 @@ module Rails
         #
         #   class AppGeneratorTest < Rails::Generators::TestCase
         #     tests AppGenerator
-        #     destination File.expand_path("../tmp", File.dirname(__FILE__))
+        #     destination File.expand_path("../tmp", __dir__)
         #     setup :prepare_destination
         #
         #     test "database.yml is not created when skipping Active Record" do

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -16,7 +16,7 @@ namespace :app do
   namespace :templates do
     # desc "Copy all the templates from rails to the application directory for customization. Already existing local copies will be overwritten"
     task :copy do
-      generators_lib = File.expand_path("../../generators", __FILE__)
+      generators_lib = File.expand_path("../generators", __dir__)
       project_templates = "#{Rails.root}/lib/templates"
 
       default_templates = { "erb"   => %w{controller mailer scaffold},

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path("../../RAILS_VERSION", __FILE__)).strip
+version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -12,7 +12,7 @@ require "rails/all"
 
 module TestApp
   class Application < Rails::Application
-    config.root = File.dirname(__FILE__)
+    config.root = __dir__
     secrets.secret_key_base = "b3c631c314c0bbca50c1b2843150fe33"
   end
 end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -469,7 +469,7 @@ module ApplicationTests
     def test_run_app_without_rails_loaded
       # Simulate a real Rails app boot.
       app_file "config/boot.rb", <<-RUBY
-        ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+        ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
         require 'bundler/setup' # Set up gems listed in the Gemfile.
       RUBY

--- a/railties/test/code_statistics_calculator_test.rb
+++ b/railties/test/code_statistics_calculator_test.rb
@@ -317,7 +317,7 @@ class Animal
 
   private
     def temp_file(name, content)
-      dir = File.expand_path "../fixtures/tmp", __FILE__
+      dir = File.expand_path "fixtures/tmp", __dir__
       path = "#{dir}/#{name}"
 
       FileUtils.mkdir_p dir

--- a/railties/test/code_statistics_test.rb
+++ b/railties/test/code_statistics_test.rb
@@ -3,7 +3,7 @@ require "rails/code_statistics"
 
 class CodeStatisticsTest < ActiveSupport::TestCase
   def setup
-    @tmp_path = File.expand_path(File.join(File.dirname(__FILE__), "fixtures", "tmp"))
+    @tmp_path = File.expand_path("fixtures/tmp", __dir__)
     @dir_js   = File.join(@tmp_path, "lib.js")
     FileUtils.mkdir_p(@dir_js)
   end

--- a/railties/test/fixtures/lib/generators/usage_template/usage_template_generator.rb
+++ b/railties/test/fixtures/lib/generators/usage_template/usage_template_generator.rb
@@ -1,5 +1,5 @@
 require "rails/generators"
 
 class UsageTemplateGenerator < Rails::Generators::Base
-  source_root File.expand_path("templates", File.dirname(__FILE__))
+  source_root File.expand_path("templates", __dir__)
 end

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -9,7 +9,7 @@ module Rails
   class << self
     remove_possible_method :root
     def root
-      @root ||= Pathname.new(File.expand_path("../../fixtures", __FILE__))
+      @root ||= Pathname.new(File.expand_path("../fixtures", __dir__))
     end
   end
 end
@@ -41,7 +41,7 @@ module GeneratorsTestHelper
   end
 
   def copy_routes
-    routes = File.expand_path("../../../lib/rails/generators/rails/app/templates/config/routes.rb", __FILE__)
+    routes = File.expand_path("../../lib/rails/generators/rails/app/templates/config/routes.rb", __dir__)
     destination = File.join(destination_root, "config")
     FileUtils.mkdir_p(destination)
     FileUtils.cp routes, destination

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -294,7 +294,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "hyphenated-name/config/routes.rb",              /Rails.application.routes.draw do/
     assert_file "hyphenated-name/lib/hyphenated/name/engine.rb", /module Hyphenated\n  module Name\n    class Engine < ::Rails::Engine\n    end\n  end\nend/
     assert_file "hyphenated-name/lib/hyphenated/name.rb",        /require "hyphenated\/name\/engine"/
-    assert_file "hyphenated-name/bin/rails",                     /\.\.\/\.\.\/lib\/hyphenated\/name\/engine/
+    assert_file "hyphenated-name/bin/rails",                     /\.\.\/lib\/hyphenated\/name\/engine/
   end
 
   def test_creating_engine_with_hyphenated_and_underscored_name_in_full_mode
@@ -311,7 +311,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "my_hyphenated-name/config/routes.rb",              /Rails\.application\.routes\.draw do/
     assert_file "my_hyphenated-name/lib/my_hyphenated/name/engine.rb", /module MyHyphenated\n  module Name\n    class Engine < ::Rails::Engine\n    end\n  end\nend/
     assert_file "my_hyphenated-name/lib/my_hyphenated/name.rb",        /require "my_hyphenated\/name\/engine"/
-    assert_file "my_hyphenated-name/bin/rails",                     /\.\.\/\.\.\/lib\/my_hyphenated\/name\/engine/
+    assert_file "my_hyphenated-name/bin/rails",                     /\.\.\/lib\/my_hyphenated\/name\/engine/
   end
 
   def test_being_quiet_while_creating_dummy_application
@@ -420,9 +420,9 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
   def test_usage_of_engine_commands
     run_generator [destination_root, "--full"]
-    assert_file "bin/rails", /ENGINE_PATH = File\.expand_path\('\.\.\/\.\.\/lib\/bukkits\/engine', __FILE__\)/
-    assert_file "bin/rails", /ENGINE_ROOT = File\.expand_path\('\.\.\/\.\.', __FILE__\)/
-    assert_file "bin/rails", %r|APP_PATH = File\.expand_path\('\.\./\.\./test/dummy/config/application', __FILE__\)|
+    assert_file "bin/rails", /ENGINE_PATH = File\.expand_path\('\.\.\/lib\/bukkits\/engine', __dir__\)/
+    assert_file "bin/rails", /ENGINE_ROOT = File\.expand_path\('\.\.', __dir__\)/
+    assert_file "bin/rails", %r|APP_PATH = File\.expand_path\('\.\./test/dummy/config/application', __dir__\)|
     assert_file "bin/rails", /require 'rails\/all'/
     assert_file "bin/rails", /require 'rails\/engine\/commands'/
   end
@@ -741,7 +741,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     quietly { Rails::Engine::Updater.run(:create_bin_files) }
 
     assert_file "#{destination_root}/bin/rails" do |content|
-      assert_match(%r|APP_PATH = File\.expand_path\('\.\./\.\./test/dummy/config/application', __FILE__\)|, content)
+      assert_match(%r|APP_PATH = File\.expand_path\('\.\./test/dummy/config/application', __dir__\)|, content)
     end
   ensure
     Object.send(:remove_const, "ENGINE_ROOT")

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -233,7 +233,7 @@ class GeneratorsTest < Rails::Generators::TestCase
   end
 
   def test_usage_with_embedded_ruby
-    require File.expand_path("fixtures/lib/generators/usage_template/usage_template_generator", File.dirname(__FILE__))
+    require File.expand_path("fixtures/lib/generators/usage_template/usage_template_generator", __dir__)
     output = capture(:stdout) { Rails::Generators.invoke :usage_template, ["--help"] }
     assert_match(/:: 2 ::/, output)
   end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -14,7 +14,7 @@ require "active_support/testing/autorun"
 require "active_support/testing/stream"
 require "active_support/test_case"
 
-RAILS_FRAMEWORK_ROOT = File.expand_path("#{File.dirname(__FILE__)}/../../..")
+RAILS_FRAMEWORK_ROOT = File.expand_path("../../..", __dir__)
 
 # These files do not require any others and are needed
 # to run the tests

--- a/railties/test/rails_info_test.rb
+++ b/railties/test/rails_info_test.rb
@@ -39,7 +39,7 @@ class InfoTest < ActiveSupport::TestCase
 
   def test_rails_version
     assert_property "Rails version",
-      File.read(File.realpath("../../../RAILS_VERSION", __FILE__)).chomp
+      File.read(File.realpath("../../RAILS_VERSION", __dir__)).chomp
   end
 
   def test_html_includes_middleware

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -1,7 +1,7 @@
 FRAMEWORKS = %w( activesupport activemodel activerecord actionview actionpack activejob actionmailer actioncable railties )
 FRAMEWORK_NAMES = Hash.new { |h, k| k.split(/(?<=active|action)/).map(&:capitalize).join(" ") }
 
-root    = File.expand_path("../../", __FILE__)
+root    = File.expand_path("..", __dir__)
 version = File.read("#{root}/RAILS_VERSION").strip
 tag     = "v#{version}"
 gem_version = Gem::Version.new(version)


### PR DESCRIPTION
> "... with \_\_dir\_\_ we can restore order in the Universe." - by @fxn.

This words inspired me to restore order in Rails and my own projects.

I read [Contributing to Ruby on Rails](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html) and know about "cosmetic changes", but in this case, i think it something more - Very often new code written under the influence of old code so this PR will inspire to define a path with `__dir__` in this case.
We have some examples of code, that includes "defining a path", in our guide -  it also important.

Also, with `__dir__`, code in some cases became more readable. Example:
```diff
- append_view_path File.expand_path(File.join(File.dirname(__FILE__), "views"))
+ append_view_path File.expand_path("views", __dir__)
```

Feel free to close this PR if something wrong.

Related to 5b8738c2df003a96f0e490c43559747618d10f5f
r? @fxn 