### PR TITLE
Allow bin/rails test to accept absolute paths

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow `bin/rails test` to take absolute paths as arguments
+
+    *Pawan Dubey*
+
 *   Support `-` as a platform-agnostic way to run a script from stdin with
     `rails runner`
 

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -58,7 +58,7 @@ module Rails
 
         private
           def extract_filters(argv)
-            argv.select { |arg| arg =~ /^\w+\// }.map do |path|
+            argv.select { |arg| arg =~ %r{^/?\w+/} }.map do |path|
               case
               when path =~ /(:\d+)+$/
                 file, *lines = path.split(":")
@@ -66,11 +66,11 @@ module Rails
                 file
               when Dir.exist?(path)
                 "#{path}/**/*_test.rb"
-              else
+              when path !~ /\/$/
                 filters << [ path, [] ]
                 path
               end
-            end
+            end.compact
           end
       end
     end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -45,8 +45,10 @@ module ApplicationTests
 
     def test_run_multiple_files_with_absolute_paths
       create_test_file :models,  "foo"
-      create_test_file :models,  "bar"
-      assert_match "2 runs, 2 assertions, 0 failures", run_test_command("#{app_path}/test/models/foo_test.rb #{app_path}/test/models/bar_test.rb")
+      create_test_file :controllers,  "foobar_controller"
+      create_test_file :models, "bar"
+
+      assert_match "2 runs, 2 assertions, 0 failures", run_test_command("#{app_path}/test/models/foo_test.rb #{app_path}/test/controllers/foobar_controller_test.rb")
     end
 
     def test_run_file_with_syntax_error
@@ -279,6 +281,7 @@ module ApplicationTests
     def test_run_multiple_folders_with_absolute_paths
       create_test_file :models, "account"
       create_test_file :controllers, "accounts_controller"
+      create_test_file :helpers, "foo_helper"
 
       run_test_command("#{app_path}/test/models #{app_path}/test/controllers").tap do |output|
         assert_match "AccountTest", output

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -31,10 +31,22 @@ module ApplicationTests
       assert_match "1 runs, 1 assertions, 0 failures", run_test_command("test/models/foo_test.rb")
     end
 
+    def test_run_single_file_with_absolute_path
+      create_test_file :models, "foo"
+      create_test_file :models, "bar"
+      assert_match "1 runs, 1 assertions, 0 failures", run_test_command("#{app_path}/test/models/foo_test.rb")
+    end
+
     def test_run_multiple_files
       create_test_file :models,  "foo"
       create_test_file :models,  "bar"
       assert_match "2 runs, 2 assertions, 0 failures", run_test_command("test/models/foo_test.rb test/models/bar_test.rb")
+    end
+
+    def test_run_multiple_files_with_absolute_paths
+      create_test_file :models,  "foo"
+      create_test_file :models,  "bar"
+      assert_match "2 runs, 2 assertions, 0 failures", run_test_command("#{app_path}/test/models/foo_test.rb #{app_path}/test/models/bar_test.rb")
     end
 
     def test_run_file_with_syntax_error
@@ -258,6 +270,17 @@ module ApplicationTests
       create_test_file :controllers, "accounts_controller"
 
       run_test_command("test/models test/controllers").tap do |output|
+        assert_match "AccountTest", output
+        assert_match "AccountsControllerTest", output
+        assert_match "2 runs, 2 assertions, 0 failures, 0 errors, 0 skips", output
+      end
+    end
+
+    def test_run_multiple_folders_with_absolute_paths
+      create_test_file :models, "account"
+      create_test_file :controllers, "accounts_controller"
+
+      run_test_command("#{app_path}/test/models #{app_path}/test/controllers").tap do |output|
         assert_match "AccountTest", output
         assert_match "AccountsControllerTest", output
         assert_match "2 runs, 2 assertions, 0 failures, 0 errors, 0 skips", output


### PR DESCRIPTION
### Summary

Fixes #29923 

This fixes an issue with the `rails test` task which doesn't accept absolute paths to test targets introduced in 796a1cf0e.
This is done via tweaking the regex in `Rails::TestUnit::Runner.extract_filters` to allow paths with leading slashes to be added to the `patterns` array.

Regression tests are included.