### PR TITLE
Set ActiveStorage::Blob.service when ActiveStorage::Blob is loaded

### DIFF
--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -34,22 +34,21 @@ module ActiveStorage
     end
 
     initializer "active_storage.services" do
-      config.after_initialize do |app|
-        if config_choice = app.config.active_storage.service
-          config_file = Pathname.new(Rails.root.join("config/storage.yml"))
-          raise("Couldn't find Active Storage configuration in #{config_file}") unless config_file.exist?
+      config.to_prepare do
+        if config_choice = Rails.configuration.active_storage.service
+          configs = Rails.configuration.active_storage.service_configurations ||= begin
+            config_file = Pathname.new(Rails.root.join("config/storage.yml"))
+            raise("Couldn't find Active Storage configuration in #{config_file}") unless config_file.exist?
 
-          require "yaml"
-          require "erb"
+            require "yaml"
+            require "erb"
 
-          configs =
-            begin
-              YAML.load(ERB.new(config_file.read).result) || {}
-            rescue Psych::SyntaxError => e
-              raise "YAML syntax error occurred while parsing #{config_file}. " \
-                    "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \
-                    "Error: #{e.message}"
-            end
+            YAML.load(ERB.new(config_file.read).result) || {}
+          rescue Psych::SyntaxError => e
+            raise "YAML syntax error occurred while parsing #{config_file}. " \
+                  "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \
+                  "Error: #{e.message}"
+          end
 
           ActiveStorage::Blob.service =
             begin


### PR DESCRIPTION
Fixes that `ActiveStorage::Blob.service` is unset when `ActiveStorage::Blob` is reloaded.