### PR TITLE
Added the connection's spec_name to the instrumentation:

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -568,12 +568,16 @@ module ActiveRecord
         end
 
         def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil) # :doc:
-          resolver = ConnectionSpecification::Resolver.new(Base.configurations)
+          spec_name = if pool
+            pool.spec.name
+          else
+            ConnectionSpecification::Resolver.new(Base.configurations).spec(@config).name
+          end
 
           @instrumenter.instrument(
             "sql.active_record",
             sql:               sql,
-            spec_name:         resolver.spec(@config).name,
+            spec_name:         spec_name,
             name:              name,
             binds:             binds,
             type_casted_binds: type_casted_binds,

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -568,11 +568,12 @@ module ActiveRecord
         end
 
         def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil) # :doc:
-          spec_name = if pool
-            pool.spec.name
-          else
-            ConnectionSpecification::Resolver.new(Base.configurations).spec(@config).name
-          end
+          spec_name =
+            if pool
+              pool.spec.name
+            else
+              ConnectionSpecification::Resolver.new(Base.configurations).spec(@config).name
+            end
 
           @instrumenter.instrument(
             "sql.active_record",

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -568,9 +568,12 @@ module ActiveRecord
         end
 
         def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil) # :doc:
+          resolver = ConnectionSpecification::Resolver.new(Base.configurations)
+
           @instrumenter.instrument(
             "sql.active_record",
             sql:               sql,
+            spec_name:         resolver.spec(@config).name,
             name:              name,
             binds:             binds,
             type_casted_binds: type_casted_binds,

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -134,7 +134,7 @@ module ActiveRecord
     def test_spec_name_is_logged
       @connection.exec_query("SELECT $1::integer", "SQL")
 
-      assert @subscriber.payloads.last[:spec_name]
+      assert_equal "primary", @subscriber.payloads.last[:spec_name]
     end
 
     if ActiveRecord::Base.connection.prepared_statements

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -131,6 +131,12 @@ module ActiveRecord
       assert_equal "SCHEMA", @subscriber.logged[0][1]
     end
 
+    def test_spec_name_is_logged
+      @connection.exec_query("SELECT $1::integer", "SQL")
+
+      assert @subscriber.payloads.last[:spec_name]
+    end
+
     if ActiveRecord::Base.connection.prepared_statements
       def test_statement_key_is_logged
         binds = [bind_attribute(nil, 1)]

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -403,6 +403,7 @@ module ActiveRecord
           subscription = ActiveSupport::Notifications.subscribe("sql.active_record", subscriber)
           yield
           assert_equal logs, subscriber.logged
+          refute_nil subscriber.payloads.last[:spec_name]
         ensure
           ActiveSupport::Notifications.unsubscribe(subscription)
         end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -403,7 +403,7 @@ module ActiveRecord
           subscription = ActiveSupport::Notifications.subscribe("sql.active_record", subscriber)
           yield
           assert_equal logs, subscriber.logged
-          refute_nil subscriber.payloads.last[:spec_name]
+          assert_equal "primary", subscriber.payloads.last[:spec_name]
         ensure
           ActiveSupport::Notifications.unsubscribe(subscription)
         end

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -73,6 +73,7 @@ if ActiveRecord::Base.connection.prepared_statements
           payload = {
             name: "SQL",
             sql: "select * from topics where id = ?",
+            spec_name: "primary",
             binds: binds,
             type_casted_binds: @connection.type_casted_binds(binds)
           }

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -252,6 +252,7 @@ Active Record
 | Key              | Value                                    |
 | ---------------- | ---------------------------------------- |
 | `:sql`           | SQL statement                            |
+| `:spec_name`     | Connection specification name            |
 | `:name`          | Name of the operation                    |
 | `:connection_id` | `self.object_id`                         |
 | `:binds`         | Bind parameters                          |


### PR DESCRIPTION
- When `AbtractAdapter#log` dispatches the event, it's usefull to add the connection spec name. Subscriber of this event are able to retrieve the connection pool using the connection spec name using [#retrieve_connection_pool](https://github.com/rails/rails/blob/a9bb9d7abc59d497d443d463544d5d859d08463b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L958)


