### PR TITLE
Fix `Relation#exists?` queries with query cache

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -13,15 +13,6 @@ module ActiveRecord
           result
         end
 
-        # Returns an array of arrays containing the field values.
-        # Order is the same as that returned by +columns+.
-        def select_rows(arel, name = nil, binds = []) # :nodoc:
-          select_result(arel, name, binds) do |result|
-            @connection.next_result while @connection.more_results?
-            result.to_a
-          end
-        end
-
         # Executes the SQL statement in the context of this connection.
         def execute(sql, name = nil)
           # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been
@@ -56,16 +47,6 @@ module ActiveRecord
 
           def last_inserted_id(result)
             @connection.last_id
-          end
-
-          def select_result(arel, name, binds)
-            arel, binds = binds_from_relation(arel, binds)
-            sql = to_sql(arel, binds)
-            if without_prepared_statement?(binds)
-              execute_and_free(sql, name) { |result| yield result }
-            else
-              exec_stmt_and_free(sql, name, binds, cache_stmt: true) { |_, result| yield result }
-            end
           end
 
           def exec_stmt_and_free(sql, name, binds, cache_stmt: false)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -7,30 +7,6 @@ module ActiveRecord
           PostgreSQL::ExplainPrettyPrinter.new.pp(exec_query(sql, "EXPLAIN", binds))
         end
 
-        def select_value(arel, name = nil, binds = []) # :nodoc:
-          select_result(arel, name, binds) do |result|
-            result.getvalue(0, 0) if result.ntuples > 0 && result.nfields > 0
-          end
-        end
-
-        def select_values(arel, name = nil, binds = []) # :nodoc:
-          select_result(arel, name, binds) do |result|
-            if result.nfields > 0
-              result.column_values(0)
-            else
-              []
-            end
-          end
-        end
-
-        # Executes a SELECT query and returns an array of rows. Each row is an
-        # array of field values.
-        def select_rows(arel, name = nil, binds = []) # :nodoc:
-          select_result(arel, name, binds) do |result|
-            result.values
-          end
-        end
-
         # The internal PostgreSQL identifier of the money data type.
         MONEY_COLUMN_TYPE_OID = 790 #:nodoc:
         # The internal PostgreSQL identifier of the BYTEA data type.
@@ -174,14 +150,6 @@ module ActiveRecord
 
           def suppress_composite_primary_key(pk)
             pk unless pk.is_a?(Array)
-          end
-
-          def select_result(arel, name, binds)
-            arel, binds = binds_from_relation(arel, binds)
-            sql = to_sql(arel, binds)
-            execute_and_clear(sql, name, binds) do |result|
-              yield result
-            end
           end
       end
     end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -316,7 +316,7 @@ module ActiveRecord
 
       relation = construct_relation_for_exists(relation, conditions)
 
-      connection.select_value(relation, "#{name} Exists", relation.bound_attributes) ? true : false
+      connection.select_one(relation.arel, "#{name} Exists", relation.bound_attributes) ? true : false
     rescue ::RangeError
       false
     end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -316,7 +316,7 @@ module ActiveRecord
 
       relation = construct_relation_for_exists(relation, conditions)
 
-      connection.select_one(relation.arel, "#{name} Exists", relation.bound_attributes) ? true : false
+      connection.select_value(relation, "#{name} Exists", relation.bound_attributes) ? true : false
     rescue ::RangeError
       false
     end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -204,6 +204,12 @@ class QueryCacheTest < ActiveRecord::TestCase
     end
   end
 
+  def test_exists_queries_with_cache
+    Post.cache do
+      assert_queries(1) { Post.exists?; Post.exists? }
+    end
+  end
+
   def test_query_cache_dups_results_correctly
     Task.cache do
       now  = Time.now.utc

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -210,6 +210,46 @@ class QueryCacheTest < ActiveRecord::TestCase
     end
   end
 
+  def test_select_all_with_cache
+    Post.cache do
+      assert_queries(1) do
+        2.times { Post.connection.select_all(Post.all) }
+      end
+    end
+  end
+
+  def test_select_one_with_cache
+    Post.cache do
+      assert_queries(1) do
+        2.times { Post.connection.select_one(Post.all) }
+      end
+    end
+  end
+
+  def test_select_value_with_cache
+    Post.cache do
+      assert_queries(1) do
+        2.times { Post.connection.select_value(Post.all) }
+      end
+    end
+  end
+
+  def test_select_values_with_cache
+    Post.cache do
+      assert_queries(1) do
+        2.times { Post.connection.select_values(Post.all) }
+      end
+    end
+  end
+
+  def test_select_rows_with_cache
+    Post.cache do
+      assert_queries(1) do
+        2.times { Post.connection.select_rows(Post.all) }
+      end
+    end
+  end
+
   def test_query_cache_dups_results_correctly
     Task.cache do
       now  = Time.now.utc


### PR DESCRIPTION
If a connection adapter overrides `select_*` methods, query caching will
doesn't work. This patch changes `select_value` to `select_one` in
`Relation#exists?` to ensure query caching.

Fixes #29449.