### PR TITLE
Pass `structure_dump_flags` / `structure_load_flags` options before any other:

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -59,7 +59,6 @@ module ActiveRecord
         args.concat(["--no-data"])
         args.concat(["--routines"])
         args.concat(["--skip-comments"])
-        args.concat(Array(extra_flags)) if extra_flags
 
         ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
         if ignore_tables.any?
@@ -67,6 +66,7 @@ module ActiveRecord
         end
 
         args.concat(["#{configuration['database']}"])
+        args.insert(0, Array(extra_flags)).flatten! if extra_flags
 
         run_cmd("mysqldump", args, "dumping")
       end
@@ -75,7 +75,7 @@ module ActiveRecord
         args = prepare_command_options
         args.concat(["--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}])
         args.concat(["--database", "#{configuration['database']}"])
-        args.concat(Array(extra_flags)) if extra_flags
+        args.insert(0, Array(extra_flags)).flatten! if extra_flags
 
         run_cmd("mysql", args, "loading")
       end

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -66,7 +66,7 @@ module ActiveRecord
         end
 
         args.concat(["#{configuration['database']}"])
-        args.insert(0, Array(extra_flags)).flatten! if extra_flags
+        args.unshift(*extra_flags) if extra_flags
 
         run_cmd("mysqldump", args, "dumping")
       end
@@ -75,7 +75,7 @@ module ActiveRecord
         args = prepare_command_options
         args.concat(["--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}])
         args.concat(["--database", "#{configuration['database']}"])
-        args.insert(0, Array(extra_flags)).flatten! if extra_flags
+        args.unshift(*extra_flags) if extra_flags
 
         run_cmd("mysql", args, "loading")
       end

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -296,7 +296,7 @@ if current_adapter?(:Mysql2Adapter)
 
       def test_structure_dump_with_extra_flags
         filename = "awesome-file.sql"
-        expected_command = ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "--noop", "test-db"]
+        expected_command = ["mysqldump", "--noop", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"]
 
         assert_called_with(Kernel, :system, expected_command, returns: true) do
           with_structure_dump_flags(["--noop"]) do
@@ -364,7 +364,7 @@ if current_adapter?(:Mysql2Adapter)
 
       def test_structure_load
         filename = "awesome-file.sql"
-        expected_command = ["mysql", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db", "--noop"]
+        expected_command = ["mysql", "--noop", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db"]
 
         assert_called_with(Kernel, :system, expected_command, returns: true) do
           with_structure_load_flags(["--noop"]) do


### PR DESCRIPTION
Pass `structure_dump_flags` / `structure_load_flags` options before any other:

- On Mysql, some command line options that affect option-file handling such as `--no-defaults` have to be passed before any other options
- I believe we should be good passing any options in the `structure_dump_flags` and `structure_load_flags` config before anything else
- Ref https://dev.mysql.com/doc/refman/5.7/en/option-file-options.html and https://bugs.mysql.com/bug.php?id=83386
- Ref #27437

cc @rafaelfranca @kirs 
