### PR TITLE
Load schema before assertion

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -718,21 +718,27 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_pluck_loaded_relation
+    Company.attribute_names # Load schema information so we don't query below
     companies = Company.order(:id).limit(3).load
+
     assert_no_queries do
       assert_equal ["37signals", "Summit", "Microsoft"], companies.pluck(:name)
     end
   end
 
   def test_pluck_loaded_relation_multiple_columns
+    Company.attribute_names # Load schema information so we don't query below
     companies = Company.order(:id).limit(3).load
+
     assert_no_queries do
       assert_equal [[1, "37signals"], [2, "Summit"], [3, "Microsoft"]], companies.pluck(:id, :name)
     end
   end
 
   def test_pluck_loaded_relation_sql_fragment
+    Company.attribute_names # Load schema information so we don't query below
     companies = Company.order(:name).limit(3).load
+
     assert_queries 1 do
       assert_equal ["37signals", "Apex", "Ex Nihilo"], companies.pluck("DISTINCT name")
     end


### PR DESCRIPTION
Without this, test fails because the load schema when pluck is executed.

Steps to reproduce:

```
bin/test -a postgresql -w --seed 61689 test/cases/*test.rb -n "/^(?:InheritanceComputeTypeTest#(?:test_inheritance_new_with_subclass_as_default)|CalculationsTest#(?:test_pluck_loaded_relation))$/"

# Running:

.F

Failure:
CalculationsTest#test_pluck_loaded_relation [/home/yaginuma/program/rails/master_y_yagi/rails/activerecord/test/cases/calculations_test.rb:722]:
1 instead of 0 queries were executed.
Queries:
SELECT c.relname FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = ANY (current_schemas(false)) AND c.relname = 'companies' AND c.relkind IN ('r','v','m').
Expected: 0
  Actual: 1

bin/test test/cases/calculations_test.rb:7
```
