### PR TITLE
Clarify add_column limit documentation

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -511,6 +511,7 @@ module ActiveRecord
       # * <tt>:limit</tt> -
       #   Requests a maximum column length. This is the number of characters for a <tt>:string</tt> column
       #   and number of bytes for <tt>:text</tt>, <tt>:binary</tt> and <tt>:integer</tt> columns.
+      #   This option is ignored by some backends.
       # * <tt>:default</tt> -
       #   The column's default value. Use +nil+ for +NULL+.
       # * <tt>:null</tt> -


### PR DESCRIPTION
### Summary
The limit option is ignored by PostgreSQL and may be ignored by 3rd
party backends.  Make this clear in the docs.  Fixes #29922.

r? @sgrif 