### PR TITLE
Explicitly load `globalid` files

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/hash"
+require "global_id/locator"
+require "global_id/identification"
 
 module ActiveJob
   # Raised when an exception is raised during job arguments deserialization.


### PR DESCRIPTION
GlobalID uses `autoload` for the class load.
https://github.com/rails/globalid/blob/c08e9a0a20e7b040d0ec5c55612afae8b40f16f6/lib/global_id.rb#L3..L9

In a thread-based backend like Sidekiq, there is a possibility that autoload may occur simultaneously in multiple threads, and as a result, it is presumed that an error may be caused by contention of autoload.

In order to avoid the above issue, explicitly loaded the class at startup.
Maybe fixes https://github.com/rails/globalid/issues/101

