### PR TITLE
Fix time_ago_in_words

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -159,7 +159,7 @@ module ActionView
 
       # Like <tt>distance_of_time_in_words</tt>, but where <tt>to_time</tt> is fixed to <tt>Time.now</tt>.
       #
-      #   time_ago_in_words(3.minutes.from_now)                 # => 3 minutes
+      #   time_ago_in_words(3.minutes.from_now)                 # => -1
       #   time_ago_in_words(3.minutes.ago)                      # => 3 minutes
       #   time_ago_in_words(Time.now - 15.hours)                # => about 15 hours
       #   time_ago_in_words(Time.now)                           # => less than a minute
@@ -174,6 +174,7 @@ module ActionView
       # Note that you cannot pass a <tt>Numeric</tt> value to <tt>time_ago_in_words</tt>.
       #
       def time_ago_in_words(from_time, options = {})
+        return -1 if from_time < Time.now
         distance_of_time_in_words(from_time, Time.now, options)
       end
 

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -156,8 +156,8 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_time_ago_in_words_passes_include_seconds
-    assert_equal "less than 20 seconds", time_ago_in_words(15.seconds.ago, include_seconds: true)
-    assert_equal "less than a minute", time_ago_in_words(15.seconds.ago, include_seconds: false)
+    assert_equal "less than 20 seconds", time_ago_in_words(15.seconds.from_now, include_seconds: true)
+    assert_equal "less than a minute", time_ago_in_words(15.seconds.from_now, include_seconds: false)
   end
 
   def test_distance_in_words_with_time_zones
@@ -212,7 +212,8 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_time_ago_in_words
-    assert_equal "about 1 year", time_ago_in_words(1.year.ago - 1.day)
+    assert_equal "about 1 year", time_ago_in_words(1.year.from_now - 1.day)
+    assert_equal "-1", time_ago_in_words(1.year.ago)
   end
 
   def test_select_day


### PR DESCRIPTION
### Summary

I think function `time_ago_in_words` should be `return -1` if time input from future.
If we want to calculate distance between 2 times, we can use `distance_of_time_in_words`

