### PR TITLE
Fix typo in `AC::UnfilteredParameters` message [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -245,7 +245,7 @@ module ActionController
     #     oddity: "Heavy stone crab"
     #   })
     #   params.to_h
-    #   # => ActionController::UnfilteredParameters: unable to convert unfiltered parameters to hash
+    #   # => ActionController::UnfilteredParameters: unable to convert unpermitted parameters to hash
     #
     #   safe_params = params.permit(:name)
     #   safe_params.to_h # => {"name"=>"Senjougahara Hitagi"}
@@ -265,7 +265,7 @@ module ActionController
     #     oddity: "Heavy stone crab"
     #   })
     #   params.to_hash
-    #   # => ActionController::UnfilteredParameters: unable to convert unfiltered parameters to hash
+    #   # => ActionController::UnfilteredParameters: unable to convert unpermitted parameters to hash
     #
     #   safe_params = params.permit(:name)
     #   safe_params.to_hash # => {"name"=>"Senjougahara Hitagi"}


### PR DESCRIPTION
Ref: https://github.com/rails/rails/blob/33b596709388cc48d90ab6d1de99d7bd6e85f916/actionpack/lib/action_controller/metal/strong_parameters.rb#L52..L56