### PR TITLE
Remove duplicated `table_name`

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1073,10 +1073,6 @@ module ActiveRecord
         @reflection.scope
       end
 
-      def table_name
-        @reflection.table_name
-      end
-
       def plural_name
         @reflection.plural_name
       end
@@ -1110,10 +1106,6 @@ module ActiveRecord
 
       def klass
         @association.klass
-      end
-
-      def table_name
-        klass.table_name
       end
 
       def constraints


### PR DESCRIPTION
It can use `AbstractReflection#table_name` simply.