### PR TITLE
Ensure fixtures are loaded for FoxyFixturesTest

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -809,6 +809,8 @@ class FasterFixturesTest < ActiveRecord::TestCase
 end
 
 class FoxyFixturesTest < ActiveRecord::TestCase
+  # Set to false to blow away fixtures cache and ensure our fixtures are loaded
+  self.use_transactional_tests = false
   fixtures :parrots, :parrots_pirates, :pirates, :treasures, :mateys, :ships, :computers,
            :developers, :"admin/accounts", :"admin/users", :live_parrots, :dead_parrots, :books
 


### PR DESCRIPTION
*NOTE: Related to the **Unlock minitest for Rails' test suite** PR - https://github.com/rails/rails/pull/29271*

## Failing Seed
`bin/test --seed 59389 test/cases/fixtures_test.rb`
When tests are randomized, sometimes FoxyFixturesTests are failing due to unloaded
fixtures.

## Solution
I followed along with what many of the other tests are doing  in the file to bypass this issue by using `self.use_transactional_tests = false`.
