### PR TITLE
Remove blank lines in setup

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -15,10 +15,11 @@ chdir APP_ROOT do
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
-<% unless options[:skip_yarn] %>
+<% unless options[:skip_yarn] -%>
+
   # Install JavaScript dependencies if using Yarn
   # system('bin/yarn')
-<% end %>
+<% end -%>
 <% unless options.skip_active_record -%>
 
   # puts "\n== Copying sample files =="


### PR DESCRIPTION
I've make pr again #29795. It seems that includes unintentionally multiple newlines...

## Before

```ruby
  puts '== Installing dependencies =='
  system! 'gem install bundler --conservative'
  system('bundle check') || system!('bundle install')

  # Install JavaScript dependencies if using Yarn
  # system('bin/yarn')


  # puts "\n== Copying sample files =="
  # unless File.exist?('config/database.yml')

  puts "\n== Preparing database =="
  system! 'bin/rails db:setup'
```

## After

```ruby
  puts '== Installing dependencies =='
  system! 'gem install bundler --conservative'
  system('bundle check') || system!('bundle install')

  # Install JavaScript dependencies if using Yarn
  # system('bin/yarn')

  # puts "\n== Copying sample files =="
  # unless File.exist?('config/database.yml')

  puts "\n== Preparing database =="
  system! 'bin/rails db:setup'
```