### PR TITLE
Raise on create for singular association when parent is unpersisted

### DIFF
--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -63,6 +63,10 @@ module ActiveRecord
         end
 
         def _create_record(attributes, raise_error = false)
+          unless owner.persisted?
+            raise ActiveRecord::RecordNotSaved, "You cannot call create unless the parent is saved"
+          end
+
           record = build_record(attributes)
           yield(record) if block_given?
           saved = record.save

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -307,6 +307,15 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_create_when_parent_is_new_raises
+    firm = Firm.new
+    error = assert_raise(ActiveRecord::RecordNotSaved) do
+      firm.create_account
+    end
+
+    assert_equal "You cannot call create unless the parent is saved", error.message
+  end
+
   def test_reload_association
     odegy = companies(:odegy)
 

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -117,7 +117,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
 
   def test_reject_if_with_a_proc_which_returns_true_always_for_has_one
     Pirate.accepts_nested_attributes_for :ship, reject_if: proc { |attributes| true }
-    pirate = Pirate.new(catchphrase: "Stop wastin' me time")
+    pirate = Pirate.create(catchphrase: "Stop wastin' me time")
     ship = pirate.create_ship(name: "s1")
     pirate.update(ship_attributes: { name: "s2", id: ship.id })
     assert_equal "s1", ship.reload.name


### PR DESCRIPTION
A [collection association will raise](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/collection_association.rb#L350) on `#create_association` when the parent is unpersisted. A singular association should do the same. This addresses issue #29219.

