### PR TITLE
Remove time stubs after each test

### DIFF
--- a/activerecord/test/cases/mixin_test.rb
+++ b/activerecord/test/cases/mixin_test.rb
@@ -10,10 +10,6 @@ class TouchTest < ActiveRecord::TestCase
     travel_to Time.now
   end
 
-  teardown do
-    travel_back
-  end
-
   def test_update
     stamped = Mixin.new
 

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -51,8 +51,14 @@ module ActiveSupport
 
     # Contains helpers that help you test passage of time.
     module TimeHelpers
+      def after_teardown
+        travel_back
+        super
+      end
+
       # Changes current time to the time in the future or in the past by a given time difference by
-      # stubbing +Time.now+, +Date.today+, and +DateTime.now+.
+      # stubbing +Time.now+, +Date.today+, and +DateTime.now+. The stubs are automatically removed
+      # at the end of the test.
       #
       #   Time.current     # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       #   travel 1.day
@@ -74,6 +80,7 @@ module ActiveSupport
 
       # Changes current time to the given time by stubbing +Time.now+,
       # +Date.today+, and +DateTime.now+ to return the time or date passed into this method.
+      # The stubs are automatically removed at the end of the test.
       #
       #   Time.current     # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       #   travel_to Time.zone.local(2004, 11, 24, 01, 04, 44)

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -103,7 +103,6 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal Date.new(2000, 1, 1), ActiveSupport::TimeZone["Eastern Time (US & Canada)"].today
     travel_to(Time.utc(2000, 1, 2, 5)) # midnight Jan 2 EST
     assert_equal Date.new(2000, 1, 2), ActiveSupport::TimeZone["Eastern Time (US & Canada)"].today
-    travel_back
   end
 
   def test_tomorrow
@@ -115,7 +114,6 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal Date.new(2000, 1, 2), ActiveSupport::TimeZone["Eastern Time (US & Canada)"].tomorrow
     travel_to(Time.utc(2000, 1, 2, 5)) # midnight Jan 2 EST
     assert_equal Date.new(2000, 1, 3), ActiveSupport::TimeZone["Eastern Time (US & Canada)"].tomorrow
-    travel_back
   end
 
   def test_yesterday
@@ -127,7 +125,6 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal Date.new(1999, 12, 31), ActiveSupport::TimeZone["Eastern Time (US & Canada)"].yesterday
     travel_to(Time.utc(2000, 1, 2, 5)) # midnight Jan 2 EST
     assert_equal Date.new(2000, 1, 1), ActiveSupport::TimeZone["Eastern Time (US & Canada)"].yesterday
-    travel_back
   end
 
   def test_travel_to_a_date


### PR DESCRIPTION
Fixes that time stubs added by calls to `travel` and `travel_to` are preserved between subsequent tests. This is rarely (if ever) desirable, especially considering that tests are run in random order by default.

Without this change, every Rails application’s test helper must include a boilerplate teardown callback.