### PR TITLE
Do not generate unused components contents in `app:update` task

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Skip unused components when running `bin/rails app:update`.
+
+    If the initial app generation skipped Action Cable, Active Record etc.,
+    the update task honors those skips too.
+
+    *Yuji Yaginuma*
+
 *   Make Rails' test runner work better with minitest plugins.
 
     By demoting the Rails test runner to just another minitest plugin —

--- a/railties/lib/rails/app_updater.rb
+++ b/railties/lib/rails/app_updater.rb
@@ -1,0 +1,31 @@
+require "rails/generators"
+require "rails/generators/rails/app/app_generator"
+
+module Rails
+  class AppUpdater # :nodoc:
+    class << self
+      def invoke_from_app_generator(method)
+        app_generator.send(method)
+      end
+
+      def app_generator
+        @app_generator ||= begin
+          gen = Rails::Generators::AppGenerator.new ["rails"], generator_options, destination_root: Rails.root
+          File.exist?(Rails.root.join("config", "application.rb")) ? gen.send(:app_const) : gen.send(:valid_const?)
+          gen
+        end
+      end
+
+      private
+        def generator_options
+          options = { api: !!Rails.application.config.api_only, update: true }
+          options[:skip_active_record] = !defined?(ActiveRecord::Railtie)
+          options[:skip_action_mailer] = !defined?(ActionMailer::Railtie)
+          options[:skip_action_cable]  = !defined?(ActionCable::Engine)
+          options[:skip_sprockets]     = !defined?(Sprockets::Railtie)
+          options[:skip_puma]          = !defined?(Puma)
+          options
+        end
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -128,7 +128,7 @@ module Rails
         gsub_file "config/initializers/cookies_serializer.rb", /json(?!,)/, "marshal"
       end
 
-      unless action_cable_config_exist
+      if !options[:skip_action_cable] && !action_cable_config_exist
         template "config/cable.yml"
       end
 

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -36,38 +36,21 @@ namespace :app do
   end
 
   namespace :update do
-    class RailsUpdate
-      def self.invoke_from_app_generator(method)
-        app_generator.send(method)
-      end
-
-      def self.app_generator
-        @app_generator ||= begin
-          require_relative "../generators"
-          require_relative "../generators/rails/app/app_generator"
-          gen = Rails::Generators::AppGenerator.new ["rails"],
-                                                    { api: !!Rails.application.config.api_only, update: true },
-                                                    destination_root: Rails.root
-          File.exist?(Rails.root.join("config", "application.rb")) ?
-            gen.send(:app_const) : gen.send(:valid_const?)
-          gen
-        end
-      end
-    end
+    require_relative "../app_updater"
 
     # desc "Update config/boot.rb from your current rails install"
     task :configs do
-      RailsUpdate.invoke_from_app_generator :create_boot_file
-      RailsUpdate.invoke_from_app_generator :update_config_files
+      Rails::AppUpdater.invoke_from_app_generator :create_boot_file
+      Rails::AppUpdater.invoke_from_app_generator :update_config_files
     end
 
     # desc "Adds new executables to the application bin/ directory"
     task :bin do
-      RailsUpdate.invoke_from_app_generator :update_bin_files
+      Rails::AppUpdater.invoke_from_app_generator :update_bin_files
     end
 
     task :upgrade_guide_info do
-      RailsUpdate.invoke_from_app_generator :display_upgrade_guide_info
+      Rails::AppUpdater.invoke_from_app_generator :display_upgrade_guide_info
     end
   end
 end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -278,6 +278,22 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_app_update_does_not_generate_action_cable_contents_when_skip_action_cable_is_given
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root, "--skip-action-cable"]
+
+    FileUtils.cd(app_root) do
+      # For avoid conflict file
+      FileUtils.rm("#{app_root}/config/secrets.yml")
+      quietly { system("bin/rails app:update") }
+    end
+
+    assert_no_file "#{app_root}/config/cable.yml"
+    assert_file "#{app_root}/config/environments/production.rb" do |content|
+      assert_no_match(/config\.action_cable/, content)
+    end
+  end
+
   def test_application_names_are_not_singularized
     run_generator [File.join(destination_root, "hats")]
     assert_file "hats/config/environment.rb", /Rails\.application\.initialize!/


### PR DESCRIPTION
Currently, `app:update` generates all contents regardless of the component using in application.

For example, even if not using Action Cable, `app:update` will generate a contents related to Action Cable. This is a little inconvenient.
This PR checks the existence of the component and does not generate unnecessary contents.
Can not check all options in this way. However, it will be able to prevent the generation of unnecessary files.
