### PR TITLE
Optimize indentation for generator actions

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Optimize indentation for generator actions.
+
+    *Yoshiyuki Hirano*
+
 *   Add `--skip-action-cable` option to the plugin generator.
 
     *bogdanvlviv*

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -10,6 +10,7 @@ require "active_support/core_ext/kernel/singleton_class"
 require "active_support/core_ext/array/extract_options"
 require "active_support/core_ext/hash/deep_merge"
 require "active_support/core_ext/module/attribute_accessors"
+require "active_support/core_ext/string/indent"
 require "active_support/core_ext/string/inflections"
 
 module Rails

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -139,14 +139,14 @@ class ActionsTest < Rails::Generators::TestCase
     run_generator
     autoload_paths = 'config.autoload_paths += %w["#{Rails.root}/app/extras"]'
     action :environment, autoload_paths
-    assert_file "config/application.rb", /  class Application < Rails::Application\n    #{Regexp.escape(autoload_paths)}/
+    assert_file "config/application.rb", /  class Application < Rails::Application\n    #{Regexp.escape(autoload_paths)}\n/
   end
 
   def test_environment_should_include_data_in_environment_initializer_block_with_env_option
     run_generator
     autoload_paths = 'config.autoload_paths += %w["#{Rails.root}/app/extras"]'
     action :environment, autoload_paths, env: "development"
-    assert_file "config/environments/development.rb", /Rails\.application\.configure do\n  #{Regexp.escape(autoload_paths)}/
+    assert_file "config/environments/development.rb", /Rails\.application\.configure do\n  #{Regexp.escape(autoload_paths)}\n/
   end
 
   def test_environment_with_block_should_include_block_contents_in_environment_initializer_block
@@ -163,6 +163,26 @@ class ActionsTest < Rails::Generators::TestCase
     end
   end
 
+  def test_environment_with_block_should_include_block_contents_with_multiline_data_in_environment_initializer_block
+    run_generator
+    data = <<-RUBY
+      config.encoding = "utf-8"
+      config.time_zone = "UTC"
+    RUBY
+    action(:environment) { data }
+    assert_file "config/application.rb", /  class Application < Rails::Application\n#{Regexp.escape(data.strip_heredoc.indent(4))}/
+  end
+
+  def test_environment_should_include_block_contents_with_multiline_data_in_environment_initializer_block_with_env_option
+    run_generator
+    data = <<-RUBY
+      config.encoding = "utf-8"
+      config.time_zone = "UTC"
+    RUBY
+    action(:environment, nil, env: "development") { data }
+    assert_file "config/environments/development.rb", /Rails\.application\.configure do\n#{Regexp.escape(data.strip_heredoc.indent(2))}/
+  end
+
   def test_git_with_symbol_should_run_command_using_git_scm
     assert_called_with(generator, :run, ["git init"]) do
       action :git, :init
@@ -177,22 +197,62 @@ class ActionsTest < Rails::Generators::TestCase
 
   def test_vendor_should_write_data_to_file_in_vendor
     action :vendor, "vendor_file.rb", "# vendor data"
-    assert_file "vendor/vendor_file.rb", "# vendor data"
+    assert_file "vendor/vendor_file.rb", "# vendor data\n"
+  end
+
+  def test_vendor_should_write_data_to_file_with_block_in_vendor
+    code = <<-RUBY
+      puts "one"
+      puts "two"
+      puts "three"
+    RUBY
+    action(:vendor, "vendor_file.rb") { code }
+    assert_file "vendor/vendor_file.rb", code.strip_heredoc
   end
 
   def test_lib_should_write_data_to_file_in_lib
     action :lib, "my_library.rb", "class MyLibrary"
-    assert_file "lib/my_library.rb", "class MyLibrary"
+    assert_file "lib/my_library.rb", "class MyLibrary\n"
+  end
+
+  def test_lib_should_write_data_to_file_with_block_in_lib
+    code = <<-RUBY
+      class MyLib
+        MY_CONSTANT = 123
+      end
+    RUBY
+    action(:lib, "my_library.rb") { code }
+    assert_file "lib/my_library.rb", code.strip_heredoc
   end
 
   def test_rakefile_should_write_date_to_file_in_lib_tasks
     action :rakefile, "myapp.rake", "task run: [:environment]"
-    assert_file "lib/tasks/myapp.rake", "task run: [:environment]"
+    assert_file "lib/tasks/myapp.rake", "task run: [:environment]\n"
+  end
+
+  def test_rakefile_should_write_date_to_file_with_block_in_lib_tasks
+    code = <<-RUBY
+      task rock: :environment do
+        puts "Rockin'"
+      end
+    RUBY
+    action(:rakefile, "myapp.rake") { code }
+    assert_file "lib/tasks/myapp.rake", code.strip_heredoc
   end
 
   def test_initializer_should_write_date_to_file_in_config_initializers
     action :initializer, "constants.rb", "MY_CONSTANT = 42"
-    assert_file "config/initializers/constants.rb", "MY_CONSTANT = 42"
+    assert_file "config/initializers/constants.rb", "MY_CONSTANT = 42\n"
+  end
+
+  def test_initializer_should_write_date_to_file_with_block_in_config_initializers
+    code = <<-RUBY
+      MyLib.configure do |config|
+        config.value = 123
+      end
+    RUBY
+    action(:initializer, "constants.rb") { code }
+    assert_file "config/initializers/constants.rb", code.strip_heredoc
   end
 
   def test_generate_should_run_script_generate_with_argument_and_options


### PR DESCRIPTION
### Summary

I've found that indentations are broken on `environment` method that is generator's one of actions.

#### Example template

```ruby
environment "config.x.a = 1"
environment "config.x.b = 2"
environment do
  <<~RUBY
    config.x.c = 3
    config.x.d = 4
    config.x.e = 5
  RUBY
end

environment "config.x.a = 1", env: "development"
environment "config.x.b = 2", env: "development"
environment nil, env: "development" do
  <<~RUBY
    config.x.c = 3
    config.x.d = 4
    config.x.e = 5
  RUBY
end
```

#### Command

`$ bin/rails app:template LOCATION=./template.rb`

#### Before

It seems that it's not supported to be used on multiple lines.

```diff
$ git diff
diff --git a/config/application.rb b/config/application.rb
index f150d0f..41ae6f8 100644
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,12 @@ Bundler.require(*Rails.groups)

 module Foobar
   class Application < Rails::Application
+    config.x.c = 3
+config.x.d = 4
+config.x.e = 5
+
+    config.x.b = 2
+    config.x.a = 1
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1

diff --git a/config/environments/development.rb b/config/environments/development.rb
index 2c15c69..f6b467c 100644
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,10 @@
 Rails.application.configure do
+  config.x.c = 3
+config.x.d = 4
+config.x.e = 5
+
+  config.x.b = 2
+  config.x.a = 1
   # Settings specified here will take precedence over those in config/application.rb.

   # In the development environment your application's code is reloaded on
```

#### After

```diff
$ git diff
diff --git a/config/application.rb b/config/application.rb
index f150d0f..2254e12 100644
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,11 @@ Bundler.require(*Rails.groups)

 module Foobar
   class Application < Rails::Application
+    config.x.c = 3
+    config.x.d = 4
+    config.x.e = 5
+    config.x.b = 2
+    config.x.a = 1
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1

diff --git a/config/environments/development.rb b/config/environments/development.rb
index 2c15c69..bf1d891 100644
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,9 @@
 Rails.application.configure do
+  config.x.c = 3
+  config.x.d = 4
+  config.x.e = 5
+  config.x.b = 2
+  config.x.a = 1
   # Settings specified here will take precedence over those in config/application.rb.

   # In the development environment your application's code is reloaded on
```

### Other Information

This is my use case.

```ruby
application do
  <<~RUBY
    config.encoding  = "utf-8"
    config.time_zone = "UTC"
    config.active_record.default_timezone = :utc
    config.autoload_paths   += %W(\#{config.root}/lib)
    config.eager_load_paths += %W(\#{config.root}/lib)
  RUBY
end
```