### PR TITLE
Prevent making bind param if casted value is nil

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Prevent making bind param if casted value is nil.
+
+    *Ryuta Kamizono*
+
 *   Deprecate passing arguments and block at the same time to `count` and `sum` in `ActiveRecord::Calculations`.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/relation/where_clause_factory.rb
+++ b/activerecord/lib/active_record/relation/where_clause_factory.rb
@@ -57,7 +57,7 @@ module ActiveRecord
             else
               column = klass.column_for_attribute(attribute)
 
-              binds << predicate_builder.send(:build_bind_param, attribute, value)
+              binds << predicate_builder.send(:build_bind_attribute, attribute, value)
               value = Arel::Nodes::BindParam.new
 
               predicate = if options[:case_sensitive]

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -60,6 +60,7 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_equal @book, Book.where(status: [:written]).first
     assert_not_equal @book, Book.where.not(status: :published).first
     assert_equal @book, Book.where.not(status: :written).first
+    assert_equal books(:ddd), Book.where(read_status: :forgotten).first
   end
 
   test "find via where with strings" do
@@ -69,6 +70,7 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_equal @book, Book.where(status: ["written"]).first
     assert_not_equal @book, Book.where.not(status: "published").first
     assert_equal @book, Book.where.not(status: "written").first
+    assert_equal books(:ddd), Book.where(read_status: "forgotten").first
   end
 
   test "build from scope" do

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -15,7 +15,7 @@ require "models/vertex"
 
 module ActiveRecord
   class WhereTest < ActiveRecord::TestCase
-    fixtures :posts, :edges, :authors, :author_addresses, :binaries, :essays, :cars, :treasures, :price_estimates
+    fixtures :posts, :edges, :authors, :author_addresses, :binaries, :essays, :cars, :treasures, :price_estimates, :topics
 
     def test_where_copies_bind_params
       author = authors(:david)
@@ -46,6 +46,10 @@ module ActiveRecord
       chefs = Chef.where(employable: cake_designers)
 
       assert_equal [chef], chefs.to_a
+    end
+
+    def test_where_with_casted_value_is_nil
+      assert_equal 4, Topic.where(last_read: "").count
     end
 
     def test_rewhere_on_root


### PR DESCRIPTION
If casted value is nil, generated SQL should be `IS NULL`. But currently
it is generated as `= NULL`. To prevent this behavior, avoid making bind
param if casted value is nil.

Fixes #28945.