### PR TITLE
Generate field ids in `collection_check_boxes` and `collection_radio_buttons`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Generate field ids in `collection_check_boxes` and `collection_radio_buttons`.
+
+    This makes sure that the labels are linked up with the fields.
+
+    Fixes #29014.
+
+    *Yuji Yaginuma*
+
 *   Add `:json` type to `auto_discovery_link_tag` to support [JSON Feeds](https://jsonfeed.org/version/1)
 
     *Mike Gunderloy*

--- a/actionview/lib/action_view/helpers/tags/collection_check_boxes.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_check_boxes.rb
@@ -10,6 +10,7 @@ module ActionView
           def check_box(extra_html_options = {})
             html_options = extra_html_options.merge(@input_html_options)
             html_options[:multiple] = true
+            html_options[:skip_default_ids] = false
             @template_object.check_box(@object_name, @method_name, html_options, @value, nil)
           end
         end

--- a/actionview/lib/action_view/helpers/tags/collection_radio_buttons.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_radio_buttons.rb
@@ -9,6 +9,7 @@ module ActionView
         class RadioButtonBuilder < Builder # :nodoc:
           def radio_button(extra_html_options = {})
             html_options = extra_html_options.merge(@input_html_options)
+            html_options[:skip_default_ids] = false
             @template_object.radio_button(@object_name, @method_name, @value, html_options)
           end
         end

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -403,9 +403,9 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts") do
       "<input type='hidden' name='post[active]' value='' />" \
-      "<input name='post[active]' type='radio' value='true' />" \
+      "<input name='post[active]' type='radio' value='true' id='post_active_true' />" \
       "<label for='post_active_true'>true</label>" \
-      "<input checked='checked' name='post[active]' type='radio' value='false' />" \
+      "<input checked='checked' name='post[active]' type='radio' value='false' id='post_active_false' />" \
       "<label for='post_active_false'>false</label>"
     end
 
@@ -426,10 +426,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts") do
       "<input type='hidden' name='post[active]' value='' />" \
       "<label for='post_active_true'>" \
-      "<input name='post[active]' type='radio' value='true' />" \
+      "<input name='post[active]' type='radio' value='true' id='post_active_true' />" \
       "true</label>" \
       "<label for='post_active_false'>" \
-      "<input checked='checked' name='post[active]' type='radio' value='false' />" \
+      "<input checked='checked' name='post[active]' type='radio' value='false' id='post_active_false' />" \
       "false</label>"
     end
 
@@ -452,10 +452,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts") do
       "<input type='hidden' name='post[active]' value='' />" \
       "<label for='post_active_true'>" \
-      "<input name='post[active]' type='radio' value='true' />" \
+      "<input name='post[active]' type='radio' value='true' id='post_active_true' />" \
       "true</label>" \
       "<label for='post_active_false'>" \
-      "<input checked='checked' name='post[active]' type='radio' value='false' />" \
+      "<input checked='checked' name='post[active]' type='radio' value='false' id='post_active_false' />" \
       "false</label>" \
       "<input name='post[id]' type='hidden' value='1' />"
     end
@@ -473,9 +473,9 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts") do
       "<input type='hidden' name='post[1][active]' value='' />" \
-      "<input name='post[1][active]' type='radio' value='true' />" \
+      "<input name='post[1][active]' type='radio' value='true' id='post_1_active_true' />" \
       "<label for='post_1_active_true'>true</label>" \
-      "<input checked='checked' name='post[1][active]' type='radio' value='false' />" \
+      "<input checked='checked' name='post[1][active]' type='radio' value='false' id='post_1_active_false' />" \
       "<label for='post_1_active_false'>false</label>"
     end
 
@@ -492,11 +492,11 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts") do
       "<input name='post[tag_ids][]' type='hidden' value='' />" \
-      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' />" \
+      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' id='post_tag_ids_1' />" \
       "<label for='post_tag_ids_1'>Tag 1</label>" \
-      "<input name='post[tag_ids][]' type='checkbox' value='2' />" \
+      "<input name='post[tag_ids][]' type='checkbox' value='2' id='post_tag_ids_2' />" \
       "<label for='post_tag_ids_2'>Tag 2</label>" \
-      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='3' />" \
+      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='3' id='post_tag_ids_3' />" \
       "<label for='post_tag_ids_3'>Tag 3</label>"
     end
 
@@ -517,13 +517,13 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts") do
       "<input name='post[tag_ids][]' type='hidden' value='' />" \
       "<label for='post_tag_ids_1'>" \
-      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' />" \
+      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' id='post_tag_ids_1' />" \
       "Tag 1</label>" \
       "<label for='post_tag_ids_2'>" \
-      "<input name='post[tag_ids][]' type='checkbox' value='2' />" \
+      "<input name='post[tag_ids][]' type='checkbox' value='2' id='post_tag_ids_2' />" \
       "Tag 2</label>" \
       "<label for='post_tag_ids_3'>" \
-      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='3' />" \
+      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='3' id='post_tag_ids_3' />" \
       "Tag 3</label>"
     end
 
@@ -547,13 +547,13 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts") do
       "<input name='post[tag_ids][]' type='hidden' value='' />" \
       "<label for='post_tag_ids_1'>" \
-      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' />" \
+      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' id='post_tag_ids_1' />" \
       "Tag 1</label>" \
       "<label for='post_tag_ids_2'>" \
-      "<input name='post[tag_ids][]' type='checkbox' value='2' />" \
+      "<input name='post[tag_ids][]' type='checkbox' value='2' id='post_tag_ids_2' />" \
       "Tag 2</label>" \
       "<label for='post_tag_ids_3'>" \
-      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='3' />" \
+      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='3' id='post_tag_ids_3' />" \
       "Tag 3</label>" \
       "<input name='post[id]' type='hidden' value='1' />"
     end
@@ -572,7 +572,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts") do
       "<input name='post[1][tag_ids][]' type='hidden' value='' />" \
-      "<input checked='checked' name='post[1][tag_ids][]' type='checkbox' value='1' />" \
+      "<input checked='checked' name='post[1][tag_ids][]' type='checkbox' value='1' id='post_1_tag_ids_1' />" \
       "<label for='post_1_tag_ids_1'>Tag 1</label>"
     end
 


### PR DESCRIPTION
This makes sure that the labels are linked up with the fields.
Fixes #29014

r? @kaspth 