### PR TITLE
Activestorage rack test uploaded file

### DIFF
--- a/activestorage/lib/active_storage/attached.rb
+++ b/activestorage/lib/active_storage/attached.rb
@@ -17,7 +17,7 @@ module ActiveStorage
         case attachable
         when ActiveStorage::Blob
           attachable
-        when ActionDispatch::Http::UploadedFile
+        when ActionDispatch::Http::UploadedFile, Rack::Test::UploadedFile
           ActiveStorage::Blob.create_after_upload! \
             io: attachable.open,
             filename: attachable.original_filename,

--- a/activestorage/test/models/attachments_test.rb
+++ b/activestorage/test/models/attachments_test.rb
@@ -18,9 +18,15 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     assert_equal "funky.jpg", @user.avatar.filename.to_s
   end
 
-  test "attach new blob" do
+  test "attach new blob from a Hash" do
     @user.avatar.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg"
     assert_equal "town.jpg", @user.avatar.filename.to_s
+  end
+
+  test "attach new blob from an UploadedFile" do
+    file = file_fixture "racecar.jpg"
+    @user.avatar.attach Rack::Test::UploadedFile.new file
+    assert_equal "racecar.jpg", @user.avatar.filename.to_s
   end
 
   test "access underlying associations of new blob" do


### PR DESCRIPTION
### Summary

I was writing a test that looks something like this:

```
RSpec.describe MyModel do
  include ActionDispatch::TestProcess::FixtureFile
  subject { FactoryGirl.create(:my_model) }

  let(:attachments) { [fixture_file_upload('file1.pdf'), fixture_file_upload('file2.pdf')] }

  it "has attachments" do
    expect { subject.attachments.attach attachments }.to change { ActiveStorage::Blob.count }.by 2
  end  
end
```

This PR has 2 changes that were necessary in order to make this test pass.