### PR TITLE
[API DOCUMENTATION] [MINOR] Correct description of ActionController::Parameters#delete

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -673,10 +673,10 @@ module ActionController
       self
     end
 
-    # Deletes and returns a key-value pair from +Parameters+ whose key is equal
-    # to key. If the key is not found, returns the default value. If the
-    # optional code block is given and the key is not found, pass in the key
-    # and return the result of block.
+    # Deletes a key-value pair from +Parameters+ and returns the value. If
+    # +key+ is not found, returns +nil+ (or, with optional code block, yields
+    # +key+ and returns the result). Cf. +#extract!+, which returns the
+    # corresponding +ActionController::Paramters+ object.
     def delete(key, &block)
       convert_value_to_parameters(@parameters.delete(key, &block))
     end

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -676,7 +676,7 @@ module ActionController
     # Deletes a key-value pair from +Parameters+ and returns the value. If
     # +key+ is not found, returns +nil+ (or, with optional code block, yields
     # +key+ and returns the result). Cf. +#extract!+, which returns the
-    # corresponding +ActionController::Paramters+ object.
+    # corresponding +ActionController::Parameters+ object.
     def delete(key, &block)
       convert_value_to_parameters(@parameters.delete(key, &block))
     end


### PR DESCRIPTION
The API documentation for ActionController::Parameters#delete currently states (emphasis mine):

> Deletes and **returns a key-value pair** from `Parameters` whose key is equal to key. If the key is not found, **returns the default value**. If the optional code block is given and the key is not found, pass in the key and return the result of block.

This definition is outdated: the method delegates to `Hash#delete`, which itself has changed in recent versions of Ruby:

1. Since Ruby 2.0, [`#delete` returns only the value of the deleted key-value pair](http://ruby-doc.org/core-2.0.0/Hash.html#method-i-delete) (not the [whole key-value pair itself, as was the case in 1.9](http://ruby-doc.org/core-1.9.3/Hash.html#method-i-delete)).
2. Since Ruby 2.3, [`#delete` returns `nil` if `key` is not found](http://ruby-doc.org/core-2.3.0/Hash.html#method-i-delete) (not the [_default value_, as was the case in 2.2](http://ruby-doc.org/core-2.2.0/Hash.html#method-i-delete)). In any case, the “default value” of a hash does not apply to `ActionController::Parameters`.