### PR TITLE
Add a setting to specify that all string columns should be immutable

### DIFF
--- a/activemodel/lib/active_model/type/string.rb
+++ b/activemodel/lib/active_model/type/string.rb
@@ -11,6 +11,14 @@ module ActiveModel
         end
       end
 
+      def to_immutable_string
+        ImmutableString.new(
+          limit: limit,
+          precision: precision,
+          scale: scale,
+        )
+      end
+
       private
 
         def cast_value(value)

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Added the setting `ActiveRecord::Base.immutable_strings_by_default`, which
+    allows you to specify that all string columns should be frozen unless
+    otherwise specified. This will reduce memory pressure for applications which
+    do not generally mutate string properties of Active Record objects.
+
+    *Sean Griffin*
+
 *   ApplicationRecord is no longer generated when generating models.  If you
     need to generate it, it can be created with `rails g application_record`.
 

--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -60,6 +60,7 @@ module ActiveRecord
     Decimal = ActiveModel::Type::Decimal
     Float = ActiveModel::Type::Float
     Integer = ActiveModel::Type::Integer
+    ImmutableString = ActiveModel::Type::ImmutableString
     String = ActiveModel::Type::String
     Value = ActiveModel::Type::Value
 

--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -72,6 +72,7 @@ module ActiveRecord
     register(:decimal, Type::Decimal, override: false)
     register(:float, Type::Float, override: false)
     register(:integer, Type::Integer, override: false)
+    register(:immutable_string, Type::ImmutableString, override: false)
     register(:json, Type::Json, override: false)
     register(:string, Type::String, override: false)
     register(:text, Type::Text, override: false)

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -271,7 +271,8 @@ module ActiveRecord
     test "immutable_strings_by_default changes schema inference for string columns" do
       with_immutable_strings do
         OverloadedType.reset_column_information
-        assert_instance_of Type::ImmutableString, OverloadedType.type_for_attribute("inferred_string")
+        immutable_string_type = Type.lookup(:immutable_string).class
+        assert_instance_of immutable_string_type, OverloadedType.type_for_attribute("inferred_string")
       end
     end
 
@@ -285,7 +286,8 @@ module ActiveRecord
     test "immutable_strings_by_default does not affect `attribute :foo, :string`" do
       with_immutable_strings do
         OverloadedType.reset_column_information
-        assert_instance_of Type::String, OverloadedType.type_for_attribute("string_with_default")
+        default_string_type = Type.lookup(:string).class
+        assert_instance_of default_string_type, OverloadedType.type_for_attribute("string_with_default")
       end
     end
 

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -100,20 +100,22 @@ module ActiveRecord
 
     test "overloading properties does not attribute method order" do
       attribute_names = OverloadedType.attribute_names
-      assert_equal %w(id overloaded_float unoverloaded_float overloaded_string_with_limit string_with_default non_existent_decimal), attribute_names
+      expected = OverloadedType.column_names + ["non_existent_decimal"]
+      assert_equal expected, attribute_names
     end
 
     test "caches are cleared" do
       klass = Class.new(OverloadedType)
+      column_count = klass.columns.length
 
-      assert_equal 6, klass.attribute_types.length
-      assert_equal 6, klass.column_defaults.length
+      assert_equal column_count + 1, klass.attribute_types.length
+      assert_equal column_count + 1, klass.column_defaults.length
       assert_not klass.attribute_types.include?("wibble")
 
       klass.attribute :wibble, Type::Value.new
 
-      assert_equal 7, klass.attribute_types.length
-      assert_equal 7, klass.column_defaults.length
+      assert_equal column_count + 2, klass.attribute_types.length
+      assert_equal column_count + 2, klass.column_defaults.length
       assert_includes klass.attribute_types, "wibble"
     end
 
@@ -265,5 +267,36 @@ module ActiveRecord
       assert_equal 1, klass.new(no_type: 1).no_type
       assert_equal "foo", klass.new(no_type: "foo").no_type
     end
+
+    test "immutable_strings_by_default changes schema inference for string columns" do
+      with_immutable_strings do
+        OverloadedType.reset_column_information
+        assert_instance_of Type::ImmutableString, OverloadedType.type_for_attribute("inferred_string")
+      end
+    end
+
+    test "immutable_strings_by_default retains limit information" do
+      with_immutable_strings do
+        OverloadedType.reset_column_information
+        assert_equal 255, OverloadedType.type_for_attribute("inferred_string").limit
+      end
+    end
+
+    test "immutable_strings_by_default does not affect `attribute :foo, :string`" do
+      with_immutable_strings do
+        OverloadedType.reset_column_information
+        assert_instance_of Type::String, OverloadedType.type_for_attribute("string_with_default")
+      end
+    end
+
+    private
+
+      def with_immutable_strings
+        old_value = ActiveRecord::Base.immutable_strings_by_default
+        ActiveRecord::Base.immutable_strings_by_default = true
+        yield
+      ensure
+        ActiveRecord::Base.immutable_strings_by_default = old_value
+      end
   end
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1044,6 +1044,7 @@ ActiveRecord::Schema.define do
     t.float :unoverloaded_float
     t.string :overloaded_string_with_limit, limit: 255
     t.string :string_with_default, default: "the original default"
+    t.string :inferred_string, limit: 255
   end
 
   create_table :users, force: true do |t|


### PR DESCRIPTION
In Rails 4.2 we introduced mutation detection, to remove the need to
call `attribute_will_change!` after modifying a field. One side effect
of that change was that we needed to enforce that the
`_before_type_cast` form of a value is a different object than the post
type cast value, if the value is mutable. That contract is really only
relevant for strings, but it meant we needed to dup them.

In Rails 5 we added the `ImmutableString` type, to allow people to opt
out of this duping in places where the memory usage was causing
problems, and they don't need to mutate that field.

This takes that a step further, and adds a class-level setting to
specify whether strings should be frozen by default or not. The default
value of this setting is `false` (strings are mutable), and I do not
plan on changing that.

While I think that immutable strings by default would be a reasonable
default for new applications, I do not think that we would be able to
document the value of this setting in a place that people will be
looking when they can't figure out why some string is frozen.
Realistically, the number of applications where this setting is relevant
is fairly small, so I don't think it would make sense to ever enable it
by default.

r? @rafaelfranca 