### PR TITLE
Change setting position of environment variable

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Change setting position of environment variable from end of command to
+    beginning of command.
+
+    *Yoshiyuki Hirano*
+
 *   Add `ruby x.x.x` version to `Gemfile` and create `.ruby-version`
     root file containing current Ruby version when new Rails applications are
     created.

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -281,7 +281,7 @@ module Rails
           log executor, command
           env  = options[:env] || ENV["RAILS_ENV"] || "development"
           sudo = options[:sudo] && !Gem.win_platform? ? "sudo " : ""
-          in_root { run("#{sudo}#{extify(executor)} #{command} RAILS_ENV=#{env}", verbose: false) }
+          in_root { run("RAILS_ENV=#{env} #{sudo}#{extify(executor)} #{command}", verbose: false) }
         end
 
         # Add an extension to the given name based on the platform.

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -202,7 +202,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_rails_should_run_rake_command_with_default_env
-    assert_called_with(generator, :run, ["rake log:clear RAILS_ENV=development", verbose: false]) do
+    assert_called_with(generator, :run, ["RAILS_ENV=development rake log:clear", verbose: false]) do
       with_rails_env nil do
         action :rake, "log:clear"
       end
@@ -210,13 +210,13 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_rails_with_env_option_should_run_rake_command_in_env
-    assert_called_with(generator, :run, ["rake log:clear RAILS_ENV=production", verbose: false]) do
+    assert_called_with(generator, :run, ["RAILS_ENV=production rake log:clear", verbose: false]) do
       action :rake, "log:clear", env: "production"
     end
   end
 
   test "rails command with RAILS_ENV variable should run rake command in env" do
-    assert_called_with(generator, :run, ["rake log:clear RAILS_ENV=production", verbose: false]) do
+    assert_called_with(generator, :run, ["RAILS_ENV=production rake log:clear", verbose: false]) do
       with_rails_env "production" do
         action :rake, "log:clear"
       end
@@ -224,7 +224,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   test "env option should win over RAILS_ENV variable when running rake" do
-    assert_called_with(generator, :run, ["rake log:clear RAILS_ENV=production", verbose: false]) do
+    assert_called_with(generator, :run, ["RAILS_ENV=production rake log:clear", verbose: false]) do
       with_rails_env "staging" do
         action :rake, "log:clear", env: "production"
       end
@@ -232,7 +232,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   test "rails command with sudo option should run rake command with sudo" do
-    assert_called_with(generator, :run, ["sudo rake log:clear RAILS_ENV=development", verbose: false]) do
+    assert_called_with(generator, :run, ["RAILS_ENV=development sudo rake log:clear", verbose: false]) do
       with_rails_env nil do
         action :rake, "log:clear", sudo: true
       end
@@ -240,7 +240,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   test "rails command should run rails_command with default env" do
-    assert_called_with(generator, :run, ["rails log:clear RAILS_ENV=development", verbose: false]) do
+    assert_called_with(generator, :run, ["RAILS_ENV=development rails log:clear", verbose: false]) do
       with_rails_env nil do
         action :rails_command, "log:clear"
       end
@@ -248,13 +248,13 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   test "rails command with env option should run rails_command with same env" do
-    assert_called_with(generator, :run, ["rails log:clear RAILS_ENV=production", verbose: false]) do
+    assert_called_with(generator, :run, ["RAILS_ENV=production rails log:clear", verbose: false]) do
       action :rails_command, "log:clear", env: "production"
     end
   end
 
   test "rails command with RAILS_ENV variable should run rails_command in env" do
-    assert_called_with(generator, :run, ["rails log:clear RAILS_ENV=production", verbose: false]) do
+    assert_called_with(generator, :run, ["RAILS_ENV=production rails log:clear", verbose: false]) do
       with_rails_env "production" do
         action :rails_command, "log:clear"
       end
@@ -262,7 +262,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   def test_env_option_should_win_over_rails_env_variable_when_running_rails
-    assert_called_with(generator, :run, ["rails log:clear RAILS_ENV=production", verbose: false]) do
+    assert_called_with(generator, :run, ["RAILS_ENV=production rails log:clear", verbose: false]) do
       with_rails_env "staging" do
         action :rails_command, "log:clear", env: "production"
       end
@@ -270,7 +270,7 @@ class ActionsTest < Rails::Generators::TestCase
   end
 
   test "rails command with sudo option should run rails_command with sudo" do
-    assert_called_with(generator, :run, ["sudo rails log:clear RAILS_ENV=development", verbose: false]) do
+    assert_called_with(generator, :run, ["RAILS_ENV=development sudo rails log:clear", verbose: false]) do
       with_rails_env nil do
         action :rails_command, "log:clear", sudo: true
       end


### PR DESCRIPTION
I've changed setting position of environment variable from end of command to beginning of command. So if it execute rails command such as `rails_command("generate controller Home index")`,  `RAILS_ENV=development` will be recognized as not environment variables.

This is a execution result same as my explaination:

```
% bin/rails g controller Home index RAILS_ENV=development
Running via Spring preloader in process 96480
      create  app/controllers/home_controller.rb
       route  get 'home/RAILS_ENV=development'
       route  get 'home/index'
      invoke  erb
      create    app/views/home
      create    app/views/home/index.html.erb
      create    app/views/home/RAILS_ENV=development.html.erb
      invoke  test_unit
      create    test/controllers/home_controller_test.rb
```

Of cause `rails_command` method aim for executing rake task. But just by making this change, I thought it would be useful in multiple situations or usages which don't be considered.