### PR TITLE
Fallback Parameters#to_s to Hash#to_s

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -180,6 +180,13 @@ module ActionController
     # Returns a new array of the keys of the parameters.
 
     ##
+    # :method: to_s
+    #
+    # :call-seq:
+    #   to_s()
+    # Returns the content of the parameters as a string.
+
+    ##
     # :method: value?
     #
     # :call-seq:
@@ -195,7 +202,7 @@ module ActionController
     #
     # Returns a new array of the values of the parameters.
     delegate :keys, :key?, :has_key?, :values, :has_value?, :value?, :empty?, :include?,
-      :as_json, to: :@parameters
+      :as_json, :to_s, to: :@parameters
 
     # By default, never raise an UnpermittedParameters exception if these
     # params are present. The default includes both 'controller' and 'action'

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -35,6 +35,11 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert @params.as_json.key? "person"
   end
 
+  test "to_s returns the string representation of the parameters hash" do
+    assert_equal '{"person"=>{"age"=>"32", "name"=>{"first"=>"David", "last"=>"Heinemeier Hansson"}, ' \
+      '"addresses"=>[{"city"=>"Chicago", "state"=>"Illinois"}]}}', @params.to_s
+  end
+
   test "each carries permitted status" do
     @params.permit!
     @params.each { |key, value| assert(value.permitted?) if key == "person" }

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -345,6 +345,12 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal expected, actual
   end
 
+  def test_text_field_tag_with_ac_parameters
+    actual = text_field_tag "title", ActionController::Parameters.new(key: "value")
+    expected = %(<input id="title" name="title" type="text" value="{&quot;key&quot;=&gt;&quot;value&quot;}" />)
+    assert_dom_equal expected, actual
+  end
+
   def test_text_field_tag_size_string
     actual = text_field_tag "title", "Hello!", "size" => "75"
     expected = %(<input id="title" name="title" size="75" type="text" value="Hello!" />)


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/29617

```
text_field_tag(:test, ActionController::Parameters.new(foo: 'bar'))
=> "<input type=\"text\" name=\"test\" id=\"test\" value=\"#&lt;ActionController::Parameters:0x007fe2bbee53e0&gt;\" />"
```

The result would be exposing Ruby internals and the object ID to the website visitors:

<img width="959" alt="screen shot 2017-06-29 at 20 27 04" src="https://user-images.githubusercontent.com/522155/27701381-6144400c-5d09-11e7-9b5b-697e6228d9b3.png">

As mentioned in the issue, instead of that we should fall back to `Hash#to_s`.

I agree with Rafael's opinion that normally developers shouldn't rely on `Parameters` having a Hash-like behaviour, but at the same time I agree that the framework shouldn't expose Ruby internals to output HTML. I think that returning **escaped** `to_s` of unpermitted Hash is be better anyway.

@rafaelfranca @JasonBarnabe 