### PR TITLE
Add Monitor to ModelSchema#load_schema

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Loading model schema from database is now thread-safe. GH#28589
+
+    *David Abdemoulaie*
+    *Vikrant Chaudhary*
+
 *   Add `ActiveRecord::Base#cache_version` to support recyclable cache keys via the new versioned entries
     in `ActiveSupport::Cache`. This also means that `ActiveRecord::Base#cache_key` will now return a stable key
     that does not include a timestamp any more.

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -435,6 +435,15 @@ module ActiveRecord
         initialize_find_by_cache
       end
 
+      def inherited(child_class)
+        child_class.initialize_load_schema_monitor
+        super
+      end
+
+      def initialize_load_schema_monitor
+        @load_schema_monitor = Monitor.new
+      end
+
       private
 
         def schema_loaded?
@@ -442,8 +451,8 @@ module ActiveRecord
         end
 
         def load_schema
-          unless schema_loaded?
-            load_schema!
+          @load_schema_monitor.synchronize do
+            load_schema! unless schema_loaded?
           end
         end
 

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -349,4 +349,34 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     topic.foo
     refute topic.changed?
   end
+
+  def test_serialized_attribute_works_under_concurrent_access
+    Topic.serialize :content, JSON
+    Topic.reset_column_information
+
+    concurrency = 4
+
+    barrier = Concurrent::CyclicBarrier.new(concurrency)
+    jobs = Array.new(concurrency) do
+      lambda do
+        Topic.last
+      end
+    end
+
+    process = lambda do |i|
+      barrier.wait
+      begin
+        jobs[i].call
+      ensure
+        barrier.wait
+      end
+    end
+
+    threads = concurrency.times.map { |i| Thread.new(i, &process) }
+
+    threads.map(&:join)
+
+    assert_instance_of(ActiveRecord::Type::Serialized, Topic.attribute_types['content'])
+    assert_instance_of(ActiveModel::Type::Text, Topic.attribute_types['content'].subtype)
+  end
 end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -376,7 +376,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
 
     threads.map(&:join)
 
-    assert_instance_of(ActiveRecord::Type::Serialized, Topic.attribute_types['content'])
-    assert_instance_of(ActiveModel::Type::Text, Topic.attribute_types['content'].subtype)
+    assert_instance_of(ActiveRecord::Type::Serialized, Topic.attribute_types["content"])
+    assert_instance_of(ActiveModel::Type::Text, Topic.attribute_types["content"].subtype)
   end
 end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -377,6 +377,6 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     threads.map(&:join)
 
     assert_instance_of(ActiveRecord::Type::Serialized, Topic.attribute_types["content"])
-    assert_instance_of(ActiveModel::Type::Text, Topic.attribute_types["content"].subtype)
+    assert_instance_of(ActiveRecord::Type::Text, Topic.attribute_types["content"].subtype)
   end
 end


### PR DESCRIPTION
Fixes #28589

This prevents multiple distinct threads from attempting to call `load_schema!`. On JRuby this bug would result in serialized attributes being deeply recursively nested.

Note: This test will occasionally flake due to #14021 (See also #27418).

Needs to be backported to 5.0/5.1

### Summary

See #28589 
Duplicates (Improves) #28756 
