### PR TITLE
Fix `test_pluck_without_column_names` when using Oracle

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -580,8 +580,11 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_pluck_without_column_names
-    assert_equal [[1, "Firm", 1, nil, "37signals", nil, 1, nil, ""]],
-      Company.order(:id).limit(1).pluck
+    if current_adapter?(:OracleAdapter)
+      assert_equal [[1, "Firm", 1, nil, "37signals", nil, 1, nil, nil]], Company.order(:id).limit(1).pluck
+    else
+      assert_equal [[1, "Firm", 1, nil, "37signals", nil, 1, nil, ""]], Company.order(:id).limit(1).pluck
+    end
   end
 
   def test_pluck_type_cast


### PR DESCRIPTION
### Summary

This PR fixes the following failure when using Oracle (11g) .

```console
% ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
% ARCONN=oracle bundle exec ruby -w -Itest test/cases/calculations_test.rb -n test_pluck_without_column_names
Using oracle
Run options: -n test_pluck_without_column_names --seed 19062

# Running:

F

Finished in 0.373614s, 2.6766 runs/s, 2.6766 assertions/s.

  1) Failure:
CalculationsTest#test_pluck_without_column_names [test/cases/calculations_test.rb:583]:
--- expected
+++ actual
@@ -1 +1 @@
-[[1, "Firm", 1, nil, "37signals", nil, 1, nil, ""]]
+[[1, "Firm", 1, nil, "37signals", nil, 1, nil, nil]]


1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

This test uses the following schema.

```ruby
create_table :companies, force: true do |t|
  ...
  t.string :description, default: ""
  ...
end
```

https://github.com/rails/rails/blob/600f0d4bea1c2df2a9efffcb0802c4b48e6c84c9/activerecord/test/schema/schema.rb#L202

Oracle does not distinguish empty characters from NULL. Therefore, the return value is `nil`, not the value of `default: ""`.
