### PR TITLE
Fix performance issue with NameError#missing_name on ruby >= v2.3.0.

### DIFF
--- a/activesupport/lib/active_support/core_ext/name_error.rb
+++ b/activesupport/lib/active_support/core_ext/name_error.rb
@@ -8,6 +8,11 @@ class NameError
   #   end
   #   # => "HelloWorld"
   def missing_name
+    # Since ruby v2.3.0 `did_you_mean` gem is loaded by default.
+    # It extends NameError#message with spell corrections which are SLOW.
+    # We should use original_message message instead.
+    message = respond_to?(:original_message) ? original_message : self.message
+
     if /undefined local variable or method/ !~ message
       $1 if /((::)?([A-Z]\w*)(::[A-Z]\w*)*)$/ =~ message
     end


### PR DESCRIPTION
Fix performance issue on ruby with `did_you_mean` gem.

### Summary

Since ruby v2.3.0 `did_you_mean` gem shipped and ENABLED by default.
It patches NameError#message with spell corrections which are SLOW.
We should use `original_message` instead.

### Another options

* gem uninstall did_you_mean
* ruby --disable-did-you-mean -e ...
* RUBYOPT=--disable-did-you-mean ruby ...
* add RUBYOPT=--disable-did-you-mean to your bash/dash/foo shell rc

That's very bad that this fancy gem is enabled by default (even in production environment).
But anyway if it enabled rails should NOT be slow.

### Benchmark script

```ruby
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", path: ENV.fetch('RAILS_REPO')
end

require "active_support"
require "active_support/core_ext/name_error"
require "benchmark"


class Foo
end

puts "-"*80
p RUBY_VERSION
p NameError.ancestors

Benchmark.bmbm do |x|
  x.report 'NameError#missing_message' do
    100.times do
      begin
        Foo1
      rescue NameError => e
        e.missing_name
      end
    end
  end
end
```

### Original version

`$ RAILS_REPO=rails/rails ruby bench.rb`

```
--------------------------------------------------------------------------------
"2.4.1"
[DidYouMean::Correctable, NameError, StandardError, Exception, ActiveSupport::ToJsonWithActiveSupportEncoder, Object, JSON::Ext::Generator::GeneratorMethods::Object, ActiveSupport::Tryable, Kernel, BasicObject]
Rehearsal -------------------------------------------------------------
NameError#missing_message   0.100000   0.000000   0.100000 (  0.099724)
---------------------------------------------------- total: 0.100000sec

                                user     system      total        real
NameError#missing_message   0.100000   0.000000   0.100000 (  0.096193)
```

### Optimized version

`RAILS_REPO=ayanko/rails ruby bench.rb`

```
--------------------------------------------------------------------------------
"2.4.1"
[DidYouMean::Correctable, NameError, StandardError, Exception, ActiveSupport::ToJsonWithActiveSupportEncoder, Object, JSON::Ext::Generator::GeneratorMethods::Object, ActiveSupport::Tryable, Kernel, BasicObject]
Rehearsal -------------------------------------------------------------
NameError#missing_message   0.000000   0.000000   0.000000 (  0.001005)
---------------------------------------------------- total: 0.000000sec

                                user     system      total        real
NameError#missing_message   0.000000   0.000000   0.000000 (  0.000767)
```

### Conclusion

`DidYouMean` brings **serious performance degradation**.
