### PR TITLE
Add test for backward compatibility when using change_table

### DIFF
--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -90,6 +90,21 @@ module ActiveRecord
         connection.drop_table :more_testings rescue nil
       end
 
+      def test_timestamps_have_null_constraints_if_not_present_in_migration_of_change_table
+        migration = Class.new(ActiveRecord::Migration[4.2]) {
+          def migrate(x)
+            change_table :testings do |t|
+              t.timestamps
+            end
+          end
+        }.new
+
+        ActiveRecord::Migrator.new(:up, [migration]).migrate
+
+        assert connection.columns(:testings).find { |c| c.name == "created_at" }.null
+        assert connection.columns(:testings).find { |c| c.name == "updated_at" }.null
+      end
+
       def test_timestamps_have_null_constraints_if_not_present_in_migration_for_adding_timestamps_to_existing_table
         migration = Class.new(ActiveRecord::Migration[4.2]) {
           def migrate(x)


### PR DESCRIPTION
Follow up of https://github.com/rails/rails/pull/29433#issuecomment-308128556.

This PR adds a test to prepare for unintentional change to `AR::Migration::Compatibility::V4_2#change_table`.