### PR TITLE
Building `where_clause` in `UniquenessValidator` is no longer needed

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -79,10 +79,7 @@ module ActiveRecord
         else
           klass.connection.case_sensitive_comparison(table, attribute, column, value)
         end
-        klass.unscoped.tap do |scope|
-          parts = [comparison]
-          scope.where_clause += Relation::WhereClause.new(parts)
-        end
+        klass.unscoped.where!(comparison)
       end
 
       def scope_relation(record, relation)


### PR DESCRIPTION
Building `where_clause` manually was introduced at #26073 to include
both `comparison` and `binds` in `where_clause`. Since 213796f,
`comparison` includes `binds`, so it is enough to use `where` simply.