### PR TITLE
Updates Rails upgrade guide on `ActionView::Helpers::RecordTagHelper`

### DIFF
--- a/actionview/lib/action_view/helpers/record_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/record_tag_helper.rb
@@ -1,7 +1,7 @@
 module ActionView
   module Helpers
     module RecordTagHelper
-      def div_for(*)
+      def div_for(*) # :nodoc:
         raise NoMethodError, "The `div_for` method has been removed from " \
           "Rails. To continue using it, add the `record_tag_helper` gem to " \
           "your Gemfile:\n" \
@@ -9,7 +9,7 @@ module ActionView
           "Consult the Rails upgrade guide for details."
       end
 
-      def content_tag_for(*)
+      def content_tag_for(*) # :nodoc:
         raise NoMethodError, "The `content_tag_for` method has been removed from " \
           "Rails. To continue using it, add the `record_tag_helper` gem to " \
           "your Gemfile:\n" \

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -276,6 +276,16 @@ You can now just call the dependency once with a wildcard.
 <% # Template Dependency: recordings/threads/events/* %>
 ```
 
+### `ActionView::Helpers::RecordTagHelper` moved to external gem (record_tag_helper)
+
+`content_tag_for` and `div_for` has been removed in favor of just using `content_tag`. To continue using it, add the `record_tag_helper` gem to your Gemfile:
+
+```ruby
+gem 'record_tag_helper', '~> 1.0'
+```
+
+See [#18411](https://github.com/rails/rails/pull/18411) for more details.
+
 ### Removed Support for `protected_attributes` Gem
 
 The `protected_attributes` gem is no longer supported in Rails 5.


### PR DESCRIPTION
### Summary

Adds documentation for removed `AV#content_tag_for` and `AV#div_for` for completion.

### Other details

I've also added a `:nodoc:` for the following methods (since I've accidentally ran into them by using Rdoc) and thought that they still existed as available methods for Rails 5.