### PR TITLE
Fix `where` with relations in an array

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -13,7 +13,7 @@ module ActiveRecord
 
         values = value.map { |x| x.is_a?(Base) ? x.id : x }
         nils, values = values.partition(&:nil?)
-        ranges, values = values.partition { |v| v.is_a?(Range) }
+        others, values = values.partition { |v| v.is_a?(Range) || v.is_a?(Relation) }
 
         values_predicate =
           case values.length
@@ -30,7 +30,7 @@ module ActiveRecord
           values_predicate = values_predicate.or(predicate_builder.build(attribute, nil))
         end
 
-        array_predicates = ranges.map { |range| predicate_builder.build(attribute, range) }
+        array_predicates = others.map { |other| predicate_builder.build(attribute, other) }
         array_predicates.unshift(values_predicate)
         array_predicates.inject(&:or)
       end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -713,6 +713,11 @@ class RelationTest < ActiveRecord::TestCase
     assert authors.to_a.blank?
   end
 
+  def test_where_with_relations_in_array
+    authors = Author.where(id: [Author.where(id: 1), Author.where(id: 2)])
+    assert_equal Author.where(id: [1, 2]), authors.to_a
+  end
+
   def test_where_with_ar_object
     author = Author.first
     authors = Author.all.where(id: author)


### PR DESCRIPTION
Reopen #28539.

Subqueries cannot be in the `IN`, so it should be excluded in `values`.

Fixes #26541.