### PR TITLE
Do not run yarn install during assets:precompile

### DIFF
--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -4,8 +4,3 @@ namespace :yarn do
     system("./bin/yarn install --no-progress")
   end
 end
-
-# Run Yarn prior to Sprockets assets precompilation, so dependencies are available for use.
-if Rake::Task.task_defined?("assets:precompile")
-  Rake::Task["assets:precompile"].enhance [ "yarn:install" ]
-end


### PR DESCRIPTION
See also: rails/webpacker#405

Yarn just like bundler is usually run explicitly and only when dependencies are updated. Invoking yarn on every asset precompilation is unnecessary, it can also be problematic if you've cleaned yarn cache prior because you have everything you need, yarn install would also run any post-install scripts regardless of whether any new dependencies had to actually be installed or not
