### PR TITLE
Fix RuboCop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,7 @@ Style/AndOr:
 # method call.
 Style/BracesAroundHashParameters:
   Enabled: true
+  EnforcedStyle: context_dependent
 
 # Align `when` with `case`.
 Layout/CaseIndentation:

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -154,7 +154,7 @@ module ActionCable::StreamTests
         subscribe_to connection, identifiers: { id: 1 }
 
         connection.websocket.expects(:transmit)
-        @server.broadcast "test_room_1", { foo: "bar" }, coder: DummyEncoder
+        @server.broadcast "test_room_1", { foo: "bar" }, { coder: DummyEncoder }
         wait_for_async
         wait_for_executor connection.server.worker_pool.executor
       end

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -30,7 +30,7 @@ module ActionController
       def sse_with_retry
         sse = SSE.new(response.stream, retry: 1000)
         sse.write("{\"name\":\"John\"}")
-        sse.write({ name: "Ryan" }, retry: 1500)
+        sse.write({ name: "Ryan" }, { retry: 1500 })
       ensure
         sse.close
       end
@@ -38,7 +38,7 @@ module ActionController
       def sse_with_id
         sse = SSE.new(response.stream)
         sse.write("{\"name\":\"John\"}", id: 1)
-        sse.write({ name: "Ryan" }, id: 2)
+        sse.write({ name: "Ryan" }, { id: 2 })
       ensure
         sse.close
       end

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -35,7 +35,7 @@ class RedirectController < ActionController::Base
   end
 
   def redirect_with_status_hash
-    redirect_to({ action: "hello_world" }, status: 301)
+    redirect_to({ action: "hello_world" }, { status: 301 })
   end
 
   def redirect_with_protocol

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -943,8 +943,8 @@ class ResourcesTest < ActionController::TestCase
       assert_resource_allowed_routes("products", {},                    { id: "1" }, [], [:index, :new, :create, :show, :edit, :update, :destroy])
       assert_resource_allowed_routes("products", { format: "xml" },  { id: "1" }, [], [:index, :new, :create, :show, :edit, :update, :destroy])
 
-      assert_recognizes({ controller: "products", action: "sale" },                   path: "products/sale",     method: :get)
-      assert_recognizes({ controller: "products", action: "sale", format: "xml" }, path: "products/sale.xml", method: :get)
+      assert_recognizes({ controller: "products", action: "sale" },                   { path: "products/sale",     method: :get })
+      assert_recognizes({ controller: "products", action: "sale", format: "xml" }, { path: "products/sale.xml", method: :get })
     end
   end
 
@@ -959,8 +959,8 @@ class ResourcesTest < ActionController::TestCase
       assert_resource_allowed_routes("products", {},                    { id: "1" }, [], [:index, :new, :create, :show, :edit, :update, :destroy])
       assert_resource_allowed_routes("products", { format: "xml" },  { id: "1" }, [], [:index, :new, :create, :show, :edit, :update, :destroy])
 
-      assert_recognizes({ controller: "products", action: "preview", id: "1" },                    path: "products/1/preview",      method: :get)
-      assert_recognizes({ controller: "products", action: "preview", id: "1", format: "xml" },  path: "products/1/preview.xml",  method: :get)
+      assert_recognizes({ controller: "products", action: "preview", id: "1" },                    { path: "products/1/preview",      method: :get })
+      assert_recognizes({ controller: "products", action: "preview", id: "1", format: "xml" },  { path: "products/1/preview.xml",  method: :get })
     end
   end
 
@@ -977,8 +977,8 @@ class ResourcesTest < ActionController::TestCase
       assert_singleton_resource_allowed_routes("accounts", {},                    [], [:new, :create, :show, :edit, :update, :destroy])
       assert_singleton_resource_allowed_routes("accounts", { format: "xml" },  [], [:new, :create, :show, :edit, :update, :destroy])
 
-      assert_recognizes({ controller: "accounts", action: "signup" },                   path: "account/signup",      method: :get)
-      assert_recognizes({ controller: "accounts", action: "signup", format: "xml" }, path: "account/signup.xml",  method: :get)
+      assert_recognizes({ controller: "accounts", action: "signup" },                   { path: "account/signup",      method: :get })
+      assert_recognizes({ controller: "accounts", action: "signup", format: "xml" }, { path: "account/signup.xml",  method: :get })
     end
   end
 
@@ -995,8 +995,8 @@ class ResourcesTest < ActionController::TestCase
       assert_resource_allowed_routes("images", { product_id: "1" },                    { id: "2" }, :show, [:index, :new, :create, :edit, :update, :destroy], "products/1/images")
       assert_resource_allowed_routes("images", { product_id: "1", format: "xml" },  { id: "2" }, :show, [:index, :new, :create, :edit, :update, :destroy], "products/1/images")
 
-      assert_recognizes({ controller: "images", action: "thumbnail", product_id: "1", id: "2" },                    path: "products/1/images/2/thumbnail", method: :get)
-      assert_recognizes({ controller: "images", action: "thumbnail", product_id: "1", id: "2", format: "jpg" },  path: "products/1/images/2/thumbnail.jpg", method: :get)
+      assert_recognizes({ controller: "images", action: "thumbnail", product_id: "1", id: "2" },                    { path: "products/1/images/2/thumbnail", method: :get })
+      assert_recognizes({ controller: "images", action: "thumbnail", product_id: "1", id: "2", format: "jpg" },  { path: "products/1/images/2/thumbnail.jpg", method: :get })
     end
   end
 
@@ -1069,7 +1069,7 @@ class ResourcesTest < ActionController::TestCase
         match "/products", to: "products#show", via: :all
       end
 
-      assert_routing({ method: "all", path: "/products" }, controller: "products", action: "show")
+      assert_routing({ method: "all", path: "/products" }, { controller: "products", action: "show" })
     end
   end
 
@@ -1080,7 +1080,7 @@ class ResourcesTest < ActionController::TestCase
       end
 
       assert_raises(Minitest::Assertion) do
-        assert_routing({ method: "all", path: "/products" }, controller: "products", action: "show")
+        assert_routing({ method: "all", path: "/products" }, { controller: "products", action: "show" })
       end
     end
   end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -392,9 +392,9 @@ XML
 
   def test_assert_generates
     assert_generates "controller/action/5", controller: "controller", action: "action", id: "5"
-    assert_generates "controller/action/7", { id: "7" }, controller: "controller", action: "action"
-    assert_generates "controller/action/5", { controller: "controller", action: "action", id: "5", name: "bob" }, {}, name: "bob"
-    assert_generates "controller/action/7", { id: "7", name: "bob" }, { controller: "controller", action: "action" }, name: "bob"
+    assert_generates "controller/action/7", { id: "7" }, { controller: "controller", action: "action" }
+    assert_generates "controller/action/5", { controller: "controller", action: "action", id: "5", name: "bob" }, {}, { name: "bob" }
+    assert_generates "controller/action/7", { id: "7", name: "bob" }, { controller: "controller", action: "action" }, { name: "bob" }
     assert_generates "controller/action/7", { id: "7" }, { controller: "controller", action: "action", name: "bob" }, {}
   end
 
@@ -405,7 +405,7 @@ XML
   def test_assert_routing_with_method
     with_routing do |set|
       set.draw { resources(:content) }
-      assert_routing({ method: "post", path: "content" }, controller: "content", action: "create")
+      assert_routing({ method: "post", path: "content" }, { controller: "content", action: "create" })
     end
   end
 

--- a/actionpack/test/dispatch/routing_assertions_test.rb
+++ b/actionpack/test/dispatch/routing_assertions_test.rb
@@ -33,11 +33,11 @@ class RoutingAssertionsTest < ActionController::TestCase
   end
 
   def test_assert_generates_with_defaults
-    assert_generates("/articles/1/edit", { controller: "articles", action: "edit" }, id: "1")
+    assert_generates("/articles/1/edit", { controller: "articles", action: "edit" }, { id: "1" })
   end
 
   def test_assert_generates_with_extras
-    assert_generates("/articles", { controller: "articles", action: "index", page: "1" }, {}, page: "1")
+    assert_generates("/articles", { controller: "articles", action: "index", page: "1" }, {}, { page: "1" })
   end
 
   def test_assert_recognizes
@@ -50,8 +50,8 @@ class RoutingAssertionsTest < ActionController::TestCase
   end
 
   def test_assert_recognizes_with_method
-    assert_recognizes({ controller: "articles", action: "create" }, path: "/articles", method: :post)
-    assert_recognizes({ controller: "articles", action: "update", id: "1" }, path: "/articles/1", method: :put)
+    assert_recognizes({ controller: "articles", action: "create" }, { path: "/articles", method: :post })
+    assert_recognizes({ controller: "articles", action: "update", id: "1" }, { path: "/articles/1", method: :put })
   end
 
   def test_assert_recognizes_with_hash_constraint
@@ -96,11 +96,11 @@ class RoutingAssertionsTest < ActionController::TestCase
   end
 
   def test_assert_routing_with_defaults
-    assert_routing("/articles/1/edit", { controller: "articles", action: "edit", id: "1" }, id: "1")
+    assert_routing("/articles/1/edit", { controller: "articles", action: "edit", id: "1" }, { id: "1" })
   end
 
   def test_assert_routing_with_extras
-    assert_routing("/articles", { controller: "articles", action: "index", page: "1" }, {}, page: "1")
+    assert_routing("/articles", { controller: "articles", action: "index", page: "1" }, {}, { page: "1" })
   end
 
   def test_assert_routing_with_hash_constraint

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -186,14 +186,14 @@ module ActionDispatch
       def test_required_part_in_recall
         get "/messages/:a/:b", to: "foo#bar"
 
-        path, _ = @formatter.generate(nil, { controller: "foo", action: "bar", a: "a" }, b: "b")
+        path, _ = @formatter.generate(nil, { controller: "foo", action: "bar", a: "a" }, { b: "b" })
         assert_equal "/messages/a/b", path
       end
 
       def test_splat_in_recall
         get "/*path", to: "foo#bar"
 
-        path, _ = @formatter.generate(nil, { controller: "foo", action: "bar" }, path: "b")
+        path, _ = @formatter.generate(nil, { controller: "foo", action: "bar" }, { path: "b" })
         assert_equal "/b", path
       end
 
@@ -201,7 +201,7 @@ module ActionDispatch
         get "/messages/:action(/:id(.:format))", to: "foo#bar"
         get "/messages/:id(.:format)", to: "bar#baz"
 
-        path, _ = @formatter.generate(nil, { controller: "foo", id: 10 }, action: "index")
+        path, _ = @formatter.generate(nil, { controller: "foo", id: 10 }, { action: "index" })
         assert_equal "/messages/index/10", path
       end
 
@@ -314,7 +314,7 @@ module ActionDispatch
         path, params = @formatter.generate(
           nil,
           { controller: "tasks", id: 10 },
-          action: "index")
+          { action: "index" })
         assert_equal "/tasks/index/10", path
         assert_equal({}, params)
       end
@@ -325,7 +325,7 @@ module ActionDispatch
         path, params = @formatter.generate(
           "tasks",
           { controller: "tasks" },
-          controller: "tasks", action: "index")
+          { controller: "tasks", action: "index" })
         assert_equal "/tasks", path
         assert_equal({}, params)
       end

--- a/actionview/test/actionpack/abstract/abstract_controller_test.rb
+++ b/actionview/test/actionpack/abstract/abstract_controller_test.rb
@@ -191,10 +191,10 @@ module AbstractController
 
       private
         def self.layout(formats)
-          find_template(name.underscore, { formats: formats }, _prefixes: ["layouts"])
+          find_template(name.underscore, { formats: formats }, { _prefixes: ["layouts"] })
         rescue ActionView::MissingTemplate
           begin
-            find_template("application", { formats: formats }, _prefixes: ["layouts"])
+            find_template("application", { formats: formats }, { _prefixes: ["layouts"] })
           rescue ActionView::MissingTemplate
           end
         end

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -255,8 +255,8 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_day(Time.mktime(2003, 8, 16), {}, class: "selector")
-    assert_dom_equal expected, select_day(16, {}, class: "selector")
+    assert_dom_equal expected, select_day(Time.mktime(2003, 8, 16), {}, { class: "selector" })
+    assert_dom_equal expected, select_day(16, {}, { class: "selector" })
   end
 
   def test_select_day_with_default_prompt
@@ -425,7 +425,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_month(Time.mktime(2003, 8, 16), {}, class: "selector", accesskey: "M")
+    assert_dom_equal expected, select_month(Time.mktime(2003, 8, 16), {}, { class: "selector", accesskey: "M" })
   end
 
   def test_select_month_with_default_prompt
@@ -520,7 +520,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_year(Time.mktime(2003, 8, 16), { start_year: 2003, end_year: 2005 }, class: "selector", accesskey: "M")
+    assert_dom_equal expected, select_year(Time.mktime(2003, 8, 16), { start_year: 2003, end_year: 2005 }, { class: "selector", accesskey: "M" })
   end
 
   def test_select_year_with_default_prompt
@@ -615,7 +615,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_hour(Time.mktime(2003, 8, 16, 8, 4, 18), {}, class: "selector", accesskey: "M")
+    assert_dom_equal expected, select_hour(Time.mktime(2003, 8, 16, 8, 4, 18), {}, { class: "selector", accesskey: "M" })
   end
 
   def test_select_hour_with_default_prompt
@@ -719,7 +719,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04" selected="selected">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_minute(Time.mktime(2003, 8, 16, 8, 4, 18), {}, class: "selector", accesskey: "M")
+    assert_dom_equal expected, select_minute(Time.mktime(2003, 8, 16, 8, 4, 18), {}, { class: "selector", accesskey: "M" })
   end
 
   def test_select_minute_with_default_prompt
@@ -799,7 +799,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18" selected="selected">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_second(Time.mktime(2003, 8, 16, 8, 4, 18), {}, class: "selector", accesskey: "M")
+    assert_dom_equal expected, select_second(Time.mktime(2003, 8, 16, 8, 4, 18), {}, { class: "selector", accesskey: "M" })
   end
 
   def test_select_second_with_default_prompt
@@ -1066,7 +1066,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), { start_year: 2003, end_year: 2005, prefix: "date[first]" }, class: "selector")
+    assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), { start_year: 2003, end_year: 2005, prefix: "date[first]" }, { class: "selector" })
   end
 
   def test_select_date_with_separator
@@ -1170,7 +1170,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), { start_year: 2003, end_year: 2005, prefix: "date[first]", with_css_classes: true }, class: "datetime optional")
+    assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), { start_year: 2003, end_year: 2005, prefix: "date[first]", with_css_classes: true }, { class: "datetime optional" })
   end
 
   def test_select_date_with_custom_with_css_classes_and_html_class_option
@@ -1186,7 +1186,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), { start_year: 2003, end_year: 2005, with_css_classes: { year: "my-year", month: "my-month", day: "my-day" } }, class: "date optional")
+    assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), { start_year: 2003, end_year: 2005, with_css_classes: { year: "my-year", month: "my-month", day: "my-day" } }, { class: "date optional" })
   end
 
   def test_select_date_with_partial_with_css_classes_and_html_class_option
@@ -1202,7 +1202,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), { start_year: 2003, end_year: 2005, with_css_classes: { month: "my-month custom-grid" } }, class: "date optional")
+    assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), { start_year: 2003, end_year: 2005, with_css_classes: { month: "my-month custom-grid" } }, { class: "date optional" })
   end
 
   def test_select_date_with_html_class_option
@@ -1218,7 +1218,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), { start_year: 2003, end_year: 2005 }, class: "date optional custom-grid")
+    assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), { start_year: 2003, end_year: 2005 }, { class: "date optional custom-grid" })
   end
 
   def test_select_datetime
@@ -1358,7 +1358,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04" selected="selected">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_datetime(Time.mktime(2003, 8, 16, 8, 4, 18), { start_year: 2003, end_year: 2005, prefix: "date[first]" }, class: "selector")
+    assert_dom_equal expected, select_datetime(Time.mktime(2003, 8, 16, 8, 4, 18), { start_year: 2003, end_year: 2005, prefix: "date[first]" }, { class: "selector" })
   end
 
   def test_select_datetime_with_all_separators
@@ -1390,7 +1390,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04" selected="selected">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_datetime(Time.mktime(2003, 8, 16, 8, 4, 18), { datetime_separator: "&mdash;", date_separator: "/", time_separator: ":", start_year: 2003, end_year: 2005, prefix: "date[first]" }, class: "selector")
+    assert_dom_equal expected, select_datetime(Time.mktime(2003, 8, 16, 8, 4, 18), { datetime_separator: "&mdash;", date_separator: "/", time_separator: ":", start_year: 2003, end_year: 2005, prefix: "date[first]" }, { class: "selector" })
   end
 
   def test_select_datetime_should_work_with_date
@@ -1670,8 +1670,8 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04" selected="selected">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n)
     expected << "</select>\n"
 
-    assert_dom_equal expected, select_time(Time.mktime(2003, 8, 16, 8, 4, 18), {}, class: "selector")
-    assert_dom_equal expected, select_time(Time.mktime(2003, 8, 16, 8, 4, 18), { include_seconds: false }, class: "selector")
+    assert_dom_equal expected, select_time(Time.mktime(2003, 8, 16, 8, 4, 18), {}, { class: "selector" })
+    assert_dom_equal expected, select_time(Time.mktime(2003, 8, 16, 8, 4, 18), { include_seconds: false }, { class: "selector" })
   end
 
   def test_select_time_should_work_with_date
@@ -1928,7 +1928,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
     expected << "</select>\n"
 
-    assert_dom_equal expected, date_select("post", "written_on", { order: [ :month, :year ] }, disabled: true)
+    assert_dom_equal expected, date_select("post", "written_on", { order: [ :month, :year ] }, { disabled: true })
   end
 
   def test_date_select_within_fields_for
@@ -2170,7 +2170,7 @@ class DateHelperTest < ActionView::TestCase
 
     expected << "</select>\n"
 
-    assert_dom_equal expected, date_select("post", "written_on", {}, class: "selector")
+    assert_dom_equal expected, date_select("post", "written_on", {}, { class: "selector" })
   end
 
   def test_date_select_with_html_options_within_fields_for
@@ -2178,7 +2178,7 @@ class DateHelperTest < ActionView::TestCase
     @post.written_on = Date.new(2004, 6, 15)
 
     output_buffer = fields_for :post, @post do |f|
-      concat f.date_select(:written_on, {}, class: "selector")
+      concat f.date_select(:written_on, {}, { class: "selector" })
     end
 
     expected = %{<select id="post_written_on_1i" name="post[written_on(1i)]" class="selector">\n}.dup
@@ -2453,7 +2453,7 @@ class DateHelperTest < ActionView::TestCase
     0.upto(59) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 16}>#{sprintf("%02d", i)}</option>\n) }
     expected << "</select>\n"
 
-    assert_dom_equal expected, time_select("post", "written_on", {}, class: "selector")
+    assert_dom_equal expected, time_select("post", "written_on", {}, { class: "selector" })
   end
 
   def test_time_select_with_html_options_within_fields_for
@@ -2461,7 +2461,7 @@ class DateHelperTest < ActionView::TestCase
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
     output_buffer = fields_for :post, @post do |f|
-      concat f.time_select(:written_on, {}, class: "selector")
+      concat f.time_select(:written_on, {}, { class: "selector" })
     end
 
     expected = %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}.dup
@@ -2606,7 +2606,7 @@ class DateHelperTest < ActionView::TestCase
     0.upto(59) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 16}>#{sprintf("%02d", i)}</option>\n) }
     expected << "</select>\n"
 
-    assert_dom_equal expected, time_select("post", "written_on", {}, disabled: true)
+    assert_dom_equal expected, time_select("post", "written_on", {}, { disabled: true })
   end
 
   def test_datetime_select
@@ -2740,7 +2740,7 @@ class DateHelperTest < ActionView::TestCase
     @post.updated_at = Time.local(2004, 6, 15, 16, 35)
 
     output_buffer = fields_for :post, @post do |f|
-      concat f.datetime_select(:updated_at, {}, class: "selector")
+      concat f.datetime_select(:updated_at, {}, { class: "selector" })
     end
 
     expected = %{<select id="post_updated_at_1i" name="post[updated_at(1i)]" class="selector">\n<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n</select>\n}.dup
@@ -3222,7 +3222,7 @@ class DateHelperTest < ActionView::TestCase
     0.upto(59) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 16}>#{sprintf("%02d", i)}</option>\n) }
     expected << "</select>\n"
 
-    assert_dom_equal expected, datetime_select("post", "updated_at", { discard_year: true, discard_month: true }, disabled: true)
+    assert_dom_equal expected, datetime_select("post", "updated_at", { discard_year: true, discard_month: true }, { disabled: true })
   end
 
   def test_datetime_select_discard_hour
@@ -3442,7 +3442,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %{<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n<option value="32">32</option>\n<option value="33">33</option>\n<option value="34">34</option>\n<option value="35" selected="selected">35</option>\n<option value="36">36</option>\n<option value="37">37</option>\n<option value="38">38</option>\n<option value="39">39</option>\n<option value="40">40</option>\n<option value="41">41</option>\n<option value="42">42</option>\n<option value="43">43</option>\n<option value="44">44</option>\n<option value="45">45</option>\n<option value="46">46</option>\n<option value="47">47</option>\n<option value="48">48</option>\n<option value="49">49</option>\n<option value="50">50</option>\n<option value="51">51</option>\n<option value="52">52</option>\n<option value="53">53</option>\n<option value="54">54</option>\n<option value="55">55</option>\n<option value="56">56</option>\n<option value="57">57</option>\n<option value="58">58</option>\n<option value="59">59</option>\n}
     expected << "</select>\n"
 
-    assert_dom_equal expected, datetime_select("post", "updated_at", {}, class: "selector")
+    assert_dom_equal expected, datetime_select("post", "updated_at", {}, { class: "selector" })
   end
 
   def test_date_select_should_not_change_passed_options_hash
@@ -3602,7 +3602,7 @@ class DateHelperTest < ActionView::TestCase
     assert select_minute(8, use_hidden: true).html_safe?
     assert select_month(8, prompt: "Choose month").html_safe?
 
-    assert select_time(Time.mktime(2003, 8, 16, 8, 4, 18), {}, class: "selector").html_safe?
+    assert select_time(Time.mktime(2003, 8, 16, 8, 4, 18), {}, { class: "selector" }).html_safe?
     assert select_date(Time.mktime(2003, 8, 16), date_separator: " / ", start_year: 2003, end_year: 2005, prefix: "date[first]").html_safe?
   end
 

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -95,7 +95,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection radio accepts html options as input" do
     collection = [[1, true], [0, false]]
-    with_collection_radio_buttons :user, :active, collection, :last, :first, {}, class: "special-radio"
+    with_collection_radio_buttons :user, :active, collection, :last, :first, {}, { class: "special-radio" }
 
     assert_select "input[type=radio][value=true].special-radio#user_active_true"
     assert_select "input[type=radio][value=false].special-radio#user_active_false"
@@ -215,7 +215,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection radio buttons generates a hidden field using the given :name in :html_options" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
-    with_collection_radio_buttons :user, :category_ids, collection, :id, :name, {}, name: "user[other_category_ids]"
+    with_collection_radio_buttons :user, :category_ids, collection, :id, :name, {}, { name: "user[other_category_ids]" }
 
     assert_select "input[type=hidden][name='user[other_category_ids]'][value='']", count: 1
   end
@@ -259,7 +259,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes generates a hidden field using the given :name in :html_options" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
-    with_collection_check_boxes :user, :category_ids, collection, :id, :name, {}, name: "user[other_category_ids][]"
+    with_collection_check_boxes :user, :category_ids, collection, :id, :name, {}, { name: "user[other_category_ids][]" }
 
     assert_select "input[type=hidden][name='user[other_category_ids][]'][value='']", count: 1
   end
@@ -446,7 +446,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes accepts html options" do
     collection = [[1, "Category 1"], [2, "Category 2"]]
-    with_collection_check_boxes :user, :category_ids, collection, :first, :last, {}, class: "check"
+    with_collection_check_boxes :user, :category_ids, collection, :first, :last, {}, { class: "check" }
 
     assert_select 'input.check[type=checkbox][value="1"]'
     assert_select 'input.check[type=checkbox][value="2"]'

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1386,7 +1386,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       '<select name="post[secret]"></select>',
-      select("post", "secret", [], {}, "id" => nil)
+      select("post", "secret", [], {}, { "id" => nil })
     )
     assert_dom_equal(
       text_field("post", "title", "id" => nil),

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -491,7 +491,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_select_without_multiple
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"></select>",
-      select(:post, :category, "", {}, multiple: false)
+      select(:post, :category, "", {}, { multiple: false })
     )
   end
 
@@ -639,7 +639,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   end
 
   def test_select_with_multiple_to_add_hidden_input
-    output_buffer = select(:post, :category, "", {}, multiple: true)
+    output_buffer = select(:post, :category, "", {}, { multiple: true })
     assert_dom_equal(
       "<input type=\"hidden\" name=\"post[category][]\" value=\"\"/><select multiple=\"multiple\" id=\"post_category\" name=\"post[category][]\"></select>",
       output_buffer
@@ -647,7 +647,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   end
 
   def test_select_with_multiple_and_without_hidden_input
-    output_buffer = select(:post, :category, "", { include_hidden: false }, multiple: true)
+    output_buffer = select(:post, :category, "", { include_hidden: false }, { multiple: true })
     assert_dom_equal(
       "<select multiple=\"multiple\" id=\"post_category\" name=\"post[category][]\"></select>",
       output_buffer
@@ -655,7 +655,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   end
 
   def test_select_with_multiple_and_with_explicit_name_ending_with_brackets
-    output_buffer = select(:post, :category, [], { include_hidden: false }, multiple: true, name: "post[category][]")
+    output_buffer = select(:post, :category, [], { include_hidden: false }, { multiple: true, name: "post[category][]" })
     assert_dom_equal(
       "<select multiple=\"multiple\" id=\"post_category\" name=\"post[category][]\"></select>",
       output_buffer
@@ -663,7 +663,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   end
 
   def test_select_with_multiple_and_disabled_to_add_disabled_hidden_input
-    output_buffer = select(:post, :category, "", {}, multiple: true, disabled: true)
+    output_buffer = select(:post, :category, "", {}, { multiple: true, disabled: true })
     assert_dom_equal(
       "<input disabled=\"disabled\"type=\"hidden\" name=\"post[category][]\" value=\"\"/><select multiple=\"multiple\" disabled=\"disabled\" id=\"post_category\" name=\"post[category][]\"></select>",
       output_buffer
@@ -682,7 +682,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_select_with_include_blank_false_and_required
     @post = Post.new
     @post.category = "<mus>"
-    e = assert_raises(ArgumentError) { select("post", "category", %w( abe <mus> hest), { include_blank: false }, required: "required") }
+    e = assert_raises(ArgumentError) { select("post", "category", %w( abe <mus> hest), { include_blank: false }, { required: "required" }) }
     assert_match(/include_blank cannot be false for a required field./, e.message)
   end
 
@@ -762,7 +762,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post.category = ""
     assert_dom_equal(
       "<select class=\"disabled\" disabled=\"disabled\" name=\"post[category]\" id=\"post_category\"><option value=\"\">Please select</option>\n<option value=\"\"></option>\n</select>",
-      select("post", "category", [], { prompt: true, include_blank: true }, class: "disabled", disabled: true)
+      select("post", "category", [], { prompt: true, include_blank: true }, { class: "disabled", disabled: true })
     )
   end
 
@@ -778,42 +778,42 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_required_select
     assert_dom_equal(
       %(<select id="post_category" name="post[category]" required="required"><option value=""></option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
-      select("post", "category", %w(abe mus hest), {}, required: true)
+      select("post", "category", %w(abe mus hest), {}, { required: true })
     )
   end
 
   def test_required_select_with_include_blank_prompt
     assert_dom_equal(
       %(<select id="post_category" name="post[category]" required="required"><option value="">Select one</option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
-      select("post", "category", %w(abe mus hest), { include_blank: "Select one" }, required: true)
+      select("post", "category", %w(abe mus hest), { include_blank: "Select one" }, { required: true })
     )
   end
 
   def test_required_select_with_prompt
     assert_dom_equal(
       %(<select id="post_category" name="post[category]" required="required"><option value="">Select one</option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
-      select("post", "category", %w(abe mus hest), { prompt: "Select one" }, required: true)
+      select("post", "category", %w(abe mus hest), { prompt: "Select one" }, { required: true })
     )
   end
 
   def test_required_select_display_size_equals_to_one
     assert_dom_equal(
       %(<select id="post_category" name="post[category]" required="required" size="1"><option value=""></option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
-      select("post", "category", %w(abe mus hest), {}, required: true, size: 1)
+      select("post", "category", %w(abe mus hest), {}, { required: true, size: 1 })
     )
   end
 
   def test_required_select_with_display_size_bigger_than_one
     assert_dom_equal(
       %(<select id="post_category" name="post[category]" required="required" size="2"><option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
-      select("post", "category", %w(abe mus hest), {}, required: true, size: 2)
+      select("post", "category", %w(abe mus hest), {}, { required: true, size: 2 })
     )
   end
 
   def test_required_select_with_multiple_option
     assert_dom_equal(
       %(<input name="post[category][]" type="hidden" value=""/><select id="post_category" multiple="multiple" name="post[category][]" required="required"><option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
-      select("post", "category", %w(abe mus hest), {}, required: true, multiple: true)
+      select("post", "category", %w(abe mus hest), {}, { required: true, multiple: true })
     )
   end
 
@@ -852,7 +852,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       expected,
-      select("album[]", "genre", %w[rap rock country], {}, index: nil)
+      select("album[]", "genre", %w[rap rock country], {}, { index: nil })
     )
   end
 
@@ -982,7 +982,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       "<select id=\"post_author_name\" name=\"post[author_name]\" style=\"width: 200px\"><option value=\"\"></option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
-      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: true }, "style" => "width: 200px")
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: true }, { "style" => "width: 200px" })
     )
   end
 
@@ -992,7 +992,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       "<select id=\"post_author_name\" name=\"post[author_name]\" style=\"width: 200px\"><option value=\"\">No Selection</option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>",
-      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: "No Selection" }, "style" => "width: 200px")
+      collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: "No Selection" }, { "style" => "width: 200px" })
     )
   end
 
@@ -1003,10 +1003,10 @@ class FormOptionsHelperTest < ActionView::TestCase
     expected = "<input type=\"hidden\" name=\"post[author_name][]\" value=\"\"/><select id=\"post_author_name\" name=\"post[author_name][]\" multiple=\"multiple\"><option value=\"\"></option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>"
 
     # Should suffix default name with [].
-    assert_dom_equal expected, collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: true }, multiple: true)
+    assert_dom_equal expected, collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: true }, { multiple: true })
 
     # Shouldn't suffix custom name with [].
-    assert_dom_equal expected, collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: true, name: "post[author_name][]" }, multiple: true)
+    assert_dom_equal expected, collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: true, name: "post[author_name][]" }, { multiple: true })
   end
 
   def test_collection_select_with_blank_and_selected
@@ -1149,7 +1149,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_time_zone_select_with_style
     @firm = Firm.new("D")
     html = time_zone_select("firm", "time_zone", nil, {},
-      "style" => "color: red")
+      { "style" => "color: red" })
     assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\" style=\"color: red\">" \
                  "<option value=\"A\">A</option>\n" \
                  "<option value=\"B\">B</option>\n" \
@@ -1159,13 +1159,13 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "</select>",
                  html
     assert_dom_equal html, time_zone_select("firm", "time_zone", nil, {},
-      style: "color: red")
+      { style: "color: red" })
   end
 
   def test_time_zone_select_with_blank_and_style
     @firm = Firm.new("D")
     html = time_zone_select("firm", "time_zone", nil,
-      { include_blank: true }, "style" => "color: red")
+      { include_blank: true }, { "style" => "color: red" })
     assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\" style=\"color: red\">" \
                  "<option value=\"\"></option>\n" \
                  "<option value=\"A\">A</option>\n" \
@@ -1176,13 +1176,13 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "</select>",
                  html
     assert_dom_equal html, time_zone_select("firm", "time_zone", nil,
-      { include_blank: true }, style: "color: red")
+      { include_blank: true }, { style: "color: red" })
   end
 
   def test_time_zone_select_with_blank_as_string_and_style
     @firm = Firm.new("D")
     html = time_zone_select("firm", "time_zone", nil,
-      { include_blank: "No Zone" }, "style" => "color: red")
+      { include_blank: "No Zone" }, { "style" => "color: red" })
     assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\" style=\"color: red\">" \
                  "<option value=\"\">No Zone</option>\n" \
                  "<option value=\"A\">A</option>\n" \
@@ -1193,7 +1193,7 @@ class FormOptionsHelperTest < ActionView::TestCase
                  "</select>",
                  html
     assert_dom_equal html, time_zone_select("firm", "time_zone", nil,
-      { include_blank: "No Zone" }, style: "color: red")
+      { include_blank: "No Zone" }, { style: "color: red" })
   end
 
   def test_time_zone_select_with_priority_zones

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -100,53 +100,53 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_form_tag_multipart
-    actual = form_tag({}, "multipart" => true)
+    actual = form_tag({}, { "multipart" => true })
     expected = whole_form("http://www.example.com", enctype: true)
     assert_dom_equal expected, actual
   end
 
   def test_form_tag_with_method_patch
-    actual = form_tag({}, method: :patch)
+    actual = form_tag({}, { method: :patch })
     expected = whole_form("http://www.example.com", method: :patch)
     assert_dom_equal expected, actual
   end
 
   def test_form_tag_with_method_put
-    actual = form_tag({}, method: :put)
+    actual = form_tag({}, { method: :put })
     expected = whole_form("http://www.example.com", method: :put)
     assert_dom_equal expected, actual
   end
 
   def test_form_tag_with_method_delete
-    actual = form_tag({}, method: :delete)
+    actual = form_tag({}, { method: :delete })
 
     expected = whole_form("http://www.example.com", method: :delete)
     assert_dom_equal expected, actual
   end
 
   def test_form_tag_with_remote
-    actual = form_tag({}, remote: true)
+    actual = form_tag({}, { remote: true })
 
     expected = whole_form("http://www.example.com", remote: true)
     assert_dom_equal expected, actual
   end
 
   def test_form_tag_with_remote_false
-    actual = form_tag({}, remote: false)
+    actual = form_tag({}, { remote: false })
 
     expected = whole_form
     assert_dom_equal expected, actual
   end
 
   def test_form_tag_enforce_utf8_true
-    actual = form_tag({}, enforce_utf8: true)
+    actual = form_tag({}, { enforce_utf8: true })
     expected = whole_form("http://www.example.com", enforce_utf8: true)
     assert_dom_equal expected, actual
     assert actual.html_safe?
   end
 
   def test_form_tag_enforce_utf8_false
-    actual = form_tag({}, enforce_utf8: false)
+    actual = form_tag({}, { enforce_utf8: false })
     expected = whole_form("http://www.example.com", enforce_utf8: false)
     assert_dom_equal expected, actual
     assert actual.html_safe?

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -50,19 +50,19 @@ class TextHelperTest < ActionView::TestCase
 
   def test_simple_format_should_sanitize_input_when_sanitize_option_is_true
     assert_equal "<p><b> test with unsafe string </b>code!</p>",
-      simple_format("<b> test with unsafe string </b><script>code!</script>", {}, sanitize: true)
+      simple_format("<b> test with unsafe string </b><script>code!</script>", {}, { sanitize: true })
   end
 
   def test_simple_format_should_not_sanitize_input_when_sanitize_option_is_false
-    assert_equal "<p><b> test with unsafe string </b><script>code!</script></p>", simple_format("<b> test with unsafe string </b><script>code!</script>", {}, sanitize: false)
+    assert_equal "<p><b> test with unsafe string </b><script>code!</script></p>", simple_format("<b> test with unsafe string </b><script>code!</script>", {}, { sanitize: false })
   end
 
   def test_simple_format_with_custom_wrapper
-    assert_equal "<div></div>", simple_format(nil, {}, wrapper_tag: "div")
+    assert_equal "<div></div>", simple_format(nil, {}, { wrapper_tag: "div" })
   end
 
   def test_simple_format_with_custom_wrapper_and_multi_line_breaks
-    assert_equal "<div>We want to put a wrapper...</div>\n\n<div>...right there.</div>", simple_format("We want to put a wrapper...\n\n...right there.", {}, wrapper_tag: "div")
+    assert_equal "<div>We want to put a wrapper...</div>\n\n<div>...right there.</div>", simple_format("We want to put a wrapper...\n\n...right there.", {}, { wrapper_tag: "div" })
   end
 
   def test_simple_format_should_not_change_the_text_passed

--- a/activerecord/lib/rails/generators/active_record/application_record/application_record_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/application_record/application_record_generator.rb
@@ -15,11 +15,12 @@ module ActiveRecord
       private
 
         def application_record_file_name
-          @application_record_file_name ||= if namespaced?
-                                              "app/models/#{namespaced_path}/application_record.rb"
-                                            else
-                                              "app/models/application_record.rb"
-                                            end
+          @application_record_file_name ||=
+            if namespaced?
+              "app/models/#{namespaced_path}/application_record.rb"
+            else
+              "app/models/application_record.rb"
+            end
         end
     end
   end

--- a/activerecord/test/cases/attribute_set_test.rb
+++ b/activerecord/test/cases/attribute_set_test.rb
@@ -16,7 +16,7 @@ module ActiveRecord
 
     test "building with custom types" do
       builder = AttributeSet::Builder.new(foo: Type::Float.new)
-      attributes = builder.build_from_database({ foo: "3.3", bar: "4.4" }, bar: Type::Integer.new)
+      attributes = builder.build_from_database({ foo: "3.3", bar: "4.4" }, { bar: Type::Integer.new })
 
       assert_equal 3.3, attributes[:foo].value
       assert_equal 4, attributes[:bar].value

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -84,8 +84,8 @@ module ActiveStorage
             content_length: content_length,
             checksum: checksum
           },
-          expires_in: expires_in,
-          purpose: :blob_token
+          { expires_in: expires_in,
+          purpose: :blob_token }
         )
 
         generated_url =

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -100,11 +100,11 @@ class TestJSONEncoding < ActiveSupport::TestCase
   end
 
   def test_hash_should_allow_key_filtering_with_only
-    assert_equal %({"a":1}), ActiveSupport::JSON.encode({ "a" => 1, :b => 2, :c => 3 }, only: "a")
+    assert_equal %({"a":1}), ActiveSupport::JSON.encode({ "a" => 1, :b => 2, :c => 3 }, { only: "a" })
   end
 
   def test_hash_should_allow_key_filtering_with_except
-    assert_equal %({"b":2}), ActiveSupport::JSON.encode({ "foo" => "bar", :b => 2, :c => 3 }, except: ["foo", :c])
+    assert_equal %({"b":2}), ActiveSupport::JSON.encode({ "foo" => "bar", :b => 2, :c => 3 }, { except: ["foo", :c] })
   end
 
   def test_time_to_json_includes_local_offset

--- a/railties/lib/rails/engine/updater.rb
+++ b/railties/lib/rails/engine/updater.rb
@@ -9,7 +9,7 @@ module Rails
       class << self
         def generator
           @generator ||= Rails::Generators::PluginGenerator.new ["plugin"],
-            { engine: true }, destination_root: ENGINE_ROOT
+            { engine: true }, { destination_root: ENGINE_ROOT }
         end
 
         def run(action)

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -11,7 +11,7 @@ namespace :app do
     template = File.expand_path(template) if template !~ %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://}
     require_relative "../generators"
     require_relative "../generators/rails/app/app_generator"
-    generator = Rails::Generators::AppGenerator.new [Rails.root], {}, destination_root: Rails.root
+    generator = Rails::Generators::AppGenerator.new [Rails.root], {}, { destination_root: Rails.root }
     generator.apply template, verbose: false
   end
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -477,9 +477,9 @@ module ApplicationTests
 
       class ::PostsController < ActionController::Base; end
 
-      get "/posts", {}, "HTTPS" => "off"
+      get "/posts", {}, { "HTTPS" => "off" }
       assert_match('src="http://example.com/assets/application.self.js', last_response.body)
-      get "/posts", {}, "HTTPS" => "on"
+      get "/posts", {}, { "HTTPS" => "on" }
       assert_match('src="https://example.com/assets/application.self.js', last_response.body)
     end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1333,10 +1333,10 @@ module ApplicationTests
         end
       end
 
-      get "/", {}, "HTTP_ACCEPT" => "application/xml"
+      get "/", {}, { "HTTP_ACCEPT" => "application/xml" }
       assert_equal "HTML", last_response.body
 
-      get "/", { format: :xml }, "HTTP_ACCEPT" => "application/xml"
+      get "/", { format: :xml }, { "HTTP_ACCEPT" => "application/xml" }
       assert_equal "XML", last_response.body
     end
 

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -32,7 +32,7 @@ module ApplicationTests
     test "/rails/mailers is accessible with correct configuration" do
       add_to_config "config.action_mailer.show_previews = true"
       app("production")
-      get "/rails/mailers", {}, "REMOTE_ADDR" => "4.2.42.42"
+      get "/rails/mailers", {}, { "REMOTE_ADDR" => "4.2.42.42" }
       assert_equal 200, last_response.status
     end
 
@@ -482,7 +482,7 @@ module ApplicationTests
 
       app("development")
 
-      get "/rails/mailers", {}, "SCRIPT_NAME" => "/my_app"
+      get "/rails/mailers", {}, { "SCRIPT_NAME" => "/my_app" }
       assert_match '<h3><a href="/my_app/rails/mailers/notifier">Notifier</a></h3>', last_response.body
       assert_match '<li><a href="/my_app/rails/mailers/notifier/foo">foo</a></li>', last_response.body
     end

--- a/railties/test/application/middleware/cache_test.rb
+++ b/railties/test/application/middleware/cache_test.rb
@@ -56,7 +56,7 @@ module ApplicationTests
       simple_controller
       expected = "Wed, 30 May 1984 19:43:31 GMT"
 
-      get "/expires/keeps_if_modified_since", {}, "HTTP_IF_MODIFIED_SINCE" => expected
+      get "/expires/keeps_if_modified_since", {}, { "HTTP_IF_MODIFIED_SINCE" => expected }
 
       assert_equal 200, last_response.status
       assert_equal expected, last_response.body, "cache should have kept If-Modified-Since"
@@ -121,7 +121,7 @@ module ApplicationTests
 
       etag = last_response.headers["ETag"]
 
-      get "/expires/expires_etag", {}, "HTTP_IF_NONE_MATCH" => etag
+      get "/expires/expires_etag", {}, { "HTTP_IF_NONE_MATCH" => etag }
       assert_equal "stale, valid, store", last_response.headers["X-Rack-Cache"]
       assert_equal 304, last_response.status
       assert_equal "", last_response.body
@@ -139,7 +139,7 @@ module ApplicationTests
       body = last_response.body
       etag = last_response.headers["ETag"]
 
-      get "/expires/expires_etag", { private: true }, "HTTP_IF_NONE_MATCH" => etag
+      get "/expires/expires_etag", { private: true }, { "HTTP_IF_NONE_MATCH" => etag }
       assert_equal     "miss", last_response.headers["X-Rack-Cache"]
       assert_not_equal body,   last_response.body
     end
@@ -155,7 +155,7 @@ module ApplicationTests
 
       last = last_response.headers["Last-Modified"]
 
-      get "/expires/expires_last_modified", {}, "HTTP_IF_MODIFIED_SINCE" => last
+      get "/expires/expires_last_modified", {}, { "HTTP_IF_MODIFIED_SINCE" => last }
       assert_equal "stale, valid, store", last_response.headers["X-Rack-Cache"]
       assert_equal 304, last_response.status
       assert_equal "", last_response.body
@@ -173,7 +173,7 @@ module ApplicationTests
       body = last_response.body
       last = last_response.headers["Last-Modified"]
 
-      get "/expires/expires_last_modified", { private: true }, "HTTP_IF_MODIFIED_SINCE" => last
+      get "/expires/expires_last_modified", { private: true }, { "HTTP_IF_MODIFIED_SINCE" => last }
       assert_equal     "miss", last_response.headers["X-Rack-Cache"]
       assert_not_equal body,   last_response.body
     end

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -276,7 +276,7 @@ module ApplicationTests
       assert_equal "max-age=0, private, must-revalidate", last_response.headers["Cache-Control"]
       assert_equal etag, last_response.headers["Etag"]
 
-      get "/", {}, "HTTP_IF_NONE_MATCH" => etag
+      get "/", {}, { "HTTP_IF_NONE_MATCH" => etag }
       assert_equal 304, last_response.status
       assert_equal "", last_response.body
       assert_nil last_response.headers["Content-Type"]

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -67,7 +67,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     generator = Rails::Generators::AppGenerator.new ["rails"],
-      { api: true, update: true }, destination_root: destination_root, shell: @shell
+      { api: true, update: true }, { destination_root: destination_root, shell: @shell }
     quietly { generator.send(:update_config_files) }
 
     assert_no_file "config/initializers/cookies_serializer.rb"
@@ -78,7 +78,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     generator = Rails::Generators::AppGenerator.new ["rails"],
-      { api: true, update: true }, destination_root: destination_root, shell: @shell
+      { api: true, update: true }, { destination_root: destination_root, shell: @shell }
     quietly { generator.send(:update_bin_files) }
 
     assert_no_file "bin/yarn"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -248,7 +248,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "#{app_root}/config/initializers/new_framework_defaults_5_2.rb"
 
     stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], { update: true }, destination_root: app_root, shell: @shell
+      generator = Rails::Generators::AppGenerator.new ["rails"], { update: true }, { destination_root: app_root, shell: @shell }
       generator.send(:app_const)
       quietly { generator.send(:update_config_files) }
 

--- a/railties/test/generators/create_migration_test.rb
+++ b/railties/test/generators/create_migration_test.rb
@@ -53,7 +53,7 @@ class CreateMigrationTest < Rails::Generators::TestCase
   end
 
   def test_invoke_pretended
-    create_migration(default_destination_path, {}, pretend: true)
+    create_migration(default_destination_path, {}, { pretend: true })
 
     assert_no_file @migration.destination
   end
@@ -94,7 +94,7 @@ class CreateMigrationTest < Rails::Generators::TestCase
 
   def test_invoke_forced_pretended_when_exists_not_identical
     migration_exists!
-    create_migration(default_destination_path, { force: true }, pretend: true) do
+    create_migration(default_destination_path, { force: true }, { pretend: true }) do
       "different content"
     end
 
@@ -106,7 +106,7 @@ class CreateMigrationTest < Rails::Generators::TestCase
 
   def test_invoke_skipped_when_exists_not_identical
     migration_exists!
-    create_migration(default_destination_path, {}, skip: true) { "different content" }
+    create_migration(default_destination_path, {}, { skip: true }) { "different content" }
 
     assert_match(/skip  db\/migrate\/2_create_articles\.rb\n/, invoke!)
     assert_no_file @migration.destination
@@ -122,7 +122,7 @@ class CreateMigrationTest < Rails::Generators::TestCase
 
   def test_revoke_pretended
     migration_exists!
-    create_migration(default_destination_path, {}, pretend: true)
+    create_migration(default_destination_path, {}, { pretend: true })
 
     assert_match(/remove  db\/migrate\/1_create_articles\.rb\n/, revoke!)
     assert_file @existing_migration.destination

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1297,10 +1297,10 @@ YAML
 
       boot_rails
 
-      get("/bukkits/bukkit", {}, "SCRIPT_NAME" => "/foo")
+      get("/bukkits/bukkit", {}, { "SCRIPT_NAME" => "/foo" })
       assert_equal "/foo/bar", last_response.body
 
-      get("/bar", {}, "SCRIPT_NAME" => "/foo")
+      get("/bar", {}, { "SCRIPT_NAME" => "/foo" })
       assert_equal "/foo/bukkits/bukkit", last_response.body
     end
 
@@ -1346,10 +1346,10 @@ YAML
 
       boot_rails
 
-      get("/bukkits/bukkit", {}, "SCRIPT_NAME" => "/foo")
+      get("/bukkits/bukkit", {}, { "SCRIPT_NAME" => "/foo" })
       assert_equal "/foo/bar", last_response.body
 
-      get("/bar", {}, "SCRIPT_NAME" => "/foo")
+      get("/bar", {}, { "SCRIPT_NAME" => "/foo" })
       assert_equal "/foo/bukkits/bukkit", last_response.body
     end
 

--- a/railties/test/railties/mounted_engine_test.rb
+++ b/railties/test/railties/mounted_engine_test.rb
@@ -208,7 +208,7 @@ module ApplicationTests
       assert_equal "/ada/blog/posts/1", last_response.body
 
       # test generating engine's route from engine with default_url_options
-      get "/john/blog/posts", {}, "SCRIPT_NAME" => "/foo"
+      get "/john/blog/posts", {}, { "SCRIPT_NAME" => "/foo" }
       assert_equal "/foo/john/blog/posts/1", last_response.body
 
       # test generating engine's route from application
@@ -222,10 +222,10 @@ module ApplicationTests
       assert_equal "/john/blog/posts", last_response.body
 
       # test generating engine's route from application with default_url_options
-      get "/engine_route", {}, "SCRIPT_NAME" => "/foo"
+      get "/engine_route", {}, { "SCRIPT_NAME" => "/foo" }
       assert_equal "/foo/anonymous/blog/posts", last_response.body
 
-      get "/url_for_engine_route", {}, "SCRIPT_NAME" => "/foo"
+      get "/url_for_engine_route", {}, { "SCRIPT_NAME" => "/foo" }
       assert_equal "/foo/john/blog/posts", last_response.body
 
       # test generating application's route from engine
@@ -243,14 +243,14 @@ module ApplicationTests
       assert_equal "/anonymous/blog/posts/1", last_response.body
 
       # test generating engine's route from other engine with default_url_options
-      get "/metrics/generate_blog_route", {}, "SCRIPT_NAME" => "/foo"
+      get "/metrics/generate_blog_route", {}, { "SCRIPT_NAME" => "/foo" }
       assert_equal "/foo/anonymous/blog/posts/1", last_response.body
 
-      get "/metrics/generate_blog_route_in_view", {}, "SCRIPT_NAME" => "/foo"
+      get "/metrics/generate_blog_route_in_view", {}, { "SCRIPT_NAME" => "/foo" }
       assert_equal "/foo/anonymous/blog/posts/1", last_response.body
 
       # test generating application's route from engine with default_url_options
-      get "/someone/blog/generate_application_route", {}, "SCRIPT_NAME" => "/foo"
+      get "/someone/blog/generate_application_route", {}, { "SCRIPT_NAME" => "/foo" }
       assert_equal "/foo/", last_response.body
 
       # test polymorphic routes


### PR DESCRIPTION
### Summary

This PR fixes the following offenses.

```console
% bundle exec rubocop

(snip)

Offenses:

activerecord/lib/rails/generators/active_record/application_record/application_record_generator.rb:19:11: C: Use 2 (not 36) spaces for indentation.
                                              "app/models/#{namespaced_path}/application_record.rb"
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
activerecord/lib/rails/generators/active_record/application_record/application_record_generator.rb:22:45: W: end at 22, 44 is not aligned with @application_record_file_name ||= if at 18, 10.
                                            end
                                            ^^^
activestorage/lib/active_storage/attached.rb:7:1: C: Incorrect indentation detected (column 0 instead of 2).
# classes that both provide proxy access to the blob association for a record.
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
activestorage/test/models/attachments_test.rb:71:7: C: Redundant curly braces around a hash parameter.
      { io: StringIO.new("IT"), filename: "country.jpg", content_type: "image/jpg" })
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
activestorage/test/models/attachments_test.rb:80:7: C: Redundant curly braces around a hash parameter.
      { io: StringIO.new("IT"), filename: "country.jpg", content_type: "image/jpg" })
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
activestorage/test/models/attachments_test.rb:91:7: C: Redundant curly braces around a hash parameter.
      { io: StringIO.new("IT"), filename: "country.jpg", content_type: "image/jpg" })
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

2324 files inspected, 6 offenses detected
```
