### PR TITLE
Allow the use of Bundler 2.0

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |s|
   s.add_dependency "actioncable",   version
   s.add_dependency "railties",      version
 
-  s.add_dependency "bundler",         ">= 1.3.0", "< 2.0"
+  s.add_dependency "bundler",         ">= 1.3.0"
   s.add_dependency "sprockets-rails", ">= 2.0.0"
 end


### PR DESCRIPTION
### Summary

In https://github.com/rails/rails/pull/8234 we introduced a change that placed an upper bound on Bundler at 2.0

Bundler 2.0 is on the near horizon with a release expected later this year.

Previous reports claimed that there would be major changes, and while there are breaking changes (like the `Gemfile.lock` being totally rewritten), it does not block a Rails app from running.

Using Bundler master, I was able to enable Bundler 2.0 with all major deprecations, `bundle install` and `require 'bundler/setup'` via `bin/rake environment` without any issue whatsoever.

In preparation for Bundler 2.0 release, this PR removes that upper bound.

It is important to note that Bundler currently will print a warning but continue to run if you use Bundler 2.0 - so this isn't changing much except that a warning won't be printed.

cc @rafaelfranca 
