### PR TITLE
[ci skip] Document how to initialize an ActionDispatch::Http::UploadedFile

### DIFF
--- a/actionpack/lib/action_dispatch/http/upload.rb
+++ b/actionpack/lib/action_dispatch/http/upload.rb
@@ -23,7 +23,30 @@ module ActionDispatch
       # A string with the headers of the multipart request.
       attr_accessor :headers
 
-      def initialize(hash) # :nodoc:
+      # An ActionDispatch::Http::UploadedFile accepts an options hash and sets
+      # the following keys:
+      #
+      #   upload = ActionDispatch::Http::UploadedFile.new({
+      #     tempfile: File.new("/test/fixtures/photo.jpg"),
+      #     filename: "photo.jpg",
+      #     type: "image/jpeg",
+      #     head: "Content-Disposition: form-data; name=\"file\"; filename=\"photo.jpg\"\r\nContent-Type: image/jpeg\r\n"
+      #   })
+      #
+      # After initialization, the following attributes return:
+      #
+      #   upload.tempfile
+      #   => #<File:/test/fixtures/photo.jpg>
+      #
+      #   upload.original_filename
+      #   => "photo.jpg"
+      #
+      #   upload.content_type
+      #   => "image/jpeg"
+      #
+      #   upload.headers
+      #   => "Content-Disposition: form-data; name=\"file\"; filename=\"photo.jpg\"\r\nContent-Type: image/jpeg\r\n"
+      def initialize(hash)
         @tempfile = hash[:tempfile]
         raise(ArgumentError, ":tempfile is required") unless @tempfile
 


### PR DESCRIPTION
**This PR:**

Adds information on how to initialize an `ActionDispatch::Http::UploadedFile`. 

**Why**

There is a discrepancy between `::UploadedFile`'s attribute accessors and the hash keys that it is initialized with, making initialization non intuitive at first glance.

Instances where this was asked on StackOverflow: [#1](https://stackoverflow.com/questions/26261227/reading-and-writing-file-attributes#answer-26262081), [#2](https://stackoverflow.com/questions/23899860/actiondispatchhttpuploadedfile-content-type-not-being-initialized-in-rspec-t#answer-24215061)

**Preview**

<img width="833" alt="screen shot 2017-06-08 at 10 30 34 pm" src="https://user-images.githubusercontent.com/5669259/26958719-28534c86-4c9a-11e7-8057-6adebab084c4.png">

**Note**

If it would be beneficial to add the ability to initialize an `::UploadedFile` using it's attribute accessors, or aliasing the hash keys accordingly, I would be more than happy to provide that contribution as well as re-update the docs. 😄 