### PR TITLE
Ensure `false` is preserved in attr serialization

### DIFF
--- a/activerecord/lib/active_record/attribute.rb
+++ b/activerecord/lib/active_record/attribute.rb
@@ -122,7 +122,7 @@ module ActiveRecord
 
     def encode_with(coder)
       coder["name"] = name
-      coder["value_before_type_cast"] = value_before_type_cast if value_before_type_cast
+      coder["value_before_type_cast"] = value_before_type_cast unless value_before_type_cast.nil?
       coder["type"] = type if type
       coder["original_attribute"] = original_attribute if original_attribute
       coder["value"] = value if defined?(@value)

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -119,6 +119,14 @@ class YamlSerializationTest < ActiveRecord::TestCase
     assert_equal author.changes, dumped.changes
   end
 
+  def test_yaml_encoding_keeps_false_values
+    topic = Topic.first
+    topic.approved = false
+    dumped = YAML.load(YAML.dump(topic))
+
+    assert_equal false, dumped.approved
+  end
+
   private
 
     def yaml_fixture(file_name)


### PR DESCRIPTION
### Summary

Roundtrip YAML serialization would result  in `false` values coming back as `nil`. For example:
```ruby
record = SomeModel.new(some_boolean: false)
dumped = YAML.load(YAML.dump(record))
dumped.some_boolean # => nil
```

Note about the implementation:
- `type` and `original_attribute` have the same presence check. I didn't update these because I wanted to keep the change specific to the problem I encountered, but I'd be happy to update those lines as well.