### PR TITLE
Rework code statistics task

### DIFF
--- a/railties/lib/rails/code_statistics/helpers.rb
+++ b/railties/lib/rails/code_statistics/helpers.rb
@@ -1,0 +1,29 @@
+module CodeStatistics::Helpers #:nodoc:
+  extend self
+
+  def eager_loaded_paths
+    config = Rails.application.config
+    paths = (config.autoload_paths + config.eager_load_paths + config.autoload_once_paths).uniq
+    paths = remove_child_paths(paths)
+    convert_to_relative(paths, config.root)
+  end
+
+  def dir_label(dir)
+    if dir =~ /app\/(.+)/
+      $1.gsub("/", " ").titleize
+    else
+      dir.pluralize.titleize
+    end
+  end
+
+  private
+    def remove_child_paths(paths)
+      paths.reject do |path|
+        paths.any? { |child| child != path && path.starts_with?(child) }
+      end
+    end
+
+    def convert_to_relative(paths, root)
+      paths.map { |n| Pathname.new(n).relative_path_from(root).to_s }
+    end
+end

--- a/railties/lib/rails/code_statistics/registry.rb
+++ b/railties/lib/rails/code_statistics/registry.rb
@@ -1,0 +1,41 @@
+class CodeStatistics::Registry
+  Entity = Struct.new(:label, :dir, :tests?)
+
+  attr_reader :entities
+
+  # This method should not be called directly.
+  # Access the registry via CodeStatistics.registry
+  def initialize
+    @entities = []
+    @root = Rails.root
+  end
+
+  # Adds directory to the code statistics registry.
+  # Note that it shouldn't be a subdirectory of a path
+  # that is already tracked (app/models/concerns vs app/models)
+  #
+  # For example, if you want it to track code in config/nginx:
+  #   CodeStatistics.registry.add("Nginx configs", "config/nginx")
+  def add(label, dir)
+    dir = @root.join(dir)
+    return unless dir.directory?
+    @entities << Entity.new(label, dir, false)
+  end
+
+  # Adds tests directory to the code statistics registry.
+  # Example:
+  #   CodeStatistics.registry.add("Feature tests", "test/features")
+  def add_tests(label, dir)
+    dir = @root.join(dir)
+    return unless dir.directory?
+    @entities << Entity.new(label, dir, true)
+  end
+
+  # Deletes directory from the code statistics registry.
+  # Example:
+  #   CodeStatistics.registry.delete("app/services")
+  def delete(dir)
+    dir = @root.join(dir)
+    @entities.delete_if { |entity| entity.dir == dir }
+  end
+end

--- a/railties/test/code_statistics_test.rb
+++ b/railties/test/code_statistics_test.rb
@@ -1,11 +1,13 @@
 require "abstract_unit"
 require "rails/code_statistics"
+require "rails/code_statistics/registry"
 
 class CodeStatisticsTest < ActiveSupport::TestCase
   def setup
     @tmp_path = File.expand_path("fixtures/tmp", __dir__)
     @dir_js   = File.join(@tmp_path, "lib.js")
     FileUtils.mkdir_p(@dir_js)
+    @registry = CodeStatistics::Registry.new
   end
 
   def teardown
@@ -14,7 +16,8 @@ class CodeStatisticsTest < ActiveSupport::TestCase
 
   test "ignores directories that happen to have source files extensions" do
     assert_nothing_raised do
-      @code_statistics = CodeStatistics.new(["tmp dir", @tmp_path])
+      @registry.add("tmp dir", @tmp_path)
+      @code_statistics = CodeStatistics.new(@registry)
     end
   end
 
@@ -26,7 +29,7 @@ class CodeStatisticsTest < ActiveSupport::TestCase
     CODE
 
     assert_nothing_raised do
-      CodeStatistics.new(["hidden file", @tmp_path])
+      CodeStatistics.new(@registry)
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/29497

This PR solves two issues with `rails stats` command:

1) It doesn't track any code outside of hardcoded list of paths, for instance code in `app/services` would never be counted
2) The hardcoded list of paths lives in a top-level constant (`STATS_DIRECTORIES`) 🙈 , which is mutated by gems and apps to extend the list of directories to calculate stats.

## Eager load paths

To get a complete list of all dirs in the app (including custom paths like `app/services` or top-level `eagerlib/`, this PR leverages `Rails.application.config.paths` to get this information.

## Registry

To move away from a hardcoded list, I've introduced a simple registry that stores a list of directories to count the code. The registry separates actual code from the tests to count the `code:test` ratio.

The registry is provided to gems as a public API in order to add new directories. An example for RSpec would be:

```ruby
CodeStatistics.registry.add_tests("Controller specs", "spec/controllers")
CodeStatistics.registry.add_tests("Model specs", "spec/models")
```

The registry could also help apps that have a complex structure and need a way to extend `rails stats` (e.g. Shopify).

## Backward compatibility

Previously, Rails exposed a global top-level constant (`STATS_DIRECTORIES`). Gems like rspec [appended values](https://github.com/rspec/rspec-rails/blob/master/lib/rspec/rails/tasks/rspec.rake#L53-L54) to this constant to add custom directories like `spec/controllers`.

With the new implementation, we still support this flow by checking if any new values were appended `STATS_DIRECTORIES`. If there were, we push them to the registry and print a deprecation message. I tested it with rspec-rails and it just works.

## Notes

* my plan was to move away from a rake task and make it a Rails command, but the way how gems are currently using to extend it (https://github.com/rspec/rspec-rails/blob/master/lib/rspec/rails/tasks/rspec.rake#L53-L54) is tied to a rake task. This PR preserves backward compatibility and I don't see a way how we could preserve it with moving the code into Rails command
* now the task requires Rails environment to be loaded in order to fetch `eager_load_paths`
* this PR is missing tests. I'm looking forward to your opinion whether how we should test it (e2e test of a rake task vs unit tests)