### PR TITLE
Fix `where` with a custom table

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1048,7 +1048,7 @@ module ActiveRecord
         if select_values.any?
           arel.project(*arel_columns(select_values.uniq))
         else
-          arel.project(@klass.arel_table[Arel.star])
+          arel.project(table[Arel.star])
         end
       end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1915,11 +1915,11 @@ class RelationTest < ActiveRecord::TestCase
 
     table_metadata = ActiveRecord::TableMetadata.new(Post, table_alias)
     predicate_builder = ActiveRecord::PredicateBuilder.new(table_metadata)
-    relation = ActiveRecord::Relation.new(Post, table_alias, predicate_builder)
-    relation.where!(foo: "bar")
+    relation = ActiveRecord::Relation.create(Post, table_alias, predicate_builder)
 
-    node = relation.arel.constraints.first.grep(Arel::Attributes::Attribute).first
-    assert_equal table_alias, node.relation
+    post = posts(:welcome)
+
+    assert_equal post, relation.where!(title: post.title).take
   end
 
   test "#load" do


### PR DESCRIPTION
Without this fix, SELECT clause doesn't use a custom table alias name:

```
% ARCONN=sqlite3 be ruby -w -Itest test/cases/relations_test.rb -n test_using_a_custom_table_affects_the_wheres
Using sqlite3
Run options: -n test_using_a_custom_table_affects_the_wheres --seed 31818

E

Error:
RelationTest#test_using_a_custom_table_affects_the_wheres:
ActiveRecord::StatementInvalid: SQLite3::SQLException: no such table: posts: SELECT  "posts".* FROM "posts" "omg_posts" WHERE "omg_posts"."title" = ? LIMIT ?
```