### PR TITLE
Add note to Railtie docs to use unique filenames

### DIFF
--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -103,6 +103,9 @@ module Rails
   #     end
   #   end
   #
+  # Since filenames on the load path are shared across gems, be sure that files you load
+  # through a railtie have unique names.
+  #
   # == Application and Engine
   #
   # An engine is nothing more than a railtie with some initializers already set. And since


### PR DESCRIPTION
The fact that the names need to be globally unique was not obvious to me, so I
thought it'd be worth documenting. This not being clear was the cause of both
ctran/annotate_models#468 and instructure/outrigger#1.

[ci skip]