### PR TITLE
Set `RAILS_ENV` before load application file

### DIFF
--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -11,7 +11,7 @@ module Rails
     end
 
     def start
-      ENV["RAILS_ENV"] = @options[:environment] || environment
+      ENV["RAILS_ENV"] ||= @options[:environment] || environment
 
       case config["adapter"]
       when /^(jdbc)?mysql/
@@ -156,6 +156,9 @@ module Rails
 
       def perform
         extract_environment_option_from_argument
+
+        # RAILS_ENV needs to be set before config/application is required.
+        ENV["RAILS_ENV"] = options[:environment]
 
         require_application_and_environment!
         Rails::DBConsole.start(options)


### PR DESCRIPTION
Since #29725, load application file when `dbconsole` command is executed.
However, if do not set `RAILS_ENV` before reading the application file, can not connect to the env specified in option, so added the setting of `RAILS_ENV`.
Sorry, this is my bad.