### PR TITLE
Ignore primary_key_prefix_type on HABTM join models

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -20,6 +20,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
           attr_accessor :right_reflection
         end
 
+        def self.primary_key_prefix_type
+          nil
+        end
+
         def self.table_name
           # Table name needs to be resolved lazily
           # because RHS class might not have been loaded

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -166,6 +166,21 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, country.treaties.count
   end
 
+  def test_join_table_ignores_primary_key_prefix_type
+    old_primary_key_prefix_type = ActiveRecord::Base.primary_key_prefix_type
+
+    ActiveRecord::Base.primary_key_prefix_type = :table_name_with_underscore
+
+    load "models/country.rb"
+    load "models/treaty.rb"
+    setup_data_for_habtm_case
+
+    country = Country.first
+    assert_equal 1, country.treaties.count
+  ensure
+    ActiveRecord::Base.primary_key_prefix_type = old_primary_key_prefix_type
+  end
+
   def test_join_table_composite_primary_key_should_not_warn
     country = Country.new(name: "India")
     country.country_id = "c1"


### PR DESCRIPTION
### Summary
HABTM join models do not have primary keys by default,
but setting `primary_key_prefix_type` on `ActiveRecord::Base`
will cause all models to expect primary keys to be present.

Overriding the value to `nil` will cause the model to check
the db for its primary key instead.

Resolves https://github.com/rails/rails/issues/28502
