### PR TITLE
Fix test runner's output

### DIFF
--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -489,7 +489,7 @@ module ApplicationTests
       create_test_file :models, "post", pass: false
 
       output = run_test_command("test/models/post_test.rb")
-      assert_match %r{Finished in.*\n\n1 runs, 1 assertions}, output
+      assert_match %r{Finished in.*\n1 runs, 1 assertions}, output
     end
 
     def test_fail_fast

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -71,7 +71,7 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
     create_test_file "post", pass: false
 
     output = run_test_command("test/post_test.rb")
-    assert_match %r{Finished in.*\n\n1 runs, 1 assertions}, output
+    assert_match %r{Finished in.*\n1 runs, 1 assertions}, output
   end
 
   def test_fail_fast


### PR DESCRIPTION
Output changed due to specification change of `SummaryReporter#aggregated_results`
in minitest 5.10.2.
In my opinion, that should fix rails's test runner(proceeding with #29354).
However, we still need discussion and the fix itself is minor, so I think that we can fix only the test first.

