### PR TITLE
Establish a connection with all available configurations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Open a connection for each environment's specification using a
+    3-level database configuration.
+
+    *Robin Dupret*
+
 *   Prevent making bind param if casted value is nil.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -151,7 +151,10 @@ module ActiveRecord
           config = configurations.dup
 
           if env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
-            env_config = config[env] if config[env].is_a?(Hash) && !(config[env].key?("adapter") || config[env].key?("url"))
+            if config[env].is_a?(Hash) && !(config[env].key?("adapter") || config[env].key?("url"))
+              env_config = config[env]
+              env_config.each { |connection, config| config["environment"] = env }
+            end
           end
 
           config.reject! { |k, v| v.is_a?(Hash) && !(v.key?("adapter") || v.key?("url")) }

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -121,7 +121,15 @@ module ActiveRecord
         self.configurations = Rails.application.config.database_configuration
 
         begin
-          establish_connection
+          connections = configurations.select { |n, c| c["environment"] == Rails.env }
+
+          unless configurations.key?(Rails.env) || connections.empty?
+            connections.each do |name, value|
+              connection_handler.establish_connection(name.to_sym)
+            end
+          else
+            establish_connection
+          end
         rescue ActiveRecord::NoDatabaseError
           warn <<-end_warning
 Oops - You have a database configured, but it doesn't exist yet!


### PR DESCRIPTION
Hello,

This pull request is a sort-of follow-up to the following ones:

* #24965
* #24844
* #28095

This patch is split into 2 commits which should be self-explanatory. In a nutshell, though, the first commit attaches the original environment to the connection because 3-level configuration may be used but not by all environments (and we don't want to open useless connections). The second one make Active Record to create a connection pool for each available connection for the current environment.  

This is not acceptable as is but I took the liberty to open a discussion as I wanted to use the 3 level deep configuration flavour in an application but wasn't able to do it easily. Also, as discussed in #24844, `connection_specification_name` should be used rather than directly relying on `establish_connection` at the model level.

There are several things to consider:

* Maybe people want to control the way the pools are created and it should be easy to opt-out from the behavior this PR introduces.
* At the moment, we don't have any documentation for working with multiple connections / databases. [Something like this](https://gist.github.com/robin850/ce867eedbfccb327d637e274c9a622cc) could be interesting but is too specific to be added to a guide and too tiny to constitute a whole guide (unless we go really in depth).
* I didn't write any test because there seems to be no tests for `resolve_all` and I don't know whether this behavior is acceptable at all.

Let me know what do you think about this.

Have a nice day ! :-)