### PR TITLE
Add optional to the model generator

### DIFF
--- a/activerecord/lib/rails/generators/active_record/model/templates/model.rb
+++ b/activerecord/lib/rails/generators/active_record/model/templates/model.rb
@@ -1,7 +1,7 @@
 <% module_namespacing do -%>
 class <%= class_name %> < <%= parent_class_name.classify %>
 <% attributes.select(&:reference?).each do |attribute| -%>
-  belongs_to :<%= attribute.name %><%= ', polymorphic: true' if attribute.polymorphic? %><%= ', required: true' if attribute.required? %>
+  belongs_to :<%= attribute.name %><%= ', polymorphic: true' if attribute.polymorphic? %><%= ', optional: true' if attribute.optional? %>
 <% end -%>
 <% attributes.select(&:token?).each do |attribute| -%>
   has_secure_token<% if attribute.name != "token" %> :<%= attribute.name %><% end %>

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add an `optional` option to the model generator and remove a `required` option.
+    The generator creates `null: false` option by default.
+
+    *Takumi Shotoku*
+
 *   Support `-` as a platform-agnostic way to run a script from stdin with
     `rails runner`
 

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -48,7 +48,8 @@ module Rails
           when /(references|belongs_to)\{(.+)\}/
             type = $1
             provided_options = $2.split(/[,.-]/)
-            options = Hash[provided_options.map { |opt| [opt.to_sym, true] }]
+            valid_options = provided_options & %w(index foreign_key polymorphic null required)
+            options = Hash[valid_options.map { |opt| [opt.to_sym, true] }]
             return type, options
           else
             return type, {}

--- a/railties/lib/rails/generators/rails/model/USAGE
+++ b/railties/lib/rails/generators/rails/model/USAGE
@@ -67,16 +67,20 @@ Available field types:
 
         `rails generate model product 'price:decimal{10,2}'`
 
+    You can set a `null` or `optional` in curly braces to add a `null: true` option in the migration:
+
+        `rails generate model user pseudo:string{optional}`
+
     You can add a `:uniq` or `:index` suffix for unique or standard indexes
     respectively:
 
         `rails generate model user pseudo:string:uniq`
         `rails generate model user pseudo:string:index`
 
-    You can combine any single curly brace option with the index options:
+    You can combine any curly brace option with the index options:
 
-        `rails generate model user username:string{30}:uniq`
-        `rails generate model product supplier:references{polymorphic}:index`
+        `rails generate model user 'username:string{30,optional}:uniq'`
+        `rails generate model product 'supplier:references{polymorphic,optional}:index'`
 
     If you require a `password_digest` string column for use with
     has_secure_password, you can specify `password:digest`:

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -142,11 +142,11 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     assert_equal "post_id", create_generated_attribute("belongs_to", "post").column_name
   end
 
-  def test_parse_required_attribute_with_index
-    att = Rails::Generators::GeneratedAttribute.parse("supplier:references{required}:index")
+  def test_parse_optional_attribute_with_index
+    att = Rails::Generators::GeneratedAttribute.parse("supplier:references{optional}:index")
     assert_equal "supplier", att.name
     assert_equal :references, att.type
     assert att.has_index?
-    assert att.required?
+    assert att.optional?
   end
 end

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -320,6 +320,18 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     Rails.application.config.paths["db/migrate"] = old_paths
   end
 
+  def test_add_migration_with_wrong_attribute_options
+    migration = "add_references_to_books"
+    run_generator [migration, "author:belongs_to{polymorphik}"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/add_reference :books, :author/, change)
+      end
+      assert_no_match(/polymorphik/, content)
+    end
+  end
+
   private
 
     def with_singular_table_name

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -172,14 +172,16 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_add_migration_with_required_references
+  def test_add_migration_with_optional_attributes
     migration = "add_references_to_books"
-    run_generator [migration, "author:belongs_to{required}", "distributor:references{polymorphic,required}"]
+    run_generator [migration, "author:belongs_to{optional}", "distributor:references{polymorphic,optional}", "title:string{optional}", "price:integer{optional}"]
 
     assert_migration "db/migrate/#{migration}.rb" do |content|
       assert_method :change, content do |change|
-        assert_match(/add_reference :books, :author, null: false/, change)
-        assert_match(/add_reference :books, :distributor, polymorphic: true, null: false/, change)
+        assert_match(/add_reference :books, :author, null: true/, change)
+        assert_match(/add_reference :books, :distributor, polymorphic: true, null: true/, change)
+        assert_match(/add_column :books, :title, :string, null: true/, change)
+        assert_match(/add_column :books, :price, :integer, null: true/, change)
       end
     end
   end

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -393,45 +393,45 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_required_belongs_to_adds_required_association
-    run_generator ["account", "supplier:references{required}"]
+  def test_optional_belongs_to_adds_optional_association
+    run_generator ["account", "supplier:references{optional}"]
 
     expected_file = <<-FILE.strip_heredoc
     class Account < ApplicationRecord
-      belongs_to :supplier, required: true
+      belongs_to :supplier, optional: true
     end
     FILE
     assert_file "app/models/account.rb", expected_file
   end
 
-  def test_required_polymorphic_belongs_to_generages_correct_model
-    run_generator ["account", "supplier:references{required,polymorphic}"]
+  def test_optional_polymorphic_belongs_to_generages_correct_model
+    run_generator ["account", "supplier:references{optional,polymorphic}"]
 
     expected_file = <<-FILE.strip_heredoc
     class Account < ApplicationRecord
-      belongs_to :supplier, polymorphic: true, required: true
+      belongs_to :supplier, polymorphic: true, optional: true
     end
     FILE
     assert_file "app/models/account.rb", expected_file
   end
 
-  def test_required_and_polymorphic_are_order_independent
-    run_generator ["account", "supplier:references{polymorphic.required}"]
+  def test_optional_and_polymorphic_are_order_independent
+    run_generator ["account", "supplier:references{polymorphic.optional}"]
 
     expected_file = <<-FILE.strip_heredoc
     class Account < ApplicationRecord
-      belongs_to :supplier, polymorphic: true, required: true
+      belongs_to :supplier, polymorphic: true, optional: true
     end
     FILE
     assert_file "app/models/account.rb", expected_file
   end
 
-  def test_required_adds_null_false_to_column
-    run_generator ["account", "supplier:references{required}"]
+  def test_optional_adds_null_false_to_column
+    run_generator ["account", "supplier:references{optional}"]
 
     assert_migration "db/migrate/create_accounts.rb" do |m|
       assert_method :change, m do |up|
-        assert_match(/t\.references :supplier,.*\snull: false/, up)
+        assert_match(/t\.references :supplier,.*\snull: true/, up)
       end
     end
   end


### PR DESCRIPTION
### Summary

Since Rails v5.0, the `belongs_to` method to `required: true` by default.
Likewise `add_column` should default to `null: false`, and the generator should not generate deprecated `required: true` option in `belongs_to`.

The `required` option is unnecessary with this change, so removed it.

### Compatibility

The model generator ignores wrong options, so the `required` option is removed there is no problem.
