### PR TITLE
Insert environment value to `InternalMetadata` table before check environment

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -1,6 +1,8 @@
 require "cases/helper"
 
 class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
+  self.use_transactional_tests = false
+
   def test_renaming_index_on_foreign_key
     connection.add_index "engines", "car_id"
     connection.add_foreign_key :engines, :cars, name: "fk_engines_cars"
@@ -31,6 +33,8 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
 
       assert connection.column_exists?(table_name, :key, :string)
     end
+  ensure
+    ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Migrator.current_environment
   end
 
   private


### PR DESCRIPTION
Sometimes `ActiveRecord::DatabaseTasksUtilsTask#test_raises_an_error_when_called_with_protected_environment` test fails.
https://travis-ci.org/rails/rails/jobs/238861562
https://travis-ci.org/rails/rails/jobs/239950092

There seems to be an error because `environment` value is not exist.
Therefore, fixed to insert a `environment` value when `environment` value is not exist.

