### PR TITLE
Remove useless `aliased_table_name` in `JoinDependency`

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -33,12 +33,8 @@ module ActiveRecord
         end
 
         Table = Struct.new(:node, :columns) do # :nodoc:
-          def table
-            Arel::Nodes::TableAlias.new node.table, node.aliased_table_name
-          end
-
           def column_aliases
-            t = table
+            t = node.table
             columns.map { |column| t[column.name].as Arel.sql column.alias }
           end
         end

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -57,10 +57,6 @@ module ActiveRecord
         def table
           tables.first
         end
-
-        def aliased_table_name
-          table.table_alias || table.name
-        end
       end
     end
   end

--- a/activerecord/lib/active_record/associations/join_dependency/join_base.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_base.rb
@@ -12,10 +12,6 @@ module ActiveRecord
         def table
           base_klass.arel_table
         end
-
-        def aliased_table_name
-          base_klass.table_name
-        end
       end
     end
   end

--- a/activerecord/lib/active_record/associations/join_dependency/join_part.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_part.rb
@@ -36,11 +36,6 @@ module ActiveRecord
           raise NotImplementedError
         end
 
-        # The alias for the active_record's table
-        def aliased_table_name
-          raise NotImplementedError
-        end
-
         def extract_record(row, column_names_with_alias)
           # This code is performance critical as it is called per row.
           # see: https://github.com/rails/rails/pull/12185


### PR DESCRIPTION
If `table.table_alias` is not nil, it is enough to use `table` simply.