### PR TITLE
Allow to pass a connection to the `dbconsole` command

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Allow to pass a custom connection name to the `rails dbconsole`
+    command when using a 3-level database configuration.
+
+        $ bin/rails dbconsole -c replica
+
+    *Robin Dupret*, *Jeremy Daer*
+
 *   Skip unused components when running `bin/rails app:update`.
 
     If the initial app generation skipped Action Cable, Active Record etc.,

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Properly expand shortcuts for environment's name running the `console`
+    and `dbconsole` commands.
+
+    *Robin Dupret*
+
 *   Passing the environment's name as a regular argument to the
     `rails dbconsole` and `rails console` commands is deprecated.
     The `-e` option should be used instead.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Passing the environment's name as a regular argument to the
+    `rails dbconsole` and `rails console` commands is deprecated.
+    The `-e` option should be used instead.
+
+    Previously:
+
+        $ bin/rails dbconsole production
+
+    Now:
+
+        $ bin/rails dbconsole -e production
+
+    *Robin Dupret*, *Kasper Timm Hansen*
+
 *   Allow to pass a custom connection name to the `rails dbconsole`
     command when using a 3-level database configuration.
 

--- a/railties/lib/rails/command/environment_argument.rb
+++ b/railties/lib/rails/command/environment_argument.rb
@@ -13,6 +13,12 @@ module Rails
         def extract_environment_option_from_argument
           if environment
             self.options = options.merge(environment: acceptable_environment(environment))
+
+            ActiveSupport::Deprecation.warn "Passing the environment's name as a " \
+                                            "regular argument is deprecated and "  \
+                                            "will be removed in the next Rails "   \
+                                            "version. Please, use the -e option "  \
+                                            "instead."
           elsif !options[:environment]
             self.options = options.merge(environment: Rails::Command.environment)
           end

--- a/railties/lib/rails/command/environment_argument.rb
+++ b/railties/lib/rails/command/environment_argument.rb
@@ -7,6 +7,9 @@ module Rails
 
       included do
         argument :environment, optional: true, banner: "environment"
+
+        class_option :environment, aliases: "-e", type: :string,
+          desc: "Specifies the environment to run this console under (test/development/production)."
       end
 
       private
@@ -19,7 +22,9 @@ module Rails
                                             "will be removed in the next Rails "   \
                                             "version. Please, use the -e option "  \
                                             "instead."
-          elsif !options[:environment]
+          elsif options[:environment]
+            self.options = options.merge(environment: acceptable_environment(options[:environment]))
+          else
             self.options = options.merge(environment: Rails::Command.environment)
           end
         end

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -70,9 +70,6 @@ module Rails
       class_option :sandbox, aliases: "-s", type: :boolean, default: false,
         desc: "Rollback database modifications on exit."
 
-      class_option :environment, aliases: "-e", type: :string,
-        desc: "Specifies the environment to run this console under (test/development/production)."
-
       def initialize(args = [], local_options = {}, config = {})
         console_options = []
 

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -151,9 +151,6 @@ module Rails
 
       class_option :header, type: :boolean
 
-      class_option :environment, aliases: "-e", type: :string,
-        desc: "Specifies the environment to run this console under (test/development/production)."
-
       class_option :connection, aliases: "-c", type: :string,
         desc: "Specifies the connection to use."
 

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -87,16 +87,25 @@ module Rails
 
     def config
       @config ||= begin
-        if configurations[environment].blank?
+        # We need to check whether the user passed the connection the
+        # first time around to show a consistent error message to people
+        # relying on 2-level database configuration.
+        if @options["connection"] && configurations[connection].blank?
+          raise ActiveRecord::AdapterNotSpecified, "'#{connection}' connection is not configured. Available configuration: #{configurations.inspect}"
+        elsif configurations[environment].blank? && configurations[connection].blank?
           raise ActiveRecord::AdapterNotSpecified, "'#{environment}' database is not configured. Available configuration: #{configurations.inspect}"
         else
-          configurations[environment]
+          configurations[environment].presence || configurations[connection]
         end
       end
     end
 
     def environment
       Rails.respond_to?(:env) ? Rails.env : Rails::Command.environment
+    end
+
+    def connection
+      @options.fetch(:connection, "primary")
     end
 
     private
@@ -144,6 +153,9 @@ module Rails
 
       class_option :environment, aliases: "-e", type: :string,
         desc: "Specifies the environment to run this console under (test/development/production)."
+
+      class_option :connection, aliases: "-c", type: :string,
+        desc: "Specifies the connection to use."
 
       def perform
         extract_environment_option_from_argument

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -82,6 +82,11 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     assert_match(/\sspecial-production\s/, output)
   end
 
+  def test_e_option_is_properly_expanded
+    start ["-e", "prod"]
+    assert_match(/\sproduction\s/, output)
+  end
+
   def test_environment_option
     start ["--environment=special-production"]
     assert_match(/\sspecial-production\s/, output)

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -47,7 +47,7 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
   end
 
   def test_console_with_environment
-    start ["-e production"]
+    start ["-e", "production"]
     assert_match(/\sproduction\s/, output)
   end
 
@@ -88,18 +88,24 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
   end
 
   def test_rails_env_is_production_when_first_argument_is_p
-    start ["p"]
-    assert_match(/\sproduction\s/, output)
+    assert_deprecated do
+      start ["p"]
+      assert_match(/\sproduction\s/, output)
+    end
   end
 
   def test_rails_env_is_test_when_first_argument_is_t
-    start ["t"]
-    assert_match(/\stest\s/, output)
+    assert_deprecated do
+      start ["t"]
+      assert_match(/\stest\s/, output)
+    end
   end
 
   def test_rails_env_is_development_when_argument_is_d
-    start ["d"]
-    assert_match(/\sdevelopment\s/, output)
+    assert_deprecated do
+      start ["d"]
+      assert_match(/\sdevelopment\s/, output)
+    end
   end
 
   def test_rails_env_is_dev_when_argument_is_dev_and_dev_env_is_present
@@ -111,7 +117,9 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
       end
     end
 
-    assert_match("dev", parse_arguments(["dev"])[:environment])
+    assert_deprecated do
+      assert_match("dev", parse_arguments(["dev"])[:environment])
+    end
   ensure
     Rails::Command::ConsoleCommand.class_eval do
       undef_method :available_environments

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -98,14 +98,18 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   end
 
   def test_rails_env_is_development_when_argument_is_dev
-    stub_available_environments([ "development", "test" ]) do
-      assert_match("development", parse_arguments([ "dev" ])[:environment])
+    assert_deprecated do
+      stub_available_environments([ "development", "test" ]) do
+        assert_match("development", parse_arguments([ "dev" ])[:environment])
+      end
     end
   end
 
   def test_rails_env_is_dev_when_argument_is_dev_and_dev_env_is_present
-    stub_available_environments([ "dev" ]) do
-      assert_match("dev", parse_arguments([ "dev" ])[:environment])
+    assert_deprecated do
+      stub_available_environments([ "dev" ]) do
+        assert_match("dev", parse_arguments([ "dev" ])[:environment])
+      end
     end
   end
 

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -105,6 +105,12 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     end
   end
 
+  def test_rails_env_is_development_when_environment_option_is_dev
+    stub_available_environments([ "development", "test" ]) do
+      assert_match("development", parse_arguments([ "-e", "dev" ])[:environment])
+    end
+  end
+
   def test_rails_env_is_dev_when_argument_is_dev_and_dev_env_is_present
     assert_deprecated do
       stub_available_environments([ "dev" ]) do


### PR DESCRIPTION
Hello,

Since 0a4f6009, it's possible to specify a 3-level database configuration to gather connections by environment.

The `dbconsole` command will try to look for a database configuration which points to the current environment but with such flavour, the environment key is flushed out so let's add the ability to specify the connection and pick `primary` by default to be consistent with Active Record.

Have a nice day !