### PR TITLE
Rails 5.1.2.rc1 regression - Clear offset cache on CollectionProxy reset/reload

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1088,7 +1088,6 @@ module ActiveRecord
       #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
       def reload
         proxy_association.reload
-        @offsets = {}
         reset_scope
       end
 
@@ -1111,11 +1110,11 @@ module ActiveRecord
       def reset
         proxy_association.reset
         proxy_association.reset_scope
-        @offsets = {}
         reset_scope
       end
 
       def reset_scope # :nodoc:
+        @offsets = {}
         @scope = nil
         self
       end

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1088,6 +1088,7 @@ module ActiveRecord
       #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
       def reload
         proxy_association.reload
+        @offsets = {}
         reset_scope
       end
 
@@ -1110,6 +1111,7 @@ module ActiveRecord
       def reset
         proxy_association.reset
         proxy_association.reset_scope
+        @offsets = {}
         reset_scope
       end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -741,6 +741,32 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal client2, firm.clients.merge!(where: ["#{QUOTED_TYPE} = :type", { type: "Client" }], order: "id").first
   end
 
+  def test_find_first_after_reset
+    firm = Firm.all.merge!(order: "id").first
+
+    # Calling first twice should return the same object
+    original_object_id = firm.clients.first.object_id
+    assert_equal firm.clients.first.object_id, original_object_id, "Expected multiple invocations of #first to return the same object"
+
+    firm.clients.reset
+
+    # It should return a different object, since the association has been reloaded
+    assert_not_equal original_object_id, firm.clients.first.object_id, "Expected #first after #reload to return a new object"
+  end
+
+  def test_find_first_after_reload
+    firm = Firm.all.merge!(order: "id").first
+
+    # Calling first twice should return the same object
+    original_object_id = firm.clients.first.object_id
+    assert_equal firm.clients.first.object_id, original_object_id, "Expected multiple invocations of #first to return the same object"
+
+    firm.clients.reload
+
+    # It should return a different object, since the association has been reloaded
+    assert_not_equal original_object_id, firm.clients.first.object_id, "Expected #first after #reload to return a new object"
+  end
+
   def test_find_all_with_include_and_conditions
     assert_nothing_raised do
       Developer.all.merge!(joins: :audit_logs, where: { "audit_logs.message" => nil, :name => "Smith" }).to_a

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -741,30 +741,39 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal client2, firm.clients.merge!(where: ["#{QUOTED_TYPE} = :type", { type: "Client" }], order: "id").first
   end
 
-  def test_find_first_after_reset
+  def test_find_first_after_reset_scope
     firm = Firm.all.merge!(order: "id").first
+    collection = firm.clients
 
-    # Calling first twice should return the same object
-    original_object_id = firm.clients.first.object_id
-    assert_equal firm.clients.first.object_id, original_object_id, "Expected multiple invocations of #first to return the same object"
-
-    firm.clients.reset
+    original_object_id = collection.first.object_id
+    assert_equal original_object_id, collection.first.object_id, "Expected second call to #first to cache the same object"
 
     # It should return a different object, since the association has been reloaded
-    assert_not_equal original_object_id, firm.clients.first.object_id, "Expected #first after #reload to return a new object"
+    assert_not_equal original_object_id, firm.clients.first.object_id, "Expected #first to return a new object"
+  end
+
+  def test_find_first_after_reset
+    firm = Firm.all.merge!(order: "id").first
+    collection = firm.clients
+
+    original_object_id = collection.first.object_id
+    assert_equal original_object_id, collection.first.object_id, "Expected second call to #first to cache the same object"
+    collection.reset
+
+    # It should return a different object, since the association has been reloaded
+    assert_not_equal original_object_id, collection.first.object_id, "Expected #first after #reload to return a new object"
   end
 
   def test_find_first_after_reload
     firm = Firm.all.merge!(order: "id").first
+    collection = firm.clients
 
-    # Calling first twice should return the same object
-    original_object_id = firm.clients.first.object_id
-    assert_equal firm.clients.first.object_id, original_object_id, "Expected multiple invocations of #first to return the same object"
-
-    firm.clients.reload
+    original_object_id = collection.first.object_id
+    assert_equal original_object_id, collection.first.object_id, "Expected second call to #first to cache the same object"
+    collection.reset
 
     # It should return a different object, since the association has been reloaded
-    assert_not_equal original_object_id, firm.clients.first.object_id, "Expected #first after #reload to return a new object"
+    assert_not_equal original_object_id, collection.first.object_id, "Expected #first after #reload to return a new object"
   end
 
   def test_find_all_with_include_and_conditions


### PR DESCRIPTION
The `@offsets` cache is used by `FinderMethods` to cache records found by find_nth. This cache is cleared in `AR::Relation#reset`, but not in `CollectionProxy#reset` or `CollectionProxy#reload`.

Because of this, since #29098, calling `#first`, `#find_nth`, etc. after calling `#reload` or `#reset` on an association would return a stale record. This is an issue both when the full association target is loaded and
when the item is loaded in `#find_nth`.

This commit solves the problem by clearing the `@offsets` cache in `CollectionProxy#reset` and `CollectionProxy#reload`.

The provided two test cases fail without the changes to `collection_proxy.rb`. 

Many :heart:s

_edit: I don't think the CI failure is related_