### PR TITLE
nodoc AC::Connection::WebSocket

### DIFF
--- a/actioncable/lib/action_cable/connection/web_socket.rb
+++ b/actioncable/lib/action_cable/connection/web_socket.rb
@@ -3,7 +3,7 @@ require "websocket/driver"
 module ActionCable
   module Connection
     # Wrap the real socket to minimize the externally-presented API
-    class WebSocket
+    class WebSocket # :nodoc:
       def initialize(env, event_target, event_loop, protocols: ActionCable::INTERNAL[:protocols])
         @websocket = ::WebSocket::Driver.websocket?(env) ? ClientSocket.new(env, event_target, event_loop, protocols) : nil
       end


### PR DESCRIPTION
Users should never publicly be interacting with an instance of this.  The instance that comes along with an `AC::Connection::Base` instance (the only thing a user should be working with) is [itself intended to be private](https://github.com/tjschuck/rails/blob/master/actioncable/lib/action_cable/connection/base.rb#L137-L140).

[ci skip]