### PR TITLE
Rename `ColumnDumper` to `SchemaDumper` in `schema_dumper.rb`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     # dumper itself. This code represents the normal case.
     # We can then redefine how certain data types may be handled in the schema dumper on the
     # Adapter level by over-writing this code inside the database specific adapters
-    module ColumnDumper
+    module SchemaDumper # :nodoc:
       def column_spec(column)
         [schema_type_with_virtual(column), prepare_column_options(column)]
       end
@@ -22,7 +22,7 @@ module ActiveRecord
 
       # This can be overridden on an Adapter level basis to support other
       # extended datatypes (Example: Adding an array option in the
-      # PostgreSQL::ColumnDumper)
+      # PostgreSQL::SchemaDumper)
       def prepare_column_options(column)
         spec = {}
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -72,7 +72,7 @@ module ActiveRecord
       include Quoting, DatabaseStatements, SchemaStatements
       include DatabaseLimits
       include QueryCache
-      include ColumnDumper
+      include SchemaDumper
       include Savepoints
 
       SIMPLE_INT = /\A\d+\z/

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -17,7 +17,7 @@ module ActiveRecord
   module ConnectionAdapters
     class AbstractMysqlAdapter < AbstractAdapter
       include MySQL::Quoting
-      include MySQL::ColumnDumper
+      include MySQL::SchemaDumper
       include MySQL::SchemaStatements
 
       def update_table_definition(table_name, base) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module MySQL
-      module ColumnDumper # :nodoc:
+      module SchemaDumper # :nodoc:
         def prepare_column_options(column)
           spec = super
           spec[:unsigned] = "true" if column.unsigned?

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
-      module ColumnDumper # :nodoc:
+      module SchemaDumper # :nodoc:
         # Adds +:array+ option to the default set
         def prepare_column_options(column)
           spec = super

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -119,9 +119,9 @@ module ActiveRecord
 
       include PostgreSQL::Quoting
       include PostgreSQL::ReferentialIntegrity
+      include PostgreSQL::SchemaDumper
       include PostgreSQL::SchemaStatements
       include PostgreSQL::DatabaseStatements
-      include PostgreSQL::ColumnDumper
 
       def supports_index_sort_order?
         true

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module SQLite3
-      module ColumnDumper # :nodoc:
+      module SchemaDumper # :nodoc:
         private
 
           def default_primary_key?(column)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -57,7 +57,7 @@ module ActiveRecord
       ADAPTER_NAME = "SQLite".freeze
 
       include SQLite3::Quoting
-      include SQLite3::ColumnDumper
+      include SQLite3::SchemaDumper
       include SQLite3::SchemaStatements
 
       NATIVE_DATABASE_TYPES = {


### PR DESCRIPTION
I think it is confusing because it violates the naming convention.
And also, the module is only used for `ActiveRecord::SchemaDumper`
internal class. So I think it should be hidden in the doc.