### PR TITLE
Move `reset_pk_sequence!` test to `AdapterTestWithoutTransaction`

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -156,26 +156,6 @@ module ActiveRecord
       end
     end
 
-    # test resetting sequences in odd tables in PostgreSQL
-    if ActiveRecord::Base.connection.respond_to?(:reset_pk_sequence!)
-      require "models/movie"
-      require "models/subscriber"
-
-      def test_reset_empty_table_with_custom_pk
-        Movie.delete_all
-        Movie.connection.reset_pk_sequence! "movies"
-        assert_equal 1, Movie.create(name: "fight club").id
-      end
-
-      def test_reset_table_with_non_integer_pk
-        Subscriber.delete_all
-        Subscriber.connection.reset_pk_sequence! "subscribers"
-        sub = Subscriber.new(name: "robert drake")
-        sub.id = "bob drake"
-        assert_nothing_raised { sub.save! }
-      end
-    end
-
     def test_uniqueness_violations_are_translated_to_specific_exception
       @connection.execute "INSERT INTO subscribers(nick) VALUES('me')"
       error = assert_raises(ActiveRecord::RecordNotUnique) do
@@ -366,6 +346,26 @@ module ActiveRecord
         assert @connection.transaction_open?
         @connection.disconnect!
         assert !@connection.transaction_open?
+      end
+    end
+
+    # test resetting sequences in odd tables in PostgreSQL
+    if ActiveRecord::Base.connection.respond_to?(:reset_pk_sequence!)
+      require "models/movie"
+      require "models/subscriber"
+
+      def test_reset_empty_table_with_custom_pk
+        Movie.delete_all
+        Movie.connection.reset_pk_sequence! "movies"
+        assert_equal 1, Movie.create(name: "fight club").id
+      end
+
+      def test_reset_table_with_non_integer_pk
+        Subscriber.delete_all
+        Subscriber.connection.reset_pk_sequence! "subscribers"
+        sub = Subscriber.new(name: "robert drake")
+        sub.id = "bob drake"
+        assert_nothing_raised { sub.save! }
       end
     end
   end


### PR DESCRIPTION
If execute PostgreSQL test with specifying 53853 for seed, the following error will occur.

```
  1) Error:
TransactionTest#test_restore_custom_primary_key_after_rollback:
ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "movies_pkey"
DETAIL:  Key (movieid)=(2) already exists.
: INSERT INTO "movies" ("name") VALUES ($1) RETURNING "movieid"
```

travis is here https://travis-ci.org/rails/rails/jobs/254095918

As with #29287, it seems like a problem that the value of primary key obtained from connection gets different.
Therefore, fixed to execute that test within transaction.

