### PR TITLE
Fix testing helpers that use Action View's capturing helpers (e.g. content_for)

### DIFF
--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -103,6 +103,7 @@ module ActionView
       def setup_with_controller
         @controller = ActionView::TestCase::TestController.new
         @request = @controller.request
+        @view_flow = ActionView::OutputFlow.new
         # empty string ensures buffer has UTF-8 encoding as
         # new without arguments returns ASCII-8BIT encoded buffer like String#new
         @output_buffer = ActiveSupport::SafeBuffer.new ""
@@ -246,6 +247,7 @@ module ActionView
         :@test_passed,
         :@view,
         :@view_context_class,
+        :@view_flow,
         :@_subscribers,
         :@html_document
       ]

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -282,6 +282,14 @@ module ActionView
       @customers = [DeveloperStruct.new("Eloy"), DeveloperStruct.new("Manfred")]
       assert_match(/Hello: EloyHello: Manfred/, render(file: "test/list"))
     end
+
+    test "is able to use helpers that depend on the view flow" do
+      assert_not content_for?(:foo)
+
+      content_for :foo, "bar"
+      assert content_for?(:foo)
+      assert_equal "bar", content_for(:foo)
+    end
   end
 
   class AssertionsTest < ActionView::TestCase


### PR DESCRIPTION
Capturing helpers like `content_for` expect `@view_flow` to be set. `ActionView::TestCase` doesn’t set it, so helpers that use `content_for` can’t be tested easily:

```ruby
class ApplicationHelperTest < ActionView::TestCase
  test "is able to use helpers that depend on the view flow" do
    assert_not content_for?(:foo)

    content_for :foo, "bar"
    assert content_for?(:foo)
    assert_equal "bar", content_for(:foo)
  end
end
```

```
Error:
ApplicationHelperTest#test_is_able_to_use_helpers_that_depend_on_the_view_flow:
NoMethodError: undefined method `get' for nil:NilClass
```

Per [the docs for `ActionView::Context`](https://github.com/rails/rails/blob/4fb518c28ce2b66ddb5483c07a2f185394ed80c4/actionview/lib/action_view/context.rb#L14-L16), setting `@view_flow` is the responsibility of `ActionView::TestCase`.