### PR TITLE
Fix #29632 - nil #path leads to NoMethodError in LoadError#is_missing?

### DIFF
--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -11,6 +11,6 @@ class LoadError
   # Returns true if the given path name (except perhaps for the ".rb"
   # extension) is the missing file which caused the exception to be raised.
   def is_missing?(location)
-    location.sub(/\.rb$/, "".freeze) == path.sub(/\.rb$/, "".freeze)
+    location.sub(/\.rb$/, "".freeze) == path.to_s.sub(/\.rb$/, "".freeze)
   end
 end


### PR DESCRIPTION
### Summary

See #29632 for details. In short, it's possible to enter `LoadError#is_missing?` when `LoadError#path` returns `nil`, leading to `path.sub` throwing an none-to-helpful `NoMethodError`.

This tiniest of patch inserts `#to_s` before the `sub` call to make sure it succeeds. Affected surface area should be just as tiny since something has already gone wrong to get us into `#is_missing?` and the current behavior when `#path` returns `nil` seems clearly not intended.
