### PR TITLE
Don't require 'unscope' to be the same on both sides of an 'or' relation

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1167,7 +1167,7 @@ module ActiveRecord
         end
       end
 
-      STRUCTURAL_OR_METHODS = Relation::VALUE_METHODS - [:extending, :where, :having]
+      STRUCTURAL_OR_METHODS = Relation::VALUE_METHODS - [:extending, :where, :having, :unscope]
       def structurally_incompatible_values_for_or(other)
         STRUCTURAL_OR_METHODS.reject do |method|
           get_value(method) == other.get_value(method)

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -59,6 +59,31 @@ module ActiveRecord
       assert_equal "Relation passed to #or must be structurally compatible. Incompatible values: [:order]", error.message
     end
 
+    def test_or_with_unscope_where
+      expected = Post.where("id = 1 or id = 2")
+      partial = Post.where("id = 1 and id != 2")
+      assert_equal expected, partial.or(partial.unscope(:where).where("id = 2")).to_a
+    end
+
+    def test_or_with_unscope_where_column
+      expected = Post.where("id = 1 or id = 2")
+      partial = Post.where(id: 1).where.not(id: 2)
+      assert_equal expected, partial.or(partial.unscope(where: :id).where("id = 2")).to_a
+    end
+
+    def test_or_with_unscope_order
+      expected = Post.where("id = 1 or id = 2")
+      assert_equal expected, Post.order("body asc").where("id = 1").unscope(:order).or(Post.where("id = 2")).to_a
+    end
+
+    def test_or_with_incompatible_unscope
+      error = assert_raises ArgumentError do
+        Post.order("body asc").where("id = 1").or(Post.order("body asc").where("id = 2").unscope(:order)).to_a
+      end
+
+      assert_equal "Relation passed to #or must be structurally compatible. Incompatible values: [:order]", error.message
+    end
+
     def test_or_when_grouping
       groups = Post.where("id < 10").group("body").select("body, COUNT(*) AS c")
       expected = groups.having("COUNT(*) > 1 OR body like 'Such%'").to_a.map { |o| [o.body, o.c] }


### PR DESCRIPTION
When trying to `or` on top of a scope that had both `where` and `joins` I had the grand idea to use the scope on both sides, and just `unscope` the existing `where` on the side I wanted a different condition.  

this gave me the error: `Relation passed to #or must be structurally compatible. Incompatible values: [:unscope]` which seemed to be a bug.

I've included tests for allowing unscoping `where` both ways, and ensuring that if I unscope e.g. `order` on only one side, its becomes "structurally incompatible", and if I unscope e.g. `order` that was only appearing on one side, then it would be structurally compatible.

The actual code change feels almost too easy.

as it's a one-symbol change it doesn't feel like it justifies a changeling entry