### PR TITLE
Fix tests for AWS buckets that include a .

### DIFF
--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -24,7 +24,8 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
         assert_equal 6, details["byte_size"]
         assert_equal checksum, details["checksum"]
         assert_equal "text/plain", details["content_type"]
-        assert_match /#{SERVICE_CONFIGURATIONS[:s3][:bucket]}\.s3.(\S+)?amazonaws\.com/, details["direct_upload"]["url"]
+        assert_match SERVICE_CONFIGURATIONS[:s3][:bucket], details["direct_upload"]["url"]
+        assert_match /s3\.(\S+)?amazonaws\.com/, details["direct_upload"]["url"]
         assert_equal({ "Content-Type" => "text/plain", "Content-MD5" => checksum }, details["direct_upload"]["headers"])
       end
     end

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -30,8 +30,11 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
     end
 
     test "signed URL generation" do
-      assert_match /#{SERVICE_CONFIGURATIONS[:s3][:bucket]}\.s3.(\S+)?amazonaws.com.*response-content-disposition=inline.*avatar\.png.*response-content-type=image%2Fpng/,
-        @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: :inline, filename: "avatar.png", content_type: "image/png")
+      url = @service.url(FIXTURE_KEY, expires_in: 5.minutes,
+        disposition: :inline, filename: "avatar.png", content_type: "image/png")
+
+      assert_match /s3\.(\S+)?amazonaws.com.*response-content-disposition=inline.*avatar\.png.*response-content-type=image%2Fpng/, url
+      assert_match SERVICE_CONFIGURATIONS[:s3][:bucket], url
     end
 
     test "uploading with server-side encryption" do


### PR DESCRIPTION
If an AWS bucket name includes a `.` (e.g. `bucket.name`), then the canonical
URL for an object will start with "https://s3.amazonaws.com/bucket.name/"
and not with "https://bucket.name.s3.amazonaws.com/".

The URL tests have now been separated into two separate asserts, to ensure
that both the "s3.amazonaws.com" and the "bucket.name" components are included,
but not specifically in that order.