### PR TITLE
Fix `warning: ambiguous first argument`

### DIFF
--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -262,7 +262,7 @@ module ApplicationTests
       test "db:schema:load fails if schema.rb doesn't exist yet" do
         Dir.chdir(app_path) do
           stderr_output = capture(:stderr) { `bin/rails db:schema:load` }
-          assert_match /Run `rails db:migrate` to create it/, stderr_output
+          assert_match(/Run `rails db:migrate` to create it/, stderr_output)
         end
       end
 


### PR DESCRIPTION
This fixes the following warning:

```
railties/test/application/rake/dbs_test.rb:265: warning: ambiguous first argument; put parentheses or a space even after `/' operator
```
