### PR TITLE
Fix `counter_cache` double increment

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -32,9 +32,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
           foreign_key  = reflection.foreign_key
           cache_column = reflection.counter_cache_column
 
-          if (@_after_create_counter_called ||= false)
-            @_after_create_counter_called = false
-          elsif (@_after_replace_counter_called ||= false)
+          if (@_after_replace_counter_called ||= false)
             @_after_replace_counter_called = false
           elsif saved_change_to_attribute?(foreign_key) && !new_record?
             if reflection.polymorphic?

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -180,7 +180,6 @@ module ActiveRecord
         each_counter_cached_associations do |association|
           if send(association.reflection.name)
             association.increment_counters
-            @_after_create_counter_called = true
           end
         end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1167,6 +1167,17 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     Column.create! record: record
     assert_equal 1, Column.count
   end
+
+  def test_multiple_counter_cache_with_after_create_update
+    post = posts(:welcome)
+    parent = comments(:greetings)
+
+    assert_difference "parent.reload.children_count", +1 do
+      assert_difference "post.reload.comments_count", +1 do
+        comment = CommentWithAfterCreateUpdate.create(body: "foo", post: post, parent: parent)
+      end
+    end
+  end
 end
 
 class BelongsToWithForeignKeyTest < ActiveRecord::TestCase

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -75,3 +75,9 @@ class CommentWithDefaultScopeReferencesAssociation < Comment
   default_scope -> { includes(:developer).order("developers.name").references(:developer) }
   belongs_to :developer
 end
+
+class CommentWithAfterCreateUpdate < Comment
+  after_create do
+    update_attributes(body: "bar")
+  end
+end


### PR DESCRIPTION
Fixes #29762

### Summary
~~When an `after_create` callback did `update_attributes` on a record with multiple `belongs_to` associations with counter caches, when doing `belongs_to_counter_cache_after_update` for the first association, it would set `@_after_create_counter_called` to false to prepare for subsequent operations, but then the following association would get re-incremented.  This splits out `@_after_create_counter_called` as a hash keyed by the foreign key to track each separately.~~

The need for `@_after_create_counter_called` was removed altogether by 020abad, which also makes the test added in this PR pass.

### Other Information
~~A similar fix may be required for `@_after_replace_counter_called`, but I couldn't figure out a failing test case and so didn't want to do it unnecessarily.~~
It may also be safe to remove `@_after_replace_counter_called`.