### PR TITLE
Don't wrap parameters if key already exists

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -282,7 +282,7 @@ module ActionController
         return false unless request.has_content_type?
 
         ref = request.content_mime_type.ref
-        _wrapper_formats.include?(ref) && _wrapper_key && !request.request_parameters[_wrapper_key]
+        _wrapper_formats.include?(ref) && _wrapper_key && !request.request_parameters.key?(_wrapper_key)
       end
   end
 end

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -170,6 +170,14 @@ class ParamsWrapperTest < ActionController::TestCase
     end
   end
 
+  def test_no_double_wrap_if_key_exists_and_value_is_nil
+    with_default_wrapper_options do
+      @request.env["CONTENT_TYPE"] = "application/json"
+      post :parse, params: { "user" => nil }
+      assert_parameters("user" => nil)
+    end
+  end
+
   def test_nested_params
     with_default_wrapper_options do
       @request.env["CONTENT_TYPE"] = "application/json"


### PR DESCRIPTION
We shouldn't perform parameter wrapping if it would overwrite one of the parameters sent with the request, as that would interfere with reading the parameter directly from the top level `params` hash.

The current implementation has logic for this case, but it doesn't handle `nil`/`false` values, which means these parameters:

    { "user" => nil }

are transformed into this `params` hash:

    { "user" => { "user" => nil } }

and `params["user"]` no longer returns the original parameter value.