### PR TITLE
Use `AR::Migrator.migrations_paths` instead of "db/migrate"

### DIFF
--- a/activestorage/lib/tasks/activestorage.rake
+++ b/activestorage/lib/tasks/activestorage.rake
@@ -3,8 +3,9 @@ require "fileutils"
 namespace :activestorage do
   desc "Copy over the migration needed to the application"
   task :install do
-    migration_file_path = "db/migrate/#{Time.now.utc.strftime("%Y%m%d%H%M%S")}_active_storage_create_tables.rb"
-    FileUtils.mkdir_p Rails.root.join("db/migrate")
+    migration_root = ActiveRecord::Migrator.migrations_paths.first
+    migration_file_path = "#{migration_root}/#{Time.now.utc.strftime("%Y%m%d%H%M%S")}_active_storage_create_tables.rb"
+    FileUtils.mkdir_p Rails.root.join(migration_root)
     FileUtils.cp File.expand_path("../../active_storage/migration.rb", __FILE__), Rails.root.join(migration_file_path)
     puts "Copied migration to #{migration_file_path}"
 


### PR DESCRIPTION
### Summary

This PR uses `ActiveRecord::Migrator.migrations_paths` to make a migration root path other than `"db/migrate"` available, when running `rake activestorage:install`.
