### PR TITLE
Issue 29202 cant bundle due to coffee rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "capybara", "~> 2.13"
 
 gem "rack-cache", "~> 1.2"
 gem "jquery-rails"
-gem "coffee-rails"
+gem "coffee-rails", github: "rails/coffee-rails"
 gem "sass-rails"
 gem "turbolinks", "~> 5"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,14 @@ GIT
   specs:
     arel (8.0.0)
 
+GIT
+  remote: https://github.com/rails/coffee-rails.git
+  revision: db1ed754360faddf9d29895466b6acef78aa0563
+  specs:
+    coffee-rails (4.2.1)
+      coffee-script (>= 2.2.0)
+      railties (>= 4.0.0, < 6.0.x)
+
 PATH
   remote: .
   specs:
@@ -134,9 +142,6 @@ GEM
       xpath (~> 2.0)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
-    coffee-rails (4.2.1)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.2.x)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -385,7 +390,7 @@ DEPENDENCIES
   blade-sauce_labs_plugin
   byebug
   capybara (~> 2.13)
-  coffee-rails
+  coffee-rails!
   dalli (>= 2.2.1)
   delayed_job
   delayed_job_active_record

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Edge and Dev generated apps should use the edge version of coffee-rails.
+
+    Fixes #29202.
+
+    *Rasesh Patel*
+
 *   Allow irb options to be passed from `rails console` command.
 
     Fixes #28988.

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -246,6 +246,8 @@ module Rails
         dev_edge_common = [
           GemfileEntry.github("arel", "rails/arel"),
         ]
+        dev_edge_common << GemfileEntry.github("coffee-rails", "rails/coffee-rails") unless options[:skip_coffee]
+
         if options.dev?
           [
             GemfileEntry.path("rails", Rails::Generators::RAILS_DEV_PATH)
@@ -337,7 +339,7 @@ module Rails
           []
         else
           gems = [javascript_runtime_gemfile_entry]
-          gems << coffee_gemfile_entry unless options[:skip_coffee]
+          gems << coffee_gemfile_entry unless options[:skip_coffee] || options.dev? || options.edge?
 
           unless options[:skip_turbolinks]
             gems << GemfileEntry.version("turbolinks", "~> 5",


### PR DESCRIPTION
### Summary

Fix for #29202 

```rails new app --dev```
```rails new app --edge```
Fails since using an outdated version of coffee-rails plugin
We should be able to at least generate new apps on dev and edge, and since dev and edge will always be ahead of the released coffee-rails version we should just map our edge to their edge.

Update the generator to only use the coffee-rails github in dev or edge mode.