### PR TITLE
Remove needless gitignore

### DIFF
--- a/activejob/.gitignore
+++ b/activejob/.gitignore
@@ -1,1 +1,0 @@
-test/dummy


### PR DESCRIPTION
The dummy application is created under the tmp directory. Nothing is created in the `test/dummy` directory.
https://github.com/rails/rails/blob/40bdbce191ad90dfea43dad51fac5c4726b89392/activejob/test/support/integration/helper.rb#L9



I guess that this comment makes it unnecessary.
https://github.com/rails/rails/pull/16541#r16986711
