### PR TITLE
Bugfix: unscope(where: [columns]) would not remove the correct binds

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Fix `unscoped(where: [columns])` removing the wrong bind values
+
+    When the `where` is called on a relation after a `or`, unscoping the column of that later `where` removed
+    bind values used by the `or` instead. (possibly other cases too)
+
+    ```
+    Post.where(id: 1).or(Post.where(id: 2)).where(foo: 3).unscope(where: :foo).to_sql
+    # Currently:
+    #     SELECT "posts".* FROM "posts" WHERE ("posts"."id" = 2 OR "posts"."id" = 3)
+    # With fix:
+    #     SELECT "posts".* FROM "posts" WHERE ("posts"."id" = 1 OR "posts"."id" = 2)
+    ```
+
+    *Maxime Handfield Lapointe*
+
 *   Change sqlite3 boolean serialization to use 1 and 0
 
     SQLite natively recognizes 1 and 0 as true and false, but does not natively

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -136,10 +136,11 @@ module ActiveRecord
           binds_index = 0
 
           predicates = self.predicates.reject do |node|
+            binds_contains = node.grep(Arel::Nodes::BindParam).size if node.is_a?(Arel::Nodes::Node)
+
             except = \
               case node
               when Arel::Nodes::Between, Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality, Arel::Nodes::NotEqual, Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual
-                binds_contains = node.grep(Arel::Nodes::BindParam).size
                 subrelation = (node.left.kind_of?(Arel::Attributes::Attribute) ? node.left : node.right)
                 columns.include?(subrelation.name.to_s)
               end


### PR DESCRIPTION
Right now, unscope sometimes doesn't skip a bind as it iterates over the different conditions. For example, when that bind is used as part of an OR clause. As a result, the unscope will remove the wrong bind.

For example:

```
Post.where(id: 1).or(Post.where(id: 2)).where(foo: 3).unscope(where: :foo).to_sql
# Currently:
#     SELECT "posts".* FROM "posts" WHERE ("posts"."id" = 2 OR "posts"."id" = 3)
# With fix:
#     SELECT "posts".* FROM "posts" WHERE ("posts"."id" = 1 OR "posts"."id" = 2)
```

I propose this bugfix gets also backported to Rails 5.1. Rails 5.0 had a different version that was probably more buggy, since a bugfix was applied to this same function as part of 5.1, making it harder to backport to 5.0.