### PR TITLE
Make ActiveSupport frozen-string-literal friendly.

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -120,7 +120,7 @@ class BaseTest < ActiveSupport::TestCase
     email = BaseMailer.attachment_with_hash
     assert_equal(1, email.attachments.length)
     assert_equal("invoice.jpg", email.attachments[0].filename)
-    expected = "\312\213\254\232)b"
+    expected = "\312\213\254\232)b".dup
     expected.force_encoding(Encoding::BINARY)
     assert_equal expected, email.attachments["invoice.jpg"].decoded
   end
@@ -129,7 +129,7 @@ class BaseTest < ActiveSupport::TestCase
     email = BaseMailer.attachment_with_hash_default_encoding
     assert_equal(1, email.attachments.length)
     assert_equal("invoice.jpg", email.attachments[0].filename)
-    expected = "\312\213\254\232)b"
+    expected = "\312\213\254\232)b".dup
     expected.force_encoding(Encoding::BINARY)
     assert_equal expected, email.attachments["invoice.jpg"].decoded
   end

--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -24,7 +24,7 @@ module ActionController
           exception_class_name = payload[:exception].first
           status = ActionDispatch::ExceptionWrapper.status_code_for_exception(exception_class_name)
         end
-        message = "Completed #{status} #{Rack::Utils::HTTP_STATUS_CODES[status]} in #{event.duration.round}ms"
+        message = "Completed #{status} #{Rack::Utils::HTTP_STATUS_CODES[status]} in #{event.duration.round}ms".dup
         message << " (#{additions.join(" | ".freeze)})" unless additions.empty?
         message << "\n\n" if defined?(Rails.env) && Rails.env.development?
 

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -103,7 +103,7 @@ module ActionDispatch # :nodoc:
 
       def body
         @str_body ||= begin
-          buf = ""
+          buf = "".dup
           each { |chunk| buf << chunk }
           buf
         end

--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -29,7 +29,7 @@ module ActionDispatch
           ENCODE   = "%%%02X".freeze
           US_ASCII = Encoding::US_ASCII
           UTF_8    = Encoding::UTF_8
-          EMPTY    = "".force_encoding(US_ASCII).freeze
+          EMPTY    = "".dup.force_encoding(US_ASCII).freeze
           DEC2HEX  = (0..255).to_a.map { |i| ENCODE % i }.map { |s| s.force_encoding(US_ASCII) }
 
           ALPHA = "a-zA-Z".freeze

--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -18,7 +18,7 @@ module ActionDispatch
           path.squeeze!("/".freeze)
           path.sub!(%r{/+\Z}, "".freeze)
           path.gsub!(/(%[a-f0-9]{2})/) { $1.upcase }
-          path = "/" if path == "".freeze
+          path = "/".dup if path == "".freeze
           path.force_encoding(encoding)
           path
         end

--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -14,7 +14,7 @@ module ActionDispatch
         #   normalize_path("/%ab")  # => "/%AB"
         def self.normalize_path(path)
           encoding = path.encoding
-          path = "/#{path}"
+          path = "/#{path}".dup
           path.squeeze!("/".freeze)
           path.sub!(%r{/+\Z}, "".freeze)
           path.gsub!(/(%[a-f0-9]{2})/) { $1.upcase }

--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -79,7 +79,7 @@ module ActionDispatch
         def generate_response_message(expected, actual = @response.response_code)
           "Expected response to be a <#{code_with_name(expected)}>,"\
           " but was a <#{code_with_name(actual)}>"
-            .concat(location_if_redirected).concat(response_body_if_short)
+            .dup.concat(location_if_redirected).concat(response_body_if_short)
         end
 
         def response_body_if_short

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -1007,7 +1007,7 @@ module ActionView
           select_options[:disabled] = "disabled" if @options[:disabled]
           select_options[:class] = css_class_attribute(type, select_options[:class], @options[:with_css_classes]) if @options[:with_css_classes]
 
-          select_html = "\n"
+          select_html = "\n".dup
           select_html << content_tag("option".freeze, "", value: "") + "\n" if @options[:include_blank]
           select_html << prompt_option_tag(type, @options[:prompt]) + "\n" if @options[:prompt]
           select_html << select_options_as_html
@@ -1089,7 +1089,7 @@ module ActionView
         # Given an ordering of datetime components, create the selection HTML
         # and join them with their appropriate separators.
         def build_selects_from_types(order)
-          select = ""
+          select = "".dup
           first_visible = order.find { |type| !@options[:"discard_#{type}"] }
           order.reverse_each do |type|
             separator = separator(type) unless type == first_visible # don't add before first visible field

--- a/actionview/lib/action_view/helpers/javascript_helper.rb
+++ b/actionview/lib/action_view/helpers/javascript_helper.rb
@@ -13,8 +13,8 @@ module ActionView
         "'"     => "\\'"
       }
 
-      JS_ESCAPE_MAP["\342\200\250".force_encoding(Encoding::UTF_8).encode!] = "&#x2028;"
-      JS_ESCAPE_MAP["\342\200\251".force_encoding(Encoding::UTF_8).encode!] = "&#x2029;"
+      JS_ESCAPE_MAP["\342\200\250".dup.force_encoding(Encoding::UTF_8).encode!] = "&#x2028;"
+      JS_ESCAPE_MAP["\342\200\251".dup.force_encoding(Encoding::UTF_8).encode!] = "&#x2029;"
 
       # Escapes carriage returns and single and double quotes for JavaScript segments.
       #

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -95,7 +95,7 @@ module ActionView
           raise e if raise_error
 
           keys = I18n.normalize_keys(e.locale, e.key, e.options[:scope])
-          title = "translation missing: #{keys.join('.')}"
+          title = "translation missing: #{keys.join('.')}".dup
 
           interpolations = options.except(:default, :scope)
           if interpolations.any?

--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -14,7 +14,7 @@ module ActionView
 
     def render_template(event)
       info do
-        message = "  Rendered #{from_rails_root(event.payload[:identifier])}"
+        message = "  Rendered #{from_rails_root(event.payload[:identifier])}".dup
         message << " within #{from_rails_root(event.payload[:layout])}" if event.payload[:layout]
         message << " (#{event.duration.round(1)}ms)"
       end
@@ -22,7 +22,7 @@ module ActionView
 
     def render_partial(event)
       info do
-        message = "  Rendered #{from_rails_root(event.payload[:identifier])}"
+        message = "  Rendered #{from_rails_root(event.payload[:identifier])}".dup
         message << " within #{from_rails_root(event.payload[:layout])}" if event.payload[:layout]
         message << " (#{event.duration.round(1)}ms)"
         message << " #{cache_message(event.payload)}" unless event.payload[:cache_hit].nil?

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -329,7 +329,7 @@ module ActionView
         locals = locals.grep(/\A@?(?![A-Z0-9])(?:[[:alnum:]_]|[^\0-\177])+\z/)
 
         # Double assign to suppress the dreaded 'assigned but unused variable' warning
-        locals.each_with_object("") { |key, code| code << "#{key} = #{key} = local_assigns[:#{key}];" }
+        locals.each_with_object("".dup) { |key, code| code << "#{key} = #{key} = local_assigns[:#{key}];" }
       end
 
       def method_name

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -282,7 +282,7 @@ module ActionView
 
         # Make sure that the resulting String to be eval'd is in the
         # encoding of the code
-        source = <<-end_src
+        source = <<-end_src.dup
           def #{method_name}(local_assigns, output_buffer)
             _old_virtual_path, @virtual_path = @virtual_path, #{@virtual_path.inspect};_old_output_buffer = @output_buffer;#{locals_code};#{code}
           ensure
@@ -334,7 +334,7 @@ module ActionView
 
       def method_name
         @method_name ||= begin
-          m = "_#{identifier_method_name}__#{@identifier.hash}_#{__id__}"
+          m = "_#{identifier_method_name}__#{@identifier.hash}_#{__id__}".dup
           m.tr!("-".freeze, "_".freeze)
           m
         end

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -14,7 +14,7 @@ module ActionView
       alias_method :partial?, :partial
 
       def self.build(name, prefix, partial)
-        virtual = ""
+        virtual = "".dup
         virtual << "#{prefix}/" unless prefix.empty?
         virtual << (partial ? "_#{name}" : name)
         new name, prefix, partial, virtual

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -104,7 +104,7 @@ module ActionView
         # empty string ensures buffer has UTF-8 encoding as
         # new without arguments returns ASCII-8BIT encoded buffer like String#new
         @output_buffer = ActiveSupport::SafeBuffer.new ""
-        @rendered = ""
+        @rendered = "".dup
 
         make_test_case_available_to_view!
         say_no_to_protect_against_forgery!

--- a/actionview/lib/action_view/testing/resolvers.rb
+++ b/actionview/lib/action_view/testing/resolvers.rb
@@ -20,7 +20,7 @@ module ActionView #:nodoc:
     private
 
       def query(path, exts, _, _)
-        query = ""
+        query = "".dup
         EXTENSIONS.each_key do |ext|
           query << "(" << exts[ext].map { |e| e && Regexp.escape(".#{e}") }.join("|") << "|)"
         end

--- a/actionview/test/activerecord/form_helper_activerecord_test.rb
+++ b/actionview/test/activerecord/form_helper_activerecord_test.rb
@@ -55,7 +55,7 @@ class FormHelperActiveRecordTest < ActionView::TestCase
   private
 
     def hidden_fields(method = nil)
-      txt = %{<input name="utf8" type="hidden" value="&#x2713;" />}
+      txt = %{<input name="utf8" type="hidden" value="&#x2713;" />}.dup
 
       if method && !%w(get post).include?(method.to_s)
         txt << %{<input name="_method" type="hidden" value="#{method}" />}
@@ -65,7 +65,7 @@ class FormHelperActiveRecordTest < ActionView::TestCase
     end
 
     def form_text(action = "/", id = nil, html_class = nil, remote = nil, multipart = nil, method = nil)
-      txt =  %{<form accept-charset="UTF-8" action="#{action}"}
+      txt =  %{<form accept-charset="UTF-8" action="#{action}"}.dup
       txt << %{ enctype="multipart/form-data"} if multipart
       txt << %{ data-remote="true"} if remote
       txt << %{ class="#{html_class}"} if html_class

--- a/actionview/test/fixtures/ruby_template.ruby
+++ b/actionview/test/fixtures/ruby_template.ruby
@@ -1,2 +1,2 @@
-body = ""
+body = "".dup
 body << ["Hello", "from", "Ruby", "code"].join(" ")

--- a/actionview/test/template/atom_feed_helper_test.rb
+++ b/actionview/test/template/atom_feed_helper_test.rb
@@ -194,7 +194,7 @@ class ScrollsController < ActionController::Base
   FEEDS["provide_builder"] = <<-'EOT'
           # we pass in the new_xml to the helper so it doesn't
           # call anything on the original builder
-          new_xml = Builder::XmlMarkup.new(:target=>'')
+          new_xml = Builder::XmlMarkup.new(:target=>''.dup)
           atom_feed(:xml => new_xml) do |feed|
             feed.title("My great blog!")
             feed.updated(@scrolls.first.created_at)

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -214,7 +214,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_day
-    expected = %(<select id="date_day" name="date[day]">\n)
+    expected = %(<select id="date_day" name="date[day]">\n).dup
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
@@ -223,7 +223,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_day_with_blank
-    expected = %(<select id="date_day" name="date[day]">\n)
+    expected = %(<select id="date_day" name="date[day]">\n).dup
     expected << %(<option value=""></option>\n<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
@@ -232,7 +232,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_day_nil_with_blank
-    expected = %(<select id="date_day" name="date[day]">\n)
+    expected = %(<select id="date_day" name="date[day]">\n).dup
     expected << %(<option value=""></option>\n<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
@@ -240,7 +240,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_day_with_two_digit_numbers
-    expected = %(<select id="date_day" name="date[day]">\n)
+    expected = %(<select id="date_day" name="date[day]">\n).dup
     expected << %(<option value="1">01</option>\n<option selected="selected" value="2">02</option>\n<option value="3">03</option>\n<option value="4">04</option>\n<option value="5">05</option>\n<option value="6">06</option>\n<option value="7">07</option>\n<option value="8">08</option>\n<option value="9">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
@@ -249,7 +249,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_day_with_html_options
-    expected = %(<select id="date_day" name="date[day]" class="selector">\n)
+    expected = %(<select id="date_day" name="date[day]" class="selector">\n).dup
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
@@ -258,7 +258,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_day_with_default_prompt
-    expected = %(<select id="date_day" name="date[day]">\n)
+    expected = %(<select id="date_day" name="date[day]">\n).dup
     expected << %(<option value="">Day</option>\n<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
@@ -266,7 +266,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_day_with_custom_prompt
-    expected = %(<select id="date_day" name="date[day]">\n)
+    expected = %(<select id="date_day" name="date[day]">\n).dup
     expected << %(<option value="">Choose day</option>\n<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
@@ -274,7 +274,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_day_with_generic_with_css_classes
-    expected = %(<select id="date_day" name="date[day]" class="day">\n)
+    expected = %(<select id="date_day" name="date[day]" class="day">\n).dup
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
@@ -282,7 +282,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_day_with_custom_with_css_classes
-    expected = %(<select id="date_day" name="date[day]" class="my-day">\n)
+    expected = %(<select id="date_day" name="date[day]" class="my-day">\n).dup
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
@@ -290,7 +290,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month
-    expected = %(<select id="date_month" name="date[month]">\n)
+    expected = %(<select id="date_month" name="date[month]">\n).dup
     expected << %(<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
     expected << "</select>\n"
 
@@ -299,7 +299,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_two_digit_numbers
-    expected = %(<select id="date_month" name="date[month]">\n)
+    expected = %(<select id="date_month" name="date[month]">\n).dup
     expected << %(<option value="1">01</option>\n<option value="2">02</option>\n<option value="3">03</option>\n<option value="4">04</option>\n<option value="5">05</option>\n<option value="6">06</option>\n<option value="7">07</option>\n<option value="8" selected="selected">08</option>\n<option value="9">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n)
     expected << "</select>\n"
 
@@ -308,7 +308,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_disabled
-    expected = %(<select id="date_month" name="date[month]" disabled="disabled">\n)
+    expected = %(<select id="date_month" name="date[month]" disabled="disabled">\n).dup
     expected << %(<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
     expected << "</select>\n"
 
@@ -317,7 +317,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_field_name_override
-    expected = %(<select id="date_mois" name="date[mois]">\n)
+    expected = %(<select id="date_mois" name="date[mois]">\n).dup
     expected << %(<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
     expected << "</select>\n"
 
@@ -326,7 +326,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_blank
-    expected = %(<select id="date_month" name="date[month]">\n)
+    expected = %(<select id="date_month" name="date[month]">\n).dup
     expected << %(<option value=""></option>\n<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
     expected << "</select>\n"
 
@@ -335,7 +335,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_nil_with_blank
-    expected = %(<select id="date_month" name="date[month]">\n)
+    expected = %(<select id="date_month" name="date[month]">\n).dup
     expected << %(<option value=""></option>\n<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
     expected << "</select>\n"
 
@@ -343,7 +343,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_numbers
-    expected = %(<select id="date_month" name="date[month]">\n)
+    expected = %(<select id="date_month" name="date[month]">\n).dup
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8" selected="selected">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n)
     expected << "</select>\n"
 
@@ -352,7 +352,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_numbers_and_names
-    expected = %(<select id="date_month" name="date[month]">\n)
+    expected = %(<select id="date_month" name="date[month]">\n).dup
     expected << %(<option value="1">1 - January</option>\n<option value="2">2 - February</option>\n<option value="3">3 - March</option>\n<option value="4">4 - April</option>\n<option value="5">5 - May</option>\n<option value="6">6 - June</option>\n<option value="7">7 - July</option>\n<option value="8" selected="selected">8 - August</option>\n<option value="9">9 - September</option>\n<option value="10">10 - October</option>\n<option value="11">11 - November</option>\n<option value="12">12 - December</option>\n)
     expected << "</select>\n"
 
@@ -361,7 +361,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_format_string
-    expected = %(<select id="date_month" name="date[month]">\n)
+    expected = %(<select id="date_month" name="date[month]">\n).dup
     expected << %(<option value="1">January (01)</option>\n<option value="2">February (02)</option>\n<option value="3">March (03)</option>\n<option value="4">April (04)</option>\n<option value="5">May (05)</option>\n<option value="6">June (06)</option>\n<option value="7">July (07)</option>\n<option value="8" selected="selected">August (08)</option>\n<option value="9">September (09)</option>\n<option value="10">October (10)</option>\n<option value="11">November (11)</option>\n<option value="12">December (12)</option>\n)
     expected << "</select>\n"
 
@@ -371,7 +371,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_numbers_and_names_with_abbv
-    expected = %(<select id="date_month" name="date[month]">\n)
+    expected = %(<select id="date_month" name="date[month]">\n).dup
     expected << %(<option value="1">1 - Jan</option>\n<option value="2">2 - Feb</option>\n<option value="3">3 - Mar</option>\n<option value="4">4 - Apr</option>\n<option value="5">5 - May</option>\n<option value="6">6 - Jun</option>\n<option value="7">7 - Jul</option>\n<option value="8" selected="selected">8 - Aug</option>\n<option value="9">9 - Sep</option>\n<option value="10">10 - Oct</option>\n<option value="11">11 - Nov</option>\n<option value="12">12 - Dec</option>\n)
     expected << "</select>\n"
 
@@ -380,7 +380,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_abbv
-    expected = %(<select id="date_month" name="date[month]">\n)
+    expected = %(<select id="date_month" name="date[month]">\n).dup
     expected << %(<option value="1">Jan</option>\n<option value="2">Feb</option>\n<option value="3">Mar</option>\n<option value="4">Apr</option>\n<option value="5">May</option>\n<option value="6">Jun</option>\n<option value="7">Jul</option>\n<option value="8" selected="selected">Aug</option>\n<option value="9">Sep</option>\n<option value="10">Oct</option>\n<option value="11">Nov</option>\n<option value="12">Dec</option>\n)
     expected << "</select>\n"
 
@@ -391,7 +391,7 @@ class DateHelperTest < ActionView::TestCase
   def test_select_month_with_custom_names
     month_names = %w(nil Januar Februar Marts April Maj Juni Juli August September Oktober November December)
 
-    expected = %(<select id="date_month" name="date[month]">\n)
+    expected = %(<select id="date_month" name="date[month]">\n).dup
     1.upto(12) { |month| expected << %(<option value="#{month}"#{' selected="selected"' if month == 8}>#{month_names[month]}</option>\n) }
     expected << "</select>\n"
 
@@ -402,7 +402,7 @@ class DateHelperTest < ActionView::TestCase
   def test_select_month_with_zero_indexed_custom_names
     month_names = %w(Januar Februar Marts April Maj Juni Juli August September Oktober November December)
 
-    expected = %(<select id="date_month" name="date[month]">\n)
+    expected = %(<select id="date_month" name="date[month]">\n).dup
     1.upto(12) { |month| expected << %(<option value="#{month}"#{' selected="selected"' if month == 8}>#{month_names[month - 1]}</option>\n) }
     expected << "</select>\n"
 
@@ -419,7 +419,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_html_options
-    expected = %(<select id="date_month" name="date[month]" class="selector" accesskey="M">\n)
+    expected = %(<select id="date_month" name="date[month]" class="selector" accesskey="M">\n).dup
     expected << %(<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
     expected << "</select>\n"
 
@@ -427,7 +427,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_default_prompt
-    expected = %(<select id="date_month" name="date[month]">\n)
+    expected = %(<select id="date_month" name="date[month]">\n).dup
     expected << %(<option value="">Month</option>\n<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
     expected << "</select>\n"
 
@@ -435,7 +435,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_custom_prompt
-    expected = %(<select id="date_month" name="date[month]">\n)
+    expected = %(<select id="date_month" name="date[month]">\n).dup
     expected << %(<option value="">Choose month</option>\n<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
     expected << "</select>\n"
 
@@ -443,7 +443,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_generic_with_css_classes
-    expected = %(<select id="date_month" name="date[month]" class="month">\n)
+    expected = %(<select id="date_month" name="date[month]" class="month">\n).dup
     expected << %(<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
     expected << "</select>\n"
 
@@ -451,7 +451,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_custom_with_css_classes
-    expected = %(<select id="date_month" name="date[month]" class="my-month">\n)
+    expected = %(<select id="date_month" name="date[month]" class="my-month">\n).dup
     expected << %(<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
     expected << "</select>\n"
 
@@ -459,7 +459,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_year
-    expected = %(<select id="date_year" name="date[year]">\n)
+    expected = %(<select id="date_year" name="date[year]">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -468,7 +468,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_year_with_disabled
-    expected = %(<select id="date_year" name="date[year]" disabled="disabled">\n)
+    expected = %(<select id="date_year" name="date[year]" disabled="disabled">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -477,7 +477,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_year_with_field_name_override
-    expected = %(<select id="date_annee" name="date[annee]">\n)
+    expected = %(<select id="date_annee" name="date[annee]">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -486,7 +486,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_year_with_type_discarding
-    expected = %(<select id="date_year" name="date_year">\n)
+    expected = %(<select id="date_year" name="date_year">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -497,7 +497,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_year_descending
-    expected = %(<select id="date_year" name="date[year]">\n)
+    expected = %(<select id="date_year" name="date[year]">\n).dup
     expected << %(<option value="2005" selected="selected">2005</option>\n<option value="2004">2004</option>\n<option value="2003">2003</option>\n)
     expected << "</select>\n"
 
@@ -514,7 +514,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_year_with_html_options
-    expected = %(<select id="date_year" name="date[year]" class="selector" accesskey="M">\n)
+    expected = %(<select id="date_year" name="date[year]" class="selector" accesskey="M">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -522,7 +522,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_year_with_default_prompt
-    expected = %(<select id="date_year" name="date[year]">\n)
+    expected = %(<select id="date_year" name="date[year]">\n).dup
     expected << %(<option value="">Year</option>\n<option value="2003">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -530,7 +530,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_year_with_custom_prompt
-    expected = %(<select id="date_year" name="date[year]">\n)
+    expected = %(<select id="date_year" name="date[year]">\n).dup
     expected << %(<option value="">Choose year</option>\n<option value="2003">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -538,7 +538,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_year_with_generic_with_css_classes
-    expected = %(<select id="date_year" name="date[year]" class="year">\n)
+    expected = %(<select id="date_year" name="date[year]" class="year">\n).dup
     expected << %(<option value="2003">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -546,7 +546,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_year_with_custom_with_css_classes
-    expected = %(<select id="date_year" name="date[year]" class="my-year">\n)
+    expected = %(<select id="date_year" name="date[year]" class="my-year">\n).dup
     expected << %(<option value="2003">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -554,14 +554,14 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_year_with_position
-    expected = %(<select id="date_year_1i" name="date[year(1i)]">\n)
+    expected = %(<select id="date_year_1i" name="date[year(1i)]">\n).dup
     expected << %(<option value="2003">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
     assert_dom_equal expected, select_year(Date.current, include_position: true,  start_year: 2003, end_year: 2005)
   end
 
   def test_select_hour
-    expected = %(<select id="date_hour" name="date[hour]">\n)
+    expected = %(<select id="date_hour" name="date[hour]">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
     expected << "</select>\n"
 
@@ -569,7 +569,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_hour_with_ampm
-    expected = %(<select id="date_hour" name="date[hour]">\n)
+    expected = %(<select id="date_hour" name="date[hour]">\n).dup
     expected << %(<option value="00">12 AM</option>\n<option value="01">01 AM</option>\n<option value="02">02 AM</option>\n<option value="03">03 AM</option>\n<option value="04">04 AM</option>\n<option value="05">05 AM</option>\n<option value="06">06 AM</option>\n<option value="07">07 AM</option>\n<option value="08" selected="selected">08 AM</option>\n<option value="09">09 AM</option>\n<option value="10">10 AM</option>\n<option value="11">11 AM</option>\n<option value="12">12 PM</option>\n<option value="13">01 PM</option>\n<option value="14">02 PM</option>\n<option value="15">03 PM</option>\n<option value="16">04 PM</option>\n<option value="17">05 PM</option>\n<option value="18">06 PM</option>\n<option value="19">07 PM</option>\n<option value="20">08 PM</option>\n<option value="21">09 PM</option>\n<option value="22">10 PM</option>\n<option value="23">11 PM</option>\n)
     expected << "</select>\n"
 
@@ -577,7 +577,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_hour_with_disabled
-    expected = %(<select id="date_hour" name="date[hour]" disabled="disabled">\n)
+    expected = %(<select id="date_hour" name="date[hour]" disabled="disabled">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
     expected << "</select>\n"
 
@@ -585,7 +585,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_hour_with_field_name_override
-    expected = %(<select id="date_heure" name="date[heure]">\n)
+    expected = %(<select id="date_heure" name="date[heure]">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
     expected << "</select>\n"
 
@@ -593,7 +593,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_hour_with_blank
-    expected = %(<select id="date_hour" name="date[hour]">\n)
+    expected = %(<select id="date_hour" name="date[hour]">\n).dup
     expected << %(<option value=""></option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
     expected << "</select>\n"
 
@@ -601,7 +601,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_hour_nil_with_blank
-    expected = %(<select id="date_hour" name="date[hour]">\n)
+    expected = %(<select id="date_hour" name="date[hour]">\n).dup
     expected << %(<option value=""></option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
     expected << "</select>\n"
 
@@ -609,7 +609,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_hour_with_html_options
-    expected = %(<select id="date_hour" name="date[hour]" class="selector" accesskey="M">\n)
+    expected = %(<select id="date_hour" name="date[hour]" class="selector" accesskey="M">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
     expected << "</select>\n"
 
@@ -617,7 +617,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_hour_with_default_prompt
-    expected = %(<select id="date_hour" name="date[hour]">\n)
+    expected = %(<select id="date_hour" name="date[hour]">\n).dup
     expected << %(<option value="">Hour</option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
     expected << "</select>\n"
 
@@ -625,7 +625,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_hour_with_custom_prompt
-    expected = %(<select id="date_hour" name="date[hour]">\n)
+    expected = %(<select id="date_hour" name="date[hour]">\n).dup
     expected << %(<option value="">Choose hour</option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
     expected << "</select>\n"
 
@@ -633,7 +633,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_hour_with_generic_with_css_classes
-    expected = %(<select id="date_hour" name="date[hour]" class="hour">\n)
+    expected = %(<select id="date_hour" name="date[hour]" class="hour">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
     expected << "</select>\n"
 
@@ -641,7 +641,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_hour_with_custom_with_css_classes
-    expected = %(<select id="date_hour" name="date[hour]" class="my-hour">\n)
+    expected = %(<select id="date_hour" name="date[hour]" class="my-hour">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
     expected << "</select>\n"
 
@@ -649,7 +649,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_minute
-    expected = %(<select id="date_minute" name="date[minute]">\n)
+    expected = %(<select id="date_minute" name="date[minute]">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04" selected="selected">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -657,7 +657,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_minute_with_disabled
-    expected = %(<select id="date_minute" name="date[minute]" disabled="disabled">\n)
+    expected = %(<select id="date_minute" name="date[minute]" disabled="disabled">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04" selected="selected">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -665,7 +665,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_minute_with_field_name_override
-    expected = %(<select id="date_minuto" name="date[minuto]">\n)
+    expected = %(<select id="date_minuto" name="date[minuto]">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04" selected="selected">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -673,7 +673,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_minute_with_blank
-    expected = %(<select id="date_minute" name="date[minute]">\n)
+    expected = %(<select id="date_minute" name="date[minute]">\n).dup
     expected << %(<option value=""></option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04" selected="selected">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -681,7 +681,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_minute_with_blank_and_step
-    expected = %(<select id="date_minute" name="date[minute]">\n)
+    expected = %(<select id="date_minute" name="date[minute]">\n).dup
     expected << %(<option value=""></option>\n<option value="00">00</option>\n<option value="15">15</option>\n<option value="30">30</option>\n<option value="45">45</option>\n)
     expected << "</select>\n"
 
@@ -689,7 +689,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_minute_nil_with_blank
-    expected = %(<select id="date_minute" name="date[minute]">\n)
+    expected = %(<select id="date_minute" name="date[minute]">\n).dup
     expected << %(<option value=""></option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -697,7 +697,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_minute_nil_with_blank_and_step
-    expected = %(<select id="date_minute" name="date[minute]">\n)
+    expected = %(<select id="date_minute" name="date[minute]">\n).dup
     expected << %(<option value=""></option>\n<option value="00">00</option>\n<option value="15">15</option>\n<option value="30">30</option>\n<option value="45">45</option>\n)
     expected << "</select>\n"
 
@@ -713,7 +713,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_minute_with_html_options
-    expected = %(<select id="date_minute" name="date[minute]" class="selector" accesskey="M">\n)
+    expected = %(<select id="date_minute" name="date[minute]" class="selector" accesskey="M">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04" selected="selected">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -721,7 +721,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_minute_with_default_prompt
-    expected = %(<select id="date_minute" name="date[minute]">\n)
+    expected = %(<select id="date_minute" name="date[minute]">\n).dup
     expected << %(<option value="">Minute</option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04" selected="selected">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -729,7 +729,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_minute_with_custom_prompt
-    expected = %(<select id="date_minute" name="date[minute]">\n)
+    expected = %(<select id="date_minute" name="date[minute]">\n).dup
     expected << %(<option value="">Choose minute</option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04" selected="selected">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -737,7 +737,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_minute_with_generic_with_css_classes
-    expected = %(<select id="date_minute" name="date[minute]" class="minute">\n)
+    expected = %(<select id="date_minute" name="date[minute]" class="minute">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04" selected="selected">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -745,7 +745,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_minute_with_custom_with_css_classes
-    expected = %(<select id="date_minute" name="date[minute]" class="my-minute">\n)
+    expected = %(<select id="date_minute" name="date[minute]" class="my-minute">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04" selected="selected">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -753,7 +753,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_second
-    expected = %(<select id="date_second" name="date[second]">\n)
+    expected = %(<select id="date_second" name="date[second]">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18" selected="selected">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -761,7 +761,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_second_with_disabled
-    expected = %(<select id="date_second" name="date[second]" disabled="disabled">\n)
+    expected = %(<select id="date_second" name="date[second]" disabled="disabled">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18" selected="selected">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -769,7 +769,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_second_with_field_name_override
-    expected = %(<select id="date_segundo" name="date[segundo]">\n)
+    expected = %(<select id="date_segundo" name="date[segundo]">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18" selected="selected">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -777,7 +777,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_second_with_blank
-    expected = %(<select id="date_second" name="date[second]">\n)
+    expected = %(<select id="date_second" name="date[second]">\n).dup
     expected << %(<option value=""></option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18" selected="selected">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -785,7 +785,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_second_nil_with_blank
-    expected = %(<select id="date_second" name="date[second]">\n)
+    expected = %(<select id="date_second" name="date[second]">\n).dup
     expected << %(<option value=""></option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -793,7 +793,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_second_with_html_options
-    expected = %(<select id="date_second" name="date[second]" class="selector" accesskey="M">\n)
+    expected = %(<select id="date_second" name="date[second]" class="selector" accesskey="M">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18" selected="selected">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -801,7 +801,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_second_with_default_prompt
-    expected = %(<select id="date_second" name="date[second]">\n)
+    expected = %(<select id="date_second" name="date[second]">\n).dup
     expected << %(<option value="">Seconds</option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18" selected="selected">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -809,7 +809,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_second_with_custom_prompt
-    expected = %(<select id="date_second" name="date[second]">\n)
+    expected = %(<select id="date_second" name="date[second]">\n).dup
     expected << %(<option value="">Choose seconds</option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18" selected="selected">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -817,7 +817,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_second_with_generic_with_css_classes
-    expected = %(<select id="date_second" name="date[second]" class="second">\n)
+    expected = %(<select id="date_second" name="date[second]" class="second">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18" selected="selected">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -825,7 +825,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_second_with_custom_with_css_classes
-    expected = %(<select id="date_second" name="date[second]" class="my-second">\n)
+    expected = %(<select id="date_second" name="date[second]" class="my-second">\n).dup
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18" selected="selected">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
@@ -833,7 +833,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date
-    expected =  %(<select id="date_first_year" name="date[first][year]">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -858,7 +858,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_order
-    expected = %(<select id="date_first_month" name="date[first][month]">\n)
+    expected = %(<select id="date_first_month" name="date[first][month]">\n).dup
     expected << %(<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
     expected << "</select>\n"
 
@@ -875,7 +875,7 @@ class DateHelperTest < ActionView::TestCase
 
   def test_select_date_with_incomplete_order
     # Since the order is incomplete nothing will be shown
-    expected = %(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" />\n)
+    expected = %(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" />\n).dup
     expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" />\n)
     expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="1" />\n)
 
@@ -883,7 +883,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_disabled
-    expected =  %(<select id="date_first_year" name="date[first][year]" disabled="disabled">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]" disabled="disabled">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -899,7 +899,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_no_start_year
-    expected = %(<select id="date_first_year" name="date[first][year]">\n)
+    expected = %(<select id="date_first_year" name="date[first][year]">\n).dup
     (Date.today.year - 5).upto(Date.today.year + 1) do |y|
       if y == Date.today.year
         expected << %(<option value="#{y}" selected="selected">#{y}</option>\n)
@@ -923,7 +923,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_no_end_year
-    expected = %(<select id="date_first_year" name="date[first][year]">\n)
+    expected = %(<select id="date_first_year" name="date[first][year]">\n).dup
     2003.upto(2008) do |y|
       if y == 2003
         expected << %(<option value="#{y}" selected="selected">#{y}</option>\n)
@@ -947,7 +947,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_no_start_or_end_year
-    expected = %(<select id="date_first_year" name="date[first][year]">\n)
+    expected = %(<select id="date_first_year" name="date[first][year]">\n).dup
     (Date.today.year - 5).upto(Date.today.year + 5) do |y|
       if y == Date.today.year
         expected << %(<option value="#{y}" selected="selected">#{y}</option>\n)
@@ -971,7 +971,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_zero_value
-    expected =  %(<select id="date_first_year" name="date[first][year]">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
     expected << %(<option value="2003">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -987,7 +987,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_zero_value_and_no_start_year
-    expected = %(<select id="date_first_year" name="date[first][year]">\n)
+    expected = %(<select id="date_first_year" name="date[first][year]">\n).dup
     (Date.today.year - 5).upto(Date.today.year + 1) { |y| expected << %(<option value="#{y}">#{y}</option>\n) }
     expected << "</select>\n"
 
@@ -1003,7 +1003,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_zero_value_and_no_end_year
-    expected =  %(<select id="date_first_year" name="date[first][year]">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
     last_year = Time.now.year + 5
     2003.upto(last_year) { |y| expected << %(<option value="#{y}">#{y}</option>\n) }
     expected << "</select>\n"
@@ -1020,7 +1020,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_zero_value_and_no_start_and_end_year
-    expected = %(<select id="date_first_year" name="date[first][year]">\n)
+    expected = %(<select id="date_first_year" name="date[first][year]">\n).dup
     (Date.today.year - 5).upto(Date.today.year + 5) { |y| expected << %(<option value="#{y}">#{y}</option>\n) }
     expected << "</select>\n"
 
@@ -1036,7 +1036,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_nil_value_and_no_start_and_end_year
-    expected = %(<select id="date_first_year" name="date[first][year]">\n)
+    expected = %(<select id="date_first_year" name="date[first][year]">\n).dup
     (Date.today.year - 5).upto(Date.today.year + 5) { |y| expected << %(<option value="#{y}">#{y}</option>\n) }
     expected << "</select>\n"
 
@@ -1052,7 +1052,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_html_options
-    expected =  %(<select id="date_first_year" name="date[first][year]" class="selector">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]" class="selector">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1068,7 +1068,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_separator
-    expected =  %(<select id="date_first_year" name="date[first][year]">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1088,7 +1088,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_separator_and_discard_day
-    expected =  %(<select id="date_first_year" name="date[first][year]">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1104,7 +1104,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_separator_discard_month_and_day
-    expected =  %(<select id="date_first_year" name="date[first][year]">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1115,7 +1115,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_hidden
-    expected =  %(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003"/>\n)
+    expected =  %(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003"/>\n).dup
     expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" />\n)
     expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" />\n)
 
@@ -1124,7 +1124,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_css_classes_option
-    expected =  %(<select id="date_first_year" name="date[first][year]" class="year">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]" class="year">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1140,7 +1140,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_custom_with_css_classes
-    expected =  %(<select id="date_year" name="date[year]" class="my-year">\n)
+    expected =  %(<select id="date_year" name="date[year]" class="my-year">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1156,7 +1156,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_css_classes_option_and_html_class_option
-    expected =  %(<select id="date_first_year" name="date[first][year]" class="datetime optional year">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]" class="datetime optional year">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1172,7 +1172,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_custom_with_css_classes_and_html_class_option
-    expected =  %(<select id="date_year" name="date[year]" class="date optional my-year">\n)
+    expected =  %(<select id="date_year" name="date[year]" class="date optional my-year">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1188,7 +1188,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_partial_with_css_classes_and_html_class_option
-    expected =  %(<select id="date_year" name="date[year]" class="date optional">\n)
+    expected =  %(<select id="date_year" name="date[year]" class="date optional">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1204,7 +1204,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_date_with_html_class_option
-    expected =  %(<select id="date_year" name="date[year]" class="date optional custom-grid">\n)
+    expected =  %(<select id="date_year" name="date[year]" class="date optional custom-grid">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1220,7 +1220,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime
-    expected =  %(<select id="date_first_year" name="date[first][year]">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1248,7 +1248,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime_with_ampm
-    expected =  %(<select id="date_first_year" name="date[first][year]">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1276,7 +1276,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime_with_separators
-    expected =  %(<select id="date_first_year" name="date[first][year]">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1304,7 +1304,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime_with_nil_value_and_no_start_and_end_year
-    expected = %(<select id="date_first_year" name="date[first][year]">\n)
+    expected = %(<select id="date_first_year" name="date[first][year]">\n).dup
     (Date.today.year - 5).upto(Date.today.year + 5) { |y| expected << %(<option value="#{y}">#{y}</option>\n) }
     expected << "</select>\n"
 
@@ -1332,7 +1332,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime_with_html_options
-    expected =  %(<select id="date_first_year" name="date[first][year]" class="selector">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]" class="selector">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1360,7 +1360,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime_with_all_separators
-    expected =  %(<select id="date_first_year" name="date[first][year]" class="selector">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]" class="selector">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1396,7 +1396,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime_with_default_prompt
-    expected =  %(<select id="date_first_year" name="date[first][year]">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
     expected << %(<option value="">Year</option>\n<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1425,7 +1425,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime_with_custom_prompt
-    expected =  %(<select id="date_first_year" name="date[first][year]">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
     expected << %(<option value="">Choose year</option>\n<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1454,7 +1454,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime_with_generic_with_css_classes
-    expected =  %(<select id="date_year" name="date[year]" class="year">\n)
+    expected =  %(<select id="date_year" name="date[year]" class="year">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1482,7 +1482,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime_with_custom_with_css_classes
-    expected =  %(<select id="date_year" name="date[year]" class="my-year">\n)
+    expected =  %(<select id="date_year" name="date[year]" class="my-year">\n).dup
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1510,7 +1510,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime_with_custom_hours
-    expected =  %(<select id="date_first_year" name="date[first][year]">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
     expected << %(<option value="">Choose year</option>\n<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
@@ -1539,7 +1539,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime_with_hidden
-    expected =  %(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" />\n)
+    expected =  %(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" />\n).dup
     expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" />\n)
     expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" />\n)
     expected << %(<input id="date_first_hour" name="date[first][hour]" type="hidden" value="8" />\n)
@@ -1551,7 +1551,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time
-    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
+    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n).dup
     expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
     expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
 
@@ -1570,7 +1570,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_ampm
-    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
+    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n).dup
     expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
     expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
 
@@ -1588,7 +1588,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_separator
-    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
+    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n).dup
     expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
     expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
     expected << %(<select id="date_hour" name="date[hour]">\n)
@@ -1606,7 +1606,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_seconds
-    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
+    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n).dup
     expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
     expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
 
@@ -1630,7 +1630,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_seconds_and_separator
-    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
+    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n).dup
     expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
     expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
 
@@ -1654,7 +1654,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_html_options
-    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
+    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n).dup
     expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
     expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
 
@@ -1677,7 +1677,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_default_prompt
-    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
+    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n).dup
     expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
     expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
 
@@ -1701,7 +1701,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_custom_prompt
-    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
+    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n).dup
     expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
     expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
 
@@ -1726,7 +1726,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_generic_with_css_classes
-    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
+    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n).dup
     expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
     expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
 
@@ -1750,7 +1750,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_custom_with_css_classes
-    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
+    expected = %(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n).dup
     expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
     expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
 
@@ -1774,7 +1774,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_hidden
-    expected =  %(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" />\n)
+    expected =  %(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" />\n).dup
     expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" />\n)
     expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" />\n)
     expected << %(<input id="date_first_hour" name="date[first][hour]" type="hidden" value="8" />\n)
@@ -1788,7 +1788,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -1808,7 +1808,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -1828,7 +1828,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -1866,7 +1866,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = "<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" />\n"
+    expected = "<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" />\n".dup
 
     expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
     expected << %{<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6" selected="selected">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
@@ -1883,7 +1883,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 2, 29)
 
-    expected = "<input type=\"hidden\" id=\"post_written_on_2i\" name=\"post[written_on(2i)]\" value=\"2\" />\n"
+    expected = "<input type=\"hidden\" id=\"post_written_on_2i\" name=\"post[written_on(2i)]\" value=\"2\" />\n".dup
     expected << "<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" />\n"
 
     expected << %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
@@ -1897,7 +1897,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = "<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" />\n"
+    expected = "<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" />\n".dup
 
     expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
     expected << %{<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6" selected="selected">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
@@ -1916,7 +1916,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = "<input type=\"hidden\" id=\"post_written_on_3i\" disabled=\"disabled\" name=\"post[written_on(3i)]\" value=\"1\" />\n"
+    expected = "<input type=\"hidden\" id=\"post_written_on_3i\" disabled=\"disabled\" name=\"post[written_on(3i)]\" value=\"1\" />\n".dup
 
     expected << %{<select id="post_written_on_2i" disabled="disabled" name="post[written_on(2i)]">\n}
     expected << %{<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6" selected="selected">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
@@ -1937,7 +1937,7 @@ class DateHelperTest < ActionView::TestCase
       concat f.date_select(:written_on)
     end
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n</select>\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n</select>\n}.dup
     expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option selected="selected" value="6">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n</select>\n}
     expected << %{<select id="post_written_on_3i" name="post[written_on(3i)]">\n<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option selected="selected" value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n</select>\n}
 
@@ -1953,7 +1953,7 @@ class DateHelperTest < ActionView::TestCase
       concat f.date_select(:written_on)
     end
 
-    expected = %{<select id="post_#{id}_written_on_1i" name="post[#{id}][written_on(1i)]">\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n</select>\n}
+    expected = %{<select id="post_#{id}_written_on_1i" name="post[#{id}][written_on(1i)]">\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n</select>\n}.dup
     expected << %{<select id="post_#{id}_written_on_2i" name="post[#{id}][written_on(2i)]">\n<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option selected="selected" value="6">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n</select>\n}
     expected << %{<select id="post_#{id}_written_on_3i" name="post[#{id}][written_on(3i)]">\n<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option selected="selected" value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n</select>\n}
 
@@ -1969,7 +1969,7 @@ class DateHelperTest < ActionView::TestCase
       concat f.date_select(:written_on)
     end
 
-    expected = %{<select id="post_#{id}_written_on_1i" name="post[#{id}][written_on(1i)]">\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n</select>\n}
+    expected = %{<select id="post_#{id}_written_on_1i" name="post[#{id}][written_on(1i)]">\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n</select>\n}.dup
     expected << %{<select id="post_#{id}_written_on_2i" name="post[#{id}][written_on(2i)]">\n<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option selected="selected" value="6">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n</select>\n}
     expected << %{<select id="post_#{id}_written_on_3i" name="post[#{id}][written_on(3i)]">\n<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option selected="selected" value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n</select>\n}
 
@@ -1981,7 +1981,7 @@ class DateHelperTest < ActionView::TestCase
     @post.written_on = Date.new(2004, 6, 15)
     id = 456
 
-    expected = %{<select id="post_456_written_on_1i" name="post[#{id}][written_on(1i)]">\n}
+    expected = %{<select id="post_456_written_on_1i" name="post[#{id}][written_on(1i)]">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2001,7 +2001,7 @@ class DateHelperTest < ActionView::TestCase
     @post.written_on = Date.new(2004, 6, 15)
     id = 123
 
-    expected = %{<select id="post_123_written_on_1i" name="post[#{id}][written_on(1i)]">\n}
+    expected = %{<select id="post_123_written_on_1i" name="post[#{id}][written_on(1i)]">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2020,7 +2020,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = %{<select id="post_written_on_3i" name="post[written_on(3i)]">\n}
+    expected = %{<select id="post_written_on_3i" name="post[written_on(3i)]">\n}.dup
     1.upto(31) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 15}>#{i}</option>\n) }
     expected << "</select>\n"
 
@@ -2040,7 +2040,7 @@ class DateHelperTest < ActionView::TestCase
 
     start_year = Time.now.year - 5
     end_year   = Time.now.year + 5
-    expected =   %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
+    expected =   %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}.dup
     start_year.upto(end_year) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == Time.now.year}>#{i}</option>\n) }
     expected << "</select>\n"
 
@@ -2060,7 +2060,7 @@ class DateHelperTest < ActionView::TestCase
 
     start_year = Time.now.year - 5
     end_year   = Time.now.year + 5
-    expected =   %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
+    expected =   %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}.dup
     expected << "<option value=\"\"></option>\n"
     start_year.upto(end_year) { |i| expected << %(<option value="#{i}">#{i}</option>\n) }
     expected << "</select>\n"
@@ -2104,7 +2104,7 @@ class DateHelperTest < ActionView::TestCase
     start_year = Time.now.year - 5
     end_year   = Time.now.year + 5
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}.dup
     expected << "<option value=\"\"></option>\n"
     start_year.upto(end_year) { |i| expected << %(<option value="#{i}">#{i}</option>\n) }
     expected << "</select>\n"
@@ -2136,7 +2136,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2155,7 +2155,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]" class="selector">\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]" class="selector">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2179,7 +2179,7 @@ class DateHelperTest < ActionView::TestCase
       concat f.date_select(:written_on, {}, class: "selector")
     end
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]" class="selector">\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]" class="selector">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2199,7 +2199,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2223,7 +2223,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = %{<select id="post_written_on_3i" name="post[written_on(3i)]">\n}
+    expected = %{<select id="post_written_on_3i" name="post[written_on(3i)]">\n}.dup
     expected << %{<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15" selected="selected">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n}
     expected << "</select>\n"
 
@@ -2246,7 +2246,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = %{<select id="post_written_on_3i" name="post[written_on(3i)]">\n}
+    expected = %{<select id="post_written_on_3i" name="post[written_on(3i)]">\n}.dup
     expected << %{<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15" selected="selected">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n}
     expected << "</select>\n"
 
@@ -2264,7 +2264,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}.dup
     expected << %{<option value="">Year</option>\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2284,7 +2284,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}.dup
     expected << %{<option value="">Choose year</option>\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2304,7 +2304,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]" class="year">\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]" class="year">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2324,7 +2324,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]" class="my-year">\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]" class="my-year">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2344,7 +2344,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}.dup
     expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
     expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
 
@@ -2363,7 +2363,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}.dup
     expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
     expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
 
@@ -2382,7 +2382,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="1" />\n}
+    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="1" />\n}.dup
     expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="1" />\n}
     expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="1" />\n}
 
@@ -2401,7 +2401,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
+    expected = %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n).dup
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
     expected << "</select>\n"
     expected << " : "
@@ -2416,7 +2416,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}.dup
     expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
     expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
 
@@ -2439,7 +2439,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}.dup
     expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
     expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
 
@@ -2462,7 +2462,7 @@ class DateHelperTest < ActionView::TestCase
       concat f.time_select(:written_on, {}, class: "selector")
     end
 
-    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}.dup
     expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
     expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
 
@@ -2481,7 +2481,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}.dup
     expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
     expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
 
@@ -2508,7 +2508,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}.dup
     expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
     expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
 
@@ -2529,7 +2529,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}.dup
     expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
     expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
 
@@ -2550,7 +2550,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}.dup
     expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
     expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
 
@@ -2571,7 +2571,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}.dup
     expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
     expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
 
@@ -2592,7 +2592,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_written_on_1i" disabled="disabled" name="post[written_on(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_written_on_1i" disabled="disabled" name="post[written_on(1i)]" value="2004" />\n}.dup
     expected << %{<input type="hidden" id="post_written_on_2i" disabled="disabled" name="post[written_on(2i)]" value="6" />\n}
     expected << %{<input type="hidden" id="post_written_on_3i" disabled="disabled" name="post[written_on(3i)]" value="15" />\n}
 
@@ -2611,7 +2611,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 16, 35)
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2640,7 +2640,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 16, 35)
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2706,7 +2706,7 @@ class DateHelperTest < ActionView::TestCase
 
     @post = Post.new
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2741,7 +2741,7 @@ class DateHelperTest < ActionView::TestCase
       concat f.datetime_select(:updated_at, {}, class: "selector")
     end
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]" class="selector">\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n</select>\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]" class="selector">\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n</select>\n}.dup
     expected << %{<select id="post_updated_at_2i" name="post[updated_at(2i)]" class="selector">\n<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option selected="selected" value="6">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n</select>\n}
     expected << %{<select id="post_updated_at_3i" name="post[updated_at(3i)]" class="selector">\n<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option selected="selected" value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n</select>\n}
     expected << %{ &mdash; <select id="post_updated_at_4i" name="post[updated_at(4i)]" class="selector">\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option selected="selected" value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n}
@@ -2754,7 +2754,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2807,7 +2807,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = nil
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}.dup
     expected << %{<option value="">Year</option>\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2836,7 +2836,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = nil
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}.dup
     expected << %{<option value="">Choose year</option>\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2865,7 +2865,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]" class="year">\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]" class="year">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2894,7 +2894,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]" class="my-year">\n}
+    expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]" class="my-year">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -2920,7 +2920,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_date_select_with_zero_value_and_no_start_year
-    expected = %(<select id="date_first_year" name="date[first][year]">\n)
+    expected = %(<select id="date_first_year" name="date[first][year]">\n).dup
     (Date.today.year - 5).upto(Date.today.year + 1) { |y| expected << %(<option value="#{y}">#{y}</option>\n) }
     expected << "</select>\n"
 
@@ -2936,7 +2936,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_date_select_with_zero_value_and_no_end_year
-    expected =  %(<select id="date_first_year" name="date[first][year]">\n)
+    expected =  %(<select id="date_first_year" name="date[first][year]">\n).dup
     last_year = Time.now.year + 5
     2003.upto(last_year) { |y| expected << %(<option value="#{y}">#{y}</option>\n) }
     expected << "</select>\n"
@@ -2953,7 +2953,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_date_select_with_zero_value_and_no_start_and_end_year
-    expected = %(<select id="date_first_year" name="date[first][year]">\n)
+    expected = %(<select id="date_first_year" name="date[first][year]">\n).dup
     (Date.today.year - 5).upto(Date.today.year + 5) { |y| expected << %(<option value="#{y}">#{y}</option>\n) }
     expected << "</select>\n"
 
@@ -2969,7 +2969,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_date_select_with_nil_value_and_no_start_and_end_year
-    expected = %(<select id="date_first_year" name="date[first][year]">\n)
+    expected = %(<select id="date_first_year" name="date[first][year]">\n).dup
     (Date.today.year - 5).upto(Date.today.year + 5) { |y| expected << %(<option value="#{y}">#{y}</option>\n) }
     expected << "</select>\n"
 
@@ -2985,7 +2985,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_datetime_select_with_nil_value_and_no_start_and_end_year
-    expected = %(<select id="date_first_year" name="date[first][year]">\n)
+    expected = %(<select id="date_first_year" name="date[first][year]">\n).dup
     (Date.today.year - 5).upto(Date.today.year + 5) { |y| expected << %(<option value="#{y}">#{y}</option>\n) }
     expected << "</select>\n"
 
@@ -3017,7 +3017,7 @@ class DateHelperTest < ActionView::TestCase
     @post.updated_at = Time.local(2004, 6, 15, 16, 35)
     id = 456
 
-    expected = %{<select id="post_456_updated_at_1i" name="post[#{id}][updated_at(1i)]">\n}
+    expected = %{<select id="post_456_updated_at_1i" name="post[#{id}][updated_at(1i)]">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -3051,7 +3051,7 @@ class DateHelperTest < ActionView::TestCase
       concat f.datetime_select(:updated_at)
     end
 
-    expected = %{<select id="post_456_updated_at_1i" name="post[#{id}][updated_at(1i)]">\n}
+    expected = %{<select id="post_456_updated_at_1i" name="post[#{id}][updated_at(1i)]">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -3081,7 +3081,7 @@ class DateHelperTest < ActionView::TestCase
     @post.updated_at = Time.local(2004, 6, 15, 16, 35)
     id = @post.id
 
-    expected = %{<select id="post_123_updated_at_1i" name="post[#{id}][updated_at(1i)]">\n}
+    expected = %{<select id="post_123_updated_at_1i" name="post[#{id}][updated_at(1i)]">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
@@ -3110,7 +3110,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}.dup
     1999.upto(2009) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 2004}>#{i}</option>\n) }
     expected << "</select>\n"
     expected << %{<select id="post_updated_at_2i" name="post[updated_at(2i)]">\n}
@@ -3141,7 +3141,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" />\n}.dup
     expected << %{<select id="post_updated_at_2i" name="post[updated_at(2i)]">\n}
     1.upto(12) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 6}>#{Date::MONTHNAMES[i]}</option>\n) }
     expected << "</select>\n"
@@ -3166,7 +3166,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}.dup
     1999.upto(2009) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 2004}>#{i}</option>\n) }
     expected << "</select>\n"
     expected << %{<input type="hidden" id="post_updated_at_2i" name="post[updated_at(2i)]" value="6" />\n}
@@ -3189,7 +3189,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" />\n}.dup
     expected << %{<input type="hidden" id="post_updated_at_2i" name="post[updated_at(2i)]" value="6" />\n}
     expected << %{<input type="hidden" id="post_updated_at_3i" name="post[updated_at(3i)]" value="1" />\n}
 
@@ -3208,7 +3208,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_updated_at_1i" disabled="disabled" name="post[updated_at(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_updated_at_1i" disabled="disabled" name="post[updated_at(1i)]" value="2004" />\n}.dup
     expected << %{<input type="hidden" id="post_updated_at_2i" disabled="disabled" name="post[updated_at(2i)]" value="6" />\n}
     expected << %{<input type="hidden" id="post_updated_at_3i" disabled="disabled" name="post[updated_at(3i)]" value="1" />\n}
 
@@ -3227,7 +3227,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}.dup
     1999.upto(2009) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 2004}>#{i}</option>\n) }
     expected << "</select>\n"
     expected << %{<select id="post_updated_at_2i" name="post[updated_at(2i)]">\n}
@@ -3244,7 +3244,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}.dup
     1999.upto(2009) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 2004}>#{i}</option>\n) }
     expected << "</select>\n"
     expected << %{<select id="post_updated_at_2i" name="post[updated_at(2i)]">\n}
@@ -3268,7 +3268,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<select id="post_updated_at_1i" disabled="disabled" name="post[updated_at(1i)]">\n}
+    expected = %{<select id="post_updated_at_1i" disabled="disabled" name="post[updated_at(1i)]">\n}.dup
     1999.upto(2009) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 2004}>#{i}</option>\n) }
     expected << "</select>\n"
     expected << %{<select id="post_updated_at_2i" disabled="disabled" name="post[updated_at(2i)]">\n}
@@ -3292,7 +3292,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<select id="post_updated_at_3i" name="post[updated_at(3i)]">\n}
+    expected = %{<select id="post_updated_at_3i" name="post[updated_at(3i)]">\n}.dup
     1.upto(31) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 15}>#{i}</option>\n) }
     expected << "</select>\n"
     expected << %{<select id="post_updated_at_2i" name="post[updated_at(2i)]">\n}
@@ -3319,7 +3319,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = %{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" />\n}
+    expected = %{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" />\n}.dup
     expected << %{<select id="post_updated_at_3i" name="post[updated_at(3i)]">\n}
     1.upto(31) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 15}>#{i}</option>\n) }
     expected << "</select>\n"
@@ -3344,7 +3344,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = nil
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}.dup
     2001.upto(2011) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 2006}>#{i}</option>\n) }
     expected << "</select>\n"
     expected << %{<select id="post_updated_at_2i" name="post[updated_at(2i)]">\n}
@@ -3371,7 +3371,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = nil
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}.dup
     expected << %(<option value=""></option>\n)
     (Time.now.year - 5).upto(Time.now.year + 5) { |i| expected << %(<option value="#{i}">#{i}</option>\n) }
     expected << "</select>\n"
@@ -3391,7 +3391,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = nil
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}.dup
     (Time.now.year - 5).upto(Time.now.year + 5) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == Time.now.year}>#{i}</option>\n) }
     expected << "</select>\n"
     expected << %{<select id="post_updated_at_2i" name="post[updated_at(2i)]">\n}
@@ -3418,7 +3418,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 16, 35)
 
-    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]" class="selector">\n}
+    expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]" class="selector">\n}.dup
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -16,7 +16,7 @@ class FormWithActsLikeFormTagTest < FormWithTest
     method = options[:method]
     skip_enforcing_utf8 = options.fetch(:skip_enforcing_utf8, false)
 
-    "".tap do |txt|
+    "".dup.tap do |txt|
       unless skip_enforcing_utf8
         txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
       end
@@ -32,7 +32,7 @@ class FormWithActsLikeFormTagTest < FormWithTest
 
     method = method.to_s == "get" ? "get" : "post"
 
-    txt =  %{<form accept-charset="UTF-8" action="#{action}"}
+    txt =  %{<form accept-charset="UTF-8" action="#{action}"}.dup
     txt << %{ enctype="multipart/form-data"} if enctype
     txt << %{ data-remote="true"} unless local
     txt << %{ class="#{html_class}"} if html_class
@@ -2194,9 +2194,9 @@ class FormWithActsLikeFormForTest < FormWithTest
       method = options[:method]
 
       if options.fetch(:skip_enforcing_utf8, false)
-        txt = ""
+        txt = "".dup
       else
-        txt = %{<input name="utf8" type="hidden" value="&#x2713;" />}
+        txt = %{<input name="utf8" type="hidden" value="&#x2713;" />}.dup
       end
 
       if method && !%w(get post).include?(method.to_s)
@@ -2207,7 +2207,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     def form_text(action = "/", id = nil, html_class = nil, local = nil, multipart = nil, method = nil)
-      txt =  %{<form accept-charset="UTF-8" action="#{action}"}
+      txt =  %{<form accept-charset="UTF-8" action="#{action}"}.dup
       txt << %{ enctype="multipart/form-data"} if multipart
       txt << %{ data-remote="true"} unless local
       txt << %{ class="#{html_class}"} if html_class

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -3446,9 +3446,9 @@ class FormHelperTest < ActionView::TestCase
       method = options[:method]
 
       if options.fetch(:enforce_utf8, true)
-        txt = %{<input name="utf8" type="hidden" value="&#x2713;" />}
+        txt = %{<input name="utf8" type="hidden" value="&#x2713;" />}.dup
       else
-        txt = ""
+        txt = "".dup
       end
 
       if method && !%w(get post).include?(method.to_s)
@@ -3459,7 +3459,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     def form_text(action = "/", id = nil, html_class = nil, remote = nil, multipart = nil, method = nil)
-      txt =  %{<form accept-charset="UTF-8" action="#{action}"}
+      txt =  %{<form accept-charset="UTF-8" action="#{action}"}.dup
       txt << %{ enctype="multipart/form-data"} if multipart
       txt << %{ data-remote="true"} if remote
       txt << %{ class="#{html_class}"} if html_class

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -14,7 +14,7 @@ class FormTagHelperTest < ActionView::TestCase
     method = options[:method]
     enforce_utf8 = options.fetch(:enforce_utf8, true)
 
-    "".tap do |txt|
+    "".dup.tap do |txt|
       if enforce_utf8
         txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
       end
@@ -30,7 +30,7 @@ class FormTagHelperTest < ActionView::TestCase
 
     method = method.to_s == "get" ? "get" : "post"
 
-    txt =  %{<form accept-charset="UTF-8" action="#{action}"}
+    txt =  %{<form accept-charset="UTF-8" action="#{action}"}.dup
     txt << %{ enctype="multipart/form-data"} if enctype
     txt << %{ data-remote="true"} if remote
     txt << %{ class="#{html_class}"} if html_class

--- a/actionview/test/template/javascript_helper_test.rb
+++ b/actionview/test/template/javascript_helper_test.rb
@@ -20,8 +20,8 @@ class JavaScriptHelperTest < ActionView::TestCase
     assert_equal %(This \\"thing\\" is really\\n netos\\'), escape_javascript(%(This "thing" is really\n netos'))
     assert_equal %(backslash\\\\test), escape_javascript(%(backslash\\test))
     assert_equal %(dont <\\/close> tags), escape_javascript(%(dont </close> tags))
-    assert_equal %(unicode &#x2028; newline), escape_javascript(%(unicode \342\200\250 newline).force_encoding(Encoding::UTF_8).encode!)
-    assert_equal %(unicode &#x2029; newline), escape_javascript(%(unicode \342\200\251 newline).force_encoding(Encoding::UTF_8).encode!)
+    assert_equal %(unicode &#x2028; newline), escape_javascript(%(unicode \342\200\250 newline).dup.force_encoding(Encoding::UTF_8).encode!)
+    assert_equal %(unicode &#x2029; newline), escape_javascript(%(unicode \342\200\251 newline).dup.force_encoding(Encoding::UTF_8).encode!)
 
     assert_equal %(dont <\\/close> tags), j(%(dont </close> tags))
   end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -439,7 +439,7 @@ module RenderTestCases
   end
 
   CustomHandler = lambda do |template|
-    "@output_buffer = ''\n" \
+    "@output_buffer = ''.dup\n" \
       "@output_buffer << 'source: #{template.source.inspect}'\n"
   end
 
@@ -583,7 +583,7 @@ module RenderTestCases
 
   def test_render_with_passing_couple_extensions_to_one_register_template_handler_function_call
     ActionView::Template.register_template_handler :foo1, :foo2, CustomHandler
-    assert_equal @view.render(inline: "Hello, World!", type: :foo1), @view.render(inline: "Hello, World!", type: :foo2)
+    assert_equal @view.render(inline: "Hello, World!".dup, type: :foo1), @view.render(inline: "Hello, World!".dup, type: :foo2)
   ensure
     ActionView::Template.unregister_template_handler :foo1, :foo2
   end

--- a/actionview/test/template/streaming_render_test.rb
+++ b/actionview/test/template/streaming_render_test.rb
@@ -17,7 +17,7 @@ class FiberedTest < ActiveSupport::TestCase
 
   def buffered_render(options)
     body = render_body(options)
-    string = ""
+    string = "".dup
     body.each do |piece|
       string << piece
     end

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -53,7 +53,7 @@ class TestERBTemplate < ActiveSupport::TestCase
   end
 
   def new_template(body = "<%= hello %>", details = { format: :html })
-    ActionView::Template.new(body, "hello template", details.fetch(:handler) { ERBHandler }, { virtual_path: "hello" }.merge!(details))
+    ActionView::Template.new(body.dup, "hello template", details.fetch(:handler) { ERBHandler }, { virtual_path: "hello" }.merge!(details))
   end
 
   def render(locals = {})

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -11,7 +11,7 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_concat
-    self.output_buffer = "foo"
+    self.output_buffer = "foo".dup
     assert_equal "foobar", concat("bar")
     assert_equal "foobar", output_buffer
   end
@@ -104,8 +104,8 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_truncate_multibyte
-    assert_equal "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 ...".force_encoding(Encoding::UTF_8),
-      truncate("\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 \354\225\204\353\235\274\353\246\254\354\230\244".force_encoding(Encoding::UTF_8), length: 10)
+    assert_equal "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 ...".dup.force_encoding(Encoding::UTF_8),
+      truncate("\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 \354\225\204\353\235\274\353\246\254\354\230\244".dup.force_encoding(Encoding::UTF_8), length: 10)
   end
 
   def test_truncate_does_not_modify_the_options_hash
@@ -325,7 +325,7 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_excerpt_with_utf8
-    assert_equal("...\357\254\203ciency could not be...".force_encoding(Encoding::UTF_8), excerpt("That's why e\357\254\203ciency could not be helped".force_encoding(Encoding::UTF_8), "could", radius: 8))
+    assert_equal("...\357\254\203ciency could not be...".dup.force_encoding(Encoding::UTF_8), excerpt("That's why e\357\254\203ciency could not be helped".dup.force_encoding(Encoding::UTF_8), "could", radius: 8))
   end
 
   def test_excerpt_does_not_modify_the_options_hash

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -535,7 +535,7 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_current_page_with_escaped_params_with_different_encoding
     @request = request_for_url("/")
-    @request.stub(:path, "/category/administra%c3%a7%c3%a3o".force_encoding(Encoding::ASCII_8BIT)) do
+    @request.stub(:path, "/category/administra%c3%a7%c3%a3o".dup.force_encoding(Encoding::ASCII_8BIT)) do
       assert current_page?(controller: "foo", action: "category", category: "administração")
       assert current_page?("http://www.example.com/category/administra%c3%a7%c3%a3o")
     end

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -96,7 +96,7 @@ class DirtyTest < ActiveModel::TestCase
   end
 
   test "attribute mutation" do
-    @model.instance_variable_set("@name", "Yam")
+    @model.instance_variable_set("@name", "Yam".dup)
     assert !@model.name_changed?
     @model.name.replace("Hadad")
     assert !@model.name_changed?

--- a/activemodel/test/cases/type/string_test.rb
+++ b/activemodel/test/cases/type/string_test.rb
@@ -14,7 +14,7 @@ module ActiveModel
       test "cast strings are mutable" do
         type = Type::String.new
 
-        s = "foo"
+        s = "foo".dup
         assert_equal false, type.cast(s).frozen?
         assert_equal false, s.frozen?
 

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -197,8 +197,7 @@ module ActiveRecord
 
         def table_alias_for(reflection, parent, join)
           name = "#{reflection.plural_name}_#{parent.table_name}"
-          name << "_join" if join
-          name
+          join ? "#{name}_join" : name
         end
 
         def walk(left, right)

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -679,7 +679,7 @@ module ActiveRecord
           # this block can't be easily moved into attempt_to_checkout_all_existing_connections's
           # rescue block, because doing so would put it outside of synchronize section, without
           # being in a critical section thread_report might become inaccurate
-          msg = "could not obtain ownership of all database connections in #{checkout_timeout} seconds"
+          msg = "could not obtain ownership of all database connections in #{checkout_timeout} seconds".dup
 
           thread_report = []
           @connections.each do |conn|

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -22,7 +22,7 @@ module ActiveRecord
         private
 
           def visit_AlterTable(o)
-            sql = "ALTER TABLE #{quote_table_name(o.name)} "
+            sql = "ALTER TABLE #{quote_table_name(o.name)} ".dup
             sql << o.adds.map { |col| accept col }.join(" ")
             sql << o.foreign_key_adds.map { |fk| visit_AddForeignKey fk }.join(" ")
             sql << o.foreign_key_drops.map { |fk| visit_DropForeignKey fk }.join(" ")
@@ -30,17 +30,17 @@ module ActiveRecord
 
           def visit_ColumnDefinition(o)
             o.sql_type = type_to_sql(o.type, o.options)
-            column_sql = "#{quote_column_name(o.name)} #{o.sql_type}"
+            column_sql = "#{quote_column_name(o.name)} #{o.sql_type}".dup
             add_column_options!(column_sql, column_options(o)) unless o.type == :primary_key
             column_sql
           end
 
           def visit_AddColumnDefinition(o)
-            "ADD #{accept(o.column)}"
+            "ADD #{accept(o.column)}".dup
           end
 
           def visit_TableDefinition(o)
-            create_sql = "CREATE#{' TEMPORARY' if o.temporary} TABLE #{quote_table_name(o.name)} "
+            create_sql = "CREATE#{' TEMPORARY' if o.temporary} TABLE #{quote_table_name(o.name)} ".dup
 
             statements = o.columns.map { |c| accept c }
             statements << accept(o.primary_keys) if o.primary_keys

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1348,7 +1348,7 @@ module ActiveRecord
           sm_table = quote_table_name(ActiveRecord::SchemaMigration.table_name)
 
           if versions.is_a?(Array)
-            sql = "INSERT INTO #{sm_table} (version) VALUES\n"
+            sql = "INSERT INTO #{sm_table} (version) VALUES\n".dup
             sql << versions.map { |v| "(#{quote(v)})" }.join(",\n")
             sql << ";\n\n"
             sql

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -147,7 +147,7 @@ module ActiveRecord
       # this method must only be called while holding connection pool's mutex
       def lease
         if in_use?
-          msg = "Cannot lease connection, "
+          msg = "Cannot lease connection, ".dup
           if @owner == Thread.current
             msg << "it is already leased by the current thread."
           else

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -132,7 +132,7 @@ module ActiveRecord
       end
 
       def index_algorithms
-        { default: "ALGORITHM = DEFAULT", copy: "ALGORITHM = COPY", inplace: "ALGORITHM = INPLACE" }
+        { default: "ALGORITHM = DEFAULT".dup, copy: "ALGORITHM = COPY".dup, inplace: "ALGORITHM = INPLACE".dup }
       end
 
       # HELPER METHODS ===========================================
@@ -379,7 +379,7 @@ module ActiveRecord
 
       def add_index(table_name, column_name, options = {}) #:nodoc:
         index_name, index_type, index_columns, _, index_algorithm, index_using, comment = add_index_options(table_name, column_name, options)
-        sql = "CREATE #{index_type} INDEX #{quote_column_name(index_name)} #{index_using} ON #{quote_table_name(table_name)} (#{index_columns}) #{index_algorithm}"
+        sql = "CREATE #{index_type} INDEX #{quote_column_name(index_name)} #{index_using} ON #{quote_table_name(table_name)} (#{index_columns}) #{index_algorithm}".dup
         execute add_sql_comment!(sql, comment)
       end
 
@@ -464,7 +464,7 @@ module ActiveRecord
             super
           end
 
-        sql << " unsigned" if unsigned && type != :primary_key
+        sql = "#{sql} unsigned" if unsigned && type != :primary_key
         sql
       end
 
@@ -761,7 +761,7 @@ module ActiveRecord
           # http://dev.mysql.com/doc/refman/5.7/en/set-statement.html#id944430
           # (trailing comma because variable_assignments will always have content)
           if @config[:encoding]
-            encoding = "NAMES #{@config[:encoding]}"
+            encoding = "NAMES #{@config[:encoding]}".dup
             encoding << " COLLATE #{@config[:collation]}" if @config[:collation]
             encoding << ", "
           end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -16,7 +16,7 @@ module ActiveRecord
           end
 
           def visit_ChangeColumnDefinition(o)
-            change_column_sql = "CHANGE #{quote_column_name(o.name)} #{accept(o.column)}"
+            change_column_sql = "CHANGE #{quote_column_name(o.name)} #{accept(o.column)}".dup
             add_column_position!(change_column_sql, column_options(o.column))
           end
 
@@ -63,7 +63,7 @@ module ActiveRecord
 
           def index_in_create(table_name, column_name, options)
             index_name, index_type, index_columns, _, _, index_using, comment = @conn.add_index_options(table_name, column_name, options)
-            add_sql_comment!("#{index_type} INDEX #{quote_column_name(index_name)} #{index_using} (#{index_columns})", comment)
+            add_sql_comment!("#{index_type} INDEX #{quote_column_name(index_name)} #{index_using} (#{index_columns})".dup, comment)
           end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -102,7 +102,7 @@ module ActiveRecord
           def data_source_sql(name = nil, type: nil)
             scope = quoted_scope(name, type: type)
 
-            sql = "SELECT table_name FROM information_schema.tables"
+            sql = "SELECT table_name FROM information_schema.tables".dup
             sql << " WHERE table_schema = #{scope[:schema]}"
             sql << " AND table_name = #{scope[:name]}" if scope[:name]
             sql << " AND table_type = #{scope[:type]}" if scope[:type]

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -408,7 +408,7 @@ module ActiveRecord
           quoted_table_name = quote_table_name(table_name)
           quoted_column_name = quote_column_name(column_name)
           sql_type = type_to_sql(type, options)
-          sql = "ALTER TABLE #{quoted_table_name} ALTER COLUMN #{quoted_column_name} TYPE #{sql_type}"
+          sql = "ALTER TABLE #{quoted_table_name} ALTER COLUMN #{quoted_column_name} TYPE #{sql_type}".dup
           if options[:collation]
             sql << " COLLATE \"#{options[:collation]}\""
           end
@@ -568,7 +568,7 @@ module ActiveRecord
               super
             end
 
-          sql << "[]" if array && type != :primary_key
+          sql = "#{sql}[]" if array && type != :primary_key
           sql
         end
 
@@ -637,7 +637,7 @@ module ActiveRecord
             scope = quoted_scope(name, type: type)
             scope[:type] ||= "'r','v','m'" # (r)elation/table, (v)iew, (m)aterialized view
 
-            sql = "SELECT c.relname FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace"
+            sql = "SELECT c.relname FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace".dup
             sql << " WHERE n.nspname = #{scope[:schema]}"
             sql << " AND c.relname = #{scope[:name]}" if scope[:name]
             sql << " AND c.relkind IN (#{scope[:type]})"

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -67,7 +67,7 @@ module ActiveRecord
             scope = quoted_scope(name, type: type)
             scope[:type] ||= "'table','view'"
 
-            sql = "SELECT name FROM sqlite_master WHERE name <> 'sqlite_sequence'"
+            sql = "SELECT name FROM sqlite_master WHERE name <> 'sqlite_sequence'".dup
             sql << " AND name = #{scope[:name]}" if scope[:name]
             sql << " AND type IN (#{scope[:type]})"
             sql

--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -16,7 +16,7 @@ module ActiveRecord
     # Returns a formatted string ready to be logged.
     def exec_explain(queries) # :nodoc:
       str = queries.map do |sql, binds|
-        msg = "EXPLAIN for: #{sql}"
+        msg = "EXPLAIN for: #{sql}".dup
         unless binds.empty?
           msg << " "
           msg << binds.map { |attr| render_bind(attr) }.inspect

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -157,7 +157,7 @@ module ActiveRecord
 
   class ProtectedEnvironmentError < ActiveRecordError #:nodoc:
     def initialize(env = "production")
-      msg = "You are attempting to run a destructive action against your '#{env}' database.\n"
+      msg = "You are attempting to run a destructive action against your '#{env}' database.\n".dup
       msg << "If you are sure you want to continue, run the same command with the environment variable:\n"
       msg << "DISABLE_DATABASE_ENVIRONMENT_CHECK=1"
       super(msg)
@@ -166,7 +166,7 @@ module ActiveRecord
 
   class EnvironmentMismatchError < ActiveRecordError
     def initialize(current: nil, stored: nil)
-      msg =  "You are attempting to modify a database that was last run in `#{ stored }` environment.\n"
+      msg =  "You are attempting to modify a database that was last run in `#{ stored }` environment.\n".dup
       msg << "You are running in `#{ current }` environment. "
       msg << "If you are sure you want to continue, first set the environment using:\n\n"
       msg << "        bin/rails db:environment:set"
@@ -1239,7 +1239,7 @@ module ActiveRecord
           record_version_state_after_migrating(migration.version)
         end
       rescue => e
-        msg = "An error has occurred, "
+        msg = "An error has occurred, ".dup
         msg << "this and " if use_transaction?(migration)
         msg << "all later migrations canceled:\n\n#{e}"
         raise StandardError, msg, e.backtrace

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -335,14 +335,14 @@ module ActiveRecord
       name = @klass.name
 
       if ids.nil?
-        error = "Couldn't find #{name}"
+        error = "Couldn't find #{name}".dup
         error << " with#{conditions}" if conditions
         raise RecordNotFound.new(error, name)
       elsif Array(ids).size == 1
         error = "Couldn't find #{name} with '#{key}'=#{ids}#{conditions}"
         raise RecordNotFound.new(error, name, key, ids)
       else
-        error = "Couldn't find all #{name.pluralize} with '#{key}': "
+        error = "Couldn't find all #{name.pluralize} with '#{key}': ".dup
         error << "(#{ids.join(", ")})#{conditions} (found #{result_size} results, but was looking for #{expected_size})"
 
         raise RecordNotFound.new(error, name, primary_key, ids)

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -151,7 +151,7 @@ IDENTIFIED BY '#{configuration['password']}' WITH GRANT OPTION;
         end
 
         def run_cmd_error(cmd, args, action)
-          msg = "failed to execute: `#{cmd}`\n"
+          msg = "failed to execute: `#{cmd}`\n".dup
           msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"
           msg
         end

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -47,7 +47,7 @@ class PostgresqlByteaTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_type_cast_binary_value
-    data = "\u001F\x8B".force_encoding("BINARY")
+    data = "\u001F\x8B".dup.force_encoding("BINARY")
     assert_equal(data, @type.deserialize(data))
   end
 

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -47,10 +47,10 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
 
   def test_money_type_cast
     type = PostgresqlMoney.type_for_attribute("wealth")
-    assert_equal(12345678.12, type.cast("$12,345,678.12"))
-    assert_equal(12345678.12, type.cast("$12.345.678,12"))
-    assert_equal(-1.15, type.cast("-$1.15"))
-    assert_equal(-2.25, type.cast("($2.25)"))
+    assert_equal(12345678.12, type.cast("$12,345,678.12".dup))
+    assert_equal(12345678.12, type.cast("$12.345.678,12".dup))
+    assert_equal(-1.15, type.cast("-$1.15".dup))
+    assert_equal(-2.25, type.cast("($2.25)".dup))
   end
 
   def test_schema_dumping
@@ -60,7 +60,7 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_create_and_update_money
-    money = PostgresqlMoney.create(wealth: "987.65")
+    money = PostgresqlMoney.create(wealth: "987.65".dup)
     assert_equal 987.65, money.wealth
 
     new_value = BigDecimal.new("123.45")

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -165,7 +165,7 @@ module ActiveRecord
             data binary
           )
         eosql
-        str = "\x80".force_encoding("ASCII-8BIT")
+        str = "\x80".dup.force_encoding("ASCII-8BIT")
         binary = DualEncoding.new name: "いただきます！", data: str
         binary.save!
         assert_equal str, binary.data
@@ -174,7 +174,7 @@ module ActiveRecord
       end
 
       def test_type_cast_should_not_mutate_encoding
-        name = "hello".force_encoding(Encoding::ASCII_8BIT)
+        name = "hello".dup.force_encoding(Encoding::ASCII_8BIT)
         Owner.create(name: name)
         assert_equal Encoding::ASCII_8BIT, name.encoding
       ensure

--- a/activerecord/test/cases/attribute_test.rb
+++ b/activerecord/test/cases/attribute_test.rb
@@ -76,7 +76,7 @@ module ActiveRecord
     end
 
     test "duping dups the value" do
-      @type.expect(:deserialize, "type cast", ["a value"])
+      @type.expect(:deserialize, "type cast".dup, ["a value"])
       attribute = Attribute.from_database(nil, "a value", @type)
 
       value_from_orig = attribute.value
@@ -244,7 +244,7 @@ module ActiveRecord
     end
 
     test "with_type preserves mutations" do
-      attribute = Attribute.from_database(:foo, "", Type::Value.new)
+      attribute = Attribute.from_database(:foo, "".dup, Type::Value.new)
       attribute.value << "1"
 
       assert_equal 1, attribute.with_type(Type::Integer.new).value

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -152,7 +152,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_find_in_batches_should_not_use_records_after_yielding_them_in_case_original_array_is_modified
-    not_a_post = "not a post"
+    not_a_post = "not a post".dup
     def not_a_post.id; end
     not_a_post.stub(:id, -> { raise StandardError.new("not_a_post had #id called on it") }) do
       assert_nothing_raised do
@@ -417,7 +417,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_should_not_use_records_after_yielding_them_in_case_original_array_is_modified
-    not_a_post = "not a post"
+    not_a_post = "not a post".dup
     def not_a_post.id
       raise StandardError.new("not_a_post had #id called on it")
     end

--- a/activerecord/test/cases/binary_test.rb
+++ b/activerecord/test/cases/binary_test.rb
@@ -10,7 +10,7 @@ unless current_adapter?(:DB2Adapter)
     FIXTURES = %w(flowers.jpg example.log test.txt)
 
     def test_mixed_encoding
-      str = "\x80"
+      str = "\x80".dup
       str.force_encoding("ASCII-8BIT")
 
       binary = Binary.new name: "いただきます！", data: str

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -35,7 +35,7 @@ class CoreTest < ActiveRecord::TestCase
 
   def test_pretty_print_new
     topic = Topic.new
-    actual = ""
+    actual = "".dup
     PP.pp(topic, StringIO.new(actual))
     expected = <<-PRETTY.strip_heredoc
     #<Topic:0xXXXXXX
@@ -64,7 +64,7 @@ class CoreTest < ActiveRecord::TestCase
 
   def test_pretty_print_persisted
     topic = topics(:first)
-    actual = ""
+    actual = "".dup
     PP.pp(topic, StringIO.new(actual))
     expected = <<-PRETTY.strip_heredoc
     #<Topic:0x\\w+
@@ -92,7 +92,7 @@ class CoreTest < ActiveRecord::TestCase
 
   def test_pretty_print_uninitialized
     topic = Topic.allocate
-    actual = ""
+    actual = "".dup
     PP.pp(topic, StringIO.new(actual))
     expected = "#<Topic:XXXXXX not initialized>\n"
     assert actual.start_with?(expected.split("XXXXXX").first)
@@ -105,7 +105,7 @@ class CoreTest < ActiveRecord::TestCase
         "inspecting topic"
       end
     end
-    actual = ""
+    actual = "".dup
     PP.pp(subtopic.new, StringIO.new(actual))
     assert_equal "inspecting topic\n", actual
   end

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -75,7 +75,7 @@ module ActiveSupport
       #
       # The +key+ argument can also respond to +cache_key+ or +to_param+.
       def expand_cache_key(key, namespace = nil)
-        expanded_cache_key = namespace ? "#{namespace}/" : ""
+        expanded_cache_key = (namespace ? "#{namespace}/" : "").dup
 
         if prefix = ENV["RAILS_CACHE_ID"] || ENV["RAILS_APP_VERSION"]
           expanded_cache_key << "#{prefix}/"

--- a/activesupport/lib/active_support/duration/iso8601_serializer.rb
+++ b/activesupport/lib/active_support/duration/iso8601_serializer.rb
@@ -15,12 +15,12 @@ module ActiveSupport
         parts, sign = normalize
         return "PT0S".freeze if parts.empty?
 
-        output = "P"
+        output = "P".dup
         output << "#{parts[:years]}Y"   if parts.key?(:years)
         output << "#{parts[:months]}M"  if parts.key?(:months)
         output << "#{parts[:weeks]}W"   if parts.key?(:weeks)
         output << "#{parts[:days]}D"    if parts.key?(:days)
-        time = ""
+        time = "".dup
         time << "#{parts[:hours]}H"     if parts.key?(:hours)
         time << "#{parts[:minutes]}M"   if parts.key?(:minutes)
         if parts.key?(:seconds)

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -114,7 +114,7 @@ module ActiveSupport
         encrypted_data << cipher.final
 
         blob = "#{::Base64.strict_encode64 encrypted_data}--#{::Base64.strict_encode64 iv}"
-        blob << "--#{::Base64.strict_encode64 cipher.auth_tag}" if aead_mode?
+        blob = "#{blob}--#{::Base64.strict_encode64 cipher.auth_tag}" if aead_mode?
         blob
       end
 

--- a/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
@@ -2,7 +2,7 @@ module ActiveSupport
   module NumberHelper
     class NumberToPhoneConverter < NumberConverter #:nodoc:
       def convert
-        str = country_code(opts[:country_code])
+        str = country_code(opts[:country_code]).dup
         str << convert_to_phone_number(number.to_s.strip)
         str << phone_ext(opts[:extension])
       end

--- a/activesupport/lib/active_support/xml_mini/libxml.rb
+++ b/activesupport/lib/active_support/xml_mini/libxml.rb
@@ -53,7 +53,7 @@ module LibXML #:nodoc:
           if c.element?
             c.to_hash(node_hash)
           elsif c.text? || c.cdata?
-            node_hash[CONTENT_ROOT] ||= ""
+            node_hash[CONTENT_ROOT] ||= "".dup
             node_hash[CONTENT_ROOT] << c.content
           end
         end

--- a/activesupport/lib/active_support/xml_mini/libxmlsax.rb
+++ b/activesupport/lib/active_support/xml_mini/libxmlsax.rb
@@ -21,7 +21,7 @@ module ActiveSupport
       end
 
       def on_start_document
-        @hash = { CONTENT_KEY => "" }
+        @hash = { CONTENT_KEY => "".dup }
         @hash_stack = [@hash]
       end
 
@@ -31,7 +31,7 @@ module ActiveSupport
       end
 
       def on_start_element(name, attrs = {})
-        new_hash = { CONTENT_KEY => "" }.merge!(attrs)
+        new_hash = { CONTENT_KEY => "".dup }.merge!(attrs)
         new_hash[HASH_SIZE_KEY] = new_hash.size + 1
 
         case current_hash[name]

--- a/activesupport/lib/active_support/xml_mini/nokogiri.rb
+++ b/activesupport/lib/active_support/xml_mini/nokogiri.rb
@@ -57,7 +57,7 @@ module ActiveSupport
             if c.element?
               c.to_hash(node_hash)
             elsif c.text? || c.cdata?
-              node_hash[CONTENT_ROOT] ||= ""
+              node_hash[CONTENT_ROOT] ||= "".dup
               node_hash[CONTENT_ROOT] << c.content
             end
           end

--- a/activesupport/lib/active_support/xml_mini/nokogirisax.rb
+++ b/activesupport/lib/active_support/xml_mini/nokogirisax.rb
@@ -37,7 +37,7 @@ module ActiveSupport
       end
 
       def start_element(name, attrs = [])
-        new_hash = { CONTENT_KEY => "" }.merge!(Hash[attrs])
+        new_hash = { CONTENT_KEY => "".dup }.merge!(Hash[attrs])
         new_hash[HASH_SIZE_KEY] = new_hash.size + 1
 
         case current_hash[name]

--- a/activesupport/lib/active_support/xml_mini/rexml.rb
+++ b/activesupport/lib/active_support/xml_mini/rexml.rb
@@ -74,7 +74,7 @@ module ActiveSupport
           hash
         else
           # must use value to prevent double-escaping
-          texts = ""
+          texts = "".dup
           element.texts.each { |t| texts << t.value }
           merge!(hash, CONTENT_KEY, texts)
         end

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -196,7 +196,7 @@ module CacheStoreBehavior
   end
 
   def test_original_store_objects_should_not_be_immutable
-    bar = "bar"
+    bar = "bar".dup
     @cache.write("foo", bar)
     assert_nothing_raised { bar.gsub!(/.*/, "baz") }
   end
@@ -285,7 +285,7 @@ module CacheStoreBehavior
   end
 
   def test_really_long_keys
-    key = ""
+    key = "".dup
     900.times { key << "x" }
     assert @cache.write(key, "bar")
     assert_equal "bar", @cache.read(key)

--- a/activesupport/test/cache/behaviors/encoded_key_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/encoded_key_cache_behavior.rb
@@ -4,7 +4,7 @@
 module EncodedKeyCacheBehavior
   Encoding.list.each do |encoding|
     define_method "test_#{encoding.name.underscore}_encoded_values" do
-      key = "foo".force_encoding(encoding)
+      key = "foo".dup.force_encoding(encoding)
       assert @cache.write(key, "1", raw: true)
       assert_equal "1", @cache.read(key)
       assert_equal "1", @cache.fetch(key)
@@ -16,7 +16,7 @@ module EncodedKeyCacheBehavior
   end
 
   def test_common_utf8_values
-    key = "\xC3\xBCmlaut".force_encoding(Encoding::UTF_8)
+    key = "\xC3\xBCmlaut".dup.force_encoding(Encoding::UTF_8)
     assert @cache.write(key, "1", raw: true)
     assert_equal "1", @cache.read(key)
     assert_equal "1", @cache.fetch(key)
@@ -27,7 +27,7 @@ module EncodedKeyCacheBehavior
   end
 
   def test_retains_encoding
-    key = "\xC3\xBCmlaut".force_encoding(Encoding::UTF_8)
+    key = "\xC3\xBCmlaut".dup.force_encoding(Encoding::UTF_8)
     assert @cache.write(key, "1", raw: true)
     assert_equal Encoding::UTF_8, key.encoding
   end

--- a/activesupport/test/cache/cache_key_test.rb
+++ b/activesupport/test/cache/cache_key_test.rb
@@ -45,7 +45,7 @@ class CacheKeyTest < ActiveSupport::TestCase
   end
 
   def test_expand_cache_key_respond_to_cache_key
-    key = "foo"
+    key = "foo".dup
     def key.cache_key
       :foo_key
     end
@@ -53,7 +53,7 @@ class CacheKeyTest < ActiveSupport::TestCase
   end
 
   def test_expand_cache_key_array_with_something_that_responds_to_cache_key
-    key = "foo"
+    key = "foo".dup
     def key.cache_key
       :foo_key
     end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -233,7 +233,7 @@ class StringInflectionsTest < ActiveSupport::TestCase
 
   def test_string_squish
     original = %{\u205f\u3000 A string surrounded by various unicode spaces,
-      with tabs(\t\t), newlines(\n\n), unicode nextlines(\u0085\u0085) and many spaces(  ). \u00a0\u2007}
+      with tabs(\t\t), newlines(\n\n), unicode nextlines(\u0085\u0085) and many spaces(  ). \u00a0\u2007}.dup
 
     expected = "A string surrounded by various unicode spaces, " \
       "with tabs( ), newlines( ), unicode nextlines( ) and many spaces( )."
@@ -303,8 +303,8 @@ class StringInflectionsTest < ActiveSupport::TestCase
   end
 
   def test_truncate_multibyte
-    assert_equal "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 ...".force_encoding(Encoding::UTF_8),
-      "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 \354\225\204\353\235\274\353\246\254\354\230\244".force_encoding(Encoding::UTF_8).truncate(10)
+    assert_equal "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 ...".dup.force_encoding(Encoding::UTF_8),
+      "\354\225\204\353\246\254\353\236\221 \354\225\204\353\246\254 \354\225\204\353\235\274\353\246\254\354\230\244".dup.force_encoding(Encoding::UTF_8).truncate(10)
   end
 
   def test_truncate_should_not_be_html_safe
@@ -325,7 +325,7 @@ class StringInflectionsTest < ActiveSupport::TestCase
   end
 
   def test_remove!
-    original = "This is a very good day to die"
+    original = "This is a very good day to die".dup
     assert_equal "This is a good day to die", original.remove!(" very")
     assert_equal "This is a good day to die", original
     assert_equal "This is a good day", original.remove!(" to ", /die/)
@@ -658,7 +658,7 @@ end
 
 class OutputSafetyTest < ActiveSupport::TestCase
   def setup
-    @string = "hello"
+    @string = "hello".dup
     @object = Class.new(Object) do
       def to_s
         "other"
@@ -734,7 +734,7 @@ class OutputSafetyTest < ActiveSupport::TestCase
   end
 
   test "Concatting safe onto unsafe yields unsafe" do
-    @other_string = "other"
+    @other_string = "other".dup
 
     string = @string.html_safe
     @other_string.concat(string)
@@ -757,7 +757,7 @@ class OutputSafetyTest < ActiveSupport::TestCase
   end
 
   test "Concatting safe onto unsafe with << yields unsafe" do
-    @other_string = "other"
+    @other_string = "other".dup
     string = @string.html_safe
 
     @other_string << string
@@ -813,7 +813,7 @@ class OutputSafetyTest < ActiveSupport::TestCase
   test "Concatting an integer to safe always yields safe" do
     string = @string.html_safe
     string = string.concat(13)
-    assert_equal "hello".concat(13), string
+    assert_equal "hello".dup.concat(13), string
     assert string.html_safe?
   end
 
@@ -868,7 +868,8 @@ end
 
 class StringIndentTest < ActiveSupport::TestCase
   test "does not indent strings that only contain newlines (edge cases)" do
-    ["", "\n", "\n" * 7].each do |str|
+    ["", "\n", "\n" * 7].each do |string|
+      str = string.dup
       assert_nil str.indent!(8)
       assert_equal str, str.indent(8)
       assert_equal str, str.indent(1, "\t")

--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -37,7 +37,7 @@ class LoggerTest < ActiveSupport::TestCase
     logger = Logger.new f
     logger.level = Logger::DEBUG
 
-    str = "\x80"
+    str = "\x80".dup
     str.force_encoding("ASCII-8BIT")
 
     logger.add Logger::DEBUG, str
@@ -55,7 +55,7 @@ class LoggerTest < ActiveSupport::TestCase
     logger = Logger.new f
     logger.level = Logger::DEBUG
 
-    str = "\x80"
+    str = "\x80".dup
     str.force_encoding("ASCII-8BIT")
 
     logger.add Logger::DEBUG, str

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -51,7 +51,7 @@ class MultibyteCharsTest < ActiveSupport::TestCase
   end
 
   def test_forwarded_method_with_non_string_result_should_be_returned_verbatim
-    str = ""
+    str = "".dup
     str.singleton_class.class_eval { def __method_for_multibyte_testing_with_integer_result; 1; end }
     @chars.wrapped_string.singleton_class.class_eval { def __method_for_multibyte_testing_with_integer_result; 1; end }
 
@@ -59,14 +59,14 @@ class MultibyteCharsTest < ActiveSupport::TestCase
   end
 
   def test_should_concatenate
-    mb_a = "a".mb_chars
-    mb_b = "b".mb_chars
+    mb_a = "a".dup.mb_chars
+    mb_b = "b".dup.mb_chars
     assert_equal "ab", mb_a + "b"
     assert_equal "ab", "a" + mb_b
     assert_equal "ab", mb_a + mb_b
 
     assert_equal "ab", mb_a << "b"
-    assert_equal "ab", "a" << mb_b
+    assert_equal "ab", "a".dup << mb_b
     assert_equal "abb", mb_a << mb_b
   end
 
@@ -78,7 +78,7 @@ class MultibyteCharsTest < ActiveSupport::TestCase
 
   def test_concatenation_should_return_a_proxy_class_instance
     assert_equal ActiveSupport::Multibyte.proxy_class, ("a".mb_chars + "b").class
-    assert_equal ActiveSupport::Multibyte.proxy_class, ("a".mb_chars << "b").class
+    assert_equal ActiveSupport::Multibyte.proxy_class, ("a".dup.mb_chars << "b").class
   end
 
   def test_ascii_strings_are_treated_at_utf8_strings
@@ -88,8 +88,8 @@ class MultibyteCharsTest < ActiveSupport::TestCase
   def test_concatenate_should_return_proxy_instance
     assert(("a".mb_chars + "b").kind_of?(@proxy_class))
     assert(("a".mb_chars + "b".mb_chars).kind_of?(@proxy_class))
-    assert(("a".mb_chars << "b").kind_of?(@proxy_class))
-    assert(("a".mb_chars << "b".mb_chars).kind_of?(@proxy_class))
+    assert(("a".dup.mb_chars << "b").kind_of?(@proxy_class))
+    assert(("a".dup.mb_chars << "b".mb_chars).kind_of?(@proxy_class))
   end
 
   def test_should_return_string_as_json
@@ -115,12 +115,12 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
   %w{capitalize downcase lstrip reverse rstrip swapcase upcase}.each do |method|
     class_eval(<<-EOTESTS, __FILE__, __LINE__ + 1)
       def test_#{method}_bang_should_return_self_when_modifying_wrapped_string
-        chars = ' él piDió Un bUen café '
+        chars = ' él piDió Un bUen café '.dup
         assert_equal chars.object_id, chars.send("#{method}!").object_id
       end
 
       def test_#{method}_bang_should_change_wrapped_string
-        original = ' él piDió Un bUen café '
+        original = ' él piDió Un bUen café '.dup
         proxy = chars(original.dup)
         proxy.send("#{method}!")
         assert_not_equal original, proxy.to_s
@@ -133,7 +133,7 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
   end
 
   def test_tidy_bytes_bang_should_change_wrapped_string
-    original = " Un bUen café \x92"
+    original = " Un bUen café \x92".dup
     proxy = chars(original.dup)
     proxy.tidy_bytes!
     assert_not_equal original, proxy.to_s
@@ -150,7 +150,7 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
   end
 
   def test_string_methods_are_chainable
-    assert chars("").insert(0, "").kind_of?(ActiveSupport::Multibyte.proxy_class)
+    assert chars("".dup).insert(0, "").kind_of?(ActiveSupport::Multibyte.proxy_class)
     assert chars("").rjust(1).kind_of?(ActiveSupport::Multibyte.proxy_class)
     assert chars("").ljust(1).kind_of?(ActiveSupport::Multibyte.proxy_class)
     assert chars("").center(1).kind_of?(ActiveSupport::Multibyte.proxy_class)
@@ -195,7 +195,7 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
   end
 
   def test_should_use_character_offsets_for_insert_offsets
-    assert_equal "", "".mb_chars.insert(0, "")
+    assert_equal "", "".dup.mb_chars.insert(0, "")
     assert_equal "こわにちわ", @chars.insert(1, "わ")
     assert_equal "こわわわにちわ", @chars.insert(2, "わわ")
     assert_equal "わこわわわにちわ", @chars.insert(0, "わ")
@@ -418,13 +418,13 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
   end
 
   def test_slice_bang_removes_the_slice_from_the_receiver
-    chars = "úüù".mb_chars
+    chars = "úüù".dup.mb_chars
     chars.slice!(0, 2)
     assert_equal "ù", chars
   end
 
   def test_slice_bang_returns_nil_and_does_not_modify_receiver_if_out_of_bounds
-    string = "úüù"
+    string = "úüù".dup
     chars = string.mb_chars
     assert_nil chars.slice!(4, 5)
     assert_equal "úüù", chars

--- a/activesupport/test/multibyte_test_helpers.rb
+++ b/activesupport/test/multibyte_test_helpers.rb
@@ -23,7 +23,7 @@ module MultibyteTestHelpers
 
   UNICODE_STRING = "こにちわ".freeze
   ASCII_STRING = "ohayo".freeze
-  BYTE_STRING = "\270\236\010\210\245".force_encoding("ASCII-8BIT").freeze
+  BYTE_STRING = "\270\236\010\210\245".dup.force_encoding("ASCII-8BIT").freeze
 
   def chars(str)
     ActiveSupport::Multibyte::Chars.new(str)


### PR DESCRIPTION
As I'm sure many folks are aware, MRI 2.3 added the ability to have [all string literals frozen by default](https://wyeworks.com/blog/2015/12/1/immutable-strings-in-ruby-2-dot-3), which has performance/memory usage benefits. It will become the default behaviour in MRI 3.0, though that is quite some time away!

This PR covers what's needed to make ActiveSupport play nicely when this feature is enabled. The test suite as it currently stands will continue to pass, there are no behaviour changes. Yes, it's for ActiveSupport only, but I figure it's a good place to start.

If this change is appreciated, then I can work further on the rest of the Rails gems to ensure they're working with frozen string literals as well. And if you want to have Travis run the tests with checks for this behaviour, then using pragmater and a test script can help with that (such as what I've done in [my own gems](https://github.com/pat/thinking-sphinx/blob/develop/bin/literals) and suggested [for others](https://github.com/plataformatec/devise/pull/4566)).

## Running the tests with frozen string literals enabled

Of course, if you want to run the test suite with frozen string literals enabled, you'll need the following locally:
* Use the latest commits from dalli, rather than the latest gem release.
* Use my PR for Builder, rather than the latest gem release: https://github.com/tenderlove/builder/pull/6
* Use Nokogiri 1.8.0

Beyond that, all external dependencies (at least, to the extent they’re used by ActiveSupport) play happily with frozen string literals enabled by default in MRI 2.4 (which can be done so by the `RUBYOPT` environment variable: `RUBYOPT="--enable-frozen-string-literal"`).