### PR TITLE
Remove a redundant default_scope tests

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -695,16 +695,6 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
-  def test_default_scope_with_conditions_string
-    assert_equal Developer.where(name: "David").map(&:id).sort, DeveloperCalledDavid.all.map(&:id).sort
-    assert_nil DeveloperCalledDavid.create!.name
-  end
-
-  def test_default_scope_with_conditions_hash
-    assert_equal Developer.where(name: "Jamis").map(&:id).sort, DeveloperCalledJamis.all.map(&:id).sort
-    assert_equal "Jamis", DeveloperCalledJamis.create!.name
-  end
-
   def test_default_scoping_finder_methods
     developers = DeveloperCalledDavid.order("id").map(&:id).sort
     assert_equal Developer.where(name: "David").map(&:id).sort, developers


### PR DESCRIPTION
The following test cases are the same.

- [test/cases/scoping/default_scoping_test.rb#L698-L706](https://github.com/rails/rails/blob/7e2465c6de86b43028685c0de434e60cb21773d0/activerecord/test/cases/relations_test.rb#L698-L706)
- [test/cases/scoping/default_scoping_test.rb#L52-L60](https://github.com/rails/rails/blob/7e2465c6de86b43028685c0de434e60cb21773d0/activerecord/test/cases/scoping/default_scoping_test.rb#L52-L60)

This PR leave test cases of `test/cases/relations_test.rb` where the tests of the near intention are gathered. And redundant test cases of `test/cases/finder_test.rb` are removed.