### PR TITLE
DRY up Gemfile by reading Ruby version from .ruby-version file

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby IO.read(File.expand_path("#{File.dirname(__FILE__)}/.ruby-version")).strip
+ruby IO.read(".ruby-version")
 
 <% unless gemfile_entries.first.comment -%>
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby IO.read(".ruby-version")
+ruby IO.read(".ruby-version").strip
 
 <% unless gemfile_entries.first.comment -%>
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby <%= "'#{RUBY_VERSION}'" -%>
+ruby IO.read(File.expand_path("#{File.dirname(__FILE__)}/.ruby-version")).strip
 
 <% unless gemfile_entries.first.comment -%>
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -813,7 +813,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "Gemfile" do |content|
-      assert_match(/ruby '#{RUBY_VERSION}'/, content)
+      assert_match(/ruby IO.read/, content)
     end
     assert_file ".ruby-version" do |content|
       assert_match(/#{RUBY_VERSION}/, content)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -813,7 +813,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "Gemfile" do |content|
-      assert_match(/ruby IO.read/, content)
+      assert_match(/ruby IO.read(".ruby-version")/, content)
     end
     assert_file ".ruby-version" do |content|
       assert_match(/#{RUBY_VERSION}/, content)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -813,7 +813,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "Gemfile" do |content|
-      assert_match(/ruby IO.read(".ruby-version")/, content)
+      assert_match(/ruby IO\.read\("\.ruby-version"\)\.strip/, content)
     end
     assert_file ".ruby-version" do |content|
       assert_match(/#{RUBY_VERSION}/, content)


### PR DESCRIPTION
### Summary

Follow up on https://github.com/rails/rails/pull/30016 to ensure Ruby version is only specified in a single place.

~~Gemfile code is pinched from [ossfriday](https://github.com/ossfriday/ossfriday/blob/master/Gemfile).~~

### Other Information

An alternative implementation would be to include `ruby RUBY_VERSION` in the `Gemfile`. I've opted for explicitly loading in the `.ruby-version` file because it would make it obvious to anyone where the version is being set.