### PR TITLE
Add uniq processing to keys for store_accessor

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add uniq processing to keys for `store_accessor`
+
+    The purpose of this change is to avoid duplicate definitions.
+
+    *Yoshiyuki Hirano*
+
 *   Fix `COUNT(DISTINCT ...)` with `ORDER BY` and `LIMIT` to keep the existing select list.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -85,7 +85,7 @@ module ActiveRecord
       end
 
       def store_accessor(store_attribute, *keys)
-        keys = keys.flatten
+        keys = keys.flatten.uniq
 
         _store_accessors_module.module_eval do
           keys.each do |key|


### PR DESCRIPTION
The purpose of this change is to avoid duplicate definitions.