### PR TITLE
Remove encoding utf-8 magic comment

### DIFF
--- a/activesupport/test/multibyte_grapheme_break_conformance_test.rb
+++ b/activesupport/test/multibyte_grapheme_break_conformance_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require "abstract_unit"

--- a/activesupport/test/multibyte_normalization_conformance_test.rb
+++ b/activesupport/test/multibyte_normalization_conformance_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require "abstract_unit"


### PR DESCRIPTION
### Summary

The default script encoding from Ruby 2.0 is UTF-8.

https://bugs.ruby-lang.org/issues/6679

There are unnecessary `# encoding: utf-8` magic comment for currently maintained Ruby 2.2.2 or higher. This PR removes magic comment.