### PR TITLE
Do not show URL in boot info when using Puma

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -64,9 +64,9 @@ module Rails
       end
 
       def print_boot_information
-        url = "#{options[:SSLEnable] ? 'https' : 'http'}://#{options[:Host]}:#{options[:Port]}"
+        url = "on #{options[:SSLEnable] ? 'https' : 'http'}://#{options[:Host]}:#{options[:Port]}" unless use_puma?
         puts "=> Booting #{ActiveSupport::Inflector.demodulize(server)}"
-        puts "=> Rails #{Rails.version} application starting in #{Rails.env} on #{url}"
+        puts "=> Rails #{Rails.version} application starting in #{Rails.env} #{url}"
         puts "=> Run `rails server -h` for more startup options"
       end
 
@@ -90,6 +90,10 @@ module Rails
 
       def restart_command
         "bin/rails server #{ARGV.join(' ')}"
+      end
+
+      def use_puma?
+        server.to_s == "Rack::Handler::Puma"
       end
   end
 


### PR DESCRIPTION
Puma has its own configuration file(e.g. `config/puma.rb`).
Can define a port and a URL to bind in the configuration file. Therefore, on Rails side, can not grasp which URI to bind finally.

Because of that, it may show a URL different from the actually bound URL, so I think that it is better not to show it.

Fixes #29880

