### PR TITLE
Fix select_all "given 4, expected 4" error

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -5,9 +5,9 @@ module ActiveRecord
         # Returns an ActiveRecord::Result instance.
         def select_all(arel, name = nil, binds = [], preparable: nil) # :nodoc:
           result = if ExplainRegistry.collect? && prepared_statements
-            unprepared_statement { super }
+            unprepared_statement { super(arel, name, binds, preparable: preparable) }
           else
-            super
+            super(arel, name, binds, preparable: preparable)
           end
           @connection.next_result while @connection.more_results?
           result


### PR DESCRIPTION
cc @zdennis

This error occurs when using https://github.com/zdennis/activerecord-import/ v0.18.3 on fairly large datasets (millions of rows).

I've not been able to reproduce it reliably, so I don't know how to make a test case. I only use MySQL, so can't speak to whether this is present in other DB adapters.

I debugged it manually, and isolated it to `ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements`. After testing several potential patch points, I found that this patch *does* work.

I don't understand *why* it works — if anyone has an idea, please LMK — but on the other hand, I also can't think of any possible negative side effect of explicitly declaring the parameters for `super`.

`ActiveRecord::ConnectionAdapters::QueryCache` has similar implicit parameters for `super`, but in my testing, patching it to be explicit did not affect the bug.

Here's a typical error:

```
ArgumentError: method 'select_all': given 4, expected 4
/Users/saizai/.rvm/gems/rbx-3.75@[redacted]/gems/activerecord-5.1.0/lib/active_record/relation/calculations.rb:169:in `pluck'
/Users/saizai/.rvm/gems/rbx-3.75@[redacted]/gems/activerecord-5.1.0/lib/active_record/schema_migration.rb:46:in `all_versions'
/Users/saizai/.rvm/gems/rbx-3.75@[redacted]/gems/activerecord-5.1.0/lib/active_record/migration.rb:1032:in `get_all_versions'
/Users/saizai/.rvm/gems/rbx-3.75@[redacted]/gems/activerecord-5.1.0/lib/active_record/migration.rb:1039:in `current_version'
/Users/saizai/.rvm/gems/rbx-3.75@[redacted]/gems/activerecord-5.1.0/lib/active_record/migration.rb:986:in `migrate'
/Users/saizai/.rvm/gems/rbx-3.75@[redacted]/gems/activerecord-5.1.0/lib/active_record/tasks/database_tasks.rb:171:in `migrate'
/Users/saizai/.rvm/gems/rbx-3.75@[redacted]/gems/activerecord-5.1.0/lib/active_record/railties/databases.rake:58:in `__script__'
core/proc.rb:20:in `call'
core/array.rb:72:in `each'
/Users/saizai/.rvm/rubies/rbx-3.75/gems/gems/rubysl-monitor-2.0.0/lib/rubysl/monitor/monitor.rb:211:in `synchronize (mon_synchronize)'
core/array.rb:72:in `each'
core/kernel.rb:572:in `load'
core/block_environment.rb:147:in `call_on_instance'
core/kernel.rb:1130:in `eval'
/Users/saizai/.rvm/gems/rbx-3.75@[redacted]/bin/ruby_executable_hooks:15:in `__script__'
core/code_loader.rb:505:in `load_script'
core/code_loader.rb:590:in `load_script'
core/loader.rb:679:in `script'
core/loader.rb:861:in `main'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```