### PR TITLE
Fix test failure in message verifier tests

### DIFF
--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -19,7 +19,7 @@ class MessageVerifierTest < ActiveSupport::TestCase
 
   def setup
     @verifier = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!")
-    @data = { some: "data", now: Time.local(2010) }
+    @data = { some: "data", now: Time.utc(2010) }
   end
 
   def test_valid_message


### PR DESCRIPTION
### Summary

Without this, I get the following result on my machine

```
# Running:

F

Failure:
MessageVerifierTest#test_backward_compatibility_messages_signed_without_metadata [/home/deivid/Code/rails/activesupport/test/message_verifier_test.rb:91]:
--- expected
+++ actual
@@ -1 +1 @@
-{:some=>"data", :now=>2010-01-01 00:00:00 +0100}
+{:some=>"data", :now=>2010-01-01 00:00:00 +0000}

bin/test test/message_verifier_test.rb:89
```