### PR TITLE
Add helper to URI (HTTP/FTP) to inject query parameters.

### DIFF
--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require "uri"
+require_relative "uri/http"
+require_relative "uri/ftp"
+
 str = "\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E" # Ni-ho-nn-go in UTF-8, means Japanese.
 parser = URI::Parser.new
 

--- a/activesupport/lib/active_support/core_ext/uri/ftp.rb
+++ b/activesupport/lib/active_support/core_ext/uri/ftp.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative "utils/query_param"
+
+URI::FTP.class_eval do
+  include URI::Utils::QueryParam
+end

--- a/activesupport/lib/active_support/core_ext/uri/http.rb
+++ b/activesupport/lib/active_support/core_ext/uri/http.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative "utils/query_param"
+
+URI::HTTP.class_eval do
+  include URI::Utils::QueryParam
+end

--- a/activesupport/lib/active_support/core_ext/uri/utils/query_param.rb
+++ b/activesupport/lib/active_support/core_ext/uri/utils/query_param.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rack/utils"
+require_relative "../../hash/keys"
+
+module URI
+  module Utils
+    module QueryParam
+      # Add key/value parameters to a url having (or not) query parameters.
+      # Takes a hash and returns a string containing the full and final
+      # query parameters.
+      #
+      #   uri = URI("http://www.test.com?a=b")
+      #   uri.add_params({ c: "d" })
+      #   uri.to_s
+      #   # => "http://www.test.com?a=b&c=d"
+      #
+      # Keys such as String and/or Symbol are accepted within +params+.
+      # If there is a collision with an already existing key, the old value
+      # will be replaced by the new one.
+      def add_params(params)
+        full_params = Rack::Utils.parse_query(query).merge(params.stringify_keys)
+        self.query  = Rack::Utils.build_query(full_params)
+      end
+    end
+  end
+end

--- a/activesupport/test/core_ext/uri/uri_ftp_test.rb
+++ b/activesupport/test/core_ext/uri/uri_ftp_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/core_ext/uri/ftp"
+
+class URIFTPTest < ActiveSupport::TestCase
+  def test_respond_to_add_params
+    assert_respond_to URI("ftp://user:pass@host.com/abc/def"), :add_params
+  end
+end

--- a/activesupport/test/core_ext/uri/uri_http_test.rb
+++ b/activesupport/test/core_ext/uri/uri_http_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/core_ext/uri/http"
+
+class URIHTTPTest < ActiveSupport::TestCase
+  def test_respond_to_add_params
+    assert_respond_to URI("http://www.example.com"), :add_params
+  end
+end

--- a/activesupport/test/core_ext/uri/uri_https_test.rb
+++ b/activesupport/test/core_ext/uri/uri_https_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/core_ext/uri/http"
+
+class URIHTTPSTest < ActiveSupport::TestCase
+  def test_respond_to_add_params
+    assert_respond_to URI("https://www.example.com"), :add_params
+  end
+end

--- a/activesupport/test/core_ext/uri/utils/uri_add_query_param_test.rb
+++ b/activesupport/test/core_ext/uri/utils/uri_add_query_param_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/core_ext/uri/http"
+require "active_support/core_ext/uri/utils/query_param"
+
+class URIAddQueryParamTest < ActiveSupport::TestCase
+  def test_uri_add_params
+    uri = URI("http://www.test.com/")
+    params = { a: "b", "c" => "d" }
+
+    uri.add_params(params)
+    assert_equal "http://www.test.com/?a=b&c=d", uri.to_s
+  end
+
+  def test_uri_add_params_with_query_parameters
+    uri = URI("http://www.test.com?a=b")
+    params = { c: "d" }
+
+    uri.add_params(params)
+    assert_equal "http://www.test.com?a=b&c=d", uri.to_s
+  end
+
+  def test_uri_add_params_collision
+    uri = URI("http://www.test.com?a=b&c=d")
+    params = { a: "b" }
+
+    uri.add_params(params)
+    assert_equal "http://www.test.com?a=b&c=d", uri.to_s
+  end
+end


### PR DESCRIPTION
This is a simple helper to easily add query parameters to `HTTP` and `FTP` urls using the `URI` Ruby module.

Here is an example _(already present in the code documentation)_:
```ruby
> uri = URI("http://www.test.com?a=b")
> uri.add_params({ c: "d" })
> uri.to_s # => "http://www.test.com?a=b&c=d"
```

_Note: Since not all the `URI` subclasses can receive query parameters, the helper has been added in a module included within specific classes instead of injecting it as a global context._