### PR TITLE
Deprecate delegating to `arel` in `Relation`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate delegating to `arel` in `Relation`.
+
+    *Ryuta Kamizono*
+
 *   Fix eager loading to respect `store_full_sti_class` setting.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -89,6 +89,8 @@ module ActiveRecord
             self.class.delegate_to_scoped_klass(method)
             scoping { @klass.public_send(method, *args, &block) }
           elsif arel.respond_to?(method)
+            ActiveSupport::Deprecation.warn \
+              "Delegating #{method} to arel is deprecated and will be removed in Rails 6.0."
             self.class.delegate method, to: :arel
             arel.public_send(method, *args, &block)
           else

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -21,8 +21,22 @@ module ActiveRecord
     end
   end
 
+  module DeprecatedArelDelegationTests
+    AREL_METHODS = [
+      :with, :orders, :froms, :project, :projections, :taken, :constraints, :exists, :locked, :where_sql,
+      :ast, :source, :join_sources, :to_dot, :bind_values, :create_insert, :create_true, :create_false
+    ]
+
+    def test_deprecate_arel_delegation
+      AREL_METHODS.each do |method|
+        assert_deprecated { target.public_send(method) }
+      end
+    end
+  end
+
   class DelegationAssociationTest < ActiveRecord::TestCase
     include DelegationWhitelistTests
+    include DeprecatedArelDelegationTests
 
     fixtures :posts
 
@@ -33,6 +47,7 @@ module ActiveRecord
 
   class DelegationRelationTest < ActiveRecord::TestCase
     include DelegationWhitelistTests
+    include DeprecatedArelDelegationTests
 
     fixtures :comments
 


### PR DESCRIPTION
Active Record doesn't rely delegating to `arel` in the internal since
425f2ca. The delegation is a lower priority than delegating to `klass`,
so it is pretty unclear which method is delegated to `arel`.

For example, `bind_values` method was removed at b06f64c (a series of
changes https://github.com/rails/rails/compare/79f71d3...b06f64c). But a
relation still could respond to the method because `arel` also have the
same named method (#28976).

Removing the delegation will achieve predictable behavior.