### PR TITLE
Inject connection in Relation

### DIFF
--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -29,7 +29,7 @@ module ActiveRecord
           arel = query.arel
         end
 
-        result = connection.select_one(arel, nil)
+        result = collection.connection.select_one(arel, nil)
 
         if result.blank?
           size = 0

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -305,13 +305,13 @@ module ActiveRecord
 
       # Determines if the primary key values should be selected from their
       # corresponding sequence before the insert statement.
-      def prefetch_primary_key?
+      def prefetch_primary_key?(connection = self.connection)
         connection.prefetch_primary_key?(table_name)
       end
 
       # Returns the next value that will be used as the primary key on
       # an insert statement.
-      def next_sequence_value
+      def next_sequence_value(connection = self.connection)
         connection.next_sequence_value(sequence_name)
       end
 

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -37,7 +37,7 @@ module ActiveRecord
     #
     #   Post.find_by_sql ["SELECT title FROM posts WHERE author = ? AND created > ?", author_id, start_date]
     #   Post.find_by_sql ["SELECT body FROM comments WHERE author = :user_id OR approved_by = :user_id", { :user_id => user_id }]
-    def find_by_sql(sql, binds = [], preparable: nil, &block)
+    def find_by_sql(sql, binds = [], preparable: nil, connection: self.connection, &block)
       result_set = connection.select_all(sanitize_sql(sql), "#{name} Load", binds, preparable: preparable)
       column_types = result_set.column_types.dup
       columns_hash.each_key { |k| column_types.delete k }

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -44,7 +44,7 @@ module ActiveRecord
              :shuffle, :split, :index, to: :records
 
     delegate :table_name, :quoted_table_name, :primary_key, :quoted_primary_key,
-             :connection, :columns_hash, to: :klass
+             :columns_hash, to: :klass
 
     module ClassSpecificRelation # :nodoc:
       extend ActiveSupport::Concern

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -42,6 +42,18 @@ module ActiveRecord
       end
     end
 
+    def test_default_connection
+      relation = Relation.new(Post, :b, nil)
+      assert_same Post.connection, relation.connection
+    end
+
+    def test_injected_connection
+      relation = Relation.new(Post, :b, nil, {}, Post.connection_handler.retrieve_connection("ARUnit2Model"))
+
+      assert_not_same Post.connection, relation.connection
+      assert_same Post.connection_handler.retrieve_connection("ARUnit2Model"), relation.connection
+    end
+
     def test_extensions
       relation = Relation.new(FakeKlass, :b, nil)
       assert_equal [], relation.extensions


### PR DESCRIPTION
### Summary

Allow injecting an alternate connection in Relation, and ensure that calls to methods on the associated ActiveRecord class use the injected connection too.

r? @sgrif 