### PR TITLE
Fix removed version 5.2 to 6.0 in the deprecation message

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -33,7 +33,7 @@ module ActiveRecord
       def set_state(state)
         ActiveSupport::Deprecation.warn(<<-MSG.squish)
           The set_state method is deprecated and will be removed in
-          Rails 5.2. Please use rollback! or commit! to set transaction
+          Rails 6.0. Please use rollback! or commit! to set transaction
           state directly.
         MSG
         case state


### PR DESCRIPTION
Because the deprecation message is not yet released.