### PR TITLE
Remove unused defined association

### DIFF
--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -143,7 +143,7 @@ class MergingDifferentRelationsTest < ActiveRecord::TestCase
     assert_equal ["Mary", "Mary", "Mary", "David"], posts_by_author_name
   end
 
-  test "relation merging (using a proc  argument)" do
+  test "relation merging (using a proc argument)" do
     dev = Developer.where(name: "Jamis").first
 
     comment_1 = dev.comments.create!(body: "I'm Jamis", post: Post.first)

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -9,7 +9,6 @@ class Comment < ActiveRecord::Base
   belongs_to :post, counter_cache: true
   belongs_to :author,   polymorphic: true
   belongs_to :resource, polymorphic: true
-  belongs_to :developer
 
   has_many :ratings
 


### PR DESCRIPTION
`belongs_to :developer` on `Comment` model was added in 431f8e0 but it
is unused.