### PR TITLE
Remove needless GlobalID

### DIFF
--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -57,10 +57,6 @@ class ActiveSupport::TestCase
     end
 end
 
-require "global_id"
-GlobalID.app = "ActiveStorageExampleApp"
-ActiveRecord::Base.send :include, GlobalID::Identification
-
 class User < ActiveRecord::Base
   has_one_attached :avatar
   has_many_attached :highlights


### PR DESCRIPTION
It seems that the removed by the following commit have returned perhaps
during the merge.
https://github.com/rails/activestorage/commit/e16d0c9ceacd771c99048385dc886c6026c7bc45
