### PR TITLE
Scrub the invalid paramter value before using it in the error

### DIFF
--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -32,7 +32,7 @@ module ActionDispatch
           unless params.valid_encoding?
             # Raise Rack::Utils::InvalidParameterError for consistency with Rack.
             # ActionDispatch::Request#GET will re-raise as a BadRequest error.
-            raise Rack::Utils::InvalidParameterError, "Non UTF-8 value: #{params}"
+            raise Rack::Utils::InvalidParameterError, "Invalid encoding for parameter: #{params.scrub}"
           end
         end
       end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1024,7 +1024,8 @@ class RequestParameters < BaseRequestTest
       request.path_parameters = { foo: "\xBE" }
     end
 
-    assert_equal "Invalid path parameters: Non UTF-8 value: \xBE", err.message
+    assert_predicate err.message, :valid_encoding?
+    assert_equal "Invalid path parameters: Invalid encoding for parameter: �", err.message
   end
 
   test "parameters not accessible after rack parse error of invalid UTF8 character" do


### PR DESCRIPTION
You should be able to safely use the String error message. So when
finding the parameter has an invalid encoding we need to remove the
invalid bytes before using it in the error. Otherwise, the caller might
get another Encoding error if they use the message.

I found this issue because due the way we parallelize CI runs, we end-up having to reply some error messages from one process to another, which we end-up having to do some string manipulation with error messages. However, in a broken test that was failing because of this error, we would get another error on top saying the Encoding of the String was invalid.

