### PR TITLE
Use File::NULL instead of "/dev/null"

### DIFF
--- a/actionpack/test/journey/gtg/transition_table_test.rb
+++ b/actionpack/test/journey/gtg/transition_table_test.rb
@@ -21,7 +21,7 @@ module ActionDispatch
           assert json["accepting"]
         end
 
-        if system("dot -V 2>/dev/null")
+        if system("dot -V", 2 => File::NULL)
           def test_to_svg
             table = tt %w{
               /articles(.:format)

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -37,7 +37,7 @@ namespace :test do
       start_time = Time.now
 
       loop do
-        break if system("lsof -i :4567 >/dev/null")
+        break if system("lsof -i :4567", 1 => File::NULL)
 
         if Time.now - start_time > 5
           puts "Timed out after 5 seconds"

--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -38,7 +38,7 @@ module SidekiqJobsManager
       # Sidekiq is not warning-clean :(
       $VERBOSE = false
 
-      $stdin.reopen("/dev/null")
+      $stdin.reopen(File::NULL)
       $stdout.sync = true
       $stderr.sync = true
 

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -24,7 +24,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     @data = @cache.instance_variable_get(:@data)
     @cache.clear
     @cache.silence!
-    @cache.logger = ActiveSupport::Logger.new("/dev/null")
+    @cache.logger = ActiveSupport::Logger.new(File::NULL)
   end
 
   include CacheStoreBehavior

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -14,7 +14,7 @@ commands = [
 ]
 
 commands.each do |command|
-  system("#{command} > /dev/null 2>&1")
+  system(command, [1, 2] => File::NULL)
 end
 
 class Build


### PR DESCRIPTION
`File::NULL` is portable than "/dev/null".


`File::NULL` is available since ruby 1.9.3.