### PR TITLE
Fix UUID column with `null: true` and `default: nil`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -62,7 +62,7 @@ module ActiveRecord
         def quote_default_expression(value, column) # :nodoc:
           if value.is_a?(Proc)
             value.call
-          elsif column.type == :uuid && value.include?("()")
+          elsif column.type == :uuid && /\(\)/.match?(value)
             value # Does not quote function default values for UUID columns
           elsif column.respond_to?(:array?)
             value = type_cast_from_column(column, value)

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -63,6 +63,16 @@ class PostgresqlUUIDTest < ActiveRecord::PostgreSQLTestCase
     UUIDType.reset_column_information
   end
 
+  def test_add_column_with_null_true_and_default_nil
+    assert_nothing_raised do
+      connection.add_column :uuid_data_type, :thingy, :uuid, null: true, default: nil
+    end
+    UUIDType.reset_column_information
+    column = UUIDType.columns_hash["thingy"]
+    assert column.null
+    assert_nil column.default
+  end
+
   def test_data_type_of_uuid_types
     column = UUIDType.columns_hash["guid"]
     assert_equal :uuid, column.type


### PR DESCRIPTION
`quote_default_expression` can be passed nil value when `null: true` and
`default: nil`. This addressed in that case.

Fixes #29222.