### PR TITLE
Fix ruby warnings

### DIFF
--- a/activestorage/lib/active_storage/attached/macros.rb
+++ b/activestorage/lib/active_storage/attached/macros.rb
@@ -22,8 +22,11 @@ module ActiveStorage::Attached::Macros
   # (i.e. destroyed) whenever the record is destroyed.
   def has_one_attached(name, dependent: :purge_later)
     define_method(name) do
-      instance_variable_get("@active_storage_attached_#{name}") ||
+      if instance_variable_defined?("@active_storage_attached_#{name}")
+        instance_variable_get("@active_storage_attached_#{name}")
+      else
         instance_variable_set("@active_storage_attached_#{name}", ActiveStorage::Attached::One.new(name, self))
+      end
     end
 
     has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record
@@ -60,8 +63,11 @@ module ActiveStorage::Attached::Macros
   # (i.e. destroyed) whenever the record is destroyed.
   def has_many_attached(name, dependent: :purge_later)
     define_method(name) do
-      instance_variable_get("@active_storage_attached_#{name}") ||
+      if instance_variable_defined?("@active_storage_attached_#{name}")
+        instance_variable_get("@active_storage_attached_#{name}")
+      else
         instance_variable_set("@active_storage_attached_#{name}", ActiveStorage::Attached::Many.new(name, self))
+      end
     end
 
     has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment"

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -25,7 +25,7 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
         assert_equal checksum, details["checksum"]
         assert_equal "text/plain", details["content_type"]
         assert_match SERVICE_CONFIGURATIONS[:s3][:bucket], details["direct_upload"]["url"]
-        assert_match /s3\.(\S+)?amazonaws\.com/, details["direct_upload"]["url"]
+        assert_match(/s3\.(\S+)?amazonaws\.com/, details["direct_upload"]["url"])
         assert_equal({ "Content-Type" => "text/plain", "Content-MD5" => checksum }, details["direct_upload"]["headers"])
       end
     end
@@ -115,7 +115,7 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
       assert_equal 6, details["byte_size"]
       assert_equal checksum, details["checksum"]
       assert_equal "text/plain", details["content_type"]
-      assert_match /rails\/active_storage\/disk/, details["direct_upload"]["url"]
+      assert_match(/rails\/active_storage\/disk/, details["direct_upload"]["url"])
       assert_equal({ "Content-Type" => "text/plain" }, details["direct_upload"]["headers"])
     end
   end

--- a/activestorage/test/controllers/variants_controller_test.rb
+++ b/activestorage/test/controllers/variants_controller_test.rb
@@ -12,7 +12,7 @@ class ActiveStorage::VariantsControllerTest < ActionDispatch::IntegrationTest
       signed_blob_id: @blob.signed_id,
       variation_key: ActiveStorage::Variation.encode(resize: "100x100"))
 
-    assert_redirected_to /racecar.jpg\?.*disposition=inline/
+    assert_redirected_to(/racecar.jpg\?.*disposition=inline/)
 
     image = read_image_variant(@blob.variant(resize: "100x100"))
     assert_equal 100, image.width

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -8,7 +8,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "resized variation" do
     variant = @blob.variant(resize: "100x100").processed
-    assert_match /racecar.jpg/, variant.service_url
+    assert_match(/racecar.jpg/, variant.service_url)
 
     image = read_image_variant(variant)
     assert_equal 100, image.width
@@ -17,11 +17,11 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "resized and monochrome variation" do
     variant = @blob.variant(resize: "100x100", monochrome: true).processed
-    assert_match /racecar.jpg/, variant.service_url
+    assert_match(/racecar.jpg/, variant.service_url)
 
     image = read_image_variant(variant)
     assert_equal 100, image.width
     assert_equal 67, image.height
-    assert_match /Gray/, image.colorspace
+    assert_match(/Gray/, image.colorspace)
   end
 end

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -6,7 +6,7 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
   include ActiveStorage::Service::SharedServiceTests
 
   test "url generation" do
-    assert_match /rails\/active_storage\/disk\/.*\/avatar\.png\?.+disposition=inline/,
-      @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: :inline, filename: "avatar.png", content_type: "image/png")
+    assert_match(/rails\/active_storage\/disk\/.*\/avatar\.png\?.+disposition=inline/,
+      @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: :inline, filename: "avatar.png", content_type: "image/png"))
   end
 end

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -33,7 +33,7 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
       url = @service.url(FIXTURE_KEY, expires_in: 5.minutes,
         disposition: :inline, filename: "avatar.png", content_type: "image/png")
 
-      assert_match /s3\.(\S+)?amazonaws.com.*response-content-disposition=inline.*avatar\.png.*response-content-type=image%2Fpng/, url
+      assert_match(/s3\.(\S+)?amazonaws.com.*response-content-disposition=inline.*avatar\.png.*response-content-type=image%2Fpng/, url)
       assert_match SERVICE_CONFIGURATIONS[:s3][:bucket], url
     end
 


### PR DESCRIPTION
This fixes following warnings:

```
test/models/variant_test.rb:11: warning: ambiguous first argument; put parentheses or a space even after `/' operator
lib/active_storage/attached/macros.rb:63: warning: instance variable @active_storage_attached_highlights not initialized
lib/active_storage/attached/macros.rb:25: warning: instance variable @active_storage_attached_avatar not initialized
```
