### PR TITLE
Add source code and changelog links to gemspecs

### DIFF
--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |s|
   s.files        = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*"]
   s.require_path = "lib"
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actioncable",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actioncable/CHANGELOG.md"
+  }
+
   s.add_dependency "actionpack", version
 
   s.add_dependency "nio4r",            "~> 2.0"

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -19,6 +19,11 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actionmailer",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionmailer/CHANGELOG.md"
+  }
+
   s.add_dependency "actionpack", version
   s.add_dependency "actionview", version
   s.add_dependency "activejob", version

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -19,6 +19,11 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actionpack",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionpack/CHANGELOG.md"
+  }
+
   s.add_dependency "activesupport", version
 
   s.add_dependency "rack",      "~> 2.0"

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -19,6 +19,11 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actionview",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionview/CHANGELOG.md"
+  }
+
   s.add_dependency "activesupport", version
 
   s.add_dependency "builder",       "~> 3.1"

--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |s|
   s.files        = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*"]
   s.require_path = "lib"
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activejob",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activejob/CHANGELOG.md"
+  }
+
   s.add_dependency "activesupport", version
   s.add_dependency "globalid", ">= 0.3.6"
 end

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -18,5 +18,10 @@ Gem::Specification.new do |s|
   s.files        = Dir["CHANGELOG.md", "MIT-LICENSE", "README.rdoc", "lib/**/*"]
   s.require_path = "lib"
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activemodel",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activemodel/CHANGELOG.md"
+  }
+
   s.add_dependency "activesupport", version
 end

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -21,6 +21,11 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w(README.rdoc)
   s.rdoc_options.concat ["--main",  "README.rdoc"]
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activerecord",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activerecord/CHANGELOG.md"
+  }
+
   s.add_dependency "activesupport", version
   s.add_dependency "activemodel",   version
 

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -20,6 +20,11 @@ Gem::Specification.new do |s|
 
   s.rdoc_options.concat ["--encoding",  "UTF-8"]
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activesupport",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activesupport/CHANGELOG.md"
+  }
+
   s.add_dependency "i18n",       "~> 0.7"
   s.add_dependency "tzinfo",     "~> 1.1"
   s.add_dependency "minitest",   "~> 5.1"


### PR DESCRIPTION
Makes it easy to programatically find the source code and changelog for each of the Rails gems, using the rubygems API. More details on metadata links in gemspecs is [here](https://github.com/rubygems/rubygems.org/issues/1127) and [here](https://github.com/rubygems/rubygems.org/pull/1234).

(My interest in this is so that [Dependabot](https://dependabot.com) can find a link to the `activesupport` source code etc., when it creates PRs. Without that link, it generates PRs like [this one](https://github.com/greysteil/travis-build/pull/9), rather than PRs like [this one](https://github.com/greysteil/onebody/pull/12).)