### PR TITLE
Fix `ids_reader` to respect case sensitive primary key

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -44,10 +44,7 @@ module ActiveRecord
         if loaded?
           target.pluck(reflection.association_primary_key)
         else
-          @association_ids ||= (
-            column = "#{reflection.quoted_table_name}.#{reflection.association_primary_key}"
-            scope.pluck(column)
-          )
+          @association_ids ||= scope.pluck(reflection.association_primary_key)
         end
       end
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -107,7 +107,7 @@ ActiveRecord::Schema.define do
     t.boolean :has_fun, null: false, default: false
   end
 
-  create_table :bulbs, force: true do |t|
+  create_table :bulbs, primary_key: "ID", force: true do |t|
     t.integer :car_id
     t.string  :name
     t.boolean :frickinawesome, default: false


### PR DESCRIPTION
```ruby
  car = Car.create!(name: "Tofaş")

  # Before
  car.bulb_ids # => SELECT "bulbs".ID FROM "bulbs" WHERE "bulbs"."name" = $1 AND "bulbs"."car_id" = $2  [["name", "defaulty"], ["car_id", 3]]

  # After
  car.bulb_ids # => SELECT "bulbs"."ID" FROM "bulbs" WHERE "bulbs"."name" = $1 AND "bulbs"."car_id" = $2  [["name", "defaulty"], ["car_id", 3]]
```