### PR TITLE
Return correct date in ActiveModel for time to date conversions

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,6 +1,21 @@
 ## Rails 5.2.0.beta2 (November 28, 2017) ##
 
-*   No changes.
+*  Return correct date while converting parameters in `value_from_multiparameter_assignment`
+    for `ActiveModel::Type::Date`
+
+    Before:
+
+        Day.new({"day(1i)"=>"1", "day(2i)"=>"1", "day(3i)"=>"1"})
+        => #<Day id: nil, day: "0001-01-03", created_at: nil, updated_at: nil>
+
+    After:
+
+        Day.new({"day(1i)"=>"1", "day(2i)"=>"1", "day(3i)"=>"1"})
+        => #<Day id: nil, day: "0001-01-01", created_at: nil, updated_at: nil>
+
+    Fixes #28521
+
+    *Sayan Chakraborty*
 
 
 ## Rails 5.2.0.beta1 (November 27, 2017) ##

--- a/activemodel/lib/active_model/type/date.rb
+++ b/activemodel/lib/active_model/type/date.rb
@@ -17,6 +17,18 @@ module ActiveModel
         value.to_s(:db).inspect
       end
 
+      def is_utc?
+        ::Time.zone_default.nil? || ::Time.zone_default =~ "UTC"
+      end
+
+      def default_timezone
+        if is_utc?
+          :utc
+        else
+          :local
+        end
+      end
+
       private
 
         def cast_value(value)
@@ -49,7 +61,7 @@ module ActiveModel
 
         def value_from_multiparameter_assignment(*)
           time = super
-          time && time.to_date
+          time && new_date(time.year, time.mon, time.mday)
         end
     end
   end

--- a/activemodel/test/cases/type/date_test.rb
+++ b/activemodel/test/cases/type/date_test.rb
@@ -15,6 +15,17 @@ module ActiveModel
         date_string = ::Time.now.utc.strftime("%F")
         assert_equal date_string, type.cast(date_string).strftime("%F")
       end
+
+      def test_returns_correct_year
+        type = Type::Date.new
+
+        time = ::Time.utc(1, 1, 1)
+        date = ::Date.new(time.year, time.mon, time.mday)
+
+        values_hash_for_multiparameter_assignment = { 1 => 1, 2 => 1, 3 => 1 }
+
+        assert_equal date, type.cast(values_hash_for_multiparameter_assignment)
+      end
     end
   end
 end


### PR DESCRIPTION
time.to_date conversion happens considering leap years in Ruby.
So a conversion of  Day.new({"day(1i)"=>"1", "day(2i)"=>"1", "day(3i)"=>"1"}) or 0001-01-01 00:00:00 UTC results in saving the date in DB as Mon, 03 Jan 0001.
Which might seem weird on the user level, hence falling back to parsing on string level resolves this data mismatch respecting the parameters passed
Fixes #28521