### PR TITLE
Default Message Encryptor Cipher to AES-256-GCM From AES-256-CBC

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -630,7 +630,7 @@ module ActionDispatch
         secret = key_generator.generate_key(request.encrypted_cookie_salt || "")[0, ActiveSupport::MessageEncryptor.key_len]
         sign_secret = key_generator.generate_key(request.encrypted_signed_cookie_salt || "")
 
-        @legacy_encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret, digest: digest, serializer: ActiveSupport::MessageEncryptor::NullSerializer)
+        @legacy_encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret, cipher: "aes-256-cbc", digest: digest, serializer: ActiveSupport::MessageEncryptor::NullSerializer)
       end
 
       def decrypt_and_verify_legacy_encrypted_message(name, signed_message)

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -19,7 +19,17 @@ module ActiveSupport
   #   encrypted_data = crypt.encrypt_and_sign('my secret data')                  # => "NlFBTTMwOUV5UlA1QlNEN2xkY2d6eThYWWh..."
   #   crypt.decrypt_and_verify(encrypted_data)                                   # => "my secret data"
   class MessageEncryptor
-    DEFAULT_CIPHER = "aes-256-cbc"
+    class << self
+      attr_accessor :use_authenticated_message_encryption #:nodoc:
+
+      def default_cipher #:nodoc:
+        if use_authenticated_message_encryption
+          "aes-256-gcm"
+        else
+          "aes-256-cbc"
+        end
+      end
+    end
 
     module NullSerializer #:nodoc:
       def self.load(value)
@@ -45,7 +55,7 @@ module ActiveSupport
     OpenSSLCipherError = OpenSSL::Cipher::CipherError
 
     # Initialize a new MessageEncryptor. +secret+ must be at least as long as
-    # the cipher key size. For the default 'aes-256-cbc' cipher, this is 256
+    # the cipher key size. For the default 'aes-256-gcm' cipher, this is 256
     # bits. If you are using a user-entered secret, you can generate a suitable
     # key by using <tt>ActiveSupport::KeyGenerator</tt> or a similar key
     # derivation function.
@@ -66,7 +76,7 @@ module ActiveSupport
       sign_secret = signature_key_or_options.first
       @secret = secret
       @sign_secret = sign_secret
-      @cipher = options[:cipher] || DEFAULT_CIPHER
+      @cipher = options[:cipher] || self.class.default_cipher
       @digest = options[:digest] || "SHA1" unless aead_mode?
       @verifier = resolve_verifier
       @serializer = options[:serializer] || Marshal
@@ -85,7 +95,7 @@ module ActiveSupport
     end
 
     # Given a cipher, returns the key length of the cipher to help generate the key of desired size
-    def self.key_len(cipher = DEFAULT_CIPHER)
+    def self.key_len(cipher = default_cipher)
       OpenSSL::Cipher.new(cipher).key_len
     end
 

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -7,6 +7,13 @@ module ActiveSupport
 
     config.eager_load_namespaces << ActiveSupport
 
+    initializer "active_support.set_authenticated_message_encryption" do |app|
+      if app.config.active_support.respond_to?(:use_authenticated_message_encryption)
+        ActiveSupport::MessageEncryptor.use_authenticated_message_encryption =
+          app.config.active_support.use_authenticated_message_encryption
+      end
+    end
+
     initializer "active_support.reset_all_current_attributes_instances" do |app|
       app.reloader.before_class_unload { ActiveSupport::CurrentAttributes.clear_all }
       app.executor.to_run              { ActiveSupport::CurrentAttributes.reset_all }

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -92,6 +92,10 @@ module Rails
             action_dispatch.use_authenticated_cookie_encryption = true
           end
 
+          if respond_to?(:active_support)
+            active_support.use_authenticated_message_encryption = true
+          end
+
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_5_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_5_2.rb.tt
@@ -13,3 +13,7 @@
 # Use AES 256 GCM authenticated encryption for encrypted cookies.
 # Existing cookies will be converted on read then written with the new scheme.
 # Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = true
+
+# Use AES-256-GCM authenticated encryption as default cipher for encrypting messages
+# instead of AES-256-CBC, when use_authenticated_message_encryption is set to true.
+# Rails.application.config.active_support.use_authenticated_message_encryption = true


### PR DESCRIPTION
@kaspth 
Currently ActiveSupport::MessageEncryptor defaults to CBC encryption, but it could stand to benefit from defaulting to `aes-256-gcm` encryption for the same reasons as cookies.