### PR TITLE
Update MessageEncryptor example to use dynamic key length

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -13,11 +13,12 @@ module ActiveSupport
   # This can be used in situations similar to the <tt>MessageVerifier</tt>, but
   # where you don't want users to be able to determine the value of the payload.
   #
-  #   salt  = SecureRandom.random_bytes(64)
-  #   key   = ActiveSupport::KeyGenerator.new('password').generate_key(salt, 32) # => "\x89\xE0\x156\xAC..."
-  #   crypt = ActiveSupport::MessageEncryptor.new(key)                           # => #<ActiveSupport::MessageEncryptor ...>
-  #   encrypted_data = crypt.encrypt_and_sign('my secret data')                  # => "NlFBTTMwOUV5UlA1QlNEN2xkY2d6eThYWWh..."
-  #   crypt.decrypt_and_verify(encrypted_data)                                   # => "my secret data"
+  #   len   = ActiveSupport::MessageEncryptor.key_len
+  #   salt  = SecureRandom.random_bytes(len)
+  #   key   = ActiveSupport::KeyGenerator.new('password').generate_key(salt, len) # => "\x89\xE0\x156\xAC..."
+  #   crypt = ActiveSupport::MessageEncryptor.new(key)                            # => #<ActiveSupport::MessageEncryptor ...>
+  #   encrypted_data = crypt.encrypt_and_sign('my secret data')                   # => "NlFBTTMwOUV5UlA1QlNEN2xkY2d6eThYWWh..."
+  #   crypt.decrypt_and_verify(encrypted_data)                                    # => "my secret data"
   class MessageEncryptor
     class << self
       attr_accessor :use_authenticated_message_encryption #:nodoc:


### PR DESCRIPTION
`key_len` was introduced in https://github.com/rails/rails/pull/25758 but the example still used magic numbers. Granted, 32 is not likely to change... and 64 random bytes (512 bits) is overkill, for example UUIDs are 16 bytes.

Recommend reviewing with [?w=1](https://github.com/rails/rails/pull/29730/files?w=1)