### PR TITLE
Simplify `git_source` in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 source "https://rubygems.org"
 
-git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
-  "https://github.com/#{repo_name}.git"
-end
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 


### PR DESCRIPTION
### Summary

Follow up of https://github.com/rails/rails/commit/0b8441bd415c444b8d4afbfc93af79ec7677aa2c.

### Other Information

The template of Gemfile in Bundler is also the same.
https://github.com/bundler/bundler/blob/762e8342948147e95e18120a20e641d945e99664/lib/bundler/templates/Gemfile#L5