### PR TITLE
SystemTesting::Driver can register capybara-webkit and poltergeist

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   `driven_by` now registers poltergeist and capybara-webkit
+
+    If driver poltergeist or capybara-webkit is set for System Tests,
+    `driven_by` will register the driver and set additional options passed via
+    `:options` param.
+
+    Refer to drivers documentation to learn what options can be passed.
+
+    *Mario Chavez*
+
 *   AEAD encrypted cookies and sessions with GCM
 
     Encrypted cookies now use AES-GCM which couples authentication and

--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -67,13 +67,17 @@ module ActionDispatch
   # To use a headless driver, like Poltergeist, update your Gemfile to use
   # Poltergeist instead of Selenium and then declare the driver name in the
   # +application_system_test_case.rb+ file. In this case you would leave out the +:using+
-  # option because the driver is headless.
+  # option because the driver is headless, but you can still use
+  # +:screen_size+ to change the size of the browser screen, also you can use
+  # +:options+ to pass options supported by the driver. Please refeer to your
+  # driver documentation to learn about supported options.
   #
   #   require "test_helper"
   #   require "capybara/poltergeist"
   #
   #   class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  #     driven_by :poltergeist
+  #     driven_by :poltergeist, screen_size: [1400, 1400], options:
+  #     { js_errors: true }
   #   end
   #
   # Because <tt>ActionDispatch::SystemTestCase</tt> is a shim between Capybara

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -9,20 +9,39 @@ module ActionDispatch
       end
 
       def use
-        register if selenium?
+        register unless rack_test?
+
         setup
       end
 
       private
-        def selenium?
-          @name == :selenium
+        def rack_test?
+          @name == :rack_test
         end
 
         def register
           Capybara.register_driver @name do |app|
-            Capybara::Selenium::Driver.new(app, { browser: @browser }.merge(@options)).tap do |driver|
-              driver.browser.manage.window.size = Selenium::WebDriver::Dimension.new(*@screen_size)
+            case @name
+            when :selenium then register_selenium(app)
+            when :poltergeist then register_poltergeist(app)
+            when :webkit then register_webkit(app)
             end
+          end
+        end
+
+        def register_selenium(app)
+          Capybara::Selenium::Driver.new(app, { browser: @browser }.merge(@options)).tap do |driver|
+            driver.browser.manage.window.size = Selenium::WebDriver::Dimension.new(*@screen_size)
+          end
+        end
+
+        def register_poltergeist(app)
+          Capybara::Poltergeist::Driver.new(app, @options.merge(window_size: @screen_size))
+        end
+
+        def register_webkit(app)
+          Capybara::Webkit::Driver.new(app, Capybara::Webkit::Configuration.to_hash.merge(@options)).tap do |driver|
+            driver.resize_window(*@screen_size)
           end
         end
 

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -15,7 +15,21 @@ class DriverTest < ActiveSupport::TestCase
     assert_equal ({ url: "http://example.com/wd/hub" }), driver.instance_variable_get(:@options)
   end
 
-  test "selenium? returns false if driver is poltergeist" do
-    assert_not ActionDispatch::SystemTesting::Driver.new(:poltergeist).send(:selenium?)
+  test "initializing the driver with a poltergeist" do
+    driver = ActionDispatch::SystemTesting::Driver.new(:poltergeist, screen_size: [1400, 1400], options: { js_errors: false })
+    assert_equal :poltergeist, driver.instance_variable_get(:@name)
+    assert_equal [1400, 1400], driver.instance_variable_get(:@screen_size)
+    assert_equal ({ js_errors: false }), driver.instance_variable_get(:@options)
+  end
+
+  test "initializing the driver with a webkit" do
+    driver = ActionDispatch::SystemTesting::Driver.new(:webkit, screen_size: [1400, 1400], options: { skip_image_loading: true })
+    assert_equal :webkit, driver.instance_variable_get(:@name)
+    assert_equal [1400, 1400], driver.instance_variable_get(:@screen_size)
+    assert_equal ({ skip_image_loading: true }), driver.instance_variable_get(:@options)
+  end
+
+  test "rack_test? returns false if driver is poltergeist" do
+    assert_not ActionDispatch::SystemTesting::Driver.new(:poltergeist).send(:rack_test?)
   end
 end

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -660,8 +660,9 @@ end
 
 The driver name is a required argument for `driven_by`. The optional arguments
 that can be passed to `driven_by` are `:using` for the browser (this will only
-be used by Selenium), and `:screen_size` to change the size of the screen for
-screenshots.
+be used by Selenium), `:screen_size` to change the size of the screen for
+screenshots, and `:options` which can be used to set options supported by the
+driver.
 
 ```ruby
 require "test_helper"


### PR DESCRIPTION
drivers.

When using `driver_by` with capybara-webkit or poltergeist,
SystemTesting::Driver will register the driver while passing
`screen_size` and `options` parameteres.

`options` could contain any option supported by the underlying driver.

This PR is related to issue #29000 