### PR TITLE
Remove html tag making markdown misrender [ci skip]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,6 @@ Changes that are cosmetic in nature and do not add anything substantial to the s
 
 * Please read [Contributing to the Rails Documentation](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation).
 
-</br>
 Ruby on Rails is a volunteer effort. We encourage you to pitch in and [join the team](http://contributors.rubyonrails.org)!
 
 Thanks! :heart: :heart: :heart:


### PR DESCRIPTION
Stray html tag in this file was causing GitHub to not render the next line correctly.