### PR TITLE
Remove unnecessary `doc` directory deletion

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -120,7 +120,6 @@ task default: :test
     def test_dummy_clean
       inside dummy_path do
         remove_file "db/seeds.rb"
-        remove_file "doc"
         remove_file "Gemfile"
         remove_file "lib/tasks"
         remove_file "public/robots.txt"

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -491,7 +491,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_no_file "test/dummy/public/robots.txt"
     assert_no_file "test/dummy/README.md"
     assert_no_directory "test/dummy/lib/tasks"
-    assert_no_directory "test/dummy/doc"
     assert_no_directory "test/dummy/test"
     assert_no_directory "test/dummy/vendor"
     assert_no_directory "test/dummy/.git"


### PR DESCRIPTION
Since 553b695, `doc` directory is not created in application.
