### PR TITLE
prepare for Minitest 6

### DIFF
--- a/actionpack/test/controller/parameters/mutators_test.rb
+++ b/actionpack/test/controller/parameters/mutators_test.rb
@@ -35,7 +35,7 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
   end
 
   test "delete returns nil when the key is not present" do
-    assert_equal nil, @params[:person].delete(:first_name)
+    assert_nil @params[:person].delete(:first_name)
   end
 
   test "delete returns the value of the given block when the key is not present" do

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -315,7 +315,7 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal(1, scalar <=> 5)
     assert_equal(0, scalar <=> 10)
     assert_equal(-1, scalar <=> 15)
-    assert_equal(nil, scalar <=> "foo")
+    assert_nil(scalar <=> "foo")
   end
 
   def test_scalar_plus


### PR DESCRIPTION
Prevent warning: `DEPRECATED: Use assert_nil if expecting nil from /home/oz/code/rails/activesupport/test/core_ext/duration_test.rb:318. This will fail in Minitest 6.`