### PR TITLE
Eager load controller actions to reduce response time of the first request

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -58,6 +58,12 @@ module ActionMailer
       end
     end
 
+    initializer "action_mailer.eager_load_actions" do
+      ActiveSupport.on_load(:after_initialize) do
+        ActionMailer::Base.descendants.each(&:action_methods) if config.eager_load
+      end
+    end
+
     config.after_initialize do |app|
       options = app.config.action_mailer
 

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -77,5 +77,11 @@ module ActionController
         end
       end
     end
+
+    initializer "action_controller.eager_load_actions" do
+      ActiveSupport.on_load(:after_initialize) do
+        ActionController::Metal.descendants.each(&:action_methods) if config.eager_load
+      end
+    end
   end
 end


### PR DESCRIPTION
On the first request, `ActionController::Base#action_methods` [computes
and memoizes](https://github.com/rails/rails/blob/a3813dce9a0c950a4af7909111fa730a2622b1db/actionpack/lib/abstract_controller/base.rb#L66-L77) the list of available actions. With this PR we move this expensive operation into eager load step to reduce response time of the first request served in production.

This also reduces the memory footprint when running on forking server like Unicorn.

all credit goes to @casperisfine. I'm just pushing this patch from Shopify into upstream :blush:

@rafaelfranca @Edouard-chin 