### PR TITLE
Do not execute `secrets_test.rb` in parallel

### DIFF
--- a/railties/test/secrets_test.rb
+++ b/railties/test/secrets_test.rb
@@ -5,14 +5,13 @@ require "rails/generators/rails/encrypted_secrets/encrypted_secrets_generator"
 require "rails/secrets"
 
 class Rails::SecretsTest < ActiveSupport::TestCase
-  include ActiveSupport::Testing::Isolation
-
   def setup
     build_app
   end
 
   def teardown
     teardown_app
+    Rails::Secrets.instance_variable_set(:@encryptor, nil)
   end
 
   test "setting read to false skips parsing" do
@@ -22,6 +21,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
           yeah_yeah: lets-walk-in-the-cool-evening-light
       end_of_secrets
 
+      Rails.application.config.root = app_path
       Rails.application.config.read_encrypted_secrets = false
       Rails.application.instance_variable_set(:@secrets, nil) # Dance around caching 💃🕺
       assert_not Rails.application.secrets.yeah_yeah


### PR DESCRIPTION
In encrypted secrets, the tmp file is used as a fixed  file (`secrets.yml.enc` under the tmp directory).
And that tmp file will be removed after process.

Therefore, if test in parallel, there is a possibility to write to the same tmp file, or to remove the tmp file being used by another process yet. This occasionally caused the test to be an error.

For this reason, modified not to run in parallel.

r? @kaspth 