### PR TITLE
Add `rails secrets:show` command

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `rails secrets:show` command.
+
+    *Yuji Yaginuma*
+
 *   Allow mounting the same engine several times in different locations.
 
     Fixes #20204.

--- a/railties/lib/rails/commands/secrets/secrets_command.rb
+++ b/railties/lib/rails/commands/secrets/secrets_command.rb
@@ -48,6 +48,10 @@ module Rails
         end
       end
 
+      def show
+        say Rails::Secrets.read
+      end
+
       private
         def generator
           require_relative "../../generators"

--- a/railties/test/command/base_test.rb
+++ b/railties/test/command/base_test.rb
@@ -6,6 +6,6 @@ require "rails/commands/secrets/secrets_command"
 class Rails::Command::BaseTest < ActiveSupport::TestCase
   test "printing commands" do
     assert_equal %w(generate), Rails::Command::GenerateCommand.printing_commands
-    assert_equal %w(secrets:setup secrets:edit), Rails::Command::SecretsCommand.printing_commands
+    assert_equal %w(secrets:setup secrets:edit secrets:show), Rails::Command::SecretsCommand.printing_commands
   end
 end

--- a/railties/test/commands/secrets_test.rb
+++ b/railties/test/commands/secrets_test.rb
@@ -27,8 +27,21 @@ class Rails::Command::SecretsCommandTest < ActiveSupport::TestCase
     end
   end
 
+  test "show secrets" do
+    run_setup_command
+    assert_match(/external_api_key: 1466aac22e6a869134be3d09b9e89232fc2c2289/, run_show_command)
+  end
+
   private
     def run_edit_command(editor: "cat")
       Dir.chdir(app_path) { `EDITOR="#{editor}" bin/rails secrets:edit` }
+    end
+
+    def run_show_command
+      Dir.chdir(app_path) { `bin/rails secrets:show` }
+    end
+
+    def run_setup_command
+      Dir.chdir(app_path) { `bin/rails secrets:setup` }
     end
 end


### PR DESCRIPTION
When secrets confirmed with the `secrets:edit` command, `secrets.yml.enc` will change without updating the secrets.

Therefore, even if only want to check secrets, the difference will come out. This is a little inconvenient.
In order to solve this problem, added the `secrets:show` command. If just want to check secrets, no difference will occur use this command.

