### PR TITLE
Ignore public/assets

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -26,4 +26,8 @@
 /yarn-error.log
 
 <% end -%>
+
+<% unless options[:api] -%>
+/public/assets
+<% end -%>
 .byebug_history


### PR DESCRIPTION
### Summary

This adds `public/assets` to `.gitignore` since this should be compiled in production and the current default configuration ignores `public/assets`, but not `public/packs` when webpacker is included in the installation.

This leads to a scenario where we allow some assets to be compiled, but the packs to not be compiled.. leading to an ambiguous intent.

As @rafaelfranca suggested, the intent is to `.gitignore` all precompilation in development.

### Other Information

This change follows the discussion at with @rafaelfranca at https://github.com/rails/webpacker/issues/534
