### PR TITLE
db:schema:load_if_ruby db:schema:load_if_sql no longer run db:create

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add db:load_schema_or_structure task which loads the database schema from the file format specified by config.active_record.schema_format.
+
+    Fixes #29128.
+
+    *Boris Beginin*
+
 *   Fix eager loading/preloading association with scope including joins.
 
     Fixes #28324.

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -308,7 +308,7 @@ module ApplicationTests
           Dir.chdir(app_path) do
             database_path = `bin/rails db:setup`
             assert_equal "development.sqlite3", File.basename(database_path.strip)
-            p File.basename(database_path.strip)
+            File.basename(database_path.strip)
           end
         ensure
           ENV["RAILS_ENV"] = @old_rails_env

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -308,7 +308,6 @@ module ApplicationTests
           Dir.chdir(app_path) do
             database_path = `bin/rails db:setup`
             assert_equal "development.sqlite3", File.basename(database_path.strip)
-            File.basename(database_path.strip)
           end
         ensure
           ENV["RAILS_ENV"] = @old_rails_env

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -334,7 +334,7 @@ module ApplicationTests
         Dir.chdir(app_path) do
           db_schema_dump
           `bin/rails environment db:drop`
-          `bin/rails db:schema:load`
+          `bin/rails db:load_schema_or_structure`
           require "#{app_path}/app/models/book"
           assert_equal 0, Book.count
         end


### PR DESCRIPTION
### Summary

fixes #29128  

`db:schema:load_if_ruby`, `db:structure:load_if_sql` no longer run `db:create` like `db:schema:load` or `db:structure:load` do
r? @eugeneius
### Other Information

Should i also write documentation for this rake task? because currently it is undocumented.
