### PR TITLE
Don't translate non-database exceptions.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,5 @@
-*   Prevent AbstractAdapter from converting exceptions from ActiveSupport::Notification
-    callbacks into ActiveRecord::StatementInvalids.
+*   Prevent errors raised by sql.active_record notification subscribers from being converted into
+    ActiveRecord::StatementInvalid exceptions.
 
     *Dennis Taylor*
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Prevent AbstractAdapter from converting exceptions from ActiveSupport::Notification
+    callbacks into ActiveRecord::StatementInvalids.
+
+    *Dennis Taylor*
+
 *   Fix eager loading/preloading association with scope including joins.
 
     Fixes #28324.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -576,12 +576,14 @@ module ActiveRecord
             type_casted_binds: type_casted_binds,
             statement_name:    statement_name,
             connection_id:     object_id) do
+            begin
               @lock.synchronize do
                 yield
               end
+            rescue => e
+              raise translate_exception_class(e, sql)
             end
-        rescue => e
-          raise translate_exception_class(e, sql)
+          end
         end
 
         def translate_exception(exception, message)

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -230,7 +230,7 @@ module ActiveRecord
       end
 
       assert_instance_of ActiveRecord::StatementInvalid, error
-      assert_instance_of syntax_error_exception_class, error.cause
+      assert_kind_of Exception, error.cause
     end
 
     def test_select_all_always_return_activerecord_result
@@ -283,14 +283,6 @@ module ActiveRecord
         assert_not_nil error.message
       end
     end
-
-    private
-
-      def syntax_error_exception_class
-        return Mysql2::Error if defined?(Mysql2)
-        return PG::SyntaxError if defined?(PG)
-        return SQLite3::SQLException if defined?(SQLite3)
-      end
   end
 
   class AdapterForeignKeyTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -286,11 +286,11 @@ module ActiveRecord
 
     private
 
-    def syntax_error_exception_class
-      return Mysql2::Error if defined?(Mysql2)
-      return PG::SyntaxError if defined?(PG)
-      return SQLite3::SQLException if defined?(SQLite3)
-    end
+      def syntax_error_exception_class
+        return Mysql2::Error if defined?(Mysql2)
+        return PG::SyntaxError if defined?(PG)
+        return SQLite3::SQLException if defined?(SQLite3)
+      end
   end
 
   class AdapterForeignKeyTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -224,7 +224,7 @@ module ActiveRecord
       ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
 
-    def test_other_exceptions_are_translated_to_statement_invalid
+    def test_database_related_exceptions_are_translated_to_statement_invalid
       error = assert_raises(ActiveRecord::StatementInvalid) do
         @connection.execute("This is a syntax error")
       end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -212,9 +212,9 @@ module ActiveRecord
     end
 
     def test_exceptions_from_notifications_are_not_translated
-      original_error = RuntimeError.new("This RuntimeError shouldn't get translated")
+      original_error = StandardError.new("This StandardError shouldn't get translated")
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") { raise original_error }
-      actual_error = assert_raises(RuntimeError) do
+      actual_error = assert_raises(StandardError) do
         @connection.execute("SELECT * FROM posts")
       end
 


### PR DESCRIPTION
### Summary

The AbstractAdapter will translate all StandardErrors generated during the course of a query into ActiveRecord::StatementInvalid exceptions. Unfortunately, it'll also mangle non-database-related errors generated in ActiveSupport::Notification `sql.active_record` callbacks after the query has successfully completed.

This patch should prevent it from translating errors from ActiveSupport::Notifications. All it does is move the `rescue` that translates exceptions into StatementInvalids inside the `instrument` block, so that it only affects the database code instead of the entire ActiveSupport::Notification block. Threw in a couple of tests for good measure.

This actually bit us in a real use case recently; we use `sql.active_record` notifications to notify and/or throw exceptions for queries that run too long, and the exceptions were coming out as ActiveRecord::StatementInvalid instead of our custom LongQueryError exception type.