### PR TITLE
Fix preloading of sti models on has_many through associations

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -86,7 +86,13 @@ module ActiveRecord
             else
               unless reflection_scope.where_clause.empty?
                 scope.includes_values = Array(values[:includes] || options[:source])
-                scope.where_clause = reflection_scope.where_clause
+
+                if reflection.klass.finder_needs_type_condition?
+                  scope.where_clause = reflection_scope.where_clause.except(reflection.klass.inheritance_column)
+                else
+                  scope.where_clause = reflection_scope.where_clause
+                end
+
                 if joins = values[:joins]
                   scope.joins!(source_reflection.name => joins)
                 end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -522,6 +522,14 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal [comments(:does_it_hurt)], assert_no_queries { author.special_post_comments }
   end
 
+  def test_eager_with_has_many_through_and_sti
+    authors = Author.includes(:very_special_comments).to_a
+    assert_no_queries do
+      special_comment_authors = authors.map { |author| [author.name, author.very_special_comments.size] }
+      assert_equal [["David", 1], ["Mary", 0], ["Bob", 0]], special_comment_authors
+    end
+  end
+
   def test_eager_with_has_many_through_an_sti_join_model_with_conditions_on_both
     author = Author.all.merge!(includes: :special_nonexistent_post_comments, order: "authors.id").first
     assert_equal [], author.special_nonexistent_post_comments


### PR DESCRIPTION
Another try to fix preloading of sti models on has_many through associations by removing the type conditions from through_scope

* fixes #11078
* based on #11082 and #14312