### PR TITLE
Eager loading with scoping should behave consistently

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -114,8 +114,18 @@ module ActiveRecord
             @reflection_scope ||= reflection.scope_for(klass)
           end
 
+          def klass_scope
+            if klass.current_scope
+              klass.current_scope.clone.tap { |scope|
+                scope.preload_values = scope.includes_values = [].freeze
+              }
+            else
+              klass.default_scoped
+            end
+          end
+
           def build_scope
-            scope = klass.default_scoped
+            scope = klass_scope
 
             if reflection.type
               scope.where!(reflection.type => model.base_class.sti_name)


### PR DESCRIPTION
Currently `Post.find(1).comments` and with `.eager_load(:comments)`
behave consistently in the scoping. But with `.includes(:comments)` or
`.preload(:comments)` ignores the scoping. This means that we cannot
rewrite from `Post.find(1).comments` or with `.eager_load(:comments)` to
with `.includes(:comments)` or `.preload(:comments)` if affected in the
scoping. It should be behaved consistently.