### PR TITLE
Use `require_relative` instead of `require` with full path

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -409,7 +409,7 @@ application. The recommended basic setup is as follows:
 
 ```ruby
 # cable/config.ru
-require ::File.expand_path('../config/environment', __dir__)
+require_relative '../config/environment'
 Rails.application.eager_load!
 
 run ActionCable.server

--- a/actioncable/bin/test
+++ b/actioncable/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
-require File.expand_path("../tools/test", COMPONENT_ROOT)
+require_relative "../../tools/test"

--- a/actioncable/test/subscription_adapter/async_test.rb
+++ b/actioncable/test/subscription_adapter/async_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-require_relative "./common"
+require_relative "common"
 
 class AsyncAdapterTest < ActionCable::TestCase
   include CommonSubscriptionAdapterTest

--- a/actioncable/test/subscription_adapter/evented_redis_test.rb
+++ b/actioncable/test/subscription_adapter/evented_redis_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
-require_relative "./common"
-require_relative "./channel_prefix"
+require_relative "common"
+require_relative "channel_prefix"
 
 class EventedRedisAdapterTest < ActionCable::TestCase
   include CommonSubscriptionAdapterTest

--- a/actioncable/test/subscription_adapter/inline_test.rb
+++ b/actioncable/test/subscription_adapter/inline_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-require_relative "./common"
+require_relative "common"
 
 class InlineAdapterTest < ActionCable::TestCase
   include CommonSubscriptionAdapterTest

--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-require_relative "./common"
+require_relative "common"
 
 require "active_record"
 

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
-require_relative "./common"
-require_relative "./channel_prefix"
+require_relative "common"
+require_relative "channel_prefix"
 
 class RedisAdapterTest < ActionCable::TestCase
   include CommonSubscriptionAdapterTest

--- a/actionmailer/bin/test
+++ b/actionmailer/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
-require File.expand_path("../tools/test", COMPONENT_ROOT)
+require_relative "../../tools/test"

--- a/actionpack/bin/test
+++ b/actionpack/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
-require File.expand_path("../tools/test", COMPONENT_ROOT)
+require_relative "../../tools/test"

--- a/actionview/bin/test
+++ b/actionview/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
-require File.expand_path("../tools/test", COMPONENT_ROOT)
+require_relative "../../tools/test"

--- a/activejob/bin/test
+++ b/activejob/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
-require File.expand_path("../tools/test", COMPONENT_ROOT)
+require_relative "../../tools/test"

--- a/activemodel/bin/test
+++ b/activemodel/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
-require File.expand_path("../tools/test", COMPONENT_ROOT)
+require_relative "../../tools/test"

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -1,7 +1,7 @@
 require "rake/testtask"
 
-require File.expand_path("test/config", __dir__)
-require File.expand_path("test/support/config", __dir__)
+require_relative "test/config"
+require_relative "test/support/config"
 
 def run_without_aborting(*tasks)
   errors = []

--- a/activerecord/bin/test
+++ b/activerecord/bin/test
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
-require File.expand_path("../tools/test", COMPONENT_ROOT)
+require_relative "../../tools/test"
 
 module Minitest
   def self.plugin_active_record_options(opts, options)

--- a/activerecord/test/cases/errors_test.rb
+++ b/activerecord/test/cases/errors_test.rb
@@ -1,4 +1,4 @@
-require_relative "../cases/helper"
+require "cases/helper"
 
 class ErrorsTest < ActiveRecord::TestCase
   def test_can_be_instantiated_with_no_args

--- a/activesupport/bin/test
+++ b/activesupport/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
-require File.expand_path("../tools/test", COMPONENT_ROOT)
+require_relative "../../tools/test"

--- a/railties/bin/test
+++ b/railties/bin/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
-require File.expand_path("../tools/test", COMPONENT_ROOT)
+require_relative "../../tools/test"

--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../config/environment', __dir__)
+require_relative '../config/environment'
 require 'rails/test_help'
 
 class ActiveSupport::TestCase

--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
@@ -1,4 +1,4 @@
-require File.expand_path("../<%= options[:dummy_path] -%>/config/environment.rb", __dir__)
+require_relative "<%= File.join('..', options[:dummy_path], 'config/environment') -%>"
 <% unless options[:skip_active_record] -%>
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../<%= options[:dummy_path] -%>/db/migrate", __dir__)]
 <% if options[:mountable] -%>

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -63,7 +63,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_no_file "config/routes.rb"
     assert_no_file "app/assets/config/bukkits_manifest.js"
     assert_file "test/test_helper.rb" do |content|
-      assert_match(/require.+test\/dummy\/config\/environment/, content)
+      assert_match(/require_relative.+test\/dummy\/config\/environment/, content)
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+test\/dummy\/db\/migrate/, content)
       assert_match(/Minitest\.backtrace_filter = Minitest::BacktraceFilter\.new/, content)
       assert_match(/Rails::TestUnitReporter\.executable = 'bin\/test'/, content)
@@ -438,7 +438,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "spec/dummy/config/application.rb"
     assert_no_file "test/dummy"
     assert_file "test/test_helper.rb" do |content|
-      assert_match(/require.+spec\/dummy\/config\/environment/, content)
+      assert_match(/require_relative.+spec\/dummy\/config\/environment/, content)
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+spec\/dummy\/db\/migrate/, content)
     end
   end
@@ -449,7 +449,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "spec/fake/config/application.rb"
     assert_no_file "test/dummy"
     assert_file "test/test_helper.rb" do |content|
-      assert_match(/require.+spec\/fake\/config\/environment/, content)
+      assert_match(/require_relative.+spec\/fake\/config\/environment/, content)
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+spec\/fake\/db\/migrate/, content)
     end
   end

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -233,7 +233,7 @@ class GeneratorsTest < Rails::Generators::TestCase
   end
 
   def test_usage_with_embedded_ruby
-    require File.expand_path("fixtures/lib/generators/usage_template/usage_template_generator", __dir__)
+    require_relative "fixtures/lib/generators/usage_template/usage_template_generator"
     output = capture(:stdout) { Rails::Generators.invoke :usage_template, ["--help"] }
     assert_match(/:: 2 ::/, output)
   end


### PR DESCRIPTION
@jeremy suggested converting `require` with a full path to `require_relative`. See https://github.com/rails/rails/pull/29176#pullrequestreview-39581777

After brief discuss with @fxn we decided to do it.

There are four cases i'm not sure about using `require_relative`:
- https://github.com/rails/rails/blob/a625292c793cd1fffdcf7576ac860c259493b140/activejob/test/support/integration/dummy_app_template.rb#L8
- https://github.com/rails/rails/blob/a625292c793cd1fffdcf7576ac860c259493b140/railties/lib/rails/app_loader.rb#L45
- https://github.com/rails/rails/blob/a625292c793cd1fffdcf7576ac860c259493b140/activerecord/test/cases/migration_test.rb#L11-L14
- https://github.com/rails/rails/blob/a625292c793cd1fffdcf7576ac860c259493b140/railties/lib/rails/test_unit/test_requirer.rb#L14

Related to https://github.com/rails/rails/pull/29176

r? @fxn, @jeremy 