### PR TITLE
[ci skip]Replace jquery-ujs with rails-ujs

### DIFF
--- a/actionview/lib/action_view/helpers/csrf_helper.rb
+++ b/actionview/lib/action_view/helpers/csrf_helper.rb
@@ -15,7 +15,7 @@ module ActionView
       # You don't need to use these tags for regular forms as they generate their own hidden fields.
       #
       # For AJAX requests other than GETs, extract the "csrf-token" from the meta-tag and send as the
-      # "X-CSRF-Token" HTTP header. If you are using jQuery with jquery-rails this happens automatically.
+      # "X-CSRF-Token" HTTP header. If you are using rails-ujs this happens automatically.
       #
       def csrf_meta_tags
         if protect_against_forgery?


### PR DESCRIPTION
we now use rails-ujs instead of jquery-ujs as default.