### PR TITLE
Add git_source to Gemfile for plugin generator

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add git_source to `Gemfile` for plugin generator
+
+    *Yoshiyuki Hirano*
+
 *   Deprecate support of use `Rails::Application` subclass to start Rails server.
 
     *Yuji Yaginuma*

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 <% if options[:skip_gemspec] -%>
 <%= '# ' if options.dev? || options.edge? -%>gem 'rails', '<%= Array(rails_version_specifier).join("', '") %>'

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -82,6 +82,11 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "test/integration/navigation_test.rb", /ActionDispatch::IntegrationTest/
   end
 
+  def test_inclusion_of_git_source
+    run_generator [destination_root]
+    assert_file "Gemfile", /git_source/
+  end
+
   def test_inclusion_of_a_debugger
     run_generator [destination_root, "--full"]
     if defined?(JRUBY_VERSION) || RUBY_ENGINE == "rbx"


### PR DESCRIPTION
### Summary

Missing git_source to Gemfile for `rails plugin new` generator. So I've fixed it.