### PR TITLE
Allow `serialize` with a custom coder on `json` and `array` columns

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -70,7 +70,7 @@ module ActiveRecord
           end
 
           decorate_attribute_type(attr_name, :serialize) do |type|
-            if type_incompatible_with_serialize?(type)
+            if type_incompatible_with_serialize?(type, class_name_or_coder)
               raise ColumnNotSerializableError.new(attr_name, type)
             end
 
@@ -80,12 +80,9 @@ module ActiveRecord
 
         private
 
-          def type_incompatible_with_serialize?(type)
-            type.is_a?(ActiveRecord::Type::Json) ||
-            (
-              defined?(ActiveRecord::ConnectionAdapters::PostgreSQL) &&
-              type.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array)
-            )
+          def type_incompatible_with_serialize?(type, class_name)
+            type.is_a?(ActiveRecord::Type::Json) && class_name == ::JSON ||
+              type.respond_to?(:type_cast_array, true) && class_name == ::Array
           end
       end
     end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -47,13 +47,37 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
     assert ratings_column.array?
   end
 
-  def test_not_compatible_with_serialize
+  def test_not_compatible_with_serialize_array
     new_klass = Class.new(PgArray) do
       serialize :tags, Array
     end
     assert_raises(ActiveRecord::AttributeMethods::Serialization::ColumnNotSerializableError) do
       new_klass.new
     end
+  end
+
+  class MyTags
+    def initialize(tags); @tags = tags end
+    def to_a; @tags end
+    def self.load(tags); new(tags) end
+    def self.dump(object); object.to_a end
+  end
+
+  def test_array_with_serialized_attributes
+    new_klass = Class.new(PgArray) do
+      serialize :tags, MyTags
+    end
+
+    new_klass.create!(tags: MyTags.new(["one", "two"]))
+    record = new_klass.first
+
+    assert_instance_of MyTags, record.tags
+    assert_equal ["one", "two"], record.tags.to_a
+
+    record.tags = MyTags.new(["three", "four"])
+    record.save!
+
+    assert_equal ["three", "four"], record.reload.tags.to_a
   end
 
   def test_default


### PR DESCRIPTION
We already have a test case for `serialize` with a custom coder in
`PostgresqlHstoreTest`.

https://github.com/rails/rails/blob/v5.1.3/activerecord/test/cases/adapters/postgresql/hstore_test.rb#L316-L335