### PR TITLE
Avoid duplicate clauses when using #or

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   When using #or, extract the common conditions and put them before the OR condition.
+
+    *Maxime Handfield Lapointe*
+
 *   `Relation#or` now accepts two relations who have different values for
     `references` only, as `references` can be implicitly called by `where`.
 

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -36,12 +36,14 @@ module ActiveRecord
         common = self - left
         right = other - common
 
-        return common if left.empty? || right.empty?
-
-        or_clause = WhereClause.new(
-          [left.ast.or(right.ast)]
-        )
-        common + or_clause
+        if left.empty? || right.empty?
+          common
+        else
+          or_clause = WhereClause.new(
+            [left.ast.or(right.ast)],
+          )
+          common + or_clause
+        end
       end
 
       def to_h(table_name = nil)


### PR DESCRIPTION
Attempt number 2 for this change. A refactor of WhereClause by @sgrif made this change a lot simpler. Initial proposal at #29805.

Right now, when using `#or`, nothing is done to try to avoid duplicated conditions. As a result, query length increases at an exponential rate. This makes it really hard to parse for humans, making debugging / understanding the query log really hard.

To show the scale of the problem:
```
class Project
    scope :big, -> { where(big1: true).or(where(big2: true)) }
    scope :important, -> { where(important1: true).or(where(important2: true)) }
    scope :ongoing, -> { where(ongoing1: true).or(where(ongoing2: true)) }
end

Project.big # 2 conditions
#=> SELECT...WHERE ("projects"."big1" = ? OR "projects"."big2" = ?) 
Project.big.important # 6 conditions
#=> SELECT...WHERE (("projects"."big1" = ? OR "projects"."big2" = ?) AND "projects"."important1" = ? OR ("projects"."big1" = ? OR "projects"."big2" = ?) AND "projects"."important2" = ?)
Project.big.important.ongoing # 14 conditions
#=> To long to show
# Then 30 conditions
# Then 62
# Then 126 conditions, for using #or 6 times. This should be 12!

# After this fix, it is correctly 2, 4, 6, 8, 10, ... conditions.
```