### PR TITLE
Ensure `StatementCache#execute` handles `RangeError`

### DIFF
--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -50,8 +50,6 @@ module ActiveRecord
           sc.execute(binds, conn) do |record|
             set_inverse_instance record
           end.first
-        rescue ::RangeError
-          nil
         end
 
         def replace(record)

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -178,9 +178,6 @@ module ActiveRecord
                                    name, primary_key, id)
         end
         record
-      rescue ::RangeError
-        raise RecordNotFound.new("Couldn't find #{name} with an out of range value for '#{primary_key}'",
-                                 name, primary_key)
       end
 
       def find_by(*args) # :nodoc:
@@ -207,8 +204,6 @@ module ActiveRecord
           statement.execute(hash.values, connection).first
         rescue TypeError
           raise ActiveRecord::StatementInvalid
-        rescue ::RangeError
-          nil
         end
       end
 

--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -106,6 +106,8 @@ module ActiveRecord
       sql = query_builder.sql_for bind_values, connection
 
       klass.find_by_sql(sql, bind_values, preparable: true, &block)
+    rescue ::RangeError
+      []
     end
 
     def self.unsupported_value?(value)

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1113,17 +1113,17 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_belongs_to_with_out_of_range_value_assigning
-    model = Class.new(Comment) do
+    model = Class.new(Author) do
       def self.name; "Temp"; end
-      validates :post, presence: true
+      validates :author_address, presence: true
     end
 
-    comment = model.new
-    comment.post_id = 9223372036854775808 # out of range in the bigint
+    author = model.new
+    author.author_address_id = 9223372036854775808 # out of range in the bigint
 
-    assert_nil comment.post
-    assert_not comment.valid?
-    assert_equal [{ error: :blank }], comment.errors.details[:post]
+    assert_nil author.author_address
+    assert_not author.valid?
+    assert_equal [{ error: :blank }], author.errors.details[:author_address]
   end
 
   def test_polymorphic_with_custom_primary_key

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2614,6 +2614,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_has_many_with_out_of_range_value
+    reference = Reference.create!(id: 2147483648) # out of range in the integer
+    assert_equal [], reference.ideal_jobs
+  end
+
   private
 
     def force_signal37_to_load_all_clients_of_firm

--- a/activerecord/test/models/reference.rb
+++ b/activerecord/test/models/reference.rb
@@ -4,6 +4,7 @@ class Reference < ActiveRecord::Base
   belongs_to :person
   belongs_to :job
 
+  has_many :ideal_jobs, class_name: "Job", foreign_key: :ideal_reference_id
   has_many :agents_posts_authors, through: :person
 
   class << self; attr_accessor :make_comments; end


### PR DESCRIPTION
`StatementCache` is used for simple equality queries. This means that if
`StatementCache#execute` raises `::RangeError`, the result is always
empty. so handling the `::RangeError` in `StatementCache#execute`
instead of catching the error in several places.