### PR TITLE
Fix test directory to correct path

### DIFF
--- a/actionview/package.json
+++ b/actionview/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "bundle exec blade build",
     "test": "echo \"See the README: https://github.com/rails/rails/blob/master/actionview/app/assets/javascripts#how-to-run-tests\" && exit 1",
-    "lint": "coffeelint app/assets/javascripts && eslint test/public/test"
+    "lint": "coffeelint app/assets/javascripts && eslint test/ujs/public/test"
   },
   "repository": {
     "type": "git",

--- a/actionview/test/ujs/public/test/data-confirm.js
+++ b/actionview/test/ujs/public/test/data-confirm.js
@@ -300,7 +300,7 @@ asyncTest('clicking on the children of a disabled button should not trigger a co
   window.confirm = function(msg) { message = msg; return false }
 
   $('button[data-confirm][disabled]')
-    .html("<strong>Click me</strong>")
+    .html('<strong>Click me</strong>')
     .bindNative('confirm', function() {
       App.assertCallbackNotInvoked('confirm')
     })

--- a/actionview/test/ujs/public/test/data-remote.js
+++ b/actionview/test/ujs/public/test/data-remote.js
@@ -411,7 +411,7 @@ asyncTest('form buttons should only be serialized when clicked', 4, function() {
 asyncTest('changing a select option without "data-url" attribute still fires ajax request to current location', 1, function() {
   var currentLocation, ajaxLocation
 
-  buildSelect({'data-url': ''});
+  buildSelect({'data-url': ''})
 
   $('select[data-remote]')
     .bindNative('ajax:beforeSend', function(e, xhr, settings) {


### PR DESCRIPTION
Together, fix to the following lint violation.

```
rails/actionview/test/ujs/public/test/data-confirm.js
  303:11  error  Strings must use singlequote  quotes

rails/actionview/test/ujs/public/test/data-remote.js
  414:32  error  Extra semicolon  semi

✖ 2 problems (2 errors, 0 warnings)
```