### PR TITLE
Extract `assert_output` and `available_pty?` into `ConsoleHelpers` module

### DIFF
--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -1,4 +1,5 @@
 require "isolation/abstract_unit"
+require "console_helpers"
 
 class ConsoleTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::Isolation
@@ -93,14 +94,11 @@ class ConsoleTest < ActiveSupport::TestCase
   end
 end
 
-begin
-  require "pty"
-rescue LoadError
-end
-
 class FullStackConsoleTest < ActiveSupport::TestCase
+  include ConsoleHelpers
+
   def setup
-    skip "PTY unavailable" unless defined?(PTY) && PTY.respond_to?(:open)
+    skip "PTY unavailable" unless available_pty?
 
     build_app
     app_file "app/models/post.rb", <<-CODE
@@ -116,24 +114,11 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     teardown_app
   end
 
-  def assert_output(expected, timeout = 1)
-    timeout = Time.now + timeout
-
-    output = ""
-    until output.include?(expected) || Time.now > timeout
-      if IO.select([@master], [], [], 0.1)
-        output << @master.read(1)
-      end
-    end
-
-    assert_includes output, expected, "#{expected.inspect} expected, but got:\n\n#{output}"
-  end
-
   def write_prompt(command, expected_output = nil)
     @master.puts command
-    assert_output command
-    assert_output expected_output if expected_output
-    assert_output "> "
+    assert_output command, @master
+    assert_output expected_output, @master if expected_output
+    assert_output "> ", @master
   end
 
   def spawn_console(options)
@@ -142,7 +127,7 @@ class FullStackConsoleTest < ActiveSupport::TestCase
       in: @slave, out: @slave, err: @slave
     )
 
-    assert_output "> ", 30
+    assert_output "> ", @master, 30
   end
 
   def test_sandbox

--- a/railties/test/application/dbconsole_test.rb
+++ b/railties/test/application/dbconsole_test.rb
@@ -1,12 +1,10 @@
 require "isolation/abstract_unit"
-begin
-  require "pty"
-rescue LoadError
-end
+require "console_helpers"
 
 module ApplicationTests
   class DBConsoleTest < ActiveSupport::TestCase
     include ActiveSupport::Testing::Isolation
+    include ConsoleHelpers
 
     def setup
       skip "PTY unavailable" unless available_pty?
@@ -73,23 +71,6 @@ module ApplicationTests
     private
       def spawn_dbconsole(fd, options = nil)
         Process.spawn("#{app_path}/bin/rails dbconsole #{options}", in: fd, out: fd, err: fd)
-      end
-
-      def assert_output(expected, io, timeout = 5)
-        timeout = Time.now + timeout
-
-        output = ""
-        until output.include?(expected) || Time.now > timeout
-          if IO.select([io], [], [], 0.1)
-            output << io.read(1)
-          end
-        end
-
-        assert_includes output, expected, "#{expected.inspect} expected, but got:\n\n#{output}"
-      end
-
-      def available_pty?
-        defined?(PTY) && PTY.respond_to?(:open)
       end
   end
 end

--- a/railties/test/console_helpers.rb
+++ b/railties/test/console_helpers.rb
@@ -1,0 +1,23 @@
+begin
+  require "pty"
+rescue LoadError
+end
+
+module ConsoleHelpers
+  def assert_output(expected, io, timeout = 10)
+    timeout = Time.now + timeout
+
+    output = ""
+    until output.include?(expected) || Time.now > timeout
+      if IO.select([io], [], [], 0.1)
+        output << io.read(1)
+      end
+    end
+
+    assert_includes output, expected, "#{expected.inspect} expected, but got:\n\n#{output}"
+  end
+
+  def available_pty?
+    defined?(PTY) && PTY.respond_to?(:open)
+  end
+end

--- a/railties/test/engine/commands_test.rb
+++ b/railties/test/engine/commands_test.rb
@@ -1,10 +1,9 @@
 require "abstract_unit"
-begin
-  require "pty"
-rescue LoadError
-end
+require "console_helpers"
 
 class Rails::Engine::CommandsTest < ActiveSupport::TestCase
+  include ConsoleHelpers
+
   def setup
     @destination_root = Dir.mktmpdir("bukkits")
     Dir.chdir(@destination_root) { `bundle exec rails plugin new bukkits --mountable` }
@@ -64,28 +63,11 @@ class Rails::Engine::CommandsTest < ActiveSupport::TestCase
       "#{@destination_root}/bukkits"
     end
 
-    def assert_output(expected, io, timeout = 10)
-      timeout = Time.now + timeout
-
-      output = ""
-      until output.include?(expected) || Time.now > timeout
-        if IO.select([io], [], [], 0.1)
-          output << io.read(1)
-        end
-      end
-
-      assert_includes output, expected, "#{expected.inspect} expected, but got:\n\n#{output}"
-    end
-
     def spawn_command(command, fd)
       Process.spawn(
         "#{plugin_path}/bin/rails #{command}",
         in: fd, out: fd, err: fd
       )
-    end
-
-    def available_pty?
-      defined?(PTY) && PTY.respond_to?(:open)
     end
 
     def kill(pid)


### PR DESCRIPTION
We define almost the same method with multiple tests. Therefore, it extract into module.

