### PR TITLE
Explicitly clear type map before run `test_only_reload_type_map_once_for_every_unknown_type`

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -325,15 +325,18 @@ module ActiveRecord
       end
 
       def test_only_reload_type_map_once_for_every_unknown_type
+        reset_connection
+        connection = ActiveRecord::Base.connection
+
         silence_warnings do
           assert_queries 2, ignore_none: true do
-            @connection.select_all "SELECT NULL::anyelement"
+            connection.select_all "SELECT NULL::anyelement"
           end
           assert_queries 1, ignore_none: true do
-            @connection.select_all "SELECT NULL::anyelement"
+            connection.select_all "SELECT NULL::anyelement"
           end
           assert_queries 2, ignore_none: true do
-            @connection.select_all "SELECT NULL::anyarray"
+            connection.select_all "SELECT NULL::anyarray"
           end
         end
       ensure
@@ -341,10 +344,13 @@ module ActiveRecord
       end
 
       def test_only_warn_on_first_encounter_of_unknown_oid
+        reset_connection
+        connection = ActiveRecord::Base.connection
+
         warning = capture(:stderr) {
-          @connection.select_all "SELECT NULL::anyelement"
-          @connection.select_all "SELECT NULL::anyelement"
-          @connection.select_all "SELECT NULL::anyelement"
+          connection.select_all "SELECT NULL::anyelement"
+          connection.select_all "SELECT NULL::anyelement"
+          connection.select_all "SELECT NULL::anyelement"
         }
         assert_match(/\Aunknown OID \d+: failed to recognize type of 'anyelement'\. It will be treated as String\.\n\z/, warning)
       ensure

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -3,11 +3,9 @@ require "models/post"
 require "models/comment"
 require "models/author"
 require "models/rating"
-require "support/connection_helper"
 
 module ActiveRecord
   class RelationTest < ActiveRecord::TestCase
-    include ConnectionHelper
 
     fixtures :posts, :comments, :authors, :author_addresses
 
@@ -253,8 +251,6 @@ module ActiveRecord
 
       silence_warnings { post = Post.select("'title' as post_title").first }
       assert_equal false, post.respond_to?(:title), "post should not respond_to?(:body) since invoking it raises exception"
-    ensure
-      reset_connection
     end
 
     def test_select_quotes_when_using_from_clause


### PR DESCRIPTION
Currently, the following test fails.

```
bin/test -a sqlite3_mem --seed 37473 test/cases/relation_test.rb
```

This is due to reset connection in `test_respond_to_for_non_selected_element` postprocessing.
This reset is added with #29332 for `test_only_reload_type_map_once_for_every_unknown_type`.

Since the above test expects the type map to be empty at the time of test run, I think that it is better to empty the type map before test run.
