### PR TITLE
Deprecate support of older `config.ru`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate support of use `Rails::Application` subclass to start Rails server.
+
+    *Yuji Yaginuma*
+
 *   Add `ruby x.x.x` version to `Gemfile` and create `.ruby-version`
     root file containing current Ruby version when new Rails applications are
     created.

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -2,6 +2,8 @@ require "fileutils"
 require "optparse"
 require "action_dispatch"
 require "rails"
+require "active_support/deprecation"
+require "active_support/core_ext/string/filters"
 require_relative "../../dev_caching"
 
 module Rails
@@ -18,10 +20,15 @@ module Rails
       set_environment
     end
 
-    # TODO: this is no longer required but we keep it for the moment to support older config.ru files.
     def app
       @app ||= begin
         app = super
+        if app.is_a?(Class)
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Use `Rails::Application` subclass to start the server is deprecated and will be removed in Rails 6.0.
+            Please change `run #{app}` to `run Rails.application` in config.ru.
+          MSG
+        end
         app.respond_to?(:to_app) ? app.to_app : app
       end
     end

--- a/railties/test/application/server_test.rb
+++ b/railties/test/application/server_test.rb
@@ -1,0 +1,31 @@
+require "isolation/abstract_unit"
+require "rails/command"
+require "rails/commands/server/server_command"
+
+module ApplicationTests
+  class ServerTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    def setup
+      build_app
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    test "deprecate support of older `config.ru`" do
+      remove_file "config.ru"
+      app_file "config.ru", <<-RUBY
+        require_relative 'config/environment'
+        run AppTemplate::Application
+      RUBY
+
+      server = Rails::Server.new(config: "#{app_path}/config.ru")
+      server.app
+
+      log = File.read(Rails.application.config.paths["log"].first)
+      assert_match(/DEPRECATION WARNING: Use `Rails::Application` subclass to start the server is deprecated/, log)
+    end
+  end
+end


### PR DESCRIPTION
Since Rails 4.0, `config.ru` generated by default uses instances of `Rails.application`.  Therefore, I think that it is good to deprecate the old behavior.

Related: #9669
