### PR TITLE
Raise an exception if the foreign_key and primary_key are different types

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -29,6 +29,11 @@ module ActiveRecord
   class AssociationTypeMismatch < ActiveRecordError
   end
 
+  # Raised when an association's primary_key has a different type than the foreign_key
+  # that would be used to reference it.
+  class AssociationKeyTypeMismatchError < ActiveRecordError
+  end
+
   # Raised when unserialized object's type mismatches one specified for serializable field.
   class SerializationTypeMismatch < ActiveRecordError
   end

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -11,12 +11,14 @@ require "models/car"
 require "models/bulb"
 require "models/author"
 require "models/image"
+require "models/pet"
 require "models/post"
 require "models/drink_designer"
 require "models/chef"
 require "models/department"
 require "models/club"
 require "models/membership"
+require "models/tag"
 
 class HasOneAssociationsTest < ActiveRecord::TestCase
   self.use_transactional_tests = false unless supports_savepoints?
@@ -849,6 +851,13 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
     assert_no_difference ["DestroyableAuthor.count", "UndestroyableBook.count"] do
       assert_not author.destroy
+    end
+  end
+
+  test "association keys must match" do
+    pet = Pet.new
+    assert_raise(ActiveRecord::AssociationKeyTypeMismatchError) do
+      pet.tag = Tag.new
     end
   end
 end

--- a/activerecord/test/models/pet.rb
+++ b/activerecord/test/models/pet.rb
@@ -9,6 +9,7 @@ class Pet < ActiveRecord::Base
   has_many :pet_treasures
   has_many :treasures, through: :pet_treasures
   has_many :persons, through: :treasures, source: :looter, source_type: "Person"
+  has_one :tag, foreign_key: :animal_id
 
   class << self
     attr_accessor :after_destroy_output

--- a/activerecord/test/models/tag.rb
+++ b/activerecord/test/models/tag.rb
@@ -6,6 +6,7 @@ class Tag < ActiveRecord::Base
   has_one  :tagging
 
   has_many :tagged_posts, through: :taggings, source: "taggable", source_type: "Post"
+  belongs_to :pet, foreign_key: :animal_id
 end
 
 class OrderedTag < Tag

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -98,7 +98,7 @@ ActiveRecord::Schema.define do
   create_table :birds, force: true do |t|
     t.string :name
     t.string :color
-    t.integer :pirate_id
+    t.references :pirate
   end
 
   create_table :books, id: :integer, force: true do |t|
@@ -901,6 +901,7 @@ ActiveRecord::Schema.define do
   create_table :tags, force: true do |t|
     t.column :name, :string
     t.column :taggings_count, :integer, default: 0
+    t.string :animal_id
   end
 
   create_table :taggings, force: true do |t|


### PR DESCRIPTION
Otherwise, the user may not realize that a primary key that's, for instance, a String,
is being coerced into an integer column, making it impossible to look up the owner later

If you are concerned because this is a breaking change, we could change this from an exception to a warning.  However, this breaking change would occur when upgrading from 5.1.x to 5.2.x so AFAIK that's not a concern.

Let me know if I should add an entry to the CHANGELOG