### PR TITLE
Do not use UTF8 in test SecretsCommandTest#test_edit_secrets

### DIFF
--- a/railties/lib/rails/secrets.rb
+++ b/railties/lib/rails/secrets.rb
@@ -42,7 +42,7 @@ module Rails
         <<-end_of_template.strip_heredoc
           # See `secrets.yml` for tips on generating suitable keys.
           # production:
-          #  external_api_key: 1466aac22e6a869134be3d09b9e89232fc2c2289…
+          #  external_api_key: 1466aac22e6a869134be3d09b9e89232fc2c2289
 
         end_of_template
       end

--- a/railties/test/commands/secrets_test.rb
+++ b/railties/test/commands/secrets_test.rb
@@ -23,7 +23,7 @@ class Rails::Command::SecretsCommandTest < ActiveSupport::TestCase
 
     # Run twice to ensure encrypted secrets can be reread after first edit pass.
     2.times do
-      assert_match(/external_api_key: 1466aac22e6a869134be3d09b9e89232fc2c2289…/, run_edit_command)
+      assert_match(/external_api_key: 1466aac22e6a869134be3d09b9e89232fc2c2289/, run_edit_command)
     end
   end
 


### PR DESCRIPTION
### Summary

The test `SecretsCommandTest#test_edit_secrets` fails in case it gets executed with `LC_ALL=C` (non-UTF-8 system encoding). That is because it tries to `assert_match` UTF-8 character(triple dot).
I have removed those dots, as they are not relevant for the test nor for the `templates/config/secrets.yml.enc` file AFAIT.

I am not sure that this is the true solution for the problem, because `templates/config/secrets.yml.enc` can contain UTF-8 characters. I think these should be properly dealth with independently on current system encoding.