### PR TITLE
Merge through reflection scope properly

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -144,8 +144,8 @@ module ActiveRecord
             reflection.constraints.each do |scope_chain_item|
               item = eval_scope(reflection, table, scope_chain_item, owner)
 
-              if scope_chain_item == refl.scope
-                scope.merge! item.except(:where, :includes)
+              if reflection.class_name == refl.class_name
+                scope.merge! item.except(:where, :includes, :unscope, :order)
               end
 
               reflection.all_includes do

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1066,6 +1066,10 @@ module ActiveRecord
         end
       end
 
+      def class_name
+        @reflection.class_name
+      end
+
       def klass
         @reflection.klass
       end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1193,9 +1193,6 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_with_scope_that_should_not_be_fully_merged
-    Club.has_many :distinct_memberships, -> { distinct }, class_name: "Membership"
-    Club.has_many :special_favourites, through: :distinct_memberships, source: :member
-
     assert_nil Club.new.special_favourites.distinct_value
   end
 

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -33,6 +33,10 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal clubs(:boring_club), @member.club
   end
 
+  def test_has_one_through_with_through_scope
+    assert_equal clubs(:boring_club), @member.general_club
+  end
+
   def test_creating_association_creates_through_record
     new_member = Member.create(name: "Chris")
     new_member.club = Club.create(name: "LRUG")

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -8,6 +8,9 @@ class Club < ActiveRecord::Base
 
   has_many :favourites, -> { where(memberships: { favourite: true }) }, through: :memberships, source: :member
 
+  has_many :distinct_memberships, -> { distinct }, class_name: "Membership"
+  has_many :special_favourites, through: :distinct_memberships, source: :member
+
   scope :general, -> { left_joins(:category).where(categories: { name: "General" }) }
 
   private


### PR DESCRIPTION
If through reflection has the same target class with root reflection,
the through scope should be mereged without dropping any conditions.