### PR TITLE
Bundle capybara 2.14.1 that includes fix for Ruby warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
     bunny (2.6.2)
       amq-protocol (>= 2.0.1)
     byebug (9.0.6)
-    capybara (2.14.0)
+    capybara (2.14.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -367,7 +367,7 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    xpath (2.0.0)
+    xpath (2.1.0)
       nokogiri (~> 1.3)
 
 PLATFORMS


### PR DESCRIPTION
Ref: https://github.com/teamcapybara/capybara/pull/1868

