### PR TITLE
Active Storage: check for `app.secrets.secret_key_base`, not `app.config.secret_key_base`

### DIFF
--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -27,7 +27,7 @@ module ActiveStorage
 
     initializer "active_storage.verifier" do
       config.after_initialize do |app|
-        if app.config.secret_key_base.present?
+        if app.secrets.secret_key_base.present?
           ActiveStorage.verifier = app.message_verifier("ActiveStorage")
         end
       end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -453,10 +453,8 @@ module ApplicationTests
           secret_key_base: 123
       YAML
 
-      app "development"
-
       assert_raise(ArgumentError) do
-        app.key_generator
+        app "development"
       end
     end
 


### PR DESCRIPTION
By default, apps only have the former set.