### PR TITLE
Update String#camelize to provide feedback when a wrong option is sent

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -15,7 +15,6 @@
 
     *Ricardo Díaz*
 
-
 *   Fix modulo operations involving durations
 
     Rails 5.1 introduce an `ActiveSupport::Duration::Scalar` class as a wrapper

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Update String#camelize to provide feedback when wrong option is passed
+
+    String#camelize was returning nil without any feedback when an
+    invalid option was passed as parameter.
+
+    Previously:
+
+        'one_two'.camelize(true)
+        => nil
+
+    Now:
+
+        'one_two'.camelize(true)
+        => ArgumentError: Invalid option, use either :upper or :lower.
+
+    *Ricardo Díaz*
+
+
 *   Fix modulo operations involving durations
 
     Rails 5.1 introduce an `ActiveSupport::Duration::Scalar` class as a wrapper

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -94,6 +94,8 @@ class String
       ActiveSupport::Inflector.camelize(self, true)
     when :lower
       ActiveSupport::Inflector.camelize(self, false)
+    else
+      raise ArgumentError, "Invalid option, use either :upper or :lower."
     end
   end
   alias_method :camelcase, :camelize

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -108,6 +108,13 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal("capital", "Capital".camelize(:lower))
   end
 
+  def test_camelize_invalid_option
+    e = assert_raise ArgumentError do
+      "Capital".camelize(nil)
+    end
+    assert_equal("Invalid option, use either :upper or :lower.", e.message)
+  end
+
   def test_dasherize
     UnderscoresToDashes.each do |underscored, dasherized|
       assert_equal(dasherized, underscored.dasherize)


### PR DESCRIPTION
### Summary
`String#camelize` was returning `nil` without any feedback when an
invalid option was sent as parameter. This update makes the method to
raise an ArgumentError when the option passed is invalid, similar to what
Ruby does for `String#downcase` (and other methods) in 2.4.1.

Previously:

    'one_two'.camelize(true)
    => nil

 Now:

    'one_two'.camelize(true)
    => ArgumentError: Invalid option, use either :upper or :lower.
