### PR TITLE
Add more explicit guidance on how to fix callback deprecations

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -662,8 +662,10 @@ module ActiveSupport
 
           if options[:if].is_a?(String) || options[:unless].is_a?(String)
             ActiveSupport::Deprecation.warn(<<-MSG.squish)
-              Passing string to :if and :unless conditional options is deprecated
-              and will be removed in Rails 5.2 without replacement.
+              Passing string to be evaluated in :if and :unless conditional
+              options is deprecated and will be removed in Rails 5.2 without
+              replacement. Pass a symbol for an instance method, or a lamdba,
+              proc or block, instead.
             MSG
           end
 


### PR DESCRIPTION
This deprecation warning message will be more useful if it indicates what the string was doing — being eval'd — and what the non-deprecated options for callback conditionals are.

### Summary

After upgrading to Rails 5.1, I noticed this deprecation message in one of the dependencies. It wasn't clear to me how to fix it, as I hadn't used the conditional option for callbacks in my own code before. I had to dig into the source of Rails to confirm that the string was being eval'd and that to retain the behavior and fix the deprecation warning, I needed to replace the string with a symbol for a method that does the same thing.

Having this extra detail in the deprecation warning would have been helpful.