### PR TITLE
Make `rails yarn:install` ignore dev dependencies

### DIFF
--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -1,7 +1,7 @@
 namespace :yarn do
   desc "Install all JavaScript dependencies as specified via Yarn"
   task :install do
-    system("./bin/yarn install --no-progress")
+    system("./bin/yarn install --no-progress --production")
   end
 end
 


### PR DESCRIPTION
Yarn rebuilds native packages on every `yarn install` call (issue https://github.com/yarnpkg/yarn/issues/932). We have some native node packages in `devDependencies` to build custom fonts, and they got rebuilt on every deploy (30+ sec. instead of 2 sec.). This patch makes `rails yarn:install` which is used before `assets:precompile` ignore dev dependencies. `bin/yarn` still installs everything.

__For anybody looking for workaround__
Update `bin/yarn` with:
```ruby
# ...
  begin
    no_dev = %w[production staging].include?(ENV['RAILS_ENV'])
    exec "yarnpkg #{ARGV.join(' ')} #{'--prod' if no_dev}"
```