### PR TITLE
CI with the latest stable(GA) version of MariaDB 10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ matrix:
       env:
         - "GEM=ar:mysql2 MYSQL=mariadb"
       addons:
-        mariadb: 10.0
+        mariadb: 10.2
     - rvm: 2.3.4
       env:
         - "GEM=ar:sqlite3_mem"

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -142,6 +142,10 @@ module ActiveRecord
       end
 
       def test_remove_column_with_multi_column_index
+        # MariaDB starting with 10.2.8
+        # Dropping a column that is part of a multi-column UNIQUE constraint is not permitted.
+        skip if current_adapter?(:Mysql2Adapter) && connection.mariadb? && connection.version >= "10.2.8"
+
         add_column "test_models", :hat_size, :integer
         add_column "test_models", :hat_style, :string, limit: 100
         add_index "test_models", ["hat_style", "hat_size"], unique: true


### PR DESCRIPTION
### Summary
This pull request updates MariaDB version to 10.2 since #29708 and #29706 supports MariaDB 10.2 changes.

There was a similar pull request #29740 which was closed since MariaDB 10.2.6 GA is not supported on Ubuntu 12.04 LTS.

Now Travis CI is migrating Ubuntu version to Trusty and  MariaDB 10.2 is supported on Ubuntu Trusty I think it is good timing to open another pull request.

Refer

* https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming

* https://downloads.mariadb.org/mariadb/repositories/#mirror=digitalocean-nyc&distro=Ubuntu&distro_release=trusty--ubuntu_trusty&version=10.2

