### PR TITLE
Fix NumericalityValidator fails on equal decimal to decimal comparisons #26085

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -36,9 +36,7 @@ module ActiveModel
           return
         end
 
-        if raw_value.is_a?(Numeric)
-          value = raw_value
-        else
+        unless value.is_a?(Numeric)
           value = parse_raw_value_as_a_number(raw_value)
         end
 

--- a/activemodel/test/cases/validations/26085.rb
+++ b/activemodel/test/cases/validations/26085.rb
@@ -1,0 +1,26 @@
+require "active_record"
+require "minitest/autorun"
+require "logger"
+
+# This connection will do for database-independent bug reports.
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+ActiveRecord::Base.logger = Logger.new(STDOUT)
+
+ActiveRecord::Schema.define do
+  create_table :number_ranges, force: true do |t|
+    t.decimal :high
+    t.decimal :low
+  end
+end
+
+class NumberRange < ActiveRecord::Base
+  validates :high, numericality: { greater_than_or_equal_to: :low }
+end
+
+class BugTest < Minitest::Test
+  def test_26085
+    assert NumberRange.new(low: '65.6', high: '65.6').valid?
+    assert NumberRange.new(low: '65.6', high: '75.6').valid?
+    assert !NumberRange.new(low: '65.6', high: '55.6').valid?
+  end
+end

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -2,6 +2,7 @@ require "cases/helper"
 
 require "models/topic"
 require "models/person"
+require "models/number_range"
 
 require "bigdecimal"
 require "active_support/core_ext/big_decimal"
@@ -275,6 +276,12 @@ class NumericalityValidationTest < ActiveModel::TestCase
     assert_raise(ArgumentError) { Topic.validates_numericality_of :approved, greater_than: "foo" }
     assert_raise(ArgumentError) { Topic.validates_numericality_of :approved, less_than: "foo" }
     assert_raise(ArgumentError) { Topic.validates_numericality_of :approved, equal_to: "foo" }
+  end
+
+  def test_validates_numericality_greater_than_or_equal_for_two_big_decimals
+    assert NumberRange.new(low: '65.6', high: '65.6').valid?
+    assert NumberRange.new(low: '65.6', high: '75.6').valid?
+    assert !NumberRange.new(low: '65.6', high: '55.6').valid?
   end
 
   private

--- a/activemodel/test/models/number_range.rb
+++ b/activemodel/test/models/number_range.rb
@@ -2,7 +2,6 @@ require "active_record"
 require "minitest/autorun"
 require "logger"
 
-# This connection will do for database-independent bug reports.
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 ActiveRecord::Base.logger = Logger.new(STDOUT)
 
@@ -13,14 +12,7 @@ ActiveRecord::Schema.define do
   end
 end
 
+
 class NumberRange < ActiveRecord::Base
   validates :high, numericality: { greater_than_or_equal_to: :low }
-end
-
-class BugTest < Minitest::Test
-  def test_26085
-    assert NumberRange.new(low: '65.6', high: '65.6').valid?
-    assert NumberRange.new(low: '65.6', high: '75.6').valid?
-    assert !NumberRange.new(low: '65.6', high: '55.6').valid?
-  end
 end


### PR DESCRIPTION
Fix #26085

### Summary

NumericalityValidator#parse_raw_value_as_a_number always parses with Kernel.Float(raw_value), so the validated value is a float, while the comparison value is a BigDecimal, and so, due to precision differences, equal numbers will fail validation. This PR fixes this #26085  .

### Other Information

Test file provided by @maclover7 [here](https://gist.github.com/maclover7/f2f118e70d1191a722c7f8669a93c887) was used and is included as part of this PR.
