### PR TITLE
Fix a problem when re-defining has_many :through associations

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -33,7 +33,10 @@ module ActiveRecord
 
     def self.add_reflection(ar, name, reflection)
       ar.clear_reflections_cache
-      ar._reflections = ar._reflections.merge(name.to_s => reflection)
+
+      ar._reflections = ar._reflections
+        .without(name.to_s)
+        .merge(name.to_s => reflection)
     end
 
     def self.add_aggregate_reflection(ar, name, reflection)

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1235,6 +1235,14 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_correctly_ordered_through_association_for_redefined_association
+    assert_nothing_raised do
+      DeveloperWithRedefinedHasManyThroughAssociation.create(
+        companies: [Company.create]
+      )
+    end
+  end
+
   private
     def make_model(name)
       Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -25,6 +25,7 @@ require "models/cake_designer"
 require "models/drink_designer"
 require "models/mocktail_designer"
 require "models/recipe"
+require "models/developer"
 
 class ReflectionTest < ActiveRecord::TestCase
   include ActiveRecord::Reflection
@@ -230,6 +231,11 @@ class ReflectionTest < ActiveRecord::TestCase
 
   def test_reflections_should_return_keys_as_strings
     assert Category.reflections.keys.all? { |key| key.is_a? String }, "Model.reflections is expected to return string for keys"
+  end
+
+  def test_reflections_hash_order_is_updated_when_redefining_associations
+    klass = DeveloperWithRedefinedHasManyThroughAssociation
+    assert_equal %w(contracts companies), klass.reflections.keys
   end
 
   def test_has_and_belongs_to_many_reflection

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -266,3 +266,12 @@ class DeveloperWithIncorrectlyOrderedHasManyThrough < ActiveRecord::Base
   has_many :companies, through: :contracts
   has_many :contracts, foreign_key: :developer_id
 end
+
+class DeveloperWithRedefinedHasManyThroughAssociation < ActiveRecord::Base
+  self.table_name = "developers"
+
+  has_many :companies
+
+  has_many :contracts, foreign_key: :developer_id
+  has_many :companies, through: :contracts
+end


### PR DESCRIPTION
This is an attempt to fix this issue: https://github.com/rails/rails/issues/29123

When calling a `has_many :through` association we
check if the source association is defined after
the `has_many :through`. If it is, we throw a
`HasManyThroughOrderError`.
(See: https://github.com/rails/rails/commit/f8ab3ae18fbb5c4a4c9563296d0e7c528e754c42)

However, this error was being erroneously thrown
in cases when the `has_many :through` overrides
another association of the same name.