### PR TITLE
Remove unused test class

### DIFF
--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -237,9 +237,6 @@ class AssertDifferenceTest < ActiveSupport::TestCase
   end
 end
 
-class AlsoDoingNothingTest < ActiveSupport::TestCase
-end
-
 # Setup and teardown callbacks.
 class SetupAndTeardownTest < ActiveSupport::TestCase
   setup :reset_callback_record, :foo


### PR DESCRIPTION
`AlsoDoingNothingTest` was added in cf9be89.
It seems that it added to confirm that the test works in the child class of `ActiveSupport::TestCase`.
But now basically use `ActiveSupport::TestCase` in test, so I think it is unnecessary.

