### PR TITLE
Add teardown to reset_connection at MysqlTypeLookupTest

### DIFF
--- a/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
@@ -1,11 +1,18 @@
 require "cases/helper"
+require "support/connection_helper"
 
 if current_adapter?(:Mysql2Adapter)
   module ActiveRecord
     module ConnectionAdapters
       class MysqlTypeLookupTest < ActiveRecord::TestCase
+        include ConnectionHelper
+
         setup do
           @connection = ActiveRecord::Base.connection
+        end
+
+        def teardown
+          reset_connection
         end
 
         def test_boolean_types


### PR DESCRIPTION
This issue addresses one of random failure at `unlock-minitest` branch
https://travis-ci.org/rails/rails/jobs/239950090

### Summary
Restore `emulate_booleans` value every test at `Mysql2BooleanTest`
to avoid random failures at `Mysql2BooleanTest#test_column_type_without_emulated_booleans`

It is likely due to `Mysql2BooleanTest` changes `emulate_booleans` value to non default one but does not restore to original value in every tests.

### Steps to reproduce
1. Install Vagrant
2. At your host 
```
git clone https://github.com/rails/rails-dev-box.git
cd rails-dev-box
vagrant up
vagrant ssh
```

3. At rails-dev-box
```
git clone https://github.com/rails/rails.git
cd rails/activerecord
git checkout unlock-minitest
bundle install
wget https://gist.githubusercontent.com/yahonda/a41e73ee108a2d2e22006d33a74205eb/raw/8723b8acc661ae0380d5369bfca6844b3b1817bb/rep_mysql2_booleans_unlock_minitest.sh
sh ./rep_mysql2_booleans_unlock_minitest.sh
```

### Expected behavior
All unit tests should pass.

### Actual behavior
```ruby
Using mysql2
Run options: --seed 59459

# Running:

.........F..

Finished in 0.762664s, 15.7343 runs/s, 41.9582 assertions/s.

  1) Failure:
Mysql2BooleanTest#test_column_type_without_emulated_booleans [/home/ubuntu/rails/activerecord/test/cases/adapters/mysql2/boolean_test.rb:37]:
Expected: :integer
  Actual: :boolean

12 runs, 32 assertions, 1 failures, 0 errors, 0 skips
```

### System configuration
**Rails version**:unlock-minitest branch

**Ruby version**:ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux-gnu]