### PR TITLE
Add option for class_attribute default

### DIFF
--- a/actioncable/lib/action_cable/channel/periodic_timers.rb
+++ b/actioncable/lib/action_cable/channel/periodic_timers.rb
@@ -4,8 +4,7 @@ module ActionCable
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :periodic_timers, instance_reader: false
-        self.periodic_timers = []
+        class_attribute :periodic_timers, instance_reader: false, default: []
 
         after_subscribe   :start_periodic_timers
         after_unsubscribe :stop_periodic_timers

--- a/actioncable/lib/action_cable/connection/identification.rb
+++ b/actioncable/lib/action_cable/connection/identification.rb
@@ -6,8 +6,7 @@ module ActionCable
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :identifiers
-        self.identifiers = Set.new
+        class_attribute :identifiers, default: Set.new
       end
 
       class_methods do

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -459,8 +459,7 @@ module ActionMailer
 
     helper ActionMailer::MailHelper
 
-    class_attribute :default_params
-    self.default_params = {
+    class_attribute :default_params, default: {
       mime_version: "1.0",
       charset:      "UTF-8",
       content_type: "text/plain",

--- a/actionmailer/lib/action_mailer/delivery_methods.rb
+++ b/actionmailer/lib/action_mailer/delivery_methods.rb
@@ -7,8 +7,6 @@ module ActionMailer
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :delivery_methods, :delivery_method
-
       # Do not make this inheritable, because we always want it to propagate
       cattr_accessor :raise_delivery_errors
       self.raise_delivery_errors = true
@@ -19,8 +17,8 @@ module ActionMailer
       cattr_accessor :deliver_later_queue_name
       self.deliver_later_queue_name = :mailers
 
-      self.delivery_methods = {}.freeze
-      self.delivery_method  = :smtp
+      class_attribute :delivery_methods, default: {}.freeze
+      class_attribute :delivery_method, default: :smtp
 
       add_delivery_method :smtp, Mail::SMTP,
         address:              "localhost",

--- a/actionpack/lib/abstract_controller/caching.rb
+++ b/actionpack/lib/abstract_controller/caching.rb
@@ -37,8 +37,7 @@ module AbstractController
       config_accessor :enable_fragment_cache_logging
       self.enable_fragment_cache_logging = false
 
-      class_attribute :_view_cache_dependencies
-      self._view_cache_dependencies = []
+      class_attribute :_view_cache_dependencies, default: []
       helper_method :view_cache_dependencies if respond_to?(:helper_method)
     end
 

--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -5,11 +5,8 @@ module AbstractController
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :_helpers
-      self._helpers = Module.new
-
-      class_attribute :_helper_methods
-      self._helper_methods = Array.new
+      class_attribute :_helpers, default: Module.new
+      class_attribute :_helper_methods, default: Array.new
     end
 
     class MissingHelperError < LoadError

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -208,8 +208,7 @@ module ActionController
       @_request.reset_session
     end
 
-    class_attribute :middleware_stack
-    self.middleware_stack = ActionController::MiddlewareStack.new
+    class_attribute :middleware_stack, default: ActionController::MiddlewareStack.new
 
     def self.inherited(base) # :nodoc:
       base.middleware_stack = middleware_stack.dup

--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -7,8 +7,7 @@ module ActionController
     include Head
 
     included do
-      class_attribute :etaggers
-      self.etaggers = []
+      class_attribute :etaggers, default: []
     end
 
     module ClassMethods

--- a/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
+++ b/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
@@ -22,8 +22,7 @@ module ActionController
     include ActionController::ConditionalGet
 
     included do
-      class_attribute :etag_with_template_digest
-      self.etag_with_template_digest = true
+      class_attribute :etag_with_template_digest, default: true
 
       ActiveSupport.on_load :action_view, yield: true do
         etag do |options|

--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -3,8 +3,7 @@ module ActionController #:nodoc:
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :_flash_types, instance_accessor: false
-      self._flash_types = []
+      class_attribute :_flash_types, instance_accessor: false, default: []
 
       delegate :flash, to: :request
       add_flash_types(:alert, :notice)

--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -53,9 +53,8 @@ module ActionController
     include AbstractController::Helpers
 
     included do
-      class_attribute :helpers_path, :include_all_helpers
-      self.helpers_path ||= []
-      self.include_all_helpers = true
+      class_attribute :helpers_path, default: []
+      class_attribute :include_all_helpers, default: true
     end
 
     module ClassMethods

--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -159,8 +159,7 @@ module ActionController
     end
 
     included do
-      class_attribute :_wrapper_options
-      self._wrapper_options = Options.from_hash(format: [])
+      class_attribute :_wrapper_options, default: Options.from_hash(format: [])
     end
 
     module ClassMethods

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -26,8 +26,7 @@ module ActionController
     RENDERERS = Set.new
 
     included do
-      class_attribute :_renderers
-      self._renderers = Set.new.freeze
+      class_attribute :_renderers, default: Set.new.freeze
     end
 
     # Used in <tt>ActionController::Base</tt>

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1606,14 +1606,15 @@ module ActionView
       include ModelNaming
 
       # The methods which wrap a form helper call.
-      class_attribute :field_helpers
-      self.field_helpers = [:fields_for, :fields, :label, :text_field, :password_field,
-                            :hidden_field, :file_field, :text_area, :check_box,
-                            :radio_button, :color_field, :search_field,
-                            :telephone_field, :phone_field, :date_field,
-                            :time_field, :datetime_field, :datetime_local_field,
-                            :month_field, :week_field, :url_field, :email_field,
-                            :number_field, :range_field]
+      class_attribute :field_helpers, default: [
+        :fields_for, :fields, :label, :text_field, :password_field,
+        :hidden_field, :file_field, :text_area, :check_box,
+        :radio_button, :color_field, :search_field,
+        :telephone_field, :phone_field, :date_field,
+        :time_field, :datetime_field, :datetime_local_field,
+        :month_field, :week_field, :url_field, :email_field,
+        :number_field, :range_field
+      ]
 
       attr_accessor :object_name, :object, :options
 

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -204,9 +204,9 @@ module ActionView
     include ActionView::Rendering
 
     included do
-      class_attribute :_layout, :_layout_conditions, instance_accessor: false
-      self._layout = nil
-      self._layout_conditions = {}
+      class_attribute :_layout
+      class_attribute :_layout_conditions, instance_accessor: false, default: {}
+
       _write_layout_method
     end
 

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -204,7 +204,7 @@ module ActionView
     include ActionView::Rendering
 
     included do
-      class_attribute :_layout
+      class_attribute :_layout, instance_accessor: false
       class_attribute :_layout_conditions, instance_accessor: false, default: {}
 
       _write_layout_method

--- a/actionview/lib/action_view/template/handlers/builder.rb
+++ b/actionview/lib/action_view/template/handlers/builder.rb
@@ -1,9 +1,7 @@
 module ActionView
   module Template::Handlers
     class Builder
-      # Default format used by Builder.
-      class_attribute :default_format
-      self.default_format = :xml
+      class_attribute :default_format, default: :xml
 
       def call(template)
         require_engine
@@ -14,7 +12,6 @@ module ActionView
       end
 
       private
-
         def require_engine # :doc:
           @required ||= begin
             require "builder"

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -9,16 +9,13 @@ module ActionView
 
         # Specify trim mode for the ERB compiler. Defaults to '-'.
         # See ERB documentation for suitable values.
-        class_attribute :erb_trim_mode
-        self.erb_trim_mode = "-"
+        class_attribute :erb_trim_mode, default: "-"
 
         # Default implementation used.
-        class_attribute :erb_implementation
-        self.erb_implementation = Erubi
+        class_attribute :erb_implementation, default: Erubi
 
         # Do not escape templates of these mime types.
-        class_attribute :escape_whitelist
-        self.escape_whitelist = ["text/plain"]
+        class_attribute :escape_whitelist, default: ["text/plain"]
 
         ENCODING_TAG = Regexp.new("\\A(<%#{ENCODING_FLAG}-?%>)[ \\t]*")
 

--- a/actionview/lib/action_view/view_paths.rb
+++ b/actionview/lib/action_view/view_paths.rb
@@ -3,9 +3,7 @@ module ActionView
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :_view_paths
-      self._view_paths = ActionView::PathSet.new
-      _view_paths.freeze
+      class_attribute :_view_paths, default: ActionView::PathSet.new.freeze
     end
 
     delegate :template_exists?, :any_templates?, :view_paths, :formats, :formats=,

--- a/activejob/lib/active_job/queue_name.rb
+++ b/activejob/lib/active_job/queue_name.rb
@@ -32,11 +32,8 @@ module ActiveJob
     end
 
     included do
-      class_attribute :queue_name, instance_accessor: false
-      class_attribute :queue_name_delimiter, instance_accessor: false
-
-      self.queue_name = default_queue_name
-      self.queue_name_delimiter = "_" # set default delimiter to '_'
+      class_attribute :queue_name, instance_accessor: false, default: default_queue_name
+      class_attribute :queue_name_delimiter, instance_accessor: false, default: "_"
     end
 
     # Returns the name of the queue the job will be run on.

--- a/activejob/lib/active_job/queue_priority.rb
+++ b/activejob/lib/active_job/queue_priority.rb
@@ -27,9 +27,7 @@ module ActiveJob
     end
 
     included do
-      class_attribute :priority, instance_accessor: false
-
-      self.priority = default_priority
+      class_attribute :priority, instance_accessor: false, default: default_priority
     end
 
     # Returns the priority that the job will be created with

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -68,9 +68,8 @@ module ActiveModel
     CALL_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?]?\z/
 
     included do
-      class_attribute :attribute_aliases, :attribute_method_matchers, instance_writer: false
-      self.attribute_aliases = {}
-      self.attribute_method_matchers = [ClassMethods::AttributeMethodMatcher.new]
+      class_attribute :attribute_aliases, instance_writer: false, default: {}
+      class_attribute :attribute_method_matchers, instance_writer: false, default: [ ClassMethods::AttributeMethodMatcher.new ]
     end
 
     module ClassMethods

--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -10,8 +10,7 @@ module ActiveModel
       included do
         extend ActiveModel::Naming
 
-        class_attribute :include_root_in_json, instance_writer: false
-        self.include_root_in_json = false
+        class_attribute :include_root_in_json, instance_writer: false, default: false
       end
 
       # Returns a hash representing the model. Some configuration can be

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -49,8 +49,7 @@ module ActiveModel
       private :validation_context=
       define_callbacks :validate, scope: :name
 
-      class_attribute :_validators, instance_writer: false
-      self._validators = Hash.new { |h, k| h[k] = [] }
+      class_attribute :_validators, instance_writer: false, default: Hash.new { |h, k| h[k] = [] }
     end
 
     module ClassMethods

--- a/activerecord/lib/active_record/attribute_decorators.rb
+++ b/activerecord/lib/active_record/attribute_decorators.rb
@@ -3,8 +3,7 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :attribute_type_decorations, instance_accessor: false # :internal:
-      self.attribute_type_decorations = TypeDecorator.new
+      class_attribute :attribute_type_decorations, instance_accessor: false, default: TypeDecorator.new # :internal:
     end
 
     module ClassMethods # :nodoc:

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -14,8 +14,7 @@ module ActiveRecord
           raise "You cannot include Dirty after Timestamp"
         end
 
-        class_attribute :partial_writes, instance_writer: false
-        self.partial_writes = true
+        class_attribute :partial_writes, instance_writer: false, default: true
 
         after_create { changes_internally_applied }
         after_update { changes_internally_applied }

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -57,11 +57,8 @@ module ActiveRecord
         mattr_accessor :time_zone_aware_attributes, instance_writer: false
         self.time_zone_aware_attributes = false
 
-        class_attribute :skip_time_zone_conversion_for_attributes, instance_writer: false
-        self.skip_time_zone_conversion_for_attributes = []
-
-        class_attribute :time_zone_aware_types, instance_writer: false
-        self.time_zone_aware_types = [:datetime, :time]
+        class_attribute :skip_time_zone_conversion_for_attributes, instance_writer: false, default: []
+        class_attribute :time_zone_aware_types, instance_writer: false, default: [ :datetime, :time ]
       end
 
       module ClassMethods

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -6,8 +6,7 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :attributes_to_define_after_schema_loads, instance_accessor: false # :internal:
-      self.attributes_to_define_after_schema_loads = {}
+      class_attribute :attributes_to_define_after_schema_loads, instance_accessor: false, default: {} # :internal:
     end
 
     module ClassMethods

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -29,8 +29,7 @@ module ActiveRecord
       # to your application.rb file:
       #
       #   ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans = false
-      class_attribute :emulate_booleans
-      self.emulate_booleans = true
+      class_attribute :emulate_booleans, default: true
 
       NATIVE_DATABASE_TYPES = {
         primary_key: "bigint auto_increment PRIMARY KEY",

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -95,8 +95,7 @@ module ActiveRecord
 
   module Enum
     def self.extended(base) # :nodoc:
-      base.class_attribute(:defined_enums, instance_writer: false)
-      base.defined_enums = {}
+      base.class_attribute(:defined_enums, instance_writer: false, default: {})
     end
 
     def inherited(base) # :nodoc:

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -878,20 +878,12 @@ module ActiveRecord
 
     included do
       class_attribute :fixture_path, instance_writer: false
-      class_attribute :fixture_table_names
-      class_attribute :fixture_class_names
-      class_attribute :use_transactional_tests
-      class_attribute :use_instantiated_fixtures # true, false, or :no_instances
-      class_attribute :pre_loaded_fixtures
-      class_attribute :config
-
-      self.fixture_table_names = []
-      self.use_instantiated_fixtures = false
-      self.pre_loaded_fixtures = false
-      self.config = ActiveRecord::Base
-
-      self.fixture_class_names = {}
-      self.use_transactional_tests = true
+      class_attribute :fixture_table_names, default: []
+      class_attribute :fixture_class_names, default: {}
+      class_attribute :use_transactional_tests, default: true
+      class_attribute :use_instantiated_fixtures, default: false # true, false, or :no_instances
+      class_attribute :pre_loaded_fixtures, default: false
+      class_attribute :config, default: ActiveRecord::Base
     end
 
     module ClassMethods

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -38,8 +38,7 @@ module ActiveRecord
     included do
       # Determines whether to store the full constant name including namespace when using STI.
       # This is true, by default.
-      class_attribute :store_full_sti_class, instance_writer: false
-      self.store_full_sti_class = true
+      class_attribute :store_full_sti_class, instance_writer: false, default: true
     end
 
     module ClassMethods

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -11,8 +11,7 @@ module ActiveRecord
       # versioning is off. Accepts any of the symbols in <tt>Time::DATE_FORMATS</tt>.
       #
       # This is +:usec+, by default.
-      class_attribute :cache_timestamp_format, instance_writer: false
-      self.cache_timestamp_format = :usec
+      class_attribute :cache_timestamp_format, instance_writer: false, default: :usec
 
       ##
       # :singleton-method:
@@ -20,8 +19,7 @@ module ActiveRecord
       # by a changing version in the #cache_version method.
       #
       # This is +false+, by default until Rails 6.0.
-      class_attribute :cache_versioning, instance_writer: false
-      self.cache_versioning = false
+      class_attribute :cache_versioning, instance_writer: false, default: false
     end
 
     # Returns a +String+, which Action Pack uses for constructing a URL to this

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -51,8 +51,7 @@ module ActiveRecord
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :lock_optimistically, instance_writer: false
-        self.lock_optimistically = true
+        class_attribute :lock_optimistically, instance_writer: false, default: true
       end
 
       def locking_enabled? #:nodoc:

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -130,26 +130,13 @@ module ActiveRecord
     included do
       mattr_accessor :primary_key_prefix_type, instance_writer: false
 
-      class_attribute :table_name_prefix, instance_writer: false
-      self.table_name_prefix = ""
-
-      class_attribute :table_name_suffix, instance_writer: false
-      self.table_name_suffix = ""
-
-      class_attribute :schema_migrations_table_name, instance_accessor: false
-      self.schema_migrations_table_name = "schema_migrations"
-
-      class_attribute :internal_metadata_table_name, instance_accessor: false
-      self.internal_metadata_table_name = "ar_internal_metadata"
-
-      class_attribute :protected_environments, instance_accessor: false
-      self.protected_environments = ["production"]
-
-      class_attribute :pluralize_table_names, instance_writer: false
-      self.pluralize_table_names = true
-
-      class_attribute :ignored_columns, instance_accessor: false
-      self.ignored_columns = [].freeze
+      class_attribute :table_name_prefix, instance_writer: false, default: ""
+      class_attribute :table_name_suffix, instance_writer: false, default: ""
+      class_attribute :schema_migrations_table_name, instance_accessor: false, default: "schema_migrations"
+      class_attribute :internal_metadata_table_name, instance_accessor: false, default: "ar_internal_metadata"
+      class_attribute :protected_environments, instance_accessor: false, default: [ "production" ]
+      class_attribute :pluralize_table_names, instance_writer: false, default: true
+      class_attribute :ignored_columns, instance_accessor: false, default: [].freeze
 
       self.inheritance_column = "type"
 

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -10,8 +10,7 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :nested_attributes_options, instance_writer: false
-      self.nested_attributes_options = {}
+      class_attribute :nested_attributes_options, instance_writer: false, default: {}
     end
 
     # = Active Record Nested Attributes

--- a/activerecord/lib/active_record/readonly_attributes.rb
+++ b/activerecord/lib/active_record/readonly_attributes.rb
@@ -3,8 +3,7 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :_attr_readonly, instance_accessor: false
-      self._attr_readonly = []
+      class_attribute :_attr_readonly, instance_accessor: false, default: []
     end
 
     module ClassMethods

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -8,10 +8,8 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :_reflections, instance_writer: false
-      class_attribute :aggregate_reflections, instance_writer: false
-      self._reflections = {}
-      self.aggregate_reflections = {}
+      class_attribute :_reflections, instance_writer: false, default: {}
+      class_attribute :aggregate_reflections, instance_writer: false, default: {}
     end
 
     def self.create(macro, name, scope, options, ar)

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -5,11 +5,8 @@ module ActiveRecord
 
       included do
         # Stores the default scope for the class.
-        class_attribute :default_scopes, instance_writer: false, instance_predicate: false
-        class_attribute :default_scope_override, instance_writer: false, instance_predicate: false
-
-        self.default_scopes = []
-        self.default_scope_override = nil
+        class_attribute :default_scopes, instance_writer: false, instance_predicate: false, default: []
+        class_attribute :default_scope_override, instance_writer: false, instance_predicate: false, default: nil
       end
 
       module ClassMethods

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -43,8 +43,7 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :record_timestamps
-      self.record_timestamps = true
+      class_attribute :record_timestamps, default: true
     end
 
     def initialize_dup(other) # :nodoc:

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add default option to class_attribute. Before:
+
+      class_attribute :settings
+      self.settings = {}
+
+    Now:
+
+      class_attribute :settings, default: {}
+
+    *DHH*
+
 *   `#singularize` and `#pluralize` now respect uncountables for the specified locale.
 
     *Eilis Hamilton*

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -62,8 +62,7 @@ module ActiveSupport
 
     included do
       extend ActiveSupport::DescendantsTracker
-      class_attribute :__callbacks, instance_writer: false
-      self.__callbacks ||= {}
+      class_attribute :__callbacks, instance_writer: false, default: {}
     end
 
     CALLBACK_FILTER_TYPES = [:before, :after, :around]

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -68,6 +68,10 @@ class Class
   #   object.setting = false  # => NoMethodError
   #
   # To opt out of both instance methods, pass <tt>instance_accessor: false</tt>.
+  #
+  # To set a default value for the attribute, pass <tt>default:</tt>, like so:
+  #
+  #   class_attribute :settings, default: {}
   def class_attribute(*attrs)
     options = attrs.extract_options!
     instance_reader    = options.fetch(:instance_accessor, true) && options.fetch(:instance_reader, true)

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -70,9 +70,10 @@ class Class
   # To opt out of both instance methods, pass <tt>instance_accessor: false</tt>.
   def class_attribute(*attrs)
     options = attrs.extract_options!
-    instance_reader = options.fetch(:instance_accessor, true) && options.fetch(:instance_reader, true)
-    instance_writer = options.fetch(:instance_accessor, true) && options.fetch(:instance_writer, true)
+    instance_reader    = options.fetch(:instance_accessor, true) && options.fetch(:instance_reader, true)
+    instance_writer    = options.fetch(:instance_accessor, true) && options.fetch(:instance_writer, true)
     instance_predicate = options.fetch(:instance_predicate, true)
+    default_value      = options.fetch(:default, nil)
 
     attrs.each do |name|
       remove_possible_singleton_method(name)
@@ -122,6 +123,10 @@ class Class
       if instance_writer
         remove_possible_method "#{name}="
         attr_writer name
+      end
+
+      if default_value
+        self.send("#{name}=", default_value)
       end
     end
   end

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -125,7 +125,7 @@ class Class
         attr_writer name
       end
 
-      if default_value
+      unless default_value.nil?
         self.send("#{name}=", default_value)
       end
     end

--- a/activesupport/lib/active_support/reloader.rb
+++ b/activesupport/lib/active_support/reloader.rb
@@ -69,11 +69,8 @@ module ActiveSupport
       end
     end
 
-    class_attribute :executor
-    class_attribute :check
-
-    self.executor = Executor
-    self.check = lambda { false }
+    class_attribute :executor, default: Executor
+    class_attribute :check, default: lambda { false }
 
     def self.check! # :nodoc:
       @should_reload ||= check.call

--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -8,8 +8,7 @@ module ActiveSupport
     extend Concern
 
     included do
-      class_attribute :rescue_handlers
-      self.rescue_handlers = []
+      class_attribute :rescue_handlers, default: []
     end
 
     module ClassMethods

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -3,13 +3,21 @@ require "active_support/core_ext/class/attribute"
 
 class ClassAttributeTest < ActiveSupport::TestCase
   def setup
-    @klass = Class.new { class_attribute :setting }
+    @klass = Class.new do
+      class_attribute :setting
+      class_attribute :timeout, default: 5
+    end
+
     @sub = Class.new(@klass)
   end
 
   test "defaults to nil" do
     assert_nil @klass.setting
     assert_nil @sub.setting
+  end
+
+  test "custom default" do
+    assert_equal 5, @klass.timeout
   end
 
   test "inheritable" do

--- a/railties/lib/rails/generators/testing/behaviour.rb
+++ b/railties/lib/rails/generators/testing/behaviour.rb
@@ -14,12 +14,12 @@ module Rails
         include ActiveSupport::Testing::Stream
 
         included do
-          class_attribute :destination_root, :current_path, :generator_class, :default_arguments
-
           # Generators frequently change the current path using +FileUtils.cd+.
           # So we need to store the path at file load and revert back to it after each test.
-          self.current_path = File.expand_path(Dir.pwd)
-          self.default_arguments = []
+          class_attribute :current_path, default: File.expand_path(Dir.pwd)
+          class_attribute :default_arguments, default: []
+          class_attribute :destination_root
+          class_attribute :generator_class
         end
 
         module ClassMethods

--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -3,8 +3,7 @@ require "minitest"
 
 module Rails
   class TestUnitReporter < Minitest::StatisticsReporter
-    class_attribute :executable
-    self.executable = "bin/rails test"
+    class_attribute :executable, default: "bin/rails test"
 
     def record(result)
       super


### PR DESCRIPTION
It's extremely common, as evidenced by the commit in this PR of Rails conversions, to set a default value for a class_attribute. So let's provide that directly.