### PR TITLE
Show minitest options in test runner help

### DIFF
--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -1,5 +1,6 @@
 require "active_support/core_ext/module/attribute_accessors"
 require "rails/test_unit/reporter"
+require "rails/test_unit/runner"
 
 module Minitest
   class SuppressedSummaryReporter < SummaryReporter
@@ -10,6 +11,8 @@ module Minitest
   end
 
   def self.plugin_rails_options(opts, options)
+    Rails::TestUnit::Runner.attach_before_load_options(opts)
+
     opts.on("-b", "--backtrace", "Show the complete backtrace") do
       options[:full_backtrace] = true
     end

--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -1,33 +1,26 @@
 require_relative "../../command"
 require_relative "../../test_unit/runner"
+require_relative "../../test_unit/reporter"
 
 module Rails
   module Command
     class TestCommand < Base # :nodoc:
       no_commands do
         def help
-          require "optparse"
-          require "minitest/rails_plugin"
+          say "Usage: #{Rails::TestUnitReporter.executable} [options] [files or directories]"
+          say ""
+          say "You can run a single test by appending a line number to a filename:"
+          say ""
+          say "    #{Rails::TestUnitReporter.executable} test/models/user_test.rb:27"
+          say ""
+          say "You can run multiple files and directories at the same time:"
+          say ""
+          say "    #{Rails::TestUnitReporter.executable} test/controllers test/integration/login_test.rb"
+          say ""
+          say "By default test failures and errors are reported inline during a run."
+          say ""
 
-          opts = OptionParser.new
-          opts.banner = "Usage: #{Rails::TestUnitReporter.executable} [options] [files or directories]"
-          opts.separator ""
-          opts.separator "You can run a single test by appending a line number to a filename:"
-          opts.separator ""
-          opts.separator "    #{Rails::TestUnitReporter.executable} test/models/user_test.rb:27"
-          opts.separator ""
-          opts.separator "You can run multiple files and directories at the same time:"
-          opts.separator ""
-          opts.separator "    #{Rails::TestUnitReporter.executable} test/controllers test/integration/login_test.rb"
-          opts.separator ""
-          opts.separator "By default test failures and errors are reported inline during a run."
-          opts.separator ""
-
-          opts.separator "Rails options:"
-          Rails::TestUnit::Runner.options(opts)
-          Minitest.plugin_rails_options(opts, {})
-
-          say opts
+          Minitest.run(%w(--help))
         end
       end
 

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -11,7 +11,7 @@ module Rails
       mattr_reader :filters, default: []
 
       class << self
-        def options(opts)
+        def attach_before_load_options(opts)
           opts.on("--warnings", "-w", "Run with Ruby warnings enabled") {}
           opts.on("--environment", "-e", "Run tests in the ENV environment") {}
         end


### PR DESCRIPTION
Since #29572, minitest options are available but are no longer showed
in help. This fixed to show minitest option in help as with Rails 5.1.2.

**before**

```
./bin/rails t --help
You can run a single test by appending a line number to a filename:

    bin/rails test test/models/user_test.rb:27

You can run multiple files and directories at the same time:

    bin/rails test test/controllers test/integration/login_test.rb

By default test failures and errors are reported inline during a run.

Rails options:
    -w, --warnings                   Run with Ruby warnings enabled
    -e, --environment                Run tests in the ENV environment
    -b, --backtrace                  Show the complete backtrace
    -d, --defer-output               Output test failures and errors after the test run
    -f, --fail-fast                  Abort test run on first failure or error
    -c, --[no-]color                 Enable color in the output
```

**after**

```
./bin/rails t --help
You can run a single test by appending a line number to a filename:

    bin/rails test test/models/user_test.rb:27

You can run multiple files and directories at the same time:

    bin/rails test test/controllers test/integration/login_test.rb

By default test failures and errors are reported inline during a run.

minitest options:
    -h, --help                       Display this help.
    -s, --seed SEED                  Sets random seed. Also via env. Eg: SEED=n rake
    -v, --verbose                    Verbose. Show progress processing files.
    -n, --name PATTERN               Filter run on /regexp/ or string.
        --exclude PATTERN            Exclude /regexp/ or string from run.

Known extensions: rails, pride
    -w, --warnings                   Run with Ruby warnings enabled
    -e, --environment                Run tests in the ENV environment
    -b, --backtrace                  Show the complete backtrace
    -d, --defer-output               Output test failures and errors after the test run
    -f, --fail-fast                  Abort test run on first failure or error
    -c, --[no-]color                 Enable color in the output
    -p, --pride                      Pride. Show your testing pride!
```

r? @kaspth 