### PR TITLE
Prepare AP and AR to be frozen string friendly

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "stringio"
 
 require "active_support/inflector"

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/core_ext/module/attribute_accessors"
 
 module ActionDispatch
@@ -155,7 +156,7 @@ module ActionDispatch
           subdomain  = options.fetch :subdomain, true
           domain     = options[:domain]
 
-          host = ""
+          host = "".dup
           if subdomain == true
             return _host if domain.nil?
 

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "action_controller/metal/exceptions"
 
 module ActionDispatch
@@ -48,7 +49,7 @@ module ActionDispatch
         unmatched_keys = (missing_keys || []) & constraints.keys
         missing_keys = (missing_keys || []) - unmatched_keys
 
-        message = "No route matches #{Hash[constraints.sort_by { |k, v| k.to_s }].inspect}"
+        message = "No route matches #{Hash[constraints.sort_by { |k, v| k.to_s }].inspect}".dup
         message << ", missing required keys: #{missing_keys.sort.inspect}" if missing_keys && !missing_keys.empty?
         message << ", possible unmatched constraints: #{unmatched_keys.sort.inspect}" if unmatched_keys && !unmatched_keys.empty?
 

--- a/actionpack/lib/action_dispatch/journey/visitors.rb
+++ b/actionpack/lib/action_dispatch/journey/visitors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActionDispatch
   # :stopdoc:
   module Journey
@@ -175,7 +176,7 @@ module ActionDispatch
             last_child = node.children.last
             node.children.inject(seed) { |s, c|
               string = visit(c, s)
-              string << "|".freeze unless last_child == c
+              string << "|" unless last_child == c
               string
             }
           end
@@ -185,7 +186,7 @@ module ActionDispatch
           end
 
           def visit_GROUP(node, seed)
-            visit(node.left, seed << "(".freeze) << ")".freeze
+            visit(node.left, seed.dup << "(") << ")"
           end
 
           INSTANCE = new

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../http/request"
 require_relative "exception_wrapper"
 require_relative "../routing/inspector"
@@ -21,7 +22,7 @@ module ActionDispatch
         if clean_params.empty?
           "None"
         else
-          PP.pp(clean_params, "", 200)
+          PP.pp(clean_params, "".dup, 200)
         end
       end
 

--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActionDispatch
   # This middleware is added to the stack when `config.force_ssl = true`, and is passed
   # the options set in `config.ssl_options`. It does three jobs to enforce secure HTTP
@@ -94,7 +95,7 @@ module ActionDispatch
 
       # http://tools.ietf.org/html/rfc6797#section-6.1
       def build_hsts_header(hsts)
-        value = "max-age=#{hsts[:expires].to_i}"
+        value = "max-age=#{hsts[:expires].to_i}".dup
         value << "; includeSubDomains" if hsts[:subdomains]
         value << "; preload" if hsts[:preload]
         value
@@ -133,7 +134,7 @@ module ActionDispatch
         host = @redirect[:host] || request.host
         port = @redirect[:port] || request.port
 
-        location = "https://#{host}"
+        location = "https://#{host}".dup
         location << ":#{port}" if port != 80 && port != 443
         location << request.fullpath
         location

--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rack/utils"
 require "active_support/core_ext/uri"
 
@@ -33,7 +34,7 @@ module ActionDispatch
       paths = [path, "#{path}#{ext}", "#{path}/#{@index}#{ext}"]
 
       if match = paths.detect { |p|
-        path = File.join(@root, p.force_encoding(Encoding::UTF_8))
+        path = File.join(@root, p.dup.force_encoding(Encoding::UTF_8))
         begin
           File.file?(path) && File.readable?(path)
         rescue SystemCallError

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/core_ext/hash/slice"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/array/extract_options"
@@ -306,7 +307,7 @@ module ActionDispatch
           def check_controller_and_action(path_params, controller, action)
             hash = check_part(:controller, controller, path_params, {}) do |part|
               translate_controller(part) {
-                message = "'#{part}' is not a supported controller name. This can lead to potential routing problems."
+                message = "'#{part}' is not a supported controller name. This can lead to potential routing problems.".dup
                 message << " See http://guides.rubyonrails.org/routing.html#specifying-a-controller-to-use"
 
                 raise ArgumentError, message

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../journey"
 require "active_support/core_ext/object/to_query"
 require "active_support/core_ext/hash/slice"
@@ -233,7 +234,7 @@ module ActionDispatch
                   missing_keys << missing_key
                 }
                 constraints = Hash[@route.requirements.merge(params).sort_by { |k, v| k.to_s }]
-                message = "No route matches #{constraints.inspect}"
+                message = "No route matches #{constraints.inspect}".dup
                 message << ", missing required keys: #{missing_keys.sort.inspect}"
 
                 raise ActionController::UrlGenerationError, message

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $:.unshift File.expand_path("lib", __dir__)
 $:.unshift File.expand_path("fixtures/helpers", __dir__)
 $:.unshift File.expand_path("fixtures/alternate_helpers", __dir__)
@@ -175,7 +176,7 @@ end
 class Rack::TestCase < ActionDispatch::IntegrationTest
   def self.testing(klass = nil)
     if klass
-      @testing = "/#{klass.name.underscore}".sub!(/_controller$/, "")
+      @testing = "/#{klass.name.underscore}".sub(/_controller$/, "")
     else
       @testing
     end

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "controller/fake_controllers"
 require "active_support/core_ext/object/with_options"
@@ -656,7 +657,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     assert_equal "/page/foo", url_for(rs, controller: "content", action: "show_page", id: "foo")
     assert_equal({ controller: "content", action: "show_page", id: "foo" }, rs.recognize_path("/page/foo"))
 
-    token = "\321\202\320\265\320\272\321\201\321\202" # 'text' in Russian
+    token = "\321\202\320\265\320\272\321\201\321\202".dup # 'text' in Russian
     token.force_encoding(Encoding::BINARY)
     escaped_token = CGI::escape(token)
 

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 class DebugExceptionsTest < ActionDispatch::IntegrationTest
@@ -344,7 +345,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     })
     assert_response 500
 
-    assert_includes(body, CGI.escapeHTML(PP.pp(params, "", 200)))
+    assert_includes(body, CGI.escapeHTML(PP.pp(params, "".dup, 200)))
   end
 
   test "sets the HTTP charset parameter" do

--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "rack/test"
 require "rails/engine"
@@ -11,7 +12,7 @@ module TestGenerationPrefix
     end
 
     def self.model_name
-      klass = "Post"
+      klass = "Post".dup
       def klass.name; self end
 
       ActiveModel::Name.new(klass)

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "zlib"
 
@@ -29,7 +30,7 @@ module StaticTests
   end
 
   def test_handles_urls_with_ascii_8bit
-    assert_equal "Hello, World!", get("/doorkeeper%E3E4".force_encoding("ASCII-8BIT")).body
+    assert_equal "Hello, World!", get("/doorkeeper%E3E4".dup.force_encoding("ASCII-8BIT")).body
   end
 
   def test_handles_urls_with_ascii_8bit_on_win_31j
@@ -37,7 +38,7 @@ module StaticTests
       Encoding.default_internal = "Windows-31J"
       Encoding.default_external = "Windows-31J"
     end
-    assert_equal "Hello, World!", get("/doorkeeper%E3E4".force_encoding("ASCII-8BIT")).body
+    assert_equal "Hello, World!", get("/doorkeeper%E3E4".dup.force_encoding("ASCII-8BIT")).body
   end
 
   def test_handles_urls_with_null_byte

--- a/actionpack/test/journey/router/utils_test.rb
+++ b/actionpack/test/journey/router/utils_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 module ActionDispatch
@@ -21,7 +22,7 @@ module ActionDispatch
         end
 
         def test_uri_unescape_with_utf8_string
-          assert_equal "Šašinková", Utils.unescape_uri("%C5%A0a%C5%A1inkov%C3%A1".force_encoding(Encoding::US_ASCII))
+          assert_equal "Šašinková", Utils.unescape_uri("%C5%A0a%C5%A1inkov%C3%A1".dup.force_encoding(Encoding::US_ASCII))
         end
 
         def test_normalize_path_not_greedy

--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/log_subscriber"
 
 module ActionView
@@ -83,7 +84,7 @@ module ActionView
 
     def log_rendering_start(payload)
       info do
-        message = "  Rendering #{from_rails_root(payload[:identifier])}"
+        message = "  Rendering #{from_rails_root(payload[:identifier])}".dup
         message << " within #{from_rails_root(payload[:layout])}" if payload[:layout]
         message
       end

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/kernel/singleton_class"
 require "thread"

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/money.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/money.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
@@ -22,7 +23,7 @@ module ActiveRecord
             #  (3) -$2.55
             #  (4) ($2.55)
 
-            value.sub!(/^\((.+)\)$/, '-\1') # (4)
+            value = value.sub(/^\((.+)\)$/, '-\1') # (4)
             case value
             when /^-?\D+[\d,]+\.\d{2}$/  # (1)
               value.gsub!(/[^-\d.]/, "")


### PR DESCRIPTION
This PR makes ActionPack and ActiveRecord frozen string -friendly.
Shipping it should unblock us to move towards enforcing frozen-string-literal across all Rails components.

@matthewd 

ref https://github.com/rails/rails/pull/29540
ref https://github.com/rails/rails/pull/29506