### PR TITLE
Remove log directory in test postprocessing

### DIFF
--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -47,7 +47,7 @@ namespace :test do
       status = $?.to_i
     ensure
       Process.kill("KILL", pid) if pid
-      FileUtils.rm_f("log")
+      FileUtils.rm_rf("log")
     end
 
     exit status


### PR DESCRIPTION
The "log" is directory. So it is necessary to use `FileUtils.rm_rf`.
Ref: https://github.com/rails/rails/blob/master/actionview/Rakefile#L32