### PR TITLE
Allow `table_name_prefix` and `table_name_suffix` have `$`

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -243,7 +243,9 @@ HEADER
       end
 
       def remove_prefix_and_suffix(table)
-        table.gsub(/^(#{@options[:table_name_prefix]})(.+)(#{@options[:table_name_suffix]})$/,  "\\2")
+        prefix = Regexp.escape(@options[:table_name_prefix].to_s)
+        suffix = Regexp.escape(@options[:table_name_suffix].to_s)
+        table.sub(/\A#{prefix}(.+)#{suffix}\z/, "\\1")
       end
 
       def ignored?(table_name)


### PR DESCRIPTION
### Summary
Addresses #30044

Allow `table_name_prefix` and `table_name_suffix` have `$`.
MySQL 5.7 and PostgreSQL 9.6 allow table identifiers have the dollar sign.

* MySQL 5.7
https://dev.mysql.com/doc/refman/5.7/en/identifiers.html

> Permitted characters in unquoted identifiers:
>  ASCII: [0-9,a-z,A-Z$_] (basic Latin letters, digits 0-9, dollar, underscore)

* PostgreSQL 9.6
https://www.postgresql.org/docs/9.6/static/sql-syntax-lexical.html

> SQL identifiers and key words must begin with a letter (a-z, but also letters with diacritical marks and non-Latin letters) or an underscore (_). Subsequent characters in an identifier or key word can be letters, underscores, digits (0-9), or dollar signs ($). Note that dollar signs are not allowed in identifiers according to the letter of the SQL standard, so their use might render applications less portable. The SQL standard will not define a key word that contains digits or starts or ends with an underscore, so identifiers of this form are safe against possible conflict with future extensions of the standard.

cc @kamipo who suggests better fix by using Regexp.escape