### PR TITLE
Require alpha arel

### DIFF
--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", version
   s.add_dependency "activemodel",   version
 
-  s.add_dependency "arel", "~> 8.0"
+  s.add_dependency "arel", "9.0.0.alpha"
 end


### PR DESCRIPTION
### Summary

This pull request addresses this error by cherry-picking d361aa3895d288594d2b31eecb4614c2d6192241 into `unlock-minitest` branch.

```ruby
Bundler could not find compatible versions for gem "arel":
  In Gemfile:
    arel
    rails was resolved to 5.2.0.alpha, which depends on
      activerecord (= 5.2.0.alpha) was resolved to 5.2.0.alpha, which depends on
        arel (~> 8.0)
```
