### PR TITLE
Prevent circular callbacks for associations

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -395,7 +395,7 @@ module ActiveRecord
 
               saved = true
 
-              if autosave != false && (@new_record_before_save || record.new_record?)
+              if autosave != false && (@new_record_before_save || record.new_record?) && !record.persiting_with_callbacks?
                 if autosave
                   saved = association.insert_record(record, false)
                 else
@@ -428,7 +428,7 @@ module ActiveRecord
 
           if autosave && record.marked_for_destruction?
             record.destroy
-          elsif autosave != false
+          elsif autosave != false && !record.persiting_with_callbacks?
             key = reflection.options[:primary_key] ? send(reflection.options[:primary_key]) : id
 
             if (autosave && record.changed_for_autosave?) || new_record? || record_changed?(reflection, record, key)

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -327,21 +327,34 @@ module ActiveRecord
     end
 
     def touch(*) #:nodoc:
-      _run_touch_callbacks { super }
+      persist_with_callbacks { _run_touch_callbacks { super } }
+    end
+
+    # Returns true if the record is currently being created or updated
+    def persiting_with_callbacks?
+      @persiting_with_callbacks ||= false
     end
 
   private
 
     def create_or_update(*)
-      _run_save_callbacks { super }
+      persist_with_callbacks { _run_save_callbacks { super } }
     end
 
     def _create_record
-      _run_create_callbacks { super }
+      persist_with_callbacks { _run_create_callbacks { super } }
     end
 
     def _update_record(*)
-      _run_update_callbacks { super }
+      persist_with_callbacks { _run_update_callbacks { super } }
     end
+
+    def persist_with_callbacks
+      @persiting_with_callbacks = true
+      yield
+    ensure
+      @persiting_with_callbacks = false
+    end
+
   end
 end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -51,6 +51,10 @@ class ReadonlyTitlePost < Post
   attr_readonly :title
 end
 
+class PostWithBeforeUpdate < Post
+  before_update { self.body = 'body updated' }
+end
+
 class Weird < ActiveRecord::Base; end
 
 class LintTest < ActiveRecord::TestCase
@@ -65,6 +69,12 @@ end
 
 class BasicsTest < ActiveRecord::TestCase
   fixtures :topics, :companies, :developers, :projects, :computers, :accounts, :minimalistics, "warehouse-things", :authors, :author_addresses, :categorizations, :categories, :posts
+
+  def test_has_one_should_not_call_before_update_on_save
+    original_body = 'original body'
+    post = PostWithBeforeUpdate.create!(title: 'post title', body: original_body, author: Author.new(name: 'Jane Doe'))
+    assert_equal original_body, post.body
+  end
 
   def test_column_names_are_escaped
     conn      = ActiveRecord::Base.connection


### PR DESCRIPTION
### Summary

This pr should fix [the following issue](https://github.com/rails/rails/issues/29864). 
When trying to persist a record that had a belongs_to association, it used to save both target and main record in the before callbacks, and then update already saved record, hence the before_update callbacks were called.

