### PR TITLE
Reset time zone to previous value

### DIFF
--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -28,7 +28,14 @@ class CurrentAttributesTest < ActiveSupport::TestCase
     end
   end
 
-  setup { Current.reset }
+  setup do
+    @original_time_zone = Time.zone
+    Current.reset
+  end
+
+  teardown do
+    Time.zone = @original_time_zone
+  end
 
   test "read and write attribute" do
     Current.world = "world/1"


### PR DESCRIPTION
Since `CurrentAttributesTest` changed the global time zone, it is
necessary to restore the original value after changing the test.

The reproduction step:

```
./bin/test -w --seed 5549 test/current_attributes_test.rb test/core_ext/date_ext_test.rb
```