### PR TITLE
Should be clear `@association_ids` when joined newly associated record

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -66,6 +66,7 @@ module ActiveRecord
       def reset
         super
         @target = []
+        @association_ids = nil
       end
 
       def find(*args)
@@ -355,7 +356,10 @@ module ActiveRecord
             transaction do
               add_to_target(build_record(attributes)) do |record|
                 yield(record) if block_given?
-                insert_record(record, true, raise) { @_was_loaded = loaded? }
+                insert_record(record, true, raise) {
+                  @_was_loaded = loaded?
+                  @association_ids = nil
+                }
               end
             end
           end
@@ -428,7 +432,12 @@ module ActiveRecord
           records.each do |record|
             raise_on_type_mismatch!(record)
             add_to_target(record) do
-              result &&= insert_record(record, true, raise) { @_was_loaded = loaded? } unless owner.new_record?
+              unless owner.new_record?
+                result &&= insert_record(record, true, raise) {
+                  @_was_loaded = loaded?
+                  @association_ids = nil
+                }
+              end
             end
           end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2544,6 +2544,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal [bulb.id], car.bulb_ids
     assert_no_queries { car.bulb_ids }
+
+    bulb2 = car.bulbs.create!
+
+    assert_equal [bulb.id, bulb2.id], car.bulb_ids
+    assert_no_queries { car.bulb_ids }
   end
 
   def test_loading_association_in_validate_callback_doesnt_affect_persistence


### PR DESCRIPTION
Fixes #29627.