### PR TITLE
Allow prefix/suffix options for store accessors

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -33,12 +33,16 @@ module ActiveRecord
   #     store :settings, accessors: [ :color, :homepage ], coder: JSON
   #     store :parent, accessors: [ :name ], coder: JSON, prefix: true
   #     store :spouse, accessors: [ :name ], coder: JSON, prefix: :partner
+  #     store :settings, accessors: [ :two_factor_auth ], suffix: true
+  #     store :settings, accessors: [ :login_retry ], suffix: :config
   #   end
   #
   #   u = User.new(color: 'black', homepage: '37signals.com', parent_name: 'Mary', partner_name: 'Lily')
   #   u.color                          # Accessor stored attribute
   #   u.parent_name                    # Accessor stored attribute with prefix
   #   u.partner_name                   # Accessor stored attribute with custom prefix
+  #   u.two_factor_auth_settings       # Accessor stored attribute with suffix
+  #   u.login_retry_config             # Accessor stored attribute with custom suffix
   #   u.settings[:country] = 'Denmark' # Any attribute, even if not specified with an accessor
   #
   #   # There is no difference between strings and symbols for accessing custom attributes
@@ -49,11 +53,12 @@ module ActiveRecord
   #   class SuperUser < User
   #     store_accessor :settings, :privileges, :servants
   #     store_accessor :parent, :birthday, prefix: true
+  #     store_accessor :settings, :secret_question, suffix: :config
   #   end
   #
   # The stored attribute names can be retrieved using {.stored_attributes}[rdoc-ref:rdoc-ref:ClassMethods#stored_attributes].
   #
-  #   User.stored_attributes[:settings] # [:color, :homepage]
+  #   User.stored_attributes[:settings] # [:color, :homepage, :two_factor_auth, :login_retry]
   #
   # == Overwriting default accessors
   #
@@ -86,10 +91,10 @@ module ActiveRecord
     module ClassMethods
       def store(store_attribute, options = {})
         serialize store_attribute, IndifferentCoder.new(store_attribute, options[:coder])
-        store_accessor(store_attribute, options[:accessors], prefix: options[:prefix]) if options.has_key? :accessors
+        store_accessor(store_attribute, options[:accessors], options.slice(:prefix, :suffix)) if options.has_key? :accessors
       end
 
-      def store_accessor(store_attribute, *keys, prefix: nil)
+      def store_accessor(store_attribute, *keys, prefix: nil, suffix: nil)
         keys = keys.flatten
 
         accessor_prefix =
@@ -101,14 +106,25 @@ module ActiveRecord
           else
             ""
           end
+        accessor_suffix =
+          case suffix
+          when String, Symbol
+            "_#{suffix}"
+          when TrueClass
+            "_#{store_attribute}"
+          else
+            ""
+          end
 
         _store_accessors_module.module_eval do
           keys.each do |key|
-            define_method("#{accessor_prefix}#{key}=") do |value|
+            accessor_key = "#{accessor_prefix}#{key}#{accessor_suffix}"
+
+            define_method("#{accessor_key}=") do |value|
               write_store_attribute(store_attribute, key, value)
             end
 
-            define_method("#{accessor_prefix}#{key}") do
+            define_method(accessor_key) do
               read_store_attribute(store_attribute, key)
             end
           end

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -214,4 +214,38 @@ class StoreTest < ActiveRecord::TestCase
     second_dump = YAML.dump(loaded)
     assert_equal @john, YAML.load(second_dump)
   end
+
+  test "read store attributes through accessors with default suffix" do
+    @john.configs[:two_factor_auth] = true
+    assert_equal true, @john.two_factor_auth_configs
+  end
+
+  test "write store attributes through accessors with default suffix" do
+    @john.two_factor_auth_configs = false
+    assert_equal false, @john.configs[:two_factor_auth]
+  end
+
+  test "read store attributes through accessors with custom suffix" do
+    @john.configs[:login_retry] = 3
+    assert_equal 3, @john.login_retry_config
+  end
+
+  test "write store attributes through accessors with custom suffix" do
+    @john.login_retry_config = 5
+    assert_equal 5, @john.configs[:login_retry]
+  end
+
+  test "read accessor without pre/suffix in the same store as other pre/suffixed accessors still works" do
+    @john.configs[:secret_question] = "What is your high school?"
+    assert_equal "What is your high school?", @john.secret_question
+  end
+
+  test "write accessor without pre/suffix in the same store as other pre/suffixed accessors still works" do
+    @john.secret_question = "What was the Rails version when you first worked on it?"
+    assert_equal "What was the Rails version when you first worked on it?", @john.configs[:secret_question]
+  end
+
+  test "prefix/suffix do not affect stored attributes" do
+    assert_equal [:secret_question, :two_factor_auth, :login_retry], Admin::User.stored_attributes[:configs]
+  end
 end

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -22,6 +22,9 @@ class Admin::User < ActiveRecord::Base
   store :parent, accessors: [:birthday, :name], prefix: true
   store :spouse, accessors: [:birthday], prefix: :partner
   store_accessor :spouse, :name, prefix: :partner
+  store :configs, accessors: [ :secret_question ]
+  store :configs, accessors: [ :two_factor_auth ], suffix: true
+  store_accessor :configs, :login_retry, suffix: :config
   store :preferences, accessors: [ :remember_login ]
   store :json_data, accessors: [ :height, :weight ], coder: Coder.new
   store :json_data_empty, accessors: [ :is_a_good_guy ], coder: Coder.new

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define do
     t.string :settings, null: true, limit: 1024
     t.string :parent, null: true, limit: 1024
     t.string :spouse, null: true, limit: 1024
+    t.string :configs, null: true, limit: 1024
     # MySQL does not allow default values for blobs. Fake it out with a
     # big varchar below.
     t.string :preferences, null: true, default: "", limit: 1024


### PR DESCRIPTION
### Summary

####Background:
```ruby
class SampleModel < ApplicationRecord
  store :settings, accessors: [:color, :dependencies], coder: JSON
  has_many :dependencies
end
```
There was a situation where association ```has_many :dependencies``` existed
whereas we needed the same key "dependencies" (the value is array of dependency's names) as a part of "settings" JSON, too, so that the JSON can be consumed as it is from some other stuff.

We needed SampleModel#dependencies to return the association dependencies (and thus we wanted to add a method like setting_dependencies for JSON dependencies),
but the default behavior of SampleModel#dependencies above is to return JSON dependencies.

####Workarounds:
1. remove_method, undef or alias, etc, to override
 => Didn't quite work well.
2. ```has_many :my_dependencies, class: Dependency``` and have ```def dependencies; my_dependencies; end``` to override
 => Too much carefulness is necessary to cover other methods that has_many generates so I avoided this.
3. Do not apply ```store (or store_accessor)``` for JSON dependencies, and add ```def setting_dependencies; settings[:dependencies]; end``` (and setter also).
 => This was the most viable option. But dependencies does not show up in SampleModel.stored_attributes (however you can add it).

But in the end, among stored accessors, only dependencies had ```setting_``` prefix.
To be consistent and clearer, I ended up with adding ```setting_``` for other stored accessors, too, in the similar way as No3 above. (setting_color/setting_dependencies for SampleModel above.)

This PR allows this prefix as an option out of the box.
The above was just one case but I think there will be some other cases, too, where prefix/suffix option is convenient and useful.
(Btw I referenced enum prefix for the implementation.)

```ruby
store :settings, accessors: [ :two_factor_auth ], coder: JSON, _prefix: true
# => accessor will be model.settings_two_factor_auth
store_accessor :settings, :secret_question, _prefix: 'config'
# => accessor will be model.config_secret_question
store :settings, accessors: [ :login_retry ], _suffix: 'setting'
# => accessor will be model.login_retry_setting

```

Lastly, thank you for the great work, Rails team!


