### PR TITLE
[ci skip] Show migration from latest version in start up guide.

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -682,7 +682,7 @@ If you look in the `db/migrate/YYYYMMDDHHMMSS_create_articles.rb` file
 (remember, yours will have a slightly different name), here's what you'll find:
 
 ```ruby
-class CreateArticles < ActiveRecord::Migration[5.0]
+class CreateArticles < ActiveRecord::Migration[5.1]
   def change
     create_table :articles do |t|
       t.string :title
@@ -1552,7 +1552,7 @@ In addition to the model, Rails has also made a migration to create the
 corresponding database table:
 
 ```ruby
-class CreateComments < ActiveRecord::Migration[5.0]
+class CreateComments < ActiveRecord::Migration[5.1]
   def change
     create_table :comments do |t|
       t.string :commenter


### PR DESCRIPTION
Since latest version is mentioned in the [installation step](https://monosnap.com/file/CpEnRbb5g6cL3ViYkG0yt0xU2ulwuC), why not show appropriate version in example?