### PR TITLE
`DEFAULT_ENV` falls back to `default_env` when `RAILS_ENV` or `RACK_ENV` is an empty string

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -1,6 +1,6 @@
 module ActiveRecord
   module ConnectionHandling
-    RAILS_ENV   = -> { (Rails.env if defined?(Rails.env)) || ENV["RAILS_ENV"] || ENV["RACK_ENV"] }
+    RAILS_ENV   = -> { (Rails.env if defined?(Rails.env)) || ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence }
     DEFAULT_ENV = -> { RAILS_ENV.call || "default_env" }
 
     # Establishes the connection to the database. Accepts a hash as input where

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -9,6 +9,17 @@ module ActiveRecord
         @pool = @handler.establish_connection(ActiveRecord::Base.configurations["arunit"])
       end
 
+      def test_default_env_fall_back_to_default_env_when_rails_env_or_rack_env_is_empty_string
+        original_rails_env = ENV["RAILS_ENV"]
+        original_rack_env  = ENV["RACK_ENV"]
+        ENV["RAILS_ENV"]   = ENV["RACK_ENV"] = ""
+
+        assert_equal "default_env", ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+      ensure
+        ENV["RAILS_ENV"] = original_rails_env
+        ENV["RACK_ENV"]  = original_rack_env
+      end
+
       def test_establish_connection_uses_spec_name
         config = { "readonly" => { "adapter" => "sqlite3" } }
         resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new(config)

--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -23,7 +23,7 @@ module Rails
       end
 
       def environment # :nodoc:
-        ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
+        ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development"
       end
 
       # Receives a namespace, arguments and the behavior to invoke the command.


### PR DESCRIPTION
Follow up of #27399.