### PR TITLE
Add an option to silence puma in system tests.

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/server.rb
+++ b/actionpack/lib/action_dispatch/system_testing/server.rb
@@ -3,6 +3,12 @@ require "rack/handler/puma"
 module ActionDispatch
   module SystemTesting
     class Server # :nodoc:
+      class << self
+        attr_accessor :silence_puma
+      end
+
+      self.silence_puma = false
+
       def run
         register
         setup
@@ -11,7 +17,12 @@ module ActionDispatch
       private
         def register
           Capybara.register_server :rails_puma do |app, port, host|
-            Rack::Handler::Puma.run(app, Port: port, Threads: "0:1")
+            Rack::Handler::Puma.run(
+              app,
+              Port: port,
+              Threads: "0:1",
+              Silent: self.class.silence_puma
+            )
           end
         end
 


### PR DESCRIPTION
This is motivated by our usage of system test in RSpec. Puma lazily
boots the first time a system test is used, but this causes some
unfortunate output to appear in the middle of the user's green dots. An
example of this can be seen in @derekprior's comment
[here](https://github.com/rspec/rspec-rails/pull/1813#issuecomment-309252314).

There are alternatives in RSpec where we attempt to intercept the puma
boot and prevent the output from being made there, but that would
involve some monkey patching. This seems like a cleaner solution.