### PR TITLE
Remove a redundant test assertion

### DIFF
--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -743,7 +743,6 @@ class FinderTest < ActiveRecord::TestCase
     assert Topic.where(author_name: "David", title: "The First Topic", replies_count: 1, approved: false).find(1)
     assert_raise(ActiveRecord::RecordNotFound) { Topic.where(author_name: "David", title: "The First Topic", replies_count: 1, approved: true).find(1) }
     assert_raise(ActiveRecord::RecordNotFound) { Topic.where(author_name: "David", title: "HHC", replies_count: 1, approved: false).find(1) }
-    assert_raise(ActiveRecord::RecordNotFound) { Topic.where(author_name: "David", title: "The First Topic", replies_count: 1, approved: true).find(1) }
   end
 
   def test_condition_interpolation


### PR DESCRIPTION
This PR will remove redundant assertion in the following address.

https://github.com/rails/rails/blob/3beb5e53ed0a63660a05f42d9dae635a6d802b25/activerecord/test/cases/finder_test.rb#L744-L746

L744 and L746 are the same.