### PR TITLE
Use `information_schema` to extract `generation_expression` for MariaDB

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -53,7 +53,7 @@ module ActiveRecord
           end
 
           def extract_expression_for_virtual_column(column)
-            if mariadb?
+            if mariadb? && version < "10.2.5"
               create_table_info = create_table_info(column.table_name)
               if %r/#{quote_column_name(column.name)} #{Regexp.quote(column.sql_type)}(?: COLLATE \w+)? AS \((?<expression>.+?)\) #{column.extra}/ =~ create_table_info
                 $~[:expression].inspect

--- a/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
@@ -52,7 +52,7 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
 
     def test_schema_dumping
       output = dump_table_schema("virtual_columns")
-      assert_match(/t\.virtual\s+"upper_name",\s+type: :string,\s+as: "UPPER\(`name`\)"$/i, output)
+      assert_match(/t\.virtual\s+"upper_name",\s+type: :string,\s+as: "(?:UPPER|UCASE)\(`name`\)"$/i, output)
       assert_match(/t\.virtual\s+"name_length",\s+type: :integer,\s+as: "LENGTH\(`name`\)",\s+stored: true$/i, output)
     end
   end


### PR DESCRIPTION
Since MariaDB 10.2.5, `information_schema` supports Virtual Columns.

Fixes #29670.