### PR TITLE
Update blank.rb

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -42,8 +42,8 @@ class Object
   #   region = params[:state].presence || params[:country].presence || 'US'
   #
   # @return [Object]
-  def presence
-    self if present?
+  def presence(object = nil)
+    present? ? self : object
   end
 end
 


### PR DESCRIPTION
### Summary
Only provide a return object if the receiving object is nil.

Examples:
```ruby
text = nil
text.presence("Default text")
# Output: Default text
```

Write:
```ruby
host = config[:host].presence('localhost')
```

Instead:
```ruby
host = config[:host].presence || 'localhost'
```
