### PR TITLE
Correct a has_many association test

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1355,7 +1355,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     Client.create(client_of: firm.id, name: "SmallTime Inc.")
     # only one of two clients is included in the association due to the :conditions key
     assert_equal 2, Client.where(client_of: firm.id).size
-    assert_equal 1, firm.dependent_sanitized_conditional_clients_of_firm.size
+    assert_equal 1, firm.dependent_hash_conditional_clients_of_firm.size
     firm.destroy
     # only the correctly associated client should have been deleted
     assert_equal 1, Client.where(client_of: firm.id).size

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -175,6 +175,7 @@ end
 class ExclusivelyDependentFirm < Company
   has_one :account, foreign_key: "firm_id", dependent: :delete
   has_many :dependent_sanitized_conditional_clients_of_firm, -> { order("id").where("name = 'BigShot Inc.'") }, foreign_key: "client_of", class_name: "Client", dependent: :delete_all
+  has_many :dependent_hash_conditional_clients_of_firm, -> { order("id").where(name: "BigShot Inc.") }, foreign_key: "client_of", class_name: "Client", dependent: :delete_all
   has_many :dependent_conditional_clients_of_firm, -> { order("id").where("name = ?", "BigShot Inc.") }, foreign_key: "client_of", class_name: "Client", dependent: :delete_all
 end
 


### PR DESCRIPTION
The changed test `test_dependent_association_respects_optional_hash_conditions_on_delete` seems to have been added by the following commit, but it looks like it was wrong.

https://github.com/rails/rails/commit/b17b9371c6a26484eb1984d45acffcdcd91b1ae1#diff-f51660d918ba5921aaae392122026533

Because it is the same as the [`test_dependent_association_respects_optional_sanitized_conditions_on_delete`](https://github.com/rails/rails/blob/908b136cf27aeb38b06dc98e7d2215d852ffc962/activerecord/test/cases/associations/has_many_associations_test.rb#L1340-L1350) test case.

This PR will correct it so that I think it was originally intended.
