### PR TITLE
Add expiry metadata to Cookies and freshen expires option to support duration

### DIFF
--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -278,6 +278,11 @@ class CookiesTest < ActionController::TestCase
     def encrypted_cookie
       cookies.encrypted["foo"]
     end
+
+    def cookie_expires_in_two_hours
+      cookies[:user_name] = { value: "assain", expires: 2.hours }
+      head :ok
+    end
   end
 
   tests TestController
@@ -1233,6 +1238,33 @@ class CookiesTest < ActionController::TestCase
     cookies.encrypted["foo"] = "bar"
     get :noop
     assert_equal "bar", @controller.encrypted_cookie
+  end
+
+  def test_signed_cookie_with_expires_set_relatively
+    cookies.signed[:user_name] = { value: "assain", expires: 2.hours }
+
+    travel 1.hour
+    assert_equal "assain", cookies.signed[:user_name]
+
+    travel 2.hours
+    assert_nil cookies.signed[:user_name]
+  end
+
+  def test_encrypted_cookie_with_expires_set_relatively
+    cookies.encrypted[:user_name] = { value: "assain", expires: 2.hours }
+
+    travel 1.hour
+    assert_equal "assain", cookies.encrypted[:user_name]
+
+    travel 2.hours
+    assert_nil cookies.encrypted[:user_name]
+  end
+
+  def test_vanilla_cookie_with_expires_set_relatively
+    travel_to Time.utc(2017, 8, 15) do
+      get :cookie_expires_in_two_hours
+      assert_cookie_header "user_name=assain; path=/; expires=Tue, 15 Aug 2017 02:00:00 -0000"
+    end
   end
 
   private

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -26,6 +26,11 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
       render plain: Rack::Utils.escape(Verifier.generate(session.to_hash))
     end
 
+    def set_session_value_expires_in_five_hours
+      session[:foo] = "bar"
+      render plain: Rack::Utils.escape(Verifier.generate(session.to_hash, expires_in: 5.hours))
+    end
+
     def get_session_value
       render plain: "foo: #{session[:foo].inspect}"
     end
@@ -283,7 +288,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
 
         cookies[SessionKey] = SignedBar
 
-        get "/set_session_value"
+        get "/set_session_value_expires_in_five_hours"
         assert_response :success
 
         cookie_body = response.body
@@ -299,7 +304,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
         get "/no_session_access"
         assert_response :success
 
-        assert_equal "_myapp_session=#{cookie_body}; path=/; expires=#{expected_expiry}; HttpOnly",
+        assert_equal "_myapp_session=#{cookies[SessionKey]}; path=/; expires=#{expected_expiry}; HttpOnly",
           headers["Set-Cookie"]
       end
     end


### PR DESCRIPTION
@kaspth 

This PR adds:
-  Expiry meta data to signed/encrypted cookies.
-  Duration support to `:expires` option, i.e. you can specify when the cookie should expire relatively.
e.g. `cookies.signed[:user_name] = { value: "bob", expires: 2.hours }`
