### PR TITLE
Improve Fixture Caching for Same Table Fixtures

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1061,3 +1061,26 @@ class SameNameDifferentDatabaseFixturesTest < ActiveRecord::TestCase
     assert_kind_of OtherDog, other_dogs(:lassie)
   end
 end
+
+class FixturesCacheTest < ActiveRecord::TestCase
+  def setup
+    ActiveRecord::FixtureSet.reset_cache
+    create_fixtures("parrots")
+  end
+
+  def test_no_queries_for_cached_fixtures
+    assert_no_queries do
+      create_fixtures("parrots")
+    end
+  end
+
+  def test_reset_cache_for_loaded_fixtures_on_same_table_as_new_fixtures
+    assert_equal 5, Parrot.count
+
+    assert_queries :any do
+      create_fixtures("parrots", "live_parrots")
+    end
+
+    assert_equal 6, Parrot.count
+  end
+end


### PR DESCRIPTION
**Note: this is a part of the https://github.com/rails/rails/pull/29271 pull request**

This is still a work in progress and needs some cleanup, but it works as a Proof-of-Concept. I wanted to get @matthewd's review on it currently.

Still needs:
- [ ] Cleanup code: refactor `reject!` out, extra local variables, cleaner flow, etc.
- [x] Way to test correctly - Currently the best way to run the tests prove it works is:
```
bin/test test/cases/fixtures_test.rb -n "/^(?:OrderedFixturesTest::A#(?:test_fixtures_loaded)|OrderedFixturesTest::B#(?:test_fixtures_loaded)|OrderedFixturesTest::C#(?:test_fixtures_loaded))$/" --seed 37827
```

### Problem

``` ruby
class A < ActiveRecord::TestCase
  fixtures :parrots

  def test_fixtures_loaded
    # Dusty may or may not be present, depending on whether some other
    # test has loaded the :live_parrots fixture.
    assert_equal [nil, "Curious George", "King Louis", "frederick", "polly"], Parrot.order(:name).pluck(:name) - ["Dusty Bluebird"]
  end
end

class B < ActiveRecord::TestCase
  fixtures :parrots, :live_parrots

  def test_fixtures_loaded
    assert_equal [nil, "Curious George", "Dusty Bluebird", "King Louis", "frederick", "polly"], Parrot.order(:name).pluck(:name)
  end
end

class C < ActiveRecord::TestCase
  fixtures :parrots

  def test_fixtures_loaded
    assert_equal [nil, "Curious George", "King Louis", "frederick", "polly"], Parrot.order(:name).pluck(:name) - ["Dusty Bluebird"]
  end
end
```
```
Run options: -n "/^(?:OrderedFixturesTest::A#(?:test_fixtures_loaded)|OrderedFixturesTest::B#(?:test_fixtures_loaded)|OrderedFixturesTest::C#(?:test_fixtures_loaded))$/" --seed 37827

# Running:
.F

Failure:
OrderedFixturesTest::B#test_fixtures_loaded [/Users/akitchens/Repos/fun/rails/activerecord/test/cases/fixtures_test.rb:1087]:
--- expected
+++ actual
@@ -1 +1 @@
-[nil, "Curious George", "Dusty Bluebird", "King Louis", "frederick", "polly"]
+["Dusty Bluebird"]

bin/test test/cases/fixtures_test.rb:1083

F

Failure:
OrderedFixturesTest::C#test_fixtures_loaded [/Users/akitchens/Repos/fun/rails/activerecord/test/cases/fixtures_test.rb:1098]:
--- expected
+++ actual
@@ -1 +1 @@
-[nil, "Curious George", "King Louis", "frederick", "polly"]
+[]
```

If Class `B` runs after class `A`, class `B`'s test will fail. Because
`:parrots` is already cached, it skips the fixture, but when it gets to
`:live_parrots`, it drops the table and loads up the `:live_parrots`
fixtures.


If Class `C` runs after class `B`, it fails because `:parrots` has been
cached, but the records are no longer in the table.

### Solution

Keep a map of fixtures by table. If when it comes time to create
fixtures and the fixtures for the table match what is cached, then we
can skip creating them in the database. If the fixtures are short of
what we have cached, then the database needs to be cleaned to remove old
records. If the fixtures are more than we have cached, then we need to
start clean to see that the table is properly loaded.

See the conversation on https://github.com/rails/rails/pull/29298 for
more information.
