### PR TITLE
Fix format of `ActionController::Parameters#to_s` doc [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -184,6 +184,7 @@ module ActionController
     #
     # :call-seq:
     #   to_s()
+    #
     # Returns the content of the parameters as a string.
 
     ##


### PR DESCRIPTION
**before**

![before](https://user-images.githubusercontent.com/987638/27757894-3676f1a4-5e43-11e7-890f-8a83d5f0115f.png)

**after**

![after](https://user-images.githubusercontent.com/987638/27757896-42076148-5e43-11e7-8fdd-27e2dc89ffcb.png)
