### PR TITLE
Fix format in test summary

### DIFF
--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -2,13 +2,6 @@ require "active_support/core_ext/module/attribute_accessors"
 require "rails/test_unit/reporter"
 
 module Minitest
-  class SuppressedSummaryReporter < SummaryReporter
-    # Disable extra failure output after a run if output is inline.
-    def aggregated_results(*)
-      super unless options[:output_inline]
-    end
-  end
-
   def self.plugin_rails_options(opts, options)
     opts.on("-b", "--backtrace", "Show the complete backtrace") do
       options[:full_backtrace] = true
@@ -40,7 +33,7 @@ module Minitest
 
     # Replace progress reporter for colors.
     reporter.reporters.delete_if { |reporter| reporter.kind_of?(SummaryReporter) || reporter.kind_of?(ProgressReporter) }
-    reporter << SuppressedSummaryReporter.new(options[:io], options)
+    reporter << ::Rails::SuppressedSummaryReporter.new(options[:io], options)
     reporter << ::Rails::TestUnitReporter.new(options[:io], options)
   end
 


### PR DESCRIPTION
If use test runner with minitest 5.10.1, there was a line break between summary and statistics, but it was not use with minitest 5.10.2.

minitest 5.10.1:

```
# Running:

.......

Finished in 1.009528s, 6.9339 runs/s, 8.9151 assertions/s.

7 runs, 9 assertions, 0 failures, 0 errors, 0 skips
```

minitest 5.10.2:

```
# Running:

.......

Finished in 1.009528s, 6.9339 runs/s, 8.9151 assertions/s.
7 runs, 9 assertions, 0 failures, 0 errors, 0 skips
```

Before minitest 5.10.2, when displaying results, called `io.puts` inside `SummaryReporter#report`.
But now calling `io.puts` inside `SummaryReporter#aggregated_results`.
https://github.com/seattlerb/minitest/commit/c6ba2afd90473b76d289562edd24f7d7ca8484f9

Therefore, we need to do the same fix in rails reporter as well.
However, `SummaryReporter#aggregated_results` is a private method.

Since there is a possibility that similar problems may occur in the future, I think that it is better to define reporter in Rails without relying on private methods.

Related: #29065

