### PR TITLE
Fix generator suggestion raise error when I18n.available_locales don’t include :en

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -274,8 +274,9 @@ module Rails
         else
           options     = sorted_groups.flat_map(&:last)
           suggestions = options.sort_by { |suggested| levenshtein_distance(namespace.to_s, suggested) }.first(3)
+          suggestions.map! { |s| "'#{s}'" }
           msg =  "Could not find generator '#{namespace}'. ".dup
-          msg << "Maybe you meant #{ suggestions.map { |s| "'#{s}'" }.to_sentence(last_word_connector: " or ", locale: :en) }\n"
+          msg << "Maybe you meant #{ suggestions[0...-1].join(', ')} or #{suggestions[-1]}\n"
           msg << "Run `rails generate --help` for more options."
           puts msg
         end

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -36,6 +36,19 @@ class GeneratorsTest < Rails::Generators::TestCase
     assert_match "Maybe you meant 'migration'", output
   end
 
+  def test_generator_suggestions_except_en_locale
+    orig_available_locales = I18n.available_locales
+    orig_default_locale = I18n.default_locale
+    I18n.available_locales = :ja
+    I18n.default_locale = :ja
+    name = :tas
+    output = capture(:stdout) { Rails::Generators.invoke name }
+    assert_match "Maybe you meant 'task', 'job' or", output
+  ensure
+    I18n.available_locales = orig_available_locales
+    I18n.default_locale = orig_default_locale
+  end
+
   def test_generator_multiple_suggestions
     name = :tas
     output = capture(:stdout) { Rails::Generators.invoke name }


### PR DESCRIPTION
### Summary

I have some rails applications only used in Japanese. So I write like following in `config/application.rb`

```ruby
config.i18n.default_locale = :ja
config.i18n.available_locales = :ja
```

Then I execute `rails g migrationz`, it should display suggestions like following.

```
Could not find generator 'migrationz'. Maybe you meant 'migration', 'generator' or 'mailer'
Run `rails generate --help` for more options.
```

But it displays error because suggestion uses hardcoded `:en` locale. I changed the locale to `I18n.default_locale` to fix it.

```
/Users/willnet/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/i18n-0.8.5/lib/i18n.rb:284:in `enforce_available_locales!': :en is not a valid locale (I18n::InvalidLocale)
	from /Users/willnet/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/i18n-0.8.5/lib/i18n.rb:151:in `translate'
	from /Users/willnet/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.2/lib/active_support/core_ext/array/conversions.rb:68:in `to_sentence'
	from /Users/willnet/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.2/lib/rails/generators.rb:274:in `invoke'
	from /Users/willnet/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.2/lib/rails/commands/generate/generate_command.rb:24:in `perform'
	from /Users/willnet/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /Users/willnet/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/willnet/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /Users/willnet/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.2/lib/rails/command/base.rb:63:in `perform'
	from /Users/willnet/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.2/lib/rails/command.rb:44:in `invoke'
	from /Users/willnet/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/railties-5.1.2/lib/rails/commands.rb:16:in `<top (required)>'
	from ./bin/rails:4:in `require'
	from ./bin/rails:4:in `<main>'
```  

