### PR TITLE
Remove unused `COMPONENT_ROOT` in `bin/test`

### DIFF
--- a/actioncable/bin/test
+++ b/actioncable/bin/test
@@ -1,4 +1,3 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"

--- a/actionmailer/bin/test
+++ b/actionmailer/bin/test
@@ -1,4 +1,3 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"

--- a/actionpack/bin/test
+++ b/actionpack/bin/test
@@ -1,4 +1,3 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"

--- a/actionview/bin/test
+++ b/actionview/bin/test
@@ -1,4 +1,3 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"

--- a/activejob/bin/test
+++ b/activejob/bin/test
@@ -1,4 +1,3 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"

--- a/activemodel/bin/test
+++ b/activemodel/bin/test
@@ -1,4 +1,3 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"

--- a/activerecord/bin/test
+++ b/activerecord/bin/test
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"
 
 module Minitest

--- a/activesupport/bin/test
+++ b/activesupport/bin/test
@@ -1,4 +1,3 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"

--- a/railties/bin/test
+++ b/railties/bin/test
@@ -1,4 +1,3 @@
 #!/usr/bin/env ruby
 
-COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"


### PR DESCRIPTION
`COMPONENT_ROOT` is no longer used since 6673cf70.