### PR TITLE
Update 500.html default to be more clear.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/public/500.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/500.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>We're sorry, but something went wrong (500)</title>
+  <title>We're sorry, but something went wrong on our end (500)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
@@ -58,7 +58,7 @@
   <!-- This file lives in public/500.html -->
   <div class="dialog">
     <div>
-      <h1>We're sorry, but something went wrong.</h1>
+      <h1>We're sorry, but something went wrong on our end.</h1>
     </div>
     <p>If you are the application owner check the logs for more information.</p>
   </div>


### PR DESCRIPTION
### Motivation
@morred gave a talk about providing better errors - the key takeaway being that end users who see server errors could be better informed.

Providing a simple change to the default to 'on our end' adds the implication that a 500 error is not something that the user has done incorrectly.

### Summary

I'm aware that it's mostly a cosmetic change (https://github.com/rails/rails/pull/13771#issuecomment-32746700), but I thought it would good to start the conversation.

Any thoughts @tenderlove and @morred? 