### PR TITLE
Return prefixed method names from `Module.delegate`, if using prefixes

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -174,7 +174,7 @@ class Module
     to = to.to_s
     to = "self.#{to}" if DELEGATION_RESERVED_METHOD_NAMES.include?(to)
 
-    methods.each do |method|
+    methods.map do |method|
       # Attribute writer methods only accept one argument. Makes sure []=
       # methods still accept two arguments.
       definition = /[^\]]=$/.match?(method) ? "arg" : "*args, &block"

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -392,4 +392,43 @@ class ModuleTest < ActiveSupport::TestCase
     event = Event.new(Tester.new)
     assert_equal 1, event.foo
   end
+
+  def test_private_delegate
+    location = Class.new do
+      def initialize(place)
+        @place = place
+      end
+
+      private *delegate(:street, :city, to: :@place)
+    end
+
+    place = location.new(Somewhere.new("Such street", "Sad city"))
+
+    assert_not place.respond_to?(:street)
+    assert_not place.respond_to?(:city)
+
+    assert place.respond_to?(:street, true) # Asking for private method
+    assert place.respond_to?(:city, true)
+  end
+
+  def test_private_delegate_prefixed
+    location = Class.new do
+      def initialize(place)
+        @place = place
+      end
+
+      private *delegate(:street, :city, to: :@place, prefix: :the)
+    end
+
+    place = location.new(Somewhere.new("Such street", "Sad city"))
+
+    assert_not place.respond_to?(:street)
+    assert_not place.respond_to?(:city)
+
+
+    assert_not place.respond_to?(:the_street)
+    assert place.respond_to?(:the_street, true)
+    assert_not place.respond_to?(:the_city)
+    assert place.respond_to?(:the_city, true)
+  end
 end


### PR DESCRIPTION
### Summary

There is a somewhat useful pattern for `delegate` when we want to make the delegated methods private:

```ruby
class MyClass
  private *delegate(:this, :that, :another, to: :some_method)
end
```

Which works because `private` can accept any number of symbols, and turn existing methods matching these names into private ones. Hence the splat, because it doesn't take an array.

This, however, breaks when using `prefix: true` (or `prefix: :anything`), because what `delegate` returns aren't the prefixed method names, but rather the raw, unprefixed ones ([iterating with #each](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/module/delegation.rb#L177) on its args). In effect, the new delegates are actually *public*, and mysterious `NameErrors` appear about the unprefixed method names being undefined.

A raw testcase [gist](https://gist.github.com/k3rni/e8bc3a0d08dc9030da087584a0818234) shows what I believe is the desired behavior, versus actual behavior.

### The fix

Change the `.each` mentioned to `.map`. At the end of each iteration we call `module_eval` with the new method text, and that conveniently returns a symbol with the (possibly prefixed) method name.

Tests added to show - `test_private_delegate_prefixed` fails before changing to `.map`.

This probably affects all ActiveSupport versions, because the `each` was there from the beginning.