### PR TITLE
Add assertions of options

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add assertions of options.
+
+    *Tsukuru Tanimichi*
+
 *   Add `srcset` option to `image_tag` helper.
 
     *Roberto Miranda*

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -128,6 +128,8 @@ module ActionView
       #   highlight('<a href="javascript:alert(\'no!\')">ruby</a> on rails', 'rails', sanitize: false)
       #   # => "<a>ruby</a> on <mark>rails</mark>"
       def highlight(text, phrases, options = {})
+        options.assert_valid_keys(:sanitize, :highlighter)
+
         text = sanitize(text) if options.fetch(:sanitize, true)
 
         if text.blank? || phrases.blank?

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -186,6 +186,8 @@ class TextHelperTest < ActionView::TestCase
       "This text is not changed because we supplied an empty phrase",
       highlight("This text is not changed because we supplied an empty phrase", nil)
     )
+
+    assert_raise(ArgumentError) { highlight("This is a beautiful morning", "beautiful", invalid_option: true) }
   end
 
   def test_highlight_pending

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add assertions of options.
+
+    *Tsukuru Tanimichi*
+
 *   Add method `#merge!` for `ActiveModel::Errors`.
 
     *Jahfer Husain*

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -51,6 +51,8 @@ module ActiveModel
       #   User.find_by(name: 'david').try(:authenticate, 'notright')      # => false
       #   User.find_by(name: 'david').try(:authenticate, 'mUc3m00RsqyRe') # => user
       def has_secure_password(options = {})
+        options.assert_valid_keys(:validations)
+
         # Load bcrypt gem only when has_secure_password is used.
         # This is to avoid ActiveModel (and by extension the entire framework)
         # being dependent on a binary library.


### PR DESCRIPTION
Some public interfaces of RoR have assertions of options, but others don't.

```bash
$ find . -name *.rb -type file | xargs grep assert_valid_keys
./actionview/lib/action_view/helpers/output_safety_helper.rb:        options.assert_valid_keys(:words_connector, :two_words_connector, :last_word_connector, :locale)
./activerecord/lib/active_record/aggregations.rb:          options.assert_valid_keys(:class_name, :mapping, :allow_nil, :constructor, :converter)
./activerecord/lib/active_record/associations/builder/association.rb:      options.assert_valid_keys(valid_options(options))
./activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:        options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :using, :algorithm, :type)
./activerecord/lib/active_record/nested_attributes.rb:        options.assert_valid_keys(:allow_destroy, :reject_if, :limit, :update_only)
./activerecord/lib/active_record/relation/merger.rb:        hash.assert_valid_keys(*Relation::VALUE_METHODS)
./activesupport/lib/active_support/benchmarkable.rb:        options.assert_valid_keys(:level, :silence)
./activesupport/lib/active_support/core_ext/array/conversions.rb:    options.assert_valid_keys(:words_connector, :two_words_connector, :last_word_connector, :locale)
./activesupport/lib/active_support/core_ext/hash/keys.rb:  #   { name: 'Rob', years: '28' }.assert_valid_keys(:name, :age) # => raises "ArgumentError: Unknown key: :years. Valid keys are: :name, :age"
./activesupport/lib/active_support/core_ext/hash/keys.rb:  #   { name: 'Rob', age: '28' }.assert_valid_keys('name', 'age') # => raises "ArgumentError: Unknown key: :name. Valid keys are: 'name', 'age'"
./activesupport/lib/active_support/core_ext/hash/keys.rb:  #   { name: 'Rob', age: '28' }.assert_valid_keys(:name, :age)   # => passes, raises nothing
./activesupport/lib/active_support/core_ext/hash/keys.rb:  def assert_valid_keys(*valid_keys)
./activesupport/lib/active_support/core_ext/hash/slice.rb:  #     criteria.assert_valid_keys(:mass, :velocity, :time)
./activesupport/test/core_ext/hash_ext_test.rb:  def test_assert_valid_keys
./activesupport/test/core_ext/hash_ext_test.rb:      { failure: "stuff", funny: "business" }.assert_valid_keys([ :failure, :funny ])
./activesupport/test/core_ext/hash_ext_test.rb:      { failure: "stuff", funny: "business" }.assert_valid_keys(:failure, :funny)
./activesupport/test/core_ext/hash_ext_test.rb:      { failure: "stuff", funny: "business" }.assert_valid_keys([ :failure, :funny, :sunny ])
./activesupport/test/core_ext/hash_ext_test.rb:      { failure: "stuff", funny: "business" }.assert_valid_keys(:failure, :funny, :sunny)
./activesupport/test/core_ext/hash_ext_test.rb:      { failore: "stuff", funny: "business" }.assert_valid_keys([ :failure, :funny ])
./activesupport/test/core_ext/hash_ext_test.rb:      { failore: "stuff", funny: "business" }.assert_valid_keys(:failure, :funny)
./activesupport/test/core_ext/hash_ext_test.rb:      { failore: "stuff", funny: "business" }.assert_valid_keys([ :failure ])
./activesupport/test/core_ext/hash_ext_test.rb:      { failore: "stuff", funny: "business" }.assert_valid_keys(:failure)
```