### PR TITLE
Add bootsnap to default Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ gem "libxml-ruby", platforms: :ruby
 # Action View. For testing Erubis handler deprecation.
 gem "erubis", "~> 2.7.0", require: false
 
+# for railties app_generator_test
+gem "bootsnap", ">= 1.1.0", require: false
+
 # Active Job.
 group :job do
   gem "resque", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,8 @@ GEM
       childprocess
       faraday
       selenium-webdriver
+    bootsnap (1.1.0)
+      msgpack (~> 1.0)
     builder (3.2.3)
     bunny (2.6.2)
       amq-protocol (>= 2.0.1)
@@ -217,6 +219,7 @@ GEM
     mocha (0.14.0)
       metaclass (~> 0.0.1)
     mono_logger (1.1.0)
+    msgpack (1.1.0)
     multi_json (1.12.1)
     multipart-post (2.0.0)
     mustache (1.0.3)
@@ -384,6 +387,7 @@ DEPENDENCIES
   benchmark-ips
   blade
   blade-sauce_labs_plugin
+  bootsnap (>= 1.1.0)
   byebug
   capybara (~> 2.13)
   coffee-rails

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `bootsnap` to default `Gemfile`.
+
+    *Burke Libbey*
+
 *   Properly expand shortcuts for environment's name running the `console`
     and `dbconsole` commands.
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -19,6 +19,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# Reduces boot times through caching; required in config/boot.rb
+gem 'bootsnap', '>= 1.1.0', require: false
+
 <%- if options.api? -%>
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'

--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
This adds [bootsnap](https://github.com/Shopify/bootsnap) to newly-generated projects, which [generally reduces application boot times by over 50%](https://github.com/Shopify/bootsnap#quick-performance-overview).

---

I heard through the grapevine that people would be open to this.

Early releases of bootsnap only supported macOS, but recent versions now additionally support linux and (at least in theory) most *BSDs. Windows support is still not implemented.

This change is small, but not trivial, and it's been a long time since I've been in this codebase. I'm looking for guidance on how best to get this change documented, tested, and merged.

cc @rafaelfranca 