### PR TITLE
Remove a duplicate test of schema_authorization_test in AR

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
@@ -75,17 +75,6 @@ class SchemaAuthorizationTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
-  def test_schema_uniqueness
-    assert_nothing_raised do
-      set_session_auth
-      USERS.each do |u|
-        set_session_auth u
-        assert_equal u, @connection.select_value("SELECT name FROM #{TABLE_NAME} WHERE id = 1")
-        set_session_auth
-      end
-    end
-  end
-
   def test_sequence_schema_caching
     assert_nothing_raised do
       USERS.each do |u|


### PR DESCRIPTION
The following are duplicate test codes.

- [activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb#test_setting_auth_clears_stmt_cache](https://github.com/rails/rails/blob/7424a179d61c15fcbd2a2d9937202520c878b2ff/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb#L53-L62)
- [activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb#test_schema_uniqueness](https://github.com/rails/rails/blob/7424a179d61c15fcbd2a2d9937202520c878b2ff/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb#L78-L87)

The following commits made these codes the same.

https://github.com/rails/rails/pull/23953/files#diff-555806966b5334e0ff9799d5447ec802

This PR will remove the duplicate test.
