### PR TITLE
Replaces the 17 for the actual call to params[:id] that would make th…

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -47,7 +47,7 @@ get '/patients/:id', to: 'patients#show', as: 'patient'
 and your application contains this code in the controller:
 
 ```ruby
-@patient = Patient.find(17)
+@patient = Patient.find(params[:id])
 ```
 
 and this in the corresponding view:


### PR DESCRIPTION
…e code work as intended. [ci skip]

### Summary

I changed the 17 in Patient.find(17) since in my understanding, the 17 is the final value that will make it to the method call, but the real working code would not have it hard-coded. Therefore, I replaced it by a call to params[:id], reflecting the fact that the id parameter is received from a request to the url formed above with

```ruby
get '/patients/:id', to: 'patients#show', as: 'patient'
```
