### PR TITLE
Race condition when using ActionController::Live and `head :{status_code}`.

### DIFF
--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -35,8 +35,6 @@ module ActionController
       self.status = status
       self.location = url_for(location) if location
 
-      self.response_body = ""
-
       if include_content?(response_code)
         unless self.media_type
           self.content_type = content_type || (Mime[formats.first] if formats) || Mime[:html]
@@ -44,6 +42,8 @@ module ActionController
 
         response.charset = false
       end
+
+      self.response_body = ""
 
       true
     end


### PR DESCRIPTION
### Summary

When using `ActionController::Live` and `head :{status_code}`, Rails is setting content type header after a response body, which results in a race condition (throwing either `ActionDispatch::IllegalStateError: header already sent` or `RuntimeError: can't modify frozen Hash`).

### Other Information

This commit restores original order (i.e. from before 75757c5c3bb7f743eab11ee1ed5ca457810e0391).