### PR TITLE
Deserialize a raw value from the database in `changed_in_place?` for `AbstractJson`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -838,11 +838,6 @@ module ActiveRecord
         end
 
         class MysqlJson < Type::Internal::AbstractJson # :nodoc:
-          def changed_in_place?(raw_old_value, new_value)
-            # Normalization is required because MySQL JSON data format includes
-            # the space between the elements.
-            super(serialize(deserialize(raw_old_value)), new_value)
-          end
         end
 
         class MysqlString < Type::String # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/jsonb.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/jsonb.rb
@@ -6,16 +6,6 @@ module ActiveRecord
           def type
             :jsonb
           end
-
-          def changed_in_place?(raw_old_value, new_value)
-            # Postgres does not preserve insignificant whitespaces when
-            # round-tripping jsonb columns. This causes some false positives for
-            # the comparison here. Therefore, we need to parse and re-dump the
-            # raw value here to ensure the insignificant whitespaces are
-            # consistent with our encoder's output.
-            raw_old_value = serialize(deserialize(raw_old_value))
-            super(raw_old_value, new_value)
-          end
         end
       end
     end

--- a/activerecord/lib/active_record/type/internal/abstract_json.rb
+++ b/activerecord/lib/active_record/type/internal/abstract_json.rb
@@ -24,6 +24,10 @@ module ActiveRecord
           end
         end
 
+        def changed_in_place?(raw_old_value, new_value)
+          deserialize(raw_old_value) != new_value
+        end
+
         def accessor
           ActiveRecord::Store::StringKeyedHashAccessor
         end

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -160,6 +160,17 @@ module JSONSharedTestCases
     assert_not json.changed?
   end
 
+  def test_changes_in_place_with_ruby_object
+    time = Time.now.utc
+    json = JsonDataType.create!(payload: time)
+
+    json.reload
+    assert_not json.changed?
+
+    json.payload = time
+    assert_not json.changed?
+  end
+
   def test_assigning_string_literal
     json = JsonDataType.create!(payload: "foo")
     assert_equal "foo", json.payload


### PR DESCRIPTION
Splitted from #28416.

Structured type values sometimes caused representation problems (keys
sort order, spaces, etc). A raw value from the database should be
deserialized (normalized) to prevent the problems.