### PR TITLE
Railties updates for frozen string literals.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,7 +83,6 @@ Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always
   Exclude:
-    - 'railties/**/*'
     - 'actionview/test/**/*.builder'
     - 'actionview/test/**/*.ruby'
     - 'actionpack/test/**/*.builder'

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rake/testtask"
 
 task default: :test

--- a/railties/bin/test
+++ b/railties/bin/test
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"

--- a/railties/exe/rails
+++ b/railties/exe/rails
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 git_path = File.expand_path("../../.git", __dir__)
 

--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/module/attribute_accessors"
 require "rails/test_unit/reporter"
 

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "rails/ruby_version_check"
 
 require "pathname"

--- a/railties/lib/rails/all.rb
+++ b/railties/lib/rails/all.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails"
 
 %w(

--- a/railties/lib/rails/api/generator.rb
+++ b/railties/lib/rails/api/generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "sdoc"
 
 class RDoc::Generator::API < RDoc::Generator::SDoc # :nodoc:

--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rdoc/task"
 require_relative "generator"
 

--- a/railties/lib/rails/app_loader.rb
+++ b/railties/lib/rails/app_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "pathname"
 require_relative "version"
 

--- a/railties/lib/rails/app_updater.rb
+++ b/railties/lib/rails/app_updater.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails/generators"
 require "rails/generators/rails/app/app_generator"
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "yaml"
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/object/blank"

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "fileutils"
 require "active_support/notifications"
 require "active_support/dependencies"

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/kernel/reporting"
 require "active_support/file_update_checker"
 require_relative "../engine/configuration"

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   class Application
     class DefaultMiddlewareStack

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   class Application
     module Finisher

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/module/delegation"
 
 module Rails

--- a/railties/lib/rails/application_controller.rb
+++ b/railties/lib/rails/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rails::ApplicationController < ActionController::Base # :nodoc:
   self.view_paths = File.expand_path("templates", __dir__)
   layout "application"

--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/backtrace_cleaner"
 
 module Rails

--- a/railties/lib/rails/cli.rb
+++ b/railties/lib/rails/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "app_loader"
 
 # If we are inside a Rails application this method performs an exec and thus

--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "code_statistics_calculator"
 require "active_support/core_ext/enumerable"
 

--- a/railties/lib/rails/code_statistics_calculator.rb
+++ b/railties/lib/rails/code_statistics_calculator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CodeStatisticsCalculator #:nodoc:
   attr_reader :lines, :code_lines, :classes, :methods
 

--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support"
 require "active_support/dependencies/autoload"
 require "active_support/core_ext/enumerable"

--- a/railties/lib/rails/command/actions.rb
+++ b/railties/lib/rails/command/actions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Command
     module Actions

--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thor"
 require "erb"
 

--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -73,7 +73,7 @@ module Rails
 
         # Use Rails' default banner.
         def banner(*)
-          "#{executable} #{arguments.map(&:usage).join(' ')} [options]".squish!
+          "#{executable} #{arguments.map(&:usage).join(' ')} [options]".squish
         end
 
         # Sets the base_name taking into account the current class namespace.

--- a/railties/lib/rails/command/behavior.rb
+++ b/railties/lib/rails/command/behavior.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support"
 
 module Rails

--- a/railties/lib/rails/command/environment_argument.rb
+++ b/railties/lib/rails/command/environment_argument.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support"
 
 module Rails

--- a/railties/lib/rails/commands.rb
+++ b/railties/lib/rails/commands.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "command"
 
 aliases = {

--- a/railties/lib/rails/commands/application/application_command.rb
+++ b/railties/lib/rails/commands/application/application_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../generators"
 require_relative "../../generators/rails/app/app_generator"
 

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "irb"
 require "irb/completion"
 

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -58,7 +58,7 @@ module Rails
         logon = ""
 
         if config["username"]
-          logon = config["username"]
+          logon = config["username"].dup
           logon << "/#{config['password']}" if config["password"] && @options["include_password"]
           logon << "@#{config['database']}" if config["database"]
         end

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../command/environment_argument"
 
 module Rails

--- a/railties/lib/rails/commands/destroy/destroy_command.rb
+++ b/railties/lib/rails/commands/destroy/destroy_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../generators"
 
 module Rails

--- a/railties/lib/rails/commands/generate/generate_command.rb
+++ b/railties/lib/rails/commands/generate/generate_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../generators"
 
 module Rails

--- a/railties/lib/rails/commands/help/help_command.rb
+++ b/railties/lib/rails/commands/help/help_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Command
     class HelpCommand < Base # :nodoc:

--- a/railties/lib/rails/commands/new/new_command.rb
+++ b/railties/lib/rails/commands/new/new_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Command
     class NewCommand < Base # :nodoc:

--- a/railties/lib/rails/commands/plugin/plugin_command.rb
+++ b/railties/lib/rails/commands/plugin/plugin_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Command
     class PluginCommand < Base # :nodoc:

--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Command
     class RakeCommand < Base # :nodoc:

--- a/railties/lib/rails/commands/runner/runner_command.rb
+++ b/railties/lib/rails/commands/runner/runner_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Command
     class RunnerCommand < Base # :nodoc:

--- a/railties/lib/rails/commands/secrets/secrets_command.rb
+++ b/railties/lib/rails/commands/secrets/secrets_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support"
 require_relative "../../secrets"
 

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "fileutils"
 require "optparse"
 require "action_dispatch"

--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../command"
 require_relative "../../test_unit/runner"
 

--- a/railties/lib/rails/commands/version/version_command.rb
+++ b/railties/lib/rails/commands/version/version_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Command
     class VersionCommand < Base # :nodoc:

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/ordered_options"
 require "active_support/core_ext/object"
 require_relative "paths"

--- a/railties/lib/rails/console/app.rb
+++ b/railties/lib/rails/console/app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/all"
 require "action_controller"
 

--- a/railties/lib/rails/console/helpers.rb
+++ b/railties/lib/rails/console/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module ConsoleMethods
     # Gets the helper methods available to the controller.

--- a/railties/lib/rails/dev_caching.rb
+++ b/railties/lib/rails/dev_caching.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "fileutils"
 
 module Rails

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "railtie"
 require_relative "engine/railties"
 require "active_support/core_ext/module/delegation"

--- a/railties/lib/rails/engine/commands.rb
+++ b/railties/lib/rails/engine/commands.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 unless defined?(APP_PATH)
   if File.exist?(File.expand_path("test/dummy/config/application.rb", ENGINE_ROOT))
     APP_PATH = File.expand_path("test/dummy/config/application", ENGINE_ROOT)

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../railtie/configuration"
 
 module Rails

--- a/railties/lib/rails/engine/railties.rb
+++ b/railties/lib/rails/engine/railties.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   class Engine < Railtie
     class Railties

--- a/railties/lib/rails/engine/updater.rb
+++ b/railties/lib/rails/engine/updater.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../generators"
 require_relative "../generators/rails/plugin/plugin_generator"
 

--- a/railties/lib/rails/gem_version.rb
+++ b/railties/lib/rails/gem_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   # Returns the version of the currently loaded Rails as a <tt>Gem::Version</tt>
   def self.gem_version

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 activesupport_path = File.expand_path("../../../activesupport/lib", __dir__)
 $:.unshift(activesupport_path) if File.directory?(activesupport_path) && !$:.include?(activesupport_path)
 

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -271,7 +271,7 @@ module Rails
         else
           options     = sorted_groups.flat_map(&:last)
           suggestions = options.sort_by { |suggested| levenshtein_distance(namespace.to_s, suggested) }.first(3)
-          msg =  "Could not find generator '#{namespace}'. "
+          msg =  "Could not find generator '#{namespace}'. ".dup
           msg << "Maybe you meant #{ suggestions.map { |s| "'#{s}'" }.to_sentence(last_word_connector: " or ", locale: :en) }\n"
           msg << "Run `rails generate --help` for more options."
           puts msg

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     module Actions

--- a/railties/lib/rails/generators/actions/create_migration.rb
+++ b/railties/lib/rails/generators/actions/create_migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "fileutils"
 require "thor/actions"
 

--- a/railties/lib/rails/generators/active_model.rb
+++ b/railties/lib/rails/generators/active_model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     # ActiveModel is a class to be implemented by each ORM to allow Rails to

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "fileutils"
 require "digest/md5"
 require "active_support/core_ext/string/strip"

--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "thor/group"
 rescue LoadError

--- a/railties/lib/rails/generators/css/assets/assets_generator.rb
+++ b/railties/lib/rails/generators/css/assets/assets_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../named_base"
 
 module Css # :nodoc:

--- a/railties/lib/rails/generators/css/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/css/scaffold/scaffold_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../named_base"
 
 module Css # :nodoc:

--- a/railties/lib/rails/generators/erb.rb
+++ b/railties/lib/rails/generators/erb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "named_base"
 
 module Erb # :nodoc:

--- a/railties/lib/rails/generators/erb/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/erb/controller/controller_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../erb"
 
 module Erb # :nodoc:

--- a/railties/lib/rails/generators/erb/mailer/mailer_generator.rb
+++ b/railties/lib/rails/generators/erb/mailer/mailer_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../erb"
 
 module Erb # :nodoc:

--- a/railties/lib/rails/generators/erb/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/erb/scaffold/scaffold_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../erb"
 require_relative "../../resource_helpers"
 

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/time"
 
 module Rails

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -151,7 +151,7 @@ module Rails
       end
 
       def inject_options
-        "".tap { |s| options_for_migration.each { |k, v| s << ", #{k}: #{v.inspect}" } }
+        "".dup.tap { |s| options_for_migration.each { |k, v| s << ", #{k}: #{v.inspect}" } }
       end
 
       def inject_index_options

--- a/railties/lib/rails/generators/js/assets/assets_generator.rb
+++ b/railties/lib/rails/generators/js/assets/assets_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../named_base"
 
 module Js # :nodoc:

--- a/railties/lib/rails/generators/migration.rb
+++ b/railties/lib/rails/generators/migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/concern"
 require_relative "actions/create_migration"
 

--- a/railties/lib/rails/generators/model_helpers.rb
+++ b/railties/lib/rails/generators/model_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "active_model"
 
 module Rails

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/module/introspection"
 require_relative "base"
 require_relative "generated_attribute"

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../app_base"
 
 module Rails

--- a/railties/lib/rails/generators/rails/app/templates/Rakefile
+++ b/railties/lib/rails/generators/rails/app/templates/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/railties/lib/rails/generators/rails/app/templates/app/channels/application_cable/channel.rb
+++ b/railties/lib/rails/generators/rails/app/templates/app/channels/application_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/railties/lib/rails/generators/rails/app/templates/app/channels/application_cable/connection.rb
+++ b/railties/lib/rails/generators/rails/app/templates/app/channels/application_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/railties/lib/rails/generators/rails/app/templates/app/helpers/application_helper.rb
+++ b/railties/lib/rails/generators/rails/app/templates/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/railties/lib/rails/generators/rails/app/templates/app/jobs/application_job.rb
+++ b/railties/lib/rails/generators/rails/app/templates/app/jobs/application_job.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
 end

--- a/railties/lib/rails/generators/rails/app/templates/app/mailers/application_mailer.rb
+++ b/railties/lib/rails/generators/rails/app/templates/app/mailers/application_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationMailer < ActionMailer::Base
   default from: 'from@example.com'
   layout 'mailer'

--- a/railties/lib/rails/generators/rails/app/templates/app/models/application_record.rb
+++ b/railties/lib/rails/generators/rails/app/templates/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'boot'
 
 <% if include_all_railties? -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/railties/lib/rails/generators/rails/app/templates/config/environment.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require_relative 'application'
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/application_controller_renderer.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/application_controller_renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # ActiveSupport::Reloader.to_prepare do

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/backtrace_silencers.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/cookies_serializer.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/cookies_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Specify a serializer for the signed and encrypted cookie jars.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Avoid CORS issues when API is called from the frontend app.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/inflections.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/mime_types.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/mime_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match

--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/spring.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/spring.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 %w[
   .ruby-version
   .rbenv-vars

--- a/railties/lib/rails/generators/rails/app/templates/test/application_system_test_case.rb
+++ b/railties/lib/rails/generators/rails/app/templates/test/application_system_test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase

--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../config/environment'
 require 'rails/test_help'
 

--- a/railties/lib/rails/generators/rails/assets/assets_generator.rb
+++ b/railties/lib/rails/generators/rails/assets/assets_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     class AssetsGenerator < NamedBase # :nodoc:

--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     class ControllerGenerator < NamedBase # :nodoc:

--- a/railties/lib/rails/generators/rails/controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/controller/templates/controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% if namespaced? -%>
 require_dependency "<%= namespaced_path %>/application_controller"
 

--- a/railties/lib/rails/generators/rails/encrypted_secrets/encrypted_secrets_generator.rb
+++ b/railties/lib/rails/generators/rails/encrypted_secrets/encrypted_secrets_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../base"
 require_relative "../../../secrets"
 

--- a/railties/lib/rails/generators/rails/generator/generator_generator.rb
+++ b/railties/lib/rails/generators/rails/generator/generator_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     class GeneratorGenerator < NamedBase # :nodoc:

--- a/railties/lib/rails/generators/rails/helper/helper_generator.rb
+++ b/railties/lib/rails/generators/rails/helper/helper_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     class HelperGenerator < NamedBase # :nodoc:

--- a/railties/lib/rails/generators/rails/helper/templates/helper.rb
+++ b/railties/lib/rails/generators/rails/helper/templates/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing do -%>
 module <%= class_name %>Helper
 end

--- a/railties/lib/rails/generators/rails/integration_test/integration_test_generator.rb
+++ b/railties/lib/rails/generators/rails/integration_test/integration_test_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     class IntegrationTestGenerator < NamedBase # :nodoc:

--- a/railties/lib/rails/generators/rails/migration/migration_generator.rb
+++ b/railties/lib/rails/generators/rails/migration/migration_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     class MigrationGenerator < NamedBase # :nodoc:

--- a/railties/lib/rails/generators/rails/model/model_generator.rb
+++ b/railties/lib/rails/generators/rails/model/model_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../model_helpers"
 
 module Rails

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/hash/slice"
 require_relative "../app/app_generator"
 require "date"

--- a/railties/lib/rails/generators/rails/plugin/templates/Rakefile
+++ b/railties/lib/rails/generators/rails/plugin/templates/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'bundler/setup'
 rescue LoadError

--- a/railties/lib/rails/generators/rails/plugin/templates/config/routes.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% if mountable? -%>
 <%= camelized_modules %>::Engine.routes.draw do
 <% else -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% if engine? -%>
 require "<%= namespaced_name %>/engine"
 <% else -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/engine.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <%= wrap_in_modules <<-rb.strip_heredoc
   class Engine < ::Rails::Engine
   #{mountable? ? '  isolate_namespace ' + camelized_modules : ' '}

--- a/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/railtie.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <%= wrap_in_modules <<-rb.strip_heredoc
   class Railtie < ::Rails::Railtie
   end

--- a/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/version.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/version.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 <%= wrap_in_modules "VERSION = '0.1.0'" %>

--- a/railties/lib/rails/generators/rails/plugin/templates/lib/tasks/%namespaced_name%_tasks.rake
+++ b/railties/lib/rails/generators/rails/plugin/templates/lib/tasks/%namespaced_name%_tasks.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # desc "Explaining what the task does"
 # task :<%= underscored_name %> do
 #   # Task goes here

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'boot'
 
 <% if include_all_railties? -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/boot.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
 

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/routes.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   mount <%= camelized_modules %>::Engine => "/<%= name %>"
 end

--- a/railties/lib/rails/generators/rails/plugin/templates/test/%namespaced_name%_test.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/%namespaced_name%_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class <%= camelized_modules %>::Test < ActiveSupport::TestCase

--- a/railties/lib/rails/generators/rails/plugin/templates/test/application_system_test_case.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/application_system_test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase

--- a/railties/lib/rails/generators/rails/plugin/templates/test/integration/navigation_test.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/integration/navigation_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class NavigationTest < ActionDispatch::IntegrationTest

--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "<%= File.join('..', options[:dummy_path], 'config/environment') -%>"
 <% unless options[:skip_active_record] -%>
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../<%= options[:dummy_path] -%>/db/migrate", __dir__)]

--- a/railties/lib/rails/generators/rails/resource/resource_generator.rb
+++ b/railties/lib/rails/generators/rails/resource/resource_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../resource_helpers"
 require_relative "../model/model_generator"
 

--- a/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
+++ b/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
@@ -36,7 +36,7 @@ module Rails
 
       private
         def route_string
-          @route_string ||= ""
+          @route_string ||= "".dup
         end
 
         def write(str, indent)

--- a/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
+++ b/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     class ResourceRouteGenerator < NamedBase # :nodoc:

--- a/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../resource/resource_generator"
 
 module Rails

--- a/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../resource_helpers"
 
 module Rails

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% if namespaced? -%>
 require_dependency "<%= namespaced_path %>/application_controller"
 

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% if namespaced? -%>
 require_dependency "<%= namespaced_path %>/application_controller"
 

--- a/railties/lib/rails/generators/rails/system_test/system_test_generator.rb
+++ b/railties/lib/rails/generators/rails/system_test/system_test_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     class SystemTestGenerator < NamedBase # :nodoc:

--- a/railties/lib/rails/generators/rails/task/task_generator.rb
+++ b/railties/lib/rails/generators/rails/task/task_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     class TaskGenerator < NamedBase # :nodoc:

--- a/railties/lib/rails/generators/rails/task/templates/task.rb
+++ b/railties/lib/rails/generators/rails/task/templates/task.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :<%= file_name %> do
 <% actions.each do |action| -%>
   desc "TODO"

--- a/railties/lib/rails/generators/resource_helpers.rb
+++ b/railties/lib/rails/generators/resource_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "active_model"
 require_relative "model_helpers"
 

--- a/railties/lib/rails/generators/test_case.rb
+++ b/railties/lib/rails/generators/test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../generators"
 require_relative "testing/behaviour"
 require_relative "testing/setup_and_teardown"

--- a/railties/lib/rails/generators/test_unit.rb
+++ b/railties/lib/rails/generators/test_unit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "named_base"
 
 module TestUnit # :nodoc:

--- a/railties/lib/rails/generators/test_unit/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/test_unit/controller/controller_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_unit"
 
 module TestUnit # :nodoc:

--- a/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/test_unit/generator/generator_generator.rb
+++ b/railties/lib/rails/generators/test_unit/generator/generator_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_unit"
 
 module TestUnit # :nodoc:

--- a/railties/lib/rails/generators/test_unit/generator/templates/generator_test.rb
+++ b/railties/lib/rails/generators/test_unit/generator/templates/generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require '<%= generator_path %>'
 

--- a/railties/lib/rails/generators/test_unit/helper/helper_generator.rb
+++ b/railties/lib/rails/generators/test_unit/helper/helper_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_unit"
 
 module TestUnit # :nodoc:

--- a/railties/lib/rails/generators/test_unit/integration/integration_generator.rb
+++ b/railties/lib/rails/generators/test_unit/integration/integration_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_unit"
 
 module TestUnit # :nodoc:

--- a/railties/lib/rails/generators/test_unit/integration/templates/integration_test.rb
+++ b/railties/lib/rails/generators/test_unit/integration/templates/integration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/test_unit/job/job_generator.rb
+++ b/railties/lib/rails/generators/test_unit/job/job_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_unit"
 
 module TestUnit # :nodoc:

--- a/railties/lib/rails/generators/test_unit/mailer/mailer_generator.rb
+++ b/railties/lib/rails/generators/test_unit/mailer/mailer_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_unit"
 
 module TestUnit # :nodoc:

--- a/railties/lib/rails/generators/test_unit/mailer/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/mailer/templates/functional_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/test_unit/mailer/templates/preview.rb
+++ b/railties/lib/rails/generators/test_unit/mailer/templates/preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing do -%>
 # Preview all emails at http://localhost:3000/rails/mailers/<%= file_path %>_mailer
 class <%= class_name %>MailerPreview < ActionMailer::Preview

--- a/railties/lib/rails/generators/test_unit/model/model_generator.rb
+++ b/railties/lib/rails/generators/test_unit/model/model_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_unit"
 
 module TestUnit # :nodoc:

--- a/railties/lib/rails/generators/test_unit/model/templates/unit_test.rb
+++ b/railties/lib/rails/generators/test_unit/model/templates/unit_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/test_unit/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/test_unit/plugin/plugin_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_unit"
 
 module TestUnit # :nodoc:

--- a/railties/lib/rails/generators/test_unit/plugin/templates/test_helper.rb
+++ b/railties/lib/rails/generators/test_unit/plugin/templates/test_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'active_support/testing/autorun'
 require 'active_support'

--- a/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_unit"
 require_relative "../../resource_helpers"
 

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/api_functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/api_functional_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/system_test.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/system_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 <% module_namespacing do -%>

--- a/railties/lib/rails/generators/test_unit/system/system_generator.rb
+++ b/railties/lib/rails/generators/test_unit/system/system_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_unit"
 
 module TestUnit # :nodoc:

--- a/railties/lib/rails/generators/test_unit/system/templates/application_system_test_case.rb
+++ b/railties/lib/rails/generators/test_unit/system/templates/application_system_test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase

--- a/railties/lib/rails/generators/test_unit/system/templates/system_test.rb
+++ b/railties/lib/rails/generators/test_unit/system/templates/system_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class <%= class_name.pluralize %>Test < ApplicationSystemTestCase

--- a/railties/lib/rails/generators/testing/assertions.rb
+++ b/railties/lib/rails/generators/testing/assertions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     module Testing

--- a/railties/lib/rails/generators/testing/behaviour.rb
+++ b/railties/lib/rails/generators/testing/behaviour.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/class/attribute"
 require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/hash/reverse_merge"

--- a/railties/lib/rails/generators/testing/setup_and_teardown.rb
+++ b/railties/lib/rails/generators/testing/setup_and_teardown.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     module Testing

--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "cgi"
 
 module Rails

--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -39,7 +39,7 @@ module Rails
       alias inspect to_s
 
       def to_html
-        "<table>".tap do |table|
+        "<table>".dup.tap do |table|
           properties.each do |(name, value)|
             table << %(<tr><td class="name">#{CGI.escapeHTML(name.to_s)}</td>)
             formatted_value = if value.kind_of?(Array)

--- a/railties/lib/rails/info_controller.rb
+++ b/railties/lib/rails/info_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "application_controller"
 require "action_dispatch/routing/inspector"
 

--- a/railties/lib/rails/initializable.rb
+++ b/railties/lib/rails/initializable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "tsort"
 
 module Rails

--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "application_controller"
 
 class Rails::MailersController < Rails::ApplicationController # :nodoc:

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Paths
     # This object is an extended hash that behaves as root of the <tt>Rails::Paths</tt> system.

--- a/railties/lib/rails/plugin/test.rb
+++ b/railties/lib/rails/plugin/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_unit/runner"
 require_relative "../test_unit/reporter"
 

--- a/railties/lib/rails/rack.rb
+++ b/railties/lib/rails/rack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Rack
     autoload :Logger, "rails/rack/logger"

--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/time/conversions"
 require "active_support/core_ext/object/blank"
 require "active_support/log_subscriber"

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "initializable"
 require "active_support/inflector"
 require "active_support/core_ext/module/introspection"

--- a/railties/lib/rails/railtie/configurable.rb
+++ b/railties/lib/rails/railtie/configurable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/concern"
 
 module Rails

--- a/railties/lib/rails/railtie/configuration.rb
+++ b/railties/lib/rails/railtie/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../configuration"
 
 module Rails

--- a/railties/lib/rails/ruby_version_check.rb
+++ b/railties/lib/rails/ruby_version_check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if RUBY_VERSION < "2.2.2" && RUBY_ENGINE == "ruby"
   desc = defined?(RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : "ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE})"
   abort <<-end_message

--- a/railties/lib/rails/secrets.rb
+++ b/railties/lib/rails/secrets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "yaml"
 require "active_support/message_encryptor"
 require "active_support/core_ext/string/strip"

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -45,7 +45,7 @@ class SourceAnnotationExtractor
     # If +options+ has a flag <tt>:tag</tt> the tag is shown as in the example above.
     # Otherwise the string contains just line and text.
     def to_s(options = {})
-      s = "[#{line.to_s.rjust(options[:indent])}] "
+      s = "[#{line.to_s.rjust(options[:indent])}] ".dup
       s << "[#{tag}] " if options[:tag]
       s << text
     end

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Implements the logic behind the rake tasks for annotations like
 #
 #   rails notes

--- a/railties/lib/rails/tasks.rb
+++ b/railties/lib/rails/tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rake"
 
 # Load Rails Rakefile extensions

--- a/railties/lib/rails/tasks/annotations.rake
+++ b/railties/lib/rails/tasks/annotations.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../source_annotation_extractor"
 
 desc "Enumerate all annotations (use notes:optimize, :fixme, :todo for focus)"

--- a/railties/lib/rails/tasks/dev.rake
+++ b/railties/lib/rails/tasks/dev.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../dev_caching"
 
 namespace :dev do

--- a/railties/lib/rails/tasks/engine.rake
+++ b/railties/lib/rails/tasks/engine.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 task "load_app" do
   namespace :app do
     load APP_RAKEFILE

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :app do
   desc "Update configs and some other initially generated files (or use just update:configs or update:bin)"
   task update: [ "update:configs", "update:bin", "update:upgrade_guide_info" ]

--- a/railties/lib/rails/tasks/initializers.rake
+++ b/railties/lib/rails/tasks/initializers.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 desc "Print out all defined initializers in the order they are invoked by Rails."
 task initializers: :environment do
   Rails.application.initializers.tsort_each do |initializer|

--- a/railties/lib/rails/tasks/log.rake
+++ b/railties/lib/rails/tasks/log.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :log do
 
   ##

--- a/railties/lib/rails/tasks/middleware.rake
+++ b/railties/lib/rails/tasks/middleware.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 desc "Prints out your Rack middleware stack"
 task middleware: :environment do
   Rails.configuration.middleware.each do |middleware|

--- a/railties/lib/rails/tasks/misc.rake
+++ b/railties/lib/rails/tasks/misc.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 desc "Generate a cryptographically secure secret key (this is typically used to generate a secret for cookie sessions)."
 task :secret do
   require "securerandom"

--- a/railties/lib/rails/tasks/restart.rake
+++ b/railties/lib/rails/tasks/restart.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 desc "Restart app by touching tmp/restart.txt"
 task :restart do
   verbose(false) do

--- a/railties/lib/rails/tasks/routes.rake
+++ b/railties/lib/rails/tasks/routes.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "optparse"
 
 desc "Print out all defined routes in match order, with names. Target specific controller with -c option, or grep routes using -g option"

--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # While global constants are bad, many 3rd party tools depend on this one (e.g
 # rspec-rails & cucumber-rails). So a deprecation warning is needed if we want
 # to remove it.

--- a/railties/lib/rails/tasks/tmp.rake
+++ b/railties/lib/rails/tasks/tmp.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :tmp do
   desc "Clear cache, socket and screenshot files from tmp/ (narrow w/ tmp:cache:clear, tmp:sockets:clear, tmp:screenshots:clear)"
   task clear: ["tmp:cache:clear", "tmp:sockets:clear", "tmp:screenshots:clear"]

--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :yarn do
   desc "Install all JavaScript dependencies as specified via Yarn"
   task :install do

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Make double-sure the RAILS_ENV is not set to production,
 # so fixtures aren't loaded into that environment
 abort("Abort testing: Your Rails environment is running in production mode!") if Rails.env.production?

--- a/railties/lib/rails/test_unit/line_filtering.rb
+++ b/railties/lib/rails/test_unit/line_filtering.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "method_source"
 require "rails/test_unit/runner"
 

--- a/railties/lib/rails/test_unit/railtie.rb
+++ b/railties/lib/rails/test_unit/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "line_filtering"
 
 if defined?(Rake.application) && Rake.application.top_level_tasks.grep(/^(default$|test(:|$))/).any?

--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/class/attribute"
 require "minitest"
 

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 gem "minitest"
 require "minitest"
 require_relative "runner"

--- a/railties/lib/rails/version.rb
+++ b/railties/lib/rails/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "gem_version"
 
 module Rails

--- a/railties/lib/rails/welcome_controller.rb
+++ b/railties/lib/rails/welcome_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "application_controller"
 
 class Rails::WelcomeController < Rails::ApplicationController # :nodoc:

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["RAILS_ENV"] ||= "test"
 
 require "stringio"

--- a/railties/test/app_loader_test.rb
+++ b/railties/test/app_loader_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "tmpdir"
 require "abstract_unit"
 require "rails/app_loader"

--- a/railties/test/application/asset_debugging_test.rb
+++ b/railties/test/application/asset_debugging_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rack/test"
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rack/test"
 require "active_support/json"

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/configuration/custom_test.rb
+++ b/railties/test/application/configuration/custom_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rack/test"
 require "env_helpers"

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "console_helpers"
 

--- a/railties/test/application/current_attributes_integration_test.rb
+++ b/railties/test/application/current_attributes_integration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rack/test"
 

--- a/railties/test/application/dbconsole_test.rb
+++ b/railties/test/application/dbconsole_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "console_helpers"
 

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/help_test.rb
+++ b/railties/test/application/help_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 class HelpTest < ActiveSupport::TestCase

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/initializers/hooks_test.rb
+++ b/railties/test/application/initializers/hooks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/initializers/i18n_test.rb
+++ b/railties/test/application/initializers/i18n_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/initializers/load_path_test.rb
+++ b/railties/test/application/initializers/load_path_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/initializers/notifications_test.rb
+++ b/railties/test/application/initializers/notifications_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/integration_test_case_test.rb
+++ b/railties/test/application/integration_test_case_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 class LoadingTest < ActiveSupport::TestCase

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rack/test"
 require "base64"

--- a/railties/test/application/middleware/cache_test.rb
+++ b/railties/test/application/middleware/cache_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/middleware/cookies_test.rb
+++ b/railties/test/application/middleware/cookies_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rack/test"
 

--- a/railties/test/application/middleware/remote_ip_test.rb
+++ b/railties/test/application/middleware/remote_ip_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "ipaddr"
 require "isolation/abstract_unit"
 require "active_support/key_generator"

--- a/railties/test/application/middleware/sendfile_test.rb
+++ b/railties/test/application/middleware/sendfile_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rack/test"
 

--- a/railties/test/application/middleware/static_test.rb
+++ b/railties/test/application/middleware/static_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rack/test"
 

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/multiple_applications_test.rb
+++ b/railties/test/application/multiple_applications_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/paths_test.rb
+++ b/railties/test/application/paths_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/per_request_digest_cache_test.rb
+++ b/railties/test/application/per_request_digest_cache_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rack/test"
 require "minitest/mock"

--- a/railties/test/application/rack/logger_test.rb
+++ b/railties/test/application/rack/logger_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "active_support/log_subscriber/test_helper"
 require "rack/test"

--- a/railties/test/application/rackup_test.rb
+++ b/railties/test/application/rackup_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/rake/dev_test.rb
+++ b/railties/test/application/rake/dev_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/rake/framework_test.rb
+++ b/railties/test/application/rake/framework_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/rake/log_test.rb
+++ b/railties/test/application/rake/log_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rails/source_annotation_extractor"
 

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -90,7 +90,8 @@ module ApplicationTests
 
       test "custom rake task finds specific notes in specific directories" do
         app_file "app/controllers/some_controller.rb", "# TODO: note in app directory"
-        app_file "lib/some_file.rb", "# OPTIMIZE: note in lib directory\n" << "# FIXME: note in lib directory"
+        app_file "lib/some_file.rb", "# OPTIMIZE: note in lib directory\n" \
+          "# FIXME: note in lib directory"
         app_file "test/some_test.rb", 1000.times.map { "" }.join("\n") << "# TODO: note in test directory"
 
         app_file "lib/tasks/notes_custom.rake", <<-EOS

--- a/railties/test/application/rake/restart_test.rb
+++ b/railties/test/application/rake/restart_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/rake/tmp_test.rb
+++ b/railties/test/application/rake/tmp_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "active_support/core_ext/string/strip"
 

--- a/railties/test/application/rendering_test.rb
+++ b/railties/test/application/rendering_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rack/test"
 

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rack/test"
 

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "env_helpers"
 

--- a/railties/test/application/server_test.rb
+++ b/railties/test/application/server_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rails/command"
 require "rails/commands/server/server_command"

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "active_support/core_ext/string/strip"
 require "env_helpers"

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/url_generation_test.rb
+++ b/railties/test/application/url_generation_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/application/version_test.rb
+++ b/railties/test/application/version_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rails/gem_version"
 

--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "rails/backtrace_cleaner"
 

--- a/railties/test/code_statistics_calculator_test.rb
+++ b/railties/test/code_statistics_calculator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "rails/code_statistics_calculator"
 

--- a/railties/test/code_statistics_test.rb
+++ b/railties/test/code_statistics_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "rails/code_statistics"
 

--- a/railties/test/command/base_test.rb
+++ b/railties/test/command/base_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "rails/command"
 require "rails/commands/generate/generate_command"

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "env_helpers"
 require "rails/command"

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "minitest/mock"
 require "rails/command"

--- a/railties/test/commands/secrets_test.rb
+++ b/railties/test/commands/secrets_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "rails/command"
 require "rails/commands/secrets/secrets_command"

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "env_helpers"
 require "rails/command"

--- a/railties/test/configuration/middleware_stack_proxy_test.rb
+++ b/railties/test/configuration/middleware_stack_proxy_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support"
 require "active_support/testing/autorun"
 require "rails/configuration"

--- a/railties/test/console_helpers.rb
+++ b/railties/test/console_helpers.rb
@@ -7,7 +7,7 @@ module ConsoleHelpers
   def assert_output(expected, io, timeout = 10)
     timeout = Time.now + timeout
 
-    output = ""
+    output = "".dup
     until output.include?(expected) || Time.now > timeout
       if IO.select([io], [], [], 0.1)
         output << io.read(1)

--- a/railties/test/console_helpers.rb
+++ b/railties/test/console_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "pty"
 rescue LoadError

--- a/railties/test/engine/commands_test.rb
+++ b/railties/test/engine/commands_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "console_helpers"
 

--- a/railties/test/engine_test.rb
+++ b/railties/test/engine_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class EngineTest < ActiveSupport::TestCase

--- a/railties/test/env_helpers.rb
+++ b/railties/test/env_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails"
 
 module EnvHelpers

--- a/railties/test/fixtures/about_yml_plugins/bad_about_yml/init.rb
+++ b/railties/test/fixtures/about_yml_plugins/bad_about_yml/init.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 # intentionally empty

--- a/railties/test/fixtures/about_yml_plugins/plugin_without_about_yml/init.rb
+++ b/railties/test/fixtures/about_yml_plugins/plugin_without_about_yml/init.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 # intentionally empty

--- a/railties/test/fixtures/lib/create_test_dummy_template.rb
+++ b/railties/test/fixtures/lib/create_test_dummy_template.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 create_dummy_app("spec/dummy")

--- a/railties/test/fixtures/lib/generators/active_record/fixjour_generator.rb
+++ b/railties/test/fixtures/lib/generators/active_record/fixjour_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails/generators/active_record"
 
 module ActiveRecord

--- a/railties/test/fixtures/lib/generators/fixjour_generator.rb
+++ b/railties/test/fixtures/lib/generators/fixjour_generator.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class FixjourGenerator < Rails::Generators::NamedBase
 end

--- a/railties/test/fixtures/lib/generators/model_generator.rb
+++ b/railties/test/fixtures/lib/generators/model_generator.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 raise "I should never be loaded"

--- a/railties/test/fixtures/lib/generators/usage_template/usage_template_generator.rb
+++ b/railties/test/fixtures/lib/generators/usage_template/usage_template_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails/generators"
 
 class UsageTemplateGenerator < Rails::Generators::Base

--- a/railties/test/fixtures/lib/rails/generators/foobar/foobar_generator.rb
+++ b/railties/test/fixtures/lib/rails/generators/foobar/foobar_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Foobar
   class FoobarGenerator < Rails::Generators::Base
   end

--- a/railties/test/fixtures/lib/template.rb
+++ b/railties/test/fixtures/lib/template.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 say "It works from file!"

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -383,6 +383,7 @@ class ActionsTest < Rails::Generators::TestCase
     File.open(route_path, "wb") { |file| file.write(content) }
 
     routes = <<-F
+# frozen_string_literal: true
 Rails.application.routes.draw do
   root 'welcome#index'
 end
@@ -393,6 +394,7 @@ F
     action :route, "resources :product_lines"
 
     routes = <<-F
+# frozen_string_literal: true
 Rails.application.routes.draw do
   resources :product_lines
   root 'welcome#index'

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/app/app_generator"
 require "env_helpers"

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/app/app_generator"
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/app/app_generator"
 require "generators/shared_generator_tests"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -880,7 +880,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_after_bundle_callback
     path = "http://example.org/rails_template"
-    template = %{ after_bundle { run 'echo ran after_bundle' } }
+    template = %{ after_bundle { run 'echo ran after_bundle' } }.dup
     template.instance_eval "def read; self; end" # Make the string respond to read
 
     check_open = -> *args do

--- a/railties/test/generators/application_record_generator_test.rb
+++ b/railties/test/generators/application_record_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/application_record/application_record_generator"
 

--- a/railties/test/generators/argv_scrubber_test.rb
+++ b/railties/test/generators/argv_scrubber_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/test_case"
 require "active_support/testing/autorun"
 require "rails/generators/rails/app/app_generator"

--- a/railties/test/generators/assets_generator_test.rb
+++ b/railties/test/generators/assets_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/assets/assets_generator"
 

--- a/railties/test/generators/channel_generator_test.rb
+++ b/railties/test/generators/channel_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/channel/channel_generator"
 

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/controller/controller_generator"
 

--- a/railties/test/generators/create_migration_test.rb
+++ b/railties/test/generators/create_migration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/migration/migration_generator"
 

--- a/railties/test/generators/encrypted_secrets_generator_test.rb
+++ b/railties/test/generators/encrypted_secrets_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/encrypted_secrets/encrypted_secrets_generator"
 

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/generated_attribute"
 

--- a/railties/test/generators/generator_generator_test.rb
+++ b/railties/test/generators/generator_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/generator/generator_generator"
 

--- a/railties/test/generators/generator_test.rb
+++ b/railties/test/generators/generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/test_case"
 require "active_support/testing/autorun"
 require "rails/generators/app_base"

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "active_support/core_ext/module/remove_method"
 require "active_support/testing/stream"

--- a/railties/test/generators/helper_generator_test.rb
+++ b/railties/test/generators/helper_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/helper/helper_generator"
 

--- a/railties/test/generators/integration_test_generator_test.rb
+++ b/railties/test/generators/integration_test_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/integration_test/integration_test_generator"
 

--- a/railties/test/generators/job_generator_test.rb
+++ b/railties/test/generators/job_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/job/job_generator"
 

--- a/railties/test/generators/mailer_generator_test.rb
+++ b/railties/test/generators/mailer_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/mailer/mailer_generator"
 

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/migration/migration_generator"
 

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/model/model_generator"
 require "active_support/core_ext/string/strip"

--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/scaffold_controller/scaffold_controller_generator"
 

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/controller/controller_generator"
 require "rails/generators/rails/model/model_generator"

--- a/railties/test/generators/orm_test.rb
+++ b/railties/test/generators/orm_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/scaffold_controller/scaffold_controller_generator"
 

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/plugin/plugin_generator"
 require "generators/shared_generator_tests"

--- a/railties/test/generators/plugin_test_helper.rb
+++ b/railties/test/generators/plugin_test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "tmpdir"
 

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/plugin_test_helper"
 
 class PluginTestRunnerTest < ActiveSupport::TestCase

--- a/railties/test/generators/resource_generator_test.rb
+++ b/railties/test/generators/resource_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/resource/resource_generator"
 

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/scaffold_controller/scaffold_controller_generator"
 

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/scaffold/scaffold_generator"
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Tests, setup, and teardown common to the application and plugin generator suites.
 #

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -77,7 +77,7 @@ module SharedGeneratorTests
 
   def test_template_is_executed_when_supplied_an_https_path
     path = "https://gist.github.com/josevalim/103208/raw/"
-    template = %{ say "It works!" }
+    template = %{ say "It works!" }.dup
     template.instance_eval "def read; self; end" # Make the string respond to read
 
     check_open = -> *args do

--- a/railties/test/generators/system_test_generator_test.rb
+++ b/railties/test/generators/system_test_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/system_test/system_test_generator"
 

--- a/railties/test/generators/task_generator_test.rb
+++ b/railties/test/generators/task_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/task/task_generator"
 

--- a/railties/test/generators/test_runner_in_engine_test.rb
+++ b/railties/test/generators/test_runner_in_engine_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/plugin_test_helper"
 
 class TestRunnerInEngineTest < ActiveSupport::TestCase

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "generators/generators_test_helper"
 require "rails/generators/rails/model/model_generator"
 require "rails/generators/test_unit/model/model_generator"

--- a/railties/test/initializable_test.rb
+++ b/railties/test/initializable_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "rails/initializable"
 

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -66,7 +66,7 @@ module TestHelpers
     end
 
     def extract_body(response)
-      "".tap do |body|
+      "".dup.tap do |body|
         response[2].each { |chunk| body << chunk }
       end
     end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Note:
 # It is important to keep this file as light as possible
 # the goal for tests that require this is to test booting up

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -224,8 +224,8 @@ module TestHelpers
       FileUtils.mkdir_p(dir)
 
       app = File.readlines("#{app_path}/config/application.rb")
-      app.insert(2, "$:.unshift(\"#{dir}/lib\")")
-      app.insert(3, "require #{name.inspect}")
+      app.insert(4, "$:.unshift(\"#{dir}/lib\")")
+      app.insert(5, "require #{name.inspect}")
 
       File.open("#{app_path}/config/application.rb", "r+") do |f|
         f.puts app

--- a/railties/test/json_params_parsing_test.rb
+++ b/railties/test/json_params_parsing_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "action_dispatch"
 require "active_record"

--- a/railties/test/path_generation_test.rb
+++ b/railties/test/path_generation_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "active_support/core_ext/object/with_options"
 require "active_support/core_ext/object/json"

--- a/railties/test/paths_test.rb
+++ b/railties/test/paths_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "rails/paths"
 require "minitest/mock"

--- a/railties/test/rack_logger_test.rb
+++ b/railties/test/rack_logger_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "active_support/testing/autorun"
 require "active_support/test_case"

--- a/railties/test/rails_info_controller_test.rb
+++ b/railties/test/rails_info_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 module ActionController

--- a/railties/test/rails_info_test.rb
+++ b/railties/test/rails_info_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 unless defined?(Rails) && defined?(Rails::Info)

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 require "stringio"
 require "rack/test"

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -503,7 +503,7 @@ YAML
 
       def call(env)
         response = @app.call(env)
-        response[2].each(&:upcase!)
+        response[2] = response[2].collect(&:upcase)
         response
       end
     end

--- a/railties/test/railties/generators_test.rb
+++ b/railties/test/railties/generators_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RAILS_ISOLATED_ENGINE = true
 require "isolation/abstract_unit"
 

--- a/railties/test/railties/mounted_engine_test.rb
+++ b/railties/test/railties/mounted_engine_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module ApplicationTests

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "isolation/abstract_unit"
 
 module RailtiesTest

--- a/railties/test/secrets_test.rb
+++ b/railties/test/secrets_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "isolation/abstract_unit"
 require "rails/generators"

--- a/railties/test/secrets_test.rb
+++ b/railties/test/secrets_test.rb
@@ -133,7 +133,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
           api_key: 00112233445566778899aabbccddeeff…
       end_of_secrets
 
-      Rails::Secrets.write(secrets.force_encoding(Encoding::ASCII_8BIT))
+      Rails::Secrets.write(secrets.dup.force_encoding(Encoding::ASCII_8BIT))
 
       Rails::Secrets.read_for_editing do |tmp_path|
         assert_match(/production:\n\s*api_key: 00112233445566778899aabbccddeeff…\n/, File.read(tmp_path))
@@ -153,7 +153,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
       Rails::Secrets.write(secrets)
 
       Rails::Secrets.read_for_editing do |tmp_path|
-        assert_equal(secrets.force_encoding(Encoding::ASCII_8BIT), IO.binread(tmp_path))
+        assert_equal(secrets.dup.force_encoding(Encoding::ASCII_8BIT), IO.binread(tmp_path))
       end
 
       assert_equal "00112233445566778899aabbccddeeff…\n", `bin/rails runner -e production "puts Rails.application.secrets.api_key"`

--- a/railties/test/test_unit/reporter_test.rb
+++ b/railties/test/test_unit/reporter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "rails/test_unit/reporter"
 require "minitest/mock"

--- a/railties/test/version_test.rb
+++ b/railties/test/version_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class VersionTest < ActiveSupport::TestCase


### PR DESCRIPTION
Updates to railties for frozen-string-literals compatibility.

It's worth noting that there are dependencies on the following libraries that aren't yet compatible:

* [rack](https://github.com/rack/rack/pull/1182)
* [thor](https://github.com/erikhuda/thor/pull/567)
* [method_source](https://github.com/banister/method_source/pull/47)
* [puma](https://github.com/puma/puma/pull/1376)
* [sass](https://github.com/sass/sass/pull/2352)

When the above patches are in play, then the tests pass with `RUBYOPT="--enable-frozen-string-literal"`.

/cc @kirs given you're doing a lot of this work too!