### PR TITLE
Added a way to silence test output:

### DIFF
--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -26,6 +26,10 @@ module Minitest
       options[:color] = value
     end
 
+    opts.on("-s", "--silence-result-code", "Disable the result code output") do
+      options[:silence_result_code] = true
+    end
+
     options[:color] = true
     options[:output_inline] = true
   end

--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -10,7 +10,7 @@ module Rails
 
       if options[:verbose]
         io.puts color_output(format_line(result), by: result)
-      else
+      elsif output_result_code?
         io.print color_output(result.result_code, by: result)
       end
 
@@ -53,6 +53,10 @@ module Rails
     end
 
     private
+      def output_result_code?
+        !options[:silence_result_code]
+      end
+
       def output_inline?
         options[:output_inline]
       end

--- a/railties/test/test_unit/reporter_test.rb
+++ b/railties/test/test_unit/reporter_test.rb
@@ -125,6 +125,15 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     assert_no_match "Failed tests:", @output.string
   end
 
+  test "outputs does not print test result when silence_result_code is true" do
+    @output.stub(:tty?, true) do
+      colored = Rails::TestUnitReporter.new @output, color: true, silence_result_code: true
+      colored.record(passing_test)
+
+      assert_equal "", @output.string
+    end
+  end
+
   test "outputs colored passing results" do
     @output.stub(:tty?, true) do
       colored = Rails::TestUnitReporter.new @output, color: true, output_inline: true


### PR DESCRIPTION
<details>
  <summary> Weird output with a custom reporter </summary>
   
  ```text
   Loading fixtures... rebuilding cache... completed in 8.509s
   .2/6: [============================================                                                                                           
   ] 33% Time: 00:00:08,  ETA: 00:00:1.3/6: 
   [===================================================================                                                                    
   ] 50% Time: 00:00:08,  ETA: 00:00:1.4/6: 
  [======================================================================
  ===================                                              ] 66% Time: 00:00:08,  ETA: 00:00:0.5/6: 
  [======================================================================
  ==========================================                       ] 83% Time: 00:00:09,  
  ETA: 00:00:0.6/6: 
  [======================================================================
  ================================================================] 100% 
  Time: 00:00:09, Time: 00:00:09
  .
  ```
</details>

----------------------------------------

- If an app decide to have custom test output using a different reporter it would not display nice as rails will output things as well
- The custom reporter can of course take care of disabling the Rails TestUnitReporter (the same way rails does by [disabling](https://github.com/rails/rails/blob/master/railties/lib/minitest/rails_plugin.rb#L42) Minitest default reporter). The problem is that the custom reporter needs to be loaded after the rails one, (minitest loads the plugin [alphabetically](https://github.com/seattlerb/minitest/blob/44eee51ed9716c789c7cea8a90c131cf736b8915/lib/minitest.rb#L92)). I feel like having an explicit configuration flag make things much easier

