### PR TITLE
Fix random minitest error: database_statements_test

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -365,6 +365,7 @@ if Account.connection.respond_to?(:reset_pk_sequence!)
   class FixturesResetPkSequenceTest < ActiveRecord::TestCase
     fixtures :accounts
     fixtures :companies
+    self.use_transactional_tests = false
 
     def setup
       @instances = [Account.new(credit_limit: 50), Company.new(name: "RoR Consulting"), Course.new(name: "Test")]


### PR DESCRIPTION
### Issue
`ARCONN=postgresql bin/test test/cases/*test.rb --seed 48104`
With a seed of 48104, in Postgres the following test sequence fails from Duplicate Key issues:
```
FixturesResetPkSequenceTest#test_resets_to_min_pk_with_specified_pk_and_sequence) #Passes

DatabaseStatementsTest#test_create_should_return_the_inserted_id #Fails
DatabaseStatementsTest#test_exec_insert #Fails
DatabaseStatementsTest#test_insert_should_return_the_inserted_id #Fails
```

The fixtures tests creates accounts, and the database statements tests insert into the accounts table, but they are not getting the correctly incremented primary keys from the connection. This causes the DuplicateKey issues.
### Fix
The `DatabaseStatements` tests need to sync the connection to Postgres in order to use the correct `next_sequence` primary keys.