### PR TITLE
Added a way to fallback to a default message when adding an error on a model

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -400,7 +400,8 @@ module ActiveModel
       defaults.flatten!
 
       key = defaults.shift
-      defaults = options.delete(:message) if options[:message]
+      defaults = Array(options.delete(:message)) if options[:message]
+      defaults << options.delete(:default) if options[:default]
       value = (attribute != :base ? @base.send(:read_attribute_for_validation, attribute) : nil)
 
       options = {

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -157,6 +157,20 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["cannot be blank"], person.errors[:name]
   end
 
+  test "add an error code with an untranslated message fallbacks to default" do
+    person = Person.new
+    person.errors.add(:name, :untranslated_error, default: "Name contains special character")
+
+    assert_equal ["Name contains special character"], person.errors[:name]
+  end
+
+  test "add an error code which is translatable doesn't fallbacks to default" do
+    person = Person.new
+    person.errors.add(:name, :blank, default: "Name contains special character")
+
+    assert_equal ["can't be blank"], person.errors[:name]
+  end
+
   test "add an error with a symbol" do
     person = Person.new
     person.errors.add(:name, :blank)


### PR DESCRIPTION
Added a way to fallback to a default message when adding an error on a model:

- The previous behaviour when adding an error on a model with a default was to always use the default and not even look for the error code translation (i.e. `model.errors.add(:name, :blank, default: 'Hello')` would result using the `Hello` message)
- If someone wants to have that behaviour they can just use the `message` which is meant for that `model.errors.add(:name, :blank, message: 'Hello')`
- I believe the `default` option should only be used if the translation can't be found in the i18n chain


