### PR TITLE
Handling nested_attributes edge case for one to one association

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -398,7 +398,7 @@ module ActiveRecord
         if attributes.respond_to?(:permitted?)
           attributes = attributes.to_h
         end
-        attributes = attributes.with_indifferent_access
+        attributes = (attributes || {}).with_indifferent_access
         existing_record = send(association_name)
 
         if (options[:update_only] || !attributes["id"].blank?) && existing_record &&

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -232,6 +232,10 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
     assert_equal "Cannot build association `looter'. Are you trying to build a polymorphic one-to-one association?", exception.message
   end
 
+  def test_should_assign_nil_to_association_when_nil
+    assert_nil(Pirate.new(ship_attributes: nil).ship)
+  end
+
   def test_should_define_an_attribute_writer_method_for_the_association
     assert_respond_to @pirate, :ship_attributes=
   end


### PR DESCRIPTION
Calling:
Pirate.new(:ship_attributes: nil)

shouldn't raise an exception


Reopening #24059 . I had to create a new branch and this made the PR to be closed.



@eugeneius You raise two good points:
https://github.com/rails/rails/pull/24059#issuecomment-285582344
In the beginning of the method there's a check to make sure it receives an array or hash. If we get [nil] maybe it's ok to have an exception than ignore the object creation otherwise how can someone figure out that this is happening?  What do you think?

On the other hand I think it is possible to assign nil in an one-to-one association. I wouldn't expect one exception in this case. I would expect the object to be nullified/removed.

https://github.com/rails/rails/pull/24059#issuecomment-285582669
I've changed the test to be make sure that the association gets a nil value instead of asserting that it doesn't raise an exception.




