### PR TITLE
Do not apply scope to middle model in through association preload

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Stop applying parts of the association scope into the through model when
+    preloading through associations
+
+    Previously, `has_many :blue_tags, ->{ where(name: "blue") }, through: :taggings, source: :tag`
+    would fail when preloaded because it would try to apply the
+    `where(name: 'blue')` scope to Tagging as it preloaded it. Tests previously
+    'got around' this by prefixing the table name in the scope like:
+    `->{ where(tags: { name: "blue" }) }`.
+
+    *Mike Campbell*
+
 *   Fix transactions to apply state to child transactions
 
     Previously if you had a nested transaction and the outer transaction was rolledback the record from the

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -82,16 +82,6 @@ module ActiveRecord
 
             if options[:source_type]
               scope.where! reflection.foreign_type => options[:source_type]
-            else
-              unless reflection_scope.where_clause.empty?
-                scope.includes_values = Array(reflection_scope.values[:includes] || options[:source])
-                scope.where_clause = reflection_scope.where_clause
-              end
-
-              scope.references! reflection_scope.values[:references]
-              if scope.eager_loading? && order_values = reflection_scope.values[:order]
-                scope = scope.order(order_values)
-              end
             end
 
             scope

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -507,7 +507,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   def test_nested_has_many_through_with_conditions_on_through_associations_preload
     assert Author.where("tags.id" => 100).joins(:misc_post_first_blue_tags).empty?
 
-    authors = assert_queries(3) { Author.includes(:misc_post_first_blue_tags).to_a.sort_by(&:id) }
+    authors = assert_queries(5) { Author.includes(:misc_post_first_blue_tags).to_a.sort_by(&:id) }
     blue = tags(:blue)
 
     assert_no_queries do

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -133,10 +133,10 @@ class Author < ActiveRecord::Base
 
   has_many :category_post_comments, through: :categories, source: :post_comments
 
-  has_many :misc_posts, -> { where(posts: { title: ["misc post by bob", "misc post by mary"] }) }, class_name: "Post"
+  has_many :misc_posts, -> { where(title: ["misc post by bob", "misc post by mary"]) }, class_name: "Post"
   has_many :misc_post_first_blue_tags, through: :misc_posts, source: :first_blue_tags
 
-  has_many :misc_post_first_blue_tags_2, -> { where(posts: { title: ["misc post by bob", "misc post by mary"] }) },
+  has_many :misc_post_first_blue_tags_2, -> { where(posts: { title: ["misc post by bob", "misc post by mary"] }).distinct },
            through: :posts, source: :first_blue_tags_2
 
   has_many :posts_with_default_include, class_name: "PostWithDefaultInclude"

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -4,7 +4,7 @@ class Member < ActiveRecord::Base
   has_one :membership
   has_one :club, through: :current_membership
   has_one :selected_club, through: :selected_membership, source: :club
-  has_one :favourite_club, -> { where "memberships.favourite = ?", true }, through: :membership, source: :club
+  has_one :favourite_club, -> { joins(:memberships).where "memberships.favourite = ?", true }, through: :membership, source: :club
   has_one :hairy_club, -> { where clubs: { name: "Moustache and Eyebrow Fancier Club" } }, through: :membership, source: :club
   has_one :sponsor, as: :sponsorable
   has_one :sponsor_club, through: :sponsor

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -116,10 +116,10 @@ class Post < ActiveRecord::Base
   has_many :tags_with_primary_key, through: :taggings, source: :tag_with_primary_key
   has_one :tagging, as: :taggable
 
-  has_many :first_taggings, -> { where taggings: { comment: "first" } }, as: :taggable, class_name: "Tagging"
-  has_many :first_blue_tags, -> { where tags: { name: "Blue" } }, through: :first_taggings, source: :tag
+  has_many :first_taggings, -> { where comment: "first" }, as: :taggable, class_name: "Tagging"
+  has_many :first_blue_tags, -> { where name: "Blue" }, through: :first_taggings, source: :tag
 
-  has_many :first_blue_tags_2, -> { where taggings: { comment: "first" } }, through: :taggings, source: :blue_tag
+  has_many :first_blue_tags_2, -> { joins(:taggings).where(taggings: { comment: "first" }) }, through: :taggings, source: :blue_tag
 
   has_many :invalid_taggings, -> { where "taggings.id < 0" }, as: :taggable, class_name: "Tagging"
   has_many :invalid_tags, through: :invalid_taggings, source: :tag


### PR DESCRIPTION
When preloading a has_many through association, parts of the association scope were being applied to the intermediary model's preload. This removes that, and corrects some associations in the tests that were relying upon this quirky feature.

Previously, `has_many :blue_tags, ->{ where(name: "blue") }, through: :taggings, source: :tag` would fail when preloaded because it would try to apply the `where(name: 'blue')` scope to Tagging as it preloaded it. Tests previously 'got around' this by prefixing the table name in the scope like: `->{ where(tags: { name: "blue" }) }` so the scope would work on the intermediary model also. I find this confusing and unexpected. Scopes for the intermediary model, in my view, should be placed on the intermediary association.

related issues/prs: #22535 #12725

