### PR TITLE
Remove mentions of deprecated callbacks on ActionDispatch::Callbacks

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -493,8 +493,6 @@ encrypted cookies salt value. Defaults to `'signed encrypted cookie'`.
 
 * `ActionDispatch::Callbacks.before` takes a block of code to run before the request.
 
-* `ActionDispatch::Callbacks.to_prepare` takes a block to run after `ActionDispatch::Callbacks.before`, but before the request. Runs for every request in `development` mode, but only once for `production` or environments with `cache_classes` set to `true`.
-
 * `ActionDispatch::Callbacks.after` takes a block of code to run after the request.
 
 ### Configuring Action View
@@ -1188,7 +1186,7 @@ Below is a comprehensive list of all the initializers found in Rails in the orde
 
 * `finisher_hook`: Provides a hook for after the initialization of process of the application is complete, as well as running all the `config.after_initialize` blocks for the application, railties and engines.
 
-* `set_routes_reloader_hook`: Configures Action Dispatch to reload the routes file using `ActionDispatch::Callbacks.to_prepare`.
+* `set_routes_reloader_hook`: Configures Action Dispatch to reload the routes file using `ActiveSupport::Callbacks.to_run`.
 
 * `disable_dependency_loading`: Disables the automatic dependency loading if the `config.eager_load` is set to `true`.
 


### PR DESCRIPTION
ActionDispatch::Callbacks.to_prepare was removed in #27587, while `set_routes_reloader_hook` is now using the app's `reloader` instance (which is of type `ActiveSupport::Reloader`), instead of `ActionDispatch::Reloader`.