### PR TITLE
Make sure that the limits and offsets are ignored when building the j…

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -222,6 +222,7 @@ module ActiveRecord
         if klass.current_scope
           klass.current_scope.clone.tap { |scope|
             scope.joins_values = scope.left_outer_joins_values = [].freeze
+            scope.limit_value = scope.offset_value = nil
           }
         else
           klass.default_scoped(build_scope(table, predicate_builder))

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1550,6 +1550,12 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal "zyke", car2.name
   end
 
+  def test_scoping_limit_with_self_join
+    Comment.where(body: nil).joins(:children).limit(20).offset(0).scoping do
+      Comment.pluck(&:id)
+    end
+  end
+
   def test_unscoped_block_style
     assert_equal "honda", CoolCar.unscoped { CoolCar.order_using_new_style.limit(1).first.name }
     assert_equal "honda", FastCar.unscoped { FastCar.order_using_new_style.limit(1).first.name }


### PR DESCRIPTION
…oin scope.

When there is a self join to a class with limit and offset, with a current_scope setup on that class,
the join_constraints method in ActiveRecord::Associations::JoinDependency::JoinAssociation duplicates the
binds associated with limit and offset which leads to incorrect query being built. See https://github.com/rails/rails/issues/29741

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
