### PR TITLE
Add `:authors` to address random failures at HasOneAssociationsTest

### DIFF
--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -15,7 +15,7 @@ require "models/post"
 
 class HasOneAssociationsTest < ActiveRecord::TestCase
   self.use_transactional_tests = false unless supports_savepoints?
-  fixtures :accounts, :companies, :developers, :projects, :developers_projects, :ships, :pirates
+  fixtures :accounts, :companies, :developers, :projects, :developers_projects, :ships, :pirates, :authors
 
   def setup
     Account.destroyed_account_ids.clear


### PR DESCRIPTION
### Summary

This pull request addresses random failures at HasOneAssociationsTest by adding missing `:authors` fixtures.  There are some differences in database adapters. `sqlite3` has 2 failures, `mysql2` has 1 failure and `postgresql` has no failures. 

Actually, I still do not know the reason why these database adapters show different failures but I can say this commit fixes these failures.

These random failures can be reproduced by using `--seed 48032` and other options as follows:

* sqlite3 - 2 failures
```ruby
$ ARCONN=sqlite3 bin/test test/cases/associations/has_one_associations_test.rb test/cases/view_test.rb --seed 48032 -n "/^(?:ViewWithoutPrimaryKeyTest#(?:test_attributes)|HasOneAssociationsTest#(?:test_destroyed_by_association_set_in_child_destroy_callback_on_parent_destroy|test_destroyed_by_association_set_in_child_destroy_callback_on_replace))$/" --verbose
Using sqlite3
Run options: --seed 48032 -n "/^(?:ViewWithoutPrimaryKeyTest#(?:test_attributes)|HasOneAssociationsTest#(?:test_destroyed_by_association_set_in_child_destroy_callback_on_parent_destroy|test_destroyed_by_association_set_in_child_destroy_callback_on_replace))$/" --verbose

ViewWithoutPrimaryKeyTest#test_attributes = 0.02 s = .
HasOneAssociationsTest#test_destroyed_by_association_set_in_child_destroy_callback_on_replace = 0.12 s = F
HasOneAssociationsTest#test_destroyed_by_association_set_in_child_destroy_callback_on_parent_destroy = 0.01 s = F

Finished in 0.162504s, 18.4610 runs/s, 18.4610 assertions/s.

  1) Failure:
HasOneAssociationsTest#test_destroyed_by_association_set_in_child_destroy_callback_on_replace [/home/yahonda/git/rails/activerecord/test/cases/associations/has_one_associations_test.rb:725]:
Expected true to be nil or false

  2) Failure:
HasOneAssociationsTest#test_destroyed_by_association_set_in_child_destroy_callback_on_parent_destroy [/home/yahonda/git/rails/activerecord/test/cases/associations/has_one_associations_test.rb:715]:
Expected true to be nil or false

3 runs, 3 assertions, 2 failures, 0 errors, 0 skips
```

* mysql2 - 1 failure
```ruby
$ ARCONN=mysql2 bin/test test/cases/associations/has_one_associations_test.rb test/cases/view_test.rb --seed 48032 -n "/^(?:ViewWithoutPrimaryKeyTest#(?:test_attributes)|HasOneAssociationsTest#(?:test_destroyed_by_association_set_in_child_destroy_callback_on_parent_destroy|test_destroyed_by_association_set_in_child_destroy_callback_on_replace))$/" --verbose
Using mysql2
Run options: --seed 48032 -n "/^(?:ViewWithoutPrimaryKeyTest#(?:test_attributes)|HasOneAssociationsTest#(?:test_destroyed_by_association_set_in_child_destroy_callback_on_parent_destroy|test_destroyed_by_association_set_in_child_destroy_callback_on_replace))$/" --verbose

ViewWithoutPrimaryKeyTest#test_attributes = 0.07 s = .
HasOneAssociationsTest#test_destroyed_by_association_set_in_child_destroy_callback_on_replace = 0.27 s = F
HasOneAssociationsTest#test_destroyed_by_association_set_in_child_destroy_callback_on_parent_destroy = 0.02 s = .

Finished in 0.362779s, 8.2695 runs/s, 8.2695 assertions/s.

  1) Failure:
HasOneAssociationsTest#test_destroyed_by_association_set_in_child_destroy_callback_on_replace [/home/yahonda/git/rails/activerecord/test/cases/associations/has_one_associations_test.rb:725]:
Expected true to be nil or false

3 runs, 3 assertions, 1 failures, 0 errors, 0 skips
```

* postgresql - 0 failures

```ruby
$ ARCONN=postgresql bin/test test/cases/associations/has_one_associations_test.rb test/cases/view_test.rb --seed 48032 -n "/^(?:ViewWithoutPrimaryKeyTest#(?:test_attributes)|HasOneAssociationsTest#(?:test_destroyed_by_association_set_in_child_destroy_callback_on_parent_destroy|test_destroyed_by_association_set_in_child_destroy_callback_on_replace))$/" --verbose
Using postgresql
Run options: --seed 48032 -n "/^(?:ViewWithoutPrimaryKeyTest#(?:test_attributes)|HasOneAssociationsTest#(?:test_destroyed_by_association_set_in_child_destroy_callback_on_parent_destroy|test_destroyed_by_association_set_in_child_destroy_callback_on_replace))$/" --verbose

ViewWithoutPrimaryKeyTest#test_attributes = 0.06 s = .
HasOneAssociationsTest#test_destroyed_by_association_set_in_child_destroy_callback_on_parent_destroy = 0.22 s = .
HasOneAssociationsTest#test_destroyed_by_association_set_in_child_destroy_callback_on_replace = 0.02 s = .

Finished in 0.311217s, 9.6396 runs/s, 9.6396 assertions/s.

3 runs, 3 assertions, 0 failures, 0 errors, 0 skips
```

cc  @kamipo and @mtsmfm who informed and have been working on these failures.