### PR TITLE
[WIP] flaky actioncable test

### DIFF
--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -33,6 +33,7 @@ module Minitest
   # Owes great inspiration to test runner trailblazers like RSpec,
   # minitest-reporters, maxitest and others.
   def self.plugin_rails_init(options)
+    return
     unless options[:full_backtrace] || ENV["BACKTRACE"]
       # Plugin can run without Rails loaded, check before filtering.
       Minitest.backtrace_filter = ::Rails.backtrace_cleaner if ::Rails.respond_to?(:backtrace_cleaner)


### PR DESCRIPTION
The purpose of this PR is to debug flaky actioncable test suite. Here is the failure that I've been noticing a lot for the past week:

```
/home/travis/build/rails/rails/railties/lib/rails/test_unit/reporter.rb:14:in `write': stream closed (IOError)
	from /home/travis/build/rails/rails/railties/lib/rails/test_unit/reporter.rb:14:in `print'
	from /home/travis/build/rails/rails/railties/lib/rails/test_unit/reporter.rb:14:in `record'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:613:in `block in record'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:612:in `each'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:612:in `record'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:293:in `run_one_method'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:287:in `block (2 levels) in run'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:286:in `each'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:286:in `block in run'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:317:in `on_signal'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:306:in `with_info_handler'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:285:in `run'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:149:in `block in __run'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:149:in `map'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:149:in `__run'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:126:in `run'
	from /home/travis/build/rails/rails/vendor/bundle/ruby/2.3.0/gems/minitest-5.3.3/lib/minitest.rb:55:in `block in autorun'
```

[(build)](https://travis-ci.org/rails/rails/jobs/256799580)