### PR TITLE
HashWithIndifferentAccess implement symbolize_keys

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -263,8 +263,8 @@ module ActiveSupport
     def deep_stringify_keys!; self end
     def stringify_keys; dup end
     def deep_stringify_keys; dup end
-    undef :symbolize_keys!
-    undef :deep_symbolize_keys!
+    def symbolize_keys!; self end
+    def deep_symbolize_keys!; self end
     def symbolize_keys; to_hash.symbolize_keys! end
     def deep_symbolize_keys; to_hash.deep_symbolize_keys! end
     def to_options!; self end

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -63,35 +63,41 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
   end
 
   def test_symbolize_keys_bang_for_hash_with_indifferent_access
-    assert_raise(NoMethodError) { @symbols.with_indifferent_access.dup.symbolize_keys! }
-    assert_raise(NoMethodError) { @strings.with_indifferent_access.dup.symbolize_keys! }
-    assert_raise(NoMethodError) { @mixed.with_indifferent_access.dup.symbolize_keys! }
+    @strings = @strings.with_indifferent_access
+    @symbols = @symbols.with_indifferent_access
+    @mixed   = @mixed.with_indifferent_access
+    assert_equal @symbols, @symbols.dup.symbolize_keys!
+    assert_equal @strings, @strings.dup.symbolize_keys!
+    assert_equal @mixed, @mixed.dup.symbolize_keys!
   end
 
   def test_deep_symbolize_keys_bang_for_hash_with_indifferent_access
-    assert_raise(NoMethodError) { @nested_symbols.with_indifferent_access.deep_dup.deep_symbolize_keys! }
-    assert_raise(NoMethodError) { @nested_strings.with_indifferent_access.deep_dup.deep_symbolize_keys! }
-    assert_raise(NoMethodError) { @nested_mixed.with_indifferent_access.deep_dup.deep_symbolize_keys! }
+    @nested_strings = @nested_strings.with_indifferent_access
+    @nested_symbols = @nested_symbols.with_indifferent_access
+    @nested_mixed   = @nested_mixed.with_indifferent_access
+    assert_equal @nested_symbols, @nested_symbols.deep_dup.deep_symbolize_keys!
+    assert_equal @nested_strings, @nested_strings.deep_dup.deep_symbolize_keys!
+    assert_equal @nested_mixed, @nested_mixed.deep_dup.deep_symbolize_keys!
   end
 
   def test_symbolize_keys_preserves_keys_that_cant_be_symbolized_for_hash_with_indifferent_access
     assert_equal @illegal_symbols, @illegal_symbols.with_indifferent_access.symbolize_keys
-    assert_raise(NoMethodError) { @illegal_symbols.with_indifferent_access.dup.symbolize_keys! }
+    assert_equal @illegal_symbols, @illegal_symbols.with_indifferent_access.dup.symbolize_keys!
   end
 
   def test_deep_symbolize_keys_preserves_keys_that_cant_be_symbolized_for_hash_with_indifferent_access
     assert_equal @nested_illegal_symbols, @nested_illegal_symbols.with_indifferent_access.deep_symbolize_keys
-    assert_raise(NoMethodError) { @nested_illegal_symbols.with_indifferent_access.deep_dup.deep_symbolize_keys! }
+    assert_equal @nested_illegal_symbols, @nested_illegal_symbols.with_indifferent_access.deep_dup.deep_symbolize_keys!
   end
 
   def test_symbolize_keys_preserves_integer_keys_for_hash_with_indifferent_access
     assert_equal @integers, @integers.with_indifferent_access.symbolize_keys
-    assert_raise(NoMethodError) { @integers.with_indifferent_access.dup.symbolize_keys! }
+    assert_equal @integers, @integers.with_indifferent_access.dup.symbolize_keys!
   end
 
   def test_deep_symbolize_keys_preserves_integer_keys_for_hash_with_indifferent_access
     assert_equal @nested_integers, @nested_integers.with_indifferent_access.deep_symbolize_keys
-    assert_raise(NoMethodError) { @nested_integers.with_indifferent_access.deep_dup.deep_symbolize_keys! }
+    assert_equal @nested_integers, @nested_integers.with_indifferent_access.deep_dup.deep_symbolize_keys!
   end
 
   def test_stringify_keys_for_hash_with_indifferent_access


### PR DESCRIPTION
### Summary

HashWithIndifferentAccess inherits from Hash, yet doesn't support
it's full public interface. This prevents users from doing things like
duck typing. This commit implements symbolize_keys! and
deep_symbolize_keys! to return self.
