### PR TITLE
Do not pass an instance variable to a private method

### DIFF
--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -33,7 +33,7 @@ module ActionView
 
         private
 
-          def value(object)
+          def value
             if @allow_method_names_outside_object
               object.public_send @method_name if object && object.respond_to?(@method_name)
             else
@@ -41,19 +41,19 @@ module ActionView
             end
           end
 
-          def value_before_type_cast(object)
+          def value_before_type_cast
             unless object.nil?
               method_before_type_cast = @method_name + "_before_type_cast"
 
-              if value_came_from_user?(object) && object.respond_to?(method_before_type_cast)
+              if value_came_from_user? && object.respond_to?(method_before_type_cast)
                 object.public_send(method_before_type_cast)
               else
-                value(object)
+                value
               end
             end
           end
 
-          def value_came_from_user?(object)
+          def value_came_from_user?
             method_name = "#{@method_name}_came_from_user?"
             !object.respond_to?(method_name) || object.public_send(method_name)
           end
@@ -148,7 +148,7 @@ module ActionView
               options[:include_blank] ||= true unless options[:prompt]
             end
 
-            value = options.fetch(:selected) { value(object) }
+            value = options.fetch(:selected) { value() }
             select = content_tag("select", add_options(option_tags, options, value), html_options)
 
             if html_options["multiple"] && options.fetch(:include_hidden, true)

--- a/actionview/lib/action_view/helpers/tags/check_box.rb
+++ b/actionview/lib/action_view/helpers/tags/check_box.rb
@@ -16,7 +16,7 @@ module ActionView
           options = @options.stringify_keys
           options["type"]     = "checkbox"
           options["value"]    = @checked_value
-          options["checked"] = "checked" if input_checked?(object, options)
+          options["checked"] = "checked" if input_checked?(options)
 
           if options["multiple"]
             add_default_name_and_id_for_value(@checked_value, options)

--- a/actionview/lib/action_view/helpers/tags/checkable.rb
+++ b/actionview/lib/action_view/helpers/tags/checkable.rb
@@ -2,12 +2,12 @@ module ActionView
   module Helpers
     module Tags # :nodoc:
       module Checkable # :nodoc:
-        def input_checked?(object, options)
+        def input_checked?(options)
           if options.has_key?("checked")
             checked = options.delete "checked"
             checked == true || checked == "checked"
           else
-            checked?(value(object))
+            checked?(value)
           end
         end
       end

--- a/actionview/lib/action_view/helpers/tags/collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_select.rb
@@ -13,7 +13,7 @@ module ActionView
 
         def render
           option_tags_options = {
-            selected: @options.fetch(:selected) { value(@object) },
+            selected: @options.fetch(:selected) { value },
             disabled: @options[:disabled]
           }
 

--- a/actionview/lib/action_view/helpers/tags/color_field.rb
+++ b/actionview/lib/action_view/helpers/tags/color_field.rb
@@ -4,7 +4,7 @@ module ActionView
       class ColorField < TextField # :nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] ||= validate_color_string(value(object))
+          options["value"] ||= validate_color_string(value)
           @options = options
           super
         end

--- a/actionview/lib/action_view/helpers/tags/date_select.rb
+++ b/actionview/lib/action_view/helpers/tags/date_select.rb
@@ -27,7 +27,7 @@ module ActionView
           end
 
           def datetime_selector(options, html_options)
-            datetime = options.fetch(:selected) { value(object) || default_datetime(options) }
+            datetime = options.fetch(:selected) { value || default_datetime(options) }
             @auto_index ||= nil
 
             options = options.dup

--- a/actionview/lib/action_view/helpers/tags/datetime_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_field.rb
@@ -4,7 +4,7 @@ module ActionView
       class DatetimeField < TextField # :nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] ||= format_date(value(object))
+          options["value"] ||= format_date(value)
           options["min"] = format_date(datetime_value(options["min"]))
           options["max"] = format_date(datetime_value(options["max"]))
           @options = options

--- a/actionview/lib/action_view/helpers/tags/grouped_collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/grouped_collection_select.rb
@@ -15,7 +15,7 @@ module ActionView
 
         def render
           option_tags_options = {
-            selected: @options.fetch(:selected) { value(@object) },
+            selected: @options.fetch(:selected) { value },
             disabled: @options[:disabled]
           }
 

--- a/actionview/lib/action_view/helpers/tags/radio_button.rb
+++ b/actionview/lib/action_view/helpers/tags/radio_button.rb
@@ -15,7 +15,7 @@ module ActionView
           options = @options.stringify_keys
           options["type"]     = "radio"
           options["value"]    = @tag_value
-          options["checked"] = "checked" if input_checked?(object, options)
+          options["checked"] = "checked" if input_checked?(options)
           add_default_name_and_id_for_value(@tag_value, options)
           tag("input", options)
         end

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -13,7 +13,7 @@ module ActionView
 
         def render
           option_tags_options = {
-            selected: @options.fetch(:selected) { value(@object) },
+            selected: @options.fetch(:selected) { value },
             disabled: @options[:disabled]
           }
 

--- a/actionview/lib/action_view/helpers/tags/text_area.rb
+++ b/actionview/lib/action_view/helpers/tags/text_area.rb
@@ -14,7 +14,7 @@ module ActionView
             options["cols"], options["rows"] = size.split("x") if size.respond_to?(:split)
           end
 
-          content_tag("textarea", options.delete("value") { value_before_type_cast(object) }, options)
+          content_tag("textarea", options.delete("value") { value_before_type_cast }, options)
         end
       end
     end

--- a/actionview/lib/action_view/helpers/tags/text_field.rb
+++ b/actionview/lib/action_view/helpers/tags/text_field.rb
@@ -10,7 +10,7 @@ module ActionView
           options = @options.stringify_keys
           options["size"] = options["maxlength"] unless options.key?("size")
           options["type"] ||= field_type
-          options["value"] = options.fetch("value") { value_before_type_cast(object) } unless field_type == "file"
+          options["value"] = options.fetch("value") { value_before_type_cast } unless field_type == "file"
           add_default_name_and_id(options)
           tag("input", options)
         end

--- a/actionview/lib/action_view/helpers/tags/time_zone_select.rb
+++ b/actionview/lib/action_view/helpers/tags/time_zone_select.rb
@@ -11,7 +11,7 @@ module ActionView
 
         def render
           select_content_tag(
-            time_zone_options_for_select(value(@object) || @options[:default], @priority_zones, @options[:model] || ActiveSupport::TimeZone), @options, @html_options
+            time_zone_options_for_select(value || @options[:default], @priority_zones, @options[:model] || ActiveSupport::TimeZone), @options, @html_options
           )
         end
       end


### PR DESCRIPTION
`ActionView::Helpers::Tags::Base` has `@object` and
all passed arguments for `#value` are `@object`,
so we do not need to pass arguments in this case.
