### PR TITLE
SystemTesting: pre-generate the rack application

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -101,7 +101,7 @@ module ActionDispatch
         map "/" do
           run Rails.application
         end
-      end
+      end.to_app
 
       SystemTesting::Server.new.run
     end


### PR DESCRIPTION
Rack::Builder is designed to be able to be used with class reloaders, and so
for production and/or repeated/constant configuration use, it's advisable to
call to_app to fix the route table rather than regenerate it with each
invocation of #call. This change should make a minor improvement on
performance and overhead in these tests. An even better change would be to
just use `Capybara.app = Rails.application`, though that has different
semantics so this is the more conservative change to begin with.
