### PR TITLE
Allow mounting same engine under several locations

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -449,7 +449,7 @@ module ActionDispatch
         MountedHelpers
       end
 
-      def define_mounted_helper(name)
+      def define_mounted_helper(name, script_namer = nil)
         return if MountedHelpers.method_defined?(name)
 
         routes = self
@@ -457,7 +457,7 @@ module ActionDispatch
 
         MountedHelpers.class_eval do
           define_method "_#{name}" do
-            RoutesProxy.new(routes, _routes_context, helpers)
+            RoutesProxy.new(routes, _routes_context, helpers, script_namer)
           end
         end
 

--- a/actionpack/lib/action_dispatch/routing/routes_proxy.rb
+++ b/actionpack/lib/action_dispatch/routing/routes_proxy.rb
@@ -8,9 +8,10 @@ module ActionDispatch
       attr_accessor :scope, :routes
       alias :_routes :routes
 
-      def initialize(routes, scope, helpers)
+      def initialize(routes, scope, helpers, script_namer = nil)
         @routes, @scope = routes, scope
         @helpers = helpers
+        @script_namer = script_namer
       end
 
       def url_options
@@ -29,7 +30,9 @@ module ActionDispatch
           self.class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{method}(*args)
               options = args.extract_options!
-              args << url_options.merge((options || {}).symbolize_keys)
+              options = url_options.merge((options || {}).symbolize_keys)
+              options.reverse_merge!(script_name: @script_namer.call(options)) if @script_namer
+              args << options
               @helpers.#{method}(*args)
             end
           RUBY

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow mounting the same engine several times in different locations.
+
+    Fixes #20204.
+
+    *David Rodríguez*
+
 *   Clear screenshot files in `tmp:clear` task.
 
     *Yuji Yaginuma*


### PR DESCRIPTION
### Summary

Fixes #20204.

This allows mounting the same engine under different locations (using different `as:` aliases).

Mounting an engine provides "route context resolution" via customized `find_script_name` method, but when mounting the same engine several times, this definition would be overwritten and only the last `mount` would get the correct context resolution.

The solution I came up with was to move (via `lambda`) the customized `find_script_name` logic for each mounted engine together with the `define_mounted_helper` method, which is also specific to each `mount`.

### Other information

First time diving into Rails internals, hopefully I'm not doing something terribly bad here...