### PR TITLE
Fix `default_scoped` with defined `default_scope` on STI model

### DIFF
--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -107,7 +107,11 @@ module ActiveRecord
 
             if default_scope_override
               # The user has defined their own default scope method, so call that
-              evaluate_default_scope { default_scope }
+              evaluate_default_scope do
+                if scope = default_scope
+                  (base_rel ||= relation).merge(scope)
+                end
+              end
             elsif default_scopes.any?
               base_rel ||= relation
               evaluate_default_scope do

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -1,6 +1,7 @@
 require "cases/helper"
 require "models/author"
 require "models/company"
+require "models/membership"
 require "models/person"
 require "models/post"
 require "models/project"
@@ -29,7 +30,7 @@ end
 
 class InheritanceTest < ActiveRecord::TestCase
   include InheritanceTestHelper
-  fixtures :companies, :projects, :subscribers, :accounts, :vegetables
+  fixtures :companies, :projects, :subscribers, :accounts, :vegetables, :memberships
 
   def test_class_with_store_full_sti_class_returns_full_name
     with_store_full_sti_class do
@@ -434,6 +435,10 @@ class InheritanceTest < ActiveRecord::TestCase
   def test_scope_inherited_properly
     assert_nothing_raised { Company.of_first_firm }
     assert_nothing_raised { Client.of_first_firm }
+  end
+
+  def test_inheritance_with_default_scope
+    assert_equal 1, SelectedMembership.count(:all)
   end
 end
 


### PR DESCRIPTION
This regression is caused by d1249c1.
https://travis-ci.org/rails/rails/jobs/237430597#L635

If STI model is defined `default_scope`, `base_rel` is not respected.
I fixed to merge `base_rel` in that case.