### PR TITLE
Fix ApplicationController.renderer.defaults overriding in development

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/application_controller_renderer.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/application_controller_renderer.rb
@@ -1,6 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
-# ApplicationController.renderer.defaults.merge!(
-#   http_host: 'example.org',
-#   https: false
-# )
+# ActiveSupport::Reloader.to_prepare do
+#   ApplicationController.renderer.defaults.merge!(
+#     http_host: 'example.org',
+#     https: false
+#   )
+# end


### PR DESCRIPTION
### Summary

Previously overriding ApplicationController.renderer.defaults wasn't
working effectively in development. In fact the override was unset every
time the code was reloaded. The solution is to wrap the code in a
`.to_prepare` block.

Fixes #30049