### PR TITLE
Type caster should not raise `RangeError` when building SQL string in Arel

### DIFF
--- a/activerecord/lib/active_record/type_caster/map.rb
+++ b/activerecord/lib/active_record/type_caster/map.rb
@@ -11,6 +11,8 @@ module ActiveRecord
         return value if value.is_a?(Arel::Nodes::BindParam)
         type = types.type_for_attribute(attr_name.to_s)
         type.serialize(value)
+      rescue ::RangeError
+        type.cast(value)
       end
 
       # TODO Change this to private once we've dropped Ruby 2.2 support.

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -326,6 +326,17 @@ module ActiveRecord
       assert_equal author, Author.where(params.permit!).first
     end
 
+    def test_where_with_arel_attribute_works_without_range_error
+      expected = [authors(:david), authors(:mary), authors(:bob)]
+      assert_equal expected, Author.less_than(:id, "9223372036854775808").order(:id)
+    end
+
+    def test_to_sql_with_arel_attribute_works_without_range_error
+      expected = [authors(:david), authors(:mary), authors(:bob)]
+      less_than_sql = Author.less_than(:id, "9223372036854775808").order(:id).to_sql
+      assert_equal expected, Author.find_by_sql(less_than_sql)
+    end
+
     def test_where_with_unsupported_arguments
       assert_raises(ArgumentError) { Author.where(42) }
     end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Author < ActiveRecord::Base
+  scope :less_than, -> (attr_name, value) { where(arel_attribute(attr_name).lt(value)) }
+
   has_many :posts
   has_many :serialized_posts
   has_one :post


### PR DESCRIPTION
The following SQL is completely valid SQL, but currently it cannot be
built due to type caster raises `RangeError` when building SQL string in
Arel.

```sql
SELECT "authors".* FROM "authors" WHERE "authors"."id" < 9223372036854775808
```

It should not be raised in that case.