### PR TITLE
Improve railties generators tests

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `--skip-action-cable` option to the plugin generator.
+
+    *bogdanvlviv*
+
 *   Deprecate support of use `Rails::Application` subclass to start Rails server.
 
     *Yuji Yaginuma*

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -86,7 +86,7 @@ task default: :test
     end
 
     PASSTHROUGH_OPTIONS = [
-      :skip_active_record, :skip_action_mailer, :skip_javascript, :skip_sprockets, :database,
+      :skip_active_record, :skip_action_mailer, :skip_javascript, :skip_action_cable, :skip_sprockets, :database,
       :javascript, :quiet, :pretend, :force, :skip
     ]
 

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -234,6 +234,12 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   def test_action_cable_is_removed_from_frameworks_if_skip_action_cable_is_given
     run_generator [destination_root, "--skip-action-cable"]
     assert_file "test/dummy/config/application.rb", /#\s+require\s+["']action_cable\/engine["']/
+    assert_no_file "test/dummy/config/cable.yml"
+    assert_no_file "test/dummy/app/assets/javascripts/cable.js"
+    assert_no_directory "test/dummy/app/channels"
+    assert_file "Gemfile" do |content|
+      assert_no_match(/redis/, content)
+    end
   end
 
   def test_ensure_that_database_option_is_passed_to_app_generator

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -97,7 +97,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "-T", "--full"]
 
     assert_no_directory "test/integration/"
-    assert_no_file "test"
+    assert_no_directory "test"
     assert_file "Rakefile" do |contents|
       assert_no_match(/APP_RAKEFILE/, contents)
     end
@@ -106,11 +106,28 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_generating_adds_dummy_app_in_full_mode_without_sprockets
-    run_generator [destination_root, "-S", "--full"]
+  def test_generating_adds_dummy_app_without_sprockets
+    run_generator [destination_root, "--skip-sprockets"]
 
-    assert_file "test/dummy/config/environments/production.rb" do |contents|
-      assert_no_match(/config\.assets/, contents)
+    assert_no_file "test/dummy/config/initializers/assets.rb"
+
+    assert_file "test/dummy/config/application.rb", /#\s+require\s+["']sprockets\/railtie["']/
+
+    assert_file "Gemfile" do |content|
+      assert_no_match(/sass-rails/, content)
+      assert_no_match(/uglifier/, content)
+      assert_no_match(/coffee-rails/, content)
+    end
+
+    assert_file "test/dummy/config/environments/development.rb" do |content|
+      assert_no_match(/config\.assets\.debug/, content)
+    end
+
+    assert_file "test/dummy/config/environments/production.rb" do |content|
+      assert_no_match(/config\.assets\.digest/, content)
+      assert_no_match(/config\.assets\.js_compressor/, content)
+      assert_no_match(/config\.assets\.css_compressor/, content)
+      assert_no_match(/config\.assets\.compile/, content)
     end
   end
 
@@ -138,8 +155,8 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   def test_ensure_that_test_dummy_can_be_generated_from_a_template
     FileUtils.cd(Rails.root)
     run_generator([destination_root, "-m", "lib/create_test_dummy_template.rb", "--skip-test"])
-    assert_file "spec/dummy"
-    assert_no_file "test"
+    assert_directory "spec/dummy"
+    assert_no_directory "test"
   end
 
   def test_database_entry_is_generated_for_sqlite3_by_default_in_full_mode
@@ -173,7 +190,17 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
     assert_file "test/dummy/config/environments/production.rb" do |content|
       assert_match(/# config\.action_mailer\.raise_delivery_errors = false/, content)
+      assert_match(/^  config\.read_encrypted_secrets = true/, content)
     end
+  end
+
+  def test_default_frameworks_are_required_when_others_are_removed
+    run_generator [destination_root, "--skip-active-record", "--skip-action-mailer", "--skip-action-cable", "--skip-sprockets"]
+    assert_file "test/dummy/config/application.rb", /require\s+["']rails["']/
+    assert_file "test/dummy/config/application.rb", /require\s+["']active_model\/railtie["']/
+    assert_file "test/dummy/config/application.rb", /require\s+["']active_job\/railtie["']/
+    assert_file "test/dummy/config/application.rb", /require\s+["']action_controller\/railtie["']/
+    assert_file "test/dummy/config/application.rb", /require\s+["']action_view\/railtie["']/
   end
 
   def test_active_record_is_removed_from_frameworks_if_skip_active_record_is_given
@@ -201,6 +228,12 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "test/dummy/config/environments/production.rb" do |content|
       assert_no_match(/config\.action_mailer/, content)
     end
+    assert_no_directory "test/dummy/app/mailers"
+  end
+
+  def test_action_cable_is_removed_from_frameworks_if_skip_action_cable_is_given
+    run_generator [destination_root, "--skip-action-cable"]
+    assert_file "test/dummy/config/application.rb", /#\s+require\s+["']action_cable\/engine["']/
   end
 
   def test_ensure_that_database_option_is_passed_to_app_generator
@@ -463,10 +496,9 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
   def test_creating_dummy_without_tests_but_with_dummy_path
     run_generator [destination_root, "--dummy_path", "spec/dummy", "--skip-test"]
-    assert_file "spec/dummy"
-    assert_file "spec/dummy/config/application.rb"
-    assert_no_file "test"
-    assert_no_file "test/test_helper.rb"
+    assert_directory "spec/dummy"
+    assert_file "spec/dummy/config/application.rb", /#\s+require\s+["']rails\/test_unit\/railtie["']/
+    assert_no_directory "test"
     assert_file ".gitignore" do |contents|
       assert_match(/spec\/dummy/, contents)
     end
@@ -503,7 +535,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
   def test_skipping_test_files
     run_generator [destination_root, "--skip-test"]
-    assert_no_file "test"
+    assert_no_directory "test"
     assert_file ".gitignore" do |contents|
       assert_no_match(/test\/dummy/, contents)
     end


### PR DESCRIPTION
Improve plugin generator tests
Improve app generator tests
Ensure that generation `config/application.rb` is correct.
Related to #30123

<hr>

`--skip-action-cable` pass throughs `rails plugin new` (i found this when i was improving tests)

<hr>

Also, this PR will prevent making mistakes like: https://github.com/rails/rails/pull/30101#discussion_r132046176
r? @rafaelfranca 