### PR TITLE
Clear screenshots files in `tmp:clear` task

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -262,12 +262,12 @@ $ bin/rails db:migrate
 ==  CreateHighScores: migrated (0.0019s) ======================================
 ```
 
-INFO: Let's talk about unit tests. Unit tests are code that tests and makes assertions 
-about code. In unit testing, we take a little part of code, say a method of a model, 
-and test its inputs and outputs. Unit tests are your friend. The sooner you make 
-peace with the fact that your quality of life will drastically increase when you unit 
-test your code, the better. Seriously. Please visit 
-[the testing guide](http://guides.rubyonrails.org/testing.html) for an in-depth 
+INFO: Let's talk about unit tests. Unit tests are code that tests and makes assertions
+about code. In unit testing, we take a little part of code, say a method of a model,
+and test its inputs and outputs. Unit tests are your friend. The sooner you make
+peace with the fact that your quality of life will drastically increase when you unit
+test your code, the better. Seriously. Please visit
+[the testing guide](http://guides.rubyonrails.org/testing.html) for an in-depth
 look at unit testing.
 
 Let's see the interface Rails created for us.
@@ -533,7 +533,8 @@ The `tmp:` namespaced tasks will help you clear and create the `Rails.root/tmp` 
 
 * `rails tmp:cache:clear` clears `tmp/cache`.
 * `rails tmp:sockets:clear` clears `tmp/sockets`.
-* `rails tmp:clear` clears all cache and sockets files.
+* `rails tmp:screenshots:clear` clears `tmp/screenshots`.
+* `rails tmp:clear` clears all cache, sockets and screenshot files.
 * `rails tmp:create` creates tmp directories for cache, sockets and pids.
 
 ### Miscellaneous

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Clear screenshot files in `tmp:clear` task.
+
+    *Yuji Yaginuma*
+
 *   Add `railtie.rb` to the plugin generator
 
     *Tsukuru Tanimichi*

--- a/railties/lib/rails/tasks/tmp.rake
+++ b/railties/lib/rails/tasks/tmp.rake
@@ -1,6 +1,6 @@
 namespace :tmp do
-  desc "Clear cache and socket files from tmp/ (narrow w/ tmp:cache:clear, tmp:sockets:clear)"
-  task clear: ["tmp:cache:clear", "tmp:sockets:clear"]
+  desc "Clear cache, socket and screenshot files from tmp/ (narrow w/ tmp:cache:clear, tmp:sockets:clear, tmp:screenshots:clear)"
+  task clear: ["tmp:cache:clear", "tmp:sockets:clear", "tmp:screenshots:clear"]
 
   tmp_dirs = [ "tmp/cache",
                "tmp/sockets",
@@ -30,6 +30,13 @@ namespace :tmp do
     # desc "Clears all files in tmp/pids"
     task :clear do
       rm Dir["tmp/pids/[^.]*"], verbose: false
+    end
+  end
+
+  namespace :screenshots do
+    # desc "Clears all files in tmp/screenshots"
+    task :clear do
+      rm Dir["tmp/screenshots/[^.]*"], verbose: false
     end
   end
 end

--- a/railties/test/application/rake/tmp_test.rb
+++ b/railties/test/application/rake/tmp_test.rb
@@ -1,0 +1,36 @@
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  module RakeTests
+    class TmpTest < ActiveSupport::TestCase
+      include ActiveSupport::Testing::Isolation
+
+      def setup
+        build_app
+      end
+
+      def teardown
+        teardown_app
+      end
+
+      test "tmp:clear clear cache, socket and screenshot files" do
+        Dir.chdir(app_path) do
+          FileUtils.mkdir_p("tmp/cache")
+          FileUtils.touch("tmp/cache/cache_file")
+
+          FileUtils.mkdir_p("tmp/sockets")
+          FileUtils.touch("tmp/sockets/socket_file")
+
+          FileUtils.mkdir_p("tmp/screenshots")
+          FileUtils.touch("tmp/screenshots/fail.png")
+
+          `rails tmp:clear`
+
+          assert_not File.exist?("tmp/cache/cache_file")
+          assert_not File.exist?("tmp/sockets/socket_file")
+          assert_not File.exist?("tmp/screenshots/fail.png")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
If system test fails, it creates screenshot under `tmp/screenshots`.
https://github.com/rails/rails/blob/34fe2a4fc778d18b7fe6bdf3629c1481bee789b9/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb#L45

But currently, screenshot files is not cleared by `tmp:clear` task.
This patch make clears screenshot files in `tmp:clear` task as well as other tmp files.
