### PR TITLE
Show query cache keys in `test_middleware_caches`

### DIFF
--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -150,7 +150,8 @@ class QueryCacheTest < ActiveRecord::TestCase
     mw = middleware { |env|
       Task.find 1
       Task.find 1
-      assert_equal 1, ActiveRecord::Base.connection.query_cache.length
+      query_cache = ActiveRecord::Base.connection.query_cache
+      assert_equal 1, query_cache.length, query_cache.keys
       [200, {}, nil]
     }
     mw.call({})


### PR DESCRIPTION
`test_middleware_caches` also failed same as #29600.

https://travis-ci.org/rails/rails/jobs/248017174#L487-L489