### PR TITLE
Remove unnecessary `tap` call on `ActionDispatch::MiddlewareStack.new`

### DIFF
--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -10,7 +10,7 @@ module Rails
       end
 
       def build_stack
-        ActionDispatch::MiddlewareStack.new.tap do |middleware|
+        ActionDispatch::MiddlewareStack.new do |middleware|
           if config.force_ssl
             middleware.use ::ActionDispatch::SSL, config.ssl_options
           end


### PR DESCRIPTION
`ActionDispatch::MiddlewareStack`'s `initialize` method is already yields self to block, so `tap`ing on instance is unnecessary. 