### PR TITLE
Do not update `secrets.yml.enc` when secretes do not change

### DIFF
--- a/railties/lib/rails/secrets.rb
+++ b/railties/lib/rails/secrets.rb
@@ -105,7 +105,9 @@ module Rails
 
           yield tmp_path
 
-          write(File.read(tmp_path))
+          updated_contents = File.read(tmp_path)
+
+          write(updated_contents) if updated_contents != contents
         ensure
           FileUtils.rm(tmp_path) if File.exist?(tmp_path)
         end

--- a/railties/test/secrets_test.rb
+++ b/railties/test/secrets_test.rb
@@ -111,6 +111,24 @@ class Rails::SecretsTest < ActiveSupport::TestCase
     end
   end
 
+  test "do not update secrets.yml.enc when secretes do not change" do
+    run_secrets_generator do
+      Dir.chdir(app_path) do
+        Rails::Secrets.read_for_editing do |tmp_path|
+          File.write(tmp_path, "Empty streets, empty nights. The Downtown Lights.")
+        end
+
+        FileUtils.cp("config/secrets.yml.enc", "config/secrets.yml.enc.bk")
+
+        Rails::Secrets.read_for_editing do |tmp_path|
+          File.write(tmp_path, "Empty streets, empty nights. The Downtown Lights.")
+        end
+
+        assert_equal File.read("config/secrets.yml.enc.bk"), File.read("config/secrets.yml.enc")
+      end
+    end
+  end
+
   private
     def run_secrets_generator
       Dir.chdir(app_path) do


### PR DESCRIPTION
Currently, if open a file with `secrets:edit` command, `secrets.yml.enc` will be changed even if its contents do not change.
Therefore, even if only want to check secrets, the difference will come out. This is a little inconvenient.

As a fix to the above problem, when content does not change, `secrets.yml.ecn` is fixed so that it is not changed.

