### PR TITLE
Ensure MSSQL password uses real ENV var.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml
@@ -1,4 +1,4 @@
-# SQL Server (2012 or higher recommended)
+# SQL Server (2012 or higher required)
 #
 # Install the adapters and driver
 #   gem install tiny_tds
@@ -12,7 +12,7 @@ default: &default
   adapter: sqlserver
   encoding: utf8
   username: sa
-  password: <%= ENV['SA_PASSWORD'] %>
+  password: <%%= ENV['SA_PASSWORD'] %>
   host: localhost
 
 development:


### PR DESCRIPTION
I got #27820 wrong. The end result should be that setting up a new application with SQL Server will have the `password: <%= ENV['SA_PASSWORD'] %>` in the resulting YAML, not the actual password as is now.