### PR TITLE
remove depreciated assertion to eliminate warning

### DIFF
--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -560,7 +560,7 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
   def test_double_conversion_with_nil_key
     h = { nil => "defined" }.with_indifferent_access.with_indifferent_access
 
-    assert_equal nil, h[:undefined_key]
+    assert_nil h[:undefined_key]
   end
 
   def test_assorted_keys_not_stringified


### PR DESCRIPTION
This PR removes the following warning by using `assert_nil` over `assert_equal` which is depreciated.

```
Use assert_nil if expecting nil from .../rails/activesupport/test/hash_with_indifferent_access_test.rb:563:in `test_double_conversion_with_nil_key'. This will fail in MT6.
```