### PR TITLE
Remove outdated comment [ci skip]

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -590,10 +590,6 @@ module ActionMailer
 
     attr_internal :message
 
-    # Instantiate a new mailer object. If +method_name+ is not +nil+, the mailer
-    # will be initialized according to the named method. If not, the mailer will
-    # remain uninitialized (useful when you only need to invoke the "receive"
-    # method, for instance).
     def initialize
       super()
       @_mail_was_called = false


### PR DESCRIPTION
The comment was describing a previous version of the method with
a different signature. This has been outdated since e76c38e
