### PR TITLE
[ci skip] CodeTriage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ and may also be used independently outside Rails.
 
 ## Contributing
 
+[![Code Triage Badge](https://www.codetriage.com/rails/rails/badges/users.svg)](https://www.codetriage.com/rails/rails)
+
 We encourage you to contribute to Ruby on Rails! Please check out the
 [Contributing to Ruby on Rails guide](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html) for guidelines about how to proceed. [Join us!](http://contributors.rubyonrails.org)
 


### PR DESCRIPTION
[Code Triage](https://www.codetriage.com/) is an app I've maintained for the past 4-5 years with the intent of getting people involved in open source. It sends subscribers a random open issue for them to help "triage". For Ruby projects such as "rails/rails" you can also subscribe to documentation. For example you can get a few random documented methods, or if you want to write docs, get undocumented methods.

The initial approach was inspired by seeing the work of the small core team spending countless hours asking "what rails version was this in" and "can you give us an example app". The idea is to outsource these small interactions to a huge team of volunteers and let the core team focus on their work.

The purpose of the badge is to give more people an easier way to start contributing to Rails. Here's what it currently looks like:

[![Code Triage Badge](https://www.codetriage.com/rails/rails/badges/users.svg)](https://www.codetriage.com/rails/rails)

The number is how many people are currently subscribed (a.k.a. "helpers") to the project on CodeTriage, the color is based off of the number of open issues in the project. You can see an example of this badge on another popular open source repo [Crystal](github.com/crystal-lang/crystal/).

> For context to non-rails core: I also maintain sprockets (though a release hasn't happened in some time, sorry), and I have commit to Rails. I'm not some rando trying to push arbitrary links to READMEs on GitHub.
