### PR TITLE
Remove a duplicate test of migration_test in AR

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -402,33 +402,6 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Migrator.up(migrations_path)
   end
 
-  def test_migration_sets_internal_metadata_even_when_fully_migrated
-    current_env     = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
-    migrations_path = MIGRATIONS_ROOT + "/valid"
-    old_path        = ActiveRecord::Migrator.migrations_paths
-    ActiveRecord::Migrator.migrations_paths = migrations_path
-
-    ActiveRecord::Migrator.up(migrations_path)
-    assert_equal current_env, ActiveRecord::InternalMetadata[:environment]
-
-    original_rails_env  = ENV["RAILS_ENV"]
-    original_rack_env   = ENV["RACK_ENV"]
-    ENV["RAILS_ENV"]    = ENV["RACK_ENV"] = "foofoo"
-    new_env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
-
-    refute_equal current_env, new_env
-
-    sleep 1 # mysql by default does not store fractional seconds in the database
-
-    ActiveRecord::Migrator.up(migrations_path)
-    assert_equal new_env, ActiveRecord::InternalMetadata[:environment]
-  ensure
-    ActiveRecord::Migrator.migrations_paths = old_path
-    ENV["RAILS_ENV"] = original_rails_env
-    ENV["RACK_ENV"]  = original_rack_env
-    ActiveRecord::Migrator.up(migrations_path)
-  end
-
   def test_internal_metadata_stores_environment_when_other_data_exists
     ActiveRecord::InternalMetadata.delete_all
     ActiveRecord::InternalMetadata[:foo] = "bar"


### PR DESCRIPTION
I found that the contents of the following 2 tests are the same.

- [activerecord/test/cases/migration_test.rb#test_internal_metadata_stores_environment](https://github.com/rails/rails/blob/7424a179d61c15fcbd2a2d9937202520c878b2ff/activerecord/test/cases/migration_test.rb#L379-L403)
- [activerecord/test/cases/migration_test.rb#test_migration_sets_internal_metadata_even_when_fully_migrated](https://github.com/rails/rails/blob/7424a179d61c15fcbd2a2d9937202520c878b2ff/activerecord/test/cases/migration_test.rb#L405-L430)

Originally these codes differed only slightly.

https://github.com/rails/rails/pull/23017/files#diff-b36b9c41be30b05dc14d09d7f3b192efR402

The following commits made these codes the same.

https://github.com/rails/rails/commit/a95a554c7e6e787c443f025eeede50f130df5863

This PR removes the duplicate test that was added later.