### PR TITLE
Updates documentation on ActionDispatch::Integration::Session#process

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -187,6 +187,12 @@ module ActionDispatch
       #   merged into the Rack env hash.
       # - +env+: Additional env to pass, as a Hash. The headers will be
       #   merged into the Rack env hash.
+      # - +xhr+: Set to `true` if you want to make and Ajax request.
+      #   Adds request headers characteristic of XMLHttpRequest e.g. HTTP_X_REQUESTED_WITH.
+      #   The headers will be merged into the Rack env hash.
+      # - +as+: Used for encoding the request with different content type.
+      #   Supports `:json` by default and will set the approriate request headers.
+      #   The headers will be merged into the Rack env hash.
       #
       # This method is rarely used directly. Use +#get+, +#post+, or other standard
       # HTTP methods in integration tests. +#process+ is only required when using a


### PR DESCRIPTION
### Summary

Adds missing information on 2 parameters: `:xhr` and `:as` (appears in rdoc)