### PR TITLE
Remove unused Signal trap for INT

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -36,7 +36,6 @@ module Rails
 
     def start
       print_boot_information
-      trap(:INT) { exit }
       create_tmp_directories
       setup_dev_caching
       log_to_stdout if options[:log_stdout]


### PR DESCRIPTION
### Summary

This removes unused/unreferenced trapping of `INT` Signal and exiting
rails server. This is unused because `Rails::Server` inherits from
`::Rack::Server` and `Rails::Serve#start` invokes `super` which overrides the
trapping of `INT` to what is already declared in `::Rack::Server#start`.

Hence keeping this here leads to confusion.

### Other Information

Refs to `Rack::Server#start` https://github.com/rack/rack/blob/5c36acac4d298dcf04c58a10014c849a478da53f/lib/rack/server.rb#L289 
