### PR TITLE
Document public hooks in AS::Reloader

### DIFF
--- a/activesupport/lib/active_support/reloader.rb
+++ b/activesupport/lib/active_support/reloader.rb
@@ -28,14 +28,17 @@ module ActiveSupport
 
     define_callbacks :class_unload
 
+    # Registers a callback that will run once at application startup and every time the code is reloaded.
     def self.to_prepare(*args, &block)
       set_callback(:prepare, *args, &block)
     end
 
+    # Registers a callback that will run immediately before the classes are unloaded.
     def self.before_class_unload(*args, &block)
       set_callback(:class_unload, *args, &block)
     end
 
+    # Registers a callback that will run immediately after the classes are unloaded.
     def self.after_class_unload(*args, &block)
       set_callback(:class_unload, :after, *args, &block)
     end


### PR DESCRIPTION
This PR moves documentation for `AS::Reloader` hooks outside of hidden rdoc block.
I think it's important to at least document `#to_prepare`, as it can be quite useful.

@rafaelfranca 