### PR TITLE
Add `except` option for ActiveJob::TestHelper methods

### DIFF
--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -12,7 +12,7 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :test
     class TestAdapter
-      attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter)
+      attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter, :reject)
       attr_writer(:enqueued_jobs, :performed_jobs)
 
       # Provides a store of all the enqueued jobs with the TestAdapter so you can check them.
@@ -54,7 +54,13 @@ module ActiveJob
         end
 
         def filtered?(job)
-          filter && !Array(filter).include?(job.class)
+          if filter
+            !Array(filter).include?(job.class)
+          elsif reject
+            Array(reject).include?(job.class)
+          else
+            false
+          end
         end
     end
   end

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -6,6 +6,7 @@ require "active_support/core_ext/hash/keys"
 module ActiveJob
   # Provides helper methods for testing Active Job
   module TestHelper
+    class InvalidOptionsError < StandardError; end
     delegate :enqueued_jobs, :enqueued_jobs=,
       :performed_jobs, :performed_jobs=,
       to: :queue_adapter
@@ -89,10 +90,19 @@ module ActiveJob
     #     end
     #   end
     #
-    # The number of times a specific job is enqueued can be asserted.
+    # The number of times a specific job was enqueued can be asserted.
     #
     #   def test_logging_job
     #     assert_enqueued_jobs 1, only: LoggingJob do
+    #       LoggingJob.perform_later
+    #       HelloJob.perform_later('jeremy')
+    #     end
+    #   end
+    #
+    # The number of times a job except specific class was enqueued can be asserted.
+    #
+    #   def test_logging_job
+    #     assert_enqueued_jobs 1, except: HelloJob do
     #       LoggingJob.perform_later
     #       HelloJob.perform_later('jeremy')
     #     end
@@ -106,14 +116,14 @@ module ActiveJob
     #       HelloJob.perform_later('elfassy')
     #     end
     #   end
-    def assert_enqueued_jobs(number, only: nil, queue: nil)
+    def assert_enqueued_jobs(number, only: nil, except: except, queue: nil)
       if block_given?
-        original_count = enqueued_jobs_size(only: only, queue: queue)
+        original_count = enqueued_jobs_size(only: only, except: except, queue: queue)
         yield
-        new_count = enqueued_jobs_size(only: only, queue: queue)
+        new_count = enqueued_jobs_size(only: only, except: except, queue: queue)
         assert_equal number, new_count - original_count, "#{number} jobs expected, but #{new_count - original_count} were enqueued"
       else
-        actual_count = enqueued_jobs_size(only: only, queue: queue)
+        actual_count = enqueued_jobs_size(only: only, except: except, queue: queue)
         assert_equal number, actual_count, "#{number} jobs expected, but #{actual_count} were enqueued"
       end
     end
@@ -142,11 +152,19 @@ module ActiveJob
     #     end
     #   end
     #
+    # It can be asserted that no jobs except specific class are enqueued:
+    #
+    #   def test_no_logging
+    #     assert_no_enqueued_jobs except: HelloJob do
+    #       HelloJob.perform_later('jeremy')
+    #     end
+    #   end
+    #
     # Note: This assertion is simply a shortcut for:
     #
     #   assert_enqueued_jobs 0, &block
-    def assert_no_enqueued_jobs(only: nil, &block)
-      assert_enqueued_jobs 0, only: only, &block
+    def assert_no_enqueued_jobs(only: nil, except: except, &block)
+      assert_enqueued_jobs 0, only: only, except: except, &block
     end
 
     # Asserts that the number of performed jobs matches the given number.
@@ -191,6 +209,16 @@ module ActiveJob
     #       end
     #     end
     #
+    # Also if the :except option is specified,
+    # then the job(s) except specific class will be performed.
+    #
+    #     def test_hello_job
+    #       assert_performed_jobs 1, except: LoggingJob do
+    #         HelloJob.perform_later('jeremy')
+    #         LoggingJob.perform_later
+    #       end
+    #     end
+    #
     # An array may also be specified, to support testing multiple jobs.
     #
     #     def test_hello_and_logging_jobs
@@ -202,10 +230,10 @@ module ActiveJob
     #         end
     #       end
     #     end
-    def assert_performed_jobs(number, only: nil)
+    def assert_performed_jobs(number, only: nil, except: nil)
       if block_given?
         original_count = performed_jobs.size
-        perform_enqueued_jobs(only: only) { yield }
+        perform_enqueued_jobs(only: only, except: except) { yield }
         new_count = performed_jobs.size
         assert_equal number, new_count - original_count,
           "#{number} jobs expected, but #{new_count - original_count} were performed"
@@ -243,11 +271,20 @@ module ActiveJob
     #     end
     #   end
     #
+    # Also if the :except option is specified,
+    # then the job(s) except specific class will not be performed.
+    #
+    #   def test_no_logging
+    #     assert_no_performed_jobs except: HelloJob do
+    #       HelloJob.perform_later('jeremy')
+    #     end
+    #   end
+    #
     # Note: This assertion is simply a shortcut for:
     #
     #   assert_performed_jobs 0, &block
-    def assert_no_performed_jobs(only: nil, &block)
-      assert_performed_jobs 0, only: only, &block
+    def assert_no_performed_jobs(only: nil, except: nil, &block)
+      assert_performed_jobs 0, only: only, except: except, &block
     end
 
     # Asserts that the job passed in the block has been enqueued with the given arguments.
@@ -317,20 +354,36 @@ module ActiveJob
     #     end
     #     assert_performed_jobs 1
     #   end
-    def perform_enqueued_jobs(only: nil)
+    #
+    # Also if the +:except+ option is specified,
+    # then the job(s) except specific class will be performed.
+    #
+    #   def test_perform_enqueued_jobs_with_except
+    #     perform_enqueued_jobs(except: HelloJob) do
+    #       MyJob.perform_later(1, 2, 3) # will be performed
+    #       HelloJob.perform_later(1, 2, 3) # will not be performed
+    #     end
+    #     assert_performed_jobs 1
+    #   end
+    #
+    def perform_enqueued_jobs(only: nil, except: nil)
+      validate_option(only: only, except: except)
       old_perform_enqueued_jobs = queue_adapter.perform_enqueued_jobs
       old_perform_enqueued_at_jobs = queue_adapter.perform_enqueued_at_jobs
       old_filter = queue_adapter.filter
+      old_reject = queue_adapter.reject
 
       begin
         queue_adapter.perform_enqueued_jobs = true
         queue_adapter.perform_enqueued_at_jobs = true
         queue_adapter.filter = only
+        queue_adapter.reject = except
         yield
       ensure
         queue_adapter.perform_enqueued_jobs = old_perform_enqueued_jobs
         queue_adapter.perform_enqueued_at_jobs = old_perform_enqueued_at_jobs
         queue_adapter.filter = old_filter
+        queue_adapter.reject = old_reject
       end
     end
 
@@ -352,11 +405,14 @@ module ActiveJob
         performed_jobs.clear
       end
 
-      def enqueued_jobs_size(only: nil, queue: nil)
+      def enqueued_jobs_size(only: nil, except: nil, queue: nil)
+        validate_option(only: only, except: except)
         enqueued_jobs.count do |job|
           job_class = job.fetch(:job)
           if only
             next false unless Array(only).include?(job_class)
+          elsif except
+            next false if Array(except).include?(job_class)
           end
           if queue
             next false unless queue.to_s == job.fetch(:queue, job_class.queue_name)
@@ -384,6 +440,10 @@ module ActiveJob
           # only override explicitly set adapters, a quirk of `class_attribute`
           klass.singleton_class.public_instance_methods(false).include?(:_queue_adapter)
         end
+      end
+
+      def validate_option(only: nil, except: nil)
+        raise InvalidOptionsError, "Cannot specify both `:only` and `:except` options." if only && except
       end
   end
 end

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -108,8 +108,31 @@ class EnqueuedJobsTest < ActiveJob::TestCase
       assert_enqueued_jobs 1, only: HelloJob do
         HelloJob.perform_later("jeremy")
         LoggingJob.perform_later
+        LoggingJob.perform_later
       end
     end
+  end
+
+  def test_assert_enqueued_jobs_with_except_option
+    assert_nothing_raised do
+      assert_enqueued_jobs 1, except: LoggingJob do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later
+        LoggingJob.perform_later
+      end
+    end
+  end
+
+  def test_assert_enqueued_jobs_with_only_and_except_option
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_enqueued_jobs 1, only: HelloJob, except: HelloJob do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
   end
 
   def test_assert_enqueued_jobs_with_only_and_queue_option
@@ -120,6 +143,28 @@ class EnqueuedJobsTest < ActiveJob::TestCase
         LoggingJob.perform_later
       end
     end
+  end
+
+  def test_assert_enqueued_jobs_with_except_and_queue_option
+    assert_nothing_raised do
+      assert_enqueued_jobs 1, except: LoggingJob, queue: :some_queue do
+        HelloJob.set(queue: :some_queue).perform_later
+        HelloJob.set(queue: :other_queue).perform_later
+        LoggingJob.perform_later
+      end
+    end
+  end
+
+  def test_assert_enqueued_jobs_with_only_and_except_and_queue_option
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_enqueued_jobs 1, only: HelloJob, except: HelloJob, queue: :some_queue do
+        HelloJob.set(queue: :some_queue).perform_later
+        HelloJob.set(queue: :other_queue).perform_later
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
   end
 
   def test_assert_enqueued_jobs_with_queue_option
@@ -143,6 +188,26 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     assert_match(/1 .* but 0/, error.message)
   end
 
+  def test_assert_enqueued_jobs_with_except_option_and_none_sent
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_enqueued_jobs 1, except: LoggingJob do
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/1 .* but 0/, error.message)
+  end
+
+  def test_assert_enqueued_jobs_with_only_and_except_option_and_none_sent
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_enqueued_jobs 1, only: HelloJob, except: HelloJob do
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
+  end
+
   def test_assert_enqueued_jobs_with_only_option_and_too_few_sent
     error = assert_raise ActiveSupport::TestCase::Assertion do
       assert_enqueued_jobs 5, only: HelloJob do
@@ -152,6 +217,28 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
 
     assert_match(/5 .* but 1/, error.message)
+  end
+
+  def test_assert_enqueued_jobs_with_except_option_and_too_few_sent
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_enqueued_jobs 5, except: LoggingJob do
+        HelloJob.perform_later("jeremy")
+        4.times { LoggingJob.perform_later }
+      end
+    end
+
+    assert_match(/5 .* but 1/, error.message)
+  end
+
+  def test_assert_enqueued_jobs_with_only_and_except_option_and_too_few_sent
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_enqueued_jobs 5, only: HelloJob, except: HelloJob do
+        HelloJob.perform_later("jeremy")
+        4.times { LoggingJob.perform_later }
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
   end
 
   def test_assert_enqueued_jobs_with_only_option_and_too_many_sent
@@ -164,6 +251,26 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     assert_match(/1 .* but 2/, error.message)
   end
 
+  def test_assert_enqueued_jobs_with_except_option_and_too_many_sent
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_enqueued_jobs 1, except: LoggingJob do
+        2.times { HelloJob.perform_later("jeremy") }
+      end
+    end
+
+    assert_match(/1 .* but 2/, error.message)
+  end
+
+  def test_assert_enqueued_jobs_with_only_and_except_option_and_too_many_sent
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_enqueued_jobs 1, only: HelloJob, except: HelloJob do
+        2.times { HelloJob.perform_later("jeremy") }
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
+  end
+
   def test_assert_enqueued_jobs_with_only_option_as_array
     assert_nothing_raised do
       assert_enqueued_jobs 2, only: [HelloJob, LoggingJob] do
@@ -174,12 +281,52 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_enqueued_jobs_with_except_option_as_array
+    assert_nothing_raised do
+      assert_enqueued_jobs 1, except: [HelloJob, LoggingJob] do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later("stewie")
+        RescueJob.perform_later("david")
+      end
+    end
+  end
+
+  def test_assert_enqueued_jobs_with_only_and_except_option_as_array
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_enqueued_jobs 2, only: [HelloJob, LoggingJob], except: [HelloJob, LoggingJob] do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later("stewie")
+        RescueJob.perform_later("david")
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
+  end
+
   def test_assert_no_enqueued_jobs_with_only_option
     assert_nothing_raised do
       assert_no_enqueued_jobs only: HelloJob do
         LoggingJob.perform_later
       end
     end
+  end
+
+  def test_assert_no_enqueued_jobs_with_except_option
+    assert_nothing_raised do
+      assert_no_enqueued_jobs except: LoggingJob do
+        LoggingJob.perform_later
+      end
+    end
+  end
+
+  def test_assert_no_enqueued_jobs_with_only_and_except_option
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_no_enqueued_jobs only: HelloJob, except: HelloJob do
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
   end
 
   def test_assert_no_enqueued_jobs_with_only_option_failure
@@ -193,12 +340,53 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     assert_match(/0 .* but 1/, error.message)
   end
 
+  def test_assert_no_enqueued_jobs_with_except_option_failure
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_no_enqueued_jobs except: LoggingJob do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/0 .* but 1/, error.message)
+  end
+
+  def test_assert_no_enqueued_jobs_with_only_and_except_option_failure
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_no_enqueued_jobs only: HelloJob, except: HelloJob do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
+  end
+
   def test_assert_no_enqueued_jobs_with_only_option_as_array
     assert_nothing_raised do
       assert_no_enqueued_jobs only: [HelloJob, RescueJob] do
         LoggingJob.perform_later
       end
     end
+  end
+
+  def test_assert_no_enqueued_jobs_with_except_option_as_array
+    assert_nothing_raised do
+      assert_no_enqueued_jobs except: [HelloJob, RescueJob] do
+        HelloJob.perform_later
+        RescueJob.perform_later
+      end
+    end
+  end
+
+  def test_assert_no_enqueued_jobs_with_only_and_except_option_as_array
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_no_enqueued_jobs only: [HelloJob, RescueJob], except: [HelloJob, RescueJob] do
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
   end
 
   def test_assert_enqueued_job
@@ -284,6 +472,14 @@ class PerformedJobsTest < ActiveJob::TestCase
       assert_equal HelloJob, queue_adapter.filter
     end
     assert_nil queue_adapter.filter
+  end
+
+  def test_performed_enqueue_jobs_with_except_option_doesnt_leak_outside_the_block
+    assert_nil queue_adapter.reject
+    perform_enqueued_jobs except: HelloJob do
+      assert_equal HelloJob, queue_adapter.reject
+    end
+    assert_nil queue_adapter.reject
   end
 
   def test_assert_performed_jobs
@@ -391,6 +587,26 @@ class PerformedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_performed_jobs_with_except_option
+    assert_nothing_raised do
+      assert_performed_jobs 1, except: LoggingJob do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later
+      end
+    end
+  end
+
+  def test_assert_performed_jobs_with_only_and_except_option
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_performed_jobs 1, only: HelloJob, except: HelloJob do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
+  end
+
   def test_assert_performed_jobs_with_only_option_as_array
     assert_nothing_raised do
       assert_performed_jobs 2, only: [HelloJob, LoggingJob] do
@@ -401,6 +617,28 @@ class PerformedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_performed_jobs_with_except_option_as_array
+    assert_nothing_raised do
+      assert_performed_jobs 1, except: [LoggingJob, RescueJob] do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later("stewie")
+        RescueJob.perform_later("david")
+      end
+    end
+  end
+
+  def test_assert_performed_jobs_with_only_and_except_option_as_array
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_performed_jobs 2, only: [HelloJob, LoggingJob], except: [HelloJob, LoggingJob] do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later("stewie")
+        RescueJob.perform_later("david")
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
+  end
+
   def test_assert_performed_jobs_with_only_option_and_none_sent
     error = assert_raise ActiveSupport::TestCase::Assertion do
       assert_performed_jobs 1, only: HelloJob do
@@ -409,6 +647,26 @@ class PerformedJobsTest < ActiveJob::TestCase
     end
 
     assert_match(/1 .* but 0/, error.message)
+  end
+
+  def test_assert_performed_jobs_with_except_option_and_none_sent
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_performed_jobs 1, except: LoggingJob do
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/1 .* but 0/, error.message)
+  end
+
+  def test_assert_performed_jobs_with_only_and_except_option_and_none_sent
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_performed_jobs 1, only: HelloJob, except: HelloJob do
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
   end
 
   def test_assert_performed_jobs_with_only_option_and_too_few_sent
@@ -422,6 +680,28 @@ class PerformedJobsTest < ActiveJob::TestCase
     assert_match(/5 .* but 1/, error.message)
   end
 
+  def test_assert_performed_jobs_with_except_option_and_too_few_sent
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_performed_jobs 5, except: LoggingJob do
+        HelloJob.perform_later("jeremy")
+        4.times { LoggingJob.perform_later }
+      end
+    end
+
+    assert_match(/5 .* but 1/, error.message)
+  end
+
+  def test_assert_performed_jobs_with_only_and_except_option_and_too_few_sent
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_performed_jobs 5, only: HelloJob, except: HelloJob do
+        HelloJob.perform_later("jeremy")
+        4.times { LoggingJob.perform_later }
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
+  end
+
   def test_assert_performed_jobs_with_only_option_and_too_many_sent
     error = assert_raise ActiveSupport::TestCase::Assertion do
       assert_performed_jobs 1, only: HelloJob do
@@ -432,6 +712,26 @@ class PerformedJobsTest < ActiveJob::TestCase
     assert_match(/1 .* but 2/, error.message)
   end
 
+  def test_assert_performed_jobs_with_except_option_and_too_many_sent
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_performed_jobs 1, except: LoggingJob do
+        2.times { HelloJob.perform_later("jeremy") }
+      end
+    end
+
+    assert_match(/1 .* but 2/, error.message)
+  end
+
+  def test_assert_performed_jobs_with_only_and_except_option_and_too_many_sent
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_performed_jobs 1, only: HelloJob, except: HelloJob do
+        2.times { HelloJob.perform_later("jeremy") }
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
+  end
+
   def test_assert_no_performed_jobs_with_only_option
     assert_nothing_raised do
       assert_no_performed_jobs only: HelloJob do
@@ -440,12 +740,49 @@ class PerformedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_no_performed_jobs_with_except_option
+    assert_nothing_raised do
+      assert_no_performed_jobs except: LoggingJob do
+        LoggingJob.perform_later
+      end
+    end
+  end
+
+  def test_assert_no_performed_jobs_with_only_and_except_option
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_no_performed_jobs only: HelloJob, except: HelloJob do
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
+  end
+
   def test_assert_no_performed_jobs_with_only_option_as_array
     assert_nothing_raised do
       assert_no_performed_jobs only: [HelloJob, RescueJob] do
         LoggingJob.perform_later
       end
     end
+  end
+
+  def test_assert_no_performed_jobs_with_except_option_as_array
+    assert_nothing_raised do
+      assert_no_performed_jobs except: [HelloJob, RescueJob] do
+        HelloJob.perform_later
+        RescueJob.perform_later
+      end
+    end
+  end
+
+  def test_assert_no_performed_jobs_with_only_and_except_option_as_array
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_no_performed_jobs only: [HelloJob, RescueJob], except: [HelloJob, RescueJob] do
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
   end
 
   def test_assert_no_performed_jobs_with_only_option_failure
@@ -457,6 +794,28 @@ class PerformedJobsTest < ActiveJob::TestCase
     end
 
     assert_match(/0 .* but 1/, error.message)
+  end
+
+  def test_assert_no_performed_jobs_with_except_option_failure
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_no_performed_jobs except: LoggingJob do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/0 .* but 1/, error.message)
+  end
+
+  def test_assert_no_performed_jobs_with_only_and_except_option_failure
+    error = assert_raise ActiveJob::TestHelper::InvalidOptionsError do
+      assert_no_performed_jobs only: HelloJob, except: HelloJob do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later
+      end
+    end
+
+    assert_match(/`:only` and `:except`/, error.message)
   end
 
   def test_assert_performed_job


### PR DESCRIPTION
### Summary

I added `:except` keyword argument option for `ActiveJob::TestHelper` methods.
I think this option is useful in following situations:

#### case 1 
###### Many jobs perform successfully.But some jobs go wrong.
```ruby
def many_jobs
  Good1Job.perform_later
  Good2Job.perform_later
  Good3Job.perform_later
  …
  Good9Job.perform_later
  Bad1Job.perform_later # goes wrong.
end

perform_euqueued_jobs(except: Bad1Job) do
  many_jobs
end
```
#### case 2 
###### The job repeats cycles.
```ruby
def loop_cycle
  Cycle1Job.perform_later
  Cycle2Job.perform_later
  Cycle3Job.perform_later
  LoopJob.perform_later # repeats loop_cycle.
end

class LoopJob < ActiveJob::Base
  def perform
    loop_cycle
  end
end

perform_euqueued_jobs(except: LoopJob) do
  loop_cycle  
end
```
