### PR TITLE
Fix missing formats in route-set URLs

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -279,6 +279,8 @@ module ActionDispatch
               if args.size < path_params_size
                 path_params -= controller_options.keys
                 path_params -= result.keys
+              else
+                path_params = path_params.dup
               end
               inner_options.each_key do |key|
                 path_params.delete(key)

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -138,6 +138,15 @@ module ActionDispatch
         assert_equal "/a/users/1", url_helpers.user_path(1, foo: "a")
       end
 
+      test "implicit path components consistently return the same result" do
+        draw do
+          resources :users, to: SimpleApp.new("foo#index")
+        end
+        assert_equal "/users/1.json", url_helpers.user_path(1, :json)
+        assert_equal "/users/1.json", url_helpers.user_path(1, format: :json)
+        assert_equal "/users/1.json", url_helpers.user_path(1, :json)
+      end
+
       private
         def draw(&block)
           @set.draw(&block)


### PR DESCRIPTION
Before this change, `handle_positional_args` would end up mutating `@segment_keys`
if `inner_options` included path components.  Subsequent calls would then
be missing the implicit path components.

eg:
```ruby
user_path(1, :json)         # => "/users/1.json" (correct)
user_path(1, format: :json) # => "/users/1.json" (correct, but @segment_keys was mutated)
user_path(1, :json)         # => "/users/1" (oh no!)
```

This regression was introduced in 0cbec58ae48279ae5e9fdf6bbdbceb32183215dd (/cc @schneems )

Specifying a format like that is expected to be supported, right?  WDYT to this fix?