### PR TITLE
Calling `follow_redirect!` does not reset the `html_document`:

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -338,7 +338,7 @@ module ActionDispatch
         @integration_session = nil
       end
 
-      %w(get post patch put head delete cookies assigns).each do |method|
+      %w(get post patch put head delete cookies assigns follow_redirect!).each do |method|
         define_method(method) do |*args|
           # reset the html_document variable, except for cookies/assigns calls
           unless method == "cookies" || method == "assigns"

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -335,6 +335,18 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_redirect_reset_html_document
+    with_test_route_set do
+      get "/redirect"
+      previous_html_document = html_document
+
+      follow_redirect!
+
+      assert_response :ok
+      refute_same previous_html_document, html_document
+    end
+  end
+
   def test_xml_http_request_get
     with_test_route_set do
       get "/get", xhr: true


### PR DESCRIPTION
- When making a request to a controller that redirects, `follow_redirect!` would not reset the `html_document` ivar, it only resets the `html_document` ivar from the session (not the runner)
- If one was doing something like this;
  ```ruby
    get '/redirect'
    assert_select 'you are being redirected'
    follow_redirect!
    # html_document is memoized and doesn't get reset
  ```
- To fix the issue we can do the same for any other methods (`get`, `post`...) and define a method in the runner that delegates to the session but clears the html_document_first
- Fixes #29367

