### PR TITLE
Treat secrets as binary

### DIFF
--- a/railties/lib/rails/secrets.rb
+++ b/railties/lib/rails/secrets.rb
@@ -101,11 +101,11 @@ module Rails
 
         def writing(contents)
           tmp_path = File.join(Dir.tmpdir, File.basename(path))
-          File.write(tmp_path, contents)
+          IO.binwrite(tmp_path, contents)
 
           yield tmp_path
 
-          updated_contents = File.read(tmp_path)
+          updated_contents = IO.binread(tmp_path)
 
           write(updated_contents) if updated_contents != contents
         ensure


### PR DESCRIPTION
Until Rails 5.1.1 secrets was treated as binary inside Rails.
https://github.com/rails/rails/blob/v5.1.1/railties/lib/rails/secrets.rb#L59
https://github.com/rails/rails/blob/v5.1.1/railties/lib/rails/secrets.rb#L63

However, it is treated as String in Rails 5.1.2(changed by 157db872103429e8782b62d1cb5d1d91337177a7).
https://github.com/rails/rails/blob/v5.1.2/railties/lib/rails/secrets.rb#L104
https://github.com/rails/rails/blob/v5.1.2/railties/lib/rails/secrets.rb#L108

As a result, when upgrading from Rails 5.1.1 to 5.1.2, to write the value treated as binary using `File.write`, causing an error.
In order to avoid `UndefinedConversionError`, fixed it to treat it as binary like 5.1.1.

Fixes #29696

