### PR TITLE
Remove FK together with column in MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -45,6 +45,13 @@ module ActiveRecord
           indexes
         end
 
+        def remove_column(table_name, column_name, type = nil, options = {})
+          if foreign_key_exists?(table_name, column: column_name)
+            remove_foreign_key(table_name, column: column_name)
+          end
+          super
+        end
+
         def internal_string_options_for_primary_key
           super.tap do |options|
             if CHARSETS_OF_4BYTES_MAXLEN.include?(charset) && (mariadb? || version < "8.0.0")

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -139,6 +139,16 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           end
         end
 
+        test "removing column removes foreign key" do
+          @connection.create_table :testings do |t|
+            t.references :testing_parent, index: true, foreign_key: true
+          end
+
+          assert_difference "@connection.foreign_keys('testings').size", -1 do
+            @connection.remove_column :testings, :testing_parent_id
+          end
+        end
+
         test "foreign key methods respect pluralize_table_names" do
           begin
             original_pluralize_table_names = ActiveRecord::Base.pluralize_table_names


### PR DESCRIPTION
This is a successor of https://github.com/rails/rails/pull/29391

Unlike other databases, MySQL doesn't let you remove the column if there's a FK on it.
For better developer experience we should remove the FK together with the column when migration runs `remove_column`.

@dhh