### PR TITLE
Rename azure storage service

### DIFF
--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -7,7 +7,7 @@ require "active_storage/log_subscriber"
 # * +Disk+, to manage attachments saved directly on the hard drive.
 # * +GCS+, to manage attachments through Google Cloud Storage.
 # * +S3+, to manage attachments through Amazon S3.
-# * +Azure+, to manage attachments through Microsoft Azure Storage.
+# * +AzureStorage+, to manage attachments through Microsoft Azure Storage.
 # * +Mirror+, to be able to use several services to manage attachments.
 #
 # Inside a Rails application, you can set-up your services through the

--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -4,7 +4,7 @@ require "azure/storage/core/auth/shared_access_signature"
 
 # Wraps the Microsoft Azure Storage Blob Service as a Active Storage service.
 # See `ActiveStorage::Service` for the generic API documentation that applies to all services.
-class ActiveStorage::Service::AzureService < ActiveStorage::Service
+class ActiveStorage::Service::AzureStorageService < ActiveStorage::Service
   attr_reader :client, :path, :blobs, :container, :signer
 
   def initialize(path:, storage_account_name:, storage_access_key:, container:)

--- a/activestorage/lib/active_storage/service/configurator.rb
+++ b/activestorage/lib/active_storage/service/configurator.rb
@@ -22,7 +22,7 @@ class ActiveStorage::Service::Configurator #:nodoc:
     end
 
     def resolve(class_name)
-      require "active_storage/service/#{class_name.to_s.downcase}_service"
+      require "active_storage/service/#{class_name.to_s.underscore}_service"
       ActiveStorage::Service.const_get(:"#{class_name}Service")
     end
 end

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -68,7 +68,7 @@ else
 end
 
 if SERVICE_CONFIGURATIONS[:azure]
-  class ActiveStorage::AzureDirectUploadsControllerTest < ActionDispatch::IntegrationTest
+  class ActiveStorage::AzureStorageDirectUploadsControllerTest < ActionDispatch::IntegrationTest
     setup do
       @config = SERVICE_CONFIGURATIONS[:azure]
 
@@ -98,7 +98,7 @@ if SERVICE_CONFIGURATIONS[:azure]
     end
   end
 else
-  puts "Skipping Azure Direct Upload tests because no Azure configuration was supplied"
+  puts "Skipping Azure Storage Direct Upload tests because no Azure Storage configuration was supplied"
 end
 
 class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::IntegrationTest

--- a/activestorage/test/service/azure_storage_service_test.rb
+++ b/activestorage/test/service/azure_storage_service_test.rb
@@ -2,7 +2,7 @@ require "service/shared_service_tests"
 require "uri"
 
 if SERVICE_CONFIGURATIONS[:azure]
-  class ActiveStorage::Service::AzureServiceTest < ActiveSupport::TestCase
+  class ActiveStorage::Service::AzureStorageServiceTest < ActiveSupport::TestCase
     SERVICE = ActiveStorage::Service.configure(:azure, SERVICE_CONFIGURATIONS)
 
     include ActiveStorage::Service::SharedServiceTests

--- a/activestorage/test/service/configurations.yml
+++ b/activestorage/test/service/configurations.yml
@@ -21,9 +21,9 @@ s3:
 #   }
 #   project:
 #   bucket:
-# 
+#
 # azure:
-#   service: Azure
+#   service: AzureStorage
 #   path: ""
 #   storage_account_name: ""
 #   storage_access_key: ""


### PR DESCRIPTION
Azure is not the most correct name. Azure is service that contains storage,database,etc...(same as aws or google cloud).
Renaming this to `AzureStorage` would be more correct. If `AzureStorage` is not the best name we could consider abbreviation such as `MAS` (same approach as to GCS)

r? @dhh 
cc @georgeclaghorn 
