### PR TITLE
Fix `warning: assigned but unused variable - comment`

### DIFF
--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1178,7 +1178,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
     assert_difference "parent.reload.children_count", +1 do
       assert_difference "post.reload.comments_count", +1 do
-        comment = CommentWithAfterCreateUpdate.create(body: "foo", post: post, parent: parent)
+        CommentWithAfterCreateUpdate.create(body: "foo", post: post, parent: parent)
       end
     end
   end


### PR DESCRIPTION
```
% ARCONN=sqlite3 be ruby -w -Itest test/cases/associations/belongs_to_associations_test.rb -n test_multiple_counter_cache_with_after_create_update
test/cases/associations/belongs_to_associations_test.rb:1181: warning: assigned but unused variable - comment
Using sqlite3
Run options: -n test_multiple_counter_cache_with_after_create_update --seed 49644

.

Finished in 0.114266s, 8.7515 runs/s, 17.5030 assertions/s.

1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
```