### PR TITLE
Skip unused components when running `bin/rails` in Rails plugin

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Skip unused components when running `bin/rails` in Rails plugin.
+
+    *Yoshiyuki Hirano*
+
 *   Add git_source to `Gemfile` for plugin generator.
 
     *Yoshiyuki Hirano*

--- a/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
@@ -11,5 +11,20 @@ APP_PATH = File.expand_path('../<%= dummy_path -%>/config/application', __dir__)
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 
+<% if include_all_railties? -%>
 require 'rails/all'
+<% else -%>
+require "rails"
+# Pick the frameworks you want:
+require "active_model/railtie"
+require "active_job/railtie"
+<%= comment_if :skip_active_record %>require "active_record/railtie"
+require "action_controller/railtie"
+<%= comment_if :skip_action_mailer %>require "action_mailer/railtie"
+require "action_view/railtie"
+require "active_storage/engine"
+<%= comment_if :skip_action_cable %>require "action_cable/engine"
+<%= comment_if :skip_sprockets %>require "sprockets/railtie"
+<%= comment_if :skip_test %>require "rails/test_unit/railtie"
+<% end -%>
 require 'rails/engine/commands'

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -75,6 +75,18 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_no_file "bin/rails"
   end
 
+  def test_generating_in_full_mode_with_almost_of_all_skip_options
+    run_generator [destination_root, "--full", "-M", "-O", "-C", "-S", "-T"]
+    assert_file "bin/rails" do |content|
+      assert_no_match(/\s+require\s+["']rails\/all["']/, content)
+    end
+    assert_file "bin/rails", /#\s+require\s+["']active_record\/railtie["']/
+    assert_file "bin/rails", /#\s+require\s+["']action_mailer\/railtie["']/
+    assert_file "bin/rails", /#\s+require\s+["']action_cable\/engine["']/
+    assert_file "bin/rails", /#\s+require\s+["']sprockets\/railtie["']/
+    assert_file "bin/rails", /#\s+require\s+["']rails\/test_unit\/railtie["']/
+  end
+
   def test_generating_test_files_in_full_mode
     run_generator [destination_root, "--full"]
     assert_directory "test/integration/"
@@ -325,7 +337,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "app/views"
     assert_file "app/helpers"
     assert_file "app/mailers"
-    assert_file "bin/rails"
+    assert_file "bin/rails", /\s+require\s+["']rails\/all["']/
     assert_file "config/routes.rb", /Rails.application.routes.draw do/
     assert_file "lib/bukkits/engine.rb", /module Bukkits\n  class Engine < ::Rails::Engine\n  end\nend/
     assert_file "lib/bukkits.rb", /require "bukkits\/engine"/


### PR DESCRIPTION
### Summary

Though it added `-T` or `--skip-test` when generating plugin, it generate needless test files.

#### Caution

When we run engine command without test unit, we have to remove this line from `bin/rails`:

```
APP_PATH = File.expand_path('../../test/dummy/config/application', __FILE__)
```

refs #30091

#### Before

```
$ bin/rails plugin new my_plugin -T --mountable
$ cd my_plugin
$ bin/rails g model Item name:string # after bundle
      invoke  active_record
      create    db/migrate/20170807115708_create_my_plugin_items.rb
      create    app/models/my_plugin/item.rb
      invoke    test_unit
      create      test/models/my_plugin/item_test.rb
      create      test/fixtures/my_plugin/items.yml
```

#### After

```
$ bin/rails plugin new my_plugin -T --mountable
$ cd my_plugin
$ bin/rails g model Item name:string # after bundle
      invoke  active_record
      create    db/migrate/20170807115708_create_my_plugin_items.rb
      create    app/models/my_plugin/item.rb
```