### PR TITLE
Use duktape gem as default JS engine on Windows-MINGW

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -348,6 +348,8 @@ module Rails
         comment = "See https://github.com/rails/execjs#readme for more supported runtimes"
         if defined?(JRUBY_VERSION)
           GemfileEntry.version "therubyrhino", nil, comment
+        elsif RUBY_PLATFORM =~ /mingw|mswin/
+          GemfileEntry.version "duktape", nil, comment
         else
           GemfileEntry.new "mini_racer", nil, comment, { platforms: :ruby }, true
         end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -521,6 +521,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
     if defined?(JRUBY_VERSION)
       assert_gem "therubyrhino"
+    elsif RUBY_PLATFORM =~ /mingw|mswin/
+      assert_gem "duktape"
     else
       assert_file "Gemfile", /# gem 'mini_racer', platforms: :ruby/
     end


### PR DESCRIPTION
The default javascript engine on Windows is Windows Script Host (JScript). However this engine isn't able to process the default assets.

The recommended engine on other platforms `mini_racer` doesn't support Windows. There are other alternatives like Node.js, but they require additional setup. So `duktape` is the [recommended engine](https://github.com/oneclick/rubyinstaller2/wiki/FAQ#q-are-there-recommendations-for-working-with-rails) on Windows.

Fixes #30014
