### PR TITLE
More friendly exception in nested attributes

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -458,7 +458,7 @@ module ActiveRecord
         end
 
         unless attributes_collection.is_a?(Hash) || attributes_collection.is_a?(Array)
-          raise ArgumentError, "Hash or Array expected, got #{attributes_collection.class.name} (#{attributes_collection.inspect})"
+          raise ArgumentError, "Hash or Array expected for attribute `#{association_name}`, got #{attributes_collection.class.name} (#{attributes_collection.inspect})"
         end
 
         check_record_limit!(options[:limit], attributes_collection)

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -752,7 +752,7 @@ module NestedAttributesOnACollectionAssociationTests
     exception = assert_raise ArgumentError do
       @pirate.send(association_setter, "foo")
     end
-    assert_equal 'Hash or Array expected, got String ("foo")', exception.message
+    assert_equal %{Hash or Array expected for attribute `#{@association_name}`, got String ("foo")}, exception.message
   end
 
   def test_should_work_with_update_as_well


### PR DESCRIPTION
For a model with more than one nested attributes accessors, `Hash or Array expected, got String` exception doesn't tell you anything about the attribute that received the wrong input.

Mentioning the attribute would help a lot to debug things.

@matthewd 