### PR TITLE
Warning http verb method call in SystemTestCase

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -5,6 +5,7 @@ require "action_dispatch/system_testing/driver"
 require "action_dispatch/system_testing/server"
 require "action_dispatch/system_testing/test_helpers/screenshot_helper"
 require "action_dispatch/system_testing/test_helpers/setup_and_teardown"
+require "action_dispatch/system_testing/test_helpers/undef_methods"
 
 module ActionDispatch
   # = System Testing
@@ -88,6 +89,7 @@ module ActionDispatch
     include Capybara::Minitest::Assertions
     include SystemTesting::TestHelpers::SetupAndTeardown
     include SystemTesting::TestHelpers::ScreenshotHelper
+    include SystemTesting::TestHelpers::UndefMethods
 
     def initialize(*) # :nodoc:
       super

--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/undef_methods.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/undef_methods.rb
@@ -1,0 +1,24 @@
+module ActionDispatch
+  module SystemTesting
+    module TestHelpers
+      module UndefMethods # :nodoc:
+        extend ActiveSupport::Concern
+        included do
+          METHODS = %i(get post put patch delete).freeze
+
+          METHODS.each do |verb|
+            undef_method verb
+          end
+
+          def method_missing(method, *args, &block)
+            if METHODS.include?(method)
+              raise NoMethodError
+            else
+              super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/actionpack/test/dispatch/system_testing/system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/system_test_case_test.rb
@@ -31,3 +31,35 @@ class SetHostTest < DrivenByRackTest
     assert_equal "http://example.com", Capybara.app_host
   end
 end
+
+class UndefMethodsTest < DrivenBySeleniumWithChrome
+  test "get" do
+    assert_raise NoMethodError do
+      get "http://example.com"
+    end
+  end
+
+  test "post" do
+    assert_raise NoMethodError do
+      post "http://example.com"
+    end
+  end
+
+  test "put" do
+    assert_raise NoMethodError do
+      put "http://example.com"
+    end
+  end
+
+  test "patch" do
+    assert_raise NoMethodError do
+      patch "http://example.com"
+    end
+  end
+
+  test "delete" do
+    assert_raise NoMethodError do
+      delete "http://example.com"
+    end
+  end
+end


### PR DESCRIPTION
### Summary

It show warnings if anyone use http verb method in SystemTestCase.
SystemTestCase should use visit or any other Capybara API.
It is useful to show warnings.
