### PR TITLE
Deprecate an `after_bundle` callback in Rails plugin templates

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `after_bundle` callback in Rails plugin templates.
+
+    *Yuji Yaginuma*
+
 *   `rails new` and `rails plugin new` get `Active Storage` by default.
      Add ability to skip `Active Storage` with `--skip-active-storage`
      and do so automatically when `--skip-active-record` is used.

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -263,6 +263,10 @@ task default: :test
       public_task :apply_rails_template
 
       def run_after_bundle_callbacks
+        unless @after_bundle_callbacks.empty?
+          ActiveSupport::Deprecation.warn("`after_bundle` is deprecated and will be removed in the next version of Rails. ")
+        end
+
         @after_bundle_callbacks.each do |callback|
           callback.call
         end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -721,6 +721,38 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     Object.send(:remove_const, "ENGINE_ROOT")
   end
 
+  def test_after_bundle_callback
+    path = "http://example.org/rails_template"
+    template = %{ after_bundle { run "echo ran after_bundle" } }.dup
+    template.instance_eval "def read; self; end" # Make the string respond to read
+
+    check_open = -> *args do
+      assert_equal [ path, "Accept" => "application/x-thor-template" ], args
+      template
+    end
+
+    sequence = ["echo ran after_bundle"]
+    @sequence_step ||= 0
+    ensure_bundler_first = -> command do
+      assert_equal sequence[@sequence_step], command, "commands should be called in sequence #{sequence}"
+      @sequence_step += 1
+    end
+
+    content = nil
+    generator([destination_root], template: path).stub(:open, check_open, template) do
+      generator.stub(:bundle_command, ensure_bundler_first) do
+        generator.stub(:run, ensure_bundler_first) do
+          silence_stream($stdout) do
+            content = capture(:stderr) { generator.invoke_all }
+          end
+        end
+      end
+    end
+
+    assert_equal 1, @sequence_step
+    assert_match(/DEPRECATION WARNING: `after_bundle` is deprecated/, content)
+  end
+
   private
 
     def action(*args, &block)


### PR DESCRIPTION
Since fbd1e98cf983572ca9884f17f933ffe92833632a, Rails plugin does not run `bundle install` when generating.
Therefore, `after_bundle` callback is not actually executed after `bundle`.

Since there is a difference between the name and the actual behavior, I think that should be remove.
