### PR TITLE
Add tests to MessageVerifier

### DIFF
--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -99,6 +99,21 @@ class MessageVerifierMetadataTest < ActiveSupport::TestCase
     @verifier = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!", verifier_options)
   end
 
+  def test_verify_raises_when_purpose_differs
+    assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
+      @verifier.verify(@verifier.generate(@message, purpose: "payment"), purpose: "shipping")
+    end
+  end
+
+  def test_verify_raises_when_expired
+    signed_message = @verifier.generate(@message, expires_in: 1.month)
+
+    travel 2.months
+    assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
+      @verifier.verify(signed_message)
+    end
+  end
+
   private
     def generate(message, **options)
       @verifier.generate(message, options)


### PR DESCRIPTION
@kaspth 

More tests have been added to `ActiveSupport::MessageVerifier` to ensure that `verify` method raises `ActiveSupport::MessageVerifier::InvalidSignature` when you try to use an expired message or if it's used for a different purpose.