### PR TITLE
Remove HTTParty dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,8 +93,6 @@ group :cable do
 end
 
 group :storage do
-  gem "httparty"
-
   gem "aws-sdk", "~> 2", require: false
   gem "google-cloud-storage", "~> 1.3", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,8 +268,6 @@ GEM
       signet (~> 0.7)
     hiredis (0.6.1)
     http_parser.rb (0.6.0)
-    httparty (0.15.6)
-      multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     i18n (0.8.6)
     jmespath (1.3.1)
@@ -311,7 +309,6 @@ GEM
     msgpack (1.1.0-x64-mingw32)
     msgpack (1.1.0-x86-mingw32)
     multi_json (1.12.1)
-    multi_xml (0.6.0)
     multipart-post (2.0.0)
     mustache (1.0.5)
     mustermann (1.0.0)
@@ -503,7 +500,6 @@ DEPENDENCIES
   erubis (~> 2.7.0)
   google-cloud-storage (~> 1.3)
   hiredis
-  httparty
   jquery-rails
   json (>= 2.0.0)
   kindlerb (~> 1.2.0)

--- a/activestorage/test/service/azure_service_test.rb
+++ b/activestorage/test/service/azure_service_test.rb
@@ -1,5 +1,4 @@
 require "service/shared_service_tests"
-require "httparty"
 require "uri"
 
 if SERVICE_CONFIGURATIONS[:azure]

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -1,5 +1,5 @@
 require "service/shared_service_tests"
-require "httparty"
+require "net/http"
 
 if SERVICE_CONFIGURATIONS[:s3]
   class ActiveStorage::Service::S3ServiceTest < ActiveSupport::TestCase
@@ -14,12 +14,14 @@ if SERVICE_CONFIGURATIONS[:s3]
         checksum = Digest::MD5.base64digest(data)
         url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
-        HTTParty.put(
-          url,
-          body: data,
-          headers: { "Content-Type" => "text/plain", "Content-MD5" => checksum },
-          debug_output: STDOUT
-        )
+        uri = URI.parse url
+        request = Net::HTTP::Put.new uri.request_uri
+        request.body = data
+        request.add_field 'Content-Type', 'text/plain'
+        request.add_field 'Content-MD5', checksum
+        Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+          http.request request
+        end
 
         assert_equal data, @service.download(key)
       ensure


### PR DESCRIPTION
"httparty" is only added in #30020 to write two tests to make PUT requests
against S3 and GCS.

The same requests can be made with `net/http`, removing a dependency from the Gemfile.