### PR TITLE
[ci skip] Add elm option of webpack to generator description

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -205,7 +205,7 @@ module Rails
     RESERVED_NAMES = %w[application destroy plugin runner test]
 
     class AppGenerator < AppBase # :nodoc:
-      WEBPACKS = %w( react vue angular )
+      WEBPACKS = %w( react vue angular elm )
 
       add_shared_options_for "application"
 


### PR DESCRIPTION
### Summary

Added elm option of webpack to generator description because webpacker supported elm.