### PR TITLE
Fix random CI failure due to non-deterministic sorting order

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -817,7 +817,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     sarah = Person.create!(first_name: "Sarah", primary_contact_id: people(:susan).id, gender: "F", number1_fan_id: 1)
     john = Person.create!(first_name: "John", primary_contact_id: sarah.id, gender: "M", number1_fan_id: 1)
     assert_equal sarah.agents, [john]
-    assert_equal people(:susan).agents.flat_map(&:agents), people(:susan).agents_of_agents
+    assert_equal people(:susan).agents.flat_map(&:agents).sort, people(:susan).agents_of_agents.sort
   end
 
   def test_associate_existing_with_nonstandard_primary_key_on_belongs_to


### PR DESCRIPTION
It should be sorted to be deterministic executed result.

```
% bundle exec rake test_postgresql --verbose TESTOPTS="--seed=52812"

(snip)

Failure:
HasManyThroughAssociationsTest#test_has_many_association_through_a_has_many_association_to_self [/Users/kamipo/src/github.com/rails/rails/activerecord/test/cases/associations/has_many_through_associations_test.rb:820]:
--- expected
+++ actual
@@ -1 +1 @@
-[#<Person id: 85, primary_contact_id: 84, gender: "M", number1_fan_id: 1, lock_version: 0, comments: nil, followers_count: 0, friends_too_count: 0, best_friend_id: nil, best_friend_of_id: nil, insures: 0, born_at: nil, created_at: "2017-08-08 07:33:52", updated_at: "2017-08-08 07:33:52", first_name: "John">, #<Person id: 1, primary_contact_id: 2, gender: "M", number1_fan_id: 3, lock_version: 0, comments: nil, followers_count: 1, friends_too_count: 1, best_friend_id: nil, best_friend_of_id: nil, insures: 0, born_at: nil, created_at: "2017-08-08 07:33:49", updated_at: "2017-08-08 07:33:49", first_name: "Michael">, #<Person id: 3, primary_contact_id: 2, gender: "F", number1_fan_id: 1, lock_version: 0, comments: nil, followers_count: 1, friends_too_count: 1, best_friend_id: nil, best_friend_of_id: nil, insures: 0, born_at: nil, created_at: "2017-08-08 07:33:49", updated_at: "2017-08-08 07:33:49", first_name: "Susan">]
+#<ActiveRecord::Associations::CollectionProxy [#<Person id: 1, primary_contact_id: 2, gender: "M", number1_fan_id: 3, lock_version: 0, comments: nil, followers_count: 1, friends_too_count: 1, best_friend_id: nil, best_friend_of_id: nil, insures: 0, born_at: nil, created_at: "2017-08-08 07:33:49", updated_at: "2017-08-08 07:33:49", first_name: "Michael">, #<Person id: 3, primary_contact_id: 2, gender: "F", number1_fan_id: 1, lock_version: 0, comments: nil, followers_count: 1, friends_too_count: 1, best_friend_id: nil, best_friend_of_id: nil, insures: 0, born_at: nil, created_at: "2017-08-08 07:33:49", updated_at: "2017-08-08 07:33:49", first_name: "Susan">, #<Person id: 85, primary_contact_id: 84, gender: "M", number1_fan_id: 1, lock_version: 0, comments: nil, followers_count: 0, friends_too_count: 0, best_friend_id: nil, best_friend_of_id: nil, insures: 0, born_at: nil, created_at: "2017-08-08 07:33:52", updated_at: "2017-08-08 07:33:52", first_name: "John">]>
```