### PR TITLE
Catch postgres connection errors when trying to dealloc

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -184,6 +184,7 @@ module ActiveRecord
 
           def dealloc(key)
             @connection.query "DEALLOCATE #{key}" if connection_active?
+          rescue PG::Error
           end
 
           def connection_active?


### PR DESCRIPTION
### Summary

Catch postgres connection errors when trying to `dealloc` the StatementPool.  Connection errors can be raised when deallocating because `connection_active?` can return true when the connection is actually dead/disconnected (see #3392 for a discussion of why this is).  When this happens, the `DEALLOCATE` query is run on the dead connection which causes a PG connection error to be raised.  This fix catches these errors and ignores them.

Closes #29760

### Other Information

Issue #3392 details this exact same problem in another section of the PostgresAdapter that was fixed a few years ago.