### PR TITLE
Do not let use `serialize` on native JSON/array column

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -47,6 +47,15 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
     assert ratings_column.array?
   end
 
+  def test_not_compatible_with_serialize
+    new_klass = Class.new(PgArray) do
+      serialize :tags, Array
+    end
+    assert_raises(ActiveRecord::AttributeMethods::Serialization::ColumnNotSerializableError) do
+      new_klass.new
+    end
+  end
+
   def test_default
     @connection.add_column "pg_arrays", "score", :integer, array: true, default: [4, 4, 2]
     PgArray.reset_column_information

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -33,6 +33,15 @@ module PostgresqlJSONSharedTestCases
     x.reload
     assert_equal ["foo" => "bar"], x.objects
   end
+
+  def test_not_compatible_with_serialize_macro
+    new_klass = Class.new(klass) do
+      serialize :payload, JSON
+    end
+    assert_raises(ActiveRecord::AttributeMethods::Serialization::ColumnNotSerializableError) do
+      new_klass.new
+    end
+  end
 end
 
 class PostgresqlJSONTest < ActiveRecord::PostgreSQLTestCase


### PR DESCRIPTION
The check I'm introducing in the PR would prevent reports like https://github.com/rails/rails/issues/29498 when developer wants to use PostgreSQL array column and writes something like:

```ruby
class Thing < ApplicationRecord
  serialize(:tags, Array)
end
```

While the native array column works out of box without `serialize` feature. In fact adding `serialize` to native JSON or array column breaks it and makes developers frustrated.

IMO this is a developer experience issue regardless how many years you've worked with Rails. I remember asking myself "should I use serialize for Postgresql JSON column?" last time I used it in a new Rails app.

@s2t2 @rafaelfranca 