### PR TITLE
Extend image_tag to accept ActiveStorage Attachments and Variants

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -381,6 +381,8 @@ module ActionView
           else
             polymorphic_url(source)
           end
+        rescue NoMethodError => e
+          raise ArgumentError, "Can't resolve image into URL: #{e}"
         end
 
         def extract_dimensions(size)

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -240,7 +240,7 @@ module ActionView
         check_for_image_tag_errors(options)
         skip_pipeline = options.delete(:skip_pipeline)
 
-        src = options[:src] = path_to_image(source, skip_pipeline: skip_pipeline)
+        src = options[:src] = resolve_image_source(source, skip_pipeline)
 
         unless src.start_with?("cid:") || src.start_with?("data:") || src.blank?
           options[:alt] = options.fetch(:alt) { image_alt(src) }
@@ -361,6 +361,14 @@ module ActionView
           else
             options[:src] = send("path_to_#{type}", sources.first, skip_pipeline: skip_pipeline)
             content_tag(type, nil, options)
+          end
+        end
+
+        def resolve_image_source(source, skip_pipeline)
+          if source.class.in? [ActiveStorage::Variant, ActiveStorage::Blob, ActiveStorage::Attachment]
+            polymorphic_url(source)
+          else
+            path_to_image(source, skip_pipeline: skip_pipeline)
           end
         end
 

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -365,10 +365,10 @@ module ActionView
         end
 
         def resolve_image_source(source, skip_pipeline)
-          if source.class.in? [ActiveStorage::Variant, ActiveStorage::Blob, ActiveStorage::Attachment]
-            polymorphic_url(source)
-          else
+          if source.is_a?(Symbol) || source.is_a?(String)
             path_to_image(source, skip_pipeline: skip_pipeline)
+          else
+            polymorphic_url(source)
           end
         end
 

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -200,7 +200,7 @@ module ActionView
       end
 
       # Returns an HTML image tag for the +source+. The +source+ can be a full
-      # path or a file.
+      # path, a file or an Active Storage attachment.
       #
       # ==== Options
       #
@@ -216,6 +216,8 @@ module ActionView
       #   pairs, each image path will be expanded before the list is formatted as a string.
       #
       # ==== Examples
+      #
+      # Assets (images that are part of your app):
       #
       #   image_tag("icon")
       #   # => <img alt="Icon" src="/assets/icon" />
@@ -235,6 +237,15 @@ module ActionView
       #   # => <img src="/assets/icon.png" srcset="/assets/icon_2x.png 2x, /assets/icon_4x.png 4x">
       #   image_tag("pic.jpg", srcset: [["pic_1024.jpg", "1024w"], ["pic_1980.jpg", "1980w"]], sizes: "100vw")
       #   # => <img src="/assets/pic.jpg" srcset="/assets/pic_1024.jpg 1024w, /assets/pic_1980.jpg 1980w" sizes="100vw">
+      #
+      # Active Storage (images that are uploaded by the users of your app):
+      #
+      #   image_tag(user.avatar)
+      #   # => <img src="/rails/active_storage/blobs/.../tiger.jpg" alt="Tiger" />
+      #   image_tag(user.avatar.variant(resize: "100x100"))
+      #   # => <img src="/rails/active_storage/variants/.../tiger.jpg" alt="Tiger" />
+      #   image_tag(user.avatar.variant(resize: "100x100"), size: '100')
+      #   # => <img width="100" height="100" src="/rails/active_storage/variants/.../tiger.jpg" alt="Tiger" />
       def image_tag(source, options = {})
         options = options.symbolize_keys
         check_for_image_tag_errors(options)

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -565,9 +565,6 @@ class AssetTagHelperTest < ActionView::TestCase
     def blank?; true; end
     def to_s; "no-image-yet.png"; end
   end
-  def test_image_tag_with_blank_placeholder
-    assert_equal '<img alt="" src="/images/no-image-yet.png" />', image_tag(PlaceholderImage.new, alt: "")
-  end
   def test_image_path_with_blank_placeholder
     assert_equal "/images/no-image-yet.png", image_path(PlaceholderImage.new)
   end

--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -80,7 +80,7 @@ Variation of image attachment:
 
 ```erb
 <%# Hitting the variant URL will lazy transform the original blob and then redirect to its new service location %>
-<%= image_tag url_for(user.avatar.variant(resize: "100x100")) %>
+<%= image_tag user.avatar.variant(resize: "100x100") %>
 ```
 
 ## Installation

--- a/activestorage/test/template/image_tag_test.rb
+++ b/activestorage/test/template/image_tag_test.rb
@@ -26,10 +26,15 @@ class ActiveStorage::ImageTagTest < ActionView::TestCase
     assert_dom_equal %(<img alt="Racecar" src="#{polymorphic_url attachment}" />), image_tag(attachment)
   end
 
-  test "error when nothing's attached" do
+  test "error when attachment's empty" do
     @user = User.create!(name: "DHH")
 
     assert_not @user.avatar.attached?
     assert_raises { image_tag(@user.avatar) }
+  end
+
+  test "error when object can't be resolved into url" do
+    unresolvable_object = ActionView::Helpers::AssetTagHelper
+    assert_raises { image_tag(unresolvable_object) }
   end
 end

--- a/activestorage/test/template/image_tag_test.rb
+++ b/activestorage/test/template/image_tag_test.rb
@@ -9,7 +9,6 @@ class ActiveStorage::ImageTagTest < ActionView::TestCase
   tests ActionView::Helpers::AssetTagHelper
 
   setup do
-    @user = User.create!(name: "DHH")
     @blob = create_image_blob filename: "racecar.jpg"
   end
 
@@ -27,12 +26,9 @@ class ActiveStorage::ImageTagTest < ActionView::TestCase
     assert_dom_equal %(<img alt="Racecar" src="#{polymorphic_url attachment}" />), image_tag(attachment)
   end
 
-  test "attachment on a model" do
-    @user.avatar.attach @blob
-    assert_dom_equal %(<img alt="Racecar" src="#{polymorphic_url @user.avatar}" />), image_tag(@user.avatar)
-  end
-
   test "error when nothing's attached" do
+    @user = User.create!(name: "DHH")
+
     assert_not @user.avatar.attached?
     assert_raises { image_tag(@user.avatar) }
   end

--- a/activestorage/test/template/image_tag_test.rb
+++ b/activestorage/test/template/image_tag_test.rb
@@ -35,6 +35,6 @@ class ActiveStorage::ImageTagTest < ActionView::TestCase
 
   test "error when object can't be resolved into url" do
     unresolvable_object = ActionView::Helpers::AssetTagHelper
-    assert_raises { image_tag(unresolvable_object) }
+    assert_raises(ArgumentError) { image_tag(unresolvable_object) }
   end
 end

--- a/activestorage/test/template/image_tag_test.rb
+++ b/activestorage/test/template/image_tag_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+require "database/setup"
+
+class User < ActiveRecord::Base
+  has_one_attached :avatar
+end
+
+class ActiveStorage::ImageTagTest < ActionView::TestCase
+  tests ActionView::Helpers::AssetTagHelper
+
+  setup do
+    @user = User.create!(name: "DHH")
+    @blob = create_image_blob filename: "racecar.jpg"
+  end
+
+  test "blob" do
+    assert_dom_equal %(<img alt="Racecar" src="#{polymorphic_url @blob}" />), image_tag(@blob)
+  end
+
+  test "variant" do
+    variant = @blob.variant(resize: "100x100")
+    assert_dom_equal %(<img alt="Racecar" src="#{polymorphic_url variant}" />), image_tag(variant)
+  end
+
+  test "attachment" do
+    attachment = ActiveStorage::Attachment.new(blob: @blob)
+    assert_dom_equal %(<img alt="Racecar" src="#{polymorphic_url attachment}" />), image_tag(attachment)
+  end
+
+  test "attachment on a model" do
+    @user.avatar.attach @blob
+    assert_dom_equal %(<img alt="Racecar" src="#{polymorphic_url @user.avatar}" />), image_tag(@user.avatar)
+  end
+
+  test "error when nothing's attached" do
+    assert_not @user.avatar.attached?
+    assert_raises { image_tag(@user.avatar) }
+  end
+end

--- a/activestorage/test/template/image_tag_test.rb
+++ b/activestorage/test/template/image_tag_test.rb
@@ -30,7 +30,7 @@ class ActiveStorage::ImageTagTest < ActionView::TestCase
     @user = User.create!(name: "DHH")
 
     assert_not @user.avatar.attached?
-    assert_raises { image_tag(@user.avatar) }
+    assert_raises(ArgumentError) { image_tag(@user.avatar) }
   end
 
   test "error when object can't be resolved into url" do

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -273,6 +273,8 @@ class Module
       def method_missing(method, *args, &block)
         if #{target}.respond_to?(method)
           #{target}.public_send(method, *args, &block)
+        elsif #{target}.nil?
+          raise DelegationError, "\#{method} delegated to #{target}, but #{target} is nil"
         else
           super
         end


### PR DESCRIPTION
To use an ActiveStorage attachment in `image_tag`, you have to write
```erb
<%= image_tag url_for(user.avatar) %>
```
This change simplifies it to
```erb
<%= image_tag user.avatar %>
```

~~And a bonus: if you pass a Blob, not a Variant, and specify the `size` arg, the image will be automatically downsampled by applying `variant(resize: size)` behind the scenes. _This one I'm not sure of, is it too implicit?_~~