### PR TITLE
Remove unused `aliased_table_name` in `Association`

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -30,14 +30,6 @@ module ActiveRecord
         reset_scope
       end
 
-      # Returns the name of the table of the associated class:
-      #
-      #   post.comments.aliased_table_name # => "comments"
-      #
-      def aliased_table_name
-        klass.table_name
-      end
-
       # Resets the \loaded flag to +false+ and sets the \target to +nil+.
       def reset
         @loaded = false

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -380,7 +380,6 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
     sponsor.sponsorable = Member.new name: "Bert"
     assert_equal Member, sponsor.association(:sponsorable).send(:klass)
-    assert_equal "members", sponsor.association(:sponsorable).aliased_table_name
   end
 
   def test_with_polymorphic_and_condition


### PR DESCRIPTION
`aliased_table_name` in `Association` was added at a3502c4.
`aliased_table_name` in `JoinDependency` (added at 55854c4) is used, but
it looks like that added one in `Association` is never used from the
beginning.