### PR TITLE
Suppress warning from actionview controller helper.

### DIFF
--- a/actionview/lib/action_view/helpers/controller_helper.rb
+++ b/actionview/lib/action_view/helpers/controller_helper.rb
@@ -13,7 +13,7 @@ module ActionView
         :session, :cookies, :response, :headers, :flash, :action_name,
         :controller_name, :controller_path]
 
-      delegate *CONTROLLER_DELEGATES, to: :controller
+      delegate(*CONTROLLER_DELEGATES, to: :controller)
 
       def assign_controller(controller)
         if @_controller = controller


### PR DESCRIPTION
Since the commit https://github.com/rails/rails/commit/3cb7fe590f2b3cf29c2a32504fb4d24a79559a0b, `ActionView :: Helpers::ControllerHelper` started showing a warning(see below) because of the `*` operator. This commit changes the `delegate` call to use parentheses so it won't show warnings any more. 

```
/Users/artsy/Artsy/oss/rails/actionview/lib/action_view/helpers/controller_helper.rb:14: warning: `*' interpreted as argument prefix
```

