### PR TITLE
Deprecate `LoadError::REGEXPS` constant

### DIFF
--- a/activesupport/lib/active_support/core_ext/load_error.rb
+++ b/activesupport/lib/active_support/core_ext/load_error.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
 class LoadError
-  REGEXPS = [
-    /^no such file to load -- (.+)$/i,
-    /^Missing \w+ (?:file\s*)?([^\s]+.rb)$/i,
-    /^Missing API definition file in (.+)$/i,
-    /^cannot load such file -- (.+)$/i,
-  ]
-
   # Returns true if the given path name (except perhaps for the ".rb"
   # extension) is the missing file which caused the exception to be raised.
   def is_missing?(location)


### PR DESCRIPTION
since 4ad1a52, `LoadError::REGEXPS` is no longer needed.
