### PR TITLE
Fix the "International Date Line West" timezone

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -30,7 +30,7 @@ module ActiveSupport
   class TimeZone
     # Keys are Rails TimeZone names, values are TZInfo identifiers.
     MAPPING = {
-      "International Date Line West" => "Pacific/Midway",
+      "International Date Line West" => "Etc/GMT+12",
       "Midway Island"                => "Pacific/Midway",
       "American Samoa"               => "Pacific/Pago_Pago",
       "Hawaii"                       => "Pacific/Honolulu",


### PR DESCRIPTION
Change the "International Date Line West" TZInfo timezone from "Pacific/Midway" (-11) to "Etc/GMT+12" ([-12](https://en.wikipedia.org/wiki/UTC%E2%88%9212:00)).

Based on discussion at #29763.