### PR TITLE
Remove a redundant test case of HABTM_associations_test

### DIFF
--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -367,19 +367,6 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_equal Developer.find(1).projects.sort_by(&:id).last, proj  # prove join table is updated
   end
 
-  def test_create_by_new_record
-    devel = Developer.new(name: "Marcel", salary: 75000)
-    devel.projects.build(name: "Make bed")
-    proj2 = devel.projects.build(name: "Lie in it")
-    assert_equal devel.projects.last, proj2
-    assert !proj2.persisted?
-    devel.save
-    assert devel.persisted?
-    assert proj2.persisted?
-    assert_equal devel.projects.last, proj2
-    assert_equal Developer.find_by_name("Marcel").projects.last, proj2  # prove join table is updated
-  end
-
   def test_creation_respects_hash_condition
     # in Oracle '' is saved as null therefore need to save ' ' in not null column
     post = categories(:general).post_with_conditions.build(body: " ")


### PR DESCRIPTION
This PR will remove a redundant test case in the following address.

- [test/cases/associations/has_and_belongs_to_many_associations_test.rb#test_build_by_new_record](https://github.com/rails/rails/blob/ac3c04513ed3e9c47c14f1d33db02b1e3b4031b8/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb#L345-L356)
- [test/cases/associations/has_and_belongs_to_many_associations_test.rb#test_create_by_new_record](https://github.com/rails/rails/blob/ac3c04513ed3e9c47c14f1d33db02b1e3b4031b8/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb#L370-L381)

These are redundant at the time of the following commit already.

https://github.com/rails/rails/commit/5b822aca4b6524c9147224764ec0f20a728ba2a1#diff-00b60cfcb7d1660f2461ec7fe80f3f0fR220

In this PR, it leave intentional test name `test_build_by_new_record`. And `test_create_by_new_record` is removed.