### PR TITLE
Fix broken Modulo operation on Duration objects

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Fix broken Modulo operation on Duration objects
+
+    Before:
+
+        5.minutes % 2.minutes
+        => -18000 minutes and 300 seconds
+
+    Now:
+
+        5.minutes % 2.minutes
+        => 60 seconds
+
+    Fixes #29603 and #29743
+
+    *Sayan Chakraborty*
+
 *   Fix division where a duration is the denominator
 
     PR #29163 introduced a change in behavior when a duration was the denominator

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -114,6 +114,15 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal 1, 1.day / 1.day
   end
 
+  def test_modulo_operation
+    assert_equal 60.seconds, 5.minutes % 2
+    assert_instance_of ActiveSupport::Duration, 5.minutes % 2
+    assert_equal 60.seconds, 5.minutes % 2.minutes
+
+    assert_equal 900.seconds , 1501022700 % 30.minutes
+    assert_instance_of ActiveSupport::Duration, 1501022700 % 30.minutes
+  end
+
   def test_date_added_with_multiplied_duration
     assert_equal Date.civil(2017, 1, 3), Date.civil(2017, 1, 1) + 1.day * 2
   end


### PR DESCRIPTION
Fixes modulo operation on Duration objects and returns the result in seconds. Addresses issue https://github.com/rails/rails/issues/29603
Thanks!