### PR TITLE
Remove rubygems version lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 bundler_args: --without test --jobs 3 --retry 3
 before_install:
   - "rm ${BUNDLE_GEMFILE}.lock"
-  - "gem update --system 2.6.11"
+  - "gem update --system"
   - "gem update bundler"
   - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
   - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"


### PR DESCRIPTION
This version lock added by 3d890b6.
But original issue is fixed with bundler 1.15.

Ref: https://github.com/rubygems/rubygems/issues/1911#issuecomment-300148516