### PR TITLE
Prevent extra `scope` construction in `find_target`

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -276,7 +276,7 @@ module ActiveRecord
         end
 
         # Returns true if statement cache should be skipped on the association reader.
-        def skip_statement_cache?
+        def skip_statement_cache?(scope)
           reflection.has_scope? ||
             scope.eager_loading? ||
             klass.scope_attributes? ||

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -300,7 +300,8 @@ module ActiveRecord
       private
 
         def find_target
-          return scope.to_a if skip_statement_cache?
+          scope = self.scope
+          return scope.to_a if skip_statement_cache?(scope)
 
           conn = klass.connection
           sc = reflection.association_scope_cache(conn, owner) do

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -36,7 +36,8 @@ module ActiveRecord
         end
 
         def find_target
-          return scope.take if skip_statement_cache?
+          scope = self.scope
+          return scope.take if skip_statement_cache?(scope)
 
           conn = klass.connection
           sc = reflection.association_scope_cache(conn, owner) do


### PR DESCRIPTION
Because constructing `scope` is a little expensive.