### PR TITLE
Cache: write_multi

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Cache: `write_multi`
+
+        Rails.cache.write_multi foo: 'bar', baz: 'qux'
+
+    Plus faster fetch_multi with stores that implement `write_multi_entries`.
+    Keys that aren't found may be written to the cache store in one shot
+    instead of separate writes.
+
+    The default implementation simply calls `write_entry` for each entry.
+    Stores may override if they're capable of one-shot bulk writes, like
+    Redis `MSET`.
+
+    *Jeremy Daer*
+
 *   Add default option to module and class attribute accessors.
 
         mattr_accessor :settings, default: {}

--- a/activesupport/test/caching_test.rb
+++ b/activesupport/test/caching_test.rb
@@ -1299,3 +1299,61 @@ class CacheEntryTest < ActiveSupport::TestCase
     assert_equal value.bytesize, entry.size
   end
 end
+
+class CacheStoreWriteMultiEntriesStoreProviderInterfaceTest < ActiveSupport::TestCase
+  setup do
+    @cache = ActiveSupport::Cache.lookup_store(:null_store)
+  end
+
+  test "fetch_multi uses write_multi_entries store provider interface" do
+    assert_called_with(@cache, :write_multi_entries) do
+      @cache.fetch_multi "a", "b", "c" do |key|
+        key * 2
+      end
+    end
+  end
+end
+
+class CacheStoreWriteMultiInstrumentationTest < ActiveSupport::TestCase
+  setup do
+    @cache = ActiveSupport::Cache.lookup_store(:null_store)
+  end
+
+  test "instrumentation" do
+    writes = { "a" => "aa", "b" => "bb" }
+
+    events = with_instrumentation "write_multi" do
+      @cache.write_multi(writes)
+    end
+
+    assert_equal %w[ cache_write_multi.active_support ], events.map(&:name)
+    assert_nil events[0].payload[:super_operation]
+    assert_equal({ "a" => "aa", "b" => "bb" }, events[0].payload[:key])
+  end
+
+  test "instrumentation with fetch_multi as super operation" do
+    skip "fetch_multi isn't instrumented yet"
+
+    events = with_instrumentation "write_multi" do
+      @cache.fetch_multi("a", "b") { |key| key * 2 }
+    end
+
+    assert_equal %w[ cache_write_multi.active_support ], events.map(&:name)
+    assert_nil events[0].payload[:super_operation]
+    assert !events[0].payload[:hit]
+  end
+
+  private
+    def with_instrumentation(method)
+      event_name = "cache_#{method}.active_support"
+
+      [].tap do |events|
+        ActiveSupport::Notifications.subscribe event_name do |*args|
+          events << ActiveSupport::Notifications::Event.new(*args)
+        end
+        yield
+      end
+    ensure
+      ActiveSupport::Notifications.unsubscribe event_name
+    end
+end


### PR DESCRIPTION
```ruby
Rails.cache.write_multi foo: 'bar', baz: 'qux'
```

Plus faster `fetch_multi` with stores that implement `write_multi_entries`.
Keys that aren't found may be written to the cache store in one shot
instead of separate writes.

The default implementation simply calls `write_entry` for each entry.
Stores may override if they're capable of one-shot bulk writes, like
Redis `MSET`.