### PR TITLE
More robust PostgreSQL database duplication check

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -22,7 +22,7 @@ module ActiveRecord
           configuration.merge("encoding" => encoding)
         establish_connection configuration
       rescue ActiveRecord::StatementInvalid => error
-        if /database .* already exists/.match?(error.message)
+        if error.cause.is_a?(PG::DuplicateDatabase)
           raise DatabaseAlreadyExists
         else
           raise


### PR DESCRIPTION
### Summary

Currently, `db:create` for Postgres checks for error message
to guess whether the database already exists. Unfortunately, current
versions of Postgres are by default use system locale for error messages
which means that on my laptopt (with Russian locale), error message
says `ОШИБКА:  база данных "toptal_cucumber" уже существует`,
which is not caught by error message regexp. This PR changes the 
code to check against error class instead.

### Other Information

Maybe I am missing something... But I can't find any open issue/PR
describing the problem.