### PR TITLE
Should use `quote` for a string literal

### DIFF
--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -42,7 +42,7 @@ module ActiveRecord
 
         ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
         if ignore_tables.any?
-          condition = ignore_tables.map { |table| connection.quote_table_name(table) }.join(", ")
+          condition = ignore_tables.map { |table| connection.quote(table) }.join(", ")
           args << "SELECT sql FROM sqlite_master WHERE tbl_name NOT IN (#{condition}) ORDER BY tbl_name, type DESC, name"
         else
           args << ".schema"


### PR DESCRIPTION
Follow up of #29077.

Before:

```sql
SELECT sql FROM sqlite_master WHERE tbl_name NOT IN ("foo") ORDER BY tbl_name, type DESC, name
```

After:

```sql
SELECT sql FROM sqlite_master WHERE tbl_name NOT IN ('foo') ORDER BY tbl_name, type DESC, name
```

> If a keyword in double quotes (ex: "key" or "glob") is used in a
context where it cannot be resolved to an identifier but where a string
literal is allowed, then the token is understood to be a string literal
instead of an identifier.

http://www.sqlite.org/lang_keywords.html