### PR TITLE
Handle exceptions when opening websocket using proper close event codes

### DIFF
--- a/actioncable/lib/action_cable/connection/web_socket.rb
+++ b/actioncable/lib/action_cable/connection/web_socket.rb
@@ -20,8 +20,12 @@ module ActionCable
         websocket.transmit data
       end
 
-      def close
-        websocket.close
+      def close(code = nil, reason = nil)
+        websocket.close(code, reason)
+      end
+
+      def fail(error)
+        websocket.fail(error)
       end
 
       def protocol


### PR DESCRIPTION
Hello ❤️

I noticed that when there is an exception while opening a websocket (for example in the `#connect` method), the websocket might remain open. This is not a biggie if you're using the `ActionCable` javascript API, because the `ConnectionMonitor` detects that the connection has become staled, closes it and tries to open it again.

The project I'm working on, successfully implemented ActionCable in the server while keeping a custom javascript implementation. Since we do not implement a polling mechanism to know if a connection is staled, we are totally unaware if the websocket connection has raised any exception.

I've been thinking how to handle this, and in my opinion, we should close the socket with a proper close code to let know the client that there's been an issue while opening the connection. The [WebSocket Protocol RFC](https://tools.ietf.org/html/rfc6455) defines different close codes that we can use to tell the client what kind of thing has happened. 

Currently AC only allows closing the WebSocket with code 1000 (normal closing) but I think that in this case we should use the code 1011.

>  1011 indicates that a server is terminating the connection because it encountered an unexpected condition that prevented it from fulfilling the request.

I added a new method `#fail` that will emit a close signal with code `1011` and the error as `reason`

You can try this PR here: https://github.com/yukideluxe/actioncable-examples/tree/test-connection-exception

I'll add some inline comments for further explanations ✌️ This is just a raw proposal to start a discussion about this :)

👋 