### PR TITLE
Fix rubocop issues

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn
@@ -1,7 +1,7 @@
 VENDOR_PATH = File.expand_path('..', __dir__)
 Dir.chdir(VENDOR_PATH) do
   begin
-    exec "yarnpkg #{ARGV.join(" ")}"
+    exec "yarnpkg #{ARGV.join(' ')}"
   rescue Errno::ENOENT
     $stderr.puts "Yarn executable was not detected in the system."
     $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"

--- a/railties/lib/rails/generators/rails/app/templates/config/spring.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/spring.rb
@@ -1,6 +1,6 @@
-%w(
+%w[
   .ruby-version
   .rbenv-vars
   tmp/restart.txt
   tmp/caching-dev.txt
-).each { |path| Spring.watch(path) }
+].each { |path| Spring.watch(path) }


### PR DESCRIPTION
This PR fixes two small style issues in the templates that are used for new rails apps.  These issues impact projects created with `rails new`.  If those projects use rubocop to check their style, these issues will show up as violations.

1. In `config/string`, `%w()` is used.  The ruby style guide prefers `%[]`.  (See [here](https://github.com/bbatsov/ruby-style-guide#percent-literal-braces) for more info.)
2. In `bin/yarn`, interpolated double quotes are used inside a string that also uses double quotes.  In this case, rubocop prefers the inner string to use single quotes to help improve readability.
