### PR TITLE
Passing `klass` to `StatementCache.new`

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -304,15 +304,13 @@ module ActiveRecord
           return scope.to_a if skip_statement_cache?(scope)
 
           conn = klass.connection
-          sc = reflection.association_scope_cache(conn, owner) do
-            StatementCache.create(conn) { |params|
-              as = AssociationScope.create { params.bind }
-              target_scope.merge!(as.scope(self))
-            }
+          sc = reflection.association_scope_cache(conn, owner) do |params|
+            as = AssociationScope.create { params.bind }
+            target_scope.merge!(as.scope(self))
           end
 
           binds = AssociationScope.get_bind_values(owner, reflection.chain)
-          sc.execute(binds, klass, conn) do |record|
+          sc.execute(binds, conn) do |record|
             set_inverse_instance(record)
           end
         end

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -41,15 +41,13 @@ module ActiveRecord
           return scope.take if skip_statement_cache?(scope)
 
           conn = klass.connection
-          sc = reflection.association_scope_cache(conn, owner) do
-            StatementCache.create(conn) { |params|
-              as = AssociationScope.create { params.bind }
-              target_scope.merge!(as.scope(self)).limit(1)
-            }
+          sc = reflection.association_scope_cache(conn, owner) do |params|
+            as = AssociationScope.create { params.bind }
+            target_scope.merge!(as.scope(self)).limit(1)
           end
 
           binds = AssociationScope.get_bind_values(owner, reflection.chain)
-          sc.execute(binds, klass, conn) do |record|
+          sc.execute(binds, conn) do |record|
             set_inverse_instance record
           end.first
         rescue ::RangeError

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -176,7 +176,7 @@ module ActiveRecord
           where(key => params.bind).limit(1)
         }
 
-        record = statement.execute([id], self, connection).first
+        record = statement.execute([id], connection).first
         unless record
           raise RecordNotFound.new("Couldn't find #{name} with '#{primary_key}'=#{id}",
                                    name, primary_key, id)
@@ -208,7 +208,7 @@ module ActiveRecord
           where(wheres).limit(1)
         }
         begin
-          statement.execute(hash.values, self, connection).first
+          statement.execute(hash.values, connection).first
         rescue TypeError
           raise ActiveRecord::StatementInvalid
         rescue ::RangeError

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -458,13 +458,13 @@ module ActiveRecord
         end
       end
 
-      def association_scope_cache(conn, owner)
+      def association_scope_cache(conn, owner, &block)
         key = conn.prepared_statements
         if polymorphic?
           key = [key, owner._read_attribute(@foreign_type)]
         end
         @association_scope_cache[key] ||= @scope_lock.synchronize {
-          @association_scope_cache[key] ||= yield
+          @association_scope_cache[key] ||= StatementCache.create(conn, &block)
         }
       end
 

--- a/activerecord/test/cases/statement_cache_test.rb
+++ b/activerecord/test/cases/statement_cache_test.rb
@@ -21,9 +21,9 @@ module ActiveRecord
         Book.where(name: params.bind)
       end
 
-      b = cache.execute([ "my book" ], Book, Book.connection)
+      b = cache.execute([ "my book" ], Book.connection)
       assert_equal "my book", b[0].name
-      b = cache.execute([ "my other book" ], Book, Book.connection)
+      b = cache.execute([ "my other book" ], Book.connection)
       assert_equal "my other book", b[0].name
     end
 
@@ -35,9 +35,9 @@ module ActiveRecord
         Book.where(id: params.bind)
       end
 
-      b = cache.execute([ b1.id ], Book, Book.connection)
+      b = cache.execute([ b1.id ], Book.connection)
       assert_equal b1.name, b[0].name
-      b = cache.execute([ b2.id ], Book, Book.connection)
+      b = cache.execute([ b2.id ], Book.connection)
       assert_equal b2.name, b[0].name
     end
 
@@ -60,7 +60,7 @@ module ActiveRecord
 
       Book.create(name: "my book", author_id: 4)
 
-      books = cache.execute([], Book, Book.connection)
+      books = cache.execute([], Book.connection)
       assert_equal "my book", books[0].name
     end
 
@@ -73,7 +73,7 @@ module ActiveRecord
       molecule = salty.molecules.create(name: "dioxane")
       molecule.electrons.create(name: "lepton")
 
-      liquids = cache.execute([], Book, Book.connection)
+      liquids = cache.execute([], Book.connection)
       assert_equal "salty", liquids[0].name
     end
 
@@ -86,13 +86,13 @@ module ActiveRecord
         Book.create(name: "my book")
       end
 
-      first_books = cache.execute([], Book, Book.connection)
+      first_books = cache.execute([], Book.connection)
 
       3.times do
         Book.create(name: "my book")
       end
 
-      additional_books = cache.execute([], Book, Book.connection)
+      additional_books = cache.execute([], Book.connection)
       assert first_books != additional_books
     end
 


### PR DESCRIPTION
Actually `StatementCache#execute` is always passed the same klass that
the owner klass of the connection when the statement cache is created.
So passing `klass` to `StatementCache.new` will make more DRY.