### PR TITLE
Make sidekiq and resque integration tests work in CI

### DIFF
--- a/activejob/test/support/integration/adapters/resque.rb
+++ b/activejob/test/support/integration/adapters/resque.rb
@@ -2,7 +2,7 @@
 module ResqueJobsManager
   def setup
     ActiveJob::Base.queue_adapter = :resque
-    Resque.redis = Redis::Namespace.new "active_jobs_int_test", redis: Redis.connect(url: "redis://127.0.0.1:6379/12", thread_safe: true)
+    Resque.redis = Redis::Namespace.new "active_jobs_int_test", redis: Redis.connect(url: "redis://:password@127.0.0.1:6379/12", thread_safe: true)
     Resque.logger = Rails.logger
     unless can_run?
       puts "Cannot run integration tests for resque. To be able to run integration tests for resque you need to install and start redis.\n"

--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -4,6 +4,14 @@ require "sidekiq/api"
 require "sidekiq/testing"
 Sidekiq::Testing.disable!
 
+Sidekiq.configure_server do |config|
+  config.redis = { url: "redis://:password@127.0.0.1:6379/12" }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: "redis://:password@127.0.0.1:6379/12" }
+end
+
 module SidekiqJobsManager
   def setup
     ActiveJob::Base.queue_adapter = :sidekiq


### PR DESCRIPTION
Since f55ecc6, the integration test of sidekiq and resque is not working in CI.
https://travis-ci.org/rails/rails/jobs/251783876

Because f55ecc6 required a password to access redis.
Therefore, handling by passing passwords when connecting to redis.