### PR TITLE
Include rack-mini-profiler by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Include `rack-mini-profiler` gem by default. This gem allows for easy
+    visability and diagnosis of performance related issues.
+
+    *Richard Schneeman*
+
 *   Support `-` as a platform-agnostic way to run a script from stdin with
     `rails runner`
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -46,6 +46,8 @@ group :development do
   <%- else -%>
   gem 'web-console', '>= 3.3.0'
   <%- end -%>
+  # Display performance metrics on each page load. To configure for production read: https://github.com/MiniProfiler/rack-mini-profiler
+  gem 'rack-mini-profiler', '~> 0.10.5'
 <%- end -%>
 <% if depend_on_listen? -%>
   gem 'listen', '>= 3.0.5', '< 3.2'


### PR DESCRIPTION
I've used many development related performance tools, but the single most consistently helpful tool is `rack-mini-profiler`. 


The tool provides a lightweight UI element for each page, that shows the server response time. When clicked it expands to show more detail:

![](https://www.dropbox.com/s/0aciw4mk8c059n0/Screenshot%202017-07-24%2010.24.24.png?dl=1)

This can be used to detect expensive queries, N+1 issues and general performance related problems.