### PR TITLE
Remove unreachable code

### DIFF
--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -28,14 +28,7 @@ module ActiveSupport
         raise e.exception "tzinfo-data is not present. Please add gem 'tzinfo-data' to your Gemfile and run bundle install"
       end
       require "active_support/core_ext/time/zones"
-      zone_default = Time.find_zone!(app.config.time_zone)
-
-      unless zone_default
-        raise "Value assigned to config.time_zone not recognized. " \
-          'Run "rake time:zones:all" for a time zone names list.'
-      end
-
-      Time.zone_default = zone_default
+      Time.zone_default = Time.find_zone!(app.config.time_zone)
     end
 
     # Sets the default week start


### PR DESCRIPTION
`Time.find_zone!` raise `ArgumentError` if invalid value is specified.
https://github.com/rails/rails/blob/379a0b42daf0d8e14130db7fd886d05d8d88e3f2/activesupport/lib/active_support/core_ext/time/zones.rb#L97..L99

Therefore, the return value never becomes nil.
