### PR TITLE
Fix rubocop violations

### DIFF
--- a/activerecord/lib/rails/generators/active_record/application_record/application_record_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/application_record/application_record_generator.rb
@@ -16,10 +16,10 @@ module ActiveRecord
 
         def application_record_file_name
           @application_record_file_name ||= if namespaced?
-                                              "app/models/#{namespaced_path}/application_record.rb"
-                                            else
-                                              "app/models/application_record.rb"
-                                            end
+            "app/models/#{namespaced_path}/application_record.rb"
+          else
+            "app/models/application_record.rb"
+          end
         end
     end
   end


### PR DESCRIPTION
This fixes following violations:

```
Offenses:

activerecord/lib/rails/generators/active_record/application_record/application_record_generator.rb:19:11: C: Use 2 (not 36) spaces for indentation.
                                              "app/models/#{namespaced_path}/application_record.rb"
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
activerecord/lib/rails/generators/active_record/application_record/application_record_generator.rb:22:45: W: end at 22, 44 is not aligned with @application_record_file_name ||= if at 18, 10.
                                            end
                                            ^^^
```

