### PR TITLE
Remove references to deprecared raise_runtime_errors from documentation

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -572,20 +572,6 @@ would generate this HTML:
 
 The `body` param is required by Sprockets.
 
-### Runtime Error Checking
-
-By default the asset pipeline will check for potential errors in development mode during
-runtime. To disable this behavior you can set:
-
-```ruby
-config.assets.raise_runtime_errors = false
-```
-
-When this option is true, the asset pipeline will check if all the assets loaded
-in your application are included in the `config.assets.precompile` list.
-If `config.assets.digest` is also true, the asset pipeline will require that
-all requests for assets include digests.
-
 ### Raise an Error When an Asset is Not Found
 
 If you are using sprockets-rails >= 3.2.0 you can configure what happens

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -157,8 +157,6 @@ defaults to `:debug` for all environments. The available log levels are: `:debug
 * `config.assets.enabled` a flag that controls whether the asset
 pipeline is enabled. It is set to `true` by default.
 
-* `config.assets.raise_runtime_errors` Set this flag to `true` to enable additional runtime error checking. Recommended in `config/environments/development.rb` to minimize unexpected behavior when deploying to `production`.
-
 * `config.assets.css_compressor` defines the CSS compressor to use. It is set by default by `sass-rails`. The unique alternative value at the moment is `:yui`, which uses the `yui-compressor` gem.
 
 * `config.assets.js_compressor` defines the JavaScript compressor to use. Possible values are `:closure`, `:uglifier` and `:yui` which require the use of the `closure-compiler`, `uglifier` or `yui-compressor` gems respectively.


### PR DESCRIPTION
Ref: https://github.com/rails/sprockets-rails/commit/655b93bffc6f51b96a7cc097f9010942693bfaae and https://github.com/rails/rails/pull/24070 . 

