### PR TITLE
eager_loading association without primary key

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -251,7 +251,7 @@ module ActiveRecord
             end
 
             # if a model does not have primary key than we are using foreign key
-            # which is not unique so we will avoid anytype of cache
+            # which is not unique so we will avoid any type of cache
             model = seen[ar_parent.object_id][node.base_klass][id] if node.primary_key
 
             if model

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -109,12 +109,16 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_load_has_many_without_primary_key
-    pirate_id = pirates(:blackbeard)
-    mateys = Pirate.eager_load(:mateys).where(id: pirate_id).first.mateys
+    pirate = pirates(:blackbeard)
+    mateys = Pirate.eager_load(:mateys).where(id: pirate).first.mateys
     assert_equal 2, mateys.size
     targets = mateys.collect(&:target)
     assert targets.include?(pirates(:redbeard))
     assert targets.include?(pirates(:mark))
+    #negative assert
+    pirate = pirates(:pirate_without_mateys)
+    mateys = Pirate.eager_load(:mateys).where(id: pirate).first.mateys
+    assert_equal [], mateys
   end
 
   def test_eager_load_has_many_without_primary_key_does_not_run_additional_query
@@ -124,9 +128,13 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_load_has_one_without_primary_key
-    pirate_id = pirates(:mark)
-    attacker_matey = Pirate.eager_load(:attacker_matey).where(id: pirate_id).first.attacker_matey
+    pirate = pirates(:mark)
+    attacker_matey = Pirate.eager_load(:attacker_matey).where(id: pirate).first.attacker_matey
     assert_equal attacker_matey.pirate , pirates(:blackbeard)
+    #negative
+    pirate = pirates(:pirate_without_mateys)
+    attacker_matey = Pirate.eager_load(:attacker_matey).where(id: pirate).first.attacker_matey
+    assert_nil attacker_matey
   end
 
   def test_eager_load_has_one_without_primary_key_does_not_run_additional_query

--- a/activerecord/test/fixtures/mateys.yml
+++ b/activerecord/test/fixtures/mateys.yml
@@ -2,3 +2,7 @@ blackbeard_to_redbeard:
   pirate_id: <%= ActiveRecord::FixtureSet.identify(:blackbeard) %>
   target_id: <%= ActiveRecord::FixtureSet.identify(:redbeard) %>
   weight: 10
+blackbeard_to_mark:
+  pirate_id: <%= ActiveRecord::FixtureSet.identify(:blackbeard) %>
+  target_id: <%= ActiveRecord::FixtureSet.identify(:mark) %>
+  weight: 20

--- a/activerecord/test/fixtures/pirates.yml
+++ b/activerecord/test/fixtures/pirates.yml
@@ -13,3 +13,6 @@ mark:
 
 1:
   catchphrase: "#$LABEL pirate!"
+
+pirate_without_mateys:
+  catchphrase: 'Aye'

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -35,6 +35,8 @@ class Pirate < ActiveRecord::Base
     before_remove: proc { |p, b| p.ship_log << "before_removing_proc_bird_#{b.id}" },
     after_remove: proc { |p, b| p.ship_log << "after_removing_proc_bird_#{b.id}" }
   has_many :birds_with_reject_all_blank, class_name: "Bird"
+  has_many :mateys, foreign_key: :pirate_id
+  has_one :attacker_matey, foreign_key: :target_id, class_name: "Matey"
 
   has_one :foo_bulb, -> { where name: "foo" }, foreign_key: :car_id, class_name: "Bulb"
 


### PR DESCRIPTION
Fix for #29374

This will allow eager_loading models without any primary key
