### PR TITLE
Use `quote` method rather than single quotes to identifiers in SQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -694,7 +694,7 @@ module ActiveRecord
             auto_increment: column.auto_increment?
           }
 
-          current_type = select_one("SHOW COLUMNS FROM #{quote_table_name(table_name)} LIKE '#{column_name}'", "SCHEMA")["Type"]
+          current_type = select_one("SHOW COLUMNS FROM #{quote_table_name(table_name)} LIKE #{quote(column_name)}", "SCHEMA")["Type"]
           td = create_table_definition(table_name)
           cd = td.new_column_definition(new_column_name, current_type, options)
           schema_creation.accept(ChangeColumnDefinition.new(cd, column.name))

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -47,7 +47,7 @@ module ActiveRecord
           def schema_collation(column)
             if column.collation && table_name = column.table_name
               @table_collation_cache ||= {}
-              @table_collation_cache[table_name] ||= select_one("SHOW TABLE STATUS LIKE '#{table_name}'")["Collation"]
+              @table_collation_cache[table_name] ||= select_one("SHOW TABLE STATUS LIKE #{quote(table_name)}")["Collation"]
               column.collation.inspect if column.collation != @table_collation_cache[table_name]
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -147,6 +147,10 @@ module ActiveRecord
         end
 
         private
+          # Returns the current ID of a table's sequence.
+          def last_insert_id_result(sequence_name)
+            exec_query("SELECT currval(#{quote(sequence_name)})", "SQL")
+          end
 
           def suppress_composite_primary_key(pk)
             pk unless pk.is_a?(Array)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -723,11 +723,6 @@ module ActiveRecord
           end
         end
 
-        # Returns the current ID of a table's sequence.
-        def last_insert_id_result(sequence_name)
-          exec_query("SELECT currval('#{sequence_name}')", "SQL")
-        end
-
         # Returns the list of a table's column names, data types, and default values.
         #
         # The underlying query is roughly:


### PR DESCRIPTION
Because identifiers in SQL could include a single quote.

Related #24950, #26784.