### PR TITLE
Nesting adapter specific table options

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -89,9 +89,10 @@ module ActiveRecord
         end
 
         def add_table_options!(create_sql, options)
-          if options_sql = options[:options]
-            create_sql << " #{options_sql}"
-          end
+          options_sql = options[:options]
+          options_sql = options_sql[@conn.config[:adapter].to_sym] if options_sql.is_a?(Hash)
+
+          create_sql << " #{options_sql}" if options_sql.present?
           create_sql
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -41,7 +41,7 @@ module ActiveRecord
       COMMENT_REGEX = %r{/\*(?:[^\*]|\*[^/])*\*/}m
 
       attr_accessor :pool
-      attr_reader :visitor, :owner, :logger, :lock
+      attr_reader :visitor, :owner, :logger, :lock, :config
       alias :in_use? :owner
 
       set_callback :checkin, :after, :enable_lazy_transactions!

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -418,7 +418,9 @@ module ActiveRecord
         # strip AUTO_INCREMENT
         raw_table_options.sub!(/(ENGINE=\w+)(?: AUTO_INCREMENT=\d+)/, '\1')
 
-        table_options[:options] = raw_table_options unless raw_table_options.blank?
+        unless raw_table_options.blank?
+          table_options[:options] = { config[:adapter].to_sym => raw_table_options }
+        end
 
         # strip COMMENT
         if raw_table_options.sub!(/ COMMENT='.+'/, "")

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -244,7 +244,13 @@ HEADER
       end
 
       def format_options(options)
-        options.map { |key, value| "#{key}: #{value.inspect}" }.join(", ")
+        options.map do |key, value|
+          if value.is_a?(Hash)
+            "#{key}: { #{format_options(value)} }"
+          else
+            "#{key}: #{value.inspect}"
+          end
+        end.join(", ")
       end
 
       def format_index_parts(options)

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -17,28 +17,28 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
   test "table options with ENGINE" do
     @connection.create_table "mysql_table_options", force: true, options: "ENGINE=MyISAM"
     output = dump_table_schema("mysql_table_options")
-    options = %r{create_table "mysql_table_options", options: "(?<options>.*)"}.match(output)[:options]
+    options = %r/create_table "mysql_table_options", options: { mysql2: "(?<options>.*)" }/.match(output)[:options]
     assert_match %r{ENGINE=MyISAM}, options
   end
 
   test "table options with ROW_FORMAT" do
     @connection.create_table "mysql_table_options", force: true, options: "ROW_FORMAT=REDUNDANT"
     output = dump_table_schema("mysql_table_options")
-    options = %r{create_table "mysql_table_options", options: "(?<options>.*)"}.match(output)[:options]
+    options = %r/create_table "mysql_table_options", options: { mysql2: "(?<options>.*)" }/.match(output)[:options]
     assert_match %r{ROW_FORMAT=REDUNDANT}, options
   end
 
   test "table options with CHARSET" do
     @connection.create_table "mysql_table_options", force: true, options: "CHARSET=utf8mb4"
     output = dump_table_schema("mysql_table_options")
-    options = %r{create_table "mysql_table_options", options: "(?<options>.*)"}.match(output)[:options]
+    options = %r/create_table "mysql_table_options", options: { mysql2: "(?<options>.*)" }/.match(output)[:options]
     assert_match %r{CHARSET=utf8mb4}, options
   end
 
   test "table options with COLLATE" do
     @connection.create_table "mysql_table_options", force: true, options: "COLLATE=utf8mb4_bin"
     output = dump_table_schema("mysql_table_options")
-    options = %r{create_table "mysql_table_options", options: "(?<options>.*)"}.match(output)[:options]
+    options = %r/create_table "mysql_table_options", options: { mysql2: "(?<options>.*)" }/.match(output)[:options]
     assert_match %r{COLLATE=utf8mb4_bin}, options
   end
 
@@ -79,7 +79,7 @@ class Mysql2DefaultEngineOptionSchemaDumpTest < ActiveRecord::Mysql2TestCase
     ActiveRecord::Base.connection.create_table "mysql_table_options", force: true
 
     output  = dump_table_schema("mysql_table_options")
-    options = %r{create_table "mysql_table_options", options: "(?<options>.*)"}.match(output)[:options]
+    options = %r/create_table "mysql_table_options", options: { mysql2: "(?<options>.*)" }/.match(output)[:options]
     assert_match %r{ENGINE=InnoDB}, options
   end
 
@@ -93,7 +93,7 @@ class Mysql2DefaultEngineOptionSchemaDumpTest < ActiveRecord::Mysql2TestCase
     ActiveRecord::Migrator.new(:up, [migration], ActiveRecord::Base.connection.schema_migration).migrate
 
     output  = dump_table_schema("mysql_table_options")
-    options = %r{create_table "mysql_table_options", options: "(?<options>.*)"}.match(output)[:options]
+    options = %r/create_table "mysql_table_options", options: { mysql2: "(?<options>.*)" }/.match(output)[:options]
     assert_match %r{ENGINE=InnoDB}, options
   end
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema.define do
       {}
     end
 
-  create_table :accounts, force: true do |t|
+  create_table :accounts, force: true, options: { unknown: "UNKNOWN" } do |t|
     t.references :firm, index: false
     t.string  :firm_name
     t.integer :credit_limit


### PR DESCRIPTION
To ignore invalid table options for other adapter.

Fixes #26209.