### PR TITLE
Delegate respond_to? in ActionView::Helpers::ControllerHelper

### DIFF
--- a/actionview/lib/action_view/helpers/controller_helper.rb
+++ b/actionview/lib/action_view/helpers/controller_helper.rb
@@ -7,8 +7,11 @@ module ActionView
     module ControllerHelper #:nodoc:
       attr_internal :controller, :request
 
-      delegate :request_forgery_protection_token, :params, :session, :cookies, :response, :headers,
-               :flash, :action_name, :controller_name, :controller_path, to: :controller
+      CONTROLLER_DELEGATES = [:request_forgery_protection_token, :params,
+        :session, :cookies, :response, :headers, :flash, :action_name,
+        :controller_name, :controller_path]
+
+      delegate *CONTROLLER_DELEGATES, to: :controller
 
       def assign_controller(controller)
         if @_controller = controller
@@ -20,6 +23,11 @@ module ActionView
 
       def logger
         controller.logger if controller.respond_to?(:logger)
+      end
+
+      def respond_to?(method_name, include_private = false)
+        return controller.respond_to?(method_name) if CONTROLLER_DELEGATES.include?(method_name.to_sym)
+        super
       end
     end
   end

--- a/actionview/test/template/controller_helper_test.rb
+++ b/actionview/test/template/controller_helper_test.rb
@@ -18,4 +18,15 @@ class ControllerHelperTest < ActionView::TestCase
 
     assert_nil default_form_builder
   end
+
+  def test_respond_to
+    @controller = OpenStruct.new
+    assign_controller(@controller)
+    assert_not respond_to?(:params)
+    assert respond_to?(:assign_controller)
+
+    @controller.params = {}
+    assert respond_to?(:params)
+    assert respond_to?(:assign_controller)
+  end
 end


### PR DESCRIPTION
Fixes #15613

### Summary
Since methods defined in the controller helper are mostly delegated to the controller, delegate respond_to? as well, so that for example `respond_to?(:params)` behaves as expected.