### PR TITLE
Remove deprecated passing of string to :if/:unless

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -953,7 +953,7 @@ should happen, an `Array` can be used. Moreover, you can apply both `:if` and
 ```ruby
 class Computer < ApplicationRecord
   validates :mouse, presence: true,
-                    if: :desktop?,
+                    if: [Proc.new  { |c| c.market.retail? }, :desktop?],
                     unless: Proc.new { |c| c.trackpad.present? }
 end
 ```

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -953,7 +953,7 @@ should happen, an `Array` can be used. Moreover, you can apply both `:if` and
 ```ruby
 class Computer < ApplicationRecord
   validates :mouse, presence: true,
-                    if: ["market.retail?", :desktop?],
+                    if: :desktop?,
                     unless: Proc.new { |c| c.trackpad.present? }
 end
 ```


### PR DESCRIPTION
Other examples were removed in 53ff5fc62f9d11b6f60d371df959137f4bf40728