### PR TITLE
Remove useless class checking for `ActiveSupport::Callbacks`s result_lambda

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -29,7 +29,7 @@ module AbstractController
 
     included do
       define_callbacks :process_action,
-                       terminator: ->(controller, result_lambda) { result_lambda.call if result_lambda.is_a?(Proc); controller.performed? },
+                       terminator: ->(controller, result_lambda) { result_lambda.call; controller.performed? },
                        skip_after_callbacks_if_terminated: true
     end
 

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -596,7 +596,7 @@ module ActiveSupport
             Proc.new do |target, result_lambda|
               terminate = true
               catch(:abort) do
-                result_lambda.call if result_lambda.is_a?(Proc)
+                result_lambda.call
                 terminate = false
               end
               terminate


### PR DESCRIPTION
No need to check `result_lambda`s class, because it is always `lambda`.
https://github.com/rails/rails/blob/master/activesupport/lib/active_support/callbacks.rb#L177
https://github.com/rails/rails/blob/master/activesupport/lib/active_support/callbacks.rb#L196