### PR TITLE
Add a method to determine if query parameters are parsable

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add a method to determine if query parameters are parsable
+
+    *Christina Thompson*
+
 *   Protect from forgery by default
 
     Rather than protecting from forgery in the generated `ApplicationController`,

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -84,6 +84,17 @@ module ActionDispatch
         get_header(PARAMETERS_KEY) || set_header(PARAMETERS_KEY, {})
       end
 
+      # Returns true if parameters are parse-able. Otherwise returns false.
+      #
+      #   GET /posts/5?x=1&y=2            | request.params_readable? => true
+      #   GET /posts/5?x[y]=1&x[y][][w]=2 | request.params_readable? => false
+      #
+      def params_readable?
+        parameters
+      rescue ActionController::BadRequest
+        false
+      end
+
       private
 
         def set_binary_encoding(params, controller, action)

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -882,6 +882,16 @@ class RequestFormat < BaseRequestTest
     assert request.format.html?
   end
 
+  test "params_readable? returns true when parameters are valid" do
+    request = stub_request("QUERY_STRING" => "x=1&y=2")
+    assert_predicate request, :params_readable?
+  end
+
+  test "params_readable? returns false when malformed parameters" do
+    request = stub_request("QUERY_STRING" => "x[y]=1&x[y][][w]=2")
+    assert_not_predicate request, :params_readable?
+  end
+
   test "formats with xhr request" do
     request = stub_request "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest"
     assert_called(request, :parameters, times: 1, returns: {}) do


### PR DESCRIPTION
Addresses: https://github.com/rails/rails/issues/29947

Adding `#params_readable` is the proposed fix for addressing malformed query params that are unable to be parsed. We could use this method in the [request and response template](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb#L9) so the `DebugExceptions` middleware can avoid raising an exception if it's not parsable.