### PR TITLE
Avoid committing a transaction on a timeout from Timeout.timeout

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Rollback transactions where the block is exited using `return`, `break` or `throw`
+
+    *Dylan Thacker-Smith*
+
 *   Deprecate passing arguments and block at the same time to `count` and `sum` in `ActiveRecord::Calculations`.
 
     *Ryuta Kamizono*


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/29333 which changes the behaviour it deprecates to avoid having a timeout from Timeout.timeout commit the transaction.  Instead the transaction will now be rolled back.  See that linked PR for a full description of the problem.