### PR TITLE
Adds descriptions to rails-ujs methods [ci skip]

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/utils/dom.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/utils/dom.coffee
@@ -5,6 +5,13 @@ m = Element.prototype.matches or
     Element.prototype.oMatchesSelector or
     Element.prototype.webkitMatchesSelector
 
+# Checks if the given native dom element matches the selector
+# element::
+#   native DOM element
+# selector::
+#   css selector string or
+#   a javascript object with `selector` and `exclude` properties
+#   Examples: "form", { selector: "form", exclude: "form[data-remote='true']"}
 Rails.matches = (element, selector) ->
   if selector.exclude?
     m.call(element, selector.selector) and not m.call(element, selector.exclude)

--- a/actionview/app/assets/javascripts/rails-ujs/utils/event.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/utils/event.coffee
@@ -14,6 +14,13 @@ if typeof CustomEvent isnt 'function'
   CustomEvent.prototype = window.Event.prototype
 
 # Triggers a custom event on an element and returns false if the event result is false
+# obj::
+#   a native DOM element
+# name::
+#   string that corrspends to the event you want to trigger
+#   e.g. 'click', 'submit'
+# data::
+#   data you want to pass when you dispatch an event
 fire = Rails.fire = (obj, name, data) ->
   event = new CustomEvent(
     name,
@@ -31,6 +38,17 @@ Rails.stopEverything = (e) ->
   e.stopPropagation()
   e.stopImmediatePropagation()
 
+# Delegates events
+# to a specified parent `element`, which fires event `handler`
+# for the specified `selector` when an event of `eventType` is triggered
+# element::
+#   parent element that will listen for events e.g. document
+# selector::
+#   css selector; or an object that has `selector` and `exclude` properties (see: Rails.matches)
+# eventType::
+#   string representing the event e.g. 'submit', 'click'
+# handler::
+#   the event handler to be called
 Rails.delegate = (element, selector, eventType, handler) ->
   element.addEventListener eventType, (e) ->
     target = e.target


### PR DESCRIPTION
### Summary

Provides (new or additional) documentation for the following `rails-ujs` functions:
- Rails.fire
- Rails.matches
- Rails.delegate