### PR TITLE
Fix engine command

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
@@ -3,7 +3,9 @@
 
 ENGINE_ROOT = File.expand_path('..', __dir__)
 ENGINE_PATH = File.expand_path('../lib/<%= namespaced_name -%>/engine', __dir__)
+<% if with_dummy_app? -%>
 APP_PATH = File.expand_path('../<%= dummy_path -%>/config/application', __dir__)
+<% end -%>
 
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -101,6 +101,9 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "Rakefile" do |contents|
       assert_no_match(/APP_RAKEFILE/, contents)
     end
+    assert_file "bin/rails" do |contents|
+      assert_no_match(/APP_PATH/, contents)
+    end
   end
 
   def test_generating_adds_dummy_app_in_full_mode_without_sprockets
@@ -114,6 +117,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   def test_generating_adds_dummy_app_rake_tasks_without_unit_test_files
     run_generator [destination_root, "-T", "--mountable", "--dummy-path", "my_dummy_app"]
     assert_file "Rakefile", /APP_RAKEFILE/
+    assert_file "bin/rails", /APP_PATH/
   end
 
   def test_generating_adds_dummy_app_without_javascript_and_assets_deps


### PR DESCRIPTION
`bin/rails` which generated by `rails plugin new ... --no-test` includes `APP_PATH` which aims for tests. And it cause LoadError (`lib/rails/command/actions.rb:15:in require: cannot load such file`), when we execute `bin/rails`. So I've fixed it.