### PR TITLE
Fix warnings in railties tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "capybara", "~> 2.13"
 gem "rack-cache", "~> 1.2"
 gem "jquery-rails"
 gem "coffee-rails"
-gem "sass-rails"
+gem "sass-rails", github: "rails/sass-rails", branch: "5-0-stable"
 gem "turbolinks", "~> 5"
 
 # require: false so bcrypt is loaded only when has_secure_password is used.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,18 @@ GIT
   specs:
     arel (8.0.0)
 
+GIT
+  remote: https://github.com/rails/sass-rails.git
+  revision: bb5c1d34e8acad2e2960cc785184ffe17d7b3bca
+  branch: 5-0-stable
+  specs:
+    sass-rails (5.0.6)
+      railties (>= 4.0.0, < 6)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (>= 1.1, < 3)
+
 PATH
   remote: .
   specs:
@@ -305,13 +317,11 @@ GEM
     rubyzip (1.2.0)
     rufus-scheduler (3.3.2)
       tzinfo
-    sass (3.4.23)
-    sass-rails (5.0.6)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sass (3.5.1)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     sdoc (1.0.0.rc2)
       rdoc (~> 5.0)
     selenium-webdriver (3.0.5)
@@ -355,7 +365,7 @@ GEM
       rack (>= 1, < 3)
     thread (0.1.7)
     thread_safe (0.3.6)
-    tilt (2.0.5)
+    tilt (2.0.8)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.0)
@@ -430,7 +440,7 @@ DEPENDENCIES
   resque
   resque-scheduler
   rubocop (>= 0.47)
-  sass-rails
+  sass-rails!
   sdoc (> 1.0.0.rc1, < 2.0)
   sequel
   sidekiq
@@ -448,4 +458,4 @@ DEPENDENCIES
   websocket-client-simple!
 
 BUNDLED WITH
-   1.15.1
+   1.15.3


### PR DESCRIPTION
While running railties tests, I noticed hundreds of warnings like the following:

```
gems/sass-rails-5.0.6/lib/sass/rails/helpers.rb:6: warning: method redefined; discarding old asset_data_url
gems/sprockets-3.7.1/lib/sprockets/sass_processor.rb:253: warning: previous definition of asset_data_url was here
```

While we might not care about this specific warning, I think it's a good idea to get it fixed because such a cluttered test output might actually hide things we _do_ care about.

These warnings have been fixed in the `5-0-stable` branch of `sass-rails` so I pointed there to make them go.