### PR TITLE
Add `binary` helper method to fixtures.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `binary` fixture helper method.
+
+    *Atsushi Yoshida*
+
 *   When using `Relation#or`, extract the common conditions and put them before the OR condition.
 
     *Maxime Handfield Lapointe*

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -1065,6 +1065,10 @@ class ActiveRecord::FixtureSet::RenderContext # :nodoc:
       def get_binding
         binding()
       end
+
+      def binary(path)
+        %(!!binary "#{Base64.strict_encode64(File.read(path))}")
+      end
     end
   end
 end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -132,7 +132,7 @@ class FixturesTest < ActiveRecord::TestCase
   def test_no_args_record_returns_all_without_array
     all_binaries = binaries
     assert_kind_of(Array, all_binaries)
-    assert_equal 1, binaries.length
+    assert_equal 2, binaries.length
   end
 
   def test_nil_raises
@@ -313,6 +313,7 @@ class FixturesTest < ActiveRecord::TestCase
     data.force_encoding("ASCII-8BIT")
     data.freeze
     assert_equal data, @flowers.data
+    assert_equal data, @binary_helper.data
   end
 
   def test_serialized_fixtures

--- a/activerecord/test/fixtures/binaries.yml
+++ b/activerecord/test/fixtures/binaries.yml
@@ -131,3 +131,7 @@ flowers:
     SgCUASgCUASgCUASgAC74PbXOTvE5/En7jpSoLE8/wBn7uPJjKyj46T9D/NT
     pKsXyQzxNpdNP0/akB5484WkMKh4RfXG4UafNmH7b0UxWMrb7Nxg6rl9Z/Im
     w+vWq0iscQwxQroiUIvkKsRZQBKAJQBKAJQB/9k=
+
+binary_helper:
+  id: 2
+  data: <%= binary(ASSETS_ROOT + "/flowers.jpg") %>


### PR DESCRIPTION
### Summary

I want to use binary data as fixture.
I can do it but it is bothered that are needed to encode base64.
So I add the helper method it's so useful.

Thanks