### PR TITLE
Raise ArgumentError on Parameter.new

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,7 +1,8 @@
-*   Raise ArgumentError on Parameter.new
+*  Raise `ArgumentError` when passing anything that doesn't respond to `with_indifferent_access` to
+   `ActionController::Parameter.new`
 
     When we pass a non-hash argument to `ActionController::Parameters.new`
-    it now raises an `ArgumentError`
+    it now raises an `ArgumentError`.
 
     *Philibert Dugas*
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Raise ArgumentError on Parameter.new
+
+    When we pass a non-hash argument to `ActionController::Parameters.new`
+    it now raises an `ArgumentError`
+
+    *Philibert Dugas*
+
 *   Protect from forgery by default
 
     Rather than protecting from forgery in the generated `ApplicationController`,

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -231,10 +231,11 @@ module ActionController
     #   params.permitted?  # => true
     #   Person.new(params) # => #<Person id: nil, name: "Francesco">
     def initialize(parameters = {})
-      unless parameters.respond_to?(:with_indifferent_access)
+      begin
+        @parameters = parameters.with_indifferent_access
+      rescue NoMethodError
         raise ArgumentError, "invalid parameters given, the parameters should be a hash"
       end
-      @parameters = parameters.with_indifferent_access
       @permitted = self.class.permit_all_parameters
     end
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -231,6 +231,7 @@ module ActionController
     #   params.permitted?  # => true
     #   Person.new(params) # => #<Person id: nil, name: "Francesco">
     def initialize(parameters = {})
+      raise ArgumentError, "invalid parameters given, the parameters should be a hash" unless parameters.is_a?(Hash)
       @parameters = parameters.with_indifferent_access
       @permitted = self.class.permit_all_parameters
     end

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -231,7 +231,9 @@ module ActionController
     #   params.permitted?  # => true
     #   Person.new(params) # => #<Person id: nil, name: "Francesco">
     def initialize(parameters = {})
-      raise ArgumentError, "invalid parameters given, the parameters should be a hash" unless parameters.is_a?(Hash)
+      unless parameters.respond_to?(:with_indifferent_access)
+        raise ArgumentError, "invalid parameters given, the parameters should be a hash"
+      end
       @parameters = parameters.with_indifferent_access
       @permitted = self.class.permit_all_parameters
     end

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -255,6 +255,12 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_match(/permitted: true/, @params.inspect)
   end
 
+  test "new fails when the parameter is not a hash" do
+    assert_raises ArgumentError, "invalid parameters given, the parameters should be a hash" do
+      ActionController::Parameters.new("Weee")
+    end
+  end
+
   if Hash.method_defined?(:dig)
     test "#dig delegates the dig method to its values" do
       assert_equal "David", @params.dig(:person, :name, :first)


### PR DESCRIPTION
### Summary

When we pass a non-hash argument to `ActionController::Parameters.new` the error message is kinda cryptic:

```sh
[1] pry(main)> ActionController::Parameters.new("test")
NoMethodError: undefined method `with_indifferent_access' for "test":String
Did you mean?  with_indefinite_article
```

I think it would be clearer if we raise an argument error explaining clearly what we are doing wrong with something like this:

```sh
irb(main):007:0> ActionController::Parameters.new('test')
ArgumentError: invalid parameters given, the parameters should be a hash
```