### PR TITLE
Remove single element array preprocess

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -105,7 +105,7 @@ module ActiveRecord
           end
 
           def records_for(ids, &block)
-            scope.where(association_key_name => ids.size == 1 ? ids.first : ids).load(&block)
+            scope.where(association_key_name => ids).load(&block)
           end
 
           def scope

--- a/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
@@ -12,7 +12,7 @@ module ActiveRecord
         type_to_ids_mapping.map do |type, ids|
           {
             associated_table.association_foreign_type.to_s => type,
-            associated_table.association_foreign_key.to_s => ids.size > 1 ? ids : ids.first
+            associated_table.association_foreign_key.to_s => ids
           }
         end
       end


### PR DESCRIPTION
Since 213796f, array predicate handler supports making binds, so the
preprocess is no longer needed.