### PR TITLE
Do not use private API in bug report templates

### DIFF
--- a/guides/bug_report_templates/active_record_migrations_gem.rb
+++ b/guides/bug_report_templates/active_record_migrations_gem.rb
@@ -48,16 +48,14 @@ end
 
 class BugTest < Minitest::Test
   def test_migration_up
-    migrator = ActiveRecord::Migrator.new(:up, [ChangeAmountToAddScale])
-    migrator.run
+    ChangeAmountToAddScale.migrate(:up)
     Payment.reset_column_information
 
     assert_equal "decimal(10,2)", Payment.columns.last.sql_type
   end
 
   def test_migration_down
-    migrator = ActiveRecord::Migrator.new(:down, [ChangeAmountToAddScale])
-    migrator.run
+    ChangeAmountToAddScale.migrate(:down)
     Payment.reset_column_information
 
     assert_equal "decimal(10,0)", Payment.columns.last.sql_type

--- a/guides/bug_report_templates/active_record_migrations_master.rb
+++ b/guides/bug_report_templates/active_record_migrations_master.rb
@@ -48,16 +48,14 @@ end
 
 class BugTest < Minitest::Test
   def test_migration_up
-    migrator = ActiveRecord::Migrator.new(:up, [ChangeAmountToAddScale])
-    migrator.run
+    ChangeAmountToAddScale.migrate(:up)
     Payment.reset_column_information
 
     assert_equal "decimal(10,2)", Payment.columns.last.sql_type
   end
 
   def test_migration_down
-    migrator = ActiveRecord::Migrator.new(:down, [ChangeAmountToAddScale])
-    migrator.run
+    ChangeAmountToAddScale.migrate(:down)
     Payment.reset_column_information
 
     assert_equal "decimal(10,0)", Payment.columns.last.sql_type


### PR DESCRIPTION
`ActiveRecord::Migrator` is private API.
https://github.com/rails/rails/blob/bb9d6eb094f29bb94ef1f26aa44f145f17b973fe/activerecord/lib/active_record/migration.rb#L977

Therefore, it is not good to use it in bug report templates.
Instead, should use the public API `ActiveRecord::Migration#migrate`.
