### PR TITLE
Fix type casting a time for MariaDB

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -42,7 +42,6 @@ module ActiveRecord
 
         def _type_cast(value)
           case value
-          when Type::Time::Value then value.__getobj__
           when Date, Time then value
           else super
           end


### PR DESCRIPTION
Context #24542.

Since 8ebe1f2, it has lost stripping date part for a time value. But I
confirmed it is still needed even if MariaDB 10.2.6 GA.

MariaDB 10.2.6, `prepared_statements: true`:

```
% ARCONN=mysql2 be ruby -w -Itest test/cases/time_precision_test.rb -n test_formatting_time_according_to_precision
Using mysql2
Run options: -n test_formatting_time_according_to_precision --seed 37614

F

Failure:
TimePrecisionTest#test_formatting_time_according_to_precision [test/cases/time_precision_test.rb:53]:
Failed assertion, no message given.

bin/rails test test/cases/time_precision_test.rb:46

Finished in 0.040279s, 24.8268 runs/s, 24.8268 assertions/s.

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```