### PR TITLE
Fixed query building when relation is passed for has one or has many association in where 

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -305,11 +305,15 @@ module ActiveRecord
       end
 
       def get_join_keys(association_klass)
-        JoinKeys.new(join_pk(association_klass), join_fk)
+        JoinKeys.new(join_pk(association_klass), join_foreign_key)
       end
 
       def build_scope(table, predicate_builder = predicate_builder(table))
         Relation.create(klass, table, predicate_builder)
+      end
+
+      def join_foreign_key
+        active_record_primary_key
       end
 
       protected
@@ -324,10 +328,6 @@ module ActiveRecord
 
         def join_pk(_)
           foreign_key
-        end
-
-        def join_fk
-          active_record_primary_key
         end
     end
 
@@ -754,14 +754,14 @@ module ActiveRecord
         owner[foreign_key]
       end
 
+      def join_foreign_key
+        foreign_key
+      end
+
       private
 
         def calculate_constructable(macro, options)
           !polymorphic?
-        end
-
-        def join_fk
-          foreign_key
         end
 
         def join_pk(klass)

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -9,7 +9,7 @@ module ActiveRecord
       end
 
       def queries
-        [associated_table.association_foreign_key.to_s => ids]
+        [associated_table.association_join_fk.to_s => ids]
       end
 
       # TODO Change this to private once we've dropped Ruby 2.2 support.
@@ -30,7 +30,7 @@ module ActiveRecord
         end
 
         def primary_key
-          associated_table.association_primary_key
+          associated_table.association_join_keys.key
         end
 
         def convert_to_id(value)

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -9,7 +9,7 @@ module ActiveRecord
       end
 
       def queries
-        [associated_table.association_join_fk.to_s => ids]
+        [associated_table.association_join_foreign_key.to_s => ids]
       end
 
       # TODO Change this to private once we've dropped Ruby 2.2 support.

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   class TableMetadata # :nodoc:
-    delegate :foreign_type, :foreign_key, :join_keys, to: :association, prefix: true
+    delegate :foreign_type, :foreign_key, :join_keys, :join_foreign_key, to: :association, prefix: true
     delegate :association_primary_key, to: :association
 
     def initialize(klass, arel_table, association = nil)
@@ -64,10 +64,6 @@ module ActiveRecord
 
     def polymorphic_association?
       association && association.polymorphic?
-    end
-
-    def association_join_fk
-      association.send(:join_fk)
     end
 
     # TODO Change this to private once we've dropped Ruby 2.2 support.

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   class TableMetadata # :nodoc:
-    delegate :foreign_type, :foreign_key, to: :association, prefix: true
+    delegate :foreign_type, :foreign_key, :join_keys, to: :association, prefix: true
     delegate :association_primary_key, to: :association
 
     def initialize(klass, arel_table, association = nil)
@@ -64,6 +64,10 @@ module ActiveRecord
 
     def polymorphic_association?
       association && association.polymorphic?
+    end
+
+    def association_join_fk
+      association.send(:join_fk)
     end
 
     # TODO Change this to private once we've dropped Ruby 2.2 support.

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -295,6 +295,20 @@ module ActiveRecord
       assert_equal essays(:david_modest_proposal), essay
     end
 
+    def test_where_with_relation_on_has_many_association
+      essay = essays(:david_modest_proposal)
+      author = Author.where(essays: Essay.where(id: essay.id)).first
+
+      assert_equal authors(:david), author
+    end
+
+    def test_where_with_relation_on_has_one_association
+      author = authors(:david)
+      author_address = AuthorAddress.where(author: Author.where(id: author.id)).first
+      assert_equal author_addresses(:david_address), author_address
+    end
+
+
     def test_where_on_association_with_select_relation
       essay = Essay.where(author: Author.where(name: "David").select(:name)).take
       assert_equal essays(:david_modest_proposal), essay


### PR DESCRIPTION
Solution for Issue #30077

Wrong set of primary key and foreign key where used for has one and has many association. The query generated was only useful for belongs to association.

In this pull request I've added test case and solution to cover the given issue.