### PR TITLE
Remove unused `queries_predicates`

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -9,7 +9,6 @@ module ActiveRecord
 
       def call(attribute, value)
         return attribute.in([]) if value.empty?
-        return queries_predicates(value) if value.all? { |v| v.is_a?(Hash) }
 
         values = value.map { |x| x.is_a?(Base) ? x.id : x }
         nils, values = values.partition(&:nil?)
@@ -42,17 +41,6 @@ module ActiveRecord
         module NullPredicate # :nodoc:
           def self.or(other)
             other
-          end
-        end
-
-      private
-        def queries_predicates(queries)
-          if queries.size > 1
-            queries.map do |query|
-              Arel::Nodes::And.new(predicate_builder.build_from_hash(query))
-            end.inject(&:or)
-          else
-            predicate_builder.build_from_hash(queries.first)
           end
         end
     end


### PR DESCRIPTION
Since 213796f, `queries_predicates` is no longer used.