### PR TITLE
Should use the same connection in using query cache

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -108,6 +108,7 @@ module ActiveRecord
                   "sql.active_record",
                   sql: sql,
                   binds: binds,
+                  type_casted_binds: -> { type_casted_binds(binds) },
                   name: name,
                   connection_id: object_id,
                   cached: true,

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -29,7 +29,7 @@ module ActiveRecord
       binds = nil
 
       unless (payload[:binds] || []).empty?
-        casted_params = type_casted_binds(payload[:binds], payload[:type_casted_binds])
+        casted_params = type_casted_binds(payload[:type_casted_binds])
         binds = "  " + payload[:binds].zip(casted_params).map { |attr, value|
           render_bind(attr, value)
         }.inspect
@@ -42,9 +42,8 @@ module ActiveRecord
     end
 
     private
-
-      def type_casted_binds(binds, casted_binds)
-        casted_binds || ActiveRecord::Base.connection.type_casted_binds(binds)
+      def type_casted_binds(casted_binds)
+        casted_binds.respond_to?(:call) ? casted_binds.call : casted_binds
       end
 
       def render_bind(attr, value)

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -323,6 +323,7 @@ class QueryCacheTest < ActiveRecord::TestCase
   end
 
   def test_cache_is_available_when_using_a_not_connected_connection
+    skip "In-Memory DB can't test for using a not connected connection" if in_memory_db?
     with_temporary_connection_pool do
       spec_name = Task.connection_specification_name
       conf = ActiveRecord::Base.configurations["arunit"].merge("name" => "test2")
@@ -332,13 +333,6 @@ class QueryCacheTest < ActiveRecord::TestCase
 
       Task.cache do
         begin
-          if in_memory_db?
-            Task.connection.create_table :tasks do |t|
-              t.datetime :starting
-              t.datetime :ending
-            end
-            ActiveRecord::FixtureSet.create_fixtures(self.class.fixture_path, ["tasks"], {}, ActiveRecord::Base)
-          end
           assert_queries(1) { Task.find(1); Task.find(1) }
         ensure
           ActiveRecord::Base.connection_handler.remove_connection(Task.connection_specification_name)


### PR DESCRIPTION
`test_cache_is_available_when_using_a_not_connected_connection` is
always failed if running only the test since #29609.

```
% ARCONN=mysql2 be ruby -w -Itest test/cases/query_cache_test.rb -n test_cache_is_available_when_using_a_not_connected_connection
Using mysql2
Run options: -n test_cache_is_available_when_using_a_not_connected_connection --seed 15043

F

Finished in 0.070519s, 14.1806 runs/s, 28.3612 assertions/s.

  1) Failure:
QueryCacheTest#test_cache_is_available_when_using_a_not_connected_connection [test/cases/query_cache_test.rb:336]:
2 instead of 1 queries were executed.
Queries:
SELECT  `tasks`.* FROM `tasks` WHERE `tasks`.`id` = ? LIMIT ?
SET NAMES utf8 COLLATE utf8_unicode_ci,  @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO'),  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483.
Expected: 1
  Actual: 2

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

This failure is due to `LogSubscriber` will use not connected
`ActiveRecord::Base.connection` even if `Task.connection` is connected.
I fixed to always pass `type_casted_binds` to log subscriber to avoid
the issue.