### PR TITLE
correct `Request#xml_http_request?`'s behavior

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -243,7 +243,7 @@ module ActionDispatch
     # (case-insensitive), which may need to be manually added depending on the
     # choice of JavaScript libraries and frameworks.
     def xml_http_request?
-      get_header("HTTP_X_REQUESTED_WITH") =~ /XMLHttpRequest/i
+      !!(get_header("HTTP_X_REQUESTED_WITH") =~ /XMLHttpRequest/i)
     end
     alias :xhr? :xml_http_request?
 


### PR DESCRIPTION
### Summary

The doc said that `Returns true if the "X-Requested-With" header contains "XMLHttpRequest"`,
but actually it returns `0` or `nil`.
