### PR TITLE
5-1-stable: Fix default `CURRENT_TIMESTAMP` and Virtual Columns for MariaDB 10.2

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -340,8 +340,8 @@ module ActiveRecord
 
       def new_column_from_field(table_name, field) # :nodoc:
         type_metadata = fetch_type_metadata(field[:Type], field[:Extra])
-        if type_metadata.type == :datetime && field[:Default] == "CURRENT_TIMESTAMP"
-          default, default_function = nil, field[:Default]
+        if type_metadata.type == :datetime && /\ACURRENT_TIMESTAMP(?:\(\))?\z/i.match?(field[:Default])
+          default, default_function = nil, "CURRENT_TIMESTAMP"
         else
           default, default_function = field[:Default], nil
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -71,12 +71,12 @@ module ActiveRecord
         @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
 
         if version < "5.1.10"
-          raise "Your version of MySQL (#{full_version.match(/^\d+\.\d+\.\d+/)[0]}) is too old. Active Record supports MySQL >= 5.1.10."
+          raise "Your version of MySQL (#{version_string}) is too old. Active Record supports MySQL >= 5.1.10."
         end
       end
 
       def version #:nodoc:
-        @version ||= Version.new(full_version.match(/^\d+\.\d+\.\d+/)[0])
+        @version ||= Version.new(version_string)
       end
 
       def mariadb? # :nodoc:
@@ -912,6 +912,10 @@ module ActiveRecord
           when 0x1000000..0xffffffff; "longblob"
           else raise(ActiveRecordError, "No binary type has byte length #{limit}")
           end
+        end
+
+        def version_string
+          full_version.match(/^(?:5\.5\.5-)?(\d+\.\d+\.\d+)/)[1]
         end
 
         class MysqlJson < Type::Internal::AbstractJson # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -53,7 +53,7 @@ module ActiveRecord
           end
 
           def extract_expression_for_virtual_column(column)
-            if mariadb?
+            if mariadb? && version < "10.2.5"
               create_table_info = create_table_info(column.table_name)
               if %r/#{quote_column_name(column.name)} #{Regexp.quote(column.sql_type)}(?: COLLATE \w+)? AS \((?<expression>.+?)\) #{column.extra}/ =~ create_table_info
                 $~[:expression].inspect

--- a/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
@@ -52,7 +52,7 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
 
     def test_schema_dumping
       output = dump_table_schema("virtual_columns")
-      assert_match(/t\.virtual\s+"upper_name",\s+type: :string,\s+as: "UPPER\(`name`\)"$/i, output)
+      assert_match(/t\.virtual\s+"upper_name",\s+type: :string,\s+as: "(?:UPPER|UCASE)\(`name`\)"$/i, output)
       assert_match(/t\.virtual\s+"name_length",\s+type: :integer,\s+as: "LENGTH\(`name`\)",\s+stored: true$/i, output)
     end
   end


### PR DESCRIPTION
This PR backports #29704, #29706, and #29708.