### PR TITLE
Fix minitest plugin leaking into rails/rails tests

### DIFF
--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -10,6 +10,8 @@ module Minitest
   end
 
   def self.plugin_rails_options(opts, options)
+    return unless rails_app?
+
     opts.on("-b", "--backtrace", "Show the complete backtrace") do
       options[:full_backtrace] = true
     end
@@ -33,6 +35,8 @@ module Minitest
   # Owes great inspiration to test runner trailblazers like RSpec,
   # minitest-reporters, maxitest and others.
   def self.plugin_rails_init(options)
+    return unless rails_app?
+
     unless options[:full_backtrace] || ENV["BACKTRACE"]
       # Plugin can run without Rails loaded, check before filtering.
       Minitest.backtrace_filter = ::Rails.backtrace_cleaner if ::Rails.respond_to?(:backtrace_cleaner)
@@ -42,6 +46,10 @@ module Minitest
     reporter.reporters.delete_if { |reporter| reporter.kind_of?(SummaryReporter) || reporter.kind_of?(ProgressReporter) }
     reporter << SuppressedSummaryReporter.new(options[:io], options)
     reporter << ::Rails::TestUnitReporter.new(options[:io], options)
+  end
+
+  def self.rails_app?
+    Rails.respond_to?(:application)
   end
 
   # Backwardscompatibility with Rails 5.0 generated plugin test scripts


### PR DESCRIPTION
## Bug

After https://github.com/rails/rails/pull/29572 has been merged, any failing test in ActiveRecord/ActiveJob/ActiveSupport suite would fail in Minitest reporter.

## Reproduction steps

1. Add a failing test

```ruby
diff --git a/activerecord/test/cases/enum_test.rb b/activerecord/test/cases/enum_test.rb
index 4ef9a12..a353503 100644
--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -9,6 +9,10 @@ class EnumTest < ActiveRecord::TestCase
     @book = books(:awdr)
   end

+  test "omg im failing!" do
+    assert false
+  end
+
```

2. Run the test suite

```
$ bundle exec ruby -Itest test/cases/enum_test.rb
Using sqlite3
Run options: --seed 49833

# Running:

..........................F

Failure:
EnumTest#test_omg [test/cases/enum_test.rb:13]:
Failed assertion, no message given.


/Users/kir/Projects/opensource/rails/railties/lib/rails/test_unit/reporter.rb:74:in `app_root': undefined method `root' for Rails:Module (NoMethodError)
        from /Users/kir/Projects/opensource/rails/railties/lib/rails/test_unit/reporter.rb:52:in `relative_path_for'
        from /Users/kir/Projects/opensource/rails/railties/lib/rails/test_unit/reporter.rb:70:in `format_rerun_snippet'
        from /Users/kir/Projects/opensource/rails/railties/lib/rails/test_unit/reporter.rb:22:in `record'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:613:in `block in record'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:612:in `each'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:612:in `record'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:293:in `run_one_method'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:287:in `block (2 levels) in run'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:286:in `each'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:286:in `block in run'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:317:in `on_signal'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:306:in `with_info_handler'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:285:in `run'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:149:in `block in __run'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:149:in `map'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:149:in `__run'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:126:in `run'
        from /Users/kir/Projects/opensource/rails/vendor/bundle/gems/minitest-5.3.3/lib/minitest.rb:55:in `block in autorun'
```

## Fix

With https://github.com/rails/rails/pull/29572 Minitest always loads [loads](https://github.com/seattlerb/minitest/blob/master/lib/minitest.rb#L92) the plugins, including Rails test reporter plugin. This works fine if you're running a Rails application test suite, but when you're running rails/rails test suite you don't want to load custom test reporter.

In ActiveRecord tests, there's no `Rails.application` or `Rails.root` available, which makes the custom test reporter 💥 

The solution is to disable custom reporter when it's not running in the context of Rails app.