### PR TITLE
Add ActiveModel::Errors#merge!

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add method `#merge!` for `ActiveModel::Errors`.
+
+    *Jahfer Husain*
+
 *   Fix regression in numericality validator when comparing Decimal and Float input
     values with more scale than the schema.
 

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -93,6 +93,18 @@ module ActiveModel
       @details  = other.details.dup
     end
 
+    # Merges the errors from <tt>other</tt>.
+    #
+    # other - The ActiveModel::Errors instance.
+    #
+    # Examples
+    #
+    #   person.errors.merge!(other)
+    def merge!(other)
+      @messages.merge!(other.messages) { |_, ary1, ary2| ary1 + ary2 }
+      @details.merge!(other.details) { |_, ary1, ary2| ary1 + ary2 }
+    end
+
     # Clear the error messages.
     #
     #   person.errors.full_messages # => ["name cannot be nil"]

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -375,6 +375,18 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal [:name], person.errors.details.keys
   end
 
+  test "merge errors" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :invalid)
+
+    person = Person.new
+    person.errors.add(:name, :blank)
+    person.errors.merge!(errors)
+
+    assert_equal({ name: ["can't be blank", "is invalid"] }, person.errors.messages)
+    assert_equal({ name: [{ error: :blank }, { error: :invalid }] }, person.errors.details)
+  end
+
   test "errors are marshalable" do
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:name, :invalid)


### PR DESCRIPTION
### Summary

`ActiveModel::Errors#merge!` allows instances of `ActiveModel::Errors` to append errors from a separate instance of `ActiveModel::Errors` onto its own set of errors.

The implementation in this PR does a "deep" merge of the contents within each key so that any keys already containing errors will be merged with the new set, rather than overridden.

This contribution was suggested to me by @rafaelfranca.

### Example

```ruby
person = Person.new
person.errors.add(:name, :blank)

errors = ActiveModel::Errors.new(Person.new)
errors.add(:name, :invalid)

person.errors.merge!(errors)
puts person.errors.messages # => { name: ["can't be blank", "is invalid"] }
```
