### PR TITLE
Move database-specific boolean serialization back to Active Record

### DIFF
--- a/activemodel/lib/active_model/type/immutable_string.rb
+++ b/activemodel/lib/active_model/type/immutable_string.rb
@@ -10,8 +10,6 @@ module ActiveModel
       def serialize(value)
         case value
         when ::Numeric, ActiveSupport::Duration then value.to_s
-        when true then "t"
-        when false then "f"
         else super
         end
       end
@@ -19,12 +17,7 @@ module ActiveModel
       private
 
         def cast_value(value)
-          result = \
-            case value
-            when true then "t"
-            when false then "f"
-            else value.to_s
-            end
+          result = value.to_s
           result.freeze
         end
     end

--- a/activemodel/lib/active_model/type/string.rb
+++ b/activemodel/lib/active_model/type/string.rb
@@ -16,8 +16,6 @@ module ActiveModel
         def cast_value(value)
           case value
           when ::String then ::String.new(value)
-          when true then "t".freeze
-          when false then "f".freeze
           else value.to_s
           end
         end

--- a/activemodel/test/cases/type/string_test.rb
+++ b/activemodel/test/cases/type/string_test.rb
@@ -8,8 +8,8 @@ module ActiveModel
     class StringTest < ActiveModel::TestCase
       test "type casting" do
         type = Type::String.new
-        assert_equal "t", type.cast(true)
-        assert_equal "f", type.cast(false)
+        assert_equal "true", type.cast(true)
+        assert_equal "false", type.cast(false)
         assert_equal "123", type.cast(123)
       end
 

--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -8,6 +8,7 @@ require_relative "type/date"
 require_relative "type/date_time"
 require_relative "type/decimal_without_scale"
 require_relative "type/json"
+require_relative "type/string"
 require_relative "type/time"
 require_relative "type/text"
 require_relative "type/unsigned_integer"
@@ -60,7 +61,6 @@ module ActiveRecord
     Decimal = ActiveModel::Type::Decimal
     Float = ActiveModel::Type::Float
     Integer = ActiveModel::Type::Integer
-    String = ActiveModel::Type::String
     Value = ActiveModel::Type::Value
 
     register(:big_integer, Type::BigInteger, override: false)

--- a/activerecord/lib/active_record/type/string.rb
+++ b/activerecord/lib/active_record/type/string.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Type
+    class String < ActiveModel::Type::String # :nodoc:
+      def serialize(value)
+        case value
+        when true then "t"
+        when false then "f"
+        else super
+        end
+      end
+
+      private
+        def cast_value(value)
+          case value
+          when true then "t"
+          when false then "f"
+          else super
+          end
+        end
+    end
+  end
+end


### PR DESCRIPTION
Currently `ActiveRecord::Type` was moved to `ActiveModel` (9cc8c6f3730).
And moved back database-specific types (#26696). I think that casting
booleans to `"t"`/`"f"` is a database-specific representation.

WDYT?