### PR TITLE
Docs: Fix output representation [ci skip]

### DIFF
--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -19,10 +19,10 @@ module ActiveModel
     #   cat = Cat.new
     #   cat.assign_attributes(name: "Gorby", status: "yawning")
     #   cat.name # => 'Gorby'
-    #   cat.status => 'yawning'
+    #   cat.status # => 'yawning'
     #   cat.assign_attributes(status: "sleeping")
     #   cat.name # => 'Gorby'
-    #   cat.status => 'sleeping'
+    #   cat.status # => 'sleeping'
     def assign_attributes(new_attributes)
       if !new_attributes.respond_to?(:stringify_keys)
         raise ArgumentError, "When assigning attributes, you must pass a hash as an argument."


### PR DESCRIPTION
### Summary

The output of two string attributes is displayed differently in the docs. Standardize the output by always showing it as a comment.

I was reading the docs and the different output was confusing as to whether "status" attribute was special or not.
http://api.rubyonrails.org/classes/ActiveModel/AttributeAssignment.html#method-i-assign_attributes

Turns out it's the same like "name" attribute, but just its output was displayed slightly different.
