### PR TITLE
Make `secrets:edit` run `secrets:setup` if it hasn't already.

### DIFF
--- a/railties/lib/rails/commands/secrets/secrets_command.rb
+++ b/railties/lib/rails/commands/secrets/secrets_command.rb
@@ -34,7 +34,6 @@ module Rails
         require_application_and_environment!
 
         Rails::Secrets.read_for_editing do |tmp_path|
-          say "Waiting for secrets file to be saved. Abort with Ctrl-C."
           system("\$EDITOR #{tmp_path}")
         end
 

--- a/railties/lib/rails/commands/secrets/secrets_command.rb
+++ b/railties/lib/rails/commands/secrets/secrets_command.rb
@@ -13,10 +13,7 @@ module Rails
       end
 
       def setup
-        require "rails/generators"
-        require "rails/generators/rails/encrypted_secrets/encrypted_secrets_generator"
-
-        Rails::Generators::EncryptedSecretsGenerator.start
+        generator.start
       end
 
       def edit
@@ -42,7 +39,22 @@ module Rails
         say "Aborted changing encrypted secrets: nothing saved."
       rescue Rails::Secrets::MissingKeyError => error
         say error.message
+      rescue Errno::ENOENT => error
+        raise unless error.message =~ /secrets\.yml\.enc/
+
+        Rails::Secrets.read_template_for_editing do |tmp_path|
+          system("\$EDITOR #{tmp_path}")
+          generator.skip_secrets_file { setup }
+        end
       end
+
+      private
+        def generator
+          require "rails/generators"
+          require "rails/generators/rails/encrypted_secrets/encrypted_secrets_generator"
+
+          Rails::Generators::EncryptedSecretsGenerator
+        end
     end
   end
 end

--- a/railties/lib/rails/generators/rails/encrypted_secrets/encrypted_secrets_generator.rb
+++ b/railties/lib/rails/generators/rails/encrypted_secrets/encrypted_secrets_generator.rb
@@ -36,25 +36,29 @@ module Rails
       end
 
       def add_encrypted_secrets_file
-        unless File.exist?("config/secrets.yml.enc")
+        unless (defined?(@@skip_secrets_file) && @@skip_secrets_file) || File.exist?("config/secrets.yml.enc")
           say "Adding config/secrets.yml.enc to store secrets that needs to be encrypted."
           say ""
+          say "For now the file contains this but it's been encrypted with the generated key:"
+          say ""
+          say Secrets.template, :on_green
+          say ""
 
-          template "config/secrets.yml.enc" do |prefill|
-            say ""
-            say "For now the file contains this but it's been encrypted with the generated key:"
-            say ""
-            say prefill, :on_green
-            say ""
-
-            Secrets.encrypt(prefill)
-          end
+          Secrets.write(Secrets.template)
 
           say "You can edit encrypted secrets with `bin/rails secrets:edit`."
-
-          say "Add this to your config/environments/production.rb:"
-          say "config.read_encrypted_secrets = true"
+          say ""
         end
+
+        say "Add this to your config/environments/production.rb:"
+        say "config.read_encrypted_secrets = true"
+      end
+
+      def self.skip_secrets_file
+        @@skip_secrets_file = true
+        yield
+      ensure
+        @@skip_secrets_file = false
       end
 
       private

--- a/railties/lib/rails/generators/rails/encrypted_secrets/templates/config/secrets.yml.enc
+++ b/railties/lib/rails/generators/rails/encrypted_secrets/templates/config/secrets.yml.enc
@@ -1,3 +1,0 @@
-# See `secrets.yml` for tips on generating suitable keys.
-# production:
-#  external_api_key: 1466aac22e6a869134be3d09b9e89232fc2c2289…

--- a/railties/lib/rails/secrets.rb
+++ b/railties/lib/rails/secrets.rb
@@ -1,5 +1,6 @@
 require "yaml"
 require "active_support/message_encryptor"
+require "active_support/core_ext/string/strip"
 
 module Rails
   # Greatly inspired by Ara T. Howard's magnificent sekrets gem. 😘
@@ -37,6 +38,15 @@ module Rails
         ENV["RAILS_MASTER_KEY"] || read_key_file || handle_missing_key
       end
 
+      def template
+        <<-end_of_template.strip_heredoc
+          # See `secrets.yml` for tips on generating suitable keys.
+          # production:
+          #  external_api_key: 1466aac22e6a869134be3d09b9e89232fc2c2289…
+
+        end_of_template
+      end
+
       def encrypt(data)
         encryptor.encrypt_and_sign(data)
       end
@@ -54,15 +64,12 @@ module Rails
         FileUtils.mv("#{path}.tmp", path)
       end
 
-      def read_for_editing
-        tmp_path = File.join(Dir.tmpdir, File.basename(path))
-        IO.binwrite(tmp_path, read)
+      def read_for_editing(&block)
+        writing(read, &block)
+      end
 
-        yield tmp_path
-
-        write(IO.binread(tmp_path))
-      ensure
-        FileUtils.rm(tmp_path) if File.exist?(tmp_path)
+      def read_template_for_editing(&block)
+        writing(template, &block)
       end
 
       private
@@ -90,6 +97,17 @@ module Rails
           else
             IO.read(path)
           end
+        end
+
+        def writing(contents)
+          tmp_path = File.join(Dir.tmpdir, File.basename(path))
+          File.write(tmp_path, contents)
+
+          yield tmp_path
+
+          write(File.read(tmp_path))
+        ensure
+          FileUtils.rm(tmp_path) if File.exist?(tmp_path)
         end
 
         def encryptor

--- a/railties/test/commands/secrets_test.rb
+++ b/railties/test/commands/secrets_test.rb
@@ -18,7 +18,8 @@ class Rails::Command::SecretsCommandTest < ActiveSupport::TestCase
   end
 
   test "edit secrets" do
-    run_setup_command
+    # Runs setup before first edit.
+    assert_match(/Adding config\/secrets\.yml\.key to store the encryption key/, run_edit_command)
 
     # Run twice to ensure encrypted secrets can be reread after first edit pass.
     2.times do
@@ -29,9 +30,5 @@ class Rails::Command::SecretsCommandTest < ActiveSupport::TestCase
   private
     def run_edit_command(editor: "cat")
       Dir.chdir(app_path) { `EDITOR="#{editor}" bin/rails secrets:edit` }
-    end
-
-    def run_setup_command
-      Dir.chdir(app_path) { `bin/rails secrets:setup` }
     end
 end


### PR DESCRIPTION
Fixes #29194.

Then also ditch the needless "waiting for edits" message.

- [ ] See if we can't do people a solid and `config.read_encrypted_secrets = true` to their production.rb for them in case they haven't added it through `app:update`.