### PR TITLE
Add the Anywhere On Earth GMT-12.00 timezone

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -30,6 +30,7 @@ module ActiveSupport
   class TimeZone
     # Keys are Rails TimeZone names, values are TZInfo identifiers.
     MAPPING = {
+      "Anywhere On Earth"            => "Etc/GMT+12",
       "International Date Line West" => "Pacific/Midway",
       "Midway Island"                => "Pacific/Midway",
       "American Samoa"               => "Pacific/Pago_Pago",


### PR DESCRIPTION
Map the TZinfo "Etc/GMT+12" timezone to "[Anywhere On Earth](https://en.wikipedia.org/wiki/Anywhere_on_Earth)" ([GMT-12:00](https://en.wikipedia.org/wiki/UTC%E2%88%9212:00)).

This timezone is needed when you want to allow app users to set an an expiry time via an expiry date that will not prematurely expire no matter what the users' terrestrial locations.

Capital "O" "On"?