### PR TITLE
fixed no route matches favicon.ico for api projects welcome page

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Stop removing favicon.ico file when generating a new --api project.
+
+    Fixes #29578.
+
+    *David Ramirez*
+
 *   Add `railtie.rb` to the plugin generator
 
     *Tsukuru Tanimichi*

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -346,7 +346,6 @@ module Rails
           remove_file "public/500.html"
           remove_file "public/apple-touch-icon-precomposed.png"
           remove_file "public/apple-touch-icon.png"
-          remove_file "public/favicon.ico"
         end
       end
 

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -102,6 +102,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
         lib
         lib/tasks
         log
+        public/favicon.ico
         test/fixtures
         test/controllers
         test/integration
@@ -128,7 +129,6 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
          public/500.html
          public/apple-touch-icon-precomposed.png
          public/apple-touch-icon.png
-         public/favicon.icon
          package.json
       )
     end


### PR DESCRIPTION
### Summary

When loading the welcome page after creating a new rails --api project it appears an error on the rails console:

`ActionController::RoutingError (No route matches [GET] "/favicon.ico")`

This PR fixes the error by stopping removing the favicon.ico file from the public folder when generating new rails --api projects.

You can also read the issue here: https://github.com/rails/rails/issues/29578

### Other Information

/railties/changelog.md updated:

*   Stop removing favicon.ico file when generating a new --api project.

    Fixes #29578.

    *David Ramirez*
