### PR TITLE
Use nullable `id` column instead of a primary key

### DIFF
--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -814,9 +814,10 @@ ActiveRecord::Schema.define do
     t.index :id, unique: true
   end
 
-  create_table :subscribers, force: true do |t|
+  create_table :subscribers, id: false, force: true do |t|
     t.string :nick, null: false
     t.string :name
+    t.integer :id
     t.integer :books_count, null: false, default: 0
     t.integer :update_count, null: false, default: 0
     t.index :nick, unique: true


### PR DESCRIPTION
`id` column in `subscribers` was added as a primary key for ignorable in
INSERT. But it caused `NotNullViolation` for oracle-enhanced adapter.

https://github.com/rsim/oracle-enhanced/issues/1357

I changed the column to nullable to address the issue.

@yahonda Could you test the branch on oracle-enhanced adapter?