### PR TITLE
Add a test case for #28754

### DIFF
--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -169,6 +169,25 @@ module JSONSharedTestCases
     assert_not json.changed?
   end
 
+  def test_changes_in_place_ignores_key_order
+    json = klass.new
+    assert_not json.changed?
+
+    json.payload = { "three" => "four", "one" => "two" }
+    json.save!
+    json.reload
+
+    json.payload = { "three" => "four", "one" => "two" }
+    assert_not json.changed?
+
+    json.payload = [{ "three" => "four", "one" => "two" }, { "seven" => "eight", "five" => "six" }]
+    json.save!
+    json.reload
+
+    json.payload = [{ "three" => "four", "one" => "two" }, { "seven" => "eight", "five" => "six" }]
+    assert_not json.changed?
+  end
+
   def test_changes_in_place_with_ruby_object
     time = Time.now.utc
     json = klass.create!(payload: time)


### PR DESCRIPTION
A part for JSON was splitted from #28416 as #29273 and #29273 has
already been merged.

Closes #28754.
Closes #27588.