### PR TITLE
Fix `raise_on_unfiltered_parameters` configuration for 5-0-stable 

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt
@@ -8,7 +8,7 @@
 <%- end -%>
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
-Rails.application.config.raise_on_unfiltered_parameters = true
+ActionController::Parameters.raise_on_unfiltered_parameters = true
 <%- unless options[:api] -%>
 
 # Enable per-form CSRF tokens. Previous versions had false.


### PR DESCRIPTION
 * Set to ActionController::Parameters directly
   * `config.action_controller.raise_on_unfiltered_parameters` is correct,
     instead of `config.raise_on_unfiltered_parameters`
   * But it has no effect due to the order of initializers.
     `action_controller.parameters_config` is proceed before `load_config_initializers`
* ~~Switch the value by `options[:update]` for developers updating~~

refs #28803
