### PR TITLE
Fix PostgreSql adapter setup for ActionCable tests

### DIFF
--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -12,7 +12,7 @@ class PostgresqlAdapterTest < ActionCable::TestCase
     if Dir.exist?(ar_tests)
       require File.join(ar_tests, "config")
       require File.join(ar_tests, "support/config")
-      local_config = ARTest.config["arunit"]
+      local_config = ARTest.config["connections"]["postgresql"]["arunit"]
       database_config.update local_config if local_config
     end
 


### PR DESCRIPTION
`ARTest.config["arunit"]` is always `nil`, 'cause databases [config](https://github.com/rails/rails/blob/master/activerecord/test/config.example.yml) has nested structure (connections -> adapter -> id).

I'm using custom PostgreSQL credentials in `config.yml`, and it turned out that there is a bug here.

/cc @matthewd 