### PR TITLE
Return Not found Ids in ActiveRecord::NotFound

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -59,7 +59,9 @@ module ActiveRecord
           r.send(reflection.association_primary_key)
         end.values_at(*ids).compact
         if records.size != ids.size
-          klass.all.raise_record_not_found_exception!(ids, records.size, ids.size, reflection.association_primary_key)
+          found_ids = records.map { |record| record.send(reflection.association_primary_key) }
+          not_found_ids = ids - found_ids
+          klass.all.raise_record_not_found_exception!(ids, records.size, ids.size, reflection.association_primary_key, not_found_ids)
         else
           replace(records)
         end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -330,7 +330,7 @@ module ActiveRecord
     # of results obtained should be provided in the +result_size+ argument and
     # the expected number of results should be provided in the +expected_size+
     # argument.
-    def raise_record_not_found_exception!(ids = nil, result_size = nil, expected_size = nil, key = primary_key) # :nodoc:
+    def raise_record_not_found_exception!(ids = nil, result_size = nil, expected_size = nil, key = primary_key, not_found_ids = nil) # :nodoc:
       conditions = arel.where_sql(@klass)
       conditions = " [#{conditions}]" if conditions
       name = @klass.name
@@ -344,8 +344,8 @@ module ActiveRecord
         raise RecordNotFound.new(error, name, key, ids)
       else
         error = "Couldn't find all #{name.pluralize} with '#{key}': ".dup
-        error << "(#{ids.join(", ")})#{conditions} (found #{result_size} results, but was looking for #{expected_size})"
-
+        error << "(#{ids.join(", ")})#{conditions} (found #{result_size} results, but was looking for #{expected_size})."
+        error << " Couldn't find #{name.pluralize(not_found_ids.size)} with #{key.to_s.pluralize(not_found_ids.size)} #{not_found_ids.join(', ')}." if not_found_ids
         raise RecordNotFound.new(error, name, primary_key, ids)
       end
     end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -891,7 +891,8 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     company = companies(:rails_core)
     ids = [Developer.first.id, -9999]
     e = assert_raises(ActiveRecord::RecordNotFound) { company.developer_ids = ids }
-    assert_match(/Couldn't find all Developers with 'id'/, e.message)
+    msg = "Couldn't find all Developers with 'id': (1, -9999) (found 1 results, but was looking for 2). Couldn't find Developer with id -9999."
+    assert_equal(msg, e.message)
   end
 
   def test_collection_singular_ids_setter_raises_exception_when_invalid_ids_set_with_changed_primary_key
@@ -905,7 +906,8 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     author = authors(:david)
     ids = [categories(:general).name, "Unknown"]
     e = assert_raises(ActiveRecord::RecordNotFound) { author.essay_category_ids = ids }
-    assert_equal "Couldn't find all Categories with 'name': (General, Unknown) (found 1 results, but was looking for 2)", e.message
+    msg = "Couldn't find all Categories with 'name': (General, Unknown) (found 1 results, but was looking for 2). Couldn't find Category with name Unknown."
+    assert_equal msg, e.message
   end
 
   def test_build_a_model_from_hm_through_association_with_where_clause

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1153,7 +1153,7 @@ class FinderTest < ActiveRecord::TestCase
       e = assert_raises(ActiveRecord::RecordNotFound) do
         model.find "Hello", "World!"
       end
-      assert_equal "Couldn't find all MercedesCars with 'name': (Hello, World!) (found 0 results, but was looking for 2)", e.message
+      assert_equal "Couldn't find all MercedesCars with 'name': (Hello, World!) (found 0 results, but was looking for 2).", e.message
     end
   end
 


### PR DESCRIPTION

### Summary

This builds on top of 15e2da656f41af0124f7577858536f3b65462ad5.
now it also returns exact Ids which were not found.

### Use-Case - APIs

For example: if Company API is expecting `params[:developer_ids]` as input param. The client sends say 20ids of out of 18 are valid & 2 are invalid. In current version of rails, client will get the error message as given below:

> Couldn't find all Developers with 'id': (7, 2, 19, 20, 10, 15, 1, 14, 8, 11, 12, 9, 6, 5, 17, 13, 18, 4, 16, 3) (found 18 results, but was looking for 20).

Now after reading the above message, it pretty hard to figure which IDs are invalid. But After this change, the error message will tell them exactly what's wrong:


> Couldn't find all Developers with 'id': (7, 2, 19, 20, 10, 15, 1, 14, 8, 11, 12, 9, 6, 5, 17, 13, 18, 4, 16, 3) (found 18 results, but was looking for 20). Please check following 'ids': 12,18.


Good Idea?