### PR TITLE
Fix regression in Numericality validator

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix regression in numericality validator when comparing Decimal and Float input 
+    values with more scale than the schema.
+
+    *Bradley Priest*
+
 *   Fix methods `#keys`, `#values` in `ActiveModel::Errors`.
 
     Change `#keys` to only return the keys that don't have empty messages.

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -36,7 +36,9 @@ module ActiveModel
           return
         end
 
-        unless raw_value.is_a?(Numeric)
+        if raw_value.is_a?(Numeric)
+          value = raw_value
+        else
           value = parse_raw_value_as_a_number(raw_value)
         end
 

--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -167,6 +167,20 @@ class ValidationsTest < ActiveRecord::TestCase
     assert topic.valid?
   end
 
+  def test_numericality_validation_checks_against_raw_value
+    klass = Class.new(Topic) do
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "Topic")
+      end
+      attribute :wibble, :decimal, scale: 2, precision: 9
+      validates_numericality_of :wibble, greater_than_or_equal_to: BigDecimal.new("97.18")
+    end
+
+    assert_not klass.new(wibble: "97.179").valid?
+    assert_not klass.new(wibble: 97.179).valid?
+    assert_not klass.new(wibble: BigDecimal.new("97.179")).valid?
+  end
+
   def test_acceptance_validator_doesnt_require_db_connection
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "posts"


### PR DESCRIPTION
### Summary
Fixes a regression in Numericality validator where extra decimal places on a user input for a decimal column were ignored by numericality validations.
Introduced by https://github.com/rails/rails/pull/19851 

Solution is taken from a related, but different issue https://github.com/rails/rails/issues/29024#issuecomment-300881511

### Notes

Currently passing a string is working `Topic.new(wibble: "97.179")`, but passing a float or BigDecimal isn't.