### PR TITLE
Clean up `type_map` at the end of test_respond_to_for_non_selected_element

### DIFF
--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -3,9 +3,12 @@ require "models/post"
 require "models/comment"
 require "models/author"
 require "models/rating"
+require "support/connection_helper"
 
 module ActiveRecord
   class RelationTest < ActiveRecord::TestCase
+    include ConnectionHelper
+
     fixtures :posts, :comments, :authors, :author_addresses
 
     FakeKlass = Struct.new(:table_name, :name) do
@@ -250,6 +253,8 @@ module ActiveRecord
 
       silence_warnings { post = Post.select("'title' as post_title").first }
       assert_equal false, post.respond_to?(:title), "post should not respond_to?(:body) since invoking it raises exception"
+    ensure
+      reset_connection
     end
 
     def test_select_quotes_when_using_from_clause


### PR DESCRIPTION
### Summary

This pull request addresses #29331 at unlock-minitest branch.

`test_only_reload_type_map_once_for_every_unknown_type` expects no one already registers unknown OID to `type_map`. however, `test_respond_to_for_non_selected_element` registers it and does not clean up it.
