### PR TITLE
CI with the latest stable(GA) version of MariaDB 10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ matrix:
       env:
         - "GEM=ar:mysql2 MYSQL=mariadb"
       addons:
-        mariadb: 10.0
+        mariadb: 10.2
     - rvm: 2.3.4
       env:
         - "GEM=ar:sqlite3_mem"


### PR DESCRIPTION
### Summary

This pull request updates MariaDB version to 10.2 since #29708 and #29706 supports MariaDB 10.2 changes.

Refer https://mariadb.com/kb/en/mariadb/latest-releases/

