### PR TITLE
Don't passing `klass.connection` to `AssociationScope`

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -94,7 +94,7 @@ module ActiveRecord
       # actually gets built.
       def association_scope
         if klass
-          @association_scope ||= AssociationScope.scope(self, klass.connection)
+          @association_scope ||= AssociationScope.scope(self)
         end
       end
 

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -1,8 +1,8 @@
 module ActiveRecord
   module Associations
     class AssociationScope #:nodoc:
-      def self.scope(association, connection)
-        INSTANCE.scope(association, connection)
+      def self.scope(association)
+        INSTANCE.scope(association)
       end
 
       def self.create(&block)
@@ -16,12 +16,12 @@ module ActiveRecord
 
       INSTANCE = create
 
-      def scope(association, connection)
+      def scope(association)
         klass = association.klass
         reflection = association.reflection
         scope = klass.unscoped
         owner = association.owner
-        alias_tracker = AliasTracker.create connection, association.klass.table_name
+        alias_tracker = AliasTracker.create(klass.connection, klass.table_name)
         chain_head, chain_tail = get_chain(reflection, association, alias_tracker)
 
         scope.extending! reflection.extensions

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -307,7 +307,7 @@ module ActiveRecord
           sc = reflection.association_scope_cache(conn, owner) do
             StatementCache.create(conn) { |params|
               as = AssociationScope.create { params.bind }
-              target_scope.merge as.scope(self, conn)
+              target_scope.merge!(as.scope(self))
             }
           end
 

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -43,7 +43,7 @@ module ActiveRecord
           sc = reflection.association_scope_cache(conn, owner) do
             StatementCache.create(conn) { |params|
               as = AssociationScope.create { params.bind }
-              target_scope.merge(as.scope(self, conn)).limit(1)
+              target_scope.merge!(as.scope(self)).limit(1)
             }
           end
 

--- a/activerecord/test/cases/associations/association_scope_test.rb
+++ b/activerecord/test/cases/associations/association_scope_test.rb
@@ -6,8 +6,7 @@ module ActiveRecord
   module Associations
     class AssociationScopeTest < ActiveRecord::TestCase
       test "does not duplicate conditions" do
-        scope = AssociationScope.scope(Author.new.association(:welcome_posts),
-                                        Author.connection)
+        scope = AssociationScope.scope(Author.new.association(:welcome_posts))
         binds = scope.where_clause.binds.map(&:value)
         assert_equal binds.uniq, binds
       end


### PR DESCRIPTION
Passing `klass.connection` is redundant because `AssociationScope` is
passed an association itself and an association has `klass`.