### PR TITLE
Fix system test generator option to be consistent

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -37,7 +37,7 @@ module <%= app_const_base %>
 <%- elsif !depends_on_system_test? -%>
 
     # Don't generate system test files.
-    config.generators.system_tests = nil
+    config.generators.skip_system_test = true
 <%- end -%>
   end
 end

--- a/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
@@ -12,16 +12,20 @@ module Rails
       class_option :assets, type: :boolean
       class_option :resource_route, type: :boolean
       class_option :scaffold_stylesheet, type: :boolean
+      class_option :skip_system_test, type: :boolean, default: false,
+                                      desc: "Skip system test files"
 
       def handle_skip
         @options = @options.merge(stylesheets: false) unless options[:assets]
         @options = @options.merge(stylesheet_engine: false) unless options[:stylesheets] && options[:scaffold_stylesheet]
-        @options = @options.merge(system_tests: false) if options[:api]
+        @options = @options.merge(skip_system_test: true) if options[:api]
       end
 
       hook_for :scaffold_controller, required: true
 
-      hook_for :system_tests, as: :system
+      hook_for :system_tests, as: :system do |system_test|
+        invoke system_test unless options[:skip_system_test]
+      end
 
       hook_for :assets do |assets|
         invoke assets, [controller_name]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -437,7 +437,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_generator_if_skip_system_test_is_given
-    run_generator [destination_root, "--skip_system_test"]
+    run_generator [destination_root, "--skip-system-test"]
     assert_file "Gemfile" do |content|
       assert_no_match(/capybara/, content)
       assert_no_match(/selenium-webdriver/, content)
@@ -445,7 +445,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_does_not_generate_system_test_files_if_skip_system_test_is_given
-    run_generator [destination_root, "--skip_system_test"]
+    run_generator [destination_root, "--skip-system-test"]
 
     Dir.chdir(destination_root) do
       quietly { `./bin/rails g scaffold User` }


### PR DESCRIPTION
We use `skip-system-test` everywhere else so it doesn't make sense to
use `system_tests = nil` in the generator config. Otherwise we're
passing conflicting options around (`system_tests` by default
`:test_unit` otherwise `nil` vs `skip_system_test` default is false and
otherwise pass true). It gets confusing.

Because of this change we then need to apply `skip_system_test` to the
`system_test` hook. In the PR to generate a more complete system test
when generating a scaffold this will be changed to be generated with
`create_test_files` but for now this works to unblock that PR.

Noticed this was incorrect while trying to figure out the test failures in https://github.com/rails/rails/pull/29418