### PR TITLE
Remove a redundant i18n test in Railties

### DIFF
--- a/railties/test/application/initializers/i18n_test.rb
+++ b/railties/test/application/initializers/i18n_test.rb
@@ -244,12 +244,6 @@ fr:
       assert_fallbacks de: [:de, :'en-US', :en]
     end
 
-    test "[shortcut] config.i18n.fallbacks = [{ :ca => :'es-ES' }] initializes fallbacks with a mapping ca => es-ES" do
-      I18n::Railtie.config.i18n.fallbacks.map = { ca: :'es-ES' }
-      load_app
-      assert_fallbacks ca: [:ca, :"es-ES", :es, :en]
-    end
-
     test "[shortcut] config.i18n.fallbacks = [:'en-US', { :ca => :'es-ES' }] initializes fallbacks with the given arguments" do
       I18n::Railtie.config.i18n.fallbacks = [:'en-US', { ca: :'es-ES' }]
       load_app


### PR DESCRIPTION
The following test cases are the same.

- [test/application/initializers/i18n_test.rb#L235-L239](https://github.com/rails/rails/blob/7a443756fe78e44ee32226085147fc9bf6df6add/railties/test/application/initializers/i18n_test.rb#L235-L239)
- [test/application/initializers/i18n_test.rb#L247-L251](https://github.com/rails/rails/blob/7a443756fe78e44ee32226085147fc9bf6df6add/railties/test/application/initializers/i18n_test.rb#L247-L251)

This PR leaves test (L235-L239) with [test comment](https://github.com/rails/rails/blob/7a443756fe78e44ee32226085147fc9bf6df6add/railties/test/application/initializers/i18n_test.rb#L235) and [test implementation](https://github.com/rails/rails/blob/7a443756fe78e44ee32226085147fc9bf6df6add/railties/test/application/initializers/i18n_test.rb#L236) matching. And L247-L251 is removed.
