### PR TITLE
Avoid begin/rescue in fixture quoting

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -425,12 +425,11 @@ module ActiveRecord
         # are not quotable. In this case we want to convert
         # the column value to YAML.
         def with_yaml_fallback(value)
-          begin
-            quote(value)
-          rescue TypeError
-            value = YAML.dump(value)
+          if value.is_a?(Hash) || value.is_a?(Array)
+            YAML.dump(value)
+          else
+            value
           end
-          value
         end
     end
   end


### PR DESCRIPTION
Scalar values like arrays and hashes can't be inserted directly into table. Previously, the way to determine if the value is scalar was to try quoting it. If `quote` raised with an error than the value has to be converted to YAML.

This flow is not very obvious. Ideally we could have a `quotable?` method in the connection, but I think that we can avoid begin/rescue block by simply checking if the value is Array or Hash.

related: https://github.com/rails/rails/commit/aa31d21f5f4fc4d679e74a60f9df9706da7de373

@rafaelfranca 