### PR TITLE
Fix rubocop offence Layout/CommentIndentation [ci skip]

### DIFF
--- a/activestorage/lib/active_storage/attached.rb
+++ b/activestorage/lib/active_storage/attached.rb
@@ -3,8 +3,8 @@ require "action_dispatch/http/upload"
 require "active_support/core_ext/module/delegation"
 
 module ActiveStorage
-# Abstract baseclass for the concrete ActiveStorage::Attached::One and ActiveStorage::Attached::Many
-# classes that both provide proxy access to the blob association for a record.
+  # Abstract baseclass for the concrete ActiveStorage::Attached::One and ActiveStorage::Attached::Many
+  # classes that both provide proxy access to the blob association for a record.
   class Attached
     attr_reader :name, :record
 


### PR DESCRIPTION
### Summary

Fixed LayoutCommentIndentation in ActiveStorage