### PR TITLE
Fix `test_add_column_with_timestamp_type` when using Oracle

### DIFF
--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -273,6 +273,8 @@ module ActiveRecord
           assert_equal "timestamp without time zone", klass.columns_hash["foo"].sql_type
         elsif current_adapter?(:Mysql2Adapter)
           assert_equal "timestamp", klass.columns_hash["foo"].sql_type
+        elsif current_adapter?(:OracleAdapter)
+          assert_equal "TIMESTAMP(6)", klass.columns_hash["foo"].sql_type
         else
           assert_equal klass.connection.type_to_sql("datetime"), klass.columns_hash["foo"].sql_type
         end


### PR DESCRIPTION
### Summary

This PR fixes the following failure test when using Oracle (11g) .


```
% ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
% ARCONN=oracle bundle exec ruby -w -Itest test/cases/migration/change_schema_test.rb -n test_add_column_with_timestamp_type
Using oracle
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/ruby-oci8-2.2.4.1/lib/oci8/oci8.rb:627: warning: method redefined; discarding old initialize
Run options: -n test_add_column_with_timestamp_type --seed 63070

# Running:

F

Failure:
ActiveRecord::Migration::ChangeSchemaTest#test_add_column_with_timestamp_type [test/cases/migration/change_schema_test.rb:277]:
Expected: "TIMESTAMP"
  Actual: "TIMESTAMP(6)"


bin/rails test test/cases/migration/change_schema_test.rb:262



Finished in 0.106811s, 9.3623 runs/s, 18.7246 assertions/s.

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

It matched timestamp type returned by OracleAdapter.
