### PR TITLE
Allow disabling system test screenshots

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow disabling system test screenshots
+
+    Add a `disabled` option to `RAILS_SYSTEM_TESTING_SCREENSHOT`, e.g.:
+
+        RAILS_SYSTEM_TESTING_SCREENSHOT=disabled rails test:system
+
+    Which disables screenshots for failed `ApplicationSystemTestCase`s.
+
+    *David Faulkenberry*
 *   `driven_by` now registers poltergeist and capybara-webkit
 
     If driver poltergeist or capybara-webkit is set for System Tests,

--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -33,7 +33,9 @@ module ActionDispatch
         # fails add +take_failed_screenshot+ to the teardown block before clearing
         # sessions.
         def take_failed_screenshot
-          take_screenshot if failed? && supports_screenshot?
+          if failed? && supports_screenshot? && !screenshots_disabled?
+            take_screenshot
+          end
         end
 
         private
@@ -47,6 +49,10 @@ module ActionDispatch
 
           def save_image
             page.save_screenshot(Rails.root.join(image_path))
+          end
+
+          def screenshots_disabled?
+            ENV['RAILS_SYSTEM_TESTING_SCREENSHOT'] == 'disabled'
           end
 
           def output_type

--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -52,7 +52,7 @@ module ActionDispatch
           end
 
           def screenshots_disabled?
-            ENV['RAILS_SYSTEM_TESTING_SCREENSHOT'] == 'disabled'
+            ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] == "disabled"
           end
 
           def output_type

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -4,15 +4,15 @@ require "capybara/dsl"
 
 class ScreenshotHelperTest < ActiveSupport::TestCase
   test "screenshots are not taken if disabled" do
-    new_test = DrivenBySeleniumWithChrome.new('x')
+    new_test = DrivenBySeleniumWithChrome.new("x")
 
-    cached_env_value = ENV['RAILS_SYSTEM_TESTING_SCREENSHOT']
-    ENV['RAILS_SYSTEM_TESTING_SCREENSHOT'] = 'disabled'
+    cached_env_value = ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"]
+    ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] = "disabled"
 
     assert new_test.send(:screenshots_disabled?)
     assert_nil new_test.take_failed_screenshot
 
-    ENV['RAILS_SYSTEM_TESTING_SCREENSHOT'] = cached_env_value
+    ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] = cached_env_value
   end
 
   test "image path is saved in tmp directory" do

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -3,6 +3,18 @@ require "action_dispatch/system_testing/test_helpers/screenshot_helper"
 require "capybara/dsl"
 
 class ScreenshotHelperTest < ActiveSupport::TestCase
+  test "screenshots are not taken if disabled" do
+    new_test = DrivenBySeleniumWithChrome.new('x')
+
+    cached_env_value = ENV['RAILS_SYSTEM_TESTING_SCREENSHOT']
+    ENV['RAILS_SYSTEM_TESTING_SCREENSHOT'] = 'disabled'
+
+    assert new_test.send(:screenshots_disabled?)
+    assert_nil new_test.take_failed_screenshot
+
+    ENV['RAILS_SYSTEM_TESTING_SCREENSHOT'] = cached_env_value
+  end
+
   test "image path is saved in tmp directory" do
     new_test = DrivenBySeleniumWithChrome.new("x")
 


### PR DESCRIPTION
Add a `disabled` option to `RAILS_SYSTEM_TESTING_SCREENSHOT`, e.g.:

```
RAILS_SYSTEM_TESTING_SCREENSHOT=disabled bundle exec rails test:system
```

Which disables screenshots for failed `ApplicationSystemTestCase`s.

## Motivation

Currently it seems that [the only way to disable screenshots](https://stackoverflow.com/questions/44336581/turn-off-screenshots-in-rails-system-tests/44337280#44337280) is to override `ActionDispatch::TestCase#take_failed_screenshot`. This provides a more accessible way of turning them off, if for whatever reason developers would like to do that.

On my Mac, for example, the Selenium Chrome driver will usually run in the background — but will take screen focus in order to take a screenshot, which isn't necessarily desirable.