### PR TITLE
Change ActiveSupport Minitest Dependency from Runtime to Develoment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,6 @@ PATH
     activesupport (5.2.0.alpha)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
-      minitest (~> 5.1)
       tzinfo (~> 1.1)
     rails (5.2.0.alpha)
       actioncable (= 5.2.0.alpha)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "i18n",       "~> 0.7"
   s.add_dependency "tzinfo",     "~> 1.1"
-  s.add_dependency "minitest",   "~> 5.1"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
+
+  s.add_development_dependency "minitest", "~> 5.1"
 end


### PR DESCRIPTION
The ActiveSupport gemspec currently has a runtime dependency on
MiniTest which means every single Rails app bundles MiniTest
even if a different test framework is used.

By changing it to a development dependency we can run tests
with minitests without bundling it as part of the framework.

### Summary

This change is purely to remove the unnecessary dependency from ActiveSupport to allow Rails apps which use other testing frameworks - eg. rspec - to have a slightly smaller footprint. There doesn't seem to be any benefit to including this dependency.
