### PR TITLE
Ensure fixtures are loaded for CascadedEagerLoadingTest

### DIFF
--- a/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
+++ b/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
@@ -12,6 +12,7 @@ require "models/vertex"
 require "models/edge"
 
 class CascadedEagerLoadingTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
   fixtures :authors, :author_addresses, :mixins, :companies, :posts, :topics, :accounts, :comments,
            :categorizations, :people, :categories, :edges, :vertices
 


### PR DESCRIPTION
### Summary

This pull request addresses these `11 failures, 1 errors` at `unlock-minutest` branch #29271 when the seed is `28100`. Here are the link to Travis CI https://travis-ci.org/rails/rails/jobs/238861568 .

### Other Information

I have referred #29298 how to fix these failures and errors.

### Steps to reproduce:

1. Install Vagrant
2. At your host 
```
git clone https://github.com/rails/rails-dev-box.git
cd rails-dev-box
vagrant up
vagrant ssh
```

3. At rails-dev-box
```
git clone https://github.com/rails/rails.git
cd rails/activerecord
git checkout unlock-minitest
bundle install
wget https://gist.githubusercontent.com/yahonda/0b82e7fefe45dab28203742a97fefb48/raw/af369d58632438bca0d9dda7a7f67f309956d5f3/rep_28100.sh
```

### Without this pull request

```ruby
  1) Failure:
CascadedEagerLoadingTest#test_eager_association_loading_with_cascaded_two_levels_and_one_level [/home/ubuntu/rails/activerecord/test/cases/associations/cascaded_eager_loading_test.rb:29]:
Expected: 5
  Actual: 0


  2) Failure:
CascadedEagerLoadingTest#test_eager_association_loading_with_cascaded_two_levels [/home/ubuntu/rails/activerecord/test/cases/associations/cascaded_eager_loading_test.rb:21]:
Expected: 5
  Actual: 0


  3) Failure:
CascadedEagerLoadingTest#test_eager_association_loading_with_cascaded_interdependent_one_level_and_two_levels [/home/ubuntu/rails/activerecord/test/cases/associations/cascaded_eager_loading_test.rb:182]:
Expected: 10
  Actual: 0


  4) Failure:
CascadedEagerLoadingTest#test_cascaded_eager_association_loading_with_twice_includes_edge_cases [/home/ubuntu/rails/activerecord/test/cases/associations/cascaded_eager_loading_test.rb:71]:
Expected: 3
  Actual: 0


  5) Failure:
CascadedEagerLoadingTest#test_eager_association_loading_with_multiple_stis_and_order [/home/ubuntu/rails/activerecord/test/cases/associations/cascaded_eager_loading_test.rb:144]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Author id: 1, name: "David", author_address_id: 1, author_address_extra_id: 2, organization_id: "No Such Agency", owned_essay_id: "A Modest Proposal">
+nil



  6) Failure:
CascadedEagerLoadingTest#test_eager_association_loading_with_hmt_does_not_table_name_collide_when_joining_associations [/home/ubuntu/rails/activerecord/test/cases/associations/cascaded_eager_loading_test.rb:41]:
Expected: 1
  Actual: 0


  7) Failure:
CascadedEagerLoadingTest#test_eager_association_loading_with_cascaded_two_levels_and_self_table_reference [/home/ubuntu/rails/activerecord/test/cases/associations/cascaded_eager_loading_test.rb:95]:
Expected: 5
  Actual: 0


  8) Failure:
CascadedEagerLoadingTest#test_eager_association_loading_with_cascaded_two_levels_with_condition [/home/ubuntu/rails/activerecord/test/cases/associations/cascaded_eager_loading_test.rb:103]:
Expected: 5
  Actual: 0


  9) Failure:
CascadedEagerLoadingTest#test_eager_association_loading_with_cascaded_two_levels_with_two_has_many_associations [/home/ubuntu/rails/activerecord/test/cases/associations/cascaded_eager_loading_test.rb:87]:
Expected: 5
  Actual: 0


 10) Failure:
CascadedEagerLoadingTest#test_eager_association_loading_of_stis_with_multiple_references [/home/ubuntu/rails/activerecord/test/cases/associations/cascaded_eager_loading_test.rb:153]:
--- expected
+++ actual
@@ -1 +1 @@
-[#<Author id: 1, name: "David", author_address_id: 1, author_address_extra_id: 2, organization_id: "No Such Agency", owned_essay_id: "A Modest Proposal">]
+[]



 11) Failure:
CascadedEagerLoadingTest#test_eager_association_loading_with_join_for_count [/home/ubuntu/rails/activerecord/test/cases/associations/cascaded_eager_loading_test.rb:81]:
1 instead of 3 queries were executed.
Queries:
SELECT "authors".* FROM "authors" INNER JOIN "posts" ON "posts"."author_id" = "authors"."id" AND "posts"."type" IN ('SpecialPost').
Expected: 3
  Actual: 1


 12) Error:
CascadedEagerLoadingTest#test_eager_association_loading_where_first_level_returns_nil:
NoMethodError: undefined method `comments' for nil:NilClass
    /home/ubuntu/rails/activerecord/test/cases/associations/cascaded_eager_loading_test.rb:164:in `block in test_eager_association_loading_where_first_level_returns_nil'
    /home/ubuntu/rails/activerecord/test/cases/test_case.rb:50:in `assert_queries'
    /home/ubuntu/rails/activerecord/test/cases/test_case.rb:63:in `assert_no_queries'
    /home/ubuntu/rails/activerecord/test/cases/associations/cascaded_eager_loading_test.rb:163:in `test_eager_association_loading_where_first_level_returns_nil'

5516 runs, 15328 assertions, 11 failures, 1 errors, 3 skips

You have skipped tests. Run with --verbose for details.
$
```

### With this pull request

```ruby
5516 runs, 15348 assertions, 0 failures, 0 errors, 3 skips
```
