### PR TITLE
Use bulk INSERT to insert fixtures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/arel.git
-  revision: 5db56a513286814991c27000af2c0243cc19d1e2
+  revision: 67a51c62f4e19390cd8eb408596ca48bb0806362
   specs:
     arel (8.0.0)
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use bulk INSERT to insert fixtures for better performance.
+
+    *Kir Shatrov*
+
 *   Prevent making bind param if casted value is nil.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -349,6 +349,12 @@ module ActiveRecord
         end
       end
 
+      def insert_fixtures(rows, table_name)
+        rows.each do |row|
+          insert_fixture(row, table_name)
+        end
+      end
+
       private
 
         def table_structure(table_name)

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -567,9 +567,7 @@ module ActiveRecord
               end
 
               table_rows.each do |fixture_set_name, rows|
-                rows.each do |row|
-                  conn.insert_fixture(row, fixture_set_name)
-                end
+                conn.insert_fixtures(rows, fixture_set_name)
               end
 
               # Cap primary key sequences to max(pk).

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -191,6 +191,12 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
     assert_equal(PgArray.last.tags, tag_values)
   end
 
+  def test_insert_fixtures
+    tag_values = ["val1", "val2", "val3_with_'_multiple_quote_'_chars"]
+    @connection.insert_fixtures([{ "tags" => tag_values }], "pg_arrays")
+    assert_equal(PgArray.last.tags, tag_values)
+  end
+
   def test_attribute_for_inspect_for_array_field
     record = PgArray.new { |a| a.ratings = (1..10).to_a }
     assert_equal("[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]", record.attribute_for_inspect(:ratings))

--- a/activerecord/test/fixtures/naked/yml/parrots.yml
+++ b/activerecord/test/fixtures/naked/yml/parrots.yml
@@ -1,2 +1,3 @@
 george:
   arrr: "Curious George"
+  foobar: Foobar


### PR DESCRIPTION
This patch improves the performance of inserting fixtures from O(n) to O(1).
Previously it would require 50 queries to insert 50 fixtures into one table. Now it takes only one query per table.

Disabled on sqlite which doesn't support multiple inserts.

Some benchmarks:

```
With two tables, each with 1k records. Time to insert fixtures on MySQL:
before: 0.7s
after: 0.2s
```

While 1k fixtures may sound unrealistic, at Shopify scale we have hundreds of tables, each having up to 100 fixtures. In our app this patch dramatically improved the performance of test helper. This patch would be especially helpful for those apps who use `fixtures(:all)` (I heard it's the case for Basecamp too).

🎉 🎉 🎉

Closes https://github.com/rails/rails/pull/26901

@rafaelfranca @matthewd 