### PR TITLE
Deprecate committing a transaction exited with return or throw

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate using `return`, `break` or `throw` to exit a transaction block
+
+    *Dylan Thacker-Smith*
+
 * Raise error when non-existent enum used in query
   
   This change will raise an error when a non-existent enum is passed to a query. Previously

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -292,7 +292,9 @@ module ActiveRecord
       def within_new_transaction(isolation: nil, joinable: true)
         @connection.lock.synchronize do
           transaction = begin_transaction(isolation: isolation, joinable: joinable)
-          yield
+          ret = yield
+          completed = true
+          ret
         rescue Exception => error
           if transaction
             rollback_transaction
@@ -304,6 +306,16 @@ module ActiveRecord
             if Thread.current.status == "aborting"
               rollback_transaction
             else
+              unless completed
+                ActiveSupport::Deprecation.warn(<<~EOW)
+                  Using `return`, `break` or `throw` to exit a transaction block is
+                  deprecated without replacement. If the `throw` came from
+                  `Timeout.timeout(duration)`, pass an exception class as a second
+                  argument so it doesn't use `throw` to abort its block. This results
+                  in the transaction being committed, but in the next release of Rails
+                  it will raise and rollback.
+                EOW
+              end
               begin
                 commit_transaction
               rescue Exception

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -139,7 +139,9 @@ class TransactionTest < ActiveRecord::TestCase
     end
 
     assert_not_called(@first, :committed!) do
-      transaction_with_return
+      assert_deprecated do
+        transaction_with_return
+      end
     end
     assert committed
 
@@ -150,6 +152,21 @@ class TransactionTest < ActiveRecord::TestCase
       remove_method :commit_db_transaction
       alias :commit_db_transaction :real_commit_db_transaction rescue nil
     end
+  end
+
+  def test_deprecation_on_ruby_timeout
+    assert_deprecated do
+      catch do |timeout|
+        Topic.transaction do
+          @first.approved = true
+          @first.save!
+
+          throw timeout
+        end
+      end
+    end
+
+    assert Topic.find(1).approved?, "First should have been approved"
   end
 
   def test_number_of_transactions_in_commit


### PR DESCRIPTION
### Problem

I found that we had transactions that were being committed because of the use of `Timeout.timeout(duration) do` wrapping database transactions.  The reason why this was happening is that when [Timeout.timeout](http://ruby-doc.org/stdlib-2.4.1/libdoc/timeout/rdoc/Timeout.html#method-c-timeout) isn't given a second argument (an exception class) then it uses `throw` and `catch` to exit the transaction block, after which `Timeout.timeout` will raise an exception.  This why the documentation for Timeout.timeout says

> The exception thrown to terminate the given block cannot be rescued inside the block unless klass is given explicitly.

This can be reproduced using ruby code like

```ruby
Timeout.timeout(1) do
  Example.transaction do
    example.update_attributes(value: 1)
    sleep 3 # simulate something slow
  end
end
```

where the update will be committed even if the block gets a timeout exception.

The reason why this results in the transaction being committed is that https://github.com/rails/rails/commit/fc83920383b5f839cd6badbc5c962be9383fe150 was added to commit a transaction when the transaction block is exited with `return`.  Unfortunately, the `ensure` block can't distinguish between a block exited with `return`, `break` or `throw`, so we can't fix the problem with `throw` as used in `Timeout.timeout` without a backwards incompatible change.

### Solution

Set a local variable `completed = true` after the `yield` so that we can detect when the `ensure` block didn't complete, then use a deprecation warning to try to let developers know that rails will rollback instead of commit in this case in the future.

That way we can fix this behaviour in the next release for the `Timeout.timeout` case.  I will open a PR against master doing this.
