### PR TITLE
Updates README on rails internal dev tools

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -6,3 +6,5 @@ They aren't used by Rails apps directly.
   * `console` drops you in irb and loads local Rails repos
   * `profile` profiles `Kernel#require` to help reduce startup time
   * `line_statistics` provides CodeTools module and LineStatistics class to count lines
+  * `test` is loaded by every major component of Rails to simplify testing, for example:
+    `cd ./actioncable; bin/test ./path/to/actioncable_test_with_line_number.rb:5`

--- a/tools/test.rb
+++ b/tools/test.rb
@@ -8,7 +8,7 @@ require "rails/test_unit/line_filtering"
 require "active_support/test_case"
 
 class << Rails
-  # Necessary to get rerun-snippts working.
+  # Necessary to get rerun-snippets working.
   def root
     @root ||= Pathname.new(COMPONENT_ROOT)
   end


### PR DESCRIPTION
### Summary

Adds missing minor doc about `tools/test.rb` and minor typo fix regarding the same file.

### Other Information

I'm fine if this doesn't get merged, as I'm not sure if the change qualifies more under documentation (even for internal Rails dev tools) or more of just a cosmetic change. I just wanted to save someone the trouble of looking a few files deeper in order to get what the said file is for. Other files in the same directory have a brief explanation, so I thought it would make sense to write a bit about `tools/test.rb` as well. I currently just wanted to get this out of the way while resolving another rails issue that is unrelated to this change.
