### PR TITLE
Fix extracting MariaDB version

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -59,12 +59,12 @@ module ActiveRecord
         @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
 
         if version < "5.1.10"
-          raise "Your version of MySQL (#{full_version.match(/^\d+\.\d+\.\d+/)[0]}) is too old. Active Record supports MySQL >= 5.1.10."
+          raise "Your version of MySQL (#{version_string}) is too old. Active Record supports MySQL >= 5.1.10."
         end
       end
 
       def version #:nodoc:
-        @version ||= Version.new(full_version.match(/^\d+\.\d+\.\d+/)[0])
+        @version ||= Version.new(version_string)
       end
 
       def mariadb? # :nodoc:
@@ -852,6 +852,10 @@ module ActiveRecord
           when 0x1000000..0xffffffff; "longblob"
           else raise(ActiveRecordError, "No binary type has byte length #{limit}")
           end
+        end
+
+        def version_string
+          full_version.match(/^(?:5\.5\.5-)?(\d+\.\d+\.\d+)/)[1]
         end
 
         class MysqlString < Type::String # :nodoc:


### PR DESCRIPTION
Currently `version` method always returns `5.5.5` because the
`full_version` is `5.5.5-10.x.y-MariaDB...` since MariaDB 10.x.
It should be ignored if the prefix is `5.5.5-`.