### PR TITLE
Add Key Rotation to MessageEncryptor and MessageVerifier and simplify the Cookies middleware

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Simplify cookies middleware with key rotation support
+
+    Use the `rotate` method for both `MessageEncryptor` and
+    `MessageVerifier` to add key rotation support for encrypted and
+    signed cookies. This also helps simplify support for legacy cookie
+    security.
+
+    *Michael J Coyne*
+
 *  Use Capybara registered `:puma` server config.
 
     The Capybara registered `:puma` server ensures the puma server is run in process so

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -49,6 +49,18 @@ module ActionDispatch
       get_header Cookies::AUTHENTICATED_ENCRYPTED_COOKIE_SALT
     end
 
+    def use_authenticated_cookie_encryption
+      get_header Cookies::USE_AUTHENTICATED_COOKIE_ENCRYPTION
+    end
+
+    def encrypted_cookie_cipher
+      get_header Cookies::ENCRYPTED_COOKIE_CIPHER
+    end
+
+    def signed_cookie_digest
+      get_header Cookies::SIGNED_COOKIE_DIGEST
+    end
+
     def secret_token
       get_header Cookies::SECRET_TOKEN
     end
@@ -64,6 +76,11 @@ module ActionDispatch
     def cookies_digest
       get_header Cookies::COOKIES_DIGEST
     end
+
+    def cookies_rotations
+      get_header Cookies::COOKIES_ROTATIONS
+    end
+
     # :startdoc:
   end
 
@@ -157,10 +174,14 @@ module ActionDispatch
     ENCRYPTED_COOKIE_SALT = "action_dispatch.encrypted_cookie_salt".freeze
     ENCRYPTED_SIGNED_COOKIE_SALT = "action_dispatch.encrypted_signed_cookie_salt".freeze
     AUTHENTICATED_ENCRYPTED_COOKIE_SALT = "action_dispatch.authenticated_encrypted_cookie_salt".freeze
+    USE_AUTHENTICATED_COOKIE_ENCRYPTION = "action_dispatch.use_authenticated_cookie_encryption".freeze
+    ENCRYPTED_COOKIE_CIPHER = "action_dispatch.encrypted_cookie_cipher".freeze
+    SIGNED_COOKIE_DIGEST = "action_dispatch.signed_cookie_digest".freeze
     SECRET_TOKEN = "action_dispatch.secret_token".freeze
     SECRET_KEY_BASE = "action_dispatch.secret_key_base".freeze
     COOKIES_SERIALIZER = "action_dispatch.cookies_serializer".freeze
     COOKIES_DIGEST = "action_dispatch.cookies_digest".freeze
+    COOKIES_ROTATIONS = "action_dispatch.cookies_rotations".freeze
 
     # Cookies can typically store 4096 bytes.
     MAX_COOKIE_SIZE = 4096
@@ -201,12 +222,7 @@ module ActionDispatch
       #
       #   cookies.signed[:discount] # => 45
       def signed
-        @signed ||=
-          if upgrade_legacy_signed_cookies?
-            UpgradeLegacySignedCookieJar.new(self)
-          else
-            SignedCookieJar.new(self)
-          end
+        @signed ||= SignedKeyRotatingCookieJar.new(self)
       end
 
       # Returns a jar that'll automatically encrypt cookie values before sending them to the client and will decrypt them for read.
@@ -223,18 +239,11 @@ module ActionDispatch
       # Example:
       #
       #   cookies.encrypted[:discount] = 45
-      #   # => Set-Cookie: discount=ZS9ZZ1R4cG1pcUJ1bm80anhQang3dz09LS1mbDZDSU5scGdOT3ltQ2dTdlhSdWpRPT0%3D--ab54663c9f4e3bc340c790d6d2b71e92f5b60315; path=/
+      #   # => Set-Cookie: discount=DIQ7fw==--K3n//8vvnSbGq9dA--7Xh91HfLpwzbj1czhBiwOg==; path=/
       #
       #   cookies.encrypted[:discount] # => 45
       def encrypted
-        @encrypted ||=
-          if upgrade_legacy_signed_cookies?
-            UpgradeLegacyEncryptedCookieJar.new(self)
-          elsif upgrade_legacy_hmac_aes_cbc_cookies?
-            UpgradeLegacyHmacAesCbcCookieJar.new(self)
-          else
-            EncryptedCookieJar.new(self)
-          end
+        @encrypted ||= EncryptedKeyRotatingCookieJar.new(self)
       end
 
       # Returns the +signed+ or +encrypted+ jar, preferring +encrypted+ if +secret_key_base+ is set.
@@ -256,33 +265,17 @@ module ActionDispatch
 
         def upgrade_legacy_hmac_aes_cbc_cookies?
           request.secret_key_base.present?                       &&
-            request.authenticated_encrypted_cookie_salt.present? &&
             request.encrypted_signed_cookie_salt.present?        &&
-            request.encrypted_cookie_salt.present?
+            request.encrypted_cookie_salt.present?               &&
+            request.use_authenticated_cookie_encryption
         end
-    end
 
-    # Passing the ActiveSupport::MessageEncryptor::NullSerializer downstream
-    # to the Message{Encryptor,Verifier} allows us to handle the
-    # (de)serialization step within the cookie jar, which gives us the
-    # opportunity to detect and migrate legacy cookies.
-    module VerifyAndUpgradeLegacySignedMessage # :nodoc:
-      def initialize(*args)
-        super
-        @legacy_verifier = ActiveSupport::MessageVerifier.new(request.secret_token, serializer: ActiveSupport::MessageEncryptor::NullSerializer)
-      end
-
-      def verify_and_upgrade_legacy_signed_message(name, signed_message)
-        deserialize(name, @legacy_verifier.verify(signed_message)).tap do |value|
-          self[name] = { value: value }
+        def encrypted_cookie_cipher
+          request.encrypted_cookie_cipher || "aes-256-gcm"
         end
-      rescue ActiveSupport::MessageVerifier::InvalidSignature
-        nil
-      end
 
-      private
-        def parse(name, signed_message)
-          super || verify_and_upgrade_legacy_signed_message(name, signed_message)
+        def signed_cookie_digest
+          request.signed_cookie_digest || "SHA1"
         end
     end
 
@@ -524,6 +517,7 @@ module ActionDispatch
 
     module SerializedCookieJars # :nodoc:
       MARSHAL_SIGNATURE = "\x04\x08".freeze
+      SERIALIZER = ActiveSupport::MessageEncryptor::NullSerializer
 
       protected
         def needs_migration?(value)
@@ -534,12 +528,16 @@ module ActionDispatch
           serializer.dump(value)
         end
 
-        def deserialize(name, value)
+        def deserialize(name)
+          rotate = false
+          value  = yield -> { rotate = true }
+
           if value
-            if needs_migration?(value)
-              Marshal.load(value).tap do |v|
-                self[name] = { value: v }
-              end
+            case
+            when needs_migration?(value)
+              self[name] = Marshal.load(value)
+            when rotate
+              self[name] = serializer.load(value)
             else
               serializer.load(value)
             end
@@ -561,24 +559,31 @@ module ActionDispatch
         def digest
           request.cookies_digest || "SHA1"
         end
-
-        def key_generator
-          request.key_generator
-        end
     end
 
-    class SignedCookieJar < AbstractCookieJar # :nodoc:
+    class SignedKeyRotatingCookieJar < AbstractCookieJar # :nodoc:
       include SerializedCookieJars
 
       def initialize(parent_jar)
         super
-        secret = key_generator.generate_key(request.signed_cookie_salt)
-        @verifier = ActiveSupport::MessageVerifier.new(secret, digest: digest, serializer: ActiveSupport::MessageEncryptor::NullSerializer)
+
+        secret = request.key_generator.generate_key(request.signed_cookie_salt)
+        @verifier = ActiveSupport::MessageVerifier.new(secret, digest: signed_cookie_digest, serializer: SERIALIZER)
+
+        request.cookies_rotations.signed.each do |rotation_options|
+          @verifier.rotate serializer: SERIALIZER, **rotation_options
+        end
+
+        if upgrade_legacy_signed_cookies?
+          @verifier.rotate raw_key: request.secret_token, serializer: SERIALIZER
+        end
       end
 
       private
         def parse(name, signed_message)
-          deserialize name, @verifier.verified(signed_message)
+          deserialize(name) do |rotate|
+            @verifier.verified(signed_message, on_rotation: rotate)
+          end
         end
 
         def commit(options)
@@ -588,37 +593,38 @@ module ActionDispatch
         end
     end
 
-    # UpgradeLegacySignedCookieJar is used instead of SignedCookieJar if
-    # secrets.secret_token and secret_key_base are both set. It reads
-    # legacy cookies signed with the old dummy key generator and signs and
-    # re-saves them using the new key generator to provide a smooth upgrade path.
-    class UpgradeLegacySignedCookieJar < SignedCookieJar #:nodoc:
-      include VerifyAndUpgradeLegacySignedMessage
-    end
-
-    class EncryptedCookieJar < AbstractCookieJar # :nodoc:
+    class EncryptedKeyRotatingCookieJar < AbstractCookieJar # :nodoc:
       include SerializedCookieJars
 
       def initialize(parent_jar)
         super
 
-        if ActiveSupport::LegacyKeyGenerator === key_generator
-          raise "You didn't set secret_key_base, which is required for this cookie jar. " \
-            "Read the upgrade documentation to learn more about this new config option."
+        key_len = ActiveSupport::MessageEncryptor.key_len(encrypted_cookie_cipher)
+        secret = request.key_generator.generate_key(request.authenticated_encrypted_cookie_salt, key_len)
+        @encryptor = ActiveSupport::MessageEncryptor.new(secret, cipher: encrypted_cookie_cipher, serializer: SERIALIZER)
+
+        request.cookies_rotations.encrypted.each do |rotation_options|
+          @encryptor.rotate serializer: SERIALIZER, **rotation_options
         end
 
-        cipher = "aes-256-gcm"
-        key_len = ActiveSupport::MessageEncryptor.key_len(cipher)
-        secret = key_generator.generate_key(request.authenticated_encrypted_cookie_salt || "")[0, key_len]
+        if upgrade_legacy_hmac_aes_cbc_cookies?
+          @encryptor.rotate \
+            key_generator: request.key_generator, salt: request.encrypted_cookie_salt, signed_salt: request.encrypted_signed_cookie_salt,
+            cipher: "aes-256-cbc", digest: digest, serializer: SERIALIZER
+        end
 
-        @encryptor = ActiveSupport::MessageEncryptor.new(secret, cipher: cipher, serializer: ActiveSupport::MessageEncryptor::NullSerializer)
+        if upgrade_legacy_signed_cookies?
+          @legacy_verifier = ActiveSupport::MessageVerifier.new(request.secret_token, digest: digest, serializer: SERIALIZER)
+        end
       end
 
       private
         def parse(name, encrypted_message)
-          deserialize name, @encryptor.decrypt_and_verify(encrypted_message)
-        rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveSupport::MessageEncryptor::InvalidMessage
-          nil
+          deserialize(name) do |rotate|
+            @encryptor.decrypt_and_verify(encrypted_message, on_rotation: rotate)
+          end
+        rescue ActiveSupport::MessageEncryptor::InvalidMessage, ActiveSupport::MessageVerifier::InvalidSignature
+          parse_legacy_signed_message(name, encrypted_message)
         end
 
         def commit(options)
@@ -626,39 +632,15 @@ module ActionDispatch
 
           raise CookieOverflow if options[:value].bytesize > MAX_COOKIE_SIZE
         end
-    end
 
-    # UpgradeLegacyEncryptedCookieJar is used by ActionDispatch::Session::CookieStore
-    # instead of EncryptedCookieJar if secrets.secret_token and secret_key_base
-    # are both set. It reads legacy cookies signed with the old dummy key generator and
-    # encrypts and re-saves them using the new key generator to provide a smooth upgrade path.
-    class UpgradeLegacyEncryptedCookieJar < EncryptedCookieJar #:nodoc:
-      include VerifyAndUpgradeLegacySignedMessage
-    end
+        def parse_legacy_signed_message(name, legacy_signed_message)
+          if defined?(@legacy_verifier)
+            deserialize(name) do |rotate|
+              rotate.call
 
-    # UpgradeLegacyHmacAesCbcCookieJar is used by ActionDispatch::Session::CookieStore
-    # to upgrade cookies encrypted with AES-256-CBC with HMAC to AES-256-GCM
-    class UpgradeLegacyHmacAesCbcCookieJar < EncryptedCookieJar
-      def initialize(parent_jar)
-        super
-
-        secret = key_generator.generate_key(request.encrypted_cookie_salt || "")[0, ActiveSupport::MessageEncryptor.key_len]
-        sign_secret = key_generator.generate_key(request.encrypted_signed_cookie_salt || "")
-
-        @legacy_encryptor = ActiveSupport::MessageEncryptor.new(secret, sign_secret, cipher: "aes-256-cbc", digest: digest, serializer: ActiveSupport::MessageEncryptor::NullSerializer)
-      end
-
-      def decrypt_and_verify_legacy_encrypted_message(name, signed_message)
-        deserialize(name, @legacy_encryptor.decrypt_and_verify(signed_message)).tap do |value|
-          self[name] = { value: value }
-        end
-      rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveSupport::MessageEncryptor::InvalidMessage
-        nil
-      end
-
-      private
-        def parse(name, signed_message)
-          super || decrypt_and_verify_legacy_encrypted_message(name, signed_message)
+              @legacy_verifier.verified(legacy_signed_message)
+            end
+          end
         end
     end
 

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "action_dispatch"
+require "active_support/messages/rotation_configuration"
 
 module ActionDispatch
   class Railtie < Rails::Railtie # :nodoc:
@@ -18,6 +19,7 @@ module ActionDispatch
     config.action_dispatch.signed_cookie_salt = "signed cookie"
     config.action_dispatch.encrypted_cookie_salt = "encrypted cookie"
     config.action_dispatch.encrypted_signed_cookie_salt = "signed encrypted cookie"
+    config.action_dispatch.authenticated_encrypted_cookie_salt = "authenticated encrypted cookie"
     config.action_dispatch.use_authenticated_cookie_encryption = false
     config.action_dispatch.perform_deep_munge = true
 
@@ -26,6 +28,8 @@ module ActionDispatch
       "X-XSS-Protection" => "1; mode=block",
       "X-Content-Type-Options" => "nosniff"
     }
+
+    config.action_dispatch.cookies_rotations = ActiveSupport::Messages::RotationConfiguration.new
 
     config.eager_load_namespaces << ActionDispatch
 
@@ -38,8 +42,6 @@ module ActionDispatch
 
       ActionDispatch::ExceptionWrapper.rescue_responses.merge!(config.action_dispatch.rescue_responses)
       ActionDispatch::ExceptionWrapper.rescue_templates.merge!(config.action_dispatch.rescue_templates)
-
-      config.action_dispatch.authenticated_encrypted_cookie_salt = "authenticated encrypted cookie" if config.action_dispatch.use_authenticated_cookie_encryption
 
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
-require "active_support/key_generator"
+require "active_support/messages/rotation_configuration"
 
 class FlashTest < ActionController::TestCase
   class TestController < ActionController::Base
@@ -243,6 +243,7 @@ end
 class FlashIntegrationTest < ActionDispatch::IntegrationTest
   SessionKey = "_myapp_session"
   Generator  = ActiveSupport::LegacyKeyGenerator.new("b3c631c314c0bbca50c1b2843150fe33")
+  Rotations  = ActiveSupport::Messages::RotationConfiguration.new
 
   class TestController < ActionController::Base
     add_flash_types :bar
@@ -348,6 +349,7 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
       args[0] ||= {}
       args[0][:env] ||= {}
       args[0][:env]["action_dispatch.key_generator"] ||= Generator
+      args[0][:env]["action_dispatch.cookies_rotations"] = Rotations
       super(path, *args)
     end
 

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -2,6 +2,7 @@
 
 require "abstract_unit"
 require "active_support/log_subscriber/test_helper"
+require "active_support/messages/rotation_configuration"
 
 # common controller actions
 module RequestForgeryProtectionActions
@@ -630,13 +631,14 @@ end
 
 class RequestForgeryProtectionControllerUsingNullSessionTest < ActionController::TestCase
   class NullSessionDummyKeyGenerator
-    def generate_key(secret)
+    def generate_key(secret, length = nil)
       "03312270731a2ed0d11ed091c2338a06"
     end
   end
 
   def setup
     @request.env[ActionDispatch::Cookies::GENERATOR_KEY] = NullSessionDummyKeyGenerator.new
+    @request.env[ActionDispatch::Cookies::COOKIES_ROTATIONS] = ActiveSupport::Messages::RotationConfiguration.new
   end
 
   test "should allow to set signed cookies" do

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3,6 +3,7 @@
 require "erb"
 require "abstract_unit"
 require "controller/fake_controllers"
+require "active_support/messages/rotation_configuration"
 
 class TestRoutingMapper < ActionDispatch::IntegrationTest
   SprocketsApp = lambda { |env|
@@ -4947,6 +4948,7 @@ end
 class FlashRedirectTest < ActionDispatch::IntegrationTest
   SessionKey = "_myapp_session"
   Generator  = ActiveSupport::LegacyKeyGenerator.new("b3c631c314c0bbca50c1b2843150fe33")
+  Rotations  = ActiveSupport::Messages::RotationConfiguration.new
 
   class KeyGeneratorMiddleware
     def initialize(app)
@@ -4955,6 +4957,8 @@ class FlashRedirectTest < ActionDispatch::IntegrationTest
 
     def call(env)
       env["action_dispatch.key_generator"] ||= Generator
+      env["action_dispatch.cookies_rotations"] ||= Rotations
+
       @app.call(env)
     end
   end

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -3,11 +3,13 @@
 require "abstract_unit"
 require "stringio"
 require "active_support/key_generator"
+require "active_support/messages/rotation_configuration"
 
 class CookieStoreTest < ActionDispatch::IntegrationTest
   SessionKey = "_myapp_session"
   SessionSecret = "b3c631c314c0bbca50c1b2843150fe33"
   Generator = ActiveSupport::LegacyKeyGenerator.new(SessionSecret)
+  Rotations = ActiveSupport::Messages::RotationConfiguration.new
 
   Verifier = ActiveSupport::MessageVerifier.new(SessionSecret, digest: "SHA1")
   SignedBar = Verifier.generate(foo: "bar", session_id: SecureRandom.hex(16))
@@ -346,6 +348,8 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
       args[0] ||= {}
       args[0][:headers] ||= {}
       args[0][:headers]["action_dispatch.key_generator"] ||= Generator
+      args[0][:headers]["action_dispatch.cookies_rotations"] ||= Rotations
+
       super(path, *args)
     end
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add key rotation support to `MessageEncryptor` and `MessageVerifier`
+
+    This change introduces a `rotate` method to both the `MessageEncryptor` and
+    `MessageVerifier` classes. This method accepts the same arguments and
+    options as the given classes' constructor. The `encrypt_and_verify` method
+    for `MessageEncryptor` and the `verified` method for `MessageVerifier` also
+    accept an optional keyword argument `:on_rotation` block which is called
+    when a rotated instance is used to decrypt or verify the message.
+
+    *Michael J Coyne*
+
 *   Deprecate `Module#reachable?` method.
 
     *bogdanvlviv*

--- a/activesupport/lib/active_support/messages/rotation_configuration.rb
+++ b/activesupport/lib/active_support/messages/rotation_configuration.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Messages
+    class RotationConfiguration
+      attr_reader :signed, :encrypted
+
+      def initialize
+        @signed, @encrypted = [], []
+      end
+
+      def rotate(kind = nil, **options)
+        case kind
+        when :signed
+          @signed << options
+        when :encrypted
+          @encrypted << options
+        else
+          rotate :signed, options
+          rotate :encrypted, options
+        end
+      end
+    end
+  end
+end

--- a/activesupport/lib/active_support/messages/rotator.rb
+++ b/activesupport/lib/active_support/messages/rotator.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Messages
+    module Rotator # :nodoc:
+      def initialize(*args)
+        super
+
+        @rotations = []
+      end
+
+      def rotate(*args)
+        @rotations << create_rotation(*args)
+      end
+
+      module Encryptor
+        include Rotator
+
+        def decrypt_and_verify(*args, on_rotation: nil, **options)
+          super
+        rescue MessageEncryptor::InvalidMessage, MessageVerifier::InvalidSignature
+          run_rotations(on_rotation) { |encryptor| encryptor.decrypt_and_verify(*args, options) } || raise
+        end
+
+        private
+          def create_rotation(raw_key: nil, raw_signed_key: nil, **options)
+            self.class.new \
+              raw_key || extract_key(options),
+              raw_signed_key || extract_signing_key(options),
+              options.slice(:cipher, :digest, :serializer)
+          end
+
+          def extract_key(cipher:, salt:, key_generator: nil, secret: nil, **)
+            key_generator ||= key_generator_for(secret)
+            key_generator.generate_key(salt, self.class.key_len(cipher))
+          end
+
+          def extract_signing_key(cipher:, signed_salt: nil, key_generator: nil, secret: nil, **)
+            if cipher.downcase.end_with?("cbc")
+              raise ArgumentError, "missing signed_salt for signing key generation" unless signed_salt
+
+              key_generator ||= key_generator_for(secret)
+              key_generator.generate_key(signed_salt)
+            end
+          end
+      end
+
+      module Verifier
+        include Rotator
+
+        def verified(*args, on_rotation: nil, **options)
+          super || run_rotations(on_rotation) { |verifier| verifier.verified(*args, options) }
+        end
+
+        private
+          def create_rotation(raw_key: nil, digest: nil, serializer: nil, **options)
+            self.class.new(raw_key || extract_key(options), digest: digest, serializer: serializer)
+          end
+
+          def extract_key(key_generator: nil, secret: nil, salt:)
+            key_generator ||= key_generator_for(secret)
+            key_generator.generate_key(salt)
+          end
+      end
+
+      private
+        def key_generator_for(secret)
+          ActiveSupport::KeyGenerator.new(secret, iterations: 1000)
+        end
+
+        def run_rotations(on_rotation)
+          @rotations.find do |rotation|
+            if message = yield(rotation) rescue next
+              on_rotation.call if on_rotation
+              return message
+            end
+          end
+        end
+    end
+  end
+end

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -20,6 +20,7 @@ class MessageVerifierTest < ActiveSupport::TestCase
   def setup
     @verifier = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!")
     @data = { some: "data", now: Time.utc(2010) }
+    @secret = SecureRandom.random_bytes(32)
   end
 
   def test_valid_message
@@ -89,6 +90,95 @@ class MessageVerifierTest < ActiveSupport::TestCase
   def test_backward_compatibility_messages_signed_without_metadata
     signed_message = "BAh7BzoJc29tZUkiCWRhdGEGOgZFVDoIbm93SXU6CVRpbWUNIIAbgAAAAAAHOgtvZmZzZXRpADoJem9uZUkiCFVUQwY7BkY=--d03c52c91dfe4ccc5159417c660461bcce005e96"
     assert_equal @data, @verifier.verify(signed_message)
+  end
+
+  def test_with_rotated_raw_key
+    old_raw_key = SecureRandom.random_bytes(32)
+
+    old_verifier = ActiveSupport::MessageVerifier.new(old_raw_key, digest: "SHA1")
+    old_message = old_verifier.generate("message verified with old raw key")
+
+    verifier = ActiveSupport::MessageVerifier.new(@secret, digest: "SHA1")
+    verifier.rotate raw_key: old_raw_key, digest: "SHA1"
+
+    assert_equal "message verified with old raw key", verifier.verified(old_message)
+  end
+
+  def test_with_rotated_secret_and_salt
+    old_secret, old_salt = SecureRandom.random_bytes(32), "old salt"
+
+    old_raw_key = ActiveSupport::KeyGenerator.new(old_secret, iterations: 1000).generate_key(old_salt)
+    old_verifier = ActiveSupport::MessageVerifier.new(old_raw_key, digest: "SHA1")
+    old_message = old_verifier.generate("message verified with old secret and salt")
+
+    verifier = ActiveSupport::MessageVerifier.new(@secret, digest: "SHA1")
+    verifier.rotate secret: old_secret, salt: old_salt, digest: "SHA1"
+
+    assert_equal "message verified with old secret and salt", verifier.verified(old_message)
+  end
+
+  def test_with_rotated_key_generator
+    old_key_gen, old_salt = ActiveSupport::KeyGenerator.new(SecureRandom.random_bytes(32), iterations: 256), "old salt"
+
+    old_raw_key = old_key_gen.generate_key(old_salt)
+    old_verifier = ActiveSupport::MessageVerifier.new(old_raw_key, digest: "SHA1")
+    old_message = old_verifier.generate("message verified with old key generator and salt")
+
+    verifier = ActiveSupport::MessageVerifier.new(@secret, digest: "SHA1")
+    verifier.rotate key_generator: old_key_gen, salt: old_salt, digest: "SHA1"
+
+    assert_equal "message verified with old key generator and salt", verifier.verified(old_message)
+  end
+
+  def test_with_rotating_multiple_verifiers
+    old_raw_key, older_raw_key = SecureRandom.random_bytes(32), SecureRandom.random_bytes(32)
+
+    old_verifier = ActiveSupport::MessageVerifier.new(old_raw_key, digest: "SHA256")
+    old_message = old_verifier.generate("message verified with old raw key")
+
+    older_verifier = ActiveSupport::MessageVerifier.new(older_raw_key, digest: "SHA1")
+    older_message = older_verifier.generate("message verified with older raw key")
+
+    verifier = ActiveSupport::MessageVerifier.new("new secret", digest: "SHA512")
+    verifier.rotate raw_key: old_raw_key, digest: "SHA256"
+    verifier.rotate raw_key: older_raw_key, digest: "SHA1"
+
+    assert_equal "verified message", verifier.verified(verifier.generate("verified message"))
+    assert_equal "message verified with old raw key", verifier.verified(old_message)
+    assert_equal "message verified with older raw key", verifier.verified(older_message)
+  end
+
+  def test_on_rotation_keyword_block_is_called_and_verified_returns_message
+    callback_ran, message = nil, nil
+
+    old_raw_key, older_raw_key = SecureRandom.random_bytes(32), SecureRandom.random_bytes(32)
+
+    older_verifier = ActiveSupport::MessageVerifier.new(older_raw_key, digest: "SHA1")
+    older_message = older_verifier.generate(encoded: "message")
+
+    verifier = ActiveSupport::MessageVerifier.new("new secret", digest: "SHA512")
+    verifier.rotate raw_key: old_raw_key, digest: "SHA256"
+    verifier.rotate raw_key: older_raw_key, digest: "SHA1"
+
+    message = verifier.verified(older_message, on_rotation: proc { callback_ran = true })
+
+    assert callback_ran, "callback was ran"
+    assert_equal({ encoded: "message" }, message)
+  end
+
+  def test_with_rotated_metadata
+    old_secret, old_salt = SecureRandom.random_bytes(32), "old salt"
+
+    old_raw_key = ActiveSupport::KeyGenerator.new(old_secret, iterations: 1000).generate_key(old_salt)
+    old_verifier = ActiveSupport::MessageVerifier.new(old_raw_key, digest: "SHA1")
+    old_message = old_verifier.generate(
+      "message verified with old secret, salt, and metadata", purpose: "rotation")
+
+    verifier = ActiveSupport::MessageVerifier.new(@secret, digest: "SHA1")
+    verifier.rotate secret: old_secret, salt: old_salt, digest: "SHA1"
+
+    assert_equal "message verified with old secret, salt, and metadata",
+      verifier.verified(old_message, purpose: "rotation")
   end
 end
 

--- a/activesupport/test/messages/rotation_configuration_test.rb
+++ b/activesupport/test/messages/rotation_configuration_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/messages/rotation_configuration"
+
+class MessagesRotationConfiguration < ActiveSupport::TestCase
+  def setup
+    @config = ActiveSupport::Messages::RotationConfiguration.new
+  end
+
+  def test_signed_configurations
+    @config.rotate :signed, secret: "older secret", salt: "salt", digest: "SHA1"
+    @config.rotate :signed, secret: "old secret", salt: "salt", digest: "SHA256"
+
+    assert_equal [{
+      secret: "older secret", salt: "salt", digest: "SHA1"
+    }, {
+      secret: "old secret", salt: "salt", digest: "SHA256"
+    }], @config.signed
+  end
+
+  def test_encrypted_configurations
+    @config.rotate :encrypted, raw_key: "old raw key", cipher: "aes-256-gcm"
+
+    assert_equal [{
+      raw_key: "old raw key", cipher: "aes-256-gcm"
+    }], @config.encrypted
+  end
+
+  def test_rotate_without_kind
+    @config.rotate secret: "older secret", salt: "salt", digest: "SHA1"
+    @config.rotate raw_key: "old raw key", cipher: "aes-256-gcm"
+
+    expected = [{
+      secret: "older secret", salt: "salt", digest: "SHA1"
+    }, {
+      raw_key: "old raw key", cipher: "aes-256-gcm"
+    }]
+
+    assert_equal expected, @config.encrypted
+    assert_equal expected, @config.signed
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -487,6 +487,17 @@ Defaults to `'signed cookie'`.
   authenticated encrypted cookie salt. Defaults to `'authenticated encrypted
   cookie'`.
 
+* `config.action_dispatch.encrypted_cookie_cipher` sets the cipher to be
+  used for encrypted cookies. This defaults to `"aes-256-gcm"`.
+
+* `config.action_dispatch.signed_cookie_digest` sets the digest to be
+  used for signed cookies. This defaults to `"SHA1"`.
+
+* `config.action_dispatch.cookies_rotations` is set to an instance of
+  [RotationConfiguration](http://api.rubyonrails.org/classes/ActiveSupport/RotationConfiguration.html).
+  It provides an interface for rotating keys, salts, ciphers, and
+  digests for encrypted and signed cookies.
+
 * `config.action_dispatch.perform_deep_munge` configures whether `deep_munge`
   method should be performed on the parameters. See [Security Guide](security.html#unsafe-query-generation)
   for more information. It defaults to `true`.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -259,6 +259,7 @@ module Rails
           "action_dispatch.encrypted_cookie_salt" => config.action_dispatch.encrypted_cookie_salt,
           "action_dispatch.encrypted_signed_cookie_salt" => config.action_dispatch.encrypted_signed_cookie_salt,
           "action_dispatch.authenticated_encrypted_cookie_salt" => config.action_dispatch.authenticated_encrypted_cookie_salt,
+          "action_dispatch.use_authenticated_cookie_encryption" => config.action_dispatch.use_authenticated_cookie_encryption,
           "action_dispatch.encrypted_cookie_cipher" => config.action_dispatch.encrypted_cookie_cipher,
           "action_dispatch.signed_cookie_digest" => config.action_dispatch.signed_cookie_digest,
           "action_dispatch.cookies_serializer" => config.action_dispatch.cookies_serializer,

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -259,8 +259,11 @@ module Rails
           "action_dispatch.encrypted_cookie_salt" => config.action_dispatch.encrypted_cookie_salt,
           "action_dispatch.encrypted_signed_cookie_salt" => config.action_dispatch.encrypted_signed_cookie_salt,
           "action_dispatch.authenticated_encrypted_cookie_salt" => config.action_dispatch.authenticated_encrypted_cookie_salt,
+          "action_dispatch.encrypted_cookie_cipher" => config.action_dispatch.encrypted_cookie_cipher,
+          "action_dispatch.signed_cookie_digest" => config.action_dispatch.signed_cookie_digest,
           "action_dispatch.cookies_serializer" => config.action_dispatch.cookies_serializer,
-          "action_dispatch.cookies_digest" => config.action_dispatch.cookies_digest
+          "action_dispatch.cookies_digest" => config.action_dispatch.cookies_digest,
+          "action_dispatch.cookies_rotations" => config.action_dispatch.cookies_rotations
         )
       end
     end

--- a/railties/test/application/middleware/cookies_test.rb
+++ b/railties/test/application/middleware/cookies_test.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 require "isolation/abstract_unit"
+require "rack/test"
 
 module ApplicationTests
   class CookiesTest < ActiveSupport::TestCase
     include ActiveSupport::Testing::Isolation
+    include Rack::Test::Methods
 
     def new_app
       File.expand_path("#{app_path}/../new_app")
@@ -13,6 +15,10 @@ module ApplicationTests
     def setup
       build_app
       FileUtils.rm_rf("#{app_path}/config/environments")
+    end
+
+    def app
+      Rails.application
     end
 
     def teardown
@@ -43,6 +49,143 @@ module ApplicationTests
       Rails.env = "development"
       require "#{app_path}/config/environment"
       assert_equal false, ActionDispatch::Cookies::CookieJar.always_write_cookie
+    end
+
+    test "signed cookies with SHA512 digest and rotated out SHA256 and SHA1 digests" do
+      key_gen_sha1 = ActiveSupport::KeyGenerator.new("legacy sha1 secret", iterations: 1000)
+      key_gen_sha256 = ActiveSupport::KeyGenerator.new("legacy sha256 secret", iterations: 1000)
+
+      verifer_sha1 = ActiveSupport::MessageVerifier.new(key_gen_sha1.generate_key("sha1 salt"), digest: :SHA1)
+      verifer_sha256 = ActiveSupport::MessageVerifier.new(key_gen_sha256.generate_key("sha256 salt"), digest: :SHA256)
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get  ':controller(/:action)'
+          post ':controller(/:action)'
+        end
+      RUBY
+
+      controller :foo, <<-RUBY
+        class FooController < ActionController::Base
+          protect_from_forgery with: :null_session
+
+          def write_raw_cookie_sha1
+            cookies[:signed_cookie] = "#{verifer_sha1.generate("signed cookie")}"
+            head :ok
+          end
+
+          def write_raw_cookie_sha256
+            cookies[:signed_cookie] = "#{verifer_sha256.generate("signed cookie")}"
+            head :ok
+          end
+
+          def read_signed
+            render plain: cookies.signed[:signed_cookie].inspect
+          end
+
+          def read_raw_cookie
+            render plain: cookies[:signed_cookie]
+          end
+        end
+      RUBY
+
+      add_to_config <<-RUBY
+        config.action_dispatch.cookies_rotations.rotate :signed,
+          digest: "SHA1", secret: "legacy sha1 secret", salt: "sha1 salt"
+
+        config.action_dispatch.cookies_rotations.rotate :signed,
+          digest: "SHA256", secret: "legacy sha256 secret", salt: "sha256 salt"
+
+        config.action_dispatch.signed_cookie_digest = "SHA512"
+        config.action_dispatch.signed_cookie_salt = "sha512 salt"
+      RUBY
+
+      require "#{app_path}/config/environment"
+
+      verifer_sha512 = ActiveSupport::MessageVerifier.new(app.key_generator.generate_key("sha512 salt"), digest: :SHA512)
+
+      get "/foo/write_raw_cookie_sha1"
+      get "/foo/read_signed"
+      assert_equal "signed cookie".inspect, last_response.body
+
+      get "/foo/read_raw_cookie"
+      assert_equal "signed cookie", verifer_sha512.verify(last_response.body)
+
+      get "/foo/write_raw_cookie_sha256"
+      get "/foo/read_signed"
+      assert_equal "signed cookie".inspect, last_response.body
+
+      get "/foo/read_raw_cookie"
+      assert_equal "signed cookie", verifer_sha512.verify(last_response.body)
+    end
+
+    test "encrypted cookies with multiple rotated out ciphers" do
+      key_gen_one = ActiveSupport::KeyGenerator.new("legacy secret one", iterations: 1000)
+      key_gen_two = ActiveSupport::KeyGenerator.new("legacy secret two", iterations: 1000)
+
+      encryptor_one = ActiveSupport::MessageEncryptor.new(key_gen_one.generate_key("salt one", 32), cipher: "aes-256-gcm")
+      encryptor_two = ActiveSupport::MessageEncryptor.new(key_gen_two.generate_key("salt two", 32), cipher: "aes-256-gcm")
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get  ':controller(/:action)'
+          post ':controller(/:action)'
+        end
+      RUBY
+
+      controller :foo, <<-RUBY
+        class FooController < ActionController::Base
+          protect_from_forgery with: :null_session
+
+          def write_raw_cookie_one
+            cookies[:encrypted_cookie] = "#{encryptor_one.encrypt_and_sign("encrypted cookie")}"
+            head :ok
+          end
+
+          def write_raw_cookie_two
+            cookies[:encrypted_cookie] = "#{encryptor_two.encrypt_and_sign("encrypted cookie")}"
+            head :ok
+          end
+
+          def read_encrypted
+            render plain: cookies.encrypted[:encrypted_cookie].inspect
+          end
+
+          def read_raw_cookie
+            render plain: cookies[:encrypted_cookie]
+          end
+        end
+      RUBY
+
+      add_to_config <<-RUBY
+        config.action_dispatch.use_authenticated_cookie_encryption = true
+        config.action_dispatch.encrypted_cookie_cipher = "aes-256-gcm"
+        config.action_dispatch.authenticated_encrypted_cookie_salt = "salt"
+
+        config.action_dispatch.cookies_rotations.rotate :encrypted,
+          cipher: "aes-256-gcm", secret: "legacy secret one", salt: "salt one"
+
+        config.action_dispatch.cookies_rotations.rotate :encrypted,
+          cipher: "aes-256-gcm", secret: "legacy secret two", salt: "salt two"
+      RUBY
+
+      require "#{app_path}/config/environment"
+
+      encryptor = ActiveSupport::MessageEncryptor.new(app.key_generator.generate_key("salt", 32), cipher: "aes-256-gcm")
+
+      get "/foo/write_raw_cookie_one"
+      get "/foo/read_encrypted"
+      assert_equal "encrypted cookie".inspect, last_response.body
+
+      get "/foo/read_raw_cookie"
+      assert_equal "encrypted cookie", encryptor.decrypt_and_verify(last_response.body)
+
+      get "/foo/write_raw_cookie_sha256"
+      get "/foo/read_encrypted"
+      assert_equal "encrypted cookie".inspect, last_response.body
+
+      get "/foo/read_raw_cookie"
+      assert_equal "encrypted cookie", encryptor.decrypt_and_verify(last_response.body)
     end
   end
 end


### PR DESCRIPTION
### Summary

This PR introduces `ActiveSupport::KeyRotator` which wraps `KeyGenerator` as well as `MessageEncryptor` and `MessageVerifier` and provides an interface for easily rotating between different encryption ciphers or message digests, salts, and secrets.

This PR also simplifies the cookies middleware and removes several of the internal legacy middlewares. Upgrading both signed and encrypted legacy cookies is now handled by rotation capable middlewares which each use a `KeyRotator` instance. Is also introduces a new interface for configuring the middleware.

### Other Information

This feature spawned from discussions had in the Rails’ basecamp.

I still need to update the configuring and security markdown guides with details of this change. I plan on adding a new section the security guide detailing how secrets and salts can be rotated. I also want to add more rotation tests to `railties/test/application/middleware/cookies_test.rb`.

Any and all feedback is welcomed!

/cc @matthewd @kaspth
