### PR TITLE
Fix Parameters configuration integration tests

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1130,6 +1130,7 @@ module ApplicationTests
 
       app "development"
 
+      ActionController::Base.object_id # force lazy load hooks to run
       assert_equal :raise, ActionController::Parameters.action_on_unpermitted_parameters
 
       post "/posts", post: { "title" => "zomg" }
@@ -1138,6 +1139,8 @@ module ApplicationTests
 
     test "config.action_controller.always_permitted_parameters are: controller, action by default" do
       app "development"
+
+      ActionController::Base.object_id # force lazy load hooks to run
       assert_equal %w(controller action), ActionController::Parameters.always_permitted_parameters
     end
 
@@ -1148,6 +1151,7 @@ module ApplicationTests
 
       app "development"
 
+      ActionController::Base.object_id # force lazy load hooks to run
       assert_equal %w( controller action format ), ActionController::Parameters.always_permitted_parameters
     end
 
@@ -1170,6 +1174,7 @@ module ApplicationTests
 
       app "development"
 
+      ActionController::Base.object_id # force lazy load hooks to run
       assert_equal :raise, ActionController::Parameters.action_on_unpermitted_parameters
 
       post "/posts", post: { "title" => "zomg" }, format: "json"
@@ -1179,19 +1184,55 @@ module ApplicationTests
     test "config.action_controller.action_on_unpermitted_parameters is :log by default on development" do
       app "development"
 
+      ActionController::Base.object_id # force lazy load hooks to run
       assert_equal :log, ActionController::Parameters.action_on_unpermitted_parameters
     end
 
     test "config.action_controller.action_on_unpermitted_parameters is :log by default on test" do
       app "test"
 
+      ActionController::Base.object_id # force lazy load hooks to run
       assert_equal :log, ActionController::Parameters.action_on_unpermitted_parameters
     end
 
     test "config.action_controller.action_on_unpermitted_parameters is false by default on production" do
       app "production"
 
+      ActionController::Base.object_id # force lazy load hooks to run
       assert_equal false, ActionController::Parameters.action_on_unpermitted_parameters
+    end
+
+    test "config.action_controller.permit_all_parameters can be configured in an initializer" do
+      app_file "config/initializers/permit_all_parameters.rb", <<-RUBY
+        Rails.application.config.action_controller.permit_all_parameters = true
+      RUBY
+
+      app "development"
+
+      ActionController::Base.object_id # force lazy load hooks to run
+      assert_equal true, ActionController::Parameters.permit_all_parameters
+    end
+
+    test "config.action_controller.always_permitted_parameters can be configured in an initializer" do
+      app_file "config/initializers/always_permitted_parameters.rb", <<-RUBY
+        Rails.application.config.action_controller.always_permitted_parameters = []
+      RUBY
+
+      app "development"
+
+      ActionController::Base.object_id # force lazy load hooks to run
+      assert_equal [], ActionController::Parameters.always_permitted_parameters
+    end
+
+    test "config.action_controller.action_on_unpermitted_parameters can be configured in an initializer" do
+      app_file "config/initializers/action_on_unpermitted_parameters.rb", <<-RUBY
+        Rails.application.config.action_controller.action_on_unpermitted_parameters = :raise
+      RUBY
+
+      app "development"
+
+      ActionController::Base.object_id # force lazy load hooks to run
+      assert_equal :raise, ActionController::Parameters.action_on_unpermitted_parameters
     end
 
     test "config.action_dispatch.ignore_accept_header" do


### PR DESCRIPTION
These tests ensure that `ActionController::Parameters` can be configured from an application initializer, which was recently fixed in https://github.com/rails/rails/commit/4c8332c2963a33cef5d75fdcaabb65b8947fbfcd.

r? @rafaelfranca 