### PR TITLE
Show query cache keys in `test_exceptional_middleware_clears_and_disables_cache_on_error`

### DIFF
--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -42,7 +42,8 @@ class QueryCacheTest < ActiveRecord::TestCase
     mw = middleware { |env|
       Task.find 1
       Task.find 1
-      assert_equal 1, ActiveRecord::Base.connection.query_cache.length
+      query_cache = ActiveRecord::Base.connection.query_cache
+      assert_equal 1, query_cache.length, query_cache.keys
       raise "lol borked"
     }
     assert_raises(RuntimeError) { mw.call({}) }


### PR DESCRIPTION
`test_exceptional_middleware_clears_and_disables_cache_on_error` in
postgresql adapter sometimes fails recently. Show the query cache keys to
investigte the cause.

https://travis-ci.org/rails/rails/jobs/246467252#L490-L493