### PR TITLE
Fix typo in ActiveJob testing guide [ci skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1514,7 +1514,7 @@ end
 This test is pretty simple and only asserts that the job get the work done
 as expected.
 
-By default, `ActiveJob::TestCase` will set the queue adapter to `:test` so that
+By default, `ActiveJob::TestCase` will set the queue adapter to `:inline` so that
 your jobs are performed inline. It will also ensure that all previously performed
 and enqueued jobs are cleared before any test run so you can safely assume that
 no jobs have already been executed in the scope of each test.


### PR DESCRIPTION
### Summary

Fixes a typo in ActiveJob testing guide.

### Other Information

The correct option can be found in the `InlineAdapter` [source code](https://github.com/rails/rails/blob/c1f9fa8c69590222fac43d58bf64ef4a1225d7ce/activejob/lib/active_job/queue_adapters/inline_adapter.rb#L12).