### PR TITLE
Fix division on Duration objects, returning correct values and parts

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Fix Division operation to return correct values and parts in resulting Duration objects.
+
+    Before:
+
+         4.minutes / 2.minutes
+         => 0 minutes
+
+         4.minutes / 1 / 2.minutes
+         => 0 minutes
+
+    Now:
+
+         4.minutes / 2.minutes
+         => 2 minutes
+
+         4.minutes / 1 / 2.minutes
+         => 2 minutes
+
+    Fixes #29952
+
+    *Sayan Chakraborty*
+
 *   Add purpose and expiry support to `ActiveSupport::MessageVerifier` &
    `ActiveSupport::MessageEncryptor`.
 

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -76,10 +76,10 @@ module ActiveSupport
 
       def /(other)
         if Duration === other
-          new_parts = other.parts.map { |part, other_value| [part, value / other_value] }.to_h
-          new_value = new_parts.inject(0) { |total, (part, value)| total + value * Duration::PARTS_IN_SECONDS[part] }
+          new_parts = other.parts.map { |part, other_value| [part, value / (Duration::PARTS_IN_SECONDS[part] * other_value)] }.to_h
+          new_value = new_parts.inject(0) { |total, (part, value)| total + value }
 
-          Duration.new(new_value, new_parts)
+          new_value
         else
           calculate(:/, other)
         end
@@ -235,7 +235,7 @@ module ActiveSupport
     # Divides this Duration by a Numeric and returns a new Duration.
     def /(other)
       if Scalar === other || Duration === other
-        Duration.new(value / other.value, parts.map { |type, number| [type, number / other.value] })
+        value / other.value
       elsif Numeric === other
         Duration.new(value / other, parts.map { |type, number| [type, number / other] })
       else

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -111,7 +111,15 @@ class DurationTest < ActiveSupport::TestCase
   def test_divide
     assert_equal 1.day, 7.days / 7
     assert_instance_of ActiveSupport::Duration, 7.days / 7
+
     assert_equal 1, 1.day / 1.day
+    assert_kind_of Numeric, 1.day / 1.day
+
+    assert_equal 90.0, 1.5.hours / 1.minute
+    assert_kind_of Numeric, 1.5.hours / 1.minute
+
+    assert_equal 2, 4.days / 1 / 2.days
+    assert_kind_of Numeric, 4.days / 1 / 2.days
   end
 
   def test_date_added_with_multiplied_duration
@@ -412,7 +420,7 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal 10, 100.seconds / scalar
     assert_instance_of ActiveSupport::Duration, 2.seconds * scalar
     assert_equal 5, scalar / 2.seconds
-    assert_instance_of ActiveSupport::Duration, scalar / 2.seconds
+    assert_kind_of Numeric, scalar / 2.seconds
 
     exception = assert_raises(TypeError) do
       scalar / "foo"
@@ -422,12 +430,12 @@ class DurationTest < ActiveSupport::TestCase
   end
 
   def test_scalar_divide_parts
-    scalar = ActiveSupport::Duration::Scalar.new(10)
+    scalar = ActiveSupport::Duration::Scalar.new(10 * 24 * 60 * 60)
 
-    assert_equal({ days: 2 }, (scalar / 5.days).parts)
-    assert_equal(172800, (scalar / 5.days).value)
-    assert_equal({ days: -2 }, (scalar / -5.days).parts)
-    assert_equal(-172800, (scalar / -5.days).value)
+    assert_kind_of Numeric, scalar / 5.days
+    assert_equal 2, scalar / 5.days
+    assert_kind_of Numeric, scalar / -5.days
+    assert_equal -2, scalar / -5.days
   end
 
   def test_twelve_months_equals_one_year


### PR DESCRIPTION
Fixes division operation on Duration objects
Return correct values and parts while dividing Duration objects and allow operator chaining to return correct result.
More details on the issue listed here #29952 