### PR TITLE
Fix `warning: method redefined;`

### DIFF
--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -293,7 +293,7 @@ module ApplicationTests
             extend ActiveModel::Naming
             include ActiveModel::Conversion
 
-            def model_name
+            def self.model_name
               @_model_name ||= ActiveModel::Name.new(self.class, nil, "User")
             end
 
@@ -430,7 +430,7 @@ module ApplicationTests
           extend ActiveModel::Naming
           include ActiveModel::Conversion
 
-          def model_name
+          def self.model_name
             @_model_name ||= ActiveModel::Name.new(self.class, nil, "User")
           end
 
@@ -542,7 +542,7 @@ module ApplicationTests
           extend ActiveModel::Naming
           include ActiveModel::Conversion
 
-          def model_name
+          def self.model_name
             @_model_name ||= ActiveModel::Name.new(self.class, nil, "User")
           end
 


### PR DESCRIPTION
This fixes the following warning:

```
/tmp/d20170727-7039-kmdtb1/app/app/models/user.rb:5: warning: method redefined; discarding old model_name
rails/activemodel/lib/active_model/naming.rb:222: warning: previous definition of model_name was here
```
