### PR TITLE
Avoid modifying frozen string in check_schema_file

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -261,7 +261,7 @@ module ActiveRecord
 
       def check_schema_file(filename)
         unless File.exist?(filename)
-          message = %{#{filename} doesn't exist yet. Run `rails db:migrate` to create it, then try again.}
+          message = %{#{filename} doesn't exist yet. Run `rails db:migrate` to create it, then try again.}.dup
           message << %{ If you do not intend to use a database, you should instead alter #{Rails.root}/config/application.rb to limit the frameworks that will be loaded.} if defined?(::Rails.root)
           Kernel.abort message
         end

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -259,6 +259,13 @@ module ApplicationTests
         end
       end
 
+      test "db:schema:load fails if schema.rb doesn't exist yet" do
+        Dir.chdir(app_path) do
+          stderr_output = capture(:stderr) { `bin/rails db:schema:load` }
+          assert_match /Run `rails db:migrate` to create it/, stderr_output
+        end
+      end
+
       def db_test_load_structure
         Dir.chdir(app_path) do
           `bin/rails generate model book title:string;


### PR DESCRIPTION
```bash
$ rails new --edge bug
      create
# ...
$ cd bug; bin/rails db:schema:load
rails aborted!
can't modify frozen String
bin/rails:9:in `require'
bin/rails:9:in `<main>'
Tasks: TOP => db:schema:load
(See full trace by running task with --trace)
```

This was missed when the frozen string pragma was added to this file in https://github.com/rails/rails/pull/29732 because the string is only modified when running in the context of a full Rails app, which isn't covered by the test suite.

~~~I opted to manually stub the `Rails.root` method so that this code path is exercised in the existing test, using an approach cribbed from [another test file](https://github.com/rails/rails/blob/v5.1.2/actionview/test/template/log_subscriber_test.rb#L19-L22). Another option would be to add a new integration test to the Railties suite, but that seemed excessive to me for such a simple fix.~~~ I switched to an integration test!