### PR TITLE
Fix id resolution bug by changing id_in_database method name to id_in_db

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -45,7 +45,7 @@ module ActiveRecord
         attribute_was(self.class.primary_key)
       end
 
-      def id_in_database
+      def id_in_db
         sync_with_transaction_state
         attribute_in_database(self.class.primary_key)
       end
@@ -65,7 +65,7 @@ module ActiveRecord
             end
           end
 
-          ID_ATTRIBUTE_METHODS = %w(id id= id? id_before_type_cast id_was id_in_database).to_set
+          ID_ATTRIBUTE_METHODS = %w(id id= id? id_before_type_cast id_was id_in_db).to_set
 
           def dangerous_attribute_method?(method_name)
             super && !ID_ATTRIBUTE_METHODS.include?(method_name)

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -572,7 +572,7 @@ module ActiveRecord
         rows_affected = 0
         @_trigger_update_callback = true
       else
-        rows_affected = self.class.unscoped._update_record attributes_values, id, id_in_database
+        rows_affected = self.class.unscoped._update_record attributes_values, id, id_in_db
         @_trigger_update_callback = rows_affected > 0
       end
 

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -17,7 +17,7 @@ module ActiveRecord
         relation = build_relation(finder_class, attribute, value)
         if record.persisted?
           if finder_class.primary_key
-            relation = relation.where.not(finder_class.primary_key => record.id_in_database || record.id)
+            relation = relation.where.not(finder_class.primary_key => record.id_in_db || record.id)
           else
             raise UnknownPrimaryKey.new(finder_class, "Can not validate uniqueness for persisted record without primary key.")
           end


### PR DESCRIPTION
Closes #29436

This was happening because Active Model creates methods with `_in_database` suffix
for all attributes of the model. While saving the model, in persistence module
Active Record tries to call `id_in_database` method which is defined in `PrimaryKey`
module to get the primary_key value of the object but this call ends in a method which
is defined by Active Model `AttributeMethods` for id attribute of the object.
Renaming `id_in_database` method fixes the problem.
