### PR TITLE
Integration session: Set CONTENT_TYPE only if available

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -247,9 +247,11 @@ module ActionDispatch
           "REQUEST_URI"    => path,
           "HTTP_HOST"      => host,
           "REMOTE_ADDR"    => remote_addr,
-          "CONTENT_TYPE"   => request_encoder.content_type,
           "HTTP_ACCEPT"    => request_encoder.accept_header || accept
         }
+
+        content_type = request_encoder.content_type
+        request_env["CONTENT_TYPE"] = content_type if content_type
 
         wrapped_headers = Http::Headers.from_hash({})
         wrapped_headers.merge!(headers) if headers

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -569,6 +569,16 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     ActionDispatch::Request.ignore_accept_header = original_ignore_accept_header
   end
 
+  def test_request_content_type
+    with_test_route_set do
+      get "/get"
+      assert_not_includes request.env, "CONTENT_TYPE"
+
+      get "/get", as: :json
+      assert_not_nil request.env["CONTENT_TYPE"]
+    end
+  end
+
   private
     def with_default_headers(headers)
       original = ActionDispatch::Response.default_headers


### PR DESCRIPTION
By default an integration session puts a `CONTENT_TYPE` of `nil` into the request environment, which violates the Rack protocol:

> The CGI keys (named without a period) must have String values.
http://www.rubydoc.info/github/rack/rack/master/file/SPEC#The_Environment

The bug can be demonstrated like this:
```ruby
require "action_controller"

app = ->(env) { [200, {}, []] }
lint = Rack::Lint.new(app)

session = ActionDispatch::Integration::Session.new(lint)
session.get '/'
```
```
env variable CONTENT_TYPE has non-string value nil (Rack::Lint::LintError)
```
This made one of our middlewares (which proxies some requests to other apps) crash during tests.
First noticed with Rails 5.0.4; same in master (8ee9ace27b79a1e8d82e9e9482966781686d4851).

I am not quite sure where to add a test for this.