### PR TITLE
Make `type_map` to private because it is only used in the connection adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -451,12 +451,6 @@ module ActiveRecord
         pool.checkin self
       end
 
-      def type_map # :nodoc:
-        @type_map ||= Type::TypeMap.new.tap do |mapping|
-          initialize_type_map(mapping)
-        end
-      end
-
       def column_name_for_operation(operation, node) # :nodoc:
         visitor.accept(node, collector).value
       end
@@ -484,8 +478,13 @@ module ActiveRecord
       end
 
       private
+        def type_map
+          @type_map ||= Type::TypeMap.new.tap do |mapping|
+            initialize_type_map(mapping)
+          end
+        end
 
-        def initialize_type_map(m)
+        def initialize_type_map(m = type_map)
           register_class_with_limit m, %r(boolean)i,       Type::Boolean
           register_class_with_limit m, %r(char)i,          Type::String
           register_class_with_limit m, %r(binary)i,        Type::Binary
@@ -518,7 +517,7 @@ module ActiveRecord
 
         def reload_type_map
           type_map.clear
-          initialize_type_map(type_map)
+          initialize_type_map
         end
 
         def register_class_with_limit(mapping, key, klass)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -545,7 +545,7 @@ module ActiveRecord
           execute("SET @@SESSION.sql_mode = #{sql_mode}")
         end
 
-        def initialize_type_map(m)
+        def initialize_type_map(m = type_map)
           super
 
           register_class_with_limit m, %r(char)i, MysqlString

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
@@ -29,8 +29,8 @@ module ActiveRecord
             composites.each { |row| register_composite_type(row) }
           end
 
-          def query_conditions_for_initial_load(type_map)
-            known_type_names = type_map.keys.map { |n| "'#{n}'" }
+          def query_conditions_for_initial_load
+            known_type_names = @store.keys.map { |n| "'#{n}'" }
             known_type_types = %w('r' 'e' 'd')
             <<-SQL % [known_type_names.join(", "), known_type_types.join(", ")]
               WHERE

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -216,7 +216,7 @@ module ActiveRecord
         add_pg_decoders
 
         @type_map = Type::HashLookupTypeMap.new
-        initialize_type_map(type_map)
+        initialize_type_map
         @local_tz = execute("SHOW TIME ZONE", "SCHEMA").first["TimeZone"]
         @use_insert_returning = @config.key?(:insert_returning) ? self.class.type_cast_config_to_boolean(@config[:insert_returning]) : true
       end
@@ -425,7 +425,7 @@ module ActiveRecord
 
         def get_oid_type(oid, fmod, column_name, sql_type = "".freeze)
           if !type_map.key?(oid)
-            load_additional_types(type_map, [oid])
+            load_additional_types([oid])
           end
 
           type_map.fetch(oid, fmod, sql_type) {
@@ -436,7 +436,7 @@ module ActiveRecord
           }
         end
 
-        def initialize_type_map(m)
+        def initialize_type_map(m = type_map)
           register_class_with_limit m, "int2", Type::Integer
           register_class_with_limit m, "int4", Type::Integer
           register_class_with_limit m, "int8", Type::Integer
@@ -503,7 +503,7 @@ module ActiveRecord
             end
           end
 
-          load_additional_types(m)
+          load_additional_types
         end
 
         def extract_limit(sql_type)
@@ -552,7 +552,7 @@ module ActiveRecord
           !default_value && %r{\w+\(.*\)|\(.*\)::\w+|CURRENT_DATE|CURRENT_TIMESTAMP}.match?(default)
         end
 
-        def load_additional_types(type_map, oids = nil)
+        def load_additional_types(oids = nil)
           initializer = OID::TypeMapInitializer.new(type_map)
 
           if supports_ranges?
@@ -571,7 +571,7 @@ module ActiveRecord
           if oids
             query += "WHERE t.oid::integer IN (%s)" % oids.join(", ")
           else
-            query += initializer.query_conditions_for_initial_load(type_map)
+            query += initializer.query_conditions_for_initial_load
           end
 
           execute_and_clear(query, "SCHEMA", []) do |records|

--- a/activerecord/test/cases/adapters/postgresql/composite_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/composite_test.rb
@@ -104,7 +104,7 @@ class PostgresqlCompositeWithCustomOIDTest < ActiveRecord::PostgreSQLTestCase
   def setup
     super
 
-    @connection.type_map.register_type "full_address", FullAddressType.new
+    @connection.send(:type_map).register_type "full_address", FullAddressType.new
   end
 
   def test_column

--- a/activerecord/test/cases/adapters/postgresql/type_lookup_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/type_lookup_test.rb
@@ -6,16 +6,16 @@ class PostgresqlTypeLookupTest < ActiveRecord::PostgreSQLTestCase
   end
 
   test "array delimiters are looked up correctly" do
-    box_array = @connection.type_map.lookup(1020)
-    int_array = @connection.type_map.lookup(1007)
+    box_array = @connection.send(:type_map).lookup(1020)
+    int_array = @connection.send(:type_map).lookup(1007)
 
     assert_equal ";", box_array.delimiter
     assert_equal ",", int_array.delimiter
   end
 
   test "array types correctly respect registration of subtypes" do
-    int_array = @connection.type_map.lookup(1007, -1, "integer[]")
-    bigint_array = @connection.type_map.lookup(1016, -1, "bigint[]")
+    int_array = @connection.send(:type_map).lookup(1007, -1, "integer[]")
+    bigint_array = @connection.send(:type_map).lookup(1016, -1, "bigint[]")
     big_array = [123456789123456789]
 
     assert_raises(ActiveModel::RangeError) { int_array.serialize(big_array) }
@@ -23,8 +23,8 @@ class PostgresqlTypeLookupTest < ActiveRecord::PostgreSQLTestCase
   end
 
   test "range types correctly respect registration of subtypes" do
-    int_range = @connection.type_map.lookup(3904, -1, "int4range")
-    bigint_range = @connection.type_map.lookup(3926, -1, "int8range")
+    int_range = @connection.send(:type_map).lookup(3904, -1, "int4range")
+    bigint_range = @connection.send(:type_map).lookup(3926, -1, "int8range")
     big_range = 0..123456789123456789
 
     assert_raises(ActiveModel::RangeError) { int_range.serialize(big_range) }

--- a/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
@@ -47,7 +47,7 @@ if current_adapter?(:Mysql2Adapter)
         private
 
           def assert_lookup_type(type, lookup)
-            cast_type = @connection.type_map.lookup(lookup)
+            cast_type = @connection.send(:type_map).lookup(lookup)
             assert_equal type, cast_type.type
           end
 

--- a/activerecord/test/cases/connection_adapters/type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/type_lookup_test.rb
@@ -80,7 +80,7 @@ unless current_adapter?(:PostgreSQLAdapter) # PostgreSQL does not use type strin
         end
 
         def test_bigint_limit
-          cast_type = @connection.type_map.lookup("bigint")
+          cast_type = @connection.send(:type_map).lookup("bigint")
           if current_adapter?(:OracleAdapter)
             assert_equal 19, cast_type.limit
           else
@@ -98,7 +98,7 @@ unless current_adapter?(:PostgreSQLAdapter) # PostgreSQL does not use type strin
             { decimal: %w{decimal(2) decimal(2,0) numeric(2) numeric(2,0) number(2) number(2,0)} }
           end.each do |expected_type, types|
             types.each do |type|
-              cast_type = @connection.type_map.lookup(type)
+              cast_type = @connection.send(:type_map).lookup(type)
 
               assert_equal expected_type, cast_type.type
               assert_equal 2, cast_type.cast(2.1)
@@ -109,7 +109,7 @@ unless current_adapter?(:PostgreSQLAdapter) # PostgreSQL does not use type strin
         private
 
           def assert_lookup_type(type, lookup)
-            cast_type = @connection.type_map.lookup(lookup)
+            cast_type = @connection.send(:type_map).lookup(lookup)
             assert_equal type, cast_type.type
           end
       end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -400,10 +400,8 @@ class QueryCacheTest < ActiveRecord::TestCase
       # Warm the cache
       Task.find(1)
 
-      Task.connection.type_map.clear
-
       # Preload the type cache again (so we don't have those queries issued during our assertions)
-      Task.connection.send(:initialize_type_map, Task.connection.type_map)
+      Task.connection.send(:reload_type_map)
 
       # Clear places where type information is cached
       Task.reset_column_information


### PR DESCRIPTION
`type_map` is an internal API and it is only used in the connection
adapter. And also, some type map initializer methods requires passed
`type_map`, but those instances already has `type_map` in itself.
So we don't need explicit passing `type_map` to the initializers.