### PR TITLE
Delete stale comment for `AR::Associations::Builder::CollectionAssociation` [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -1,5 +1,3 @@
-# This class is inherited by the has_many and has_many_and_belongs_to_many association classes
-
 require "active_record/associations"
 
 module ActiveRecord::Associations::Builder # :nodoc:


### PR DESCRIPTION
`has_and_belongs_to_many` for a long time already not inheriting from `CollectionAssociation`, so this comment only true for `has_many` and therefore seems not useful at all.