### PR TITLE
Revert "Maintain original encoding from path"

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -13,13 +13,11 @@ module ActionDispatch
         #   normalize_path("")      # => "/"
         #   normalize_path("/%ab")  # => "/%AB"
         def self.normalize_path(path)
-          encoding = path.encoding
           path = "/#{path}"
           path.squeeze!("/".freeze)
           path.sub!(%r{/+\Z}, "".freeze)
           path.gsub!(/(%[a-f0-9]{2})/) { $1.upcase }
           path = "/" if path == "".freeze
-          path.force_encoding(encoding)
           path
         end
 

--- a/actionpack/test/journey/router/utils_test.rb
+++ b/actionpack/test/journey/router/utils_test.rb
@@ -31,11 +31,6 @@ module ActionDispatch
         def test_normalize_path_uppercase
           assert_equal "/foo%AAbar%AAbaz", Utils.normalize_path("/foo%aabar%aabaz")
         end
-
-        def test_normalize_path_maintains_string_encoding
-          path = "/foo%AAbar%AAbaz".b
-          assert_equal Encoding::ASCII_8BIT, Utils.normalize_path(path).encoding
-        end
       end
     end
   end


### PR DESCRIPTION
Reverts rails/rails#29062

The following example raises `Encoding::CompatibilityError` and my app is broken by upgrading rails ~~from 5.1.1 to 5.1.2~~ from 4.2.8 to 4.2.9.

```ruby
class UsersController < ApplicationController
  def show
    render plain: "名前: #{params[:id]}"
  end
end
```

```bash
$ curl -i -X GET http://localhost:3000/users/%E5%A4%AA%E9%83%8E
HTTP/1.1 500 Internal Server Error
Content-Type: text/plain; charset=utf-8
X-Request-Id: 2127d075-cce6-4e31-b8dd-6cdb8d3676ad
X-Runtime: 0.008499
Transfer-Encoding: chunked

Encoding::CompatibilityError at /users/%E5%A4%AA%E9%83%8E
=========================================================

> incompatible character encodings: UTF-8 and ASCII-8BIT

app/controllers/users_controller.rb, line 3
-------------------------------------------

\``` ruby
    1   class UsersController < ApplicationController
    2     def show
>   3       render plain: "名前: #{params[:id]}"
    4     end
    5   end
\```

...

```

Or should we `force_encoding` it to `utf-8`?

```diff
 class UsersController < ApplicationController
   def show
-    render plain: "名前: #{params[:id]}"
+    render plain: "名前: #{params[:id].force_encoding("utf-8")}"
   end
 end
```

rails ~5.1.1~ 4.2.8:

```ruby
params[:id] # => "東京"
```

rails ~5.1.2~ 4.2.9:

```ruby
params[:id] # => "\xE6\x9D\xB1\xE4\xBA\xAC"
```