### PR TITLE
Add `railtie.rb` to the plugin generator

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `railtie.rb` to the plugin generator
+
+    *Tsukuru Tanimichi*
+
 *   Deprecate `capify!` method in generators and templates.
 
     *Yuji Yaginuma*

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -60,7 +60,12 @@ module Rails
       template "lib/%namespaced_name%.rb"
       template "lib/tasks/%namespaced_name%_tasks.rake"
       template "lib/%namespaced_name%/version.rb"
-      template "lib/%namespaced_name%/engine.rb" if engine?
+
+      if engine?
+        template "lib/%namespaced_name%/engine.rb"
+      else
+        template "lib/%namespaced_name%/railtie.rb"
+      end
     end
 
     def config

--- a/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%.rb
@@ -1,5 +1,7 @@
 <% if engine? -%>
 require "<%= namespaced_name %>/engine"
-
+<% else -%>
+require "<%= namespaced_name %>/railtie"
 <% end -%>
+
 <%= wrap_in_modules "# Your code goes here..." %>

--- a/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/railtie.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/railtie.rb
@@ -1,0 +1,5 @@
+<%= wrap_in_modules <<-rb.strip_heredoc
+  class Railtie < ::Rails::Railtie
+  end
+rb
+%>

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -68,6 +68,8 @@ class PluginGeneratorTest < Rails::Generators::TestCase
       assert_match(/Minitest\.backtrace_filter = Minitest::BacktraceFilter\.new/, content)
       assert_match(/Rails::TestUnitReporter\.executable = 'bin\/test'/, content)
     end
+    assert_file "lib/bukkits/railtie.rb", /module Bukkits\n  class Railtie < ::Rails::Railtie\n  end\nend/
+    assert_file "lib/bukkits.rb", /require "bukkits\/railtie"/
     assert_file "test/bukkits_test.rb", /assert_kind_of Module, Bukkits/
     assert_file "bin/test"
     assert_no_file "bin/rails"


### PR DESCRIPTION
### Before

```bash
$ rails plugin new myplugin
$ ls myplugin/lib/myplugin
version.rb
```

### After

```bash
$ rails plugin new myplugin
$ ls myplugin/lib/myplugin
railtie.rb  version.rb

$ cat myplugin/lib/myplugin/railtie.rb
module Myplugin
  class Railtie < ::Rails::Railtie
  end
end
```

ref. http://api.rubyonrails.org/classes/Rails/Railtie.html
