### PR TITLE
Allow loading structure dumps from stdin

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   Allow loading database dumps from stdin with `-`.
 
+    *Michal Papis*
 
 Please check [5-2-stable](https://github.com/rails/rails/blob/5-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -273,7 +273,7 @@ module ActiveRecord
       end
 
       def check_schema_file(filename)
-        unless File.exist?(filename)
+        unless filename == "-" || File.exist?(filename)
           message = %{#{filename} doesn't exist yet. Run `rails db:migrate` to create it, then try again.}.dup
           message << %{ If you do not intend to use a database, you should instead alter #{Rails.root}/config/application.rb to limit the frameworks that will be loaded.} if defined?(::Rails.root)
           Kernel.abort message

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -59,11 +59,10 @@ module ActiveRecord
 
       def structure_load(filename, extra_flags)
         args = prepare_command_options
-        args.concat(["--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}])
         args.concat(["--database", "#{configuration['database']}"])
         args.unshift(*extra_flags) if extra_flags
 
-        run_cmd("mysql", args, "loading")
+        run_cmd("(echo 'SET FOREIGN_KEY_CHECKS = 0;' ; cat #{filename} ; echo 'SET FOREIGN_KEY_CHECKS = 1;' ) | mysql", args, "loading")
       end
 
       private

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -55,7 +55,7 @@ module ActiveRecord
       def structure_load(filename, extra_flags)
         dbfile = configuration["database"]
         flags = extra_flags.join(" ") if extra_flags
-        `sqlite3 #{flags} #{dbfile} < "#{filename}"`
+        `cat "#{filename}" | sqlite3 #{flags} #{dbfile}`
       end
 
       private

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -297,7 +297,7 @@ if current_adapter?(:Mysql2Adapter)
 
       def test_structure_load
         filename = "awesome-file.sql"
-        expected_command = ["mysql", "--noop", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db"]
+        expected_command = ["(echo 'SET FOREIGN_KEY_CHECKS = 0;' ; cat #{filename} ; echo 'SET FOREIGN_KEY_CHECKS = 1;' ) | mysql", "--noop", "--database", "test-db"]
 
         assert_called_with(Kernel, :system, expected_command, returns: true) do
           with_structure_load_flags(["--noop"]) do


### PR DESCRIPTION
### Summary

When using large compressed file from production/staging
it allows loading from the compressed file directly.

Example:

    xz -dc dump.sql.xz | SCHEMA=- rake db:structure:load

Progress:
- [x] [mysql_database_tasks.rb](https://github.com/toptal/rails/blob/18e2c068bb8183d770eb86cc1fa910a6e5c4548d/activerecord/lib/active_record/tasks/mysql_database_tasks.rb#L74)
- [x] [postgresql_database_tasks.rb](https://github.com/toptal/rails/blob/18e2c068bb8183d770eb86cc1fa910a6e5c4548d/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb#L81)
- [x] [sqlite_database_tasks.rb](https://github.com/toptal/rails/blob/18e2c068bb8183d770eb86cc1fa910a6e5c4548d/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb#L53)