### PR TITLE
Add system tests to generate scaffold

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
@@ -16,12 +16,9 @@ module Rails
       def handle_skip
         @options = @options.merge(stylesheets: false) unless options[:assets]
         @options = @options.merge(stylesheet_engine: false) unless options[:stylesheets] && options[:scaffold_stylesheet]
-        @options = @options.merge(system_tests: false) if options[:api]
       end
 
       hook_for :scaffold_controller, required: true
-
-      hook_for :system_tests, as: :system
 
       hook_for :assets do |assets|
         invoke assets, [controller_name]

--- a/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
@@ -11,12 +11,19 @@ module TestUnit # :nodoc:
       class_option :api, type: :boolean,
                          desc: "Generates API functional tests"
 
+      class_option :system_tests, type: :string,
+                         desc: "Skip system test files"
+
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
 
       def create_test_files
         template_file = options.api? ? "api_functional_test.rb" : "functional_test.rb"
         template template_file,
                  File.join("test/controllers", controller_class_path, "#{controller_file_name}_controller_test.rb")
+
+        unless options.api? || options[:system_tests].nil?
+          template "system_test.rb", File.join("test/system", class_path, "#{file_name.pluralize}_test.rb")
+        end
       end
 
       def fixture_name
@@ -30,16 +37,20 @@ module TestUnit # :nodoc:
 
       private
 
+        def attributes_string
+          attributes_hash.map { |k, v| "#{k}: #{v}" }.join(", ")
+        end
+
         def attributes_hash
-          return if attributes_names.empty?
+          return {} if attributes_names.empty?
 
           attributes_names.map do |name|
             if %w(password password_confirmation).include?(name) && attributes.any?(&:password_digest?)
-              "#{name}: 'secret'"
+              ["#{name}", "'secret'"]
             else
-              "#{name}: @#{singular_table_name}.#{name}"
+              ["#{name}", "@#{singular_table_name}.#{name}"]
             end
-          end.sort.join(", ")
+          end.sort.to_h
         end
     end
   end

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/api_functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/api_functional_test.rb
@@ -17,7 +17,7 @@ class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTe
 
   test "should create <%= singular_table_name %>" do
     assert_difference('<%= class_name %>.count') do
-      post <%= index_helper %>_url, params: { <%= "#{singular_table_name}: { #{attributes_hash} }" %> }, as: :json
+      post <%= index_helper %>_url, params: { <%= "#{singular_table_name}: { #{attributes_string} }" %> }, as: :json
     end
 
     assert_response 201
@@ -29,7 +29,7 @@ class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTe
   end
 
   test "should update <%= singular_table_name %>" do
-    patch <%= show_helper %>, params: { <%= "#{singular_table_name}: { #{attributes_hash} }" %> }, as: :json
+    patch <%= show_helper %>, params: { <%= "#{singular_table_name}: { #{attributes_string} }" %> }, as: :json
     assert_response 200
   end
 

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
@@ -22,7 +22,7 @@ class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTe
 
   test "should create <%= singular_table_name %>" do
     assert_difference('<%= class_name %>.count') do
-      post <%= index_helper %>_url, params: { <%= "#{singular_table_name}: { #{attributes_hash} }" %> }
+      post <%= index_helper %>_url, params: { <%= "#{singular_table_name}: { #{attributes_string} }" %> }
     end
 
     assert_redirected_to <%= singular_table_name %>_url(<%= class_name %>.last)
@@ -39,7 +39,7 @@ class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTe
   end
 
   test "should update <%= singular_table_name %>" do
-    patch <%= show_helper %>, params: { <%= "#{singular_table_name}: { #{attributes_hash} }" %> }
+    patch <%= show_helper %>, params: { <%= "#{singular_table_name}: { #{attributes_string} }" %> }
     assert_redirected_to <%= singular_table_name %>_url(<%= "@#{singular_table_name}" %>)
   end
 

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/system_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/system_test.rb
@@ -1,0 +1,49 @@
+require "application_system_test_case"
+
+<% module_namespacing do -%>
+class <%= class_name.pluralize %>Test < ApplicationSystemTestCase
+  setup do
+    @<%= singular_table_name %> = <%= fixture_name %>(:one)
+  end
+
+  test "visiting the index" do
+    visit <%= plural_table_name %>_url
+    assert_selector "h1", text: "<%= class_name.pluralize.titleize %>"
+  end
+
+  test "creating a <%= human_name %>" do
+    visit <%= plural_table_name %>_url
+    click_on "New <%= class_name.titleize %>"
+
+    <%- attributes_hash.each do |attr, value| -%>
+    fill_in "<%= attr.humanize.titleize %>", with: <%= value %>
+    <%- end -%>
+    click_on "Create <%= human_name %>"
+
+    assert_text "<%= human_name %> was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a <%= human_name %>" do
+    visit <%= plural_table_name %>_url
+    click_on "Edit", match: :first
+
+    <%- attributes_hash.each do |attr, value| -%>
+    fill_in "<%= attr.humanize.titleize %>", with: <%= value %>
+    <%- end -%>
+    click_on "Update <%= human_name %>"
+
+    assert_text "<%= human_name %> was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a <%= human_name %>" do
+    visit <%= plural_table_name %>_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "<%= human_name %> was successfully destroyed"
+  end
+end
+<% end -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -437,7 +437,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_generator_if_skip_system_test_is_given
-    run_generator [destination_root, "--skip_system_test"]
+    run_generator [destination_root, "--skip-system-test"]
     assert_file "Gemfile" do |content|
       assert_no_match(/capybara/, content)
       assert_no_match(/selenium-webdriver/, content)
@@ -445,7 +445,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_does_not_generate_system_test_files_if_skip_system_test_is_given
-    run_generator [destination_root, "--skip_system_test"]
+    run_generator [destination_root, "--skip-system-test"]
 
     Dir.chdir(destination_root) do
       quietly { `./bin/rails g scaffold User` }

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -65,6 +65,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     # System tests
     assert_file "test/system/product_lines_test.rb" do |test|
       assert_match(/class ProductLinesTest < ApplicationSystemTestCase/, test)
+      assert_match(/visit product_lines_url/, test)
+      assert_match(/fill_in "Title", with: @product_line\.title/, test)
+      assert_match(/assert_text "Product line was successfully updated"/, test)
     end
 
     # Views
@@ -146,6 +149,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert_no_match(/assert_redirected_to/, test)
     end
 
+    # System tests
+    assert_no_file "test/system/product_lines_test.rb"
+
     # Views
     assert_no_file "app/views/layouts/product_lines.html.erb"
 
@@ -173,6 +179,16 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_system_tests_without_attributes
+    run_generator ["product_line"]
+
+    assert_file "test/system/product_lines_test.rb" do |content|
+      assert_match(/class ProductLinesTest < ApplicationSystemTestCase/, content)
+      assert_match(/test "visiting the index"/, content)
+      assert_no_match(/fill_in/, content)
+    end
+  end
+
   def test_scaffold_on_revoke
     run_generator
     run_generator ["product_line"], behavior: :revoke
@@ -191,6 +207,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     # Controller
     assert_no_file "app/controllers/product_lines_controller.rb"
     assert_no_file "test/controllers/product_lines_controller_test.rb"
+
+    # System tests
+    assert_no_file "test/system/product_lines_test.rb"
 
     # Views
     assert_no_file "app/views/product_lines"
@@ -257,6 +276,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     assert_file "test/controllers/admin/roles_controller_test.rb",
                 /class Admin::RolesControllerTest < ActionDispatch::IntegrationTest/
 
+    assert_file "test/system/admin/roles_test.rb",
+                /class Admin::RolesTest < ApplicationSystemTestCase/
+
     # Views
     %w(index edit new show _form).each do |view|
       assert_file "app/views/admin/roles/#{view}.html.erb"
@@ -291,6 +313,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     # Controller
     assert_no_file "app/controllers/admin/roles_controller.rb"
     assert_no_file "test/controllers/admin/roles_controller_test.rb"
+
+    # System tests
+    assert_no_file "test/system/admin/roles_test.rb"
 
     # Views
     assert_no_file "app/views/admin/roles"
@@ -478,6 +503,11 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert_match(/password_confirmation: 'secret'/, content)
     end
 
+    assert_file "test/system/users_test.rb" do |content|
+      assert_match(/fill_in "Password", with: 'secret'/, content)
+      assert_match(/fill_in "Password Confirmation", with: 'secret'/, content)
+    end
+
     assert_file "test/fixtures/users.yml" do |content|
       assert_match(/password_digest: <%= BCrypt::Password.create\('secret'\) %>/, content)
     end
@@ -573,6 +603,8 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert File.exist?("app/controllers/bukkits/users_controller.rb")
       assert File.exist?("test/controllers/bukkits/users_controller_test.rb")
 
+      assert File.exist?("test/system/bukkits/users_test.rb")
+
       assert File.exist?("app/views/bukkits/users/index.html.erb")
       assert File.exist?("app/views/bukkits/users/edit.html.erb")
       assert File.exist?("app/views/bukkits/users/show.html.erb")
@@ -600,6 +632,8 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
       assert_not File.exist?("app/controllers/bukkits/users_controller.rb")
       assert_not File.exist?("test/controllers/bukkits/users_controller_test.rb")
+
+      assert_not File.exist?("test/system/bukkits/users_test.rb")
 
       assert_not File.exist?("app/views/bukkits/users/index.html.erb")
       assert_not File.exist?("app/views/bukkits/users/edit.html.erb")


### PR DESCRIPTION
`generate scaffold` currently generates a simple system test. This change
populates the generated system test with index, create, update, and destroy
behaviour. Feature request from @eileencodes 

Sample generated test from `bin/rails generate scaffold HighScore game:string score:integer`:
```
require "application_system_test_case"

class HighScoresTest < ApplicationSystemTestCase
  setup do
    @high_score = high_scores(:one)
  end

  test "visiting the index" do
    visit high_scores_url
    assert_selector "h1", text: "High Scores"
  end

  test "creating a High score" do
    visit high_scores_url
    click_on "New High Score"

    fill_in "Game", with: @high_score.game
    fill_in "Score", with: @high_score.score
    click_on "Create High score"

    assert_text "High score was successfully created"
    click_on "Back"
  end

  test "updating a High score" do
    visit high_scores_url
    click_on "Edit", match: :first

    fill_in "Game", with: @high_score.game
    fill_in "Score", with: @high_score.score
    click_on "Update High score"

    assert_text "High score was successfully updated"
    click_on "Back"
  end

  test "destroying a High score" do
    visit high_scores_url
    page.accept_confirm do
      click_on "Destroy", match: :first
    end

    assert_text "High score was successfully destroyed"
  end
end
```