### PR TITLE
Suppress deprecated warning in Action Cable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,7 @@ GEM
     erubis (2.7.0)
     et-orbi (1.0.5)
       tzinfo
-    event_emitter (0.2.5)
+    event_emitter (0.2.6)
     eventmachine (1.2.3)
     eventmachine (1.2.3-x64-mingw32)
     eventmachine (1.2.3-x86-mingw32)


### PR DESCRIPTION
### Summary

This PR suppresses the following warning of Action Cable using [event_emitter 2.2.6](https://rubygems.org/gems/event_emitter/versions/0.2.6).

```console
% ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin13]
% cd actioncable
% RUBYOPT=-w bundle exec rake
(snip)

/Users/koic/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/event_emitter-0.2.5/lib/event_emitter/emitter.rb:35: warning: constant ::Fixnum is deprecated
```

### Other Information

event_emitter 2.2.6 has been contained the following PR.

shokai/event_emitter#15

This PR suppresses deprecated warning in Ruby 2.4+.
