### PR TITLE
Add a test case for overwriting existing condition on associations

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -946,6 +946,13 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_has_many_through_polymorphic_with_rewhere
+    post = TaggedPost.create!(title: "Tagged", body: "Post")
+    tag = post.tags.create!(name: "Tag")
+    assert_equal [tag], TaggedPost.preload(:tags).last.tags
+    assert_equal [tag], TaggedPost.eager_load(:tags).last.tags
+  end
+
   def test_has_many_through_polymorphic_with_primary_key_option
     assert_equal [categories(:general)], authors(:david).essay_categories
 

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -199,6 +199,11 @@ class FirstPost < ActiveRecord::Base
   has_one  :comment,  foreign_key: :post_id
 end
 
+class TaggedPost < Post
+  has_many :taggings, -> { rewhere(taggable_type: "TaggedPost") }, as: :taggable
+  has_many :tags, through: :taggings
+end
+
 class PostWithDefaultInclude < ActiveRecord::Base
   self.inheritance_column = :disabled
   self.table_name = "posts"


### PR DESCRIPTION
Overwriting existing condition on associations has already supported
(23bcc65 for eager loading, 2bfa2c0 for preloading).

Fixes #27724.
Closes #29154.