### PR TITLE
Deprecate an `capify!` method in generators and templates

### DIFF
--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -689,14 +689,6 @@ Available options are:
 * `:env` - Specifies the environment in which to run this rake task.
 * `:sudo` - Whether or not to run this task using `sudo`. Defaults to `false`.
 
-### `capify!`
-
-Runs the `capify` command from Capistrano at the root of the application which generates Capistrano configuration.
-
-```ruby
-capify!
-```
-
 ### `route`
 
 Adds text to the `config/routes.rb` file:

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `capify!` method in generators and templates.
+
+    *Yuji Yaginuma*
+
 *   Allow irb options to be passed from `rails console` command.
 
     Fixes #28988.

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -227,6 +227,7 @@ module Rails
       #
       #   capify!
       def capify!
+        ActiveSupport::Deprecation.warn("`capify!` is deprecated and will be removed in the next version of Rails.")
         log :capify, ""
         in_root { run("#{extify(:capify)} .", verbose: false) }
       end

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -278,9 +278,12 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_capify_should_run_the_capify_command
-    assert_called_with(generator, :run, ["capify .", verbose: false]) do
-      action :capify!
+    content = capture(:stderr) do
+      assert_called_with(generator, :run, ["capify .", verbose: false]) do
+        action :capify!
+      end
     end
+    assert_match(/DEPRECATION WARNING: `capify!` is deprecated/, content)
   end
 
   def test_route_should_add_data_to_the_routes_block_in_config_routes


### PR DESCRIPTION
The `capify` command has been removed by Capistrano 3 and became to `cap install`.
Therefore, the `capify!` method has no meaning in Capistrano 3.
I think that should deprecate.

Ref: https://github.com/capistrano/capistrano/commit/492793916acf32ffe1604daec6fd4892c8935018