### PR TITLE
Isolate ActiveStorage namespaces

### DIFF
--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -5,6 +5,8 @@ require "active_storage"
 
 module ActiveStorage
   class Engine < Rails::Engine # :nodoc:
+    isolate_namespace ActiveStorage
+
     config.active_storage = ActiveSupport::OrderedOptions.new
 
     config.eager_load_namespaces << ActiveStorage

--- a/activestorage/lib/tasks/activestorage.rake
+++ b/activestorage/lib/tasks/activestorage.rake
@@ -1,6 +1,6 @@
 namespace :activestorage do
   desc "Copy over the migration needed to the application"
   task install: :environment do
-    Rake::Task["active_storage_engine:install:migrations"].invoke
+    Rake::Task["active_storage:install:migrations"].invoke
   end
 end


### PR DESCRIPTION
IMO we should make `active_storage` isolated namespaces, don't want someone to override the behaviour by mistake, or to leak something to the app. 
