### PR TITLE
5-1-stable: Deserialize a raw value from the database in `changed_in_place?` for `AbstractJson`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -919,11 +919,6 @@ module ActiveRecord
         end
 
         class MysqlJson < Type::Internal::AbstractJson # :nodoc:
-          def changed_in_place?(raw_old_value, new_value)
-            # Normalization is required because MySQL JSON data format includes
-            # the space between the elements.
-            super(serialize(deserialize(raw_old_value)), new_value)
-          end
         end
 
         class MysqlString < Type::String # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/jsonb.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/jsonb.rb
@@ -6,16 +6,6 @@ module ActiveRecord
           def type
             :jsonb
           end
-
-          def changed_in_place?(raw_old_value, new_value)
-            # Postgres does not preserve insignificant whitespaces when
-            # round-tripping jsonb columns. This causes some false positives for
-            # the comparison here. Therefore, we need to parse and re-dump the
-            # raw value here to ensure the insignificant whitespaces are
-            # consistent with our encoder's output.
-            raw_old_value = serialize(deserialize(raw_old_value))
-            super(raw_old_value, new_value)
-          end
         end
       end
     end

--- a/activerecord/lib/active_record/type/internal/abstract_json.rb
+++ b/activerecord/lib/active_record/type/internal/abstract_json.rb
@@ -24,6 +24,10 @@ module ActiveRecord
           end
         end
 
+        def changed_in_place?(raw_old_value, new_value)
+          deserialize(raw_old_value) != new_value
+        end
+
         def accessor
           ActiveRecord::Store::StringKeyedHashAccessor
         end

--- a/activerecord/test/cases/adapters/mysql2/json_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/json_test.rb
@@ -1,16 +1,10 @@
 require "cases/helper"
-require "support/schema_dumping_helper"
+require "cases/json_shared_test_cases"
 
 if ActiveRecord::Base.connection.supports_json?
   class Mysql2JSONTest < ActiveRecord::Mysql2TestCase
-    include SchemaDumpingHelper
+    include JSONSharedTestCases
     self.use_transactional_tests = false
-
-    class JsonDataType < ActiveRecord::Base
-      self.table_name = "json_data_type"
-
-      store_accessor :settings, :resolution
-    end
 
     def setup
       @connection = ActiveRecord::Base.connection
@@ -27,169 +21,9 @@ if ActiveRecord::Base.connection.supports_json?
       JsonDataType.reset_column_information
     end
 
-    def test_column
-      column = JsonDataType.columns_hash["payload"]
-      assert_equal :json, column.type
-      assert_equal "json", column.sql_type
-
-      type = JsonDataType.type_for_attribute("payload")
-      assert_not type.binary?
-    end
-
-    def test_change_table_supports_json
-      @connection.change_table("json_data_type") do |t|
-        t.json "users"
+    private
+      def column_type
+        :json
       end
-      JsonDataType.reset_column_information
-      column = JsonDataType.columns_hash["users"]
-      assert_equal :json, column.type
-    end
-
-    def test_schema_dumping
-      output = dump_table_schema("json_data_type")
-      assert_match(/t\.json\s+"settings"/, output)
-    end
-
-    def test_cast_value_on_write
-      x = JsonDataType.new payload: { "string" => "foo", :symbol => :bar }
-      assert_equal({ "string" => "foo", :symbol => :bar }, x.payload_before_type_cast)
-      assert_equal({ "string" => "foo", "symbol" => "bar" }, x.payload)
-      x.save
-      assert_equal({ "string" => "foo", "symbol" => "bar" }, x.reload.payload)
-    end
-
-    def test_type_cast_json
-      type = JsonDataType.type_for_attribute("payload")
-
-      data = "{\"a_key\":\"a_value\"}"
-      hash = type.deserialize(data)
-      assert_equal({ "a_key" => "a_value" }, hash)
-      assert_equal({ "a_key" => "a_value" }, type.deserialize(data))
-
-      assert_equal({}, type.deserialize("{}"))
-      assert_equal({ "key" => nil }, type.deserialize('{"key": null}'))
-      assert_equal({ "c" => "}", '"a"' => 'b "a b' }, type.deserialize(%q({"c":"}", "\"a\"":"b \"a b"})))
-    end
-
-    def test_rewrite
-      @connection.execute "insert into json_data_type (payload) VALUES ('{\"k\":\"v\"}')"
-      x = JsonDataType.first
-      x.payload = { '"a\'' => "b" }
-      assert x.save!
-    end
-
-    def test_select
-      @connection.execute "insert into json_data_type (payload) VALUES ('{\"k\":\"v\"}')"
-      x = JsonDataType.first
-      assert_equal({ "k" => "v" }, x.payload)
-    end
-
-    def test_select_multikey
-      @connection.execute %q|insert into json_data_type (payload) VALUES ('{"k1":"v1", "k2":"v2", "k3":[1,2,3]}')|
-      x = JsonDataType.first
-      assert_equal({ "k1" => "v1", "k2" => "v2", "k3" => [1, 2, 3] }, x.payload)
-    end
-
-    def test_null_json
-      @connection.execute "insert into json_data_type (payload) VALUES(null)"
-      x = JsonDataType.first
-      assert_nil(x.payload)
-    end
-
-    def test_select_array_json_value
-      @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
-      x = JsonDataType.first
-      assert_equal(["v0", { "k1" => "v1" }], x.payload)
-    end
-
-    def test_select_nil_json_after_create
-      json = JsonDataType.create(payload: nil)
-      x = JsonDataType.where(payload: nil).first
-      assert_equal(json, x)
-    end
-
-    def test_select_nil_json_after_update
-      json = JsonDataType.create(payload: "foo")
-      x = JsonDataType.where(payload: nil).first
-      assert_nil(x)
-
-      json.update_attributes payload: nil
-      x = JsonDataType.where(payload: nil).first
-      assert_equal(json.reload, x)
-    end
-
-    def test_rewrite_array_json_value
-      @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
-      x = JsonDataType.first
-      x.payload = ["v1", { "k2" => "v2" }, "v3"]
-      assert x.save!
-    end
-
-    def test_with_store_accessors
-      x = JsonDataType.new(resolution: "320×480")
-      assert_equal "320×480", x.resolution
-
-      x.save!
-      x = JsonDataType.first
-      assert_equal "320×480", x.resolution
-
-      x.resolution = "640×1136"
-      x.save!
-
-      x = JsonDataType.first
-      assert_equal "640×1136", x.resolution
-    end
-
-    def test_duplication_with_store_accessors
-      x = JsonDataType.new(resolution: "320×480")
-      assert_equal "320×480", x.resolution
-
-      y = x.dup
-      assert_equal "320×480", y.resolution
-    end
-
-    def test_yaml_round_trip_with_store_accessors
-      x = JsonDataType.new(resolution: "320×480")
-      assert_equal "320×480", x.resolution
-
-      y = YAML.load(YAML.dump(x))
-      assert_equal "320×480", y.resolution
-    end
-
-    def test_changes_in_place
-      json = JsonDataType.new
-      assert_not json.changed?
-
-      json.payload = { "one" => "two" }
-      assert json.changed?
-      assert json.payload_changed?
-
-      json.save!
-      assert_not json.changed?
-
-      json.payload["three"] = "four"
-      assert json.payload_changed?
-
-      json.save!
-      json.reload
-
-      assert_equal({ "one" => "two", "three" => "four" }, json.payload)
-      assert_not json.changed?
-    end
-
-    def test_assigning_string_literal
-      json = JsonDataType.create(payload: "foo")
-      assert_equal "foo", json.payload
-    end
-
-    def test_assigning_number
-      json = JsonDataType.create(payload: 1.234)
-      assert_equal 1.234, json.payload
-    end
-
-    def test_assigning_boolean
-      json = JsonDataType.create(payload: true)
-      assert_equal true, json.payload
-    end
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -1,14 +1,8 @@
 require "cases/helper"
-require "support/schema_dumping_helper"
+require "cases/json_shared_test_cases"
 
 module PostgresqlJSONSharedTestCases
-  include SchemaDumpingHelper
-
-  class JsonDataType < ActiveRecord::Base
-    self.table_name = "json_data_type"
-
-    store_accessor :settings, :resolution
-  end
+  include JSONSharedTestCases
 
   def setup
     @connection = ActiveRecord::Base.connection
@@ -28,16 +22,6 @@ module PostgresqlJSONSharedTestCases
     JsonDataType.reset_column_information
   end
 
-  def test_column
-    column = JsonDataType.columns_hash["payload"]
-    assert_equal column_type, column.type
-    assert_equal column_type.to_s, column.sql_type
-    assert_not column.array?
-
-    type = JsonDataType.type_for_attribute("payload")
-    assert_not type.binary?
-  end
-
   def test_default
     @connection.add_column "json_data_type", "permissions", column_type, default: { "users": "read", "posts": ["read", "write"] }
     JsonDataType.reset_column_information
@@ -48,34 +32,6 @@ module PostgresqlJSONSharedTestCases
     JsonDataType.reset_column_information
   end
 
-  def test_change_table_supports_json
-    @connection.transaction do
-      @connection.change_table("json_data_type") do |t|
-        t.public_send column_type, "users", default: "{}" # t.json 'users', default: '{}'
-      end
-      JsonDataType.reset_column_information
-      column = JsonDataType.columns_hash["users"]
-      assert_equal column_type, column.type
-
-      raise ActiveRecord::Rollback # reset the schema change
-    end
-  ensure
-    JsonDataType.reset_column_information
-  end
-
-  def test_schema_dumping
-    output = dump_table_schema("json_data_type")
-    assert_match(/t\.#{column_type.to_s}\s+"payload",\s+default: {}/, output)
-  end
-
-  def test_cast_value_on_write
-    x = JsonDataType.new payload: { "string" => "foo", :symbol => :bar }
-    assert_equal({ "string" => "foo", :symbol => :bar }, x.payload_before_type_cast)
-    assert_equal({ "string" => "foo", "symbol" => "bar" }, x.payload)
-    x.save
-    assert_equal({ "string" => "foo", "symbol" => "bar" }, x.reload.payload)
-  end
-
   def test_deserialize_with_array
     x = JsonDataType.new(objects: ["foo" => "bar"])
     assert_equal ["foo" => "bar"], x.objects
@@ -83,140 +39,6 @@ module PostgresqlJSONSharedTestCases
     assert_equal ["foo" => "bar"], x.objects
     x.reload
     assert_equal ["foo" => "bar"], x.objects
-  end
-
-  def test_type_cast_json
-    type = JsonDataType.type_for_attribute("payload")
-
-    data = "{\"a_key\":\"a_value\"}"
-    hash = type.deserialize(data)
-    assert_equal({ "a_key" => "a_value" }, hash)
-    assert_equal({ "a_key" => "a_value" }, type.deserialize(data))
-
-    assert_equal({}, type.deserialize("{}"))
-    assert_equal({ "key" => nil }, type.deserialize('{"key": null}'))
-    assert_equal({ "c" => "}", '"a"' => 'b "a b' }, type.deserialize(%q({"c":"}", "\"a\"":"b \"a b"})))
-  end
-
-  def test_rewrite
-    @connection.execute "insert into json_data_type (payload) VALUES ('{\"k\":\"v\"}')"
-    x = JsonDataType.first
-    x.payload = { '"a\'' => "b" }
-    assert x.save!
-  end
-
-  def test_select
-    @connection.execute "insert into json_data_type (payload) VALUES ('{\"k\":\"v\"}')"
-    x = JsonDataType.first
-    assert_equal({ "k" => "v" }, x.payload)
-  end
-
-  def test_select_multikey
-    @connection.execute %q|insert into json_data_type (payload) VALUES ('{"k1":"v1", "k2":"v2", "k3":[1,2,3]}')|
-    x = JsonDataType.first
-    assert_equal({ "k1" => "v1", "k2" => "v2", "k3" => [1, 2, 3] }, x.payload)
-  end
-
-  def test_null_json
-    @connection.execute "insert into json_data_type (payload) VALUES(null)"
-    x = JsonDataType.first
-    assert_nil(x.payload)
-  end
-
-  def test_select_nil_json_after_create
-    json = JsonDataType.create(payload: nil)
-    x = JsonDataType.where(payload: nil).first
-    assert_equal(json, x)
-  end
-
-  def test_select_nil_json_after_update
-    json = JsonDataType.create(payload: "foo")
-    x = JsonDataType.where(payload: nil).first
-    assert_nil(x)
-
-    json.update_attributes payload: nil
-    x = JsonDataType.where(payload: nil).first
-    assert_equal(json.reload, x)
-  end
-
-  def test_select_array_json_value
-    @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
-    x = JsonDataType.first
-    assert_equal(["v0", { "k1" => "v1" }], x.payload)
-  end
-
-  def test_rewrite_array_json_value
-    @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
-    x = JsonDataType.first
-    x.payload = ["v1", { "k2" => "v2" }, "v3"]
-    assert x.save!
-  end
-
-  def test_with_store_accessors
-    x = JsonDataType.new(resolution: "320×480")
-    assert_equal "320×480", x.resolution
-
-    x.save!
-    x = JsonDataType.first
-    assert_equal "320×480", x.resolution
-
-    x.resolution = "640×1136"
-    x.save!
-
-    x = JsonDataType.first
-    assert_equal "640×1136", x.resolution
-  end
-
-  def test_duplication_with_store_accessors
-    x = JsonDataType.new(resolution: "320×480")
-    assert_equal "320×480", x.resolution
-
-    y = x.dup
-    assert_equal "320×480", y.resolution
-  end
-
-  def test_yaml_round_trip_with_store_accessors
-    x = JsonDataType.new(resolution: "320×480")
-    assert_equal "320×480", x.resolution
-
-    y = YAML.load(YAML.dump(x))
-    assert_equal "320×480", y.resolution
-  end
-
-  def test_changes_in_place
-    json = JsonDataType.new
-    assert_not json.changed?
-
-    json.payload = { "one" => "two" }
-    assert json.changed?
-    assert json.payload_changed?
-
-    json.save!
-    assert_not json.changed?
-
-    json.payload["three"] = "four"
-    assert json.payload_changed?
-
-    json.save!
-    json.reload
-
-    assert_equal({ "one" => "two", "three" => "four" }, json.payload)
-    assert_not json.changed?
-  end
-
-  def test_assigning_string_literal
-    json = JsonDataType.create(payload: "foo")
-    assert_equal "foo", json.payload
-  end
-
-  def test_assigning_number
-    json = JsonDataType.create(payload: 1.234)
-    assert_equal 1.234, json.payload
-  end
-
-  def test_assigning_boolean
-    json = JsonDataType.create(payload: true)
-    assert_equal true, json.payload
   end
 end
 

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -1,0 +1,177 @@
+require "support/schema_dumping_helper"
+
+module JSONSharedTestCases
+  include SchemaDumpingHelper
+
+  class JsonDataType < ActiveRecord::Base
+    self.table_name = "json_data_type"
+
+    store_accessor :settings, :resolution
+  end
+
+  def test_column
+    column = JsonDataType.columns_hash["payload"]
+    assert_equal column_type, column.type
+    assert_equal column_type.to_s, column.sql_type
+
+    type = JsonDataType.type_for_attribute("payload")
+    assert_not type.binary?
+  end
+
+  def test_change_table_supports_json
+    @connection.change_table("json_data_type") do |t|
+      t.public_send column_type, "users"
+    end
+    JsonDataType.reset_column_information
+    column = JsonDataType.columns_hash["users"]
+    assert_equal column_type, column.type
+    assert_equal column_type.to_s, column.sql_type
+  end
+
+  def test_schema_dumping
+    output = dump_table_schema("json_data_type")
+    assert_match(/t\.#{column_type}\s+"settings"/, output)
+  end
+
+  def test_cast_value_on_write
+    x = JsonDataType.new(payload: { "string" => "foo", :symbol => :bar })
+    assert_equal({ "string" => "foo", :symbol => :bar }, x.payload_before_type_cast)
+    assert_equal({ "string" => "foo", "symbol" => "bar" }, x.payload)
+    x.save!
+    assert_equal({ "string" => "foo", "symbol" => "bar" }, x.reload.payload)
+  end
+
+  def test_type_cast_json
+    type = JsonDataType.type_for_attribute("payload")
+
+    data = '{"a_key":"a_value"}'
+    hash = type.deserialize(data)
+    assert_equal({ "a_key" => "a_value" }, hash)
+    assert_equal({ "a_key" => "a_value" }, type.deserialize(data))
+
+    assert_equal({}, type.deserialize("{}"))
+    assert_equal({ "key" => nil }, type.deserialize('{"key": null}'))
+    assert_equal({ "c" => "}", '"a"' => 'b "a b' }, type.deserialize(%q({"c":"}", "\"a\"":"b \"a b"})))
+  end
+
+  def test_rewrite
+    @connection.execute(%q|insert into json_data_type (payload) VALUES ('{"k":"v"}')|)
+    x = JsonDataType.first
+    x.payload = { '"a\'' => "b" }
+    assert x.save!
+  end
+
+  def test_select
+    @connection.execute(%q|insert into json_data_type (payload) VALUES ('{"k":"v"}')|)
+    x = JsonDataType.first
+    assert_equal({ "k" => "v" }, x.payload)
+  end
+
+  def test_select_multikey
+    @connection.execute(%q|insert into json_data_type (payload) VALUES ('{"k1":"v1", "k2":"v2", "k3":[1,2,3]}')|)
+    x = JsonDataType.first
+    assert_equal({ "k1" => "v1", "k2" => "v2", "k3" => [1, 2, 3] }, x.payload)
+  end
+
+  def test_null_json
+    @connection.execute("insert into json_data_type (payload) VALUES(null)")
+    x = JsonDataType.first
+    assert_nil(x.payload)
+  end
+
+  def test_select_nil_json_after_create
+    json = JsonDataType.create!(payload: nil)
+    x = JsonDataType.where(payload: nil).first
+    assert_equal(json, x)
+  end
+
+  def test_select_nil_json_after_update
+    json = JsonDataType.create!(payload: "foo")
+    x = JsonDataType.where(payload: nil).first
+    assert_nil(x)
+
+    json.update_attributes(payload: nil)
+    x = JsonDataType.where(payload: nil).first
+    assert_equal(json.reload, x)
+  end
+
+  def test_select_array_json_value
+    @connection.execute(%q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|)
+    x = JsonDataType.first
+    assert_equal(["v0", { "k1" => "v1" }], x.payload)
+  end
+
+  def test_rewrite_array_json_value
+    @connection.execute(%q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|)
+    x = JsonDataType.first
+    x.payload = ["v1", { "k2" => "v2" }, "v3"]
+    assert x.save!
+  end
+
+  def test_with_store_accessors
+    x = JsonDataType.new(resolution: "320×480")
+    assert_equal "320×480", x.resolution
+
+    x.save!
+    x = JsonDataType.first
+    assert_equal "320×480", x.resolution
+
+    x.resolution = "640×1136"
+    x.save!
+
+    x = JsonDataType.first
+    assert_equal "640×1136", x.resolution
+  end
+
+  def test_duplication_with_store_accessors
+    x = JsonDataType.new(resolution: "320×480")
+    assert_equal "320×480", x.resolution
+
+    y = x.dup
+    assert_equal "320×480", y.resolution
+  end
+
+  def test_yaml_round_trip_with_store_accessors
+    x = JsonDataType.new(resolution: "320×480")
+    assert_equal "320×480", x.resolution
+
+    y = YAML.load(YAML.dump(x))
+    assert_equal "320×480", y.resolution
+  end
+
+  def test_changes_in_place
+    json = JsonDataType.new
+    assert_not json.changed?
+
+    json.payload = { "one" => "two" }
+    assert json.changed?
+    assert json.payload_changed?
+
+    json.save!
+    assert_not json.changed?
+
+    json.payload["three"] = "four"
+    assert json.payload_changed?
+
+    json.save!
+    json.reload
+
+    assert_equal({ "one" => "two", "three" => "four" }, json.payload)
+    assert_not json.changed?
+  end
+
+  def test_assigning_string_literal
+    json = JsonDataType.create!(payload: "foo")
+    assert_equal "foo", json.payload
+  end
+
+  def test_assigning_number
+    json = JsonDataType.create!(payload: 1.234)
+    assert_equal 1.234, json.payload
+  end
+
+  def test_assigning_boolean
+    json = JsonDataType.create!(payload: true)
+    assert_equal true, json.payload
+  end
+end

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -160,6 +160,17 @@ module JSONSharedTestCases
     assert_not json.changed?
   end
 
+  def test_changes_in_place_with_ruby_object
+    time = Time.now.utc
+    json = JsonDataType.create!(payload: time)
+
+    json.reload
+    assert_not json.changed?
+
+    json.payload = time
+    assert_not json.changed?
+  end
+
   def test_assigning_string_literal
     json = JsonDataType.create!(payload: "foo")
     assert_equal "foo", json.payload

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -160,6 +160,25 @@ module JSONSharedTestCases
     assert_not json.changed?
   end
 
+  def test_changes_in_place_ignores_key_order
+    json = JsonDataType.new
+    assert_not json.changed?
+
+    json.payload = { "three" => "four", "one" => "two" }
+    json.save!
+    json.reload
+
+    json.payload = { "three" => "four", "one" => "two" }
+    assert_not json.changed?
+
+    json.payload = [{ "three" => "four", "one" => "two" }, { "seven" => "eight", "five" => "six" }]
+    json.save!
+    json.reload
+
+    json.payload = [{ "three" => "four", "one" => "two" }, { "seven" => "eight", "five" => "six" }]
+    assert_not json.changed?
+  end
+
   def test_changes_in_place_with_ruby_object
     time = Time.now.utc
     json = JsonDataType.create!(payload: time)


### PR DESCRIPTION
This PR backports #29175, #29273, and #29491 to fix #28754.