### PR TITLE
Add test and fix for blank Rails.configuration.database_configuration

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -156,7 +156,7 @@ module Rails
         elsif ENV["DATABASE_URL"]
           # Value from ENV['DATABASE_URL'] is set to default database connection
           # by Active Record.
-          {}
+          ActiveRecord::Base.configurations
         else
           raise "Could not load database configuration. No such file - #{paths["config/database"].instance_variable_get(:@paths)}"
         end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1441,6 +1441,34 @@ module ApplicationTests
       assert_equal "dev_db",  ar_config["development"]["database"]
     end
 
+    test "configuration.database_configuration with only ENV['DATABASE_URL'] is not blank" do
+      FileUtils.rm("#{app_path}/config/database.yml")
+      app "development"
+
+      ENV["DATABASE_URL"] = "postgresql://user:pass@127.0.0.1/my_app?encoding=utf8&pool=5&wait_timeout=5"
+
+      expected_config = {
+        "development" => {
+          "adapter"      => "postgresql",
+          "username"     => "user",
+          "password"     => "pass",
+          "host"         => "127.0.0.1",
+          "database"     => "my_app",
+          "encoding"     => "utf8",
+          "pool"         => "5",
+          "wait_timeout" => "5"
+        }
+      }
+
+      app_config = Rails.application.config.database_configuration
+      ar_config  = ActiveRecord::Base.configurations
+
+      assert_equal expected_config, ar_config
+      assert_equal expected_config, app_config
+
+      ENV.delete("DATABASE_URL")
+    end
+
     test "config.action_mailer.show_previews defaults to true in development" do
       app "development"
 


### PR DESCRIPTION
### Steps to reproduce
```bash
$ rails new --skip-test --skip-action-mailer --skip-action-cable --api -d postgresql myproject
$ rm -f config/database.yml
$ export DATABASE_URL="postgresql://user:pass@127.0.0.1/myproject?encoding=utf8&pool=5&wait_timeout=5"
$ rake db:create
$ rails c
```
### Before
```ruby
irb(main):001:0> ActiveRecord::Base.configurations
=> {"development"=>{"encoding"=>"utf8", "pool"=>"5", "wait_timeout"=>"5", "adapter"=>"postgresql", "username"=>"user", "password"=>"pass", "database"=>"myproject", "host"=>"127.0.0.1"}}
irb(main):002:0> Rails.configuration.database_configuration
=> {}
```
### After
```ruby
irb(main):001:0> ActiveRecord::Base.configurations
=> {"development"=>{"encoding"=>"utf8", "pool"=>"5", "wait_timeout"=>"5", "adapter"=>"postgresql", "username"=>"user", "password"=>"pass", "database"=>"myproject", "host"=>"127.0.0.1"}}
irb(main):002:0> Rails.configuration.database_configuration
=> {"development"=>{"encoding"=>"utf8", "pool"=>"5", "wait_timeout"=>"5", "adapter"=>"postgresql", "username"=>"user", "password"=>"pass", "database"=>"myproject", "host"=>"127.0.0.1"}}
```
### System configuration
**Rails version**: 5.0.3

**Ruby version**: 2.3.3

It looks like this was broken by https://github.com/rails/rails/commit/dd5a80dc3da794f9296ec199c492a398589257a0 and some people have [noticed](https://github.com/rails/rails/commit/dd5a80dc3da794f9296ec199c492a398589257a0#commitcomment-3129485), but it has not been fixed.