### PR TITLE
Fix typo on error message when route definition is ambiguous.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1837,7 +1837,7 @@ module ActionDispatch
             path_types.fetch(String, []).each do |_path|
               route_options = options.dup
               if _path && option_path
-                raise ArgumentError, "Ambigous route definition. Both :path and the route path where specified as strings."
+                raise ArgumentError, "Ambiguous route definition. Both :path and the route path where specified as strings."
               end
               to = get_to_from_path(_path, to, route_options[:action])
               decomposed_match(_path, controller, route_options, _path, to, via, formatted, anchor, options_constraints)


### PR DESCRIPTION
### Summary

Ambiguous was misspelled. I noticed that when upgrading an older 4.2 app.
