### PR TITLE
ASCII comes in two flavors that need to be UTF-8ified.

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -31,7 +31,7 @@ module ActionDispatch
         class UriEncoder # :nodoc:
           ENCODE   = "%%%02X".freeze
           US_ASCII = Encoding::US_ASCII
-	  ASCII_8  = Encoding::ASCII_8BIT
+          ASCII_8  = Encoding::ASCII_8BIT
           UTF_8    = Encoding::UTF_8
           EMPTY    = "".dup.force_encoding(US_ASCII).freeze
           DEC2HEX  = (0..255).to_a.map { |i| ENCODE % i }.map { |s| s.force_encoding(US_ASCII) }
@@ -61,7 +61,7 @@ module ActionDispatch
 
           def unescape_uri(uri)
             encoding = uri.encoding
-	    encoding = UTF_8 if ( encoding == US_ASCII || encoding == ASCII_8 )
+            encoding = UTF_8 if (encoding == US_ASCII || encoding == ASCII_8)
             uri.gsub(ESCAPED) { |match| [match[1, 2].hex].pack("C") }.force_encoding(encoding)
           end
 

--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -31,6 +31,7 @@ module ActionDispatch
         class UriEncoder # :nodoc:
           ENCODE   = "%%%02X".freeze
           US_ASCII = Encoding::US_ASCII
+	  ASCII_8  = Encoding::ASCII_8BIT
           UTF_8    = Encoding::UTF_8
           EMPTY    = "".dup.force_encoding(US_ASCII).freeze
           DEC2HEX  = (0..255).to_a.map { |i| ENCODE % i }.map { |s| s.force_encoding(US_ASCII) }
@@ -59,7 +60,8 @@ module ActionDispatch
           end
 
           def unescape_uri(uri)
-            encoding = uri.encoding == US_ASCII ? UTF_8 : uri.encoding
+            encoding = uri.encoding
+	    encoding = UTF_8 if ( encoding == US_ASCII || encoding == ASCII_8 )
             uri.gsub(ESCAPED) { |match| [match[1, 2].hex].pack("C") }.force_encoding(encoding)
           end
 


### PR DESCRIPTION
### Summary

Discourse found an issue where URL parameters were entering the code as ASCII-8BIT instead of UTF-8. Examining the source tree for URL unescape code, I found that almost everywhere does not specify an encoding, relying on the UTF-8 default in Ruby. *Almost everywhere.*

In ActionDispatch there is a `unescape_uri` that attempts to preserve the encoding if it is **not** US-ASCII. Changing that to UTF-8-ify ASCII-8BIT fixes the issue seen in Discourse.

### Other Information

It is noteworthy that the ASCII-8BIT encoding is used throughout as the encoding of choice before %-escaping a URL string. This encoding mirrors the widespread usage of UTF-8 in URLs getting encoded as a stream of octets instead of codepoints. Clearly ASCII-8BIT is intended to be convertible back to UTF-8.