### PR TITLE
Backport #29821 to 5-1-stable 

### DIFF
--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -11,7 +11,7 @@ module Rails
     end
 
     def start
-      ENV["RAILS_ENV"] = @options[:environment] || environment
+      ENV["RAILS_ENV"] ||= @options[:environment] || environment
 
       case config["adapter"]
       when /^(jdbc)?mysql/
@@ -147,6 +147,9 @@ module Rails
 
       def perform
         extract_environment_option_from_argument
+
+        # RAILS_ENV needs to be set before config/application is required.
+        ENV["RAILS_ENV"] = options[:environment]
 
         require_application_and_environment!
         Rails::DBConsole.start(options)


### PR DESCRIPTION
Reason: #29725 has been backported to 5-1-stable, and this fix also affects in 5-1-stable.
