### PR TITLE
Use frozen string literal in actionview/

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,6 +93,10 @@ Style/FrozenStringLiteralComment:
     - 'activejob/**/*'
     - 'activerecord/**/*'
     - 'actionmailer/**/*'
+    - 'actionview/**/*'
+  Exclude:
+    - 'actionview/test/**/*.builder'
+    - 'actionview/test/**/*.ruby'
 
 # Use `foo {}` not `foo{}`.
 Layout/SpaceBeforeBlockBraces:

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rake/testtask"
 require "fileutils"
 require "open3"

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 version = File.read(File.expand_path("../RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|

--- a/actionview/bin/test
+++ b/actionview/bin/test
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #--
 # Copyright (c) 2004-2017 David Heinemeier Hansson
 #

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/module/attr_internal"
 require "active_support/core_ext/module/attribute_accessors"
 require "active_support/ordered_options"

--- a/actionview/lib/action_view/buffers.rb
+++ b/actionview/lib/action_view/buffers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/string/output_safety"
 
 module ActionView

--- a/actionview/lib/action_view/context.rb
+++ b/actionview/lib/action_view/context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module CompiledTemplates #:nodoc:
     # holds compiled template code

--- a/actionview/lib/action_view/dependency_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "concurrent/map"
 require_relative "path_set"
 

--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "concurrent/map"
 require_relative "dependency_tracker"
 require "monitor"

--- a/actionview/lib/action_view/flows.rb
+++ b/actionview/lib/action_view/flows.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/string/output_safety"
 
 module ActionView

--- a/actionview/lib/action_view/gem_version.rb
+++ b/actionview/lib/action_view/gem_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   # Returns the version of the currently loaded Action View as a <tt>Gem::Version</tt>
   def self.gem_version

--- a/actionview/lib/action_view/helpers.rb
+++ b/actionview/lib/action_view/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/benchmarkable"
 
 module ActionView #:nodoc:

--- a/actionview/lib/action_view/helpers/active_model_helper.rb
+++ b/actionview/lib/action_view/helpers/active_model_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/module/attribute_accessors"
 require "active_support/core_ext/enumerable"
 

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/array/extract_options"
 require "active_support/core_ext/hash/keys"
 require_relative "asset_url_helper"

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "zlib"
 
 module ActionView

--- a/actionview/lib/action_view/helpers/atom_feed_helper.rb
+++ b/actionview/lib/action_view/helpers/atom_feed_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "set"
 
 module ActionView

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   # = Action View Cache Helper
   module Helpers

--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/string/output_safety"
 
 module ActionView

--- a/actionview/lib/action_view/helpers/controller_helper.rb
+++ b/actionview/lib/action_view/helpers/controller_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/module/attr_internal"
 
 module ActionView

--- a/actionview/lib/action_view/helpers/csrf_helper.rb
+++ b/actionview/lib/action_view/helpers/csrf_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   # = Action View CSRF Helper
   module Helpers

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "date"
 require_relative "tag_helper"
 require "active_support/core_ext/array/extract_options"

--- a/actionview/lib/action_view/helpers/debug_helper.rb
+++ b/actionview/lib/action_view/helpers/debug_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   # = Action View Debug Helper
   #

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "cgi"
 require_relative "date_helper"
 require_relative "tag_helper"

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "cgi"
 require "erb"
 require_relative "form_helper"

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "cgi"
 require_relative "tag_helper"
 require "active_support/core_ext/string/output_safety"

--- a/actionview/lib/action_view/helpers/javascript_helper.rb
+++ b/actionview/lib/action_view/helpers/javascript_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "tag_helper"
 
 module ActionView

--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/string/output_safety"
 require "active_support/number_helper"

--- a/actionview/lib/action_view/helpers/output_safety_helper.rb
+++ b/actionview/lib/action_view/helpers/output_safety_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/string/output_safety"
 
 module ActionView #:nodoc:

--- a/actionview/lib/action_view/helpers/record_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/record_tag_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module RecordTagHelper

--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     # = Action View Rendering

--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/object/try"
 require "rails-html-sanitizer"
 

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 require "active_support/core_ext/string/output_safety"
 require "set"

--- a/actionview/lib/action_view/helpers/tags.rb
+++ b/actionview/lib/action_view/helpers/tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags #:nodoc:

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/check_box.rb
+++ b/actionview/lib/action_view/helpers/tags/check_box.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "checkable"
 
 module ActionView

--- a/actionview/lib/action_view/helpers/tags/checkable.rb
+++ b/actionview/lib/action_view/helpers/tags/checkable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/collection_check_boxes.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_check_boxes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "collection_helpers"
 
 module ActionView

--- a/actionview/lib/action_view/helpers/tags/collection_helpers.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/collection_radio_buttons.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_radio_buttons.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "collection_helpers"
 
 module ActionView

--- a/actionview/lib/action_view/helpers/tags/collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_select.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/color_field.rb
+++ b/actionview/lib/action_view/helpers/tags/color_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/date_field.rb
+++ b/actionview/lib/action_view/helpers/tags/date_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/date_select.rb
+++ b/actionview/lib/action_view/helpers/tags/date_select.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/time/calculations"
 
 module ActionView

--- a/actionview/lib/action_view/helpers/tags/datetime_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/datetime_local_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_local_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/datetime_select.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_select.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/email_field.rb
+++ b/actionview/lib/action_view/helpers/tags/email_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/file_field.rb
+++ b/actionview/lib/action_view/helpers/tags/file_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/grouped_collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/grouped_collection_select.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/hidden_field.rb
+++ b/actionview/lib/action_view/helpers/tags/hidden_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/label.rb
+++ b/actionview/lib/action_view/helpers/tags/label.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/month_field.rb
+++ b/actionview/lib/action_view/helpers/tags/month_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/number_field.rb
+++ b/actionview/lib/action_view/helpers/tags/number_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/password_field.rb
+++ b/actionview/lib/action_view/helpers/tags/password_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/placeholderable.rb
+++ b/actionview/lib/action_view/helpers/tags/placeholderable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/radio_button.rb
+++ b/actionview/lib/action_view/helpers/tags/radio_button.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "checkable"
 
 module ActionView

--- a/actionview/lib/action_view/helpers/tags/range_field.rb
+++ b/actionview/lib/action_view/helpers/tags/range_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/search_field.rb
+++ b/actionview/lib/action_view/helpers/tags/search_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/tel_field.rb
+++ b/actionview/lib/action_view/helpers/tags/tel_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/text_area.rb
+++ b/actionview/lib/action_view/helpers/tags/text_area.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "placeholderable"
 
 module ActionView

--- a/actionview/lib/action_view/helpers/tags/text_field.rb
+++ b/actionview/lib/action_view/helpers/tags/text_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "placeholderable"
 
 module ActionView

--- a/actionview/lib/action_view/helpers/tags/time_field.rb
+++ b/actionview/lib/action_view/helpers/tags/time_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/time_select.rb
+++ b/actionview/lib/action_view/helpers/tags/time_select.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/time_zone_select.rb
+++ b/actionview/lib/action_view/helpers/tags/time_zone_select.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/translator.rb
+++ b/actionview/lib/action_view/helpers/tags/translator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/url_field.rb
+++ b/actionview/lib/action_view/helpers/tags/url_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/tags/week_field.rb
+++ b/actionview/lib/action_view/helpers/tags/week_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Helpers
     module Tags # :nodoc:

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/string/filters"
 require "active_support/core_ext/array/extract_options"
 

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "tag_helper"
 require "active_support/core_ext/string/access"
 require "i18n/exceptions"

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "javascript_helper"
 require "active_support/core_ext/array/access"
 require "active_support/core_ext/hash/keys"

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "rendering"
 require "active_support/core_ext/module/remove_method"
 

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "concurrent/map"
 require "active_support/core_ext/module/remove_method"
 require "active_support/core_ext/module/attribute_accessors"

--- a/actionview/lib/action_view/model_naming.rb
+++ b/actionview/lib/action_view/model_naming.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module ModelNaming #:nodoc:
     # Converts the given object to an ActiveModel compliant one.

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView #:nodoc:
   # = Action View PathSet
   #

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "action_view"
 require "rails"
 

--- a/actionview/lib/action_view/record_identifier.rb
+++ b/actionview/lib/action_view/record_identifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/module"
 require_relative "model_naming"
 

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   # This class defines the interface for a renderer. Each class that
   # subclasses +AbstractRenderer+ is used by the base +Renderer+ class to

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "concurrent/map"
 require_relative "partial_renderer/collection_caching"
 

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module CollectionCaching # :nodoc:
     extend ActiveSupport::Concern

--- a/actionview/lib/action_view/renderer/renderer.rb
+++ b/actionview/lib/action_view/renderer/renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   # This is the main entry point for rendering. It basically delegates
   # to other objects like TemplateRenderer and PartialRenderer which

--- a/actionview/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionview/lib/action_view/renderer/streaming_template_renderer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "fiber"
 
 module ActionView

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/object/try"
 
 module ActionView

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "view_paths"
 
 module ActionView

--- a/actionview/lib/action_view/routing_url_for.rb
+++ b/actionview/lib/action_view/routing_url_for.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "action_dispatch/routing/polymorphic_routes"
 
 module ActionView

--- a/actionview/lib/action_view/tasks/cache_digests.rake
+++ b/actionview/lib/action_view/tasks/cache_digests.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :cache_digests do
   desc "Lookup nested dependencies for TEMPLATE (like messages/show or comments/_comment.html)"
   task nested_dependencies: :environment do

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/enumerable"
 
 module ActionView

--- a/actionview/lib/action_view/template/handlers.rb
+++ b/actionview/lib/action_view/template/handlers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView #:nodoc:
   # = Action View Template Handlers
   class Template

--- a/actionview/lib/action_view/template/handlers/builder.rb
+++ b/actionview/lib/action_view/template/handlers/builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Template::Handlers
     class Builder

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   class Template
     module Handlers

--- a/actionview/lib/action_view/template/handlers/erb/deprecated_erubis.rb
+++ b/actionview/lib/action_view/template/handlers/erb/deprecated_erubis.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ::ActiveSupport::Deprecation.warn("ActionView::Template::Handlers::Erubis is deprecated and will be removed from Rails 5.2. Switch to ActionView::Template::Handlers::ERB::Erubi instead.")
 
 module ActionView

--- a/actionview/lib/action_view/template/handlers/erb/erubi.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubi.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "erubi"
 
 module ActionView

--- a/actionview/lib/action_view/template/handlers/erb/erubis.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubis.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 gem "erubis"
 require "erubis"
 

--- a/actionview/lib/action_view/template/handlers/html.rb
+++ b/actionview/lib/action_view/template/handlers/html.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Template::Handlers
     class Html < Raw

--- a/actionview/lib/action_view/template/handlers/raw.rb
+++ b/actionview/lib/action_view/template/handlers/raw.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module Template::Handlers
     class Raw

--- a/actionview/lib/action_view/template/html.rb
+++ b/actionview/lib/action_view/template/html.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView #:nodoc:
   # = Action View HTML Template
   class Template

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "pathname"
 require "active_support/core_ext/class"
 require "active_support/core_ext/module/attribute_accessors"

--- a/actionview/lib/action_view/template/text.rb
+++ b/actionview/lib/action_view/template/text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView #:nodoc:
   # = Action View Text Template
   class Template

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/module/attribute_accessors"
 
 module ActionView

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/module/remove_method"
 require "action_controller"
 require "action_controller/test_case"

--- a/actionview/lib/action_view/testing/resolvers.rb
+++ b/actionview/lib/action_view/testing/resolvers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../template/resolver"
 
 module ActionView #:nodoc:

--- a/actionview/lib/action_view/version.rb
+++ b/actionview/lib/action_view/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "gem_version"
 
 module ActionView

--- a/actionview/lib/action_view/view_paths.rb
+++ b/actionview/lib/action_view/view_paths.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionView
   module ViewPaths
     extend ActiveSupport::Concern

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $:.unshift File.expand_path("lib", __dir__)
 $:.unshift File.expand_path("fixtures/helpers", __dir__)
 $:.unshift File.expand_path("fixtures/alternate_helpers", __dir__)

--- a/actionview/test/actionpack/abstract/abstract_controller_test.rb
+++ b/actionview/test/actionpack/abstract/abstract_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "set"
 

--- a/actionview/test/actionpack/abstract/helper_test.rb
+++ b/actionview/test/actionpack/abstract/helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 ActionController::Base.helpers_path = File.expand_path("../../fixtures/helpers", __dir__)

--- a/actionview/test/actionpack/abstract/layouts_test.rb
+++ b/actionview/test/actionpack/abstract/layouts_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 module AbstractControllerTests

--- a/actionview/test/actionpack/abstract/render_test.rb
+++ b/actionview/test/actionpack/abstract/render_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 module AbstractController

--- a/actionview/test/actionpack/controller/capture_test.rb
+++ b/actionview/test/actionpack/controller/capture_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "active_support/logger"
 

--- a/actionview/test/actionpack/controller/layout_test.rb
+++ b/actionview/test/actionpack/controller/layout_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "active_support/core_ext/array/extract_options"
 

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "active_model"
 require "controller/fake_models"

--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class ViewLoadPathsTest < ActionController::TestCase

--- a/actionview/test/active_record_unit.rb
+++ b/actionview/test/active_record_unit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 # Define the essentials

--- a/actionview/test/activerecord/controller_runtime_test.rb
+++ b/actionview/test/activerecord/controller_runtime_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_record_unit"
 require "active_record/railties/controller_runtime"
 require "fixtures/project"

--- a/actionview/test/activerecord/debug_helper_test.rb
+++ b/actionview/test/activerecord/debug_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_record_unit"
 require "nokogiri"
 

--- a/actionview/test/activerecord/form_helper_activerecord_test.rb
+++ b/actionview/test/activerecord/form_helper_activerecord_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_record_unit"
 require "fixtures/project"
 require "fixtures/developer"

--- a/actionview/test/activerecord/polymorphic_routes_test.rb
+++ b/actionview/test/activerecord/polymorphic_routes_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_record_unit"
 require "fixtures/project"
 

--- a/actionview/test/activerecord/relation_cache_test.rb
+++ b/actionview/test/activerecord/relation_cache_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_record_unit"
 
 class RelationCacheTest < ActionView::TestCase

--- a/actionview/test/activerecord/render_partial_with_record_identification_test.rb
+++ b/actionview/test/activerecord/render_partial_with_record_identification_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_record_unit"
 
 class RenderPartialWithRecordIdentificationController < ActionController::Base

--- a/actionview/test/fixtures/company.rb
+++ b/actionview/test/fixtures/company.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Company < ActiveRecord::Base
   has_one :mascot
   self.sequence_name = :companies_nonstd_seq

--- a/actionview/test/fixtures/developer.rb
+++ b/actionview/test/fixtures/developer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Developer < ActiveRecord::Base
   has_and_belongs_to_many :projects
   has_many :replies

--- a/actionview/test/fixtures/helpers/abc_helper.rb
+++ b/actionview/test/fixtures/helpers/abc_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AbcHelper
   def bare_a() end
 end

--- a/actionview/test/fixtures/helpers/helpery_test_helper.rb
+++ b/actionview/test/fixtures/helpers/helpery_test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HelperyTestHelper
   def helpery_test
     "Default"

--- a/actionview/test/fixtures/helpers_missing/invalid_require_helper.rb
+++ b/actionview/test/fixtures/helpers_missing/invalid_require_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "very_invalid_file_name"
 
 module InvalidRequireHelper

--- a/actionview/test/fixtures/mascot.rb
+++ b/actionview/test/fixtures/mascot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Mascot < ActiveRecord::Base
   belongs_to :company
 end

--- a/actionview/test/fixtures/project.rb
+++ b/actionview/test/fixtures/project.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Project < ActiveRecord::Base
   has_and_belongs_to_many :developers, -> { uniq }
 

--- a/actionview/test/fixtures/reply.rb
+++ b/actionview/test/fixtures/reply.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Reply < ActiveRecord::Base
   scope :base, -> { all }
   belongs_to :topic, -> { includes(:replies) }

--- a/actionview/test/fixtures/topic.rb
+++ b/actionview/test/fixtures/topic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Topic < ActiveRecord::Base
   has_many :replies, dependent: :destroy
 end

--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_model"
 
 Customer = Struct.new(:name, :id) do

--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class ActiveModelHelperTest < ActionView::TestCase

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "active_support/ordered_options"
 

--- a/actionview/test/template/atom_feed_helper_test.rb
+++ b/actionview/test/template/atom_feed_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 Scroll = Struct.new(:id, :to_param, :title, :body, :updated_at, :created_at) do

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class CaptureHelperTest < ActionView::TestCase

--- a/actionview/test/template/compiled_templates_test.rb
+++ b/actionview/test/template/compiled_templates_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class CompiledTemplatesTest < ActiveSupport::TestCase

--- a/actionview/test/template/controller_helper_test.rb
+++ b/actionview/test/template/controller_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class ControllerHelperTest < ActionView::TestCase

--- a/actionview/test/template/date_helper_i18n_test.rb
+++ b/actionview/test/template/date_helper_i18n_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class DateHelperDistanceOfTimeInWordsI18nTests < ActiveSupport::TestCase

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class DateHelperTest < ActionView::TestCase

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "action_view/dependency_tracker"
 

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "fileutils"
 require "action_view/dependency_tracker"

--- a/actionview/test/template/erb/deprecated_erubis_implementation_test.rb
+++ b/actionview/test/template/erb/deprecated_erubis_implementation_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 module ERBTest

--- a/actionview/test/template/erb/form_for_test.rb
+++ b/actionview/test/template/erb/form_for_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "template/erb/helper"
 

--- a/actionview/test/template/erb/helper.rb
+++ b/actionview/test/template/erb/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ERBTest
   class ViewContext
     include ActionView::Helpers::UrlHelper

--- a/actionview/test/template/erb/tag_helper_test.rb
+++ b/actionview/test/template/erb/tag_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "template/erb/helper"
 

--- a/actionview/test/template/erb_util_test.rb
+++ b/actionview/test/template/erb_util_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "active_support/json"
 

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 Category = Struct.new(:id, :name)

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "controller/fake_models"
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "controller/fake_models"
 

--- a/actionview/test/template/form_options_helper_i18n_test.rb
+++ b/actionview/test/template/form_options_helper_i18n_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class FormOptionsHelperI18nTests < ActionView::TestCase

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class Map < Hash

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class FormTagHelperTest < ActionView::TestCase

--- a/actionview/test/template/html_test.rb
+++ b/actionview/test/template/html_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class HTMLTest < ActiveSupport::TestCase

--- a/actionview/test/template/javascript_helper_test.rb
+++ b/actionview/test/template/javascript_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class JavaScriptHelperTest < ActionView::TestCase

--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "active_support/log_subscriber/test_helper"
 require "action_view/log_subscriber"

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "abstract_controller/rendering"
 

--- a/actionview/test/template/number_helper_test.rb
+++ b/actionview/test/template/number_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class NumberHelperTest < ActionView::TestCase

--- a/actionview/test/template/output_safety_helper_test.rb
+++ b/actionview/test/template/output_safety_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class OutputSafetyHelperTest < ActionView::TestCase

--- a/actionview/test/template/partial_iteration_test.rb
+++ b/actionview/test/template/partial_iteration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "action_view/renderer/partial_renderer"
 

--- a/actionview/test/template/record_identifier_test.rb
+++ b/actionview/test/template/record_identifier_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "controller/fake_models"
 

--- a/actionview/test/template/record_tag_helper_test.rb
+++ b/actionview/test/template/record_tag_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class RecordTagPost

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "controller/fake_models"
 

--- a/actionview/test/template/resolver_cache_test.rb
+++ b/actionview/test/template/resolver_cache_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class ResolverCacheTest < ActiveSupport::TestCase

--- a/actionview/test/template/resolver_patterns_test.rb
+++ b/actionview/test/template/resolver_patterns_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class ResolverPatternsTest < ActiveSupport::TestCase

--- a/actionview/test/template/sanitize_helper_test.rb
+++ b/actionview/test/template/sanitize_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 # The exhaustive tests are in the rails-html-sanitizer gem.

--- a/actionview/test/template/streaming_render_test.rb
+++ b/actionview/test/template/streaming_render_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class TestController < ActionController::Base

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class TagHelperTest < ActionView::TestCase

--- a/actionview/test/template/template_error_test.rb
+++ b/actionview/test/template/template_error_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class TemplateErrorTest < ActiveSupport::TestCase

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -1,4 +1,5 @@
 # encoding: US-ASCII
+# frozen_string_literal: true
 
 require "abstract_unit"
 require "logger"

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "rails/engine"
 

--- a/actionview/test/template/test_test.rb
+++ b/actionview/test/template/test_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 module PeopleHelper

--- a/actionview/test/template/testing/fixture_resolver_test.rb
+++ b/actionview/test/template/testing/fixture_resolver_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class FixtureResolverTest < ActiveSupport::TestCase

--- a/actionview/test/template/testing/null_resolver_test.rb
+++ b/actionview/test/template/testing/null_resolver_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class NullResolverTest < ActiveSupport::TestCase

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class TextHelperTest < ActionView::TestCase

--- a/actionview/test/template/text_test.rb
+++ b/actionview/test/template/text_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class TextTest < ActiveSupport::TestCase

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 module I18n

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class UrlHelperTest < ActiveSupport::TestCase

--- a/actionview/test/ujs/config.ru
+++ b/actionview/test/ujs/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift __dir__
 require "server"
 

--- a/actionview/test/ujs/server.rb
+++ b/actionview/test/ujs/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rack"
 require "rails"
 require "action_controller/railtie"


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/29655

Extends `Style/FrozenStringLiteralComment` Rubocop rule to `actionview/`.

The commit is just `rubocop -a` after changing the Rubocop rule.

Similar to:
https://github.com/rails/rails/pull/29728
https://github.com/rails/rails/pull/29819
https://github.com/rails/rails/pull/29732
https://github.com/rails/rails/pull/29896