### PR TITLE
Fix `Style/StringLiterals` violations for Active Storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,8 +97,8 @@ group :storage do
   gem "google-cloud-storage", "~> 1.3", require: false
 
   # Contains fix to be able to test using StringIO
-  gem 'azure-core', git: "https://github.com/dixpac/azure-ruby-asm-core.git"
-  gem 'azure-storage', require: false
+  gem "azure-core", git: "https://github.com/dixpac/azure-ruby-asm-core.git"
+  gem "azure-storage", require: false
 
   gem "mini_magick"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -512,7 +512,6 @@ DEPENDENCIES
   libxml-ruby
   listen (>= 3.0.5, < 3.2)
   mini_magick
-  minitest (< 5.3.4)
   minitest-bisect
   mocha (~> 0.14)
   mysql2 (>= 0.4.4)

--- a/activestorage/test/dummy/Rakefile
+++ b/activestorage/test/dummy/Rakefile
@@ -1,3 +1,3 @@
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks

--- a/activestorage/test/dummy/bin/bundle
+++ b/activestorage/test/dummy/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-load Gem.bin_path('bundler', 'bundle')
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
+load Gem.bin_path("bundler", "bundle")

--- a/activestorage/test/dummy/bin/rails
+++ b/activestorage/test/dummy/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/activestorage/test/dummy/bin/rake
+++ b/activestorage/test/dummy/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/activestorage/test/dummy/bin/yarn
+++ b/activestorage/test/dummy/bin/yarn
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-VENDOR_PATH = File.expand_path('..', __dir__)
+VENDOR_PATH = File.expand_path("..", __dir__)
 Dir.chdir(VENDOR_PATH) do
   begin
     exec "yarnpkg #{ARGV.join(" ")}"

--- a/activestorage/test/dummy/config.ru
+++ b/activestorage/test/dummy/config.ru
@@ -1,5 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application

--- a/activestorage/test/dummy/config/application.rb
+++ b/activestorage/test/dummy/config/application.rb
@@ -1,4 +1,4 @@
-require_relative 'boot'
+require_relative "boot"
 
 require "rails"
 require "active_model/railtie"

--- a/activestorage/test/dummy/config/boot.rb
+++ b/activestorage/test/dummy/config/boot.rb
@@ -1,5 +1,5 @@
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../Gemfile", __dir__)
 
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
-$LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+$LOAD_PATH.unshift File.expand_path("../../../lib", __dir__)

--- a/activestorage/test/dummy/config/environment.rb
+++ b/activestorage/test/dummy/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/activestorage/test/dummy/config/environments/development.rb
+++ b/activestorage/test/dummy/config/environments/development.rb
@@ -13,12 +13,12 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.seconds.to_i}"
     }
   else
     config.action_controller.perform_caching = false

--- a/activestorage/test/dummy/config/environments/production.rb
+++ b/activestorage/test/dummy/config/environments/production.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/activestorage/test/dummy/config/environments/test.rb
+++ b/activestorage/test/dummy/config/environments/test.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.seconds.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.seconds.to_i}"
   }
 
   # Show full error reports and disable caching.

--- a/activestorage/test/dummy/config/initializers/assets.rb
+++ b/activestorage/test/dummy/config/initializers/assets.rb
@@ -1,12 +1,12 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -17,8 +17,8 @@ if SERVICE_CONFIGURATIONS[:gcs]
         uri = URI.parse url
         request = Net::HTTP::Put.new uri.request_uri
         request.body = data
-        request.add_field 'Content-Type', 'text/plain'
-        request.add_field 'Content-MD5', checksum
+        request.add_field "Content-Type", "text/plain"
+        request.add_field "Content-MD5", checksum
         Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
           http.request request
         end

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -17,8 +17,8 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
         uri = URI.parse url
         request = Net::HTTP::Put.new uri.request_uri
         request.body = data
-        request.add_field 'Content-Type', 'text/plain'
-        request.add_field 'Content-MD5', checksum
+        request.add_field "Content-Type", "text/plain"
+        request.add_field "Content-MD5", checksum
         Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
           http.request request
         end


### PR DESCRIPTION
```
% be rubocop -a --only Style/StringLiterals activestorage
Inspecting 74 files
........................................CCCCCCCCCC.C........CC.......C.C..

(snip)

74 files inspected, 31 offenses detected, 31 offenses corrected
```