### PR TITLE
Allow to edit secrets in mutiple apps at the same time

### DIFF
--- a/railties/lib/rails/secrets.rb
+++ b/railties/lib/rails/secrets.rb
@@ -100,7 +100,8 @@ module Rails
         end
 
         def writing(contents)
-          tmp_path = File.join(Dir.tmpdir, File.basename(path))
+          tmp_file = "#{File.basename(path)}.#{Process.pid}"
+          tmp_path = File.join(Dir.tmpdir, tmp_file)
           IO.binwrite(tmp_path, contents)
 
           yield tmp_path


### PR DESCRIPTION
In encrypted secrets, the tmp file is used as a fixed file (`secrets.yml.enc` under the tmp directory).
And that tmp file will be removed after process.

Therefore, if edit secrets at the same time with multiple applications, the tmp file was conflicting.
In order to avoid the above issue, added pid to tmp file.

Context: https://github.com/rails/rails/pull/29761#issuecomment-314756299