### PR TITLE
Use rails instead of bin/rails on generate

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use rails instead of bin/rails on generate.
+
+    *Yoshiyuki Hirano*
+
 *   Add `ruby x.x.x` version to `Gemfile` and create `.ruby-version`
     root file containing current Ruby version when new Rails applications are
     created.

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -202,7 +202,7 @@ module Rails
         log :generate, what
         argument = args.flat_map(&:to_s).join(" ")
 
-        in_root { run_ruby_script("bin/rails generate #{what} #{argument}", verbose: false) }
+        in_root { run_ruby_script("rails generate #{what} #{argument}", verbose: false) }
       end
 
       # Runs the supplied rake task (invoked with 'rake ...')

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -196,7 +196,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_generate_should_run_script_generate_with_argument_and_options
-    assert_called_with(generator, :run_ruby_script, ["bin/rails generate model MyModel", verbose: false]) do
+    assert_called_with(generator, :run_ruby_script, ["rails generate model MyModel", verbose: false]) do
       action :generate, "model", "MyModel"
     end
   end


### PR DESCRIPTION
Use `rails` instead of `bin/rails` on generate, Because it can run without binstub same as `rails_command` method. Please see [this](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/actions.rb#L284).