### PR TITLE
Use File.dirname(__dir__) where appropriate

### DIFF
--- a/actioncable/bin/test
+++ b/actioncable/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
+COMPONENT_ROOT = File.dirname(__dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)

--- a/actionmailer/bin/test
+++ b/actionmailer/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
+COMPONENT_ROOT = File.dirname(__dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)

--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -9,7 +9,7 @@ end
 
 module Rails
   def self.root
-    File.expand_path("..", __dir__)
+    File.dirname(__dir__)
   end
 end
 

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -26,7 +26,7 @@ namespace :test do
 end
 
 task :lines do
-  load File.expand_path("..", __dir__) + "/tools/line_statistics"
+  load File.join(File.dirname(__dir__), "/tools/line_statistics")
   files = FileList["lib/**/*.rb"]
   CodeTools::LineStatistics.new(files).print_loc
 end

--- a/actionpack/bin/test
+++ b/actionpack/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
+COMPONENT_ROOT = File.dirname(__dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -128,7 +128,7 @@ namespace :assets do
 end
 
 task :lines do
-  load File.join(File.expand_path("..", __dir__), "/tools/line_statistics")
+  load File.join(File.dirname(__dir__), "/tools/line_statistics")
   files = FileList["lib/**/*.rb"]
   CodeTools::LineStatistics.new(files).print_loc
 end

--- a/actionview/bin/test
+++ b/actionview/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
+COMPONENT_ROOT = File.dirname(__dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)

--- a/actionview/lib/action_view/dependency_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker.rb
@@ -154,7 +154,7 @@ module ActionView
 
           wildcard_dependencies.flat_map { |query, templates|
             @view_paths.find_all_with_query(query).map do |template|
-              "#{File.dirname(query)}/#{File.basename(template).split('.').first}"
+              "#{File.join(File.dirname(query), File.basename(template).split('.').first)}"
             end
           }.sort
         end

--- a/activejob/bin/test
+++ b/activejob/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
+COMPONENT_ROOT = File.dirname(__dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)

--- a/activemodel/bin/test
+++ b/activemodel/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
+COMPONENT_ROOT = File.dirname(__dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -134,7 +134,7 @@ task drop_postgresql_databases: "db:postgresql:drop"
 task rebuild_postgresql_databases: "db:postgresql:rebuild"
 
 task :lines do
-  load File.expand_path("../tools/line_statistics", __dir__)
+  load File.join(File.dirname(__dir__), "/tools/line_statistics")
   files = FileList["lib/active_record/**/*.rb"]
   CodeTools::LineStatistics.new(files).print_loc
 end

--- a/activerecord/bin/test
+++ b/activerecord/bin/test
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
+COMPONENT_ROOT = File.dirname(__dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)
 
 module Minitest

--- a/activesupport/bin/test
+++ b/activesupport/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
+COMPONENT_ROOT = File.dirname(__dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -66,7 +66,7 @@ module RailsGuides
       end
 
       def initialize_dirs
-        @guides_dir = File.expand_path("..", __dir__)
+        @guides_dir = File.dirname(__dir__)
 
         @source_dir  = "#{@guides_dir}/source"
         @source_dir += "/#{@language}" if @language

--- a/railties/bin/test
+++ b/railties/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
+COMPONENT_ROOT = File.dirname(__dir__)
 require File.expand_path("../tools/test", COMPONENT_ROOT)

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -1,7 +1,7 @@
 FRAMEWORKS = %w( activesupport activemodel activerecord actionview actionpack activejob actionmailer actioncable railties )
 FRAMEWORK_NAMES = Hash.new { |h, k| k.split(/(?<=active|action)/).map(&:capitalize).join(" ") }
 
-root    = File.expand_path("..", __dir__)
+root    = File.dirname(__dir__)
 version = File.read("#{root}/RAILS_VERSION").strip
 tag     = "v#{version}"
 gem_version = Gem::Version.new(version)


### PR DESCRIPTION
It's more direct than File.expand_path('..', __dir__)

Also use File.join in a few appropriate places - as of this change
/tools/line_statistics is loaded consistently across all rakefiles.