### PR TITLE
Expose Rails.confirm so that libraries can override the confirm process

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/features/confirm.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/features/confirm.coffee
@@ -5,6 +5,10 @@
 Rails.handleConfirm = (e) ->
   stopEverything(e) unless allowAction(this)
 
+# Default confirm dialog, may be overridden with custom confirm dialog in Rails.confirm
+Rails.confirm = ->
+  confirm(message)
+
 # For 'data-confirm' attribute:
 # - Fires `confirm` event
 # - Shows the confirmation dialog
@@ -20,7 +24,7 @@ allowAction = (element) ->
 
   answer = false
   if fire(element, 'confirm')
-    try answer = confirm(message)
+    try answer = Rails.confirm(message)
     callback = fire(element, 'confirm:complete', [answer])
 
   answer and callback


### PR DESCRIPTION
### Summary

One of the jQuery-ujs features we lost in rails_ujs was the ability to override the confirm method that data-confirm triggers. Right now there's no easy way to override that so this provides a method for doing so. You can override this to launch a confirmation modal with Bootstrap or another frontend framework for example instead of using the browser's confirm dialog.