### PR TITLE
Allow non-English values for collection_radio_buttons

### DIFF
--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -138,7 +138,7 @@ module ActionView
           end
 
           def sanitized_value(value)
-            value.to_s.gsub(/\s/, "_").gsub(/[^-\w]/, "").downcase
+            value.to_s.gsub(/\s/, "_").gsub(/[^-[[:word:]]]/, "").mb_chars.downcase.to_s
           end
 
           def select_content_tag(option_tags, options, html_options)

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -39,6 +39,13 @@ class FormCollectionsHelperTest < ActionView::TestCase
     assert_select "label[for=user_active_no]", "No"
   end
 
+  test "collection radio generates labels for non-English values correctly" do
+    with_collection_radio_buttons :user, :title, ["Господин", "Госпожа"], :to_s, :to_s
+
+    assert_select "input[type=radio]#user_title_господин"
+    assert_select "label[for=user_title_господин]", "Господин"
+  end
+
   test "collection radio should sanitize collection values for labels correctly" do
     with_collection_radio_buttons :user, :name, ["$0.99", "$1.99"], :to_s, :to_s
     assert_select "label[for=user_name_099]", "$0.99"
@@ -297,6 +304,13 @@ class FormCollectionsHelperTest < ActionView::TestCase
     with_collection_check_boxes :user, :name, ["$0.99", "$1.99"], :to_s, :to_s
     assert_select "label[for=user_name_099]", "$0.99"
     assert_select "label[for=user_name_199]", "$1.99"
+  end
+
+  test "collection check boxes generates labels for non-English values correctly" do
+    with_collection_check_boxes :user, :title, ["Господин", "Госпожа"], :to_s, :to_s
+
+    assert_select "input[type=checkbox]#user_title_господин"
+    assert_select "label[for=user_title_господин]", "Господин"
   end
 
   test "collection check boxes accepts html options as the last element of array" do


### PR DESCRIPTION
Is there any reason why form helpers truncate non-English characters from ids of inputs? Modern browsers support them and [HTML5 does too](https://stackoverflow.com/questions/15339844/html5-unicode-id-attribute).

Doing so breaks `collection_radio_buttons` with non-English collections: clicking the label activates the wrong radio. That's because they all end up with the same id:
```erb
<input type="radio" value="маленький" name="item[size]" id="item_size_">
<label for="item_size_">маленький</label>
<input type="radio" value="большой" name="item[size]" id="item_size_">
<label for="item_size_">большой</label>
```
<br>
This PR replaces the sanitization regex with a Unicode one to keep non-English symbols in ids.