### PR TITLE
Fix regression introduced by fixing mounting the same engine in multiple locations

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -658,6 +658,11 @@ module ActionDispatch
             script_namer = ->(options) do
               prefix_options = options.slice(*_route.segment_keys)
               prefix_options[:relative_url_root] = "".freeze
+
+              if options[:_recall]
+                prefix_options.reverse_merge!(options[:_recall].slice(*_route.segment_keys))
+              end
+
               # We must actually delete prefix segment keys to avoid passing them to next url_for.
               _route.segment_keys.each { |k| options.delete(k) }
               _routes.url_helpers.send("#{name}_path", prefix_options)

--- a/actionpack/lib/action_dispatch/routing/routes_proxy.rb
+++ b/actionpack/lib/action_dispatch/routing/routes_proxy.rb
@@ -31,7 +31,14 @@ module ActionDispatch
             def #{method}(*args)
               options = args.extract_options!
               options = url_options.merge((options || {}).symbolize_keys)
-              options.reverse_merge!(script_name: @script_namer.call(options)) if @script_namer
+
+              if @script_namer
+                options[:script_name] = merge_script_names(
+                  options[:script_name],
+                  @script_namer.call(options)
+                )
+              end
+
               args << options
               @helpers.#{method}(*args)
             end
@@ -40,6 +47,20 @@ module ActionDispatch
         else
           super
         end
+      end
+
+      # Keeps the part of the script name provided by the global
+      # context via ENV["SCRIPT_NAME"], which `mount` doesn't know
+      # about since it depends on the specific request, but use our
+      # script name resolver for the mount point dependent part.
+      def merge_script_names(previous_script_name, new_script_name)
+        return new_script_name unless previous_script_name
+
+        resolved_parts = new_script_name.count("/")
+        previous_parts = previous_script_name.count("/")
+        context_parts = previous_parts - resolved_parts + 1
+
+        (previous_script_name.split("/").slice(0, context_parts).join("/")) + new_script_name
       end
     end
   end

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1427,6 +1427,35 @@ YAML
       assert_equal "/vegetables/1/bukkits/posts", last_response.body
     end
 
+    test "route helpers resolve script name correctly when called with different script name from current one" do
+      @plugin.write "app/controllers/posts_controller.rb", <<-RUBY
+        class PostsController < ActionController::Base
+          def index
+            render plain: fruit_bukkits.posts_path(fruit_id: 2)
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          resources :fruits do
+            mount Bukkits::Engine => "/bukkits"
+          end
+        end
+      RUBY
+
+      @plugin.write "config/routes.rb", <<-RUBY
+        Bukkits::Engine.routes.draw do
+          resources :posts, only: :index
+        end
+      RUBY
+
+      boot_rails
+
+      get("/fruits/1/bukkits/posts")
+      assert_equal "/fruits/2/bukkits/posts", last_response.body
+    end
+
   private
     def app
       Rails.application

--- a/railties/test/railties/mounted_engine_test.rb
+++ b/railties/test/railties/mounted_engine_test.rb
@@ -111,6 +111,7 @@ module ApplicationTests
       @plugin.write "config/routes.rb", <<-RUBY
         Blog::Engine.routes.draw do
           resources :posts
+          get '/different_context', to: 'posts#different_context'
           get '/generate_application_route', to: 'posts#generate_application_route'
           get '/application_route_in_view', to: 'posts#application_route_in_view'
           get '/engine_polymorphic_path', to: 'posts#engine_polymorphic_path'
@@ -123,6 +124,10 @@ module ApplicationTests
           class PostsController < ActionController::Base
             def index
               render plain: blog.post_path(1)
+            end
+
+            def different_context
+              render plain: blog.post_path(1, user: "ada")
             end
 
             def generate_application_route
@@ -195,6 +200,10 @@ module ApplicationTests
       # test generating engine's route from engine
       get "/john/blog/posts"
       assert_equal "/john/blog/posts/1", last_response.body
+
+      # test generating engine route from engine with a different context
+      get "/john/blog/different_context"
+      assert_equal "/ada/blog/posts/1", last_response.body
 
       # test generating engine's route from engine with default_url_options
       get "/john/blog/posts", {}, "SCRIPT_NAME" => "/foo"


### PR DESCRIPTION
### Summary

I introduced this regression in #29662. The previous version would prefer the current `script_name` if one is available in the request for resolving the mount context in engine route helpers. But that would make them incorrect in some cases.

For example (just describing the test I added), if an engine is mounted at

```ruby
resources :fruits do
  mount Bukkits::Engine => "/bukkits"
end
```

and the current request path is `/fruits/1/bukkits/posts`, calling `fruit_bukkits.posts_path(fruit_id: 2)` would incorrectly return `/fruits/1/bukkits/posts`. This is because the `script_name` present in the request (in this case `/fruits/1/bukkits`) was preferred (by using `reverse_merge!` instead of `merge!` [here](https://github.com/rails/rails/blob/127b475dc251a06942fe0cd2de2e0545cf5ed69f/actionpack/lib/action_dispatch/routing/routes_proxy.rb#L34)).

This patch takes care of fixing that. My initial attempt was changing `reverse_merge!` with `merge!` but although that fixed the specific issue I was having, it broke some other tests. The problem is that the previous script name might contain relevant information that is not known to the `lambda` that resolves the script name from the parameters and the mount point location. For example, any context provided to the specific request via the environment's `SCRIPT_NAME` variable is not known to this method.

So instead of preferring the `script_namer` resolution, I merged that with the current script name. So if the previous script name was `/foo/fruits/1/bukkits`, and the resulting one from calling the lambda is `/fruits/2/bukkits`, the resulting script name used for the route helper will be `/foo/fruits/2/bukkits`.

### Other Information

Sorry for the probably not very well explained PR description. I'm not very familliar with rails internals, so it's hard for me to reason about them.

Also, excuse the irrelevant commits. I added them while investigating the problem, but then I found out about the imminent release, so I wanted to open this ASAP to avoid introducing the regression.

**EDIT**: I tried to improve a bit the description of the problem & the solution.

