### PR TITLE
Remove a redundant test case of command_recorder_test

### DIFF
--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -211,11 +211,6 @@ module ActiveRecord
         assert_equal [:remove_index, [:table, { name: "new_index" }]], remove
       end
 
-      def test_invert_add_index_with_no_options
-        remove = @recorder.inverse_of :add_index, [:table, [:one, :two]]
-        assert_equal [:remove_index, [:table, { column: [:one, :two] }]], remove
-      end
-
       def test_invert_remove_index
         add = @recorder.inverse_of :remove_index, [:table, :one]
         assert_equal [:add_index, [:table, :one]], add


### PR DESCRIPTION
This PR will remove redundant test case in the following address.

- [test/cases/migration/command_recorder_test.rb#test_invert_add_index](https://github.com/rails/rails/blob/b404764e15586902597d66aca31c157185b4b3a1/activerecord/test/cases/migration/command_recorder_test.rb#L204-L207)
- [test/cases/migration/command_recorder_test.rb#test_invert_add_index_with_no_options](https://github.com/rails/rails/blob/b404764e15586902597d66aca31c157185b4b3a1/activerecord/test/cases/migration/command_recorder_test.rb#L214-L217)

`test_invert_add_index_with_no_options` method is a test added with the following commit.

https://github.com/rails/rails/commit/06436b2cade183db3a231150555c4c999ca2827a

Though these test cases were different depending on the presence or absence of `options: true`, it was removed with the following commit to be the same test case.

https://github.com/rails/rails/pull/14034/files#diff-9531a83a96f7d0e6d2611e8494f50c96
