### PR TITLE
Make actioncable ready for frozen strings

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "set"
 
 module ActionCable
@@ -205,7 +207,9 @@ module ActionCable
         # Transmit a hash of data to the subscriber. The hash will automatically be wrapped in a JSON envelope with
         # the proper channel identifier marked as the recipient.
         def transmit(data, via: nil) # :doc:
-          logger.debug "#{self.class.name} transmitting #{data.inspect.truncate(300)}".tap { |m| m << " (via #{via})" if via }
+          status = "#{self.class.name} transmitting #{data.inspect.truncate(300)}"
+          status += " (via #{via})" if via
+          logger.debug(status)
 
           payload = { channel_class: self.class.name, data: data, via: via }
           ActiveSupport::Notifications.instrument("transmit.action_cable", payload) do


### PR DESCRIPTION
This PR makes actioncable ready to enable frozen string literal (https://github.com/rails/rails/pull/29820)

Similar to https://github.com/rails/rails/pull/29900