### PR TITLE
Remove requirement on mathn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,7 +154,3 @@ end
 gem "ibm_db" if ENV["IBM_DB"]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "wdm", ">= 0.1.0", platforms: [:mingw, :mswin, :x64_mingw, :mswin64]
-
-platforms :ruby_25 do
-  gem "mathn"
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.5)
       mime-types (>= 1.16, < 4)
-    mathn (0.1.0)
     metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (3.1)
@@ -397,7 +396,6 @@ DEPENDENCIES
   kindlerb (~> 1.2.0)
   libxml-ruby
   listen (>= 3.0.5, < 3.2)
-  mathn
   minitest (< 5.3.4)
   mocha (~> 0.14)
   mysql2 (>= 0.4.4)

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -138,11 +138,19 @@ class DateHelperTest < ActionView::TestCase
     assert_equal "10 minutes", distance_of_time_in_words(Time.at(600), 0)
   end
 
-  def test_distance_in_words_with_mathn_required
-    # test we avoid Integer#/ (redefined by mathn)
-    silence_warnings { require "mathn" }
+  def test_distance_in_words_doesnt_use_the_quotient_operator
+    rubinius_skip "Date is written in Ruby and relies on Fixnum#/"
+    jruby_skip "Date is written in Ruby and relies on Fixnum#/"
+
+    klass = RUBY_VERSION > "2.4" ? Integer : Fixnum
+
+    # Make sure that we avoid {Integer,Fixnum}#/ (redefined by mathn)
+    klass.send :private, :/
+
     from = Time.utc(2004, 6, 6, 21, 45, 0)
     assert_distance_of_time_in_words(from)
+  ensure
+    klass.send :public, :/
   end
 
   def test_time_ago_in_words_passes_include_seconds


### PR DESCRIPTION
Hello,

This pull request is a follow up to #28910 and https://github.com/rails/rails/commit/45d7d80ea66654cc6cb44202eb2fecac04590691.

The test using mathn was first introduced in f1d9179 to check that the `distance_of_time_in_words` properly doesn't use the `Fixnum#/` method by explicitly requiring this library as it redefines this method.

Given that `mathn` has been gemified in Ruby 2.5 and is deprecated since version 2.2, we can certainly safely assume that people will most-likely not require this library in their application. Thus, this pull request removes our requirement on it even though the code is still compatible for people using mathn ; just that we are no longer asserting that this is the case.

Have a nice day !