### PR TITLE
The receiver in a scope should be a `relation`

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -160,7 +160,7 @@ module ActiveRecord
           if body.respond_to?(:to_proc)
             singleton_class.send(:define_method, name) do |*args|
               scope = all
-              scope = scope.scoping { instance_exec(*args, &body) || scope }
+              scope = scope.instance_exec(*args, &body) || scope
               scope = scope.extending(extension) if extension
               scope
             end


### PR DESCRIPTION
Currently the receiver in a scope is `klass`, not `relation`.

https://github.com/rails/rails/blob/v5.1.1/activerecord/lib/active_record/scoping/named.rb#L159

I think it is a strange because the receiver in `default_scope` and a
scope on association is `relation`.

https://github.com/rails/rails/blob/v5.1.1/activerecord/lib/active_record/scoping/default.rb#L119
https://github.com/rails/rails/blob/v5.1.1/activerecord/lib/active_record/associations/association_scope.rb#L164

I fixed to the receiver is to be a `relation` properly for consistency.