### PR TITLE
ActiveStorage: Remove unnecessary require in test_helper

### DIFF
--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -10,8 +10,6 @@ require "active_job"
 ActiveJob::Base.queue_adapter = :test
 ActiveJob::Base.logger = nil
 
-require "active_storage"
-
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new


### PR DESCRIPTION
Remove unnecessary require in test_helper. Handled by the engine