### PR TITLE
Use `TRUE` and `FALSE` boolean literals for MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "abstract_adapter"
 require_relative "statement_pool"
 require_relative "mysql/column"
@@ -861,8 +863,8 @@ module ActiveRecord
         class MysqlString < Type::String # :nodoc:
           def serialize(value)
             case value
-            when true then MySQL::Quoting::QUOTED_TRUE
-            when false then MySQL::Quoting::QUOTED_FALSE
+            when true then "1"
+            when false then "0"
             else super
             end
           end
@@ -871,8 +873,8 @@ module ActiveRecord
 
             def cast_value(value)
               case value
-              when true then MySQL::Quoting::QUOTED_TRUE
-              when false then MySQL::Quoting::QUOTED_FALSE
+              when true then "1"
+              when false then "0"
               else super
               end
             end

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -2,8 +2,6 @@ module ActiveRecord
   module ConnectionAdapters
     module MySQL
       module Quoting # :nodoc:
-        QUOTED_TRUE, QUOTED_FALSE = "1".freeze, "0".freeze
-
         def quote_column_name(name)
           @quoted_column_names[name] ||= "`#{super.gsub('`', '``')}`".freeze
         end
@@ -12,16 +10,8 @@ module ActiveRecord
           @quoted_table_names[name] ||= super.gsub(".", "`.`").freeze
         end
 
-        def quoted_true
-          QUOTED_TRUE
-        end
-
         def unquoted_true
           1
-        end
-
-        def quoted_false
-          QUOTED_FALSE
         end
 
         def unquoted_false


### PR DESCRIPTION
Since #29699, abstract boolean serialization has been changed to use
`TRUE` and `FALSE` literals. MySQL also support the literals.
So we can use the abstract boolean serialization even for MySQL.