### PR TITLE
Move generator namespacing to Base

### DIFF
--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -16,6 +16,9 @@ module Rails
       include Thor::Actions
       include Rails::Generators::Actions
 
+      class_option :skip_namespace, type: :boolean, default: false,
+                                    desc: "Skip namespace (affects only isolated applications)"
+
       add_runtime_options!
       strict_args_position!
 
@@ -269,6 +272,40 @@ module Rails
             break unless last_module.const_defined?(nest, false)
             last_module.const_get(nest)
           end
+        end
+
+        # Wrap block with namespace of current application
+        # if namespace exists and is not skipped
+        def module_namespacing(&block) # :doc:
+          content = capture(&block)
+          content = wrap_with_namespace(content) if namespaced?
+          concat(content)
+        end
+
+        def indent(content, multiplier = 2) # :doc:
+          spaces = " " * multiplier
+          content.each_line.map { |line| line.blank? ? line : "#{spaces}#{line}" }.join
+        end
+
+        def wrap_with_namespace(content) # :doc:
+          content = indent(content).chomp
+          "module #{namespace.name}\n#{content}\nend\n"
+        end
+
+        def namespace # :doc:
+          Rails::Generators.namespace
+        end
+
+        def namespaced? # :doc:
+          !options[:skip_namespace] && namespace
+        end
+
+        def namespace_dirs
+          @namespace_dirs ||= namespace.name.split("::").map(&:underscore)
+        end
+
+        def namespaced_path # :doc:
+          @namespaced_path ||= namespace_dirs.join("/")
         end
 
         # Use Rails default banner.

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -6,8 +6,6 @@ module Rails
   module Generators
     class NamedBase < Base
       argument :name, type: :string
-      class_option :skip_namespace, type: :boolean, default: false,
-                                    desc: "Skip namespace (affects only isolated applications)"
 
       def initialize(args, *options) #:nodoc:
         @inside_template = nil
@@ -45,24 +43,6 @@ module Rails
           file_name
         end
 
-        # Wrap block with namespace of current application
-        # if namespace exists and is not skipped
-        def module_namespacing(&block) # :doc:
-          content = capture(&block)
-          content = wrap_with_namespace(content) if namespaced?
-          concat(content)
-        end
-
-        def indent(content, multiplier = 2) # :doc:
-          spaces = " " * multiplier
-          content.each_line.map { |line| line.blank? ? line : "#{spaces}#{line}" }.join
-        end
-
-        def wrap_with_namespace(content) # :doc:
-          content = indent(content).chomp
-          "module #{namespace.name}\n#{content}\nend\n"
-        end
-
         def inside_template # :doc:
           @inside_template = true
           yield
@@ -72,18 +52,6 @@ module Rails
 
         def inside_template? # :doc:
           @inside_template
-        end
-
-        def namespace # :doc:
-          Rails::Generators.namespace
-        end
-
-        def namespaced? # :doc:
-          !options[:skip_namespace] && namespace
-        end
-
-        def namespace_dirs
-          @namespace_dirs ||= namespace.name.split("::").map(&:underscore)
         end
 
         def file_path # :doc:
@@ -100,10 +68,6 @@ module Rails
 
         def namespaced_class_path # :doc:
           @namespaced_class_path ||= namespace_dirs + @class_path
-        end
-
-        def namespaced_path # :doc:
-          @namespaced_path ||= namespace_dirs.join("/")
         end
 
         def class_name # :doc:


### PR DESCRIPTION
### Summary

Generators need to be aware of namespace to work properly in engines. Methods to help with this lived in `Rails::Generators::NamedBase`, this moves them to `Rails::Generators::Base` (which `NamedBase` inherits from) allowing namespace aware unnamed generators.

### Other Information

I plan a follow-up PR in which a namespace aware unnamed generator is be created.

r? @sgrif 