### PR TITLE
Check :scope input in Uniqueness validator

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -8,6 +8,10 @@ module ActiveRecord
           raise ArgumentError, "#{options[:conditions]} was passed as :conditions but is not callable. " \
                                "Pass a callable instead: `conditions: -> { where(approved: true) }`"
         end
+        unless Array(options[:scope]).all? { |scope| scope.respond_to?(:to_sym) }
+          raise ArgumentError, "#{options[:scope]} is not supported format for :scope option. " \
+            "Pass a symbol or an array of symbols instead: `scope: :user_id`"
+        end
         super({ case_sensitive: true }.merge!(options))
         @klass = options[:class]
       end

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -156,6 +156,13 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert r3.valid?, "Saving r3"
   end
 
+  def test_validate_uniqueness_with_scope_invalid_syntax
+    error = assert_raises(ArgumentError) do
+      Reply.validates_uniqueness_of(:content, scope: { parent_id: false })
+    end
+    assert_match(/Pass a symbol or an array of symbols instead/, error.to_s)
+  end
+
   def test_validate_uniqueness_with_object_scope
     Reply.validates_uniqueness_of(:content, scope: :topic)
 


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/30156

This patch adds validation for `:scope` option of the Uniqueness validator.
Without this patch, calling something like `validates_uniqueness_of :code, :scope => [:archived => false]` would cause `NoMethodError` with a trace into AR internals.