### PR TITLE
Avoid duplicate conditions when using #or

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   When using #or, extract the common conditions and put them before the OR condition.
+
+    *Maxime Handfield Lapointe*
+
 *   Change sqlite3 boolean serialization to use 1 and 0
 
     SQLite natively recognizes 1 and 0 as true and false, but does not natively


### PR DESCRIPTION
Right now, when using `#or`, nothing is done to try to avoid duplicated conditions. As a result, query length increases at an exponential rate. This makes it really hard to parse for humans, making debugging / understanding the query log really hard.

This PR does basic work to extract the predicates and binds that are common to both associations beings `#or`-ed and put them first, before the `#or`. 

To show the scale of the problem:
```
class Project
    scope :big, -> { where(big1: true).or(where(big2: true)) }
    scope :important, -> { where(important1: true).or(where(important2: true)) }
    scope :ongoing, -> { where(ongoing1: true).or(where(ongoing2: true)) }
end

Project.big # 2 conditions
#=> SELECT...WHERE ("projects"."big1" = ? OR "projects"."big2" = ?) 
Project.big.important # 6 conditions
#=> SELECT...WHERE (("projects"."big1" = ? OR "projects"."big2" = ?) AND "projects"."important1" = ? OR ("projects"."big1" = ? OR "projects"."big2" = ?) AND "projects"."important2" = ?)
Project.big.important.ongoing # 14 conditions
#=> To long to show
# Then 30 conditions
# Then 62
# Then 126 conditions, for using #or 6 times. This should be 12!

# After this fix, it is correctly 2, 4, 6, 8, 10, ... conditions.
```

To make further development in WhereClause easier, the basic behavior of iterating over the predicate and binds has been generalized.

In the current code, there are 2 questions i ask as comments:
* I wonder if `#+` should be changed to do the same behavior as `#|`. The only reason not to, in my mind, is if someone considers this to be a performance issue.
* `#partition_common_left_right` is currently less readable than it could be if i just used the new operators I added to WhereClause. However, those operators might be a little slower since it means more iterations over the lists in the WhereClauses.

Because the the logic for finding the binds that go with a predicate has been extracted and fixed, this also fixes the #29780. However, the test case in #29780 is not included in this PR, and I assume #29780 will be backported, unlike this PR.