### PR TITLE
Add source code and changelog link to railties.gemspec

### DIFF
--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -23,6 +23,11 @@ Gem::Specification.new do |s|
 
   s.rdoc_options << "--exclude" << "."
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/railties",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/railties/CHANGELOG.md"
+  }
+
   s.add_dependency "activesupport", version
   s.add_dependency "actionpack",    version
 


### PR DESCRIPTION
Follow up of #29588.

Railties is also a gem with CHANGELOG.md. I think that it would be unified if there was a metadata link the above address.
