### PR TITLE
Fix search input's type & placeholder conflict in Routing Error page

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -17,6 +17,10 @@
     line-height: 15px;
   }
 
+  #route_table thead tr.bottom th input#search {
+    -webkit-appearance: textfield;
+  }
+
   #route_table tbody tr {
     border-bottom: 1px solid #ddd;
   }


### PR DESCRIPTION
### Summary

Some browsers are returning `-webkit-appearance: searchfield` for `<input type="search">` and place "Search" string under placeholder of input. So this PR overwrite browser's '-webkit-appearance' as 'textfield'.

### Other Information

You can find out difference via screenshots.

![screen shot 2017-07-26 at 18 54 52](https://user-images.githubusercontent.com/4572033/28632623-ec89dfd8-7239-11e7-8b88-e4e321fdb3e1.png)

And:
![screen shot 2017-07-26 at 18 55 31](https://user-images.githubusercontent.com/4572033/28632633-f01b898a-7239-11e7-9dc6-664a7d39c896.png)

