### PR TITLE
Add Dockerfiles and `--skip-dockerfile` option to the app generator

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add Dockerfiles and `--skip-dockerfile` option to the app generator
+
+    *Yoshiyuki Hirano*
+
 *   Optimize indentation for generator actions.
 
     *Yoshiyuki Hirano*

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -36,6 +36,9 @@ module Rails
         class_option :skip_gemfile,       type: :boolean, default: false,
                                           desc: "Don't create a Gemfile"
 
+        class_option :skip_dockerfile,    type: :boolean, default: false,
+                                          desc: "Don't create a Dockerfile and docker-compose.yml"
+
         class_option :skip_git,           type: :boolean, aliases: "-G", default: false,
                                           desc: "Skip .gitignore file"
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -75,6 +75,12 @@ module Rails
       template "package.json"
     end
 
+    def dockerfile
+      template "dockerfile", ".dockerignore"
+      template "Dockerfile"
+      template "docker-compose.yml"
+    end
+
     def app
       directory "app"
 
@@ -263,6 +269,7 @@ module Rails
         build(:gemfile)     unless options[:skip_gemfile]
         build(:version_control)
         build(:package_json) unless options[:skip_yarn]
+        build(:dockerfile) unless options[:skip_dockerfile]
       end
 
       def create_app_files

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:<%= RUBY_VERSION %>
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN mkdir /<%= app_name %>
+WORKDIR /<%= app_name %>
+ADD Gemfile /<%= app_name %>/Gemfile
+ADD Gemfile.lock /<%= app_name %>/Gemfile.lock
+RUN bundle install
+ADD . /<%= app_name %>

--- a/railties/lib/rails/generators/rails/app/templates/docker-compose.yml
+++ b/railties/lib/rails/generators/rails/app/templates/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  db:
+    # Please change the image you want
+    image: postgres
+  web:
+    build: .
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    volumes:
+      - .:/<%= app_name %>
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db

--- a/railties/lib/rails/generators/rails/app/templates/dockerignore
+++ b/railties/lib/rails/generators/rails/app/templates/dockerignore
@@ -1,0 +1,14 @@
+<% if options.skip_git? -%>
+.git
+<% end -%>
+.dockerignore
+log
+tmp
+storage
+<% if sqlite3? -%>
+db/*.sqlite3
+db/*.sqlite3-journal
+<% end -%>
+<% unless options.skip_yarn? -%>
+node_modules
+<% end -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -3,12 +3,15 @@ require "rails/generators/rails/app/app_generator"
 require "generators/shared_generator_tests"
 
 DEFAULT_APP_FILES = %w(
+  .dockerignore
   .gitignore
   .ruby-version
   README.md
   Gemfile
   Rakefile
   config.ru
+  Dockerfile
+  docker-compose.yml
   app/assets/config/manifest.js
   app/assets/images
   app/assets/javascripts
@@ -405,7 +408,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_generator_defaults_to_puma_version
-    run_generator [destination_root]
+    run_generator
     assert_gem "puma", "'~> 3.7'"
   end
 
@@ -591,7 +594,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_generator_for_yarn
-    run_generator([destination_root])
+    run_generator
     assert_file "package.json", /dependencies/
     assert_file "config/initializers/assets.rb", /node_modules/
 
@@ -614,6 +617,20 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_no_match(/node_modules/, content)
       assert_no_match(/yarn-error\.log/, content)
     end
+  end
+
+  def test_generator_for_dockerfile
+    run_generator
+    assert_file ".dockerignore", /dockerignore/
+    assert_file "docker-compose.yml", /bundle\sexec\srails/
+    assert_file "Dockerfile", /WORKDIR\s\/tmp/
+  end
+
+  def test_generator_if_skip_dockerfile_is_given
+    run_generator([destination_root, "--skip-dockerfile"])
+    assert_no_file ".dockerignore"
+    assert_no_file "docker-compose.yml"
+    assert_no_file "Dockerfile"
   end
 
   def test_inclusion_of_jbuilder
@@ -838,7 +855,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_version_control_initializes_git_repo
-    run_generator [destination_root]
+    run_generator
     assert_directory ".git"
   end
 


### PR DESCRIPTION
### Summary

Recently, it's not uncommon to develop and deploy using Docker. And in many cases, I'm creating `Dockerfile` and `docker-compose.yml` after generating Rails new app. Of course, we can generate them by application template. But I think that it's convenient for us to be generated them by default.

- `Dockerfile` and `docker-compose.yml` which created by generator are just [plain boiler template](https://docs.docker.com/compose/rails/).
- Intentionally, I didn't consider database differences. So docker images for databases are mixed official and unofficial ones. And I thought that it would be better to choice the image that the developer wants  (*Omakase*).