### PR TITLE
Browser caching in Active Storage

### DIFF
--- a/activestorage/app/controllers/active_storage/blobs_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs_controller.rb
@@ -5,6 +5,7 @@
 class ActiveStorage::BlobsController < ActionController::Base
   def show
     if blob = find_signed_blob
+      expires_in 5.minutes # service_url defaults to 5 minutes
       redirect_to blob.service_url(disposition: disposition_param)
     else
       head :not_found

--- a/activestorage/app/controllers/active_storage/variants_controller.rb
+++ b/activestorage/app/controllers/active_storage/variants_controller.rb
@@ -5,6 +5,7 @@
 class ActiveStorage::VariantsController < ActionController::Base
   def show
     if blob = find_signed_blob
+      expires_in 5.minutes # service_url defaults to 5 minutes
       redirect_to ActiveStorage::Variant.new(blob, decoded_variation).processed.service_url(disposition: disposition_param)
     else
       head :not_found

--- a/activestorage/test/controllers/blobs_controller_test.rb
+++ b/activestorage/test/controllers/blobs_controller_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::BlobsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @blob = create_image_blob filename: "racecar.jpg"
+  end
+
+  test "showing blob utilizes browser caching" do
+    get rails_blob_url(@blob)
+
+    assert_redirected_to(/racecar.jpg/)
+    assert_equal "max-age=300, private", @response.headers["Cache-Control"]
+  end
+end


### PR DESCRIPTION
Active Storage controllers serve blobs via redirects. Redirects are not cached by default, which leads to images being reloaded on every page visit in some browsers. Namely, Safari.

This PR enables the browser caching.