### PR TITLE
Make tld_length of setting a cookie consistent with other tld_length

### DIFF
--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -1014,6 +1014,14 @@ class CookiesTest < ActionController::TestCase
     assert_cookie_header "user_name=rizwanreza; domain=.lvh.me; path=/; SameSite=Lax"
   end
 
+  def test_cookie_with_all_domain_option_and_excludes_domain
+    request.env["action_dispatch.cookies_tld_length_excludes_domain"] = true
+    @request.host = "www.doorkeeper.co.jp"
+    get :set_cookie_with_domain_and_tld
+    assert_response :success
+    assert_cookie_header "user_name=rizwanreza; domain=.doorkeeper.co.jp; path=/; SameSite=Lax"
+  end
+
   def test_cookie_with_all_domain_option_using_host_with_port_and_tld_length
     @request.host = "nextangle.local:3000"
     get :set_cookie_with_domain_and_tld

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -266,6 +266,7 @@ module Rails
           "action_dispatch.cookies_digest" => config.action_dispatch.cookies_digest,
           "action_dispatch.cookies_rotations" => config.action_dispatch.cookies_rotations,
           "action_dispatch.cookies_same_site_protection" => config.action_dispatch.cookies_same_site_protection,
+          "action_dispatch.cookies_tld_length_excludes_domain" => config.action_dispatch.cookies_tld_length_excludes_domain,
           "action_dispatch.use_cookies_with_metadata" => config.action_dispatch.use_cookies_with_metadata,
           "action_dispatch.content_security_policy" => config.content_security_policy,
           "action_dispatch.content_security_policy_report_only" => config.content_security_policy_report_only,

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -174,6 +174,7 @@ module Rails
 
           if respond_to?(:action_dispatch)
             action_dispatch.cookies_same_site_protection = :lax
+            action_dispatch.cookies_tld_length_excludes_domain = true
           end
         else
           raise "Unknown version #{target_version.to_s.inspect}"


### PR DESCRIPTION
With the `tld_length` passed as an argument of setting a cookie, the value refers to the length of the tld plus the domain itself. So to share cookies across a.rubyonrails.co.uk and b.rubyonrails.co.uk, you'd set the tld_length to 3.

With `config.action_dispatch.tld_length`, the value refers only to the length of the tld (non-domain) portion of the domain. So for www.rubyonrails.co.uk, tld_length should be set to 2.
    
As action dispatch's `tld_length` is more logical, and most likely more widely used, this changes the `tld_length` when setting a cookie to carry the same meaning.
    
As this is a non-backwards compatible change, it introduces a new config value so that existing applications can work as before.