### PR TITLE
Set Ruby version in Gemfile and .ruby-version by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `ruby x.x.x` version to `Gemfile` and create `.ruby-version`
+    root file containing current Ruby version when new Rails applications are
+    created.
+
+    *Alberto Almagro*
+
 *   Support `-` as a platform-agnostic way to run a script from stdin with
     `rails runner`
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -49,6 +49,10 @@ module Rails
       copy_file "README.md", "README.md"
     end
 
+    def ruby_version
+      template "ruby-version", ".ruby-version"
+    end
+
     def gemfile
       template "Gemfile"
     end
@@ -242,6 +246,7 @@ module Rails
       def create_root_files
         build(:readme)
         build(:rakefile)
+        build(:ruby_version)
         build(:configru)
         build(:gitignore)   unless options[:skip_git]
         build(:gemfile)     unless options[:skip_gemfile]

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+ruby <%= "'#{RUBY_VERSION}'" %>
 
 <% gemfile_entries.each do |gem| -%>
 <% if gem.comment -%>

--- a/railties/lib/rails/generators/rails/app/templates/ruby-version
+++ b/railties/lib/rails/generators/rails/app/templates/ruby-version
@@ -1,0 +1,1 @@
+<%= RUBY_VERSION -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -4,6 +4,7 @@ require "generators/shared_generator_tests"
 
 DEFAULT_APP_FILES = %w(
   .gitignore
+  .ruby-version
   README.md
   Gemfile
   Rakefile
@@ -802,6 +803,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file ".gitignore" do |content|
       assert_no_match(/sqlite/i, content)
+    end
+  end
+
+  def test_inclusion_of_ruby_version
+    run_generator
+
+    assert_file "Gemfile" do |content|
+      assert_match(/ruby '#{RUBY_VERSION}'/, content)
+    end
+    assert_file ".ruby-version" do |content|
+      assert_match(/#{RUBY_VERSION}/, content)
     end
   end
 


### PR DESCRIPTION
### Summary

This pull request sets current Ruby version in the Gemfile and .ruby-version by default.

When running `rails new my-app` the generated application will include by default:
* A `.ruby-version` file, containing the default Ruby version.
* An entry in the `Gemfile`, with the format `ruby '2.x.x'` with the same default Ruby version.

### Implications
Among other usages:
* `.ruby-version` will help ruby version manager tools such as `rbenv` to determine which Ruby version should be used for the current Rails project.
* The entry `ruby 'version'` in the `Gemfile` may be used by deployment tools (i.e. Heroku) to determine the Ruby version that should be used to run Rails.
