### PR TITLE
Fix random CI failure due to non-deterministic sorting order

### DIFF
--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -404,7 +404,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_polymorphic_has_one
-    assert_equal Tagging.find(1, 2).sort_by(&:id), authors(:david).taggings_2
+    assert_equal Tagging.find(1, 2).sort_by(&:id), authors(:david).taggings_2.sort_by(&:id)
   end
 
   def test_has_many_through_polymorphic_has_many


### PR DESCRIPTION
```
rails/activerecord$ bundle exec rake postgresql:test --verbose TESTOPTS="--seed=36062"

Failure:
AssociationsJoinModelTest#test_has_many_through_polymorphic_has_one
[/home/travis/build/rails/rails/activerecord/test/cases/associations/join_model_test.rb:407]:
--- expected
+++ actual
@@ -1 +1 @@
-[
   #<Tagging id: 1, tag_id: 1, super_tag_id: 2, taggable_type: "Post", taggable_id: 1, comment: nil>,
   #<Tagging id: 2, tag_id: 1, super_tag_id: nil, taggable_type: "Post", taggable_id: 2, comment: nil>
 ]
+#<ActiveRecord::Associations::CollectionProxy [
   #<Tagging id: 2, tag_id: 1, super_tag_id: nil, taggable_type: "Post", taggable_id: 2, comment: nil>,
   #<Tagging id: 1, tag_id: 1, super_tag_id: 2, taggable_type: "Post", taggable_id: 1, comment: nil>
 ]>
```