### PR TITLE
Replace therubyracer with mini_racer

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -868,7 +868,7 @@ pre-existing JavaScript runtimes, you may want to add one to your Gemfile:
 
 ```ruby
 group :production do
-  gem 'therubyracer'
+  gem 'mini_racer'
 end
 ```
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -208,7 +208,7 @@ TIP: Compiling CoffeeScript and JavaScript asset compression requires you
 have a JavaScript runtime available on your system, in the absence
 of a runtime you will see an `execjs` error during asset compilation.
 Usually macOS and Windows come with a JavaScript runtime installed.
-Rails adds the `therubyracer` gem to the generated `Gemfile` in a
+Rails adds the `mini_racer` gem to the generated `Gemfile` in a
 commented line for new apps and you can uncomment if you need it.
 `therubyrhino` is the recommended runtime for JRuby users and is added by
 default to the `Gemfile` in apps generated under JRuby. You can investigate

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -349,7 +349,7 @@ module Rails
         if defined?(JRUBY_VERSION)
           GemfileEntry.version "therubyrhino", nil, comment
         else
-          GemfileEntry.new "therubyracer", nil, comment, { platforms: :ruby }, true
+          GemfileEntry.new "mini_racer", nil, comment, { platforms: :ruby }, true
         end
       end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -468,7 +468,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     if defined?(JRUBY_VERSION)
       assert_gem "therubyrhino"
     else
-      assert_file "Gemfile", /# gem 'therubyracer', platforms: :ruby/
+      assert_file "Gemfile", /# gem 'mini_racer', platforms: :ruby/
     end
   end
 


### PR DESCRIPTION
therubyracer is a relic, it depends on an ancient version of v8 that has multiple known security vulnerabilities

https://github.com/cowboyd/therubyracer/blob/master/therubyracer.gemspec#L20

In particular this is the equivalent of shipping a dependency to Chrome version 31.

Chrome 31 was released 2013-11-12

All places that talk about therubyracer or include it in templates should be replaced with mini_racer that depends on the most recent version of v8.

per: https://github.com/rails/rails/issues/29276#issuecomment-304743000