### PR TITLE
[ci skip] Add backquote to :counter_cache option

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -960,7 +960,7 @@ class Author < ApplicationRecord
 end
 ```
 
-NOTE: You only need to specify the :counter_cache option on the `belongs_to`
+NOTE: You only need to specify the `:counter_cache` option on the `belongs_to`
 side of the association.
 
 Counter cache columns are added to the containing model's list of read-only attributes through `attr_readonly`.


### PR DESCRIPTION
I found a missing backquote of :counter_cache option when translating RailsGuides into Japanese.