### PR TITLE
Use FileUpdateChecker for Migration::CheckPending

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -552,6 +552,8 @@ module ActiveRecord
         @watcher = file_watcher.new(*watchable_args) do
           @needs_check = true
           ActiveRecord::Migration.check_pending!(connection)
+
+          # Only executed when no missing migration error
           @needs_check = false
         end
       end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -544,21 +544,38 @@ module ActiveRecord
     # This class is used to verify that all migrations have been run before
     # loading a web page if <tt>config.active_record.migration_error</tt> is set to :page_load
     class CheckPending
-      def initialize(app)
+      def initialize(app, file_watcher: ActiveSupport::FileUpdateChecker)
         @app = app
-        @last_check = 0
+        @needs_check = true
+
+        @mutex = Mutex.new
+        @watcher = file_watcher.new(*watchable_args) do
+          @needs_check = true
+          ActiveRecord::Migration.check_pending!(connection)
+          @needs_check = false
+        end
       end
 
       def call(env)
-        mtime = ActiveRecord::Migrator.last_migration.mtime.to_i
-        if @last_check < mtime
-          ActiveRecord::Migration.check_pending!(connection)
-          @last_check = mtime
+        @mutex.synchronize do
+          if @needs_check
+            @watcher.execute
+          else
+            @watcher.execute_if_updated
+          end
         end
+
         @app.call(env)
       end
 
       private
+
+        def watchable_args
+          dirs_hash = ActiveRecord::Migrator.migrations_paths.map do |dir|
+            [dir, ["rb"]]
+          end.to_h
+          [[], dirs_hash]
+        end
 
         def connection
           ActiveRecord::Base.connection
@@ -950,10 +967,6 @@ module ActiveRecord
       File.basename(filename)
     end
 
-    def mtime
-      File.mtime filename
-    end
-
     delegate :migrate, :announce, :write, :disable_ddl_transaction, to: :migration
 
     private
@@ -966,16 +979,6 @@ module ActiveRecord
         require(File.expand_path(filename))
         name.constantize.new(name, version)
       end
-  end
-
-  class NullMigration < MigrationProxy #:nodoc:
-    def initialize
-      super(nil, 0, nil, nil)
-    end
-
-    def mtime
-      0
-    end
   end
 
   class Migrator#:nodoc:
@@ -1049,10 +1052,6 @@ module ActiveRecord
 
       def any_migrations?
         migrations(migrations_paths).any?
-      end
-
-      def last_migration #:nodoc:
-        migrations(migrations_paths).last || NullMigration.new
       end
 
       def migrations_paths

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -76,10 +76,11 @@ module ActiveRecord
       ActiveSupport.on_load(:active_record) { self.logger ||= ::Rails.logger }
     end
 
-    initializer "active_record.migration_error" do
+    initializer "active_record.migration_error" do |app|
       if config.active_record.delete(:migration_error) == :page_load
         config.app_middleware.insert_after ::ActionDispatch::Callbacks,
-          ActiveRecord::Migration::CheckPending
+          ActiveRecord::Migration::CheckPending,
+          file_watcher: app.config.file_watcher
       end
     end
 

--- a/activerecord/test/cases/migration/pending_migrations_test.rb
+++ b/activerecord/test/cases/migration/pending_migrations_test.rb
@@ -7,21 +7,26 @@ module ActiveRecord
     class PendingMigrationsTest < ActiveRecord::TestCase
       def setup
         super
+        @migration_dir = Dir.mktmpdir("activerecord-migrations-")
+        @original_migrations_paths = ActiveRecord::Migrator.migrations_paths
+        ActiveRecord::Migrator.migrations_paths = [@migration_dir]
         @connection = Minitest::Mock.new
         @app = Minitest::Mock.new
         conn = @connection
-        @pending = Class.new(CheckPending) {
+        @pending_class = Class.new(CheckPending) {
           define_method(:connection) { conn }
-        }.new(@app)
+        }
       end
 
       def teardown
+        FileUtils.rm_rf(@migration_dir)
         assert @connection.verify
         assert @app.verify
         super
       end
 
       def test_errors_if_pending
+        @pending = @pending_class.new(@app)
         ActiveRecord::Migrator.stub :needs_migration?, true do
           assert_raise ActiveRecord::PendingMigrationError do
             @pending.call(nil)
@@ -30,11 +35,89 @@ module ActiveRecord
       end
 
       def test_checks_if_supported
+        @pending = @pending_class.new(@app)
         @app.expect :call, nil, [:foo]
 
-        ActiveRecord::Migrator.stub :needs_migration?, false do
+        ActiveRecord::Migrator.expects(:needs_migration?).returns(false)
+        @pending.call(:foo)
+      end
+
+      def test_does_not_recheck_if_nothing_changed
+        @pending = @pending_class.new(@app)
+        @app.expect :call, nil, [:foo]
+        @app.expect :call, nil, [:foo2]
+
+        ActiveRecord::Migrator.expects(:needs_migration?).returns(false)
+        @pending.call(:foo)
+
+        # Second call should not re-check migrations
+        @pending.call(:foo2)
+      end
+
+      def test_rechecks_when_file_created_or_updated2
+        @pending = @pending_class.new(@app)
+        @app.expect :call, nil, [:foo]
+        @app.expect :call, nil, [:foo2]
+        @app.expect :call, nil, [:foo3]
+        @app.expect :call, nil, [:foo4]
+
+        # Must check first time
+        ActiveRecord::Migrator.expects(:needs_migration?).returns(false)
+        @pending.call(:foo)
+
+        # Must re-check
+        ActiveRecord::Migrator.expects(:needs_migration?).returns(false)
+        FileUtils.touch(File.join(@migration_dir, "01_foobar.rb"), mtime: Time.now - 100)
+        @pending.call(:foo2)
+
+        # Nothing changed. No check
+        ActiveRecord::Migrator.expects(:needs_migration?).never
+        @pending.call(:foo3)
+
+        # File updated. Must re-check
+        ActiveRecord::Migrator.expects(:needs_migration?).returns(false)
+        FileUtils.touch(File.join(@migration_dir, "01_foobar.rb"))
+        @pending.call(:foo4)
+      end
+
+      # Regression test for https://github.com/rails/rails/pull/29759
+      def test_understands_migrations_created_out_of_order
+        # With a prior file before even initialization
+        FileUtils.touch(File.join(@migration_dir, "05_baz.rb"))
+
+        @pending = @pending_class.new(@app)
+        @app.expect :call, nil, [:foo]
+
+        # And no necessary migrations on our first check
+        ActiveRecord::Migrator.expects(:needs_migration?).returns(false)
+        @pending.call(:foo)
+
+        # It understands the new migration created at 01
+        FileUtils.touch(File.join(@migration_dir, "01_foobar.rb"))
+        ActiveRecord::Migrator.expects(:needs_migration?).returns(true)
+        assert_raise ActiveRecord::PendingMigrationError do
+          @pending.call(:foo2)
+        end
+      end
+
+      def test_continues_raising_until_fixed
+        @pending = @pending_class.new(@app)
+        @app.expect :call, nil, [:foo3]
+
+        ActiveRecord::Migrator.expects(:needs_migration?).returns(true)
+        assert_raise ActiveRecord::PendingMigrationError do
           @pending.call(:foo)
         end
+
+        # Second call should re-check migrations, continue raising
+        ActiveRecord::Migrator.expects(:needs_migration?).returns(true)
+        assert_raise ActiveRecord::PendingMigrationError do
+          @pending.call(:foo2)
+        end
+
+        # Finally we re-check, pass, and continue to the app
+        ActiveRecord::Migrator.expects(:needs_migration?).returns(false)
+        @pending.call(:foo3)
       end
     end
   end

--- a/activerecord/test/cases/migration/pending_migrations_test.rb
+++ b/activerecord/test/cases/migration/pending_migrations_test.rb
@@ -13,7 +13,6 @@ module ActiveRecord
         @pending = Class.new(CheckPending) {
           define_method(:connection) { conn }
         }.new(@app)
-        @pending.instance_variable_set :@last_check, -1 # Force checking
       end
 
       def teardown


### PR DESCRIPTION
`Migration::CheckPending` is a rack middleware normally used in development to raise an exception when there are pending migrations.

This commit replaces the existing caching, which avoided checking all migrations if the newest migration hasn't changed. Instead, we now use `FileUpdateChecker`, which has two advantages: it can detect new migrations which aren't the highest version number, and it is faster.

## Improved checking

The existing code watched for the value of `last_migration.mtime` to change, the modification time on the  file with the highest version number. This works most of the time, but when merging/rebasing/checking out other branches, it's likely to have "new" migrations arrive with a lower version number than the previous highest. In this event the `CheckPending` will not notice and not re-check that migrations are up to date.

What we really want is to check for the greatest `mtime` of all migrations, and re-check if any files are new. This is exactly what `ActiveSupport::FileUpdateChecker` does for us! :tada: 

## Improved performance

This middleware is probably only run in development, which we don't heavily optimize for, but this check was actually relatively slow, I started looking into this because it was taking ~10ms on each request in my development server (not reported in logs because this middleware is before dispatch).

This slowness is because `last_migration` is `migrations.last`, and `migrations` for each migration file needs to run `File.basename`, a regex to extract version/name/scope, and `camelize`.

My first attempt to improve this was to avoid the call to `camelize`, which is faster, but still not as fast as just using `FileUpdateChecker` (which surprised me, I expected a `stat` syscall for each file to be slow). This will use `EventedFileUpdateChecker` if it is set as `config.file_watcher` (it is by default), which is much faster.

## Performance testing

For testing, I made a new rails application, and generated 500 migrations

```
$ bundle exec rails new --dev sandbox
$ cd sandbox && rails c
> require 'rails/generators/active_record/migration/migration_generator'
> (1...500).each {|i| ActiveRecord::Generators::MigrationGenerator.start(["TestSomeMigrations#{i}"]) }
$ rake db:migrate
```

I have the following benchmark script
``` ruby
require 'benchmark/ips'
require './config/environment'

check_pending = ActiveRecord::Migration::CheckPending.new(->(env){})
# check_pending = ActiveRecord::Migration::CheckPending.new(->(env){}, file_watcher: ActiveSupport::EventedFileUpdateChecker)

env = {}

Benchmark.ips do |x|
  x.config(:time => 5, :warmup => 2)

  x.report("CheckPending#call") { check_pending.call(env) }
end
```

**Original**
```
CheckPending#call    111.225  (± 0.9%) i/s -    560.000  in   5.035700s
```

**This PR** (when `file_watcher == FileUpdateChecker`)
```
CheckPending#call    615.889  (± 1.9%) i/s -      3.132k in   5.087336s
```

**This PR** (when `file_watcher == EventedFileUpdateChecker`)

```
CheckPending#call    942.572k (± 0.2%) i/s -      4.727M in   5.015013s
```

~~It would be awesome to use `ActiveSupport::EventedFileUpdateChecker`, if available, which is over 1000x faster than the non evented version in my benchmark. I couldn't find a way to properly get access to 
`Rails.application.config.file_watcher` from either `CheckPending` itself or [where it is initialized in the ActiveRecord railtie](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/railtie.rb#L76-L77). Any suggestions?~~ This now uses `ActiveSupport::EventedFileUpdateChecker`, if configured as `config.file_watcher`


Thanks for reading