### PR TITLE
transform_keys should return self.class.new

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -11,7 +11,7 @@ class Hash
   #  hash.transform_keys.with_index { |k, i| [k, i].join } # => {"name0"=>"Rob", "age1"=>"28"}
   def transform_keys
     return enum_for(:transform_keys) { size } unless block_given?
-    result = {}
+    result = self.class.new
     each_key do |key|
       result[yield(key)] = self[key]
     end


### PR DESCRIPTION
transform_keys should return self.class.new with modifications instead of Hash. This enables inherited custom hashes to operate. #29590 