### PR TITLE
Remove useless `JoinInformation`

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -174,9 +174,9 @@ module ActiveRecord
 
         def make_join_constraints(parent, child, join_type, aliasing = false)
           tables = aliasing ? table_aliases_for(parent, child) : child.tables
-          info   = make_constraints(parent, child, tables, join_type)
+          joins  = make_constraints(parent, child, tables, join_type)
 
-          [info] + child.children.flat_map { |c| make_join_constraints(child, c, join_type, aliasing) }
+          joins.concat child.children.flat_map { |c| make_join_constraints(child, c, join_type, aliasing) }
         end
 
         def table_aliases_for(parent, node)

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -23,8 +23,6 @@ module ActiveRecord
           super && reflection == other.reflection
         end
 
-        JoinInformation = Struct.new :joins
-
         def join_constraints(foreign_table, foreign_klass, join_type, tables, chain)
           joins         = []
           tables        = tables.reverse
@@ -51,7 +49,7 @@ module ActiveRecord
             foreign_table, foreign_klass = table, klass
           end
 
-          JoinInformation.new joins
+          joins
         end
 
         def table

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1014,11 +1014,8 @@ module ActiveRecord
           klass, table, association_joins, join_list
         )
 
-        join_infos = join_dependency.join_constraints stashed_association_joins, join_type
-
-        join_infos.each do |info|
-          info.joins.each { |join| manager.from(join) }
-        end
+        joins = join_dependency.join_constraints(stashed_association_joins, join_type)
+        joins.each { |join| manager.from(join) }
 
         manager.join_sources.concat(join_list)
 


### PR DESCRIPTION
Since 213796f removed `binds`, `JoinInformation` only contain `joins`.
So it is enough to return `joins` simply.