### PR TITLE
Move database-specific `DEFAULT_LIMIT` back to Active Record

### DIFF
--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -5,10 +5,6 @@ module ActiveModel
     class Integer < Value # :nodoc:
       include Helpers::Numeric
 
-      # Column storage size in bytes.
-      # 4 bytes means an integer as opposed to smallint etc.
-      DEFAULT_LIMIT = 4
-
       def initialize(*)
         super
         @range = min_value...max_value
@@ -55,7 +51,11 @@ module ActiveModel
         end
 
         def max_value
-          1 << (_limit * 8 - 1) # 8 bits per byte with one bit for sign
+          if _limit
+            1 << (_limit * 8 - 1) # 8 bits per byte with one bit for sign
+          else
+            ::Float::INFINITY
+          end
         end
 
         def min_value
@@ -63,7 +63,7 @@ module ActiveModel
         end
 
         def _limit
-          limit || DEFAULT_LIMIT
+          limit
         end
     end
   end

--- a/activemodel/test/cases/type/integer_test.rb
+++ b/activemodel/test/cases/type/integer_test.rb
@@ -63,25 +63,25 @@ module ActiveModel
 
       test "values below int min value are out of range" do
         assert_raises(ActiveModel::RangeError) do
-          Integer.new.serialize(-2147483649)
+          Integer.new(limit: 4).serialize(-2147483649)
         end
       end
 
       test "values above int max value are out of range" do
         assert_raises(ActiveModel::RangeError) do
-          Integer.new.serialize(2147483648)
+          Integer.new(limit: 4).serialize(2147483648)
         end
       end
 
       test "very small numbers are out of range" do
         assert_raises(ActiveModel::RangeError) do
-          Integer.new.serialize(-9999999999999999999999999999999)
+          Integer.new(limit: 8).serialize(-9999999999999999999999999999999)
         end
       end
 
       test "very large numbers are out of range" do
         assert_raises(ActiveModel::RangeError) do
-          Integer.new.serialize(9999999999999999999999999999999)
+          Integer.new(limit: 8).serialize(9999999999999999999999999999999)
         end
       end
 

--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -7,6 +7,7 @@ require "active_record/type/internal/timezone"
 require "active_record/type/date"
 require "active_record/type/date_time"
 require "active_record/type/decimal_without_scale"
+require "active_record/type/integer"
 require "active_record/type/json"
 require "active_record/type/time"
 require "active_record/type/text"
@@ -59,7 +60,6 @@ module ActiveRecord
     Boolean = ActiveModel::Type::Boolean
     Decimal = ActiveModel::Type::Decimal
     Float = ActiveModel::Type::Float
-    Integer = ActiveModel::Type::Integer
     String = ActiveModel::Type::String
     Value = ActiveModel::Type::Value
 

--- a/activerecord/lib/active_record/type/integer.rb
+++ b/activerecord/lib/active_record/type/integer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Type
+    class Integer < ActiveModel::Type::Integer # :nodoc:
+      private
+        def _limit
+          limit || 4 # 4 bytes means an integer as opposed to smallint etc.
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/type/unsigned_integer.rb
+++ b/activerecord/lib/active_record/type/unsigned_integer.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   module Type
-    class UnsignedInteger < ActiveModel::Type::Integer # :nodoc:
+    class UnsignedInteger < Integer # :nodoc:
       private
 
         def max_value


### PR DESCRIPTION
Currently `ActiveRecord::Type` was moved to `ActiveModel` (9cc8c6f3730).
And moved back database-specific types (#26696). I think that assuming
`DEFAULT_LIMIT` is a database-specific feature. Active Model should not
raise `RangeError` against valid integer value in Ruby.

```
Loading development environment (Rails 5.1.0.beta1)
irb(main):001:0> type = ActiveModel::Type.lookup(:integer)
=> #<ActiveModel::Type::Integer:0x007f850967e860 @precision=nil, @scale=nil, @limit=nil, @range=-2147483648...2147483648>
irb(main):002:0> 1<<128
=> 340282366920938463463374607431768211456
irb(main):003:0> (1<<128).class
=> Integer
irb(main):004:0> type.serialize(1<<128)
ActiveModel::RangeError: 340282366920938463463374607431768211456 is out of range for ActiveModel::Type::Integer with limit 4 bytes
	from (irb):4
```
