### PR TITLE
Removed empty line from dummy_manifest

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/rails/dummy_manifest.js
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/dummy_manifest.js
@@ -1,4 +1,3 @@
-
 <% unless api? -%>
 //= link_tree ../images
 <% end -%>


### PR DESCRIPTION
### Summary

I've removed an empty line from dummy_manifest.js. I tried to be same format as [app/assets/config/manifest.js](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/app/templates/app/assets/config/manifest.js.tt)