### PR TITLE
Don't allow uuids with orphan curly braces

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     module PostgreSQL
       module OID # :nodoc:
         class Uuid < Type::Value # :nodoc:
-          ACCEPTABLE_UUID = %r{\A\{?([a-fA-F0-9]{4}-?){8}\}?\z}x
+          ACCEPTABLE_UUID = %r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}
 
           alias_method :serialize, :deserialize
 

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -124,7 +124,9 @@ class PostgresqlUUIDTest < ActiveRecord::PostgreSQLTestCase
      "Z0000C99-9C0B-4EF8-BB6D-6BB9BD380A11",
      "a0eebc999r0b4ef8ab6d6bb9bd380a11",
      "a0ee-bc99------4ef8-bb6d-6bb9-bd38-0a11",
-     "{a0eebc99-bb6d6bb9-bd380a11}"].each do |invalid_uuid|
+     "{a0eebc99-bb6d6bb9-bd380a11}",
+     "{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11",
+     "a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}"].each do |invalid_uuid|
       uuid = UUIDType.new guid: invalid_uuid
       assert_nil uuid.guid
     end


### PR DESCRIPTION
The uuid validation regex was allowing uuids to have a single leading
curly brace or single trailing curly brace. Saving with such a uuid
would cause Postgres to generate an exception even though the record
seemed valid. With this change, the regex requires both a leading *and*
a trailing curly brace or neither to be valid.