### PR TITLE
Fix broken RDoc formatting

### DIFF
--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -82,7 +82,7 @@ module ActiveModel
   #   end
   #
   # It can be useful to access the class that is using that validator when there are prerequisites such
-  # as an +attr_accessor+ being present. This class is accessible via +options[:class]+ in the constructor.
+  # as an +attr_accessor+ being present. This class is accessible via <tt>options[:class]</tt> in the constructor.
   # To setup your validator override the constructor.
   #
   #   class MyValidator < ActiveModel::Validator


### PR DESCRIPTION
The square brackets and colon were just too much for RDoc's `+` code formatting; needed `<tt>`.