### PR TITLE
Allow `uuid_test.rb` to be loaded on all adapters

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -40,7 +40,8 @@ class PostgresqlUUIDTest < ActiveRecord::PostgreSQLTestCase
     drop_table "uuid_data_type"
   end
 
-  if ActiveRecord::Base.connection.supports_pgcrypto_uuid?
+  if ActiveRecord::Base.connection.respond_to?(:supports_pgcrypto_uuid?) &&
+      ActiveRecord::Base.connection.supports_pgcrypto_uuid?
     def test_uuid_column_default
       connection.add_column :uuid_data_type, :thingy, :uuid, null: false, default: "gen_random_uuid()"
       UUIDType.reset_column_information


### PR DESCRIPTION
Running `bin/test` from the activerecord directory produces this error since https://github.com/rails/rails/pull/25395:

    test/cases/adapters/postgresql/uuid_test.rb:43:in `<class:PostgresqlUUIDTest>': undefined method `supports_pgcrypto_uuid?' for #<ActiveRecord::ConnectionAdapters::SQLite3Adapter:0x007fc405e72a68> (NoMethodError)

The test only actually runs on the PostgreSQL adapter; by waiting until then to decide whether to skip it, we can avoid triggering the error on other adapters.