### PR TITLE
Make it clear what `#sending_file=` is

### DIFF
--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -113,7 +113,7 @@ module ActionController #:nodoc:
 
         content_type = options.fetch(:type, DEFAULT_SEND_FILE_TYPE)
         self.content_type = content_type
-        response.sending_file = true
+        response.omit_charset
 
         raise ArgumentError, ":type option required" if content_type.nil?
 

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -247,8 +247,12 @@ module ActionDispatch # :nodoc:
 
     def sending_file=(v)
       if true == v
-        self.charset = false
+        omit_charset
       end
+    end
+
+    def omit_charset # :nodoc:
+      self.charset = false
     end
 
     # Sets the HTTP character set. In case of +nil+ parameter


### PR DESCRIPTION
`#sending_file=` was implemented as `attr_writer`
with `@sending_file` instance variable.
By 1cc315c83c6d823a6041361bf468b82c541d31ee commit,
a method removing charset was name as `#sending_file=`
(maybe) for back compatibility.

This commit introduces `#omit_charset` as a private api method
and move core logic to it, and leaves `#sending_file=`
for back compatibility.