### PR TITLE
Emulate JSON types for SQLite3 adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -204,6 +204,7 @@ module ActiveRecord
         :decimal,
         :float,
         :integer,
+        :json,
         :string,
         :text,
         :time,

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -32,10 +32,6 @@ module ActiveRecord
           args.each { |name| column(name, :longtext, options) }
         end
 
-        def json(*args, **options)
-          args.each { |name| column(name, :json, options) }
-        end
-
         def unsigned_integer(*args, **options)
           args.each { |name| column(name, :unsigned_integer, options) }
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -95,10 +95,6 @@ module ActiveRecord
           args.each { |name| column(name, :int8range, options) }
         end
 
-        def json(*args, **options)
-          args.each { |name| column(name, :json, options) }
-        end
-
         def jsonb(*args, **options)
           args.each { |name| column(name, :jsonb, options) }
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -70,7 +70,8 @@ module ActiveRecord
         time:         { name: "time" },
         date:         { name: "date" },
         binary:       { name: "blob" },
-        boolean:      { name: "boolean" }
+        boolean:      { name: "boolean" },
+        json:         { name: "json" },
       }
 
       ##
@@ -132,6 +133,10 @@ module ActiveRecord
       end
 
       def supports_datetime_with_precision?
+        true
+      end
+
+      def supports_json?
         true
       end
 

--- a/activerecord/test/cases/adapters/sqlite3/json_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/json_test.rb
@@ -9,8 +9,8 @@ class SQLite3JSONTest < ActiveRecord::SQLite3TestCase
   def setup
     super
     @connection.create_table("json_data_type") do |t|
-      t.column "payload", :json, default: {}
-      t.column "settings", :json
+      t.json "payload", default: {}
+      t.json "settings"
     end
   end
 

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -30,7 +30,6 @@ module JSONSharedTestCases
   end
 
   def test_change_table_supports_json
-    skip unless @connection.supports_json?
     @connection.change_table("json_data_type") do |t|
       t.public_send column_type, "users"
     end
@@ -41,7 +40,6 @@ module JSONSharedTestCases
   end
 
   def test_schema_dumping
-    skip unless @connection.supports_json?
     output = dump_table_schema("json_data_type")
     assert_match(/t\.#{column_type}\s+"settings"/, output)
   end


### PR DESCRIPTION
Actually SQLite3 doesn't have JSON storage class (so it is stored as a
TEXT like Date and Time). But emulating JSON types is convinient for
making database agnostic migrations.