### PR TITLE
Load Parameters configurations on :action_controller only once

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -24,7 +24,7 @@ module ActionController
     initializer "action_controller.parameters_config" do |app|
       options = app.config.action_controller
 
-      ActiveSupport.on_load(:action_controller) do
+      ActiveSupport.on_load(:action_controller, run_once: true) do
         ActionController::Parameters.permit_all_parameters = options.delete(:permit_all_parameters) { false }
         if app.config.action_controller[:always_permitted_parameters]
           ActionController::Parameters.always_permitted_parameters =

--- a/activesupport/lib/active_support/lazy_load_hooks.rb
+++ b/activesupport/lib/active_support/lazy_load_hooks.rb
@@ -27,11 +27,17 @@ module ActiveSupport
       base.class_eval do
         @load_hooks = Hash.new { |h, k| h[k] = [] }
         @loaded     = Hash.new { |h, k| h[k] = [] }
+        @run_once   = Hash.new { |h, k| h[k] = [] }
       end
     end
 
     # Declares a block that will be executed when a Rails component is fully
     # loaded.
+    #
+    # Options:
+    #
+    # * <tt>:yield</tt> - Yields the object that run_load_hooks to +block+.
+    # * <tt>:run_once</tt> - Given +block+ will run only once.
     def on_load(name, options = {}, &block)
       @loaded[name].each do |base|
         execute_hook(base, options, block)
@@ -40,20 +46,32 @@ module ActiveSupport
       @load_hooks[name] << [block, options]
     end
 
-    def execute_hook(base, options, block)
-      if options[:yield]
-        block.call(base)
-      else
-        base.instance_eval(&block)
-      end
-    end
-
     def run_load_hooks(name, base = Object)
       @loaded[name] << base
       @load_hooks[name].each do |hook, options|
         execute_hook(base, options, hook)
       end
     end
+
+    private
+
+      def with_execution_control(name, block, once)
+        unless @run_once[name].include?(block)
+          @run_once[name] << block if once
+
+          yield
+        end
+      end
+
+      def execute_hook(base, options, block)
+        with_execution_control(name, block, options[:run_once]) do
+          if options[:yield]
+            block.call(base)
+          else
+            base.instance_eval(&block)
+          end
+        end
+      end
   end
 
   extend LazyLoadHooks

--- a/activesupport/test/lazy_load_hooks_test.rb
+++ b/activesupport/test/lazy_load_hooks_test.rb
@@ -20,6 +20,18 @@ class LazyLoadHooksTest < ActiveSupport::TestCase
     assert_equal 7, i
   end
 
+  def test_basic_hook_with_two_registrations_only_once
+    i = 0
+    ActiveSupport.on_load(:basic_hook_with_two_once, run_once: true) do
+      i += incr
+    end
+    assert_equal 0, i
+    ActiveSupport.run_load_hooks(:basic_hook_with_two_once, FakeContext.new(2))
+    assert_equal 2, i
+    ActiveSupport.run_load_hooks(:basic_hook_with_two_once, FakeContext.new(5))
+    assert_equal 2, i
+  end
+
   def test_hook_registered_after_run
     i = 0
     ActiveSupport.run_load_hooks(:registered_after)
@@ -37,6 +49,15 @@ class LazyLoadHooksTest < ActiveSupport::TestCase
     assert_equal 7, i
   end
 
+  def test_hook_registered_after_run_with_two_registrations_only_once
+    i = 0
+    ActiveSupport.run_load_hooks(:registered_after_with_two_once, FakeContext.new(2))
+    ActiveSupport.run_load_hooks(:registered_after_with_two_once, FakeContext.new(5))
+    assert_equal 0, i
+    ActiveSupport.on_load(:registered_after_with_two_once, run_once: true) { i += incr }
+    assert_equal 2, i
+  end
+
   def test_hook_registered_interleaved_run_with_two_registrations
     i = 0
     ActiveSupport.run_load_hooks(:registered_interleaved_with_two, FakeContext.new(2))
@@ -45,6 +66,22 @@ class LazyLoadHooksTest < ActiveSupport::TestCase
     assert_equal 2, i
     ActiveSupport.run_load_hooks(:registered_interleaved_with_two, FakeContext.new(5))
     assert_equal 7, i
+  end
+
+  def test_hook_registered_interleaved_run_with_two_registrations_once
+    i = 0
+    ActiveSupport
+      .run_load_hooks(:registered_interleaved_with_two_once, FakeContext.new(2))
+    assert_equal 0, i
+
+    ActiveSupport.on_load(:registered_interleaved_with_two_once, run_once: true) do
+      i += incr
+    end
+    assert_equal 2, i
+
+    ActiveSupport
+      .run_load_hooks(:registered_interleaved_with_two_once, FakeContext.new(5))
+    assert_equal 2, i
   end
 
   def test_hook_receives_a_context


### PR DESCRIPTION
### Summary

This PR fixes the regression where ActionController::UnpermittedParameters exceptions are not being raised.

To accomplish that the following has been made:
* Allow `ActiveSupport::LazyLoadHooks` to be executed only once.
Provide `run_once: true` option to `on_load` in case you want a hook only to be executed once. This may be useful in cases where executing a hook several times may have undesired side effects. Example: `ActiveSupport.on_load(:action_controller, run_once: true)`
* Load Parameters configurations on `:action_controller` only once.
By using the new `ActiveSupport::LazyLoadHooks`functionality described above fixes regression `ActionController::UnpermittedParameters` not raised. The inner hook was being executed twice, once when `ActionController::Base` was loaded and again when `ActionController::API` was loaded. As `options.delete` operations inside the block are not idempotent, the second time it was run there was no configuration option available.
### Other Information

More information can be found in Issue [30025](https://github.com/rails/rails/issues/30025).
