### PR TITLE
Don't wrap parameters if query parameter exists

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -232,12 +232,7 @@ module ActionController
     # by the metal call stack.
     def process_action(*args)
       if _wrapper_enabled?
-        if request.parameters[_wrapper_key].present?
-          wrapped_hash = _extract_parameters(request.parameters)
-        else
-          wrapped_hash = _wrap_parameters request.request_parameters
-        end
-
+        wrapped_hash = _wrap_parameters request.request_parameters
         wrapped_keys = request.request_parameters.keys
         wrapped_filtered_hash = _wrap_parameters request.filtered_parameters.slice(*wrapped_keys)
 
@@ -282,7 +277,7 @@ module ActionController
         return false unless request.has_content_type?
 
         ref = request.content_mime_type.ref
-        _wrapper_formats.include?(ref) && _wrapper_key && !request.request_parameters.key?(_wrapper_key)
+        _wrapper_formats.include?(ref) && _wrapper_key && !request.parameters.key?(_wrapper_key)
       end
   end
 end

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -226,6 +226,14 @@ class ParamsWrapperTest < ActionController::TestCase
     end
   end
 
+  def test_preserves_query_string_params_in_filtered_params
+    with_default_wrapper_options do
+      @request.env["CONTENT_TYPE"] = "application/json"
+      get :parse, params: { "user" => { "username" => "nixon" } }
+      assert_equal({ "controller" => "params_wrapper_test/users", "action" => "parse", "user" => { "username" => "nixon" } }, @request.filtered_parameters)
+    end
+  end
+
   def test_empty_parameter_set
     with_default_wrapper_options do
       @request.env["CONTENT_TYPE"] = "application/json"


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/29553.

We want to avoid overwriting a query parameter with the wrapped parameters hash. This was implemented in https://github.com/rails/rails/pull/13863 by merging the wrapped parameters at the root level if the key already existed, which was effectively a no-op. The query parameter was still overwritten in the filtered parameters hash, however.

We can fix that discrepancy with a simpler implementation and less unnecessary work by skipping parameter wrapping entirely if the key was sent as a query parameter.

r? @kaspth 