### PR TITLE
Let ActiveStorage tests pass only for Disk

### DIFF
--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -14,7 +14,9 @@ require "active_storage"
 
 require "yaml"
 SERVICE_CONFIGURATIONS = begin
-  YAML.load(ERB.new(Pathname.new(File.expand_path("../service/configurations.yml", __FILE__)).read).result).deep_symbolize_keys
+  erb = ERB.new(Pathname.new(File.expand_path("../service/configurations.yml", __FILE__)).read)
+  configuration = YAML.load(erb.result) || {}
+  configuration.deep_symbolize_keys
 rescue Errno::ENOENT
   puts "Missing service configuration file in test/service/configurations.yml"
   {}


### PR DESCRIPTION
If you have a "service/configurations.yml" file, but every single line is
commented out, then an error occurs when running tests:

```
git:active-storage-import~/code/rails/activestorage$ rake
~/code/rails/activestorage/test/test_helper.rb:17:in `<top (required)>': undefined method `deep_symbolize_keys' for false:FalseClass (NoMethodError)
	from ~/code/rails/activestorage/test/controllers/direct_uploads_controller_test.rb:1:in `require'
```

The reason is that `YAML.load(..an empty file content..)` simply returns `false`, and not `{}`.

This PR fixes this behavior so tests can also run when no remote service
is available.

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
