### PR TITLE
Drop IRB out of the web-console Gemfile comment

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -37,7 +37,7 @@ end
 
 group :development do
 <%- unless options.api? -%>
-  # Access an IRB console on exception pages or by using <%%= console %> anywhere in the code.
+  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   <%- if options.dev? || options.edge? -%>
   gem 'web-console', github: 'rails/web-console'
   <%- else -%>


### PR DESCRIPTION
We don't provide exactly the same experience as IRB does, so let's not
advertize it like that. We can say that it's an interactive console,
without further references. I have also followed byebug's comment and
changed the calling `console` part. Hopefully, this can hint that the
invocation is not view specific and you can use it like the debugger
statement.