### PR TITLE
Specify branch in the benchmark template

### DIFF
--- a/guides/bug_report_templates/benchmark.rb
+++ b/guides/bug_report_templates/benchmark.rb
@@ -7,7 +7,7 @@ end
 
 gemfile(true) do
   source "https://rubygems.org"
-  gem "rails", github: "rails/rails"
+  gem "rails", github: "rails/rails", branch: "5-1-stable"
   gem "benchmark-ips"
 end
 


### PR DESCRIPTION
Because other bug report templates specify branch.
https://github.com/rails/rails/blob/5-1-stable/guides/bug_report_templates/action_controller_master.rb#L10
https://github.com/rails/rails/blob/5-1-stable/guides/bug_report_templates/active_job_master.rb#L10
https://github.com/rails/rails/blob/5-1-stable/guides/bug_report_templates/active_record_master.rb#L10
https://github.com/rails/rails/blob/5-1-stable/guides/bug_report_templates/active_record_migrations_master.rb#L10
https://github.com/rails/rails/blob/5-1-stable/guides/bug_report_templates/generic_master.rb#L10

This also fixes broken tests.
Ref: https://travis-ci.org/rails/rails/jobs/262443113