### PR TITLE
ActiveRecord initialization optimizations

### DIFF
--- a/activerecord/lib/active_record/attribute_set.rb
+++ b/activerecord/lib/active_record/attribute_set.rb
@@ -64,9 +64,7 @@ module ActiveRecord
     end
 
     def deep_dup
-      dup.tap do |copy|
-        copy.instance_variable_set(:@attributes, attributes.deep_dup)
-      end
+      self.class.new(attributes.deep_dup)
     end
 
     def initialize_dup(_)

--- a/activerecord/lib/active_record/attribute_set.rb
+++ b/activerecord/lib/active_record/attribute_set.rb
@@ -64,7 +64,9 @@ module ActiveRecord
     end
 
     def deep_dup
-      self.class.new(attributes.deep_dup)
+      self.class.allocate.tap do |copy|
+        copy.instance_variable_set(:@attributes, attributes.deep_dup)
+      end
     end
 
     def initialize_dup(_)

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -217,7 +217,7 @@ module ActiveRecord
         def subclass_from_attributes(attrs)
           attrs = attrs.to_h if attrs.respond_to?(:permitted?)
           if attrs.is_a?(Hash)
-            subclass_name = attrs.with_indifferent_access[inheritance_column]
+            subclass_name = attrs[inheritance_column] || attrs[inheritance_column.to_sym]
 
             if subclass_name.present?
               find_sti_class(subclass_name)

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -377,7 +377,7 @@ module ActiveRecord
       # default values when instantiating the Active Record object for this table.
       def column_defaults
         load_schema
-        _default_attributes.to_hash
+        @column_defaults ||= _default_attributes.to_hash
       end
 
       def _default_attributes # :nodoc:
@@ -466,6 +466,7 @@ module ActiveRecord
           @attribute_types = nil
           @content_columns = nil
           @default_attributes = nil
+          @column_defaults = nil
           @inheritance_column = nil unless defined?(@explicit_inheritance_column) && @explicit_inheritance_column
           @attributes_builder = nil
           @columns = nil


### PR DESCRIPTION
### Summary

ActiveRecord model initialization got a lot slower between Rails 4.2 and Rails 5 — **2-5x slower or more**, depending on the specific circumstances.

This PR includes optimizations that speed up model initialization by approximately **2x for STI models** and **1.3x for non-STI models**, as compared to vanilla 5.1, returning performance somewhat closer (but by no means entirely) to 4.2 levels.

We have been running these optimizations on our high-traffic Rails 5.0.2 app in production for the last few days without issue. We are seeing an **average response time speedup of just over 4%**, compared to vanilla Rails 5.0.2, with **certain actions showing speedup of 5-15%**. (Our app depends heavily on STI and uses a caching scheme that results in many model initializations even on cache hits; YMMV.)

### Other Information

#### Benchmarks

Highlights:

```
================ Instantiate STI base class without attributes =================

      v5.1.1 patched:    20641.2 i/s
              v5.1.1:     9916.0 i/s - 2.08x  slower

================= Instantiate Non-STI class without attributes =================

      v5.1.1 patched:    27071.0 i/s
              v5.1.1:    20723.3 i/s - 1.31x  slower
```
Details:

* [Rails 4.2.8 vanilla](https://gist.github.com/lovitt/66c4d0f1cad404b38c2f9d97736f3d9c)
* [Rails 5.1.1 vanilla compared to Rails 5.1.1 patched](https://gist.github.com/lovitt/273e8badd58b6ccf8c71cd0e7feaa50c)

#### Running the benchmarks

These benchmarks were produced by [this benchmarking script](https://gist.github.com/lovitt/b5edf05d11ef2571582c32d7547c1243) using Ruby 2.3.3 on OS X. To run them yourself, clone the gist, then:

```
# benchmark Rails 4.2.8 vanilla only
RAILS_VERSION=4.2.8 ruby ar_init_optimizations.rb  

# compare Rails 5.1.1 vanilla to Rails 5.1.1 patched
RAILS_VERSION=5.1.1 ruby ar_init_optimizations.rb
```

#### Potential future work

With these patches in place, the remaining ActiveRecord initialization slowness introduced in Rails 5.0 seems to be related to changes in `ActiveRecord::Core#initialize` — in particular, in calls to `AttributeSet#deep_dup` and `Scoping#initialize_internals_callback`. 

I'm no expert in this area of the Rails codebase, and I could not find a relevant PR that describes the rationale behind these changes, but I think any further optimizations would be much more involved than the straightforward changes made here.

---

Credit to @jamiemccarthy and @thenonsequitur for the investigative and profiling work behind this PR.
 
