### PR TITLE
Add the `<app_root>/test` dir to the `$LOAD_PATH` as a string:

### DIFF
--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -11,7 +11,7 @@ module Rails
       end
 
       def perform(*)
-        $LOAD_PATH << Rails::Command.root.join("test")
+        $LOAD_PATH << Rails::Command.root.join("test").to_s
 
         Minitest.run_via = :rails
 


### PR DESCRIPTION
- [Rails <= 5.0](https://github.com/rails/rails/blob/5-0-stable/railties/lib/rails/commands/test.rb#L6) used to add the `<app_root>/test` as a string; this behaviour changed in rails 5.1 and it's now appending a `Pathname` object


Not sure if this requires a test, happy to add one if so