### PR TITLE
Fix to scoping is correctly restored

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -333,7 +333,7 @@ module ActiveRecord
     # Please check unscoped if you want to remove all previous scopes (including
     # the default_scope) during the execution of a block.
     def scoping
-      previous, klass.current_scope = klass.current_scope, self
+      previous, klass.current_scope = klass.current_scope(true), self
       yield
     ensure
       klass.current_scope = previous

--- a/activerecord/lib/active_record/scoping.rb
+++ b/activerecord/lib/active_record/scoping.rb
@@ -10,8 +10,8 @@ module ActiveRecord
     end
 
     module ClassMethods
-      def current_scope #:nodoc:
-        ScopeRegistry.value_for(:current_scope, self)
+      def current_scope(skip_inherited_scope = false) # :nodoc:
+        ScopeRegistry.value_for(:current_scope, self, skip_inherited_scope)
       end
 
       def current_scope=(scope) #:nodoc:
@@ -75,8 +75,9 @@ module ActiveRecord
       end
 
       # Obtains the value for a given +scope_type+ and +model+.
-      def value_for(scope_type, model)
+      def value_for(scope_type, model, skip_inherited_scope = false)
         raise_invalid_scope_type!(scope_type)
+        return @registry[scope_type][model.name] if skip_inherited_scope
         klass = model
         base = model.base_class
         while klass <= base

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -229,6 +229,15 @@ class RelationScopingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_scoping_is_correctly_restored
+    Comment.unscoped do
+      SpecialComment.unscoped.created
+    end
+
+    assert_nil Comment.current_scope
+    assert_nil SpecialComment.current_scope
+  end
+
   def test_circular_joins_with_scoping_does_not_crash
     posts = Post.joins(comments: :post).scoping do
       Post.first(10)


### PR DESCRIPTION
This regression was caused by #23004.

If STI subclass is using scoping in parent class scoping,
`current_scope` in subclass is never restored.
I fixed to restore `current_scope` to previous value correctly.