### PR TITLE
Use frozen-string-literal in ActiveSupport

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,6 +77,12 @@ Layout/SpaceBeforeFirstArg:
 Style/MethodDefParentheses:
   Enabled: true
 
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+  Include:
+    - 'activesupport/**/*'
+
 # Use `foo {}` not `foo{}`.
 Layout/SpaceBeforeBlockBraces:
   Enabled: true

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rake/testtask"
 
 task default: :test

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|

--- a/activesupport/bin/generate_tables
+++ b/activesupport/bin/generate_tables
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 begin
   $:.unshift(File.expand_path("../lib", __dir__))

--- a/activesupport/bin/test
+++ b/activesupport/bin/test
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # Copyright (c) 2005-2017 David Heinemeier Hansson
 #

--- a/activesupport/lib/active_support/all.rb
+++ b/activesupport/lib/active_support/all.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support"
 require_relative "time"
 require_relative "core_ext"

--- a/activesupport/lib/active_support/array_inquirer.rb
+++ b/activesupport/lib/active_support/array_inquirer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   # Wrapping an array in an +ArrayInquirer+ gives a friendlier way to check
   # its string-like contents:

--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   # Backtraces often include many lines that are not relevant for the context
   # under review. This makes it hard to find the signal amongst the backtrace

--- a/activesupport/lib/active_support/benchmarkable.rb
+++ b/activesupport/lib/active_support/benchmarkable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "core_ext/benchmark"
 require_relative "core_ext/hash/keys"
 

--- a/activesupport/lib/active_support/builder.rb
+++ b/activesupport/lib/active_support/builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 begin
   require "builder"
 rescue LoadError => e

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "zlib"
 require_relative "core_ext/array/extract_options"
 require_relative "core_ext/array/wrap"

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../core_ext/marshal"
 require_relative "../core_ext/file/atomic"
 require_relative "../core_ext/string/conversions"

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 begin
   require "dalli"
 rescue LoadError => e

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "monitor"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/cache/null_store.rb
+++ b/activesupport/lib/active_support/cache/null_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module Cache
     # A cache store implementation which doesn't actually store anything. Useful in

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../core_ext/object/duplicable"
 require_relative "../../core_ext/string/inflections"
 require_relative "../../per_thread_registry"

--- a/activesupport/lib/active_support/cache/strategy/local_cache_middleware.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache_middleware.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rack/body_proxy"
 require "rack/utils"
 

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "concern"
 require_relative "descendants_tracker"
 require_relative "core_ext/array/extract_options"

--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   # A typical module looks like this:
   #

--- a/activesupport/lib/active_support/concurrency/share_lock.rb
+++ b/activesupport/lib/active_support/concurrency/share_lock.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "thread"
 require "monitor"
 

--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "concern"
 require_relative "ordered_options"
 require_relative "core_ext/array/extract_options"

--- a/activesupport/lib/active_support/core_ext.rb
+++ b/activesupport/lib/active_support/core_ext.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Dir.glob(File.expand_path("core_ext/*.rb", __dir__)).each do |path|
   require path
 end

--- a/activesupport/lib/active_support/core_ext/array.rb
+++ b/activesupport/lib/active_support/core_ext/array.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "array/wrap"
 require_relative "array/access"
 require_relative "array/conversions"

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Array
   # Returns the tail of the array from +position+.
   #

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../xml_mini"
 require_relative "../hash/keys"
 require_relative "../string/inflections"

--- a/activesupport/lib/active_support/core_ext/array/extract_options.rb
+++ b/activesupport/lib/active_support/core_ext/array/extract_options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Hash
   # By default, only instances of Hash itself are extractable.
   # Subclasses of Hash may implement this method and return

--- a/activesupport/lib/active_support/core_ext/array/grouping.rb
+++ b/activesupport/lib/active_support/core_ext/array/grouping.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Array
   # Splits or iterates over the array in groups of size +number+,
   # padding any remaining slots with +fill_with+ unless it is +false+.

--- a/activesupport/lib/active_support/core_ext/array/inquiry.rb
+++ b/activesupport/lib/active_support/core_ext/array/inquiry.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../array_inquirer"
 
 class Array

--- a/activesupport/lib/active_support/core_ext/array/prepend_and_append.rb
+++ b/activesupport/lib/active_support/core_ext/array/prepend_and_append.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Array
   # The human way of thinking about adding stuff to the end of a list is with append.
   alias_method :append,  :push unless [].respond_to?(:append)

--- a/activesupport/lib/active_support/core_ext/array/wrap.rb
+++ b/activesupport/lib/active_support/core_ext/array/wrap.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Array
   # Wraps its argument in an array unless it is already an array (or array-like).
   #

--- a/activesupport/lib/active_support/core_ext/benchmark.rb
+++ b/activesupport/lib/active_support/core_ext/benchmark.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "benchmark"
 
 class << Benchmark

--- a/activesupport/lib/active_support/core_ext/big_decimal.rb
+++ b/activesupport/lib/active_support/core_ext/big_decimal.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 require_relative "big_decimal/conversions"

--- a/activesupport/lib/active_support/core_ext/big_decimal/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/big_decimal/conversions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "bigdecimal"
 require "bigdecimal/util"
 

--- a/activesupport/lib/active_support/core_ext/class.rb
+++ b/activesupport/lib/active_support/core_ext/class.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 require_relative "class/attribute"
 require_relative "class/subclasses"

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../kernel/singleton_class"
 require_relative "../module/remove_method"
 require_relative "../array/extract_options"

--- a/activesupport/lib/active_support/core_ext/class/attribute_accessors.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute_accessors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # cattr_* became mattr_* aliases in 7dfbd91b0780fbd6a1dd9bfbc176e10894871d2d,
 # but we keep this around for libraries that directly require it knowing they
 # want cattr_*. No need to deprecate.

--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../module/anonymous"
 require_relative "../module/reachable"
 

--- a/activesupport/lib/active_support/core_ext/date.rb
+++ b/activesupport/lib/active_support/core_ext/date.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "date/acts_like"
 require_relative "date/blank"
 require_relative "date/calculations"

--- a/activesupport/lib/active_support/core_ext/date/acts_like.rb
+++ b/activesupport/lib/active_support/core_ext/date/acts_like.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../object/acts_like"
 
 class Date

--- a/activesupport/lib/active_support/core_ext/date/blank.rb
+++ b/activesupport/lib/active_support/core_ext/date/blank.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "date"
 
 class Date #:nodoc:

--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "date"
 require_relative "../../duration"
 require_relative "../object/acts_like"

--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "date"
 require_relative "../../inflector/methods"
 require_relative "zones"

--- a/activesupport/lib/active_support/core_ext/date/zones.rb
+++ b/activesupport/lib/active_support/core_ext/date/zones.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "date"
 require_relative "../date_and_time/zones"
 

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../object/try"
 
 module DateAndTime

--- a/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../module/attribute_accessors"
 
 module DateAndTime

--- a/activesupport/lib/active_support/core_ext/date_and_time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/zones.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module DateAndTime
   module Zones
     # Returns the simultaneous time in <tt>Time.zone</tt> if a zone is given or

--- a/activesupport/lib/active_support/core_ext/date_time.rb
+++ b/activesupport/lib/active_support/core_ext/date_time.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "date_time/acts_like"
 require_relative "date_time/blank"
 require_relative "date_time/calculations"

--- a/activesupport/lib/active_support/core_ext/date_time/acts_like.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/acts_like.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "date"
 require_relative "../object/acts_like"
 

--- a/activesupport/lib/active_support/core_ext/date_time/blank.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/blank.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "date"
 
 class DateTime #:nodoc:

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "date"
 
 class DateTime

--- a/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../date_and_time/compatibility"
 require_relative "../module/remove_method"
 

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "date"
 require_relative "../../inflector/methods"
 require_relative "../time/conversions"

--- a/activesupport/lib/active_support/core_ext/digest/uuid.rb
+++ b/activesupport/lib/active_support/core_ext/digest/uuid.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "securerandom"
 
 module Digest

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Enumerable
   # Enumerable#sum was added in Ruby 2.4, but it only works with Numeric elements
   # when we omit an identity.

--- a/activesupport/lib/active_support/core_ext/file.rb
+++ b/activesupport/lib/active_support/core_ext/file.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 require_relative "file/atomic"

--- a/activesupport/lib/active_support/core_ext/file/atomic.rb
+++ b/activesupport/lib/active_support/core_ext/file/atomic.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "fileutils"
 
 class File

--- a/activesupport/lib/active_support/core_ext/hash.rb
+++ b/activesupport/lib/active_support/core_ext/hash.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "hash/compact"
 require_relative "hash/conversions"
 require_relative "hash/deep_merge"

--- a/activesupport/lib/active_support/core_ext/hash/compact.rb
+++ b/activesupport/lib/active_support/core_ext/hash/compact.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Hash
   unless Hash.instance_methods(false).include?(:compact)
     # Returns a hash with non +nil+ values.

--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../xml_mini"
 require_relative "../../time"
 require_relative "../object/blank"

--- a/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Hash
   # Returns a new hash with +self+ and +other_hash+ merged recursively.
   #

--- a/activesupport/lib/active_support/core_ext/hash/except.rb
+++ b/activesupport/lib/active_support/core_ext/hash/except.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Hash
   # Returns a hash that includes everything except given keys.
   #   hash = { a: true, b: false, c: nil }

--- a/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb
+++ b/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../hash_with_indifferent_access"
 
 class Hash

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Hash
   # Returns a new hash with all keys converted using the +block+ operation.
   #

--- a/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Hash
   # Merges the caller into +other_hash+. For example,
   #

--- a/activesupport/lib/active_support/core_ext/hash/slice.rb
+++ b/activesupport/lib/active_support/core_ext/hash/slice.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Hash
   # Slices a hash to include only the given keys. Returns a hash containing
   # the given keys.

--- a/activesupport/lib/active_support/core_ext/hash/transform_values.rb
+++ b/activesupport/lib/active_support/core_ext/hash/transform_values.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Hash
   # Returns a new hash with the results of running +block+ once for every value.
   # The keys are unchanged.

--- a/activesupport/lib/active_support/core_ext/integer.rb
+++ b/activesupport/lib/active_support/core_ext/integer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "integer/multiple"
 require_relative "integer/inflections"
 require_relative "integer/time"

--- a/activesupport/lib/active_support/core_ext/integer/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/integer/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../inflector"
 
 class Integer

--- a/activesupport/lib/active_support/core_ext/integer/multiple.rb
+++ b/activesupport/lib/active_support/core_ext/integer/multiple.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Integer
   # Check whether the integer is evenly divisible by the argument.
   #

--- a/activesupport/lib/active_support/core_ext/integer/time.rb
+++ b/activesupport/lib/active_support/core_ext/integer/time.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../duration"
 require_relative "../numeric/time"
 

--- a/activesupport/lib/active_support/core_ext/kernel.rb
+++ b/activesupport/lib/active_support/core_ext/kernel.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "kernel/agnostics"
 require_relative "kernel/concern"
 require_relative "kernel/reporting"

--- a/activesupport/lib/active_support/core_ext/kernel/agnostics.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/agnostics.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Object
   # Makes backticks behave (somewhat more) similarly on all platforms.
   # On win32 `nonexistent_command` raises Errno::ENOENT; on Unix, the

--- a/activesupport/lib/active_support/core_ext/kernel/concern.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/concern.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../module/concerning"
 
 module Kernel

--- a/activesupport/lib/active_support/core_ext/kernel/reporting.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/reporting.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Kernel
   module_function
 

--- a/activesupport/lib/active_support/core_ext/kernel/singleton_class.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/singleton_class.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Kernel
   # class_eval on an object acts like singleton_class.class_eval.
   def class_eval(*args, &block)

--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class LoadError
   REGEXPS = [
     /^no such file to load -- (.+)$/i,

--- a/activesupport/lib/active_support/core_ext/marshal.rb
+++ b/activesupport/lib/active_support/core_ext/marshal.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module MarshalWithAutoloading # :nodoc:
     def load(source, proc = nil)

--- a/activesupport/lib/active_support/core_ext/module.rb
+++ b/activesupport/lib/active_support/core_ext/module.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "module/aliasing"
 require_relative "module/introspection"
 require_relative "module/anonymous"

--- a/activesupport/lib/active_support/core_ext/module/aliasing.rb
+++ b/activesupport/lib/active_support/core_ext/module/aliasing.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Module
   # Allows you to make aliases for attributes, which includes
   # getter, setter, and a predicate.

--- a/activesupport/lib/active_support/core_ext/module/anonymous.rb
+++ b/activesupport/lib/active_support/core_ext/module/anonymous.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Module
   # A module may or may not have a name.
   #

--- a/activesupport/lib/active_support/core_ext/module/attr_internal.rb
+++ b/activesupport/lib/active_support/core_ext/module/attr_internal.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Module
   # Declares an attribute reader backed by an internally-named instance variable.
   def attr_internal_reader(*attrs)

--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../array/extract_options"
 require_relative "../regexp"
 

--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../array/extract_options"
 require_relative "../regexp"
 

--- a/activesupport/lib/active_support/core_ext/module/concerning.rb
+++ b/activesupport/lib/active_support/core_ext/module/concerning.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../concern"
 
 class Module

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "set"
 require_relative "../regexp"
 

--- a/activesupport/lib/active_support/core_ext/module/deprecation.rb
+++ b/activesupport/lib/active_support/core_ext/module/deprecation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Module
   #   deprecate :foo
   #   deprecate bar: 'message'

--- a/activesupport/lib/active_support/core_ext/module/introspection.rb
+++ b/activesupport/lib/active_support/core_ext/module/introspection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../inflector"
 
 class Module

--- a/activesupport/lib/active_support/core_ext/module/reachable.rb
+++ b/activesupport/lib/active_support/core_ext/module/reachable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "anonymous"
 require_relative "../string/inflections"
 

--- a/activesupport/lib/active_support/core_ext/module/remove_method.rb
+++ b/activesupport/lib/active_support/core_ext/module/remove_method.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Module
   # Removes the named method, if it exists.
   def remove_possible_method(method)

--- a/activesupport/lib/active_support/core_ext/name_error.rb
+++ b/activesupport/lib/active_support/core_ext/name_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class NameError
   # Extract the name of the missing constant from the exception message.
   #

--- a/activesupport/lib/active_support/core_ext/numeric.rb
+++ b/activesupport/lib/active_support/core_ext/numeric.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "numeric/bytes"
 require_relative "numeric/time"
 require_relative "numeric/inquiry"

--- a/activesupport/lib/active_support/core_ext/numeric/bytes.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/bytes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Numeric
   KILOBYTE = 1024
   MEGABYTE = KILOBYTE * 1024

--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../big_decimal/conversions"
 require_relative "../../number_helper"
 require_relative "../module/deprecation"

--- a/activesupport/lib/active_support/core_ext/numeric/inquiry.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/inquiry.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 unless 1.respond_to?(:positive?) # TODO: Remove this file when we drop support to ruby < 2.3
   class Numeric
     # Returns true if the number is positive.

--- a/activesupport/lib/active_support/core_ext/numeric/time.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/time.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../duration"
 require_relative "../time/calculations"
 require_relative "../time/acts_like"

--- a/activesupport/lib/active_support/core_ext/object.rb
+++ b/activesupport/lib/active_support/core_ext/object.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "object/acts_like"
 require_relative "object/blank"
 require_relative "object/duplicable"

--- a/activesupport/lib/active_support/core_ext/object/acts_like.rb
+++ b/activesupport/lib/active_support/core_ext/object/acts_like.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Object
   # A duck-type assistant method. For example, Active Support extends Date
   # to define an <tt>acts_like_date?</tt> method, and extends Time to define

--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../regexp"
 
 class Object

--- a/activesupport/lib/active_support/core_ext/object/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/object/conversions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "to_param"
 require_relative "to_query"
 require_relative "../array/conversions"

--- a/activesupport/lib/active_support/core_ext/object/deep_dup.rb
+++ b/activesupport/lib/active_support/core_ext/object/deep_dup.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "duplicable"
 
 class Object

--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # Most objects are cloneable, but not all. For example you can't dup methods:
 #

--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Object
   # Returns true if this object is included in the argument. Argument must be
   # any object which responds to +#include?+. Usage:

--- a/activesupport/lib/active_support/core_ext/object/instance_variables.rb
+++ b/activesupport/lib/active_support/core_ext/object/instance_variables.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Object
   # Returns a hash with string keys that maps instance variable names without "@" to their
   # corresponding values.

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Hack to load json gem first so we can overwrite its to_json.
 require "json"
 require "bigdecimal"

--- a/activesupport/lib/active_support/core_ext/object/to_param.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_param.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 require_relative "to_query"

--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "cgi"
 
 class Object

--- a/activesupport/lib/active_support/core_ext/object/try.rb
+++ b/activesupport/lib/active_support/core_ext/object/try.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "delegate"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/core_ext/object/with_options.rb
+++ b/activesupport/lib/active_support/core_ext/object/with_options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../option_merger"
 
 class Object

--- a/activesupport/lib/active_support/core_ext/range.rb
+++ b/activesupport/lib/active_support/core_ext/range.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "range/conversions"
 require_relative "range/include_range"
 require_relative "range/overlaps"

--- a/activesupport/lib/active_support/core_ext/range/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/range/conversions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport::RangeWithFormat
   RANGE_FORMATS = {
     db: Proc.new { |start, stop| "BETWEEN '#{start.to_s(:db)}' AND '#{stop.to_s(:db)}'" }

--- a/activesupport/lib/active_support/core_ext/range/each.rb
+++ b/activesupport/lib/active_support/core_ext/range/each.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module EachTimeWithZone #:nodoc:
     def each(&block)

--- a/activesupport/lib/active_support/core_ext/range/include_range.rb
+++ b/activesupport/lib/active_support/core_ext/range/include_range.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module IncludeWithRange #:nodoc:
     # Extends the default Range#include? to support range comparisons.

--- a/activesupport/lib/active_support/core_ext/range/overlaps.rb
+++ b/activesupport/lib/active_support/core_ext/range/overlaps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Range
   # Compare two ranges and see if they overlap each other
   #  (1..5).overlaps?(4..6) # => true

--- a/activesupport/lib/active_support/core_ext/regexp.rb
+++ b/activesupport/lib/active_support/core_ext/regexp.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Regexp #:nodoc:
   def multiline?
     options & MULTILINE == MULTILINE

--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "securerandom"
 
 module SecureRandom

--- a/activesupport/lib/active_support/core_ext/string.rb
+++ b/activesupport/lib/active_support/core_ext/string.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "string/conversions"
 require_relative "string/filters"
 require_relative "string/multibyte"

--- a/activesupport/lib/active_support/core_ext/string/access.rb
+++ b/activesupport/lib/active_support/core_ext/string/access.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class String
   # If you pass a single integer, returns a substring of one character at that
   # position. The first character of the string is at position 0, the next at

--- a/activesupport/lib/active_support/core_ext/string/behavior.rb
+++ b/activesupport/lib/active_support/core_ext/string/behavior.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class String
   # Enables more predictable duck-typing on String-like classes. See <tt>Object#acts_like?</tt>.
   def acts_like_string?

--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "date"
 require_relative "../time/calculations"
 

--- a/activesupport/lib/active_support/core_ext/string/exclude.rb
+++ b/activesupport/lib/active_support/core_ext/string/exclude.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class String
   # The inverse of <tt>String#include?</tt>. Returns true if the string
   # does not include the other string.

--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class String
   # Returns the string, first removing all whitespace on both ends of
   # the string, and then changing remaining consecutive whitespace

--- a/activesupport/lib/active_support/core_ext/string/indent.rb
+++ b/activesupport/lib/active_support/core_ext/string/indent.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class String
   # Same as +indent+, except it indents the receiver in-place.
   #

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../inflector/methods"
 require_relative "../../inflector/transliterate"
 

--- a/activesupport/lib/active_support/core_ext/string/inquiry.rb
+++ b/activesupport/lib/active_support/core_ext/string/inquiry.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../string_inquirer"
 
 class String

--- a/activesupport/lib/active_support/core_ext/string/multibyte.rb
+++ b/activesupport/lib/active_support/core_ext/string/multibyte.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../multibyte"
 
 class String

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "erb"
 require_relative "../kernel/singleton_class"
 require_relative "../../multibyte/unicode"

--- a/activesupport/lib/active_support/core_ext/string/starts_ends_with.rb
+++ b/activesupport/lib/active_support/core_ext/string/starts_ends_with.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class String
   alias_method :starts_with?, :start_with?
   alias_method :ends_with?, :end_with?

--- a/activesupport/lib/active_support/core_ext/string/strip.rb
+++ b/activesupport/lib/active_support/core_ext/string/strip.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class String
   # Strips indentation in heredocs.
   #

--- a/activesupport/lib/active_support/core_ext/string/zones.rb
+++ b/activesupport/lib/active_support/core_ext/string/zones.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "conversions"
 require_relative "../time/zones"
 

--- a/activesupport/lib/active_support/core_ext/time.rb
+++ b/activesupport/lib/active_support/core_ext/time.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "time/acts_like"
 require_relative "time/calculations"
 require_relative "time/compatibility"

--- a/activesupport/lib/active_support/core_ext/time/acts_like.rb
+++ b/activesupport/lib/active_support/core_ext/time/acts_like.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../object/acts_like"
 
 class Time

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../duration"
 require_relative "conversions"
 require_relative "../../time_with_zone"

--- a/activesupport/lib/active_support/core_ext/time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/time/compatibility.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../date_and_time/compatibility"
 require_relative "../module/remove_method"
 

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../inflector/methods"
 require_relative "../../values/time_zone"
 

--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../../time_with_zone"
 require_relative "acts_like"
 require_relative "../date_and_time/zones"

--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "uri"
 str = "\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E" # Ni-ho-nn-go in UTF-8, means Japanese.
 parser = URI::Parser.new

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   # Abstract super class that provides a thread-isolated attributes singleton, which resets automatically
   # before and after each request. This allows you to keep all the per-request attributes easily

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "set"
 require "thread"
 require "concurrent/map"

--- a/activesupport/lib/active_support/dependencies/autoload.rb
+++ b/activesupport/lib/active_support/dependencies/autoload.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../inflector/methods"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/dependencies/interlock.rb
+++ b/activesupport/lib/active_support/dependencies/interlock.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../concurrency/share_lock"
 
 module ActiveSupport #:nodoc:

--- a/activesupport/lib/active_support/deprecation.rb
+++ b/activesupport/lib/active_support/deprecation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "singleton"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/deprecation/behaviors.rb
+++ b/activesupport/lib/active_support/deprecation/behaviors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../notifications"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/deprecation/constant_accessor.rb
+++ b/activesupport/lib/active_support/deprecation/constant_accessor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../inflector/methods"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/deprecation/instance_delegator.rb
+++ b/activesupport/lib/active_support/deprecation/instance_delegator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../core_ext/kernel/singleton_class"
 require_relative "../core_ext/module/delegation"
 

--- a/activesupport/lib/active_support/deprecation/method_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/method_wrappers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../core_ext/module/aliasing"
 require_relative "../core_ext/array/extract_options"
 

--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../inflector/methods"
 require_relative "../core_ext/regexp"
 

--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rbconfig"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/descendants_tracker.rb
+++ b/activesupport/lib/active_support/descendants_tracker.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   # This module provides an internal implementation to track descendants
   # which is faster than iterating through ObjectSpace.

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "core_ext/array/conversions"
 require_relative "core_ext/module/delegation"
 require_relative "core_ext/object/acts_like"

--- a/activesupport/lib/active_support/duration/iso8601_parser.rb
+++ b/activesupport/lib/active_support/duration/iso8601_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "strscan"
 require_relative "../core_ext/regexp"
 

--- a/activesupport/lib/active_support/duration/iso8601_serializer.rb
+++ b/activesupport/lib/active_support/duration/iso8601_serializer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../core_ext/object/blank"
 require_relative "../core_ext/hash/transform_values"
 

--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "set"
 require "pathname"
 require "concurrent/atomic/atomic_boolean"

--- a/activesupport/lib/active_support/execution_wrapper.rb
+++ b/activesupport/lib/active_support/execution_wrapper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "callbacks"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/executor.rb
+++ b/activesupport/lib/active_support/executor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "execution_wrapper"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "core_ext/time/calculations"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/gem_version.rb
+++ b/activesupport/lib/active_support/gem_version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   # Returns the version of the currently loaded Active Support as a <tt>Gem::Version</tt>.
   def self.gem_version

--- a/activesupport/lib/active_support/gzip.rb
+++ b/activesupport/lib/active_support/gzip.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "zlib"
 require "stringio"
 

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "core_ext/hash/keys"
 require_relative "core_ext/hash/reverse_merge"
 

--- a/activesupport/lib/active_support/i18n.rb
+++ b/activesupport/lib/active_support/i18n.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "core_ext/hash/deep_merge"
 require_relative "core_ext/hash/except"
 require_relative "core_ext/hash/slice"

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support"
 require_relative "file_update_checker"
 require_relative "core_ext/array/wrap"

--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "inflector/inflections"
 
 #--

--- a/activesupport/lib/active_support/inflector.rb
+++ b/activesupport/lib/active_support/inflector.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # in case active_support/inflector is required without the rest of active_support
 require_relative "inflector/inflections"
 require_relative "inflector/transliterate"

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "concurrent/map"
 require_relative "../core_ext/array/prepend_and_append"
 require_relative "../core_ext/regexp"

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../inflections"
 require_relative "../core_ext/regexp"
 

--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../core_ext/string/multibyte"
 require_relative "../i18n"
 

--- a/activesupport/lib/active_support/json.rb
+++ b/activesupport/lib/active_support/json.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 require_relative "json/decoding"
 require_relative "json/encoding"

--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../core_ext/module/attribute_accessors"
 require_relative "../core_ext/module/delegation"
 require "json"

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../core_ext/object/json"
 require_relative "../core_ext/module/delegation"
 

--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "concurrent/map"
 require "openssl"
 

--- a/activesupport/lib/active_support/lazy_load_hooks.rb
+++ b/activesupport/lib/active_support/lazy_load_hooks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   # lazy_load_hooks allows Rails to lazily load a lot of components and thus
   # making the app boot faster. Because of this feature now there is no need to

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "core_ext/module/attribute_accessors"
 require_relative "core_ext/class/attribute"
 require_relative "subscriber"

--- a/activesupport/lib/active_support/log_subscriber/test_helper.rb
+++ b/activesupport/lib/active_support/log_subscriber/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../log_subscriber"
 require_relative "../logger"
 require_relative "../notifications"

--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "logger_silence"
 require_relative "logger_thread_safe_level"
 require "logger"

--- a/activesupport/lib/active_support/logger_silence.rb
+++ b/activesupport/lib/active_support/logger_silence.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "concern"
 require_relative "core_ext/module/attribute_accessors"
 require "concurrent"

--- a/activesupport/lib/active_support/logger_thread_safe_level.rb
+++ b/activesupport/lib/active_support/logger_thread_safe_level.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "concern"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "openssl"
 require "base64"
 require_relative "core_ext/array/extract_options"

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "base64"
 require_relative "core_ext/object/blank"
 require_relative "security_utils"

--- a/activesupport/lib/active_support/multibyte.rb
+++ b/activesupport/lib/active_support/multibyte.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport #:nodoc:
   module Multibyte
     autoload :Chars, "active_support/multibyte/chars"

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../json"
 require_relative "../core_ext/string/access"
 require_relative "../core_ext/string/behavior"

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module Multibyte
     module Unicode

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "notifications/instrumenter"
 require_relative "notifications/fanout"
 require_relative "per_thread_registry"

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "mutex_m"
 require "concurrent/map"
 

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "securerandom"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module NumberHelper
     extend ActiveSupport::Autoload

--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../core_ext/big_decimal/conversions"
 require_relative "../core_ext/object/blank"
 require_relative "../core_ext/hash/keys"

--- a/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../core_ext/numeric/inquiry"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module NumberHelper
     class NumberToDelimitedConverter < NumberConverter #:nodoc:

--- a/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_converter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module NumberHelper
     class NumberToHumanConverter < NumberConverter # :nodoc:

--- a/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module NumberHelper
     class NumberToHumanSizeConverter < NumberConverter #:nodoc:

--- a/activesupport/lib/active_support/number_helper/number_to_percentage_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_percentage_converter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module NumberHelper
     class NumberToPercentageConverter < NumberConverter # :nodoc:

--- a/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module NumberHelper
     class NumberToPhoneConverter < NumberConverter #:nodoc:

--- a/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module NumberHelper
     class NumberToRoundedConverter < NumberConverter # :nodoc:

--- a/activesupport/lib/active_support/number_helper/rounding_helper.rb
+++ b/activesupport/lib/active_support/number_helper/rounding_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module NumberHelper
     class RoundingHelper # :nodoc:

--- a/activesupport/lib/active_support/option_merger.rb
+++ b/activesupport/lib/active_support/option_merger.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "core_ext/hash/deep_merge"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/ordered_hash.rb
+++ b/activesupport/lib/active_support/ordered_hash.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "yaml"
 
 YAML.add_builtin_type("omap") do |type, val|

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "core_ext/object/blank"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/per_thread_registry.rb
+++ b/activesupport/lib/active_support/per_thread_registry.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "core_ext/module/delegation"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/proxy_object.rb
+++ b/activesupport/lib/active_support/proxy_object.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   # A class with no predefined methods that behaves similarly to Builder's
   # BlankSlate. Used for proxy classes.

--- a/activesupport/lib/active_support/rails.rb
+++ b/activesupport/lib/active_support/rails.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This is private interface.
 #
 # Rails components cherry pick from Active Support as needed, but there are a

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support"
 require_relative "i18n_railtie"
 

--- a/activesupport/lib/active_support/reloader.rb
+++ b/activesupport/lib/active_support/reloader.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "execution_wrapper"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "concern"
 require_relative "core_ext/class/attribute"
 require_relative "core_ext/string/inflections"

--- a/activesupport/lib/active_support/security_utils.rb
+++ b/activesupport/lib/active_support/security_utils.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "digest"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   # Wrapping a string in this class gives you a prettier way to test
   # for equality. The value returned by <tt>Rails.env</tt> is wrapped

--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "per_thread_registry"
 require_relative "notifications"
 

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "core_ext/module/delegation"
 require_relative "core_ext/object/blank"
 require "logger"

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 gem "minitest" # make sure we get the gem, not stdlib
 require "minitest"
 require_relative "testing/tagged_logging"

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module Testing
     module Assertions

--- a/activesupport/lib/active_support/testing/autorun.rb
+++ b/activesupport/lib/active_support/testing/autorun.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 gem "minitest"
 
 require "minitest"

--- a/activesupport/lib/active_support/testing/constant_lookup.rb
+++ b/activesupport/lib/active_support/testing/constant_lookup.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../concern"
 require_relative "../inflector"
 

--- a/activesupport/lib/active_support/testing/declarative.rb
+++ b/activesupport/lib/active_support/testing/declarative.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module Testing
     module Declarative

--- a/activesupport/lib/active_support/testing/deprecation.rb
+++ b/activesupport/lib/active_support/testing/deprecation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../deprecation"
 require_relative "../core_ext/regexp"
 

--- a/activesupport/lib/active_support/testing/file_fixtures.rb
+++ b/activesupport/lib/active_support/testing/file_fixtures.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module Testing
     # Adds simple access to sample files called file fixtures.

--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module Testing
     module Isolation

--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "minitest/mock"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../concern"
 require_relative "../callbacks"
 

--- a/activesupport/lib/active_support/testing/stream.rb
+++ b/activesupport/lib/active_support/testing/stream.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module Testing
     module Stream #:nodoc:

--- a/activesupport/lib/active_support/testing/tagged_logging.rb
+++ b/activesupport/lib/active_support/testing/tagged_logging.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   module Testing
     # Logs a "PostsControllerTest: test name" heading before each test to

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../core_ext/string/strip" # for strip_heredoc
 require_relative "../core_ext/time/calculations"
 require "concurrent/map"

--- a/activesupport/lib/active_support/time.rb
+++ b/activesupport/lib/active_support/time.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveSupport
   autoload :Duration, "active_support/duration"
   autoload :TimeWithZone, "active_support/time_with_zone"

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "duration"
 require_relative "values/time_zone"
 require_relative "core_ext/object/acts_like"

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "tzinfo"
 require "concurrent/map"
 require_relative "../core_ext/object/blank"

--- a/activesupport/lib/active_support/version.rb
+++ b/activesupport/lib/active_support/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "gem_version"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "time"
 require "base64"
 require "bigdecimal"

--- a/activesupport/lib/active_support/xml_mini/jdom.rb
+++ b/activesupport/lib/active_support/xml_mini/jdom.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 raise "JRuby is required to use the JDOM backend for XmlMini" unless RUBY_PLATFORM.include?("java")
 
 require "jruby"

--- a/activesupport/lib/active_support/xml_mini/libxml.rb
+++ b/activesupport/lib/active_support/xml_mini/libxml.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "libxml"
 require_relative "../core_ext/object/blank"
 require "stringio"

--- a/activesupport/lib/active_support/xml_mini/libxmlsax.rb
+++ b/activesupport/lib/active_support/xml_mini/libxmlsax.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "libxml"
 require_relative "../core_ext/object/blank"
 require "stringio"

--- a/activesupport/lib/active_support/xml_mini/nokogiri.rb
+++ b/activesupport/lib/active_support/xml_mini/nokogiri.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 begin
   require "nokogiri"
 rescue LoadError => e

--- a/activesupport/lib/active_support/xml_mini/nokogirisax.rb
+++ b/activesupport/lib/active_support/xml_mini/nokogirisax.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 begin
   require "nokogiri"
 rescue LoadError => e

--- a/activesupport/lib/active_support/xml_mini/rexml.rb
+++ b/activesupport/lib/active_support/xml_mini/rexml.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../core_ext/kernel/reporting"
 require_relative "../core_ext/object/blank"
 require "stringio"

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ORIG_ARGV = ARGV.dup
 
 require "active_support/core_ext/kernel/reporting"

--- a/activesupport/test/array_inquirer_test.rb
+++ b/activesupport/test/array_inquirer_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/array"
 

--- a/activesupport/test/autoload_test.rb
+++ b/activesupport/test/autoload_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 class TestAutoloadModule < ActiveSupport::TestCase

--- a/activesupport/test/autoloading_fixtures/a/b.rb
+++ b/activesupport/test/autoloading_fixtures/a/b.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class A::B
 end

--- a/activesupport/test/autoloading_fixtures/a/c/d.rb
+++ b/activesupport/test/autoloading_fixtures/a/c/d.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class A::C::D
 end

--- a/activesupport/test/autoloading_fixtures/a/c/em/f.rb
+++ b/activesupport/test/autoloading_fixtures/a/c/em/f.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class A::C::EM::F
 end

--- a/activesupport/test/autoloading_fixtures/application.rb
+++ b/activesupport/test/autoloading_fixtures/application.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 ApplicationController = 10

--- a/activesupport/test/autoloading_fixtures/circular1.rb
+++ b/activesupport/test/autoloading_fixtures/circular1.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 silence_warnings do
   Circular2
 end

--- a/activesupport/test/autoloading_fixtures/circular2.rb
+++ b/activesupport/test/autoloading_fixtures/circular2.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Circular1
 
 class Circular2

--- a/activesupport/test/autoloading_fixtures/class_folder.rb
+++ b/activesupport/test/autoloading_fixtures/class_folder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ClassFolder
   ConstantInClassFolder = "indeed"
 end

--- a/activesupport/test/autoloading_fixtures/class_folder/class_folder_subclass.rb
+++ b/activesupport/test/autoloading_fixtures/class_folder/class_folder_subclass.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ClassFolder::ClassFolderSubclass < ClassFolder
   ConstantInClassFolder = "indeed"
 end

--- a/activesupport/test/autoloading_fixtures/class_folder/inline_class.rb
+++ b/activesupport/test/autoloading_fixtures/class_folder/inline_class.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class ClassFolder::InlineClass
 end

--- a/activesupport/test/autoloading_fixtures/class_folder/nested_class.rb
+++ b/activesupport/test/autoloading_fixtures/class_folder/nested_class.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ClassFolder
   class NestedClass
   end

--- a/activesupport/test/autoloading_fixtures/conflict.rb
+++ b/activesupport/test/autoloading_fixtures/conflict.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 Conflict = 2

--- a/activesupport/test/autoloading_fixtures/counting_loader.rb
+++ b/activesupport/test/autoloading_fixtures/counting_loader.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $counting_loaded_times ||= 0
 $counting_loaded_times += 1
 

--- a/activesupport/test/autoloading_fixtures/cross_site_dependency.rb
+++ b/activesupport/test/autoloading_fixtures/cross_site_dependency.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class CrossSiteDependency
 end

--- a/activesupport/test/autoloading_fixtures/d.rb
+++ b/activesupport/test/autoloading_fixtures/d.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class D
 end

--- a/activesupport/test/autoloading_fixtures/em.rb
+++ b/activesupport/test/autoloading_fixtures/em.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class EM
 end

--- a/activesupport/test/autoloading_fixtures/html/some_class.rb
+++ b/activesupport/test/autoloading_fixtures/html/some_class.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module HTML
   class SomeClass
   end

--- a/activesupport/test/autoloading_fixtures/load_path/loaded_constant.rb
+++ b/activesupport/test/autoloading_fixtures/load_path/loaded_constant.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 module LoadedConstant
 end

--- a/activesupport/test/autoloading_fixtures/loads_constant.rb
+++ b/activesupport/test/autoloading_fixtures/loads_constant.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module LoadsConstant
 end
 

--- a/activesupport/test/autoloading_fixtures/module_folder/inline_class.rb
+++ b/activesupport/test/autoloading_fixtures/module_folder/inline_class.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class ModuleFolder::InlineClass
 end

--- a/activesupport/test/autoloading_fixtures/module_folder/nested_class.rb
+++ b/activesupport/test/autoloading_fixtures/module_folder/nested_class.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ModuleFolder
   class NestedClass
   end

--- a/activesupport/test/autoloading_fixtures/module_folder/nested_sibling.rb
+++ b/activesupport/test/autoloading_fixtures/module_folder/nested_sibling.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class ModuleFolder::NestedSibling
 end

--- a/activesupport/test/autoloading_fixtures/module_with_custom_const_missing/a/b.rb
+++ b/activesupport/test/autoloading_fixtures/module_with_custom_const_missing/a/b.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 ModuleWithCustomConstMissing::A::B = "10"

--- a/activesupport/test/autoloading_fixtures/multiple_constant_file.rb
+++ b/activesupport/test/autoloading_fixtures/multiple_constant_file.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 MultipleConstantFile = 10
 SiblingConstant = MultipleConstantFile * 2

--- a/activesupport/test/autoloading_fixtures/prepend.rb
+++ b/activesupport/test/autoloading_fixtures/prepend.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class SubClassConflict
 end
 

--- a/activesupport/test/autoloading_fixtures/prepend/sub_class_conflict.rb
+++ b/activesupport/test/autoloading_fixtures/prepend/sub_class_conflict.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class Prepend::SubClassConflict
 end

--- a/activesupport/test/autoloading_fixtures/raises_arbitrary_exception.rb
+++ b/activesupport/test/autoloading_fixtures/raises_arbitrary_exception.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RaisesArbitraryException = 1
 _ = A::B # Autoloading recursion, also expected to be watched and discarded.
 

--- a/activesupport/test/autoloading_fixtures/raises_name_error.rb
+++ b/activesupport/test/autoloading_fixtures/raises_name_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RaisesNameError
   FooBarBaz
 end

--- a/activesupport/test/autoloading_fixtures/raises_no_method_error.rb
+++ b/activesupport/test/autoloading_fixtures/raises_no_method_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RaisesNoMethodError
   self.foobar_method_doesnt_exist
 end

--- a/activesupport/test/autoloading_fixtures/requires_constant.rb
+++ b/activesupport/test/autoloading_fixtures/requires_constant.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "loaded_constant"
 
 module RequiresConstant

--- a/activesupport/test/autoloading_fixtures/should_not_be_required.rb
+++ b/activesupport/test/autoloading_fixtures/should_not_be_required.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 ShouldNotBeAutoloaded = 0

--- a/activesupport/test/autoloading_fixtures/throws.rb
+++ b/activesupport/test/autoloading_fixtures/throws.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Throws = 1
 _ = A::B # Autoloading recursion, expected to be discarded.
 

--- a/activesupport/test/autoloading_fixtures/typo.rb
+++ b/activesupport/test/autoloading_fixtures/typo.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 TypO = 1

--- a/activesupport/test/benchmarkable_test.rb
+++ b/activesupport/test/benchmarkable_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 class BenchmarkableTest < ActiveSupport::TestCase

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 module ActiveSupport

--- a/activesupport/test/cache/behaviors.rb
+++ b/activesupport/test/cache/behaviors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "behaviors/autoloading_cache_behavior"
 require_relative "behaviors/cache_delete_matched_behavior"
 require_relative "behaviors/cache_increment_decrement_behavior"

--- a/activesupport/test/cache/behaviors/autoloading_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/autoloading_cache_behavior.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "dependencies_test_helpers"
 
 module AutoloadingCacheBehavior

--- a/activesupport/test/cache/behaviors/cache_delete_matched_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_delete_matched_behavior.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CacheDeleteMatchedBehavior
   def test_delete_matched
     @cache.write("foo", "bar")

--- a/activesupport/test/cache/behaviors/cache_increment_decrement_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_increment_decrement_behavior.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CacheIncrementDecrementBehavior
   def test_increment
     @cache.write("foo", 1, raw: true)

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Tests the base functionality that should be identical across all cache stores.
 module CacheStoreBehavior
   def test_should_read_and_write_strings

--- a/activesupport/test/cache/behaviors/cache_store_version_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_version_behavior.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CacheStoreVersionBehavior
   ModelWithKeyAndVersion = Struct.new(:cache_key, :cache_version)
 

--- a/activesupport/test/cache/behaviors/encoded_key_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/encoded_key_cache_behavior.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # https://rails.lighthouseapp.com/projects/8994/tickets/6225-memcachestore-cant-deal-with-umlauts-and-special-characters
 # The error is caused by character encodings that can't be compared with ASCII-8BIT regular expressions and by special
 # characters like the umlaut in UTF-8.

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module LocalCacheBehavior
   def test_local_writes_are_persistent_on_the_remote_cache
     retval = @cache.with_local_cache do

--- a/activesupport/test/cache/cache_entry_test.rb
+++ b/activesupport/test/cache/cache_entry_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/cache"
 

--- a/activesupport/test/cache/cache_key_test.rb
+++ b/activesupport/test/cache/cache_key_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/cache"
 

--- a/activesupport/test/cache/cache_store_logger_test.rb
+++ b/activesupport/test/cache/cache_store_logger_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/cache"
 

--- a/activesupport/test/cache/cache_store_namespace_test.rb
+++ b/activesupport/test/cache/cache_store_namespace_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/cache"
 

--- a/activesupport/test/cache/cache_store_setting_test.rb
+++ b/activesupport/test/cache/cache_store_setting_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/cache"
 require "dalli"

--- a/activesupport/test/cache/cache_store_write_multi_test.rb
+++ b/activesupport/test/cache/cache_store_write_multi_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/cache"
 

--- a/activesupport/test/cache/local_cache_middleware_test.rb
+++ b/activesupport/test/cache/local_cache_middleware_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/cache"
 

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/cache"
 require_relative "../behaviors"

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/cache"
 require_relative "../behaviors"

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/cache"
 require_relative "../behaviors"

--- a/activesupport/test/cache/stores/null_store_test.rb
+++ b/activesupport/test/cache/stores/null_store_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/cache"
 require_relative "../behaviors"

--- a/activesupport/test/callback_inheritance_test.rb
+++ b/activesupport/test/callback_inheritance_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 class GrandParent

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 module CallbacksTest

--- a/activesupport/test/class_cache_test.rb
+++ b/activesupport/test/class_cache_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/dependencies"
 

--- a/activesupport/test/clean_backtrace_test.rb
+++ b/activesupport/test/clean_backtrace_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 class BacktraceCleanerFilterTest < ActiveSupport::TestCase

--- a/activesupport/test/clean_logger_test.rb
+++ b/activesupport/test/clean_logger_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "stringio"
 require "active_support/logger"

--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/concern"
 

--- a/activesupport/test/configurable_test.rb
+++ b/activesupport/test/configurable_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/configurable"
 

--- a/activesupport/test/constantize_test_cases.rb
+++ b/activesupport/test/constantize_test_cases.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "dependencies_test_helpers"
 
 module Ace

--- a/activesupport/test/core_ext/array/access_test.rb
+++ b/activesupport/test/core_ext/array/access_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/array"
 

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/array"
 require "active_support/core_ext/big_decimal"

--- a/activesupport/test/core_ext/array/extract_options_test.rb
+++ b/activesupport/test/core_ext/array/extract_options_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/array"
 require "active_support/core_ext/hash"

--- a/activesupport/test/core_ext/array/grouping_test.rb
+++ b/activesupport/test/core_ext/array/grouping_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/array"
 

--- a/activesupport/test/core_ext/array/prepend_append_test.rb
+++ b/activesupport/test/core_ext/array/prepend_append_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/array"
 

--- a/activesupport/test/core_ext/array/wrap_test.rb
+++ b/activesupport/test/core_ext/array/wrap_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/array"
 

--- a/activesupport/test/core_ext/bigdecimal_test.rb
+++ b/activesupport/test/core_ext/bigdecimal_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/big_decimal"
 

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/class/attribute"
 

--- a/activesupport/test/core_ext/class_test.rb
+++ b/activesupport/test/core_ext/class_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/class"
 require "set"

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 module DateAndTimeBehavior

--- a/activesupport/test/core_ext/date_and_time_compatibility_test.rb
+++ b/activesupport/test/core_ext/date_and_time_compatibility_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/time"
 require "time_zone_test_helpers"

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/time"
 require "core_ext/date_and_time_behavior"

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/time"
 require "core_ext/date_and_time_behavior"

--- a/activesupport/test/core_ext/digest/uuid_test.rb
+++ b/activesupport/test/core_ext/digest/uuid_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/digest/uuid"
 

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/inflector"
 require "active_support/time"

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/array"
 require "active_support/core_ext/enumerable"

--- a/activesupport/test/core_ext/file_test.rb
+++ b/activesupport/test/core_ext/file_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/file"
 

--- a/activesupport/test/core_ext/hash/transform_keys_test.rb
+++ b/activesupport/test/core_ext/hash/transform_keys_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/hash/keys"
 

--- a/activesupport/test/core_ext/hash/transform_values_test.rb
+++ b/activesupport/test/core_ext/hash/transform_values_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/hash/indifferent_access"
 require "active_support/core_ext/hash/transform_values"

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/hash"
 require "bigdecimal"

--- a/activesupport/test/core_ext/integer_ext_test.rb
+++ b/activesupport/test/core_ext/integer_ext_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/integer"
 

--- a/activesupport/test/core_ext/kernel/concern_test.rb
+++ b/activesupport/test/core_ext/kernel/concern_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/kernel/concern"
 

--- a/activesupport/test/core_ext/kernel_test.rb
+++ b/activesupport/test/core_ext/kernel_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/kernel"
 

--- a/activesupport/test/core_ext/load_error_test.rb
+++ b/activesupport/test/core_ext/load_error_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/load_error"
 

--- a/activesupport/test/core_ext/marshal_test.rb
+++ b/activesupport/test/core_ext/marshal_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/marshal"
 require "dependencies_test_helpers"

--- a/activesupport/test/core_ext/module/anonymous_test.rb
+++ b/activesupport/test/core_ext/module/anonymous_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/module/anonymous"
 

--- a/activesupport/test/core_ext/module/attr_internal_test.rb
+++ b/activesupport/test/core_ext/module/attr_internal_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/module/attr_internal"
 

--- a/activesupport/test/core_ext/module/attribute_accessor_per_thread_test.rb
+++ b/activesupport/test/core_ext/module/attribute_accessor_per_thread_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/module/attribute_accessors_per_thread"
 

--- a/activesupport/test/core_ext/module/attribute_accessor_test.rb
+++ b/activesupport/test/core_ext/module/attribute_accessor_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/module/attribute_accessors"
 

--- a/activesupport/test/core_ext/module/attribute_aliasing_test.rb
+++ b/activesupport/test/core_ext/module/attribute_aliasing_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/module/aliasing"
 

--- a/activesupport/test/core_ext/module/concerning_test.rb
+++ b/activesupport/test/core_ext/module/concerning_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/module/concerning"
 

--- a/activesupport/test/core_ext/module/introspection_test.rb
+++ b/activesupport/test/core_ext/module/introspection_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/module/introspection"
 

--- a/activesupport/test/core_ext/module/reachable_test.rb
+++ b/activesupport/test/core_ext/module/reachable_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/module/reachable"
 

--- a/activesupport/test/core_ext/module/remove_method_test.rb
+++ b/activesupport/test/core_ext/module/remove_method_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/module/remove_method"
 

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/module"
 

--- a/activesupport/test/core_ext/name_error_test.rb
+++ b/activesupport/test/core_ext/name_error_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/name_error"
 

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/time"
 require "active_support/core_ext/numeric"

--- a/activesupport/test/core_ext/object/acts_like_test.rb
+++ b/activesupport/test/core_ext/object/acts_like_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/object"
 

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/object/blank"
 

--- a/activesupport/test/core_ext/object/deep_dup_test.rb
+++ b/activesupport/test/core_ext/object/deep_dup_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/object"
 

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "bigdecimal"
 require "active_support/core_ext/object/duplicable"

--- a/activesupport/test/core_ext/object/inclusion_test.rb
+++ b/activesupport/test/core_ext/object/inclusion_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/object/inclusion"
 

--- a/activesupport/test/core_ext/object/instance_variables_test.rb
+++ b/activesupport/test/core_ext/object/instance_variables_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/object"
 

--- a/activesupport/test/core_ext/object/json_cherry_pick_test.rb
+++ b/activesupport/test/core_ext/object/json_cherry_pick_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 # These test cases were added to test that cherry-picking the json extensions

--- a/activesupport/test/core_ext/object/json_gem_encoding_test.rb
+++ b/activesupport/test/core_ext/object/json_gem_encoding_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "json"
 require "json/encoding_test_cases"

--- a/activesupport/test/core_ext/object/to_param_test.rb
+++ b/activesupport/test/core_ext/object/to_param_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/object/to_param"
 

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/ordered_hash"
 require "active_support/core_ext/object/to_query"

--- a/activesupport/test/core_ext/object/try_test.rb
+++ b/activesupport/test/core_ext/object/try_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/object"
 

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/time"
 require "active_support/core_ext/numeric"

--- a/activesupport/test/core_ext/regexp_ext_test.rb
+++ b/activesupport/test/core_ext/regexp_ext_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/regexp"
 

--- a/activesupport/test/core_ext/secure_random_test.rb
+++ b/activesupport/test/core_ext/secure_random_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/securerandom"
 

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "date"
 require "abstract_unit"
 require "timeout"

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/time"
 require "core_ext/date_and_time_behavior"

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/time"
 require "time_zone_test_helpers"

--- a/activesupport/test/core_ext/uri_ext_test.rb
+++ b/activesupport/test/core_ext/uri_ext_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "uri"
 require "active_support/core_ext/uri"

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 class CurrentAttributesTest < ActiveSupport::TestCase

--- a/activesupport/test/dependencies/check_warnings.rb
+++ b/activesupport/test/dependencies/check_warnings.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 $check_warnings_load_count += 1
 $checked_verbose = $VERBOSE

--- a/activesupport/test/dependencies/conflict.rb
+++ b/activesupport/test/dependencies/conflict.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 Conflict = 1

--- a/activesupport/test/dependencies/cross_site_depender.rb
+++ b/activesupport/test/dependencies/cross_site_depender.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CrossSiteDepender
   CrossSiteDependency
 end

--- a/activesupport/test/dependencies/mutual_one.rb
+++ b/activesupport/test/dependencies/mutual_one.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $mutual_dependencies_count += 1
 require_dependency "mutual_two"
 require_dependency "mutual_two.rb"

--- a/activesupport/test/dependencies/mutual_two.rb
+++ b/activesupport/test/dependencies/mutual_two.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $mutual_dependencies_count += 1
 require_dependency "mutual_one.rb"
 require_dependency "mutual_one"

--- a/activesupport/test/dependencies/raises_exception.rb
+++ b/activesupport/test/dependencies/raises_exception.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $raises_exception_load_count += 1
 raise Exception, "Loading me failed, so do not add to loaded or history."
 $raises_exception_load_count += 1

--- a/activesupport/test/dependencies/raises_exception_without_blame_file.rb
+++ b/activesupport/test/dependencies/raises_exception_without_blame_file.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 exception = Exception.new("I am not blamable!")
 class << exception
   undef_method(:blame_file!)

--- a/activesupport/test/dependencies/requires_nonexistent0.rb
+++ b/activesupport/test/dependencies/requires_nonexistent0.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 require "RMagickDontExistDude"

--- a/activesupport/test/dependencies/requires_nonexistent1.rb
+++ b/activesupport/test/dependencies/requires_nonexistent1.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 require_dependency "requires_nonexistent0"

--- a/activesupport/test/dependencies/service_one.rb
+++ b/activesupport/test/dependencies/service_one.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $loaded_service_one ||= 0
 $loaded_service_one += 1
 

--- a/activesupport/test/dependencies/service_two.rb
+++ b/activesupport/test/dependencies/service_two.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class ServiceTwo
 end

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "pp"
 require "active_support/dependencies"

--- a/activesupport/test/dependencies_test_helpers.rb
+++ b/activesupport/test/dependencies_test_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module DependenciesTestHelpers
   def with_loading(*from)
     old_mechanism, ActiveSupport::Dependencies.mechanism = ActiveSupport::Dependencies.mechanism, :load

--- a/activesupport/test/deprecation/method_wrappers_test.rb
+++ b/activesupport/test/deprecation/method_wrappers_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/deprecation"
 

--- a/activesupport/test/deprecation/proxy_wrappers_test.rb
+++ b/activesupport/test/deprecation/proxy_wrappers_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/deprecation"
 

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/testing/stream"
 

--- a/activesupport/test/descendants_tracker_test_cases.rb
+++ b/activesupport/test/descendants_tracker_test_cases.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "set"
 
 module DescendantsTrackerTestCases

--- a/activesupport/test/descendants_tracker_with_autoloading_test.rb
+++ b/activesupport/test/descendants_tracker_with_autoloading_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/descendants_tracker"
 require "active_support/dependencies"

--- a/activesupport/test/descendants_tracker_without_autoloading_test.rb
+++ b/activesupport/test/descendants_tracker_without_autoloading_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/descendants_tracker"
 require "descendants_tracker_test_cases"

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "pathname"
 require "file_update_checker_shared_tests"

--- a/activesupport/test/executor_test.rb
+++ b/activesupport/test/executor_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 class ExecutorTest < ActiveSupport::TestCase

--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "fileutils"
 
 module FileUpdateCheckerSharedTests

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "file_update_checker_shared_tests"
 

--- a/activesupport/test/fixtures/autoload/another_class.rb
+++ b/activesupport/test/fixtures/autoload/another_class.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class Fixtures::AnotherClass
 end

--- a/activesupport/test/fixtures/autoload/some_class.rb
+++ b/activesupport/test/fixtures/autoload/some_class.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class Fixtures::Autoload::SomeClass
 end

--- a/activesupport/test/gzip_test.rb
+++ b/activesupport/test/gzip_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/object/blank"
 

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/hash"
 require "bigdecimal"

--- a/activesupport/test/i18n_test.rb
+++ b/activesupport/test/i18n_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/time"
 require "active_support/core_ext/array/conversions"

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/inflector"
 

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module InflectorTestCases
   SingularToPlural = {
     "search"      => "searches",

--- a/activesupport/test/json/decoding_test.rb
+++ b/activesupport/test/json/decoding_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/json"
 require "active_support/time"

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "securerandom"
 require "abstract_unit"
 require "active_support/core_ext/string/inflections"

--- a/activesupport/test/json/encoding_test_cases.rb
+++ b/activesupport/test/json/encoding_test_cases.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "bigdecimal"
 require "date"
 require "time"

--- a/activesupport/test/key_generator_test.rb
+++ b/activesupport/test/key_generator_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 begin

--- a/activesupport/test/lazy_load_hooks_test.rb
+++ b/activesupport/test/lazy_load_hooks_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 class LazyLoadHooksTest < ActiveSupport::TestCase

--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/log_subscriber/test_helper"
 

--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "multibyte_test_helpers"
 require "stringio"

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "openssl"
 require "active_support/time"

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "openssl"
 require "active_support/time"

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "multibyte_test_helpers"
 require "active_support/core_ext/string/multibyte"

--- a/activesupport/test/multibyte_conformance_test.rb
+++ b/activesupport/test/multibyte_conformance_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "multibyte_test_helpers"
 

--- a/activesupport/test/multibyte_grapheme_break_conformance_test.rb
+++ b/activesupport/test/multibyte_grapheme_break_conformance_test.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require "abstract_unit"
 require "multibyte_test_helpers"

--- a/activesupport/test/multibyte_normalization_conformance_test.rb
+++ b/activesupport/test/multibyte_normalization_conformance_test.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require "abstract_unit"
 require "multibyte_test_helpers"

--- a/activesupport/test/multibyte_proxy_test.rb
+++ b/activesupport/test/multibyte_proxy_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 class MultibyteProxyText < ActiveSupport::TestCase

--- a/activesupport/test/multibyte_test_helpers.rb
+++ b/activesupport/test/multibyte_test_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module MultibyteTestHelpers
   class Downloader
     def self.download(from, to)

--- a/activesupport/test/multibyte_unicode_database_test.rb
+++ b/activesupport/test/multibyte_unicode_database_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 class MultibyteUnicodeDatabaseTest < ActiveSupport::TestCase

--- a/activesupport/test/notifications/evented_notification_test.rb
+++ b/activesupport/test/notifications/evented_notification_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 module ActiveSupport

--- a/activesupport/test/notifications/instrumenter_test.rb
+++ b/activesupport/test/notifications/instrumenter_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/notifications/instrumenter"
 

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/module/delegation"
 

--- a/activesupport/test/number_helper_i18n_test.rb
+++ b/activesupport/test/number_helper_i18n_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/number_helper"
 require "active_support/core_ext/hash/keys"

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/number_helper"
 require "active_support/core_ext/string/output_safety"

--- a/activesupport/test/option_merger_test.rb
+++ b/activesupport/test/option_merger_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/object/with_options"
 

--- a/activesupport/test/ordered_hash_test.rb
+++ b/activesupport/test/ordered_hash_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/json"
 require "active_support/core_ext/object/json"

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/ordered_options"
 

--- a/activesupport/test/reloader_test.rb
+++ b/activesupport/test/reloader_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 class ReloaderTest < ActiveSupport::TestCase

--- a/activesupport/test/rescuable_test.rb
+++ b/activesupport/test/rescuable_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 class WraithAttack < StandardError

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/string/inflections"
 require "yaml"

--- a/activesupport/test/security_utils_test.rb
+++ b/activesupport/test/security_utils_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/security_utils"
 

--- a/activesupport/test/share_lock_test.rb
+++ b/activesupport/test/share_lock_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "concurrent/atomic/count_down_latch"
 require "active_support/concurrency/share_lock"

--- a/activesupport/test/string_inquirer_test.rb
+++ b/activesupport/test/string_inquirer_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 class StringInquirerTest < ActiveSupport::TestCase

--- a/activesupport/test/subscriber_test.rb
+++ b/activesupport/test/subscriber_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/subscriber"
 

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/logger"
 require "active_support/tagged_logging"

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 class AssertDifferenceTest < ActiveSupport::TestCase

--- a/activesupport/test/testing/constant_lookup_test.rb
+++ b/activesupport/test/testing/constant_lookup_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "dependencies_test_helpers"
 

--- a/activesupport/test/testing/file_fixtures_test.rb
+++ b/activesupport/test/testing/file_fixtures_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 
 require "pathname"

--- a/activesupport/test/testing/method_call_assertions_test.rb
+++ b/activesupport/test/testing/method_call_assertions_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/testing/method_call_assertions"
 

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/core_ext/date_time"
 require "active_support/core_ext/numeric/time"

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/time"
 require "time_zone_test_helpers"

--- a/activesupport/test/time_zone_test_helpers.rb
+++ b/activesupport/test/time_zone_test_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module TimeZoneTestHelpers
   def with_tz_default(tz = nil)
     old_tz = Time.zone

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/inflector/transliterate"
 

--- a/activesupport/test/xml_mini/jdom_engine_test.rb
+++ b/activesupport/test/xml_mini/jdom_engine_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "xml_mini_engine_test"
 
 XMLMiniEngineTest.run_with_platform("java") do

--- a/activesupport/test/xml_mini/libxml_engine_test.rb
+++ b/activesupport/test/xml_mini/libxml_engine_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "xml_mini_engine_test"
 
 XMLMiniEngineTest.run_with_gem("libxml") do

--- a/activesupport/test/xml_mini/libxmlsax_engine_test.rb
+++ b/activesupport/test/xml_mini/libxmlsax_engine_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "xml_mini_engine_test"
 
 XMLMiniEngineTest.run_with_gem("libxml") do

--- a/activesupport/test/xml_mini/nokogiri_engine_test.rb
+++ b/activesupport/test/xml_mini/nokogiri_engine_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "xml_mini_engine_test"
 
 XMLMiniEngineTest.run_with_gem("nokogiri") do

--- a/activesupport/test/xml_mini/nokogirisax_engine_test.rb
+++ b/activesupport/test/xml_mini/nokogirisax_engine_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "xml_mini_engine_test"
 
 XMLMiniEngineTest.run_with_gem("nokogiri") do

--- a/activesupport/test/xml_mini/rexml_engine_test.rb
+++ b/activesupport/test/xml_mini/rexml_engine_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "xml_mini_engine_test"
 
 class REXMLEngineTest < XMLMiniEngineTest

--- a/activesupport/test/xml_mini/xml_mini_engine_test.rb
+++ b/activesupport/test/xml_mini/xml_mini_engine_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/xml_mini"
 require "active_support/core_ext/hash/conversions"

--- a/activesupport/test/xml_mini_test.rb
+++ b/activesupport/test/xml_mini_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "abstract_unit"
 require "active_support/xml_mini"
 require "active_support/builder"


### PR DESCRIPTION
My previous plan to enable frozen-string-literal across all Rails gems didn't work (https://github.com/rails/rails/pull/29540) and had to be reverted because not all components were ready for it. Let's take a more incremental approach of enabling it per gem with the rubocop `Only` option, only for gems that we know are ready for frozen string.

```
Style/FrozenStringLiteralComment:
  Enabled: true
  EnforcedStyle: always
  Include:
    - 'activesupport/**/*'
```

Thanks to @pat 's work, activesupport is now ready for frozen string literal.

Once https://github.com/rails/rails/pull/29655 is merged, I'll do the same for the rest of components.

@rafaelfranca @matthewd 