### PR TITLE
Clarify base_class tests on abstract STI vs concrete STI

### DIFF
--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -99,11 +99,11 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   end
 
   def test_polymorphic_has_many_create_model_with_inheritance_and_custom_base_class
-    post = SubStiPost.create title: "SubStiPost", body: "SubStiPost body"
-    assert_instance_of SubStiPost, post
+    post = SubAbstractStiPost.create title: "SubAbstractStiPost", body: "SubAbstractStiPost body"
+    assert_instance_of SubAbstractStiPost, post
 
     tagging = tags(:misc).taggings.create(taggable: post)
-    assert_equal "SubStiPost", tagging.taggable_type
+    assert_equal "SubAbstractStiPost", tagging.taggable_type
   end
 
   def test_polymorphic_has_many_going_through_join_model_with_inheritance

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -147,12 +147,16 @@ class InheritanceTest < ActiveRecord::TestCase
     # Concrete subclass of AR::Base.
     assert Post.descends_from_active_record?
 
+    # Concrete subclasses of a concrete class which has a type column.
+    assert !StiPost.descends_from_active_record?
+    assert !SubStiPost.descends_from_active_record?
+
     # Abstract subclass of a concrete class which has a type column.
     # This is pathological, as you'll never have Sub < Abstract < Concrete.
-    assert !StiPost.descends_from_active_record?
+    assert !AbstractStiPost.descends_from_active_record?
 
-    # Concrete subclasses an abstract class which has a type column.
-    assert !SubStiPost.descends_from_active_record?
+    # Concrete subclass of an abstract class which has a type column.
+    assert !SubAbstractStiPost.descends_from_active_record?
   end
 
   def test_company_descends_from_active_record
@@ -172,7 +176,8 @@ class InheritanceTest < ActiveRecord::TestCase
     assert_equal Post, Post.base_class
     assert_equal Post, SpecialPost.base_class
     assert_equal Post, StiPost.base_class
-    assert_equal SubStiPost, SubStiPost.base_class
+    assert_equal Post, SubStiPost.base_class
+    assert_equal SubAbstractStiPost, SubAbstractStiPost.base_class
   end
 
   def test_abstract_inheritance_base_class

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -184,13 +184,18 @@ end
 class SpecialPost < Post; end
 
 class StiPost < Post
-  self.abstract_class = true
   has_one :special_comment, class_name: "SpecialComment"
+end
+
+class AbstractStiPost < Post
+  self.abstract_class = true
 end
 
 class SubStiPost < StiPost
   self.table_name = Post.table_name
 end
+
+class SubAbstractStiPost < AbstractStiPost; end
 
 class FirstPost < ActiveRecord::Base
   self.inheritance_column = :disabled


### PR DESCRIPTION
### Summary
I had a 2 level STI model in my project and its `base_class` method actually returns its STI base class,
which doesn't match this test.
`assert_equal SubStiPost, SubStiPost.base_class`
I had to spend some time before I found the test is true only when `StiPost` (parent of `SubStiPost`) is an abstract class.

So I thought it would be great to explicitly say it is a subclass of an abstract STI class.

### Other Information


