### PR TITLE
Remove :sorted test order for isolated tests

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -313,8 +313,6 @@ class ActiveSupport::TestCase
   include TestHelpers::Rack
   include TestHelpers::Generation
   include ActiveSupport::Testing::Stream
-
-  self.test_order = :sorted
 end
 
 # Create a scope and build a fixture rails app


### PR DESCRIPTION
Currently, we have gem `minitest-bisect` in Gemfile, looks like the most convenient time for getting rid of `:sorted` tests in favor of `:random`

Related to #30085