### PR TITLE
Make attr_name parameter indifferent_access in dirty_attributes methods

### DIFF
--- a/activerecord/lib/active_record/attribute_mutation_tracker.rb
+++ b/activerecord/lib/active_record/attribute_mutation_tracker.rb
@@ -26,6 +26,7 @@ module ActiveRecord
     end
 
     def change_to_attribute(attr_name)
+      attr_name = attr_name.to_s
       if changed?(attr_name)
         [attributes[attr_name].original_value, attributes.fetch_value(attr_name)]
       end
@@ -54,7 +55,7 @@ module ActiveRecord
     end
 
     def original_value(attr_name)
-      attributes[attr_name].original_value
+      attributes[attr_name.to_s].original_value
     end
 
     def force_change(attr_name)

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -37,6 +37,35 @@ class DirtyTest < ActiveRecord::TestCase
     assert_nil pirate.catchphrase_change
   end
 
+  def test_indifferent_access_dirty_attributes_methods
+    pirate = Pirate.new catchphrase: "arrr"
+
+    # will_save_change_to_attribute?
+    assert pirate.will_save_change_to_attribute?(:catchphrase)
+    assert_equal pirate.will_save_change_to_attribute?("catchphrase"), pirate.will_save_change_to_attribute?(:catchphrase)
+
+    # attribute_change_to_be_saved
+    assert pirate.attribute_change_to_be_saved(:catchphrase)
+    assert_equal pirate.attribute_change_to_be_saved("catchphrase"), pirate.attribute_change_to_be_saved(:catchphrase)
+
+    # Saved
+    pirate.save!
+
+    # attribute_before_last_save
+    assert_nil pirate.attribute_before_last_save(:catchphrase)
+
+    # attribute_in_database
+    assert_equal "arrr", pirate.attribute_in_database(:catchphrase)
+    assert_equal pirate.attribute_in_database("catchphrase"), pirate.attribute_in_database(:catchphrase)
+
+    # saved_change_to_attribute?
+    assert pirate.saved_change_to_attribute?(:catchphrase)
+    assert_equal pirate.saved_change_to_attribute?("catchphrase"), pirate.saved_change_to_attribute?(:catchphrase)
+    # saved_change_to_attribute
+    assert [nil, "arrr"], pirate.saved_change_to_attribute(:catchphrase)
+    assert_equal pirate.saved_change_to_attribute("catchphrase"), pirate.saved_change_to_attribute(:catchphrase)
+  end
+
   def test_time_attributes_changes_with_time_zone
     in_time_zone "Paris" do
       target = Class.new(ActiveRecord::Base)


### PR DESCRIPTION
Methods like `saved_change_to_attribute` work with passing in a **symbol** or a **string** `attr_name` parameter.

Example:
```ruby
pirate = Pirate.create! catchphrase: "arrr"

# same result
pirate.saved_change_to_attribute("catchphrase") # [nil, "arrr"]
pirate.saved_change_to_attribute(:catchphrase) # [nil, "arrr"], before return [nil, nil]
```