### PR TITLE
active_record set_configs after frameworks initialize

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -106,10 +106,12 @@ module ActiveRecord
       end
     end
 
-    initializer "active_record.set_configs" do |app|
-      ActiveSupport.on_load(:active_record) do
-        app.config.active_record.each do |k, v|
-          send "#{k}=", v
+    initializer "active_record.set_configs" do
+      config.after_initialize do |app|
+        ActiveSupport.on_load(:active_record) do
+          app.config.active_record.each do |k, v|
+            send "#{k}=", v
+          end
         end
       end
     end


### PR DESCRIPTION
### Summary

when I add `Rails.application.config.active_record.belongs_to_required_by_default = false` in **config/initializers/new_framework_defaults_5_1.rb**, it is not work.

`ActiveRecord::Base.belongs_to_required_by_default` is still `true`

I think the reasion is the following:

In some gems, `ActiveRecord::Base` is used,
```
ActiveSupport.on_load(:active_record) do
  app.config.active_record.each do |k, v|
    send "#{k}=", v
  end
end
```
will be executed immediately, but at this time **config/initializers/new_framework_defaults_5_1.rb** is not executed.

Rails: 5.1.1
Ruby: 2.3.1