### PR TITLE
fixed usage of Parameters with non-numeric key in nested attributes

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -216,6 +216,12 @@ module ActionController
     #    config.always_permitted_parameters = %w( controller action format )
     cattr_accessor :always_permitted_parameters, default: %w( controller action )
 
+    class << self
+      def field_style_valid?(k = nil, v = nil)
+        k =~ /\A-?\d+\z/ && (v.is_a?(Hash) || v.is_a?(Parameters))
+      end
+    end
+
     # Returns a new instance of <tt>ActionController::Parameters</tt>.
     # Also, sets the +permitted+ attribute to the default value of
     # <tt>ActionController::Parameters.permit_all_parameters</tt>.
@@ -800,7 +806,7 @@ module ActionController
       end
 
       def fields_for_style?
-        @parameters.all? { |k, v| k =~ /\A-?\d+\z/ && (v.is_a?(Hash) || v.is_a?(Parameters)) }
+        @parameters.any? { |k, v| Parameters.field_style_valid?(k, v) }
       end
 
     private
@@ -852,7 +858,7 @@ module ActionController
         when Parameters
           if object.fields_for_style?
             hash = object.class.new
-            object.each { |k, v| hash[k] = yield v }
+            object.each { |k, v| hash[k] = yield v if Parameters.field_style_valid?(k, v) }
             hash
           else
             yield object

--- a/actionpack/test/controller/parameters/nested_parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/nested_parameters_permit_test.rb
@@ -173,7 +173,6 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
     )
   end
 
-
   test "fields_for-style nested params with negative numbers" do
     params = ActionController::Parameters.new(
       book: {

--- a/actionpack/test/controller/parameters/nested_parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/nested_parameters_permit_test.rb
@@ -163,7 +163,7 @@ class NestedParametersPermitTest < ActiveSupport::TestCase
 
     assert_not_nil permitted[:book][:authors_attributes]["0"]
     assert_not_nil permitted[:book][:authors_attributes]["1"]
-    assert_empty permitted[:book][:authors_attributes]["new_record"]
+    assert_nil permitted[:book][:authors_attributes]["new_record"]
     assert_equal "William Shakespeare", permitted[:book][:authors_attributes]["0"][:name]
     assert_equal "Unattributed Assistant", permitted[:book][:authors_attributes]["1"][:name]
 


### PR DESCRIPTION
### Summary
Fixes #29888
"Parameters" object that includes nested attributes as { "tests_attributes" => { "111" => { "name" => "aaa" }, "new_record" => { "name" => "bbb" } } } now doesn't remove the whole "tests_attributes" hash, but keeps  { "tests_attributes" => { "111" => { "name" => "aaa" } } }  part of it.
