### PR TITLE
Update Dirty docs to match ActiveRecord method `reload`

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -45,7 +45,7 @@ module ActiveModel
   #       changes_applied
   #     end
   #
-  #     def reload!
+  #     def reload
   #       # get the values from the persistence layer
   #
   #       clear_changes_information
@@ -83,7 +83,7 @@ module ActiveModel
   #   person.previous_changes         # => {"name" => [nil, "Bill"]}
   #   person.name_previously_changed? # => true
   #   person.name_previous_change     # => [nil, "Bill"]
-  #   person.reload!
+  #   person.reload
   #   person.previous_changes         # => {}
   #
   # Rollback the changes:


### PR DESCRIPTION
ActiveRecord uses bang-free `reload` method to refresh data from persistence layer (thus resetting dirty tracking). Docs were showing the console `reload!` method that reloads the Rails application.