### PR TITLE
Handling add/remove to/from migration edge cases 

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -28,7 +28,7 @@ module ActiveRecord
         def set_local_assigns!
           @migration_template = "migration.rb"
           case file_name
-          when /^(add|remove)_.*_(?:to|from)_(.*)/
+          when /^(add)_.*_to_(.*)/, /^(remove)_.*?_from_(.*)/
             @migration_action = $1
             @table_name       = normalize_table_name($2)
           when /join_table/

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -48,6 +48,17 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_add_migration_with_table_having_from_in_title
+    migration = "add_email_address_to_blacklisted_from_campaign"
+    run_generator [migration, "email_address:string"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/add_column :blacklisted_from_campaigns, :email_address, :string/, change)
+      end
+    end
+  end
+
   def test_remove_migration_with_indexed_attribute
     migration = "remove_title_body_from_posts"
     run_generator [migration, "title:string:index", "body:text"]
@@ -69,6 +80,17 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
       assert_method :change, content do |change|
         assert_match(/remove_column :posts, :title, :string/, change)
         assert_match(/remove_column :posts, :body, :text/, change)
+      end
+    end
+  end
+
+  def test_remove_migration_with_table_having_to_in_title
+    migration = "remove_email_address_from_sent_to_user"
+    run_generator [migration, "email_address:string"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/remove_column :sent_to_users, :email_address, :string/, change)
       end
     end
   end


### PR DESCRIPTION
Making sure the table name is parsed correctly when an add/remove column migration have 'from'  in the table name.