### PR TITLE
Use frozen string literal in actioncable/

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,6 +89,7 @@ Style/FrozenStringLiteralComment:
   Include:
     - 'activesupport/**/*'
     - 'activemodel/**/*'
+    - 'actioncable/**/*'
     - 'activejob/**/*'
     - 'activerecord/**/*'
     - 'actionmailer/**/*'

--- a/actioncable/Rakefile
+++ b/actioncable/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rake/testtask"
 require "pathname"
 require "open3"

--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|

--- a/actioncable/bin/test
+++ b/actioncable/bin/test
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"

--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #--
 # Copyright (c) 2015-2017 Basecamp, LLC
 #

--- a/actioncable/lib/action_cable/channel.rb
+++ b/actioncable/lib/action_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Channel
     extend ActiveSupport::Autoload

--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -270,7 +270,7 @@ module ActionCable
         end
 
         def action_signature(action, data)
-          "#{self.class.name}##{action}".tap do |signature|
+          "#{self.class.name}##{action}".dup.tap do |signature|
             if (arguments = data.except("action")).any?
               signature << "(#{arguments.inspect})"
             end

--- a/actioncable/lib/action_cable/channel/broadcasting.rb
+++ b/actioncable/lib/action_cable/channel/broadcasting.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/object/to_param"
 
 module ActionCable

--- a/actioncable/lib/action_cable/channel/callbacks.rb
+++ b/actioncable/lib/action_cable/channel/callbacks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/callbacks"
 
 module ActionCable

--- a/actioncable/lib/action_cable/channel/naming.rb
+++ b/actioncable/lib/action_cable/channel/naming.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Channel
     module Naming

--- a/actioncable/lib/action_cable/channel/periodic_timers.rb
+++ b/actioncable/lib/action_cable/channel/periodic_timers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Channel
     module PeriodicTimers

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Channel
     # Streams allow channels to route broadcastings to the subscriber. A broadcasting is, as discussed elsewhere, a pubsub queue where any data

--- a/actioncable/lib/action_cable/connection.rb
+++ b/actioncable/lib/action_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Connection
     extend ActiveSupport::Autoload

--- a/actioncable/lib/action_cable/connection/authorization.rb
+++ b/actioncable/lib/action_cable/connection/authorization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Connection
     module Authorization

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "action_dispatch"
 
 module ActionCable

--- a/actioncable/lib/action_cable/connection/client_socket.rb
+++ b/actioncable/lib/action_cable/connection/client_socket.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "websocket/driver"
 
 module ActionCable

--- a/actioncable/lib/action_cable/connection/identification.rb
+++ b/actioncable/lib/action_cable/connection/identification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "set"
 
 module ActionCable

--- a/actioncable/lib/action_cable/connection/internal_channel.rb
+++ b/actioncable/lib/action_cable/connection/internal_channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Connection
     # Makes it possible for the RemoteConnection to disconnect a specific connection.

--- a/actioncable/lib/action_cable/connection/message_buffer.rb
+++ b/actioncable/lib/action_cable/connection/message_buffer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Connection
     # Allows us to buffer messages received from the WebSocket before the Connection has been fully initialized, and is ready to receive them.

--- a/actioncable/lib/action_cable/connection/stream.rb
+++ b/actioncable/lib/action_cable/connection/stream.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thread"
 
 module ActionCable

--- a/actioncable/lib/action_cable/connection/stream_event_loop.rb
+++ b/actioncable/lib/action_cable/connection/stream_event_loop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "nio"
 require "thread"
 

--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/hash/indifferent_access"
 
 module ActionCable

--- a/actioncable/lib/action_cable/connection/tagged_logger_proxy.rb
+++ b/actioncable/lib/action_cable/connection/tagged_logger_proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Connection
     # Allows the use of per-connection tags against the server logger. This wouldn't work using the traditional

--- a/actioncable/lib/action_cable/connection/web_socket.rb
+++ b/actioncable/lib/action_cable/connection/web_socket.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "websocket/driver"
 
 module ActionCable

--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails"
 require "action_cable"
 require_relative "helpers/action_cable_helper"

--- a/actioncable/lib/action_cable/gem_version.rb
+++ b/actioncable/lib/action_cable/gem_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   # Returns the version of the currently loaded Action Cable as a <tt>Gem::Version</tt>.
   def self.gem_version

--- a/actioncable/lib/action_cable/helpers/action_cable_helper.rb
+++ b/actioncable/lib/action_cable/helpers/action_cable_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Helpers
     module ActionCableHelper

--- a/actioncable/lib/action_cable/remote_connections.rb
+++ b/actioncable/lib/action_cable/remote_connections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   # If you need to disconnect a given connection, you can go through the
   # RemoteConnections. You can find the connections you're looking for by

--- a/actioncable/lib/action_cable/server.rb
+++ b/actioncable/lib/action_cable/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Server
     extend ActiveSupport::Autoload

--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "monitor"
 
 module ActionCable

--- a/actioncable/lib/action_cable/server/broadcasting.rb
+++ b/actioncable/lib/action_cable/server/broadcasting.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Server
     # Broadcasting is how other parts of your application can send messages to a channel's subscribers. As explained in Channel, most of the time, these

--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Server
     # An instance of this configuration object is available via ActionCable.server.config, which allows you to tweak Action Cable configuration

--- a/actioncable/lib/action_cable/server/connections.rb
+++ b/actioncable/lib/action_cable/server/connections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Server
     # Collection class for all the connections that have been established on this specific server. Remember, usually you'll run many Action Cable servers, so

--- a/actioncable/lib/action_cable/server/worker.rb
+++ b/actioncable/lib/action_cable/server/worker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/callbacks"
 require "active_support/core_ext/module/attribute_accessors_per_thread"
 require "concurrent"

--- a/actioncable/lib/action_cable/server/worker/active_record_connection_management.rb
+++ b/actioncable/lib/action_cable/server/worker/active_record_connection_management.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module Server
     class Worker

--- a/actioncable/lib/action_cable/subscription_adapter.rb
+++ b/actioncable/lib/action_cable/subscription_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module SubscriptionAdapter
     extend ActiveSupport::Autoload

--- a/actioncable/lib/action_cable/subscription_adapter/async.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/async.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "inline"
 
 module ActionCable

--- a/actioncable/lib/action_cable/subscription_adapter/base.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module SubscriptionAdapter
     class Base

--- a/actioncable/lib/action_cable/subscription_adapter/channel_prefix.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/channel_prefix.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module SubscriptionAdapter
     module ChannelPrefix # :nodoc:

--- a/actioncable/lib/action_cable/subscription_adapter/evented_redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/evented_redis.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thread"
 
 gem "em-hiredis", "~> 0.3.0"

--- a/actioncable/lib/action_cable/subscription_adapter/inline.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/inline.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module SubscriptionAdapter
     class Inline < Base # :nodoc:

--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 gem "pg", "~> 0.18"
 require "pg"
 require "thread"

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thread"
 
 gem "redis", "~> 3.0"

--- a/actioncable/lib/action_cable/subscription_adapter/subscriber_map.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/subscriber_map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionCable
   module SubscriptionAdapter
     class SubscriberMap

--- a/actioncable/lib/action_cable/version.rb
+++ b/actioncable/lib/action_cable/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "gem_version"
 
 module ActionCable

--- a/actioncable/lib/rails/generators/channel/channel_generator.rb
+++ b/actioncable/lib/rails/generators/channel/channel_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     class ChannelGenerator < NamedBase

--- a/actioncable/test/channel/base_test.rb
+++ b/actioncable/test/channel/base_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_connection"
 require "stubs/room"

--- a/actioncable/test/channel/broadcasting_test.rb
+++ b/actioncable/test/channel/broadcasting_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_connection"
 require "stubs/room"

--- a/actioncable/test/channel/naming_test.rb
+++ b/actioncable/test/channel/naming_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ActionCable::Channel::NamingTest < ActiveSupport::TestCase

--- a/actioncable/test/channel/periodic_timers_test.rb
+++ b/actioncable/test/channel/periodic_timers_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_connection"
 require "stubs/room"

--- a/actioncable/test/channel/rejection_test.rb
+++ b/actioncable/test/channel/rejection_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_connection"
 require "stubs/room"

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_connection"
 require "stubs/room"

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "concurrent"
 

--- a/actioncable/test/connection/authorization_test.rb
+++ b/actioncable/test/connection/authorization_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_server"
 

--- a/actioncable/test/connection/base_test.rb
+++ b/actioncable/test/connection/base_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_server"
 require "active_support/core_ext/object/json"

--- a/actioncable/test/connection/client_socket_test.rb
+++ b/actioncable/test/connection/client_socket_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_server"
 

--- a/actioncable/test/connection/cross_site_forgery_test.rb
+++ b/actioncable/test/connection/cross_site_forgery_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_server"
 

--- a/actioncable/test/connection/identifier_test.rb
+++ b/actioncable/test/connection/identifier_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_server"
 require "stubs/user"

--- a/actioncable/test/connection/multiple_identifiers_test.rb
+++ b/actioncable/test/connection/multiple_identifiers_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_server"
 require "stubs/user"

--- a/actioncable/test/connection/stream_test.rb
+++ b/actioncable/test/connection/stream_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_server"
 

--- a/actioncable/test/connection/string_identifier_test.rb
+++ b/actioncable/test/connection/string_identifier_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_server"
 

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_server"
 require "active_support/core_ext/hash/indifferent_access"

--- a/actioncable/test/server/broadcasting_test.rb
+++ b/actioncable/test/server/broadcasting_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_server"
 

--- a/actioncable/test/stubs/global_id.rb
+++ b/actioncable/test/stubs/global_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class GlobalID
   attr_reader :uri
   delegate :to_param, :to_s, to: :uri

--- a/actioncable/test/stubs/room.rb
+++ b/actioncable/test/stubs/room.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Room
   attr_reader :id, :name
 

--- a/actioncable/test/stubs/test_adapter.rb
+++ b/actioncable/test/stubs/test_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SuccessAdapter < ActionCable::SubscriptionAdapter::Base
   def broadcast(channel, payload)
   end

--- a/actioncable/test/stubs/test_connection.rb
+++ b/actioncable/test/stubs/test_connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "stubs/user"
 
 class TestConnection

--- a/actioncable/test/stubs/test_server.rb
+++ b/actioncable/test/stubs/test_server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "ostruct"
 
 class TestServer

--- a/actioncable/test/stubs/user.rb
+++ b/actioncable/test/stubs/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User
   attr_reader :name
 

--- a/actioncable/test/subscription_adapter/async_test.rb
+++ b/actioncable/test/subscription_adapter/async_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative "common"
 

--- a/actioncable/test/subscription_adapter/base_test.rb
+++ b/actioncable/test/subscription_adapter/base_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stubs/test_server"
 

--- a/actioncable/test/subscription_adapter/channel_prefix.rb
+++ b/actioncable/test/subscription_adapter/channel_prefix.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ActionCable::Server::WithIndependentConfig < ActionCable::Server::Base

--- a/actioncable/test/subscription_adapter/common.rb
+++ b/actioncable/test/subscription_adapter/common.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "concurrent"
 

--- a/actioncable/test/subscription_adapter/evented_redis_test.rb
+++ b/actioncable/test/subscription_adapter/evented_redis_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative "common"
 require_relative "channel_prefix"

--- a/actioncable/test/subscription_adapter/inline_test.rb
+++ b/actioncable/test/subscription_adapter/inline_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative "common"
 

--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative "common"
 

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require_relative "common"
 require_relative "channel_prefix"

--- a/actioncable/test/subscription_adapter/subscriber_map_test.rb
+++ b/actioncable/test/subscription_adapter/subscriber_map_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SubscriberMapTest < ActionCable::TestCase

--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "action_cable"
 require "active_support/testing/autorun"
 

--- a/actioncable/test/worker_test.rb
+++ b/actioncable/test/worker_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class WorkerTest < ActiveSupport::TestCase


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/29655

Extends `Style/FrozenStringLiteralComment` Rubocop rule to `actioncable/`.

The commit is just `rubocop -a` after changing the Rubocop rule.

ref https://github.com/rails/rails/pull/29728

