### PR TITLE
Remove useless `arel_engine`

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -263,16 +263,6 @@ module ActiveRecord
         @arel_table ||= Arel::Table.new(table_name, type_caster: type_caster)
       end
 
-      # Returns the Arel engine.
-      def arel_engine # :nodoc:
-        @arel_engine ||=
-          if Base == self || connection_handler.retrieve_connection_pool(connection_specification_name)
-            self
-          else
-            superclass.arel_engine
-          end
-      end
-
       def arel_attribute(name, table = arel_table) # :nodoc:
         name = attribute_alias(name) if attribute_alias?(name)
         table[name]

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -467,7 +467,6 @@ module ActiveRecord
         end
 
         def reload_schema_from_cache
-          @arel_engine = nil
           @arel_table = nil
           @column_names = nil
           @attribute_types = nil

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -329,7 +329,7 @@ module ActiveRecord
     # the expected number of results should be provided in the +expected_size+
     # argument.
     def raise_record_not_found_exception!(ids = nil, result_size = nil, expected_size = nil, key = primary_key) # :nodoc:
-      conditions = arel.where_sql(@klass.arel_engine)
+      conditions = arel.where_sql(@klass)
       conditions = " [#{conditions}]" if conditions
       name = @klass.name
 

--- a/activerecord/test/cases/multiple_db_test.rb
+++ b/activerecord/test/cases/multiple_db_test.rb
@@ -90,14 +90,9 @@ class MultipleDbTest < ActiveRecord::TestCase
     assert_equal "Ruby Developer", Entrant.find(1).name
   end
 
-  def test_arel_table_engines
-    assert_not_equal Entrant.arel_engine, Bird.arel_engine
-    assert_not_equal Entrant.arel_engine, Course.arel_engine
-  end
-
   def test_connection
-    assert_equal Entrant.arel_engine.connection.object_id, Bird.arel_engine.connection.object_id
-    assert_not_equal Entrant.arel_engine.connection.object_id, Course.arel_engine.connection.object_id
+    assert_same Entrant.connection, Bird.connection
+    assert_not_same Entrant.connection, Course.connection
   end
 
   unless in_memory_db?


### PR DESCRIPTION
`arel_engine` is only used in `raise_record_not_found_exception!` to use
`engine.connection` (and `connection.visitor`) in `arel.where_sql`.

https://github.com/rails/arel/blob/v8.0.0/lib/arel/select_manager.rb#L183

But `klass.connection` will work as expected even if not using
`arel_engine` (described by `test_connection`). So `arel_engine` is no
longer needed.