### PR TITLE
Guides: Clarify partial local variable naming.

### DIFF
--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -1171,7 +1171,7 @@ To pass a local variable to a partial in only specific cases use the `local_assi
 
 This way it is possible to use the partial without the need to declare all local variables.
 
-Every partial also has a local variable with the same name as the partial (minus the underscore). You can pass an object in to this local variable via the `:object` option:
+Every partial also has a local variable with the same name as the partial (minus the leading underscore). You can pass an object in to this local variable via the `:object` option:
 
 ```erb
 <%= render partial: "customer", object: @new_customer %>


### PR DESCRIPTION
Clarify the partial local variable name as being the same as the name
of the partial, minus the _leading_ underscore.

### Summary

The local variable of a partial *_foo* is `foo`, which is the same name as the partial, minus the leading underscore. Clarify the documentation, since underscores, in general, can exist within the filename, and are not omitted in the local variable name. For example, partial *_foo_bar* has the local variable `foo_bar`.

Thank you for entertaining my minute pull request - and all things Rails!

[ci skip]