### PR TITLE
Don’t let to use remove_column for a FK column

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -594,6 +594,10 @@ module ActiveRecord
       # to provide these in a migration's +change+ method so it can be reverted.
       # In that case, +type+ and +options+ will be used by #add_column.
       def remove_column(table_name, column_name, type = nil, options = {})
+        if foreign_key_exists?(table_name, column: column_name)
+          raise ArgumentError.new("To remove a column referenced in a foreign_key, use `remove_reference` instead of `remove_column`. Example: remove_reference(:products, :user, foreign_key: true)")
+        end
+
         execute "ALTER TABLE #{quote_table_name(table_name)} DROP #{quote_column_name(column_name)}"
       end
 

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -40,6 +40,16 @@ if ActiveRecord::Base.connection.supports_foreign_keys_in_create?
           end
         end
 
+        test "remove_column is prevented for a foreign key column" do
+          @connection.create_table :testings do |t|
+            t.references :testing_parent, foreign_key: true
+          end
+
+          assert_raises(ArgumentError) do
+            @connection.remove_column("testings", "testing_parent_id")
+          end
+        end
+
         test "options hash can be passed" do
           @connection.change_table :testing_parents do |t|
             t.references :other, index: { unique: true }


### PR DESCRIPTION
As mentioned by @dhh in the Campfire:

> I'm thinking that remove_column should catch the exceptions and explain that you should use remove_reference. And remove_reference should do the work of removing the FK as well.

I agree that instead of crashing with `Mysql2::Error` we should explain developers that to remove a FK column they should use `remove_reference`.