### PR TITLE
Use frozen string literal in actionmailer/

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -91,6 +91,7 @@ Style/FrozenStringLiteralComment:
     - 'activemodel/**/*'
     - 'activejob/**/*'
     - 'activerecord/**/*'
+    - 'actionmailer/**/*'
 
 # Use `foo {}` not `foo{}`.
 Layout/SpaceBeforeBlockBraces:

--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rake/testtask"
 
 desc "Default Task"

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|

--- a/actionmailer/bin/test
+++ b/actionmailer/bin/test
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"

--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #--
 # Copyright (c) 2004-2017 David Heinemeier Hansson
 #

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "mail"
 require_relative "collector"
 require "active_support/core_ext/string/inflections"

--- a/actionmailer/lib/action_mailer/collector.rb
+++ b/actionmailer/lib/action_mailer/collector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_controller/collector"
 require "active_support/core_ext/hash/reverse_merge"
 require "active_support/core_ext/array/extract_options"

--- a/actionmailer/lib/action_mailer/delivery_job.rb
+++ b/actionmailer/lib/action_mailer/delivery_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_job"
 
 module ActionMailer

--- a/actionmailer/lib/action_mailer/delivery_methods.rb
+++ b/actionmailer/lib/action_mailer/delivery_methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "tmpdir"
 
 module ActionMailer

--- a/actionmailer/lib/action_mailer/gem_version.rb
+++ b/actionmailer/lib/action_mailer/gem_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionMailer
   # Returns the version of the currently loaded Action Mailer as a <tt>Gem::Version</tt>.
   def self.gem_version

--- a/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
+++ b/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "base64"
 
 module ActionMailer

--- a/actionmailer/lib/action_mailer/log_subscriber.rb
+++ b/actionmailer/lib/action_mailer/log_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/log_subscriber"
 
 module ActionMailer

--- a/actionmailer/lib/action_mailer/mail_helper.rb
+++ b/actionmailer/lib/action_mailer/mail_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionMailer
   # Provides helper methods for ActionMailer::Base that can be used for easily
   # formatting messages, accessing mailer or message instances, and the

--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "delegate"
 
 module ActionMailer

--- a/actionmailer/lib/action_mailer/parameterized.rb
+++ b/actionmailer/lib/action_mailer/parameterized.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionMailer
   # Provides the option to parameterize mailers in order to share instance variable
   # setup, processing, and common headers.

--- a/actionmailer/lib/action_mailer/preview.rb
+++ b/actionmailer/lib/action_mailer/preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/descendants_tracker"
 
 module ActionMailer

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_job/railtie"
 require "action_mailer"
 require "rails"

--- a/actionmailer/lib/action_mailer/rescuable.rb
+++ b/actionmailer/lib/action_mailer/rescuable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionMailer #:nodoc:
   # Provides `rescue_from` for mailers. Wraps mailer action processing,
   # mail job processing, and mail delivery.

--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/test_case"
 require "rails-dom-testing"
 

--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_job"
 
 module ActionMailer

--- a/actionmailer/lib/action_mailer/version.rb
+++ b/actionmailer/lib/action_mailer/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "gem_version"
 
 module ActionMailer

--- a/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
+++ b/actionmailer/lib/rails/generators/mailer/mailer_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Generators
     class MailerGenerator < NamedBase

--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/kernel/reporting"
 
 # These are the normal settings that will be set up by Railties

--- a/actionmailer/test/assert_select_email_test.rb
+++ b/actionmailer/test/assert_select_email_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class AssertSelectEmailTest < ActionMailer::TestCase

--- a/actionmailer/test/asset_host_test.rb
+++ b/actionmailer/test/asset_host_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "action_controller"
 

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "set"
 

--- a/actionmailer/test/caching_test.rb
+++ b/actionmailer/test/caching_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "fileutils"
 require "abstract_unit"
 require "mailers/base_mailer"

--- a/actionmailer/test/delivery_methods_test.rb
+++ b/actionmailer/test/delivery_methods_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class MyCustomDelivery

--- a/actionmailer/test/i18n_with_controller_test.rb
+++ b/actionmailer/test/i18n_with_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "action_view"
 require "action_controller"

--- a/actionmailer/test/log_subscriber_test.rb
+++ b/actionmailer/test/log_subscriber_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "mailers/base_mailer"
 require "active_support/log_subscriber/test_helper"

--- a/actionmailer/test/mail_helper_test.rb
+++ b/actionmailer/test/mail_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class HelperMailer < ActionMailer::Base

--- a/actionmailer/test/mail_layout_test.rb
+++ b/actionmailer/test/mail_layout_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class AutoLayoutMailer < ActionMailer::Base

--- a/actionmailer/test/mailers/asset_mailer.rb
+++ b/actionmailer/test/mailers/asset_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AssetMailer < ActionMailer::Base
   self.mailer_name = "asset_mailer"
 

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BaseMailer < ActionMailer::Base
   self.mailer_name = "base_mailer"
 

--- a/actionmailer/test/mailers/caching_mailer.rb
+++ b/actionmailer/test/mailers/caching_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CachingMailer < ActionMailer::Base
   self.mailer_name = "caching_mailer"
 

--- a/actionmailer/test/mailers/delayed_mailer.rb
+++ b/actionmailer/test/mailers/delayed_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_job/arguments"
 
 class DelayedMailerError < StandardError; end

--- a/actionmailer/test/mailers/params_mailer.rb
+++ b/actionmailer/test/mailers/params_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ParamsMailer < ActionMailer::Base
   before_action { @inviter, @invitee = params[:inviter], params[:invitee] }
 

--- a/actionmailer/test/mailers/proc_mailer.rb
+++ b/actionmailer/test/mailers/proc_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ProcMailer < ActionMailer::Base
   default to: "system@test.lindsaar.net",
           "X-Proc-Method" => Proc.new { Time.now.to_i.to_s },

--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "active_job"
 require "mailers/delayed_mailer"

--- a/actionmailer/test/parameterized_test.rb
+++ b/actionmailer/test/parameterized_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "active_job"
 require "mailers/params_mailer"

--- a/actionmailer/test/test_case_test.rb
+++ b/actionmailer/test/test_case_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class TestTestMailer < ActionMailer::Base

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "active_support/testing/stream"
 

--- a/actionmailer/test/url_test.rb
+++ b/actionmailer/test/url_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "action_controller"
 


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/29655

Extends `Style/FrozenStringLiteralComment` Rubocop rule to `actionmailer/`.

The commit is just `rubocop -a` after changing the Rubocop rule.

Similar to:
https://github.com/rails/rails/pull/29728
https://github.com/rails/rails/pull/29819
https://github.com/rails/rails/pull/29732

