### PR TITLE
Allow mailers to configure their delivery job

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,1 +1,11 @@
+* Allow ActionMailer classes to configure their delivery job
+
+    class MyMailer < ApplicationMailer
+      self.delivery_job = MyCustomDeliveryJob
+
+      ...
+    end
+
+  *Matthew Mongeau*
+
 Please check [5-1-stable](https://github.com/rails/rails/blob/5-1-stable/actionmailer/CHANGELOG.md) for previous changes.

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -459,6 +459,7 @@ module ActionMailer
 
     helper ActionMailer::MailHelper
 
+    class_attribute :delivery_job, default: ::ActionMailer::DeliveryJob
     class_attribute :default_params, default: {
       mime_version: "1.0",
       charset:      "UTF-8",

--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -118,7 +118,8 @@ module ActionMailer
             "method*, or 3. use a custom Active Job instead of #deliver_later."
         else
           args = @mailer_class.name, @action.to_s, delivery_method.to_s, *@args
-          ::ActionMailer::DeliveryJob.set(options).perform_later(*args)
+          job = @mailer_class.delivery_job
+          job.set(options).perform_later(*args)
         end
       end
   end

--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -95,6 +95,19 @@ class MessageDeliveryTest < ActiveSupport::TestCase
     end
   end
 
+  test "should enqueue the job with the correct delivery job" do
+    old_delivery_job = DelayedMailer.delivery_job
+    DelayedMailer.delivery_job = DummyJob
+
+    assert_performed_with(job: DummyJob, args: ["DelayedMailer", "test_message", "deliver_now", 1, 2, 3]) do
+      @mail.deliver_later
+    end
+
+    DelayedMailer.delivery_job = old_delivery_job
+  end
+
+  class DummyJob < ActionMailer::DeliveryJob; end
+
   test "can override the queue when enqueuing mail" do
     assert_performed_with(job: ActionMailer::DeliveryJob, args: ["DelayedMailer", "test_message", "deliver_now", 1, 2, 3], queue: "another_queue") do
       @mail.deliver_later(queue: :another_queue)


### PR DESCRIPTION
Setting delivery_job on a mailer class will cause MessageDelivery to use
the specified job instead of ActionMailer::DeliveryJob

    class MyMailer < ApplicationMailer
      self.delivery_job = MyCustomDeliveryJob

      ...
    end

### Summary

In some situations, a user may want to configure the delivery job in order to have
better control over errors (For example, retrying the job when deserialization fails
due to replica databases not being up to date). This adds an option to each mailer
class that can be configured to handle such behavior.