### PR TITLE
Remove unused `@last`, `@order_clause`, and `@join_dependency`

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -556,8 +556,7 @@ module ActiveRecord
     end
 
     def reset
-      @last = @to_sql = @order_clause = @scope_for_create = @arel = @loaded = nil
-      @should_eager_load = @join_dependency = nil
+      @to_sql = @scope_for_create = @arel = @loaded = @should_eager_load = nil
       @records = [].freeze
       @offsets = {}
       self


### PR DESCRIPTION
Using `@last` and `@order_clause` was removed at 8bb5274 and 90d1524.
`@join_dependency` was added at b959950 but it is unused in the first
place.