### PR TITLE
Change gem version of Active Storage to 5.2.0.alpha

### DIFF
--- a/activestorage/lib/active_storage/gem_version.rb
+++ b/activestorage/lib/active_storage/gem_version.rb
@@ -5,8 +5,8 @@ module ActiveStorage
   end
 
   module VERSION
-    MAJOR = 0
-    MINOR = 1
+    MAJOR = 5
+    MINOR = 2
     TINY  = 0
     PRE   = "alpha"
 


### PR DESCRIPTION
Active Storage was integrated to Rails 5.2.0.alpha 🎉 

Refer: rails/rails#30020.