### PR TITLE
Temporarily point to a fork of SDoc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "rubocop", ">= 0.47", require: false
 gem "rb-inotify", github: "matthewd/rb-inotify", branch: "close-handling", require: false
 
 group :doc do
-  gem "sdoc", "> 1.0.0.rc1", "< 2.0"
+  gem "sdoc", github: "robin850/sdoc", branch: "upgrade"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators"
   gem "kindlerb", "~> 1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,14 @@ GIT
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
 
+GIT
+  remote: https://github.com/robin850/sdoc.git
+  revision: 0e340352f3ab2f196c8a8743f83c2ee286e4f71c
+  branch: upgrade
+  specs:
+    sdoc (1.0.0.rc2)
+      rdoc (~> 5.0)
+
 PATH
   remote: .
   specs:
@@ -389,8 +397,6 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sdoc (1.0.0.rc2)
-      rdoc (~> 5.0)
     selenium-webdriver (3.5.1)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
@@ -521,7 +527,7 @@ DEPENDENCIES
   resque-scheduler
   rubocop (>= 0.47)
   sass-rails!
-  sdoc (> 1.0.0.rc1, < 2.0)
+  sdoc!
   sequel
   sidekiq
   sneakers


### PR DESCRIPTION
Hello,

As a beta of Rails 5.2 will be released in the near future, it would be cool to use an "updated" version of SDoc so people testing the beta can also report eventual problems / bugs on the API site to make sure that we won't have any issue with the final release's docs that would get reported a dozen times.

Pull requests have been open on the sdoc repository to bring these changes but they haven't been yet processed and since version 1.0 is still in a release candidate state and these changes would be included in 1.1, I took the liberty to create a fork with all the changes.

This fork brings the following changes:

* A tiny refresh of the default theme. (zzak/sdoc#108)
* SEO tags to class files. (zzak/sdoc#109, cross-ref #27633)
* The removal of HTML tags from search results. (zzak/sdoc#110)
* Some general template clean-up (HTML 5, removal of the jQuery
  effect library, etc.).
* A speed up of the generation time. This one hasn't been sent as a pull request as it partly depends on the previous changes.

Regarding this last point, YMMV but on my computer (macOS with an Intel Core i5 @ 2,7 GHz and Ruby 2.4.1), the generation with sdoc 1.0.0rc2 takes ~83s and with the fork ~52s.

If you have any suggestion regarding these changes, feel free to comment or open a pull request against this fork and I will happily cherry-pick commits on the relevant branches to give proper credit on the sdoc side. ❤️ 

Have a nice day !