### PR TITLE
Add document that you rake test single file by using DB(ex. postgresql)

### DIFF
--- a/activerecord/RUNNING_UNIT_TESTS.rdoc
+++ b/activerecord/RUNNING_UNIT_TESTS.rdoc
@@ -43,5 +43,9 @@ You can override the +connections:+ parameter in either file using the +ARCONN+
 
   $ ARCONN=postgresql bundle exec ruby -Itest test/cases/base_test.rb
 
+Or
+
+  $ bundle exec rake test:postgresql TEST=test/cases/base_test.rb
+
 You can specify a custom location for the config file using the +ARCONFIG+
 environment variable.


### PR DESCRIPTION
* I want to `rake test` by using DB(ex. postgresql) for single file.
* When I see [activerecord/RUNNING_UNIT_TESTS.rdoc](https://github.com/rails/rails/blob/92703a9ea5d8b96f30e0b706b801c9185ef14f0e/activerecord/RUNNING_UNIT_TESTS.rdoc),  I can not find.
* I add document.

I try like that:

```shell
$ bundle exec rake test:postgresql TEST=test/cases/base_test.rb
/Users/fukudayukihiro/.rbenv/versions/2.4.1/bin/ruby -w -I"lib:test" -I"/Users/fukudayukihiro/RubymineProjects/rails/vendor/bundle/ruby/2.4.0/gems/rake-12.0.0/lib" "/Users/fukudayukihiro/RubymineProjects/rails/vendor/bundle/ruby/2.4.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb" "test/cases/base_test.rb" 
Using postgresql
Run options: --seed 4420

# Running:

...................................................................................................................................................

Finished in 2.544319s, 57.7758 runs/s, 135.9892 assertions/s.
147 runs, 346 assertions, 0 failures, 0 errors, 0 skips

```


