### PR TITLE
Replace Erubis with Erubi in a part of guide [ci skip]

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -109,7 +109,7 @@ A standard Rails application depends on several gems, specifically:
 * arel
 * builder
 * bundler
-* erubis
+* erubi
 * i18n
 * mail
 * mime-types


### PR DESCRIPTION
### Summary

This PR is a small documentation change.

Since Rails 5.1, Erubis ERB handler has been deprecated and recommended for Erubi.

https://github.com/rails/rails/blob/v5.1.2/guides/source/5_1_release_notes.md#deprecations-1

This PR replaces Erubis with Erubi in a part of guide. Since [Erubis will be removed in Rails 5.2](https://github.com/rails/rails/blob/v5.1.2/actionview/lib/action_view/template/handlers/erb/deprecated_erubis.rb#L1), I decided to replace rather than adding Erubi to the list.
