### PR TITLE
Add listen as dependency

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_dependency "tzinfo",     "~> 1.1"
   s.add_dependency "minitest",   "~> 5.1"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
+  s.add_dependency "listen",     "~> 3.1"
 end


### PR DESCRIPTION
Used by ActiveSupport::EventedFileUpdateChecker

Which is enabled by default in rails, e.g. in `config/environments/development.rb`:

config.file_watcher = ActiveSupport::EventedFileUpdateChecker

### Summary

I removed the `listen` gem from my Gemfile and got an error from ActiveSupport.