### PR TITLE
ActiveStorage:Add migrations per rails engine conventions

### DIFF
--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -1,4 +1,4 @@
-class ActiveStorageCreateTables < ActiveRecord::Migration[5.1]
+class CreateActiveStorageTables < ActiveRecord::Migration[5.1]
   def change
     create_table :active_storage_blobs do |t|
       t.string   :key

--- a/activestorage/lib/tasks/activestorage.rake
+++ b/activestorage/lib/tasks/activestorage.rake
@@ -1,13 +1,6 @@
-require "fileutils"
-
 namespace :activestorage do
   desc "Copy over the migration needed to the application"
-  task :install do
-    migration_file_path = "db/migrate/#{Time.now.utc.strftime("%Y%m%d%H%M%S")}_active_storage_create_tables.rb"
-    FileUtils.mkdir_p Rails.root.join("db/migrate")
-    FileUtils.cp File.expand_path("../../active_storage/migration.rb", __FILE__), Rails.root.join(migration_file_path)
-    puts "Copied migration to #{migration_file_path}"
-
-    puts "Now run rails db:migrate to create the tables for Active Storage"
+  task install: :environment do
+    Rake::Task["active_storage_engine:install:migrations"].invoke
   end
 end

--- a/activestorage/test/database/setup.rb
+++ b/activestorage/test/database/setup.rb
@@ -1,6 +1,5 @@
-require "active_storage/migration"
 require_relative "create_users_migration"
 
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
-ActiveStorageCreateTables.migrate(:up)
+ActiveRecord::Migrator.migrate File.expand_path("../../../db/migrate", __FILE__)
 ActiveStorageCreateUsers.migrate(:up)

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -22,6 +22,7 @@ rescue Errno::ENOENT
   {}
 end
 
+
 require "tmpdir"
 ActiveStorage::Blob.service = ActiveStorage::Service::DiskService.new(root: Dir.mktmpdir("active_storage_tests"))
 ActiveStorage::Service.logger = ActiveSupport::Logger.new(STDOUT)

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -22,7 +22,6 @@ rescue Errno::ENOENT
   {}
 end
 
-
 require "tmpdir"
 ActiveStorage::Blob.service = ActiveStorage::Service::DiskService.new(root: Dir.mktmpdir("active_storage_tests"))
 ActiveStorage::Service.logger = ActiveSupport::Logger.new(STDOUT)

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -136,7 +136,7 @@ module RailtiesTest
         output = `bundle exec rake railties:install:migrations`.split("\n")
 
         assert_match(/Copied migration \d+_create_users\.bukkits\.rb from bukkits/, output.first)
-        assert_match(/Copied migration \d+_create_blogs\.blog_engine\.rb from blog_engine/, output.last)
+        assert_match(/Copied migration \d+_create_blogs\.blog_engine\.rb from blog_engine/, output.second)
       end
     end
 
@@ -171,7 +171,7 @@ module RailtiesTest
       Dir.chdir(app_path) do
         output = `bundle exec rake railties:install:migrations`.split("\n")
 
-        assert_match(/Copied migration \d+_create_users\.core_engine\.rb from core_engine/, output.first)
+        assert_match(/Copied migration \d+_create_users\.core_engine\.rb from core_engine/, output.second)
         assert_match(/Copied migration \d+_create_keys\.api_engine\.rb from api_engine/, output.last)
       end
     end


### PR DESCRIPTION
Move migrations to `app/db/migrate`. This way we leverage rails engine migrations fully. Rails will automatically skip migration if it already exists, etc...
Also using this approach we can add/remove columns in the future without need for developers who are using `ActiveStorage` to do this manually

r? @dhh 