### PR TITLE
Fix outdated comment for `Core::ClassMethods#===` [ci skip]

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -143,7 +143,7 @@ module ActiveRecord
       self.default_connection_handler = ConnectionAdapters::ConnectionHandler.new
     end
 
-    module ClassMethods
+    module ClassMethods # :nodoc:
       def allocate
         define_attribute_methods
         super
@@ -251,7 +251,7 @@ module ActiveRecord
         end
       end
 
-      # Overwrite the default class equality method to provide support for association proxies.
+      # Overwrite the default class equality method to provide support for decorated models.
       def ===(object)
         object.is_a?(self)
       end


### PR DESCRIPTION
This comment was added at 97849de, but `AssociationProxy` and
`test_triple_equality` was removed at 1644663. Currently the `===` is
used for `test_decorated_polymorphic_where` that added at #11945.
So I updated "association proxies" to "decorated models".

By the way, currently `ActiveRecord::Core::ClassMethods` appears in the doc.

http://api.rubyonrails.org/classes/ActiveRecord/Core/ClassMethods.html

But it looks like that the methods in the module is not public API.
So what do you think about making nodoc the module?
