### PR TITLE
Fix configuring third-party cache stores such as ActiveSupport::Cache::RedisStore

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -101,7 +101,7 @@ module ActiveSupport
         # Obtains the specified cache store class, given the name of the +store+.
         # Raises an error when the store class cannot be found.
         def retrieve_store_class(store)
-          require_relative "cache/#{store}"
+          require "active_support/cache/#{store}"
         rescue LoadError => e
           raise "Could not find cache store adapter for #{store} (#{e})"
         else


### PR DESCRIPTION
Broken in 8da30ad. Example:

```ruby
# Gemfile
gem 'redis-activesupport'

# config/environments/production.rb
config.cache_store = :redis_store, config_for('redis/cache')
```

```
Could not find cache store adapter for redis_store (cannot load such file -- /usr/local/bundle/bundler/gems/rails-e319b01de8d4/activesupport/lib/active_support/cache/redis_store) (RuntimeError)
```

/cc @amatsuda @fxn 