### PR TITLE
[ci skip] Update fedora SQLite3 package name

### DIFF
--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -62,7 +62,7 @@ $ sudo apt-get install sqlite3 libsqlite3-dev
 If you are on Fedora or CentOS, you're done with
 
 ```bash
-$ sudo yum install sqlite3 sqlite3-devel
+$ sudo yum install libsqlite3x libsqlite3x-devel 
 ```
 
 If you are on Arch Linux, you will need to run:


### PR DESCRIPTION
### Summary

This updates the documentation for installing SQLite3 on Fedora.

### Other Information

The current documentation suggests running `$ sudo yum install sqlite3 sqlite3-devel`, but those packages have been renamed.

Currently:
```
$ sudo yum install sqlite3 sqlite3-devel
Last metadata expiration check: 1:43:40 ago on Sat Jun 17 10:57:26 2017.
No package sqlite3 available.
No package sqlite3-devel available.
Error: Unable to find a match.
```