### PR TITLE
Remove the same method in an inherited AR::Migration::Compatibility

### DIFF
--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -102,19 +102,6 @@ module ActiveRecord
           end
         end
 
-        def change_table(table_name, options = {})
-          if block_given?
-            super(table_name, options) do |t|
-              class << t
-                prepend TableDefinition
-              end
-              yield t
-            end
-          else
-            super
-          end
-        end
-
         def add_reference(*, **options)
           options[:index] ||= false
           super


### PR DESCRIPTION
`AR::Migration::Compatibility::V4_2` inherits `AR::Migration::Compatibility::V5_0`.

These `change_table` method implementations are the same.

- [ActiveRecord::Migration::Compatibility::V5_0#change_table](https://github.com/rails/rails/blob/42a80721938453a2ecbba204ce21a0d496756178/activerecord/lib/active_record/migration/compatibility.rb#L59-L70)
- [ActiveRecord::Migration::Compatibility::V4_2#change_table](https://github.com/rails/rails/blob/42a80721938453a2ecbba204ce21a0d496756178/activerecord/lib/active_record/migration/compatibility.rb#L105-L116)

This PR removes `change_table` method of the subclass (`V4_2`) .