### PR TITLE
Bump RuboCop to 0.49.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ GEM
       redis (~> 3.3)
       resque (~> 1.26)
       rufus-scheduler (~> 3.2)
-    rubocop (0.49.0)
+    rubocop (0.49.1)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)


### PR DESCRIPTION
RuboCop 0.49.1 has been released.
https://github.com/bbatsov/rubocop/releases/tag/v0.49.1

This PR will bump RuboCop to 0.49.1.
There are no new offences in this change.

```console
% bundle exec rubocop -v
0.49.1
% bundle exec rubocop
Inspecting 2216 files
.........................................................................................
.........................................................................................
(snip)
.........................................................................................
.........................................................................................

2216 files inspected, no offenses detected
```