### PR TITLE
Add teardown to reset_connection at MysqlTypeLookupTest

### DIFF
--- a/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
@@ -1,11 +1,18 @@
 require "cases/helper"
+require "support/connection_helper"
 
 if current_adapter?(:Mysql2Adapter)
   module ActiveRecord
     module ConnectionAdapters
       class MysqlTypeLookupTest < ActiveRecord::TestCase
+        include ConnectionHelper
+
         setup do
           @connection = ActiveRecord::Base.connection
+        end
+
+        def teardown
+          reset_connection
         end
 
         def test_boolean_types


### PR DESCRIPTION
### Summary

This pull request addresses random failures of `Mysql2BooleanTest#test_column_type_without_emulated_booleans`  at `unlock-minitest` branch
https://travis-ci.org/rails/rails/jobs/239950090

I have closed #29379 unintentionally by removing the corresponding branch. Then reopened this one.

### Steps to reproduce

```ruby
$ cd rails/activerecord
$ git checkout unlock-minitest
$ bundle install
$ ARCONN=mysql2 bin/test $(ls "test/cases/connection_adapters/mysql_type_lookup_test.rb" "test/cases/adapters/mysql2/boolean_test.rb") -n "/^(?:ActiveRecord::ConnectionAdapters::MysqlTypeLookupTest#(?:test_enum_type_with_value_matching_other_type|test_boolean_types)|Mysql2BooleanTest#(?:test_column_type_without_emulated_booleans))$/" --seed 41495 -v
```

### Expected behavior
All unit tests should pass.

### Actual behavior

```ruby
$ ARCONN=mysql2 bin/test $(ls "test/cases/connection_adapters/mysql_type_lookup_test.rb" "test/cases/adapters/mysql2/boolean_test.rb") -n "/^(?:ActiveRecord::ConnectionAdapters::MysqlTypeLookupTest#(?:test_enum_type_with_value_matching_other_type|test_boolean_types)|Mysql2BooleanTest#(?:test_column_type_without_emulated_booleans))$/" --seed 41495 -v
Using mysql2
Run options: -n "/^(?:ActiveRecord::ConnectionAdapters::MysqlTypeLookupTest#(?:test_enum_type_with_value_matching_other_type|test_boolean_types)|Mysql2BooleanTest#(?:test_column_type_without_emulated_booleans))$/" --seed 41495 -v

# Running:

ActiveRecord::ConnectionAdapters::MysqlTypeLookupTest#test_boolean_types = 0.00 s = .
ActiveRecord::ConnectionAdapters::MysqlTypeLookupTest#test_enum_type_with_value_matching_other_type = 0.00 s = .
Mysql2BooleanTest#test_column_type_without_emulated_booleans = 0.03 s = F


Failure:
Mysql2BooleanTest#test_column_type_without_emulated_booleans [/home/yahonda/git/rails/activerecord/test/cases/adapters/mysql2/boolean_test.rb:37]:
Expected: :integer
  Actual: :boolean


bin/test test/cases/adapters/mysql2/boolean_test.rb:34


Finished in 0.039206s, 76.5191 runs/s, 102.0255 assertions/s.

3 runs, 4 assertions, 1 failures, 0 errors, 0 skips
$
```


