### PR TITLE
MySQLDatabaseTasks#create couldn't create database, but rails db:create task says "Created database"

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -32,6 +32,7 @@ module ActiveRecord
           $stderr.puts error.inspect
           $stderr.puts "Couldn't create database for #{configuration.inspect}, #{creation_options.inspect}"
           $stderr.puts "(If you set the charset manually, make sure you have a matching collation)" if configuration["encoding"]
+          raise
         end
       end
 

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -154,12 +154,12 @@ if current_adapter?(:Mysql2Adapter)
         ActiveRecord::Tasks::DatabaseTasks.create @configuration
       end
 
-      def test_sends_output_to_stderr_when_other_errors
+      def test_sends_output_to_stderr_and_raise_error_when_other_errors
         @error.stubs(:errno).returns(42)
 
         $stderr.expects(:puts).at_least_once.returns(nil)
 
-        ActiveRecord::Tasks::DatabaseTasks.create @configuration
+        assert_raises(Mysql2::Error) { ActiveRecord::Tasks::DatabaseTasks.create @configuration }
       end
 
       private


### PR DESCRIPTION
When MySQL is not running, `rails db:create` command will exit normally.

```shell
$ bin/rails db:create
#<Mysql2::Error: Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)>
Couldn't create database for {"adapter"=>"mysql2", "encoding"=>"utf8", "charset"=>"utf8", "collation"=>"utf8_general_ci", "pool"=>5, "username"=>"root", "password"=>nil, "host"=>"localhost", "port"=>nil, "database"=>"myapp_development"}, {:charset=>"utf8", :collation=>"utf8_general_ci"}
(If you set the charset manually, make sure you have a matching collation)
Created database 'myapp_development'
```

I expect `rails db:create` to exit with an error.