### PR TITLE
Add purpose to cookies

### DIFF
--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -42,6 +42,8 @@ module ActionDispatch
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie
 
+      ActionDispatch::Cookies.cookies_have_purpose = app.config.action_dispatch.cookies_have_purpose
+
       ActionDispatch.test_app = app
     end
   end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -90,6 +90,7 @@ module Rails
 
           if respond_to?(:action_dispatch)
             action_dispatch.use_authenticated_cookie_encryption = true
+            action_dispatch.cookies_have_purpose = true
           end
 
           if respond_to?(:active_support)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_5_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_5_2.rb.tt
@@ -17,3 +17,7 @@
 # Use AES-256-GCM authenticated encryption as default cipher for encrypting messages
 # instead of AES-256-CBC, when use_authenticated_message_encryption is set to true.
 # Rails.application.config.active_support.use_authenticated_message_encryption = true
+
+# Allow cookies to have a purpose, preventing cookies from being used for something it
+# wasn't meant to be used for.
+# Rails.application.config.action_dispatch.cookies_have_purpose = true


### PR DESCRIPTION
### Summary
@kaspth 
To prevent cookies from being repurposed for a completely unrelated key, the name of the cookie is tacked on along with the cookie value.