### PR TITLE
Restore `to_sql` to return only SQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -10,6 +10,11 @@ module ActiveRecord
 
       # Converts an arel AST to SQL
       def to_sql(arel_or_sql_string, binds = [])
+        sql, _ = to_sql_and_binds(arel_or_sql_string, binds)
+        sql
+      end
+
+      def to_sql_and_binds(arel_or_sql_string, binds = []) # :nodoc:
         if arel_or_sql_string.respond_to?(:ast)
           unless binds.empty?
             raise "Passing bind parameters with an arel AST is forbidden. " \
@@ -21,6 +26,7 @@ module ActiveRecord
           [arel_or_sql_string.dup.freeze, binds]
         end
       end
+      private :to_sql_and_binds
 
       # This is used in the StatementCache object. It returns an object that
       # can be used to query the database repeatedly.
@@ -39,7 +45,7 @@ module ActiveRecord
       # Returns an ActiveRecord::Result instance.
       def select_all(arel, name = nil, binds = [], preparable: nil)
         arel = arel_from_relation(arel)
-        sql, binds = to_sql(arel, binds)
+        sql, binds = to_sql_and_binds(arel, binds)
         if !prepared_statements || (arel.is_a?(String) && preparable.nil?)
           preparable = false
         else
@@ -139,7 +145,7 @@ module ActiveRecord
       # If the next id was calculated in advance (as in Oracle), it should be
       # passed in as +id_value+.
       def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil)
-        sql, binds = to_sql(arel)
+        sql, binds = to_sql_and_binds(arel)
         value = exec_insert(sql, name, binds, pk, sequence_name)
         id_value || last_inserted_id(value)
       end
@@ -147,13 +153,13 @@ module ActiveRecord
 
       # Executes the update statement and returns the number of rows affected.
       def update(arel, name = nil)
-        sql, binds = to_sql(arel)
+        sql, binds = to_sql_and_binds(arel)
         exec_update(sql, name, binds)
       end
 
       # Executes the delete statement and returns the number of rows affected.
       def delete(arel, name = nil)
-        sql, binds = to_sql(arel)
+        sql, binds = to_sql_and_binds(arel)
         exec_delete(sql, name, binds)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -93,7 +93,7 @@ module ActiveRecord
       def select_all(arel, name = nil, binds = [], preparable: nil)
         if @query_cache_enabled && !locked?(arel)
           arel = arel_from_relation(arel)
-          sql, binds = to_sql(arel, binds)
+          sql, binds = to_sql_and_binds(arel, binds)
           cache_sql(sql, name, binds) { super(sql, name, binds, preparable: preparable) }
         else
           super

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -177,8 +177,7 @@ module ActiveRecord
       #++
 
       def explain(arel, binds = [])
-        sql, binds = to_sql(arel, binds)
-        sql     = "EXPLAIN #{sql}"
+        sql     = "EXPLAIN #{to_sql(arel, binds)}"
         start   = Time.now
         result  = exec_query(sql, "EXPLAIN", binds)
         elapsed = Time.now - start

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -5,8 +5,7 @@ module ActiveRecord
     module PostgreSQL
       module DatabaseStatements
         def explain(arel, binds = [])
-          sql, binds = to_sql(arel, binds)
-          sql = "EXPLAIN #{sql}"
+          sql = "EXPLAIN #{to_sql(arel, binds)}"
           PostgreSQL::ExplainPrettyPrinter.new.pp(exec_query(sql, "EXPLAIN", binds))
         end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -203,8 +203,7 @@ module ActiveRecord
       #++
 
       def explain(arel, binds = [])
-        sql, binds = to_sql(arel, binds)
-        sql = "EXPLAIN QUERY PLAN #{sql}"
+        sql = "EXPLAIN QUERY PLAN #{to_sql(arel, binds)}"
         SQLite3::ExplainPrettyPrinter.new.pp(exec_query(sql, "EXPLAIN", []))
       end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -571,8 +571,7 @@ module ActiveRecord
 
                     conn = klass.connection
                     conn.unprepared_statement {
-                      sql, _ = conn.to_sql(relation.arel)
-                      sql
+                      conn.to_sql(relation.arel)
                     }
                   end
     end


### PR DESCRIPTION
Because `to_sql` is public API. I introduced `to_sql_and_binds` internal
API to return SQL and binds.