### PR TITLE
Add Pluck Hash method to Active Record.

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -189,6 +189,38 @@ module ActiveRecord
       end
     end
 
+    # Use #pluck_h as a shortcut to select one or more attributes without
+    # loading a bunch of records just to grab the attributes you want.
+    #
+    #   Person.pluck_h(:name)
+    #
+    # instead of
+    #
+    #   Person.all.map{|it| {name: it.name}}
+    #
+    # pluck_h returns an Array of Hashes. See also #pluck
+    #
+    #   Person.pluck_h(:name)
+    #   # SELECT people.name FROM people
+    #   # => [{name: 'David'}, {name: 'Jeremy'}, {name: 'Jose'}]
+    #
+    #   Person.pluck(:id, :name)
+    #   # SELECT people.id, people.name FROM people
+    #   # => [{id: 1, name: 'Olivia'}, {id: 2, name: 'Ava'}, {id: 3, name: 'Sophia'}]
+    #
+    #   Person.distinct.pluck(:role)
+    #   # SELECT DISTINCT role FROM people
+    #   # => [{role: 'admin'}, {role: 'member'}, {role: 'guest'}]
+    #
+    #   Person.where(age: 21).limit(5).pluck(:id)
+    #   # SELECT people.id FROM people WHERE people.age = 21 LIMIT 5
+    #   # => [{id: 2}, {id: 3}]
+    #
+    #
+    def pluck_h(*keys)
+      pluck(*keys).map{|pa| Hash[keys.zip(pa)]}
+    end
+
     # Pluck all the ID's for the relation using the table's primary key
     #
     #   Person.ids # SELECT people.id FROM people

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -196,7 +196,7 @@ module ActiveRecord
     #
     # instead of
     #
-    #   Person.all.map{|it| {name: it.name}}
+    #   Person.all.map { |it| {name: it.name} }
     #
     # pluck_h returns an Array of Hashes. See also #pluck
     #
@@ -218,7 +218,7 @@ module ActiveRecord
     #
     #
     def pluck_h(*keys)
-      pluck(*keys).map{|pa| Hash[keys.zip(pa)]}
+      pluck(*keys).map { |pa| Hash[keys.zip(pa)] }
     end
 
     # Pluck all the ID's for the relation using the table's primary key


### PR DESCRIPTION
### Summary

I recently fixed several memory bloat issues with my production rails app. Using pluck helped a bunch, but working with 2-d arrays was cumbersome. I found a pluck_to_hash method on Stack Overflow: https://stackoverflow.com/a/27995494/4190933

This PR adds a pluck_h method that behaves like pluck but returns an array of hashes instead of a 2-d array. 

### Other Information

Before writing tests and doing benchmarks I was hoping to get some feedback on this feature. Would this be a helpful addition to Active Record? Would it be added if tests and benchmarks were provided? Did I put this in the right place?

Patience and grace appreciated, this is my first open source PR. 
