### PR TITLE
Fix `ActiveModel::Type::DateTime#serialize`

### DIFF
--- a/activemodel/lib/active_model/type/date_time.rb
+++ b/activemodel/lib/active_model/type/date_time.rb
@@ -10,6 +10,10 @@ module ActiveModel
         :datetime
       end
 
+      def serialize(value)
+        super(cast(value))
+      end
+
       private
 
         def cast_value(value)

--- a/activerecord/test/cases/date_time_test.rb
+++ b/activerecord/test/cases/date_time_test.rb
@@ -58,4 +58,17 @@ class DateTimeTest < ActiveRecord::TestCase
       assert_equal now, task.starting
     end
   end
+
+  def test_date_time_with_string_value_with_subsecond_precision
+    skip unless subsecond_precision_supported?
+    string_value = "2017-07-04 14:19:00.5"
+    topic = Topic.create(written_on: string_value)
+    assert_equal topic, Topic.find_by(written_on: string_value)
+  end
+
+  def test_date_time_with_string_value_with_non_iso_format
+    string_value = "04/07/2017 2:19pm"
+    topic = Topic.create(written_on: string_value)
+    assert_equal topic, Topic.find_by(written_on: string_value)
+  end
 end


### PR DESCRIPTION
### Summary

`ActiveModel::Type::DateTime#serialize` should return a `Time` object so that finding by a datetime column works correctly.  Both added tests fail without the code change.

This was discovered in the course of investigating #27800 which correctly points out that `ActiveModel::Type::DateTime#serialize` behaved differently from `ActiveModel::Type::Date#serialize`.  The problem however, is not with Date, but with DateTime.