### PR TITLE
Remove extra empty line

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -1,7 +1,11 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-ruby <%= "'#{RUBY_VERSION}'" %>
 
+ruby <%= "'#{RUBY_VERSION}'" -%>
+
+<% unless gemfile_entries.first.comment -%>
+
+<% end -%>
 <% gemfile_entries.each do |gem| -%>
 <% if gem.comment -%>
 


### PR DESCRIPTION
**before**

```
source 'https://rubygems.org'
git_source(:github) { |repo| "https://github.com/#{repo}.git" }
ruby '2.4.1'


# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
gem 'rails'
```

**after**

```
source 'https://rubygems.org'
git_source(:github) { |repo| "https://github.com/#{repo}.git" }

ruby '2.4.1'

# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
gem 'rails', '~> 5.2.0.alpha'
```