### PR TITLE
Add missed `require`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "concurrent/map"
+
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
     module QueryCache


### PR DESCRIPTION
`ActiveRecord::ConnectionAdapters::QueryCache::ConnectionPoolConfiguration`
depends on `Concurrent::Map`.