### PR TITLE
Use `references` to respect primary key type in active storage tables

### DIFF
--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -13,14 +13,12 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.1]
     end
 
     create_table :active_storage_attachments do |t|
-      t.string  :name,        null: false
-      t.string  :record_type, null: false
-      t.integer :record_id,   null: false
-      t.integer :blob_id,     null: false
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
 
       t.datetime :created_at, null: false
 
-      t.index :blob_id
       t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
     end
   end


### PR DESCRIPTION
If created active storage tables by mysql2 or postgresql adapters, a
primary key is defined as a bigint. It should be used `references` to
the reference columns to respect primary key type.
