### PR TITLE
Fix formatting of Active Storage docs [ci skip]

### DIFF
--- a/activestorage/lib/active_storage/attached.rb
+++ b/activestorage/lib/active_storage/attached.rb
@@ -3,7 +3,7 @@ require "action_dispatch/http/upload"
 require "active_support/core_ext/module/delegation"
 
 module ActiveStorage
-# Abstract baseclass for the concrete `ActiveStorage::Attached::One` and `ActiveStorage::Attached::Many`
+# Abstract baseclass for the concrete ActiveStorage::Attached::One and ActiveStorage::Attached::Many
 # classes that both provide proxy access to the blob association for a record.
   class Attached
     attr_reader :name, :record

--- a/activestorage/lib/active_storage/attached/macros.rb
+++ b/activestorage/lib/active_storage/attached/macros.rb
@@ -10,14 +10,14 @@ module ActiveStorage
     # There is no column defined on the model side, Active Storage takes
     # care of the mapping between your records and the attachment.
     #
-    # Under the covers, this relationship is implemented as a `has_one` association to a
-    # `ActiveStorage::Attachment` record and a `has_one-through` association to a
-    # `ActiveStorage::Blob` record. These associations are available as `avatar_attachment`
-    # and `avatar_blob`. But you shouldn't need to work with these associations directly in
+    # Under the covers, this relationship is implemented as a +has_one+ association to a
+    # ActiveStorage::Attachment record and a +has_one-through+ association to a
+    # ActiveStorage::Blob record. These associations are available as +avatar_attachment+
+    # and +avatar_blob+. But you shouldn't need to work with these associations directly in
     # most circumstances.
     #
-    # The system has been designed to having you go through the `ActiveStorage::Attached::One`
-    # proxy that provides the dynamic proxy to the associations and factory methods, like `#attach`.
+    # The system has been designed to having you go through the ActiveStorage::Attached::One
+    # proxy that provides the dynamic proxy to the associations and factory methods, like +#attach+.
     #
     # If the +:dependent+ option isn't set, the attachment will be purged
     # (i.e. destroyed) whenever the record is destroyed.
@@ -51,14 +51,14 @@ module ActiveStorage
     #
     #   Gallery.where(user: Current.user).with_attached_photos
     #
-    # Under the covers, this relationship is implemented as a `has_many` association to a
-    # `ActiveStorage::Attachment` record and a `has_many-through` association to a
-    # `ActiveStorage::Blob` record. These associations are available as `photos_attachments`
-    # and `photos_blobs`. But you shouldn't need to work with these associations directly in
+    # Under the covers, this relationship is implemented as a +has_many+ association to a
+    # ActiveStorage::Attachment record and a +has_many-through+ association to a
+    # ActiveStorage::Blob record. These associations are available as +photos_attachments+
+    # and +photos_blobs+. But you shouldn't need to work with these associations directly in
     # most circumstances.
     #
-    # The system has been designed to having you go through the `ActiveStorage::Attached::Many`
-    # proxy that provides the dynamic proxy to the associations and factory methods, like `#attach`.
+    # The system has been designed to having you go through the ActiveStorage::Attached::Many
+    # proxy that provides the dynamic proxy to the associations and factory methods, like +#attach+.
     #
     # If the +:dependent+ option isn't set, all the attachments will be purged
     # (i.e. destroyed) whenever the record is destroyed.

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -5,7 +5,7 @@ module ActiveStorage
 
     # Returns all the associated attachment records.
     #
-    # All methods called on this proxy object that aren't listed here will automatically be delegated to `attachments`.
+    # All methods called on this proxy object that aren't listed here will automatically be delegated to +attachments+.
     def attachments
       record.public_send("#{name}_attachments")
     end

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -59,43 +59,43 @@ module ActiveStorage
       end
     end
 
-    # Upload the `io` to the `key` specified. If a `checksum` is provided, the service will
-    # ensure a match when the upload has completed or raise an `ActiveStorage::IntegrityError`.
+    # Upload the +io+ to the +key+ specified. If a +checksum+ is provided, the service will
+    # ensure a match when the upload has completed or raise an ActiveStorage::IntegrityError.
     def upload(key, io, checksum: nil)
       raise NotImplementedError
     end
 
-    # Return the content of the file at the `key`.
+    # Return the content of the file at the +key+.
     def download(key)
       raise NotImplementedError
     end
 
-    # Delete the file at the `key`.
+    # Delete the file at the +key+.
     def delete(key)
       raise NotImplementedError
     end
 
-    # Return true if a file exists at the `key`.
+    # Return true if a file exists at the +key+.
     def exist?(key)
       raise NotImplementedError
     end
 
-    # Returns a signed, temporary URL for the file at the `key`. The URL will be valid for the amount
-    # of seconds specified in `expires_in`. You most also provide the `disposition` (`:inline` or `:attachment`),
-    # `filename`, and `content_type` that you wish the file to be served with on request.
+    # Returns a signed, temporary URL for the file at the +key+. The URL will be valid for the amount
+    # of seconds specified in +expires_in+. You most also provide the +disposition+ (+:inline+ or +:attachment+),
+    # +filename+, and +content_type+ that you wish the file to be served with on request.
     def url(key, expires_in:, disposition:, filename:, content_type:)
       raise NotImplementedError
     end
 
-    # Returns a signed, temporary URL that a direct upload file can be PUT to on the `key`.
-    # The URL will be valid for the amount of seconds specified in `expires_in`.
-    # You most also provide the `content_type`, `content_length`, and `checksum` of the file
+    # Returns a signed, temporary URL that a direct upload file can be PUT to on the +key+.
+    # The URL will be valid for the amount of seconds specified in +expires_in+.
+    # You most also provide the +content_type+, +content_length+, and `+hecksum+ of the file
     # that will be uploaded. All these attributes will be validated by the service upon upload.
     def url_for_direct_upload(key, expires_in:, content_type:, content_length:, checksum:)
       raise NotImplementedError
     end
 
-    # Returns a Hash of headers for `url_for_direct_upload` requests.
+    # Returns a Hash of headers for +url_for_direct_upload+ requests.
     def headers_for_direct_upload(key, filename:, content_type:, content_length:, checksum:)
       {}
     end

--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -4,7 +4,7 @@ require "azure/storage/core/auth/shared_access_signature"
 
 module ActiveStorage
   # Wraps the Microsoft Azure Storage Blob Service as a Active Storage service.
-  # See `ActiveStorage::Service` for the generic API documentation that applies to all services.
+  # See ActiveStorage::Service for the generic API documentation that applies to all services.
   class Service::AzureStorageService < Service
     attr_reader :client, :path, :blobs, :container, :signer
 

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -4,7 +4,7 @@ require "digest/md5"
 require "active_support/core_ext/numeric/bytes"
 
 module ActiveStorage
-  # Wraps a local disk path as a Active Storage service. See `ActiveStorage::Service` for the generic API
+  # Wraps a local disk path as a Active Storage service. See ActiveStorage::Service for the generic API
   # documentation that applies to all services.
   class Service::DiskService < Service
     attr_reader :root

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -2,7 +2,7 @@ require "google/cloud/storage"
 require "active_support/core_ext/object/to_query"
 
 module ActiveStorage
-  # Wraps the Google Cloud Storage as a Active Storage service. See `ActiveStorage::Service` for the generic API
+  # Wraps the Google Cloud Storage as a Active Storage service. See ActiveStorage::Service for the generic API
   # documentation that applies to all services.
   class Service::GCSService < Service
     attr_reader :client, :bucket

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -1,8 +1,8 @@
 require "active_support/core_ext/module/delegation"
 
 module ActiveStorage
-  # Wraps a set of mirror services and provides a single `ActiveStorage::Service` object that will all
-  # have the files uploaded to them. A `primary` service is designated to answer calls to `download`, `exists?`,
+  # Wraps a set of mirror services and provides a single ActiveStorage::Service object that will all
+  # have the files uploaded to them. A +primary+ service is designated to answer calls to +download+, +exists?+,
   # and `url`.
   class Service::MirrorService < Service
     attr_reader :primary, :mirrors
@@ -20,15 +20,15 @@ module ActiveStorage
       @primary, @mirrors = primary, mirrors
     end
 
-    # Upload the `io` to the `key` specified to all services. If a `checksum` is provided, all services will
-    # ensure a match when the upload has completed or raise an `ActiveStorage::IntegrityError`.
+    # Upload the +io+ to the +key+ specified to all services. If a +checksum+ is provided, all services will
+    # ensure a match when the upload has completed or raise an ActiveStorage::IntegrityError.
     def upload(key, io, checksum: nil)
       each_service.collect do |service|
         service.upload key, io.tap(&:rewind), checksum: checksum
       end
     end
 
-    # Delete the file at the `key` on all services.
+    # Delete the file at the +key+ on all services.
     def delete(key)
       perform_across_services :delete, key
     end

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -3,7 +3,7 @@ require "active_support/core_ext/numeric/bytes"
 
 module ActiveStorage
   # Wraps the Amazon Simple Storage Service (S3) as a Active Storage service.
-  # See `ActiveStorage::Service` for the generic API documentation that applies to all services.
+  # See ActiveStorage::Service for the generic API documentation that applies to all services.
   class Service::S3Service < Service
     attr_reader :client, :bucket, :upload_options
 


### PR DESCRIPTION
* Use `+` instead of backquote.
* Remove escape from class to be link
