### PR TITLE
Sort enabled adapter extensions in schema dump

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -85,7 +85,7 @@ HEADER
         extensions = @connection.extensions
         if extensions.any?
           stream.puts "  # These are extensions that must be enabled in order to support this database"
-          extensions.each do |extension|
+          extensions.sort.each do |extension|
             stream.puts "  enable_extension #{extension.inspect}"
           end
           stream.puts

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -301,6 +301,20 @@ class SchemaDumperTest < ActiveRecord::TestCase
         assert_no_match "# These are extensions that must be enabled", output
         assert_no_match %r{enable_extension}, output
       end
+
+      def test_schema_dump_includes_extensions_in_alphabetic_order
+        connection = ActiveRecord::Base.connection
+
+        connection.stubs(:extensions).returns(["hstore", "uuid-ossp", "xml2"])
+        output = perform_schema_dump
+        enabled_extensions = output.scan(%r{enable_extension "(.+)"}).flatten
+        assert_equal ["hstore", "uuid-ossp", "xml2"], enabled_extensions
+
+        connection.stubs(:extensions).returns(["uuid-ossp", "xml2", "hstore"])
+        output = perform_schema_dump
+        enabled_extensions = output.scan(%r{enable_extension "(.+)"}).flatten
+        assert_equal ["hstore", "uuid-ossp", "xml2"], enabled_extensions
+      end
     end
   end
 


### PR DESCRIPTION
## Description

The list of enabled adapter extensions in the schema dump (`db/schema.rb`) isn't sorted by default, so it may happen that the sorting changes over time. If you're using a [VCS](https://en.wikipedia.org/wiki/Version_control) (e.g. Git), a change to the sorting results in a diff without any real change. Sorting the list should solve this problem.

### Problem

```diff
diff --git a/db/schema.rb b/db/schema.rb
index 32aee08..d12e441 100644
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema.define(version: 20170712084827) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "uuid-ossp"
   enable_extension "xml2"
+  enable_extension "uuid-ossp"
```