### PR TITLE
[ci skip] Prefer cookies.encrypted over signed

### DIFF
--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -53,7 +53,7 @@ module ApplicationCable
 
     private
       def find_verified_user
-        if verified_user = User.find_by(id: cookies.signed[:user_id])
+        if verified_user = User.find_by(id: cookies.encrypted[:user_id])
           verified_user
         else
           reject_unauthorized_connection

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -26,7 +26,7 @@ module ActionCable
     #
     #       private
     #         def find_verified_user
-    #           User.find_by_identity(cookies.signed[:identity_id]) ||
+    #           User.find_by_identity(cookies.encrypted[:identity_id]) ||
     #             reject_unauthorized_connection
     #         end
     #     end

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -33,7 +33,7 @@ module ActiveSupport
   #
   #     private
   #       def authenticate
-  #         if authenticated_user = User.find_by(id: cookies.signed[:user_id])
+  #         if authenticated_user = User.find_by(id: cookies.encrypted[:user_id])
   #           Current.user = authenticated_user
   #         else
   #           redirect_to new_session_url

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -64,7 +64,7 @@ module ApplicationCable
 
     private
       def find_verified_user
-        if verified_user = User.find_by(id: cookies.signed[:user_id])
+        if verified_user = User.find_by(id: cookies.encrypted[:user_id])
           verified_user
         else
           reject_unauthorized_connection


### PR DESCRIPTION
In some examples and guides we are recommending to use code like:

```ruby
verified_user = User.find_by(id: cookies.signed[:user_id])
```

My suggestion is to use instead:

```ruby
verified_user = User.find_by(id: cookies.encrypted[:user_id])
```

which invites users to prefer the "newer" encrypted cookies over the "legacy" signed cookies.

@dhh - all those examples and docs were originally added by you. 
Feel free to merge or close as you deem appropriate. Thanks!