### PR TITLE
Allows for other common redis options to be in cable.yml, by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
 
 services:
   - memcached
-  - redis
 
 addons:
   postgresql: "9.4"
@@ -34,6 +33,7 @@ before_script:
   # Decodes to e.g. `export VARIABLE=VALUE`
   - $(base64 --decode <<< "ZXhwb3J0IFNBVUNFX0FDQ0VTU19LRVk9YTAzNTM0M2YtZTkyMi00MGIzLWFhM2MtMDZiM2VhNjM1YzQ4")
   - $(base64 --decode <<< "ZXhwb3J0IFNBVUNFX1VTRVJOQU1FPXJ1YnlvbnJhaWxz")
+  - redis-server --bind 127.0.0.1 --port 6379 --requirepass 'password' --daemonize yes
 
 script: 'ci/travis.rb'
 
@@ -65,25 +65,21 @@ matrix:
       env: "GEM=aj:integration"
       services:
         - memcached
-        - redis
         - rabbitmq
     - rvm: 2.3.4
       env: "GEM=aj:integration"
       services:
         - memcached
-        - redis
         - rabbitmq
     - rvm: 2.4.1
       env: "GEM=aj:integration"
       services:
         - memcached
-        - redis
         - rabbitmq
     - rvm: ruby-head
       env: "GEM=aj:integration"
       services:
         - memcached
-        - redis
         - rabbitmq
     - rvm: 2.3.4
       env:

--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   ActionCable's `redis` adapter allows for other common redis-rb options (`host`, `port`, `db`, `password`) in cable.yml.
+
+    Previously, it accepts only a [redis:// url](https://www.iana.org/assignments/uri-schemes/prov/redis) as an option.
+    While we can add all of these options to the `url` itself, it is not explicitly documented. This alternative setup
+    is shown as the first example in the [Redis rubygem](https://github.com/redis/redis-rb#getting-started), which
+    makes this set of options as sensible as using just the `url`.
+
+    *Marc Rendl Ignacio*
+
 *   ActionCable socket errors are now logged to the console
 
     Previously any socket errors were ignored and this made it hard to diagnose socket issues (e.g. as discussed in #28362).

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -10,7 +10,9 @@ module ActionCable
 
       # Overwrite this factory method for redis connections if you want to use a different Redis library than Redis.
       # This is needed, for example, when using Makara proxies for distributed Redis.
-      cattr_accessor :redis_connector, default: ->(config) { ::Redis.new(url: config[:url]) }
+      cattr_accessor :redis_connector, default: ->(config) do
+        ::Redis.new(config.slice(:url, :host, :port, :db, :password))
+      end
 
       def initialize(*)
         super

--- a/actioncable/test/subscription_adapter/evented_redis_test.rb
+++ b/actioncable/test/subscription_adapter/evented_redis_test.rb
@@ -54,6 +54,6 @@ class EventedRedisAdapterTest < ActionCable::TestCase
   end
 
   def cable_config
-    { adapter: "evented_redis", url: "redis://127.0.0.1:6379/12" }
+    { adapter: "evented_redis", url: "redis://:password@127.0.0.1:6379/12" }
   end
 end

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -7,12 +7,20 @@ class RedisAdapterTest < ActionCable::TestCase
   include ChannelPrefixTest
 
   def cable_config
-    { adapter: "redis", driver: "ruby", url: "redis://127.0.0.1:6379/12" }
+    { adapter: "redis", driver: "ruby", url: "redis://:password@127.0.0.1:6379/12" }
   end
 end
 
 class RedisAdapterTest::Hiredis < RedisAdapterTest
   def cable_config
     super.merge(driver: "hiredis")
+  end
+end
+
+class RedisAdapterTest::AlternateConfiguration < RedisAdapterTest
+  def cable_config
+    alt_cable_config = super.dup
+    alt_cable_config.delete(:url)
+    alt_cable_config.merge(host: "127.0.0.1", port: 6379, db: 12, password: "password")
   end
 end


### PR DESCRIPTION
### Summary

Previously, the redis adapter for ActionCable accepts only a `:url` as an option. While we can follow the [redis url scheme](https://www.iana.org/assignments/uri-schemes/prov/redis), it is not documented well enough in the Rails Guides.

This allows for an alternative setup (that is as common as the previous one) for the [redis gem](https://github.com/redis/redis-rb#getting-started), so people don't occasionally trip up [like](https://github.com/rails/rails/pull/28702) [these](https://github.com/rails/rails/pull/28843). Check the commit message for more technical details.

### Other Information

There are other options that can be passed to the Redis gem (See: https://github.com/redis/redis-rb/blob/master/lib/redis/client.rb#L8), but did not include them because:
1.  it might clash with other keys already used in `#cable_config` in different context (e.g. `driver`),  
2. the problem of how to test them is non-trivial (at least on top of my head, e.g. `path`).
3. they are uncommon enough that they may warrant changing `redis_connector` on intialization, i.e. `ActionCable::SubscriptionAdapter::Redis.redis_connector =  ->() { initialization_code }`

Also, I'm not as familiar with setting up `.travis.yml` properly, you may want to check if what I did was right. I removed instances of the Travis' internal `redis` service. Instead, I used `redis-server` using the default settings + password in the `before_script`. The tests now pass though.

Let me know if there's anything else I can do @pixeltrix 