### PR TITLE
Fix dummy_app configuration

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb
@@ -3,16 +3,18 @@ require_relative 'boot'
 <% if include_all_railties? -%>
 require 'rails/all'
 <% else -%>
+require "rails"
 # Pick the frameworks you want:
+require "active_model/railtie"
+require "active_job/railtie"
 <%= comment_if :skip_active_record %>require "active_record/railtie"
 require "action_controller/railtie"
-require "action_view/railtie"
 <%= comment_if :skip_action_mailer %>require "action_mailer/railtie"
-require "active_job/railtie"
+require "action_view/railtie"
 require "active_storage/engine"
 <%= comment_if :skip_action_cable %>require "action_cable/engine"
-<%= comment_if :skip_test %>require "rails/test_unit/railtie"
 <%= comment_if :skip_sprockets %>require "sprockets/railtie"
+<%= comment_if :skip_test %>require "rails/test_unit/railtie"
 <% end -%>
 
 Bundler.require(*Rails.groups)


### PR DESCRIPTION
### Summary

Though it requires components same as [actual application](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/app/templates/config/application.rb#L3-L18), it seems that wrong requiring components and orders.