### PR TITLE
Enable query cache if set a configurations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Query cache was unavailable when entering the ActiveRecord::Base.cache block
+    without being connected.
+
+    *Tsukasa Oishi*
+
 *   Previously, when building records using a `has_many :through` association,
     if the child records were deleted before the parent was saved, they would
     still be persisted. Now, if child records are deleted before the parent is saved

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -5,20 +5,20 @@ module ActiveRecord
       # Enable the query cache within the block if Active Record is configured.
       # If it's not, it will execute the given block.
       def cache(&block)
-        if connected?
-          connection.cache(&block)
-        else
+        if configurations.empty?
           yield
+        else
+          connection.cache(&block)
         end
       end
 
       # Disable the query cache within the block if Active Record is configured.
       # If it's not, it will execute the given block.
       def uncached(&block)
-        if connected?
-          connection.uncached(&block)
-        else
+        if configurations.empty?
           yield
+        else
+          connection.uncached(&block)
         end
       end
     end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -321,18 +321,7 @@ class QueryCacheTest < ActiveRecord::TestCase
     end
   end
 
-  def test_cache_is_available_when_connection_is_connected
-    conf = ActiveRecord::Base.configurations
-
-    ActiveRecord::Base.configurations = {}
-    Task.cache do
-      assert_queries(1) { Task.find(1); Task.find(1) }
-    end
-  ensure
-    ActiveRecord::Base.configurations = conf
-  end
-
-  def test_cache_is_not_available_when_using_a_not_connected_connection
+  def test_cache_is_available_when_using_a_not_connected_connection
     with_temporary_connection_pool do
       spec_name = Task.connection_specification_name
       conf = ActiveRecord::Base.configurations["arunit"].merge("name" => "test2")
@@ -349,8 +338,7 @@ class QueryCacheTest < ActiveRecord::TestCase
             end
             ActiveRecord::FixtureSet.create_fixtures(self.class.fixture_path, ["tasks"], {}, ActiveRecord::Base)
           end
-          Task.connection # warmup postgresql connection setup queries
-          assert_queries(2) { Task.find(1); Task.find(1) }
+          assert_queries(1) { Task.find(1); Task.find(1) }
         ensure
           ActiveRecord::Base.connection_handler.remove_connection(Task.connection_specification_name)
           Task.connection_specification_name = spec_name


### PR DESCRIPTION
ActiveRecord query cache is available when a connection is connected.
Therefore, query cache is unavailable when entering the ActiveRecord::Base.cache block without being connected.

```ruby
ActiveRecord::Base.cache do
  Task.find(1) # access to database.
  Task.find(1) # access to database. unavailable query cache
end
```

If we use query cache with batch script etc, we need to connect before that.
```ruby
Task.connection

ActiveRecord::Base.cache do
  Task.find(1) # access to database.
  Task.find(1) # available query cache
end
```

Before version 3.1, query cache had been enabled if a configuration was set up.
In order to solve the `DATABASE_URL` issue(#8074), ActiveRecord has checked whether a connection is connected or not.

Today, ActiveRecord.configurations respects `DATABASE_URL`.
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/core.rb#L46