### PR TITLE
Fix cache key test failures

### DIFF
--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -560,7 +560,7 @@ class PersistenceTest < ActiveRecord::TestCase
   end
 
   def test_update_attribute_for_updated_at_on
-    developer = Developer.find(1)
+    developer = Developer.find(2)
     prev_month = Time.now.prev_month.change(usec: 0)
 
     developer.update_attribute(:updated_at, prev_month)

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -14,7 +14,7 @@ class TimestampTest < ActiveRecord::TestCase
   fixtures :developers, :owners, :pets, :toys, :cars, :tasks
 
   def setup
-    @developer = Developer.first
+    @developer = Developer.find(2)
     @owner = Owner.first
     @developer.update_columns(updated_at: Time.now.prev_month)
     @previously_updated_at = @developer.updated_at


### PR DESCRIPTION
To be honest, I'm not sure why the tests will be affected by the updated
to prev month in other tests. But I believe that it will be solved by
avoiding `Developer.first` is updated.

https://travis-ci.org/rails/rails/jobs/263667626#L785-L791