### PR TITLE
Improve `rake activestorage:install` 

### DIFF
--- a/activestorage/lib/tasks/activestorage.rake
+++ b/activestorage/lib/tasks/activestorage.rake
@@ -2,7 +2,7 @@ require "fileutils"
 
 namespace :activestorage do
   desc "Copy over the migration needed to the application"
-  task :install do
+  task install: :environment do
     migration_file_path = "db/migrate/#{Time.now.utc.strftime("%Y%m%d%H%M%S")}_active_storage_create_tables.rb"
     FileUtils.mkdir_p Rails.root.join("db/migrate")
     FileUtils.cp File.expand_path("../../active_storage/migration.rb", __FILE__), Rails.root.join(migration_file_path)

--- a/activestorage/lib/tasks/activestorage.rake
+++ b/activestorage/lib/tasks/activestorage.rake
@@ -3,11 +3,22 @@ require "fileutils"
 namespace :activestorage do
   desc "Copy over the migration needed to the application"
   task install: :environment do
-    migration_file_path = "db/migrate/#{Time.now.utc.strftime("%Y%m%d%H%M%S")}_active_storage_create_tables.rb"
-    FileUtils.mkdir_p Rails.root.join("db/migrate")
-    FileUtils.cp File.expand_path("../../active_storage/migration.rb", __FILE__), Rails.root.join(migration_file_path)
-    puts "Copied migration to #{migration_file_path}"
+    migration_root = Rails.root.join(ActiveRecord::Migrator.migrations_paths.first)
+    FileUtils.mkdir_p(migration_root)
 
-    puts "Now run rails db:migrate to create the tables for Active Storage"
+    migration_class_name = "ActiveStorageCreateTables"
+    migrations = ActiveRecord::Migrator.migrations(migration_root)
+
+    if migrations.detect { |migration| migration.name == migration_class_name }
+      puts "Migration #{migration_class_name} already exists"
+    else
+      next_migration_version = ActiveRecord::Migration.next_migration_number(migrations.empty? ? 0 : migrations.last.version + 1).to_i
+      migration_file = migration_root.join("#{next_migration_version}_active_storage_create_tables.rb")
+
+      FileUtils.cp File.expand_path("../active_storage/migration.rb", __dir__), migration_file
+      puts "Copied migration to #{migration_file.relative_path_from(Rails.root)}"
+
+      puts "Run `rails db:migrate` to create the tables for Active Storage"
+    end
   end
 end


### PR DESCRIPTION
* Set `:environment` as prerequisite `rake activestorage:install`
* Use ActiveRecord::Migrator.migrations_paths.first instead of "db/migrate"
* <s>If `db/migrate` exists, don't try to mkdir `db/migrate`</s>
* Respect `config.active_record.timestamped_migrations`
* Prevent adding migration more than one time