### PR TITLE
Use frozen-string-literal in ActiveJob

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,6 +82,7 @@ Style/FrozenStringLiteralComment:
   EnforcedStyle: always
   Include:
     - 'activesupport/**/*'
+    - 'activejob/**/*'
 
 # Use `foo {}` not `foo{}`.
 Layout/SpaceBeforeBlockBraces:

--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rake/testtask"
 
 #TODO: add qu back to the list after it support Rails 5.1

--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|

--- a/activejob/bin/test
+++ b/activejob/bin/test
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"

--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # Copyright (c) 2014-2017 David Heinemeier Hansson
 #

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/core_ext/hash"
 
 module ActiveJob

--- a/activejob/lib/active_job/base.rb
+++ b/activejob/lib/active_job/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "core"
 require_relative "queue_adapter"
 require_relative "queue_name"

--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/callbacks"
 
 module ActiveJob

--- a/activejob/lib/active_job/configured_job.rb
+++ b/activejob/lib/active_job/configured_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveJob
   class ConfiguredJob #:nodoc:
     def initialize(job_class, options = {})

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveJob
   # Provides general behavior that will be included into every Active Job
   # object that inherits from ActiveJob::Base.

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "arguments"
 
 module ActiveJob

--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/core_ext/numeric/time"
 
 module ActiveJob

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/rescuable"
 require_relative "arguments"
 

--- a/activejob/lib/active_job/gem_version.rb
+++ b/activejob/lib/active_job/gem_version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveJob
   # Returns the version of the currently loaded Active Job as a <tt>Gem::Version</tt>
   def self.gem_version

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/core_ext/hash/transform_values"
 require "active_support/core_ext/string/filters"
 require "active_support/tagged_logging"

--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/core_ext/string/inflections"
 
 module ActiveJob

--- a/activejob/lib/active_job/queue_adapters.rb
+++ b/activejob/lib/active_job/queue_adapters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveJob
   # == Active Job adapters
   #

--- a/activejob/lib/active_job/queue_adapters/async_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/async_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "securerandom"
 require "concurrent/scheduled_task"
 require "concurrent/executor/thread_pool_executor"

--- a/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "backburner"
 
 module ActiveJob

--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "delayed_job"
 
 module ActiveJob

--- a/activejob/lib/active_job/queue_adapters/inline_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/inline_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveJob
   module QueueAdapters
     # == Active Job Inline adapter

--- a/activejob/lib/active_job/queue_adapters/qu_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/qu_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "qu"
 
 module ActiveJob

--- a/activejob/lib/active_job/queue_adapters/que_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/que_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "que"
 
 module ActiveJob

--- a/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "queue_classic"
 
 module ActiveJob

--- a/activejob/lib/active_job/queue_adapters/resque_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/resque_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "resque"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/array/access"

--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "sidekiq"
 
 module ActiveJob

--- a/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "sneakers"
 require "monitor"
 

--- a/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "sucker_punch"
 
 module ActiveJob

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveJob
   module QueueAdapters
     # == Test adapter for Active Job

--- a/activejob/lib/active_job/queue_name.rb
+++ b/activejob/lib/active_job/queue_name.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveJob
   module QueueName
     extend ActiveSupport::Concern

--- a/activejob/lib/active_job/queue_priority.rb
+++ b/activejob/lib/active_job/queue_priority.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveJob
   module QueuePriority
     extend ActiveSupport::Concern

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "global_id/railtie"
 require "active_job"
 

--- a/activejob/lib/active_job/test_case.rb
+++ b/activejob/lib/active_job/test_case.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/test_case"
 
 module ActiveJob

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/core_ext/class/subclasses"
 require "active_support/core_ext/hash/keys"
 

--- a/activejob/lib/active_job/translation.rb
+++ b/activejob/lib/active_job/translation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveJob
   module Translation #:nodoc:
     extend ActiveSupport::Concern

--- a/activejob/lib/active_job/version.rb
+++ b/activejob/lib/active_job/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "gem_version"
 
 module ActiveJob

--- a/activejob/lib/rails/generators/job/job_generator.rb
+++ b/activejob/lib/rails/generators/job/job_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rails/generators/named_base"
 
 module Rails # :nodoc:

--- a/activejob/test/adapters/async.rb
+++ b/activejob/test/adapters/async.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 ActiveJob::Base.queue_adapter = :async
 ActiveJob::Base.queue_adapter.immediate = true

--- a/activejob/test/adapters/backburner.rb
+++ b/activejob/test/adapters/backburner.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "support/backburner/inline"
 
 ActiveJob::Base.queue_adapter = :backburner

--- a/activejob/test/adapters/delayed_job.rb
+++ b/activejob/test/adapters/delayed_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveJob::Base.queue_adapter = :delayed_job
 
 $LOAD_PATH << File.expand_path("../support/delayed_job", __dir__)

--- a/activejob/test/adapters/inline.rb
+++ b/activejob/test/adapters/inline.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 ActiveJob::Base.queue_adapter = :inline

--- a/activejob/test/adapters/qu.rb
+++ b/activejob/test/adapters/qu.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "qu-immediate"
 
 ActiveJob::Base.queue_adapter = :qu

--- a/activejob/test/adapters/que.rb
+++ b/activejob/test/adapters/que.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "support/que/inline"
 
 ActiveJob::Base.queue_adapter = :que

--- a/activejob/test/adapters/queue_classic.rb
+++ b/activejob/test/adapters/queue_classic.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 require "support/queue_classic/inline"
 ActiveJob::Base.queue_adapter = :queue_classic

--- a/activejob/test/adapters/resque.rb
+++ b/activejob/test/adapters/resque.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 ActiveJob::Base.queue_adapter = :resque
 Resque.inline = true

--- a/activejob/test/adapters/sidekiq.rb
+++ b/activejob/test/adapters/sidekiq.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 require "sidekiq/testing/inline"
 ActiveJob::Base.queue_adapter = :sidekiq

--- a/activejob/test/adapters/sneakers.rb
+++ b/activejob/test/adapters/sneakers.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 require "support/sneakers/inline"
 ActiveJob::Base.queue_adapter = :sneakers

--- a/activejob/test/adapters/sucker_punch.rb
+++ b/activejob/test/adapters/sucker_punch.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 require "sucker_punch/testing/inline"
 ActiveJob::Base.queue_adapter = :sucker_punch

--- a/activejob/test/adapters/test.rb
+++ b/activejob/test/adapters/test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveJob::Base.queue_adapter = :test
 ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
 ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true

--- a/activejob/test/cases/adapter_test.rb
+++ b/activejob/test/cases/adapter_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 class AdapterTest < ActiveSupport::TestCase

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 require "active_job/arguments"
 require "models/person"

--- a/activejob/test/cases/callbacks_test.rb
+++ b/activejob/test/cases/callbacks_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 require "jobs/callback_job"
 

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 require "jobs/retry_job"
 

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 require "jobs/gid_job"
 require "jobs/hello_job"

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 require "active_support/log_subscriber/test_helper"
 require "active_support/core_ext/numeric/time"

--- a/activejob/test/cases/queue_adapter_test.rb
+++ b/activejob/test/cases/queue_adapter_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 
 module ActiveJob

--- a/activejob/test/cases/queue_naming_test.rb
+++ b/activejob/test/cases/queue_naming_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 require "jobs/hello_job"
 require "jobs/logging_job"

--- a/activejob/test/cases/queue_priority_test.rb
+++ b/activejob/test/cases/queue_priority_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 require "jobs/hello_job"
 

--- a/activejob/test/cases/queuing_test.rb
+++ b/activejob/test/cases/queuing_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 require "jobs/hello_job"
 require "active_support/core_ext/numeric/time"

--- a/activejob/test/cases/rescue_test.rb
+++ b/activejob/test/cases/rescue_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 require "jobs/rescue_job"
 require "models/person"

--- a/activejob/test/cases/test_case_test.rb
+++ b/activejob/test/cases/test_case_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 require "jobs/hello_job"
 require "jobs/logging_job"

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 require "active_support/core_ext/time"
 require "active_support/core_ext/date"

--- a/activejob/test/cases/translation_test.rb
+++ b/activejob/test/cases/translation_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 require "jobs/translated_hello_job"
 

--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_job"
 require "support/job_buffer"
 

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "helper"
 require "jobs/logging_job"
 require "jobs/hello_job"

--- a/activejob/test/jobs/application_job.rb
+++ b/activejob/test/jobs/application_job.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class ApplicationJob < ActiveJob::Base
 end

--- a/activejob/test/jobs/callback_job.rb
+++ b/activejob/test/jobs/callback_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CallbackJob < ActiveJob::Base
   before_perform ->(job) { job.history << "CallbackJob ran before_perform" }
   after_perform ->(job) { job.history << "CallbackJob ran after_perform" }

--- a/activejob/test/jobs/gid_job.rb
+++ b/activejob/test/jobs/gid_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../support/job_buffer"
 
 class GidJob < ActiveJob::Base

--- a/activejob/test/jobs/hello_job.rb
+++ b/activejob/test/jobs/hello_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../support/job_buffer"
 
 class HelloJob < ActiveJob::Base

--- a/activejob/test/jobs/inherited_job.rb
+++ b/activejob/test/jobs/inherited_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "application_job"
 
 class InheritedJob < ApplicationJob

--- a/activejob/test/jobs/kwargs_job.rb
+++ b/activejob/test/jobs/kwargs_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../support/job_buffer"
 
 class KwargsJob < ActiveJob::Base

--- a/activejob/test/jobs/logging_job.rb
+++ b/activejob/test/jobs/logging_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class LoggingJob < ActiveJob::Base
   def perform(dummy)
     logger.info "Dummy, here is it: #{dummy}"

--- a/activejob/test/jobs/nested_job.rb
+++ b/activejob/test/jobs/nested_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class NestedJob < ActiveJob::Base
   def perform
     LoggingJob.perform_later "NestedJob"

--- a/activejob/test/jobs/overridden_logging_job.rb
+++ b/activejob/test/jobs/overridden_logging_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class OverriddenLoggingJob < ActiveJob::Base
   def perform(dummy)
     logger.info "Dummy, here is it: #{dummy}"

--- a/activejob/test/jobs/provider_jid_job.rb
+++ b/activejob/test/jobs/provider_jid_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../support/job_buffer"
 
 class ProviderJidJob < ActiveJob::Base

--- a/activejob/test/jobs/queue_adapter_job.rb
+++ b/activejob/test/jobs/queue_adapter_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class QueueAdapterJob < ActiveJob::Base
   self.queue_adapter = :inline
 end

--- a/activejob/test/jobs/queue_as_job.rb
+++ b/activejob/test/jobs/queue_as_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../support/job_buffer"
 
 class QueueAsJob < ActiveJob::Base

--- a/activejob/test/jobs/rescue_job.rb
+++ b/activejob/test/jobs/rescue_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../support/job_buffer"
 
 class RescueJob < ActiveJob::Base

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../support/job_buffer"
 require "active_support/core_ext/integer/inflections"
 

--- a/activejob/test/jobs/translated_hello_job.rb
+++ b/activejob/test/jobs/translated_hello_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "../support/job_buffer"
 
 class TranslatedHelloJob < ActiveJob::Base

--- a/activejob/test/models/person.rb
+++ b/activejob/test/models/person.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Person
   class RecordNotFound < StandardError; end
 

--- a/activejob/test/support/backburner/inline.rb
+++ b/activejob/test/support/backburner/inline.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "backburner"
 
 Backburner::Worker.class_eval do

--- a/activejob/test/support/delayed_job/delayed/backend/test.rb
+++ b/activejob/test/support/delayed_job/delayed/backend/test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #copied from https://github.com/collectiveidea/delayed_job/blob/master/spec/delayed/backend/test.rb
 require "ostruct"
 

--- a/activejob/test/support/integration/adapters/async.rb
+++ b/activejob/test/support/integration/adapters/async.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module AsyncJobsManager
   def setup
     ActiveJob::Base.queue_adapter = :async

--- a/activejob/test/support/integration/adapters/backburner.rb
+++ b/activejob/test/support/integration/adapters/backburner.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module BackburnerJobsManager
   def setup
     ActiveJob::Base.queue_adapter = :backburner

--- a/activejob/test/support/integration/adapters/delayed_job.rb
+++ b/activejob/test/support/integration/adapters/delayed_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "delayed_job"
 require "delayed_job_active_record"
 

--- a/activejob/test/support/integration/adapters/inline.rb
+++ b/activejob/test/support/integration/adapters/inline.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module InlineJobsManager
   def setup
     ActiveJob::Base.queue_adapter = :inline

--- a/activejob/test/support/integration/adapters/qu.rb
+++ b/activejob/test/support/integration/adapters/qu.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module QuJobsManager
   def setup
     require "qu-rails"

--- a/activejob/test/support/integration/adapters/que.rb
+++ b/activejob/test/support/integration/adapters/que.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module QueJobsManager
   def setup
     require "sequel"

--- a/activejob/test/support/integration/adapters/queue_classic.rb
+++ b/activejob/test/support/integration/adapters/queue_classic.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module QueueClassicJobsManager
   def setup
     ENV["QC_DATABASE_URL"] ||= "postgres:///active_jobs_qc_int_test"

--- a/activejob/test/support/integration/adapters/resque.rb
+++ b/activejob/test/support/integration/adapters/resque.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ResqueJobsManager
   def setup
     ActiveJob::Base.queue_adapter = :resque

--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "sidekiq/api"
 
 require "sidekiq/testing"

--- a/activejob/test/support/integration/adapters/sneakers.rb
+++ b/activejob/test/support/integration/adapters/sneakers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "sneakers/runner"
 require "sneakers/publisher"
 require "timeout"

--- a/activejob/test/support/integration/adapters/sucker_punch.rb
+++ b/activejob/test/support/integration/adapters/sucker_punch.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SuckerPunchJobsManager
   def setup
     ActiveJob::Base.queue_adapter = :sucker_punch

--- a/activejob/test/support/integration/dummy_app_template.rb
+++ b/activejob/test/support/integration/dummy_app_template.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 if ENV["AJ_ADAPTER"] == "delayed_job"
   generate "delayed_job:active_record", "--quiet"
 end

--- a/activejob/test/support/integration/helper.rb
+++ b/activejob/test/support/integration/helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 puts "\n\n*** rake aj:integration:#{ENV['AJ_ADAPTER']} ***\n"
 
 ENV["RAILS_ENV"] = "test"

--- a/activejob/test/support/integration/jobs_manager.rb
+++ b/activejob/test/support/integration/jobs_manager.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class JobsManager
   @@managers = {}
   attr :adapter_name

--- a/activejob/test/support/integration/test_case_helpers.rb
+++ b/activejob/test/support/integration/test_case_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/core_ext/string/inflections"
 require "support/integration/jobs_manager"
 

--- a/activejob/test/support/job_buffer.rb
+++ b/activejob/test/support/job_buffer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module JobBuffer
   class << self
     def clear

--- a/activejob/test/support/que/inline.rb
+++ b/activejob/test/support/que/inline.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "que"
 
 Que::Job.class_eval do

--- a/activejob/test/support/queue_classic/inline.rb
+++ b/activejob/test/support/queue_classic/inline.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "queue_classic"
 
 module QC

--- a/activejob/test/support/sneakers/inline.rb
+++ b/activejob/test/support/sneakers/inline.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "sneakers"
 
 module Sneakers


### PR DESCRIPTION
The commit is just `rubocop -a` after changing the Rubocop rule.

ref https://github.com/rails/rails/pull/29655
ref https://github.com/rails/rails/pull/29540

@matthewd @rafaelfranca 