### PR TITLE
Refactor `PredicateBuilder` to consolidate creating `binds` and `parts` steps

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -7,7 +7,6 @@ module ActiveRecord
 
       def call(attribute, value)
         return attribute.in([]) if value.empty?
-        return queries_predicates(value) if value.all? { |v| v.is_a?(Hash) }
 
         values = value.map { |x| x.is_a?(Base) ? x.id : x }
         nils, values = values.partition(&:nil?)
@@ -38,17 +37,6 @@ module ActiveRecord
         module NullPredicate # :nodoc:
           def self.or(other)
             other
-          end
-        end
-
-      private
-        def queries_predicates(queries)
-          if queries.size > 1
-            queries.map do |query|
-              Arel::Nodes::And.new(predicate_builder.build_from_hash(query))
-            end.inject(&:or)
-          else
-            predicate_builder.build_from_hash(queries.first)
           end
         end
     end

--- a/activerecord/lib/active_record/relation/where_clause_factory.rb
+++ b/activerecord/lib/active_record/relation/where_clause_factory.rb
@@ -18,8 +18,7 @@ module ActiveRecord
           if perform_case_sensitive?(options = other.last)
             parts, binds = build_for_case_sensitive(attributes, options)
           else
-            attributes, binds = predicate_builder.create_binds(attributes)
-            parts = predicate_builder.build_from_hash(attributes)
+            parts, binds = predicate_builder.build_from_hash(attributes)
           end
         when Arel::Nodes::Node
           parts = [opts]


### PR DESCRIPTION
For reducing complexity and easing to understand.