### PR TITLE
Fix a failued AR test when using OracleAdapter

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1592,7 +1592,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal ["comments"], scope.references_values
 
     scope = Post.order("#{Comment.quoted_table_name}.#{Comment.quoted_primary_key}")
-    assert_equal ["comments"], scope.references_values
+    if current_adapter?(:OracleAdapter)
+      assert_equal ["COMMENTS"], scope.references_values
+    else
+      assert_equal ["comments"], scope.references_values
+    end
 
     scope = Post.order("comments.body", "yaks.body")
     assert_equal ["comments", "yaks"], scope.references_values
@@ -1613,7 +1617,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal %w(comments), scope.references_values
 
     scope = Post.reorder("#{Comment.quoted_table_name}.#{Comment.quoted_primary_key}")
-    assert_equal ["comments"], scope.references_values
+    if current_adapter?(:OracleAdapter)
+      assert_equal ["COMMENTS"], scope.references_values
+    else
+      assert_equal ["comments"], scope.references_values
+    end
 
     scope = Post.reorder("comments.body", "yaks.body")
     assert_equal %w(comments yaks), scope.references_values


### PR DESCRIPTION
### Summary

Follow up of #29571.

This PR fixes the following failures when using Oracle (11g) .

```console
% ARCONN=oracle bundle exec ruby -w -Itest test/cases/relations_test.rb -n /test_automatically_added_.*_references/
Using oracle
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/ruby-oci8-2.2.4.1/lib/oci8/oci8.rb:627: warning: method redefined; discarding old initialize
Run options: -n /test_automatically_added_.*_references/ --seed 2823

# Running:

..F

Failure:
RelationTest#test_automatically_added_order_references [test/cases/relations_test.rb:1595]:
Expected: ["comments"]
  Actual: ["COMMENTS"]


bin/rails test test/cases/relations_test.rb:1590

.F

Failure:
RelationTest#test_automatically_added_reorder_references [test/cases/relations_test.rb:1616]:
Expected: ["comments"]
  Actual: ["COMMENTS"]


bin/rails test test/cases/relations_test.rb:1611



Finished in 0.968114s, 5.1647 runs/s, 10.3294 assertions/s.

5 runs, 10 assertions, 2 failures, 0 errors, 0 skips
```

This values are uppercase because `quoted_table_name` and` quoted_primary_key` returns uppercase in OracleAdapter.

```ruby
Post.reorder("#{Comment.quoted_table_name}.#{Comment.quoted_primary_key}").references_values #=> "COMMENTS"
Post.reorder("#{Comment.quoted_table_name}.#{Comment.quoted_primary_key}".downcase).references_values #=> "comments"
```

Since I thought that it was behavior specific to OracleAdapter, I divided assertions with `current_adapter`.
