### PR TITLE
Fix warning: `*' interpreted as argument prefix

### DIFF
--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -399,7 +399,7 @@ class ModuleTest < ActiveSupport::TestCase
         @place = place
       end
 
-      private *delegate(:street, :city, to: :@place)
+      private(*delegate(:street, :city, to: :@place))
     end
 
     place = location.new(Somewhere.new("Such street", "Sad city"))
@@ -417,7 +417,7 @@ class ModuleTest < ActiveSupport::TestCase
         @place = place
       end
 
-      private *delegate(:street, :city, to: :@place, prefix: :the)
+      private(*delegate(:street, :city, to: :@place, prefix: :the))
     end
 
     place = location.new(Somewhere.new("Such street", "Sad city"))


### PR DESCRIPTION
```
/Users/kamipo/src/github.com/rails/rails/activesupport/test/core_ext/module_test.rb:402: warning: `*' interpreted as argument prefix
/Users/kamipo/src/github.com/rails/rails/activesupport/test/core_ext/module_test.rb:420: warning: `*' interpreted as argument prefix
```