### PR TITLE
Doc updates for ActiveRecord::Batches

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -30,14 +30,14 @@ module ActiveRecord
     #   end
     #
     # ==== Options
-    # * <tt>:batch_size</tt> - Specifies the size of the batch. Default to 1000.
+    # * <tt>:batch_size</tt> - Specifies the size of the batch. Defaults to 1000.
     # * <tt>:start</tt> - Specifies the primary key value to start from, inclusive of the value.
     # * <tt>:finish</tt> - Specifies the primary key value to end at, inclusive of the value.
     # * <tt>:error_on_ignore</tt> - Overrides the application config to specify if an error should be raised when
-    #                               an order is present in the relation.
+    #   an order is present in the relation.
     #
     # Limits are honored, and if present there is no requirement for the batch
-    # size, it can be less than, equal, or greater than the limit.
+    # size: it can be less than, equal to, or greater than the limit.
     #
     # The options +start+ and +finish+ are especially useful if you want
     # multiple workers dealing with the same processing queue. You can make
@@ -89,14 +89,14 @@ module ActiveRecord
     # To be yielded each record one by one, use #find_each instead.
     #
     # ==== Options
-    # * <tt>:batch_size</tt> - Specifies the size of the batch. Default to 1000.
+    # * <tt>:batch_size</tt> - Specifies the size of the batch. Defaults to 1000.
     # * <tt>:start</tt> - Specifies the primary key value to start from, inclusive of the value.
     # * <tt>:finish</tt> - Specifies the primary key value to end at, inclusive of the value.
     # * <tt>:error_on_ignore</tt> - Overrides the application config to specify if an error should be raised when
-    #                               an order is present in the relation.
+    #   an order is present in the relation.
     #
     # Limits are honored, and if present there is no requirement for the batch
-    # size, it can be less than, equal, or greater than the limit.
+    # size: it can be less than, equal to, or greater than the limit.
     #
     # The options +start+ and +finish+ are especially useful if you want
     # multiple workers dealing with the same processing queue. You can make
@@ -140,9 +140,9 @@ module ActiveRecord
     # If you do not provide a block to #in_batches, it will return a
     # BatchEnumerator which is enumerable.
     #
-    #   Person.in_batches.with_index do |relation, batch_index|
+    #   Person.in_batches.each_with_index do |relation, batch_index|
     #     puts "Processing relation ##{batch_index}"
-    #     relation.each { |relation| relation.delete_all }
+    #     relation.delete_all
     #   end
     #
     # Examples of calling methods on the returned BatchEnumerator object:
@@ -152,12 +152,12 @@ module ActiveRecord
     #   Person.in_batches.each_record(&:party_all_night!)
     #
     # ==== Options
-    # * <tt>:of</tt> - Specifies the size of the batch. Default to 1000.
-    # * <tt>:load</tt> - Specifies if the relation should be loaded. Default to false.
+    # * <tt>:of</tt> - Specifies the size of the batch. Defaults to 1000.
+    # * <tt>:load</tt> - Specifies if the relation should be loaded. Defaults to false.
     # * <tt>:start</tt> - Specifies the primary key value to start from, inclusive of the value.
     # * <tt>:finish</tt> - Specifies the primary key value to end at, inclusive of the value.
     # * <tt>:error_on_ignore</tt> - Overrides the application config to specify if an error should be raised when
-    #                               an order is present in the relation.
+    #   an order is present in the relation.
     #
     # Limits are honored, and if present there is no requirement for the batch
     # size, it can be less than, equal, or greater than the limit.
@@ -186,7 +186,7 @@ module ActiveRecord
     #
     # NOTE: It's not possible to set the order. That is automatically set to
     # ascending on the primary key ("id ASC") to make the batch ordering
-    # consistent. Therefore the primary key must be orderable, e.g an integer
+    # consistent. Therefore the primary key must be orderable, e.g. an integer
     # or a string.
     #
     # NOTE: By its nature, batch processing is subject to race conditions if


### PR DESCRIPTION
Primarily, this is to fix the `.in_batches.with_index` example code, which does not work.  It should be `.in_batches.each_with_index`.

The example code then also called `relation.each { |relation| relation.delete_all }` inside the batch block, which also failed: `each` on the batch relation yields the records themselves, which can't have `delete_all` called on them.  It should just be `relation.delete_all`.

The last major change is removing the large amount of indentation on the option lists. Though that looks better in plaintext, it breaks the RDoc formatting, [turning the second line into a code block](https://monosnap.com/file/elAAXfPC1mCLJSqOgtKILkdx7MWB6F.png).