### PR TITLE
Removed reference to unexisting methods:

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -338,8 +338,7 @@ module ActionDispatch
         @integration_session = nil
       end
 
-      %w(get post patch put head delete cookies assigns
-         xml_http_request xhr get_via_redirect post_via_redirect).each do |method|
+      %w(get post patch put head delete cookies assigns).each do |method|
         define_method(method) do |*args|
           # reset the html_document variable, except for cookies/assigns calls
           unless method == "cookies" || method == "assigns"


### PR DESCRIPTION
`get/post_via_redirect`, `xhr` and his alias `xml_http_request` were respectively removed in 092033d59f7e2b248f6c6ab6c0b67339c5e9f2df and eb52e5d42fbdc9288925a402dcb3c5664d1125b7


