### PR TITLE
I18n load path in application.rb vs initializer

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -133,6 +133,8 @@ I18n.available_locales = [:en, :pt]
 I18n.default_locale = :pt
 ```
 
+WARNING. When updating the I18n load path in an initializer, it is possible that other translation files be appended to the load path later in the initialization process. This may result in your local translations being overriden.
+
 ### Managing the Locale across Requests
 
 The default locale is used for all translations unless `I18n.locale` is explicitly set.

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -114,7 +114,7 @@ NOTE: The backend lazy-loads these translations when a translation is looked up 
 You can change the default locale as well as configure the translations load paths in `config/application.rb` as follows:
 
 ```ruby
-  config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
+  config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}')]
   config.i18n.default_locale = :de
 ```
 


### PR DESCRIPTION
Context
---
The guides make it seem like updating the I18n load path in the `application.rb` or an initializer will result in the same outcome. This is incorrect due to load order.

How about a concrete example:

**Update I18n load path in `application.rb`**

> Given I add `config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
` to my `config/application.rb` and I have the Doorkeeper gem installed.

Result:

```
irb(main):001:0> I18n.load_path.select { |path| path.include? 'doorkeeper' }
=> ["/Users/trev/.gem/ruby/2.3.1/gems/doorkeeper-4.2.6/config/locales/en.yml", "/Users/trev/Sites/tester/config/locales/doorkeeper.en.yml"]
```

**Update I18n load path in `config/initializers/locale.rb`**

> Given I add `I18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]` to my `config/initializers/locale.rb` and I have the Doorkeeper gem installed.

Result:

```
irb(main):001:0> I18n.load_path.select { |path| path.include? 'doorkeeper' }
=> ["/Users/trev/Sites/tester/config/locales/doorkeeper.en.yml", "/Users/trev/.gem/ruby/2.3.1/gems/doorkeeper-4.2.6/config/locales/en.yml"]
```

**Note:** I used the Doorkeeper gem in this example because it uses `Rails::Engine` which automatically takes care of loading the gem's locales.