### PR TITLE
Remove a duplicate test of mysql_rake_test

### DIFF
--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -294,13 +294,6 @@ if current_adapter?(:Mysql2Adapter)
         ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
       end
 
-      def test_structure_dump
-        filename = "awesome-file.sql"
-        Kernel.expects(:system).with("mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db").returns(true)
-
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
-      end
-
       def test_structure_dump_with_extra_flags
         filename = "awesome-file.sql"
         expected_command = ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "--noop", "test-db"]


### PR DESCRIPTION
The following test codes are the same.

[test/cases/tasks/mysql_rake_test.rb#test_structure_dump](https://github.com/rails/rails/blob/7424a179d61c15fcbd2a2d9937202520c878b2ff/activerecord/test/cases/tasks/mysql_rake_test.rb#L290-L302)

Duplicates were made in PR #29077. This PR removes this duplicate code.