### PR TITLE
Don't repeat the Ruby version in the Gemfile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby <%= "'#{RUBY_VERSION}'" -%>
+ruby File.read(File.expand_path('.ruby-version', __dir__))
 
 <% unless gemfile_entries.first.comment -%>
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -823,7 +823,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "Gemfile" do |content|
-      assert_match(/ruby '#{RUBY_VERSION}'/, content)
+      assert_match(/ruby File\.read\(File\.expand_path\('\.ruby-version', __dir__\)\)/, content)
     end
     assert_file ".ruby-version" do |content|
       assert_match(/#{RUBY_VERSION}/, content)


### PR DESCRIPTION
Prior to this change, upgrading Ruby required changing the version in both
Gemfile and .ruby-version.  Now it will only need to be changed in one place