### PR TITLE
Fix default `CURRENT_TIMESTAMP` in schema dumping for MariaDB 10.2

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -73,8 +73,8 @@ module ActiveRecord
 
           def new_column_from_field(table_name, field)
             type_metadata = fetch_type_metadata(field[:Type], field[:Extra])
-            if type_metadata.type == :datetime && field[:Default] == "CURRENT_TIMESTAMP"
-              default, default_function = nil, field[:Default]
+            if type_metadata.type == :datetime && /\ACURRENT_TIMESTAMP(?:\(\))?\z/i.match?(field[:Default])
+              default, default_function = nil, "CURRENT_TIMESTAMP"
             else
               default, default_function = field[:Default], nil
             end


### PR DESCRIPTION
Since MariaDB 10.2, `CURRENT_TIMESTAMP` is shown as a function
(`current_timestamp()`). Fix matching column default to address that
case.

Fixes #29698.