### PR TITLE
Check that the candidate is a direct descendant of the constant

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -283,6 +283,11 @@ module ActiveSupport
           constant.const_get(name)
         else
           candidate = constant.const_get(name)
+          # There seems to be a bug with const_get where it can return a constant that is not the direct descendant of
+          # the constant but of one of the parents. Usually it returns nil on the second call. To guard against this, we
+          # check if the candidate is a constant of the current constant and raise NameError if it isn't found
+          Object.const_get(camel_cased_word) unless constant.constants.include?(candidate)
+
           next candidate if constant.const_defined?(name, false)
           next candidate unless Object.const_defined?(name)
 


### PR DESCRIPTION
### Summary

There seems to be a bug with `const_missing` which causes `const_get` to not return the direct descendant. Instead, it will return a constant that contains at least the first namespace (i.e. the parents). See the examples below for more information.

### Example

EDIT: Running this in a console won't produce said output because it relies on Rails monkey patching `const_missing`. I created a repo ([link here](https://github.com/matrinox/ahhh-rails-const-missing-is-broken)) that you can test it with.

```ruby
# a.rb
module A
end

# a/d.rb
module A
  class D
  end
end

# a/b/c.rb
module A
  module B
    class C
    end
  end
end

A.constants # []
"A::B::C::D".safe_constantize # A::D
```

### Problem
The problem is in `const_missing`. This is used to auto load constants in code but there's a bug.
I've traced it to this section of the code in `const_missing` (activesupport/lib/active_support/dependencies.rb):
```ruby
      elsif (parent = from_mod.parent) && parent != from_mod &&
            ! from_mod.parents.any? { |p| p.const_defined?(const_name, false) }
        # If our parents do not have a constant named +const_name+ then we are free
        # to attempt to load upwards. If they do have such a constant, then this
        # const_missing must be due to from_mod::const_name, which should not
        # return constants from from_mod's parents.
```
I think the bug is that it assumes that all of the module's parents have already loaded all of their constants. Either that or some other problem with the recursion.

Once the constant is loaded, `const_missing` will raise an error like it should. In the example above, `A::B::C.const_missing('D')` will initially return `A::D` but on the second call will return raise `NameError`.

In another words, when the constant is not loaded, `safe_constantize`, `constantize`, `const_get` will all return the wrong constant instead of raising an error. Once that wrong constant is loaded, it will raise an error.

### Proposed Solution
Instead of figuring out how to fix `const_missing`, I decided to just fix what I came here to fix: `constantize`. I fear that if I fix `const_missing`, there will be some unintended problems. Perhaps that bug is left there for backwards compatibility.

This solution adds a guard that checks if the candidate is a direct descendant of the current constant in the loop. If not, it raises `NameError` via `Object.const_get(camel_cased_word)`

### Tests
I don't know how to write a test like this. It seems like an integration test. I'm not that familiar with the rails library and the testing structure. If someone can give me directions I can fill it out.