### PR TITLE
Remove outdated `test_scoped_responds_to_delegated_methods`

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -586,14 +586,6 @@ class RelationTest < ActiveRecord::TestCase
     assert_nothing_raised { Topic.reorder([]) }
   end
 
-  def test_scoped_responds_to_delegated_methods
-    relation = Topic.all
-
-    ["map", "uniq", "sort", "insert", "delete", "update"].each do |method|
-      assert_respond_to relation, method, "Topic.all should respond to #{method.inspect}"
-    end
-  end
-
   def test_respond_to_delegates_to_arel
     relation = Topic.all
     fake_arel = Struct.new(:responds) {


### PR DESCRIPTION
This test was added at 74ed123 to ensure `respond_to?` delegate methods
to `Array` and `arel_table`. But array method delegation was removed at
9d79334 in favor of including `Enumerable`. And now `Relation` has
`insert`, `update`, and `delete` methods (63480d2, 8d31c9f, d5f9173).
So this delegation test is already outdated.