### PR TITLE
Make actionpack frozen string friendly

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "base64"
 require "active_support/security_utils"
 
@@ -475,7 +477,7 @@ module ActionController
 
       # This removes the <tt>"</tt> characters wrapping the value.
       def rewrite_param_values(array_params)
-        array_params.each { |param| (param[1] || "").gsub! %r/^"|"$/, "" }
+        array_params.each { |param| (param[1] || "".dup).gsub! %r/^"|"$/, "" }
       end
 
       # This method takes an authorization body and splits up the key-value

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -300,7 +300,7 @@ module ActionDispatch
     # variable is already set, wrap it in a StringIO.
     def body
       if raw_post = get_header("RAW_POST_DATA")
-        raw_post.force_encoding(Encoding::BINARY)
+        raw_post = raw_post.dup.force_encoding(Encoding::BINARY)
         StringIO.new(raw_post)
       else
         body_stream

--- a/actionpack/test/abstract/callbacks_test.rb
+++ b/actionpack/test/abstract/callbacks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 module AbstractController
@@ -42,7 +44,7 @@ module AbstractController
       def aroundz
         @aroundz = "FIRST"
         yield
-        @aroundz << "SECOND"
+        @aroundz += "SECOND"
       end
 
       def index

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class ActionController::Base
@@ -346,7 +348,7 @@ class FilterTest < ActionController::TestCase
   class AroundFilter
     def before(controller)
       @execution_log = "before"
-      controller.class.execution_log << " before aroundfilter " if controller.respond_to? :execution_log
+      controller.class.execution_log += " before aroundfilter " if controller.respond_to? :execution_log
       controller.instance_variable_set(:"@before_ran", true)
     end
 

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 ActionController::Base.helpers_path = File.expand_path("../fixtures/helpers", __dir__)
@@ -106,7 +108,7 @@ class HelperTest < ActiveSupport::TestCase
 
   def setup
     # Increment symbol counter.
-    @symbol = (@@counter ||= "A0").succ!.dup
+    @symbol = (@@counter ||= "A0").succ.dup
 
     # Generate new controller class.
     controller_class_name = "Helper#{@symbol}Controller"

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 class HttpTokenAuthenticationTest < ActionController::TestCase
@@ -148,7 +150,7 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
   end
 
   test "token_and_options returns empty string with empty token" do
-    token = ""
+    token = "".dup
     actual = ActionController::HttpAuthentication::Token.token_and_options(sample_request(token)).first
     expected = token
     assert_equal(expected, actual)

--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 module BareMetalTest
@@ -11,7 +13,7 @@ module BareMetalTest
     test "response body is a Rack-compatible response" do
       status, headers, body = BareController.action(:index).call(Rack::MockRequest.env_for("/"))
       assert_equal 200, status
-      string = ""
+      string = "".dup
 
       body.each do |part|
         assert part.is_a?(String), "Each part of the body must be a String"

--- a/actionpack/test/controller/new_base/middleware_test.rb
+++ b/actionpack/test/controller/new_base/middleware_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 
 module MiddlewareTest
@@ -21,7 +23,7 @@ module MiddlewareTest
 
     def call(env)
       result = @app.call(env)
-      result[1]["Middleware-Order"] << "!"
+      result[1]["Middleware-Order"] += "!"
       result
     end
   end

--- a/actionpack/test/controller/webservice_test.rb
+++ b/actionpack/test/controller/webservice_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "abstract_unit"
 require "active_support/json/decoding"
 
@@ -21,8 +23,8 @@ class WebServiceTest < ActionDispatch::IntegrationTest
           value = ""
         end
 
-        s << ", " unless s.empty?
-        s << "#{k}#{value}"
+        s += ", " unless s.empty?
+        s += "#{k}#{value}"
       end
     end
   end


### PR DESCRIPTION
This PR makes ActionPack frozen string friendly.
Shipping it should unblock us to move towards enforcing frozen-string-literal across all Rails components.

Similar to https://github.com/rails/rails/pull/29655, https://github.com/rails/rails/pull/29891