### PR TITLE
Fix HashWithIndifferentAccess#default when include?(nil)

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -76,16 +76,6 @@ module ActiveSupport
       end
     end
 
-    def default(*args)
-      arg_key = args.first
-
-      if include?(key = convert_key(arg_key))
-        self[key]
-      else
-        super
-      end
-    end
-
     def self.[](*args)
       new.merge!(Hash[*args])
     end
@@ -185,6 +175,36 @@ module ActiveSupport
     #   counters.fetch(:zoo)           # => KeyError: key not found: "zoo"
     def fetch(key, *extras)
       super(convert_key(key), *extras)
+    end
+
+    if Hash.new.respond_to?(:dig)
+      # Same as <tt>Hash#dig</tt> where the key passed as argument can be
+      # either a string or a symbol:
+      #
+      #   counters = ActiveSupport::HashWithIndifferentAccess.new
+      #   counters[:foo] = { bar: 1 }
+      #
+      #   counters.dig('foo', 'bar')     # => 1
+      #   counters.dig(:foo, :bar)       # => 1
+      #   counters.dig(:zoo)             # => nil
+      def dig(*args)
+        args[0] = convert_key(args[0]) if args.size > 0
+        super(*args)
+      end
+    end
+
+    # Same as <tt>Hash#default</tt> where the key passed as argument can be
+    # either a string or a symbol:
+    #
+    #   hash = ActiveSupport::HashWithIndifferentAccess.new(1)
+    #   hash.default                   # => 1
+    #
+    #   hash = ActiveSupport::HashWithIndifferentAccess.new { |hash, key| key }
+    #   hash.default                   # => nil
+    #   hash.default('foo')            # => 'foo'
+    #   hash.default(:foo)             # => 'foo'
+    def default(*args)
+      super(*args.map { |arg| convert_key(arg) })
     end
 
     # Returns an array of the values at the specified indices:

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -537,6 +537,32 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_equal 1234, data.dig(:this, :views)
   end
 
+  def test_argless_default_with_existing_nil_key
+    h = Hash.new(:default).merge(nil => "defined").with_indifferent_access
+
+    assert_equal :default, h.default
+  end
+
+  def test_default_with_argument
+    h = Hash.new { 5 }.merge(1 => 2).with_indifferent_access
+
+    assert_equal 5, h.default(1)
+  end
+
+  def test_default_proc
+    h = ActiveSupport::HashWithIndifferentAccess.new { |hash, key| key }
+
+    assert_nil h.default
+    assert_equal "foo", h.default("foo")
+    assert_equal "foo", h.default(:foo)
+  end
+
+  def test_double_conversion_with_nil_key
+    h = { nil => "defined" }.with_indifferent_access.with_indifferent_access
+
+    assert_equal nil, h[:undefined_key]
+  end
+
   def test_assorted_keys_not_stringified
     original = { Object.new => 2, 1 => 2, [] => true }
     indiff = original.with_indifferent_access


### PR DESCRIPTION
Fixes #29738 

### Summary

The implementation of `HashWithIndifferentAccess#default` didn't distinguish `default` from `default(nil)`, which caused an incorrect result for `default` if `nil` was used as a key.