### PR TITLE
Remove a redundant test assertion

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1094,12 +1094,6 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal authors(:david), assert_no_queries { posts[0].author }
 
     posts = assert_queries(2) do
-      Post.all.merge!(select: "distinct posts.*", includes: :author, joins: [:comments], where: "comments.body like 'Thank you%'", order: "posts.id").to_a
-    end
-    assert_equal [posts(:welcome)], posts
-    assert_equal authors(:david), assert_no_queries { posts[0].author }
-
-    posts = assert_queries(2) do
       Post.all.merge!(includes: :author, joins: { taggings: :tag }, where: "tags.name = 'General'", order: "posts.id").to_a
     end
     assert_equal posts(:welcome, :thinking), posts


### PR DESCRIPTION
This PR will remove redundant assertion in the following address.

https://github.com/rails/rails/blob/7a3db2ea15970e4c9c31a2b23303928aeadb391d/activerecord/test/cases/associations/eager_test.rb#L1090-L1100

L1090-L1094 and L1096-L1100 are the same.
