### PR TITLE
[WIP] Add support for multiple encrypted secret files.

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -388,7 +388,13 @@ module Rails
       @secrets ||= begin
         secrets = ActiveSupport::OrderedOptions.new
         files = config.paths["config/secrets"].existent
-        files = files.reject { |path| path.end_with?(".enc") } unless config.read_encrypted_secrets
+        if config.read_encrypted_secrets
+          if config.read_encrypted_secrets.is_a?(String)
+            files << config.root.join(config.read_encrypted_secrets).to_s
+          end
+        else
+          files.reject! { |path| path.end_with?(".enc") }
+        end
         secrets.merge! Rails::Secrets.parse(files, env: Rails.env)
 
         # Fallback to config.secret_key_base if secrets.secret_key_base isn't set

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -2,7 +2,6 @@ require "fileutils"
 require "active_support/notifications"
 require "active_support/dependencies"
 require "active_support/descendants_tracker"
-require_relative "../secrets"
 
 module Rails
   class Application
@@ -77,10 +76,6 @@ INFO
 
       initializer :bootstrap_hook, group: :all do |app|
         ActiveSupport.run_load_hooks(:before_initialize, app)
-      end
-
-      initializer :set_secrets_root, group: :all do
-        Rails::Secrets.root = root
       end
     end
   end

--- a/railties/lib/rails/commands/secrets/secrets_command.rb
+++ b/railties/lib/rails/commands/secrets/secrets_command.rb
@@ -12,11 +12,11 @@ module Rails
         end
       end
 
-      def setup
-        generator.start
+      def setup(path = default_path)
+        generator.start([path])
       end
 
-      def edit
+      def edit(path = default_path)
         if ENV["EDITOR"].to_s.empty?
           say "No $EDITOR to open decrypted secrets in. Assign one like this:"
           say ""
@@ -30,7 +30,7 @@ module Rails
 
         require_application_and_environment!
 
-        Rails::Secrets.read_for_editing do |tmp_path|
+        Rails::Secrets.new(path).read_for_editing do |tmp_path|
           system("#{ENV["EDITOR"]} #{tmp_path}")
         end
 
@@ -42,17 +42,21 @@ module Rails
       rescue Errno::ENOENT => error
         raise unless error.message =~ /secrets\.yml\.enc/
 
-        Rails::Secrets.read_template_for_editing do |tmp_path|
+        Rails::Secrets.new(path).read_template_for_editing do |tmp_path|
           system("#{ENV["EDITOR"]} #{tmp_path}")
           generator.skip_secrets_file { setup }
         end
       end
 
-      def show
-        say Rails::Secrets.read
+      def show(path = default_path)
+        say Rails::Secrets.new(path).read
       end
 
       private
+        def default_path
+          "config/secrets.yml.enc"
+        end
+
         def generator
           require_relative "../../generators"
           require_relative "../../generators/rails/encrypted_secrets/encrypted_secrets_generator"

--- a/railties/lib/rails/generators/rails/encrypted_secrets/encrypted_secrets_generator.rb
+++ b/railties/lib/rails/generators/rails/encrypted_secrets/encrypted_secrets_generator.rb
@@ -4,18 +4,20 @@ require_relative "../../../secrets"
 module Rails
   module Generators
     class EncryptedSecretsGenerator < Base
-      def add_secrets_key_file
-        unless File.exist?("config/secrets.yml.key") || File.exist?("config/secrets.yml.enc")
-          key = Rails::Secrets.generate_key
+      argument :path
 
-          say "Adding config/secrets.yml.key to store the encryption key: #{key}"
+      def add_secrets_key_file
+        unless File.exist?(secrets.key_path) || File.exist?(secrets.path)
+          key = Secrets.generate_key
+
+          say "Adding #{secrets.key_path} to store the encryption key: #{key}"
           say ""
           say "Save this in a password manager your team can access."
           say ""
           say "If you lose the key, no one, including you, can access any encrypted secrets."
 
           say ""
-          create_file "config/secrets.yml.key", key
+          create_file secrets.key_path, key
           say ""
         end
       end
@@ -23,28 +25,28 @@ module Rails
       def ignore_key_file
         if File.exist?(".gitignore")
           unless File.read(".gitignore").include?(key_ignore)
-            say "Ignoring config/secrets.yml.key so it won't end up in Git history:"
+            say "Ignoring #{secrets.key_path} so it won't end up in Git history:"
             say ""
             append_to_file ".gitignore", key_ignore
             say ""
           end
         else
-          say "IMPORTANT: Don't commit config/secrets.yml.key. Add this to your ignore file:"
+          say "IMPORTANT: Don't commit #{secrets.key_path}. Add this to your ignore file:"
           say key_ignore, :on_green
           say ""
         end
       end
 
       def add_encrypted_secrets_file
-        unless (defined?(@@skip_secrets_file) && @@skip_secrets_file) || File.exist?("config/secrets.yml.enc")
-          say "Adding config/secrets.yml.enc to store secrets that needs to be encrypted."
+        unless (defined?(@@skip_secrets_file) && @@skip_secrets_file) || File.exist?(secrets.path)
+          say "Adding #{secrets.path} to store secrets that needs to be encrypted."
           say ""
           say "For now the file contains this but it's been encrypted with the generated key:"
           say ""
           say Secrets.template, :on_green
           say ""
 
-          Secrets.write(Secrets.template)
+          secrets.write(Secrets.template)
 
           say "You can edit encrypted secrets with `bin/rails secrets:edit`."
           say ""
@@ -62,8 +64,12 @@ module Rails
       end
 
       private
+        def secrets
+          @secrets ||= Secrets.new(path)
+        end
+
         def key_ignore
-          [ "", "# Ignore encrypted secrets key file.", "config/secrets.yml.key", "" ].join("\n")
+          [ "", "# Ignore encrypted secrets key file.", secrets.key_path, "" ].join("\n")
         end
     end
   end

--- a/railties/test/generators/encrypted_secrets_generator_test.rb
+++ b/railties/test/generators/encrypted_secrets_generator_test.rb
@@ -10,33 +10,43 @@ class EncryptedSecretsGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_generates_key_file_and_encrypted_secrets_file
-    run_generator
+    run_generator ["config/secrets.yml.enc"]
 
     assert_file "config/secrets.yml.key", /\w+/
 
     assert File.exist?("config/secrets.yml.enc")
     assert_no_match(/production:\n#  external_api_key: \w+/, IO.binread("config/secrets.yml.enc"))
-    assert_match(/production:\n#  external_api_key: \w+/, Rails::Secrets.read)
+    assert_match(/production:\n#  external_api_key: \w+/, Rails::Secrets.new("config/secrets.yml.enc").read)
   end
 
   def test_appends_to_gitignore
     FileUtils.touch(".gitignore")
 
-    run_generator
+    run_generator ["config/secrets.yml.enc"]
 
     assert_file ".gitignore", /config\/secrets.yml.key/, /(?!config\/secrets.yml.enc)/
   end
 
   def test_warns_when_ignore_is_missing
-    assert_match(/Add this to your ignore file/i, run_generator)
+    assert_match(/Add this to your ignore file/i, run_generator(["config/secrets.yml.enc"]))
   end
 
   def test_doesnt_generate_a_new_key_file_if_already_opted_in_to_encrypted_secrets
     FileUtils.mkdir("config")
     File.open("config/secrets.yml.enc", "w") { |f| f.puts "already secrety" }
 
-    run_generator
+    run_generator ["config/secrets.yml.enc"]
 
     assert_no_file "config/secrets.yml.key"
+  end
+
+  def test_generates_key_file_and_encrypted_secrets_file_into_non_default_path
+    run_generator ["config/secrets-staging.yml.enc"]
+
+    assert_file "config/secrets-staging.yml.key", /\w+/
+
+    assert File.exist?("config/secrets-staging.yml.enc")
+    assert_no_match(/production:\n#  external_api_key: \w+/, IO.binread("config/secrets-staging.yml.enc"))
+    assert_match(/production:\n#  external_api_key: \w+/, Rails::Secrets.new("config/secrets-staging.yml.enc").read)
   end
 end

--- a/railties/test/secrets_test.rb
+++ b/railties/test/secrets_test.rb
@@ -17,7 +17,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
 
   test "setting read to false skips parsing" do
     run_secrets_generator do
-      Rails::Secrets.write(<<-end_of_secrets)
+      Rails::Secrets.new("config/secrets.yml.enc").write(<<-end_of_secrets)
         test:
           yeah_yeah: lets-walk-in-the-cool-evening-light
       end_of_secrets
@@ -33,7 +33,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
       FileUtils.rm("config/secrets.yml.key")
 
       assert_raises Rails::Secrets::MissingKeyError do
-        Rails::Secrets.key
+        Rails::Secrets.new("config/secrets.yml.enc").key
       end
     end
   end
@@ -45,7 +45,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
         ENV["RAILS_MASTER_KEY"] = IO.binread("config/secrets.yml.key").strip
         FileUtils.rm("config/secrets.yml.key")
 
-        assert_match "production:\n#  external_api_key", Rails::Secrets.read
+        assert_match "production:\n#  external_api_key", Rails::Secrets.new("config/secrets.yml.enc").read
       ensure
         ENV["RAILS_MASTER_KEY"] = old_key
       end
@@ -56,7 +56,48 @@ class Rails::SecretsTest < ActiveSupport::TestCase
     run_secrets_generator do
       File.binwrite("config/secrets.yml.key", "00112233445566778899aabbccddeeff")
 
-      assert_equal "00112233445566778899aabbccddeeff", Rails::Secrets.key
+      assert_equal "00112233445566778899aabbccddeeff", Rails::Secrets.new("config/secrets.yml.enc").key
+    end
+  end
+
+  test "reading from encrypted file in custom path using key file" do
+    run_secrets_generator do
+      Rails::Secrets.new("config/secrets.yml.enc").write(<<-end_of_secrets)
+        test:
+          api_key: "api-key"
+      end_of_secrets
+
+      FileUtils.mv("config/secrets.yml.key", "config/secrets-staging.yml.key")
+      FileUtils.mv("config/secrets.yml.enc", "config/secrets-staging.yml.enc")
+
+      Rails.application.config.read_encrypted_secrets = "config/secrets-staging.yml.enc"
+      Rails.application.instance_variable_set(:@secrets, nil) # Dance around caching 💃🕺
+
+      assert_equal "api-key", Rails.application.secrets.api_key
+    end
+  end
+
+  test "reading from encrypted file in custom path using ENV variable" do
+    run_secrets_generator do
+      begin
+        old_key = ENV["RAILS_MASTER_KEY"]
+        ENV["RAILS_MASTER_KEY"] = IO.binread("config/secrets.yml.key").strip
+
+        Rails::Secrets.new("config/secrets.yml.enc").write(<<-end_of_secrets)
+          test:
+            api_key: "api-key"
+        end_of_secrets
+
+        FileUtils.rm("config/secrets.yml.key")
+        FileUtils.mv("config/secrets.yml.enc", "config/secrets-staging.yml.enc")
+
+        Rails.application.config.read_encrypted_secrets = "config/secrets-staging.yml.enc"
+        Rails.application.instance_variable_set(:@secrets, nil) # Dance around caching 💃🕺
+
+        assert_equal "api-key", Rails.application.secrets.api_key
+      ensure
+        ENV["RAILS_MASTER_KEY"] = old_key
+      end
     end
   end
 
@@ -64,7 +105,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
     run_secrets_generator do
       decrypted_path = nil
 
-      Rails::Secrets.read_for_editing do |tmp_path|
+      Rails::Secrets.new("config/secrets.yml.enc").read_for_editing do |tmp_path|
         decrypted_path = tmp_path
 
         assert_match(/production:\n#  external_api_key/, File.read(tmp_path))
@@ -73,7 +114,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
       end
 
       assert_not File.exist?(decrypted_path)
-      assert_equal "Empty streets, empty nights. The Downtown Lights.", Rails::Secrets.read
+      assert_equal "Empty streets, empty nights. The Downtown Lights.", Rails::Secrets.new("config/secrets.yml.enc").read
     end
   end
 
@@ -84,7 +125,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
           yeah_yeah: lets-go-walking-down-this-empty-street
       end_of_secrets
 
-      Rails::Secrets.write(<<-end_of_secrets)
+      Rails::Secrets.new("config/secrets.yml.enc").write(<<-end_of_secrets)
         test:
           yeah_yeah: lets-walk-in-the-cool-evening-light
       end_of_secrets
@@ -97,7 +138,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
 
   test "refer secrets inside env config" do
     run_secrets_generator do
-      Rails::Secrets.write(<<-end_of_yaml)
+      Rails::Secrets.new("config/secrets.yml.enc").write(<<-end_of_yaml)
         production:
           some_secret: yeah yeah
       end_of_yaml
@@ -112,13 +153,13 @@ class Rails::SecretsTest < ActiveSupport::TestCase
 
   test "do not update secrets.yml.enc when secretes do not change" do
     run_secrets_generator do
-      Rails::Secrets.read_for_editing do |tmp_path|
+      Rails::Secrets.new("config/secrets.yml.enc").read_for_editing do |tmp_path|
         File.write(tmp_path, "Empty streets, empty nights. The Downtown Lights.")
       end
 
       FileUtils.cp("config/secrets.yml.enc", "config/secrets.yml.enc.bk")
 
-      Rails::Secrets.read_for_editing do |tmp_path|
+      Rails::Secrets.new("config/secrets.yml.enc").read_for_editing do |tmp_path|
         File.write(tmp_path, "Empty streets, empty nights. The Downtown Lights.")
       end
 
@@ -128,14 +169,15 @@ class Rails::SecretsTest < ActiveSupport::TestCase
 
   test "can read secrets written in binary" do
     run_secrets_generator do
-      secrets = <<-end_of_secrets
+      secrets_template = <<-end_of_secrets
         production:
           api_key: 00112233445566778899aabbccddeeff…
       end_of_secrets
 
-      Rails::Secrets.write(secrets.force_encoding(Encoding::ASCII_8BIT))
+      secrets = Rails::Secrets.new("config/secrets.yml.enc")
+      secrets.write(secrets_template.force_encoding(Encoding::ASCII_8BIT))
 
-      Rails::Secrets.read_for_editing do |tmp_path|
+      secrets.read_for_editing do |tmp_path|
         assert_match(/production:\n\s*api_key: 00112233445566778899aabbccddeeff…\n/, File.read(tmp_path))
       end
 
@@ -145,15 +187,16 @@ class Rails::SecretsTest < ActiveSupport::TestCase
 
   test "can read secrets written in non-binary" do
     run_secrets_generator do
-      secrets = <<-end_of_secrets
+      secrets_template = <<-end_of_secrets
         production:
           api_key: 00112233445566778899aabbccddeeff…
       end_of_secrets
 
-      Rails::Secrets.write(secrets)
+      secrets = Rails::Secrets.new("config/secrets.yml.enc")
+      secrets.write(secrets_template)
 
-      Rails::Secrets.read_for_editing do |tmp_path|
-        assert_equal(secrets.force_encoding(Encoding::ASCII_8BIT), IO.binread(tmp_path))
+      secrets.read_for_editing do |tmp_path|
+        assert_equal(secrets_template.force_encoding(Encoding::ASCII_8BIT), IO.binread(tmp_path))
       end
 
       assert_equal "00112233445566778899aabbccddeeff…\n", `bin/rails runner -e production "puts Rails.application.secrets.api_key"`
@@ -164,7 +207,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
     def run_secrets_generator
       Dir.chdir(app_path) do
         capture(:stdout) do
-          Rails::Generators::EncryptedSecretsGenerator.start
+          Rails::Generators::EncryptedSecretsGenerator.start(["config/secrets.yml.enc"])
         end
 
         # Make config.paths["config/secrets"] to be relative to app_path


### PR DESCRIPTION
One can add encrypted secrets with custom file, by:
`config.read_encrypted_secrets = "config/secrets-staging.yml.enc"`

Additionaly one can setup, edit and show specific secrets by providing
path to the file, ie:
```
bin/rails secrets:setup config/secrets-staging.yml.enc
bin/rails secrets:edit config/secrets-staging.yml.enc
bin/rails secrets:show config/secrets-staging.yml.enc
```
If no argument is provided then default `config/secrets.yml.enc` is in use.

To encrypt/decrypt if no `RAILS_MASTER_KEY` is set, then corresponding key file
will be searched: `config/secrets-staging.yml.enc` -> `config/secrets-staging.yml.key`

---

Open question:
Juggling with full path to the file in rails generator doesn't look nice, alternative could be:
* `bin/rails secrets:setup --name=staging` which will generate `config/secrets-staging.yml.enc` and be enabled by `config.read_encrypted_secrets = "staging"`
* `bin/rails secrets:setup --name=secrets-staging` which will generate `config/secrets-staging.yml.enc` and be enabled by `config.read_encrypted_secrets = "secrets-staging"`
* `bin/rails secrets:setup --environment=staging` which will generate `config/secrets-staging.yml.enc` and 
 be enabled by `config.read_encrypted_secrets = true`

The last one depends on the environment which is a little limiting if one have staging server running in production env but just with different environment variables as it could not distinguish the secrets files.

---
TODO:
* Update documentation/guides
* Add changelog
* Polish implementation
* Maybe add more tests if needed

---
I would like to gather your feedback before polishing it.

@kaspth as you're the main architect of this feature
@ce07c3 as you were also planning to implement it
