### PR TITLE
Use `assert_nil` if `value` is nil in `assert_field_default_value`

### DIFF
--- a/railties/lib/rails/generators/testing/assertions.rb
+++ b/railties/lib/rails/generators/testing/assertions.rb
@@ -113,7 +113,11 @@ module Rails
         #
         #   assert_field_default_value :string, "MyString"
         def assert_field_default_value(attribute_type, value)
-          assert_equal(value, create_generated_attribute(attribute_type).default)
+          if value.nil?
+            assert_nil(create_generated_attribute(attribute_type).default)
+          else
+            assert_equal(value, create_generated_attribute(attribute_type).default)
+          end
         end
       end
     end


### PR DESCRIPTION
It is deprecate to specify nil for expect argument of `assert_equal`.
Ref: https://github.com/seattlerb/minitest/commit/922bc9151a622cb3ef0b9f170aa09c3bb72c7eb8

FYI: We already have a test that specifies nil in `assert_field_default_value`
https://github.com/rails/rails/blob/5fd50c387bdfc2761859ec7a57477bcd56e93210/railties/test/generators/generated_attribute_test.rb#L84..L88