### PR TITLE
config.action_view.erb_trim_mode is not needed

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -540,8 +540,6 @@ Defaults to `'signed cookie'`.
 
 * `config.action_view.logger` accepts a logger conforming to the interface of Log4r or the default Ruby Logger class, which is then used to log information from Action View. Set to `nil` to disable logging.
 
-* `config.action_view.erb_trim_mode` gives the trim mode to be used by ERB. It defaults to `'-'`, which turns on trimming of tail spaces and newline when using `<%= -%>` or `<%= =%>`. See the [Erubis documentation](http://www.kuwata-lab.com/erubis/users-guide.06.html#topics-trimspaces) for more information.
-
 * `config.action_view.embed_authenticity_token_in_remote_forms` allows you to
   set the default behavior for `authenticity_token` in forms with `remote:
   true`. By default it's set to `false`, which means that remote forms will not


### PR DESCRIPTION
The configuration was valid when Rails was running on Erubis
(http://www.kuwata-lab.com/erubis/users-guide.06.html#topics-trimspaces)
but it looks like it doesn't have any effect now that Rails runs on Erubi.

@jeremyevans does that sound right? Thanks.

[ci skip]
