### PR TITLE
Use frozen string literal

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,6 +92,7 @@ Style/FrozenStringLiteralComment:
     - 'actionmailer/**/*'
     - 'actionview/**/*'
     - 'actionpack/**/*'
+    - 'guides/**/*'
   Exclude:
     - 'actionview/test/**/*.builder'
     - 'actionview/test/**/*.ruby'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,6 +93,7 @@ Style/FrozenStringLiteralComment:
     - 'actionview/**/*'
     - 'actionpack/**/*'
     - 'guides/**/*'
+    - 'tasks/**/*'
   Exclude:
     - 'actionview/test/**/*.builder'
     - 'actionview/test/**/*.ruby'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,6 +94,7 @@ Style/FrozenStringLiteralComment:
     - 'actionpack/**/*'
     - 'guides/**/*'
     - 'tasks/**/*'
+    - 'tools/**/*'
   Exclude:
     - 'actionview/test/**/*.builder'
     - 'actionview/test/**/*.ruby'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,20 +83,8 @@ Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always
   Include:
-    - 'activesupport/**/*'
-    - 'activemodel/**/*'
-    - 'actioncable/**/*'
-    - 'activejob/**/*'
-    - 'activerecord/**/*'
-    - 'activestorage/**/*'
-    - 'actionmailer/**/*'
-    - 'actionview/**/*'
-    - 'actionpack/**/*'
-    - 'ci/**/*'
-    - 'guides/**/*'
-    - 'tasks/**/*'
-    - 'tools/**/*'
   Exclude:
+    - 'railties/**/*'
     - 'actionview/test/**/*.builder'
     - 'actionview/test/**/*.ruby'
     - 'actionpack/test/**/*.builder'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,6 +92,7 @@ Style/FrozenStringLiteralComment:
     - 'actionmailer/**/*'
     - 'actionview/**/*'
     - 'actionpack/**/*'
+    - 'ci/**/*'
     - 'guides/**/*'
     - 'tasks/**/*'
     - 'tools/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "net/http"
 
 $:.unshift __dir__

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require "fileutils"
 include FileUtils
 

--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :guides do
   desc 'Generate guides (for authors), use ONLY=foo to process just "foo.md"'
   task generate: "generate:html"

--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_job_gem.rb
+++ b/guides/bug_report_templates/active_job_gem.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_job_master.rb
+++ b/guides/bug_report_templates/active_job_master.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_record_master.rb
+++ b/guides/bug_report_templates/active_record_master.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_record_migrations_gem.rb
+++ b/guides/bug_report_templates/active_record_migrations_gem.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_record_migrations_master.rb
+++ b/guides/bug_report_templates/active_record_migrations_master.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/benchmark.rb
+++ b/guides/bug_report_templates/benchmark.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/generic_master.rb
+++ b/guides/bug_report_templates/generic_master.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/rails_guides.rb
+++ b/guides/rails_guides.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $:.unshift __dir__
 
 as_lib = File.expand_path("../activesupport/lib", __dir__)

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "set"
 require "fileutils"
 

--- a/guides/rails_guides/helpers.rb
+++ b/guides/rails_guides/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "yaml"
 
 module RailsGuides

--- a/guides/rails_guides/indexer.rb
+++ b/guides/rails_guides/indexer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/object/blank"
 require "active_support/core_ext/string/inflections"
 

--- a/guides/rails_guides/kindle.rb
+++ b/guides/rails_guides/kindle.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "kindlerb"
 require "nokogiri"

--- a/guides/rails_guides/levenshtein.rb
+++ b/guides/rails_guides/levenshtein.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsGuides
   module Levenshtein
     # This code is based directly on the Text gem implementation.

--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "redcarpet"
 require "nokogiri"
 require "rails_guides/markdown/renderer"

--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsGuides
   class Markdown
     class Renderer < Redcarpet::Render::HTML

--- a/guides/w3c_validator.rb
+++ b/guides/w3c_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # ---------------------------------------------------------------------------
 #
 # This script validates the generated guides against the W3C Validator.

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 version = File.read(File.expand_path("RAILS_VERSION", __dir__)).strip
 
 Gem::Specification.new do |s|

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FRAMEWORKS = %w( activesupport activemodel activerecord actionview actionpack activejob actionmailer actioncable activestorage railties )
 FRAMEWORK_NAMES = Hash.new { |h, k| k.split(/(?<=active|action)/).map(&:capitalize).join(" ") }
 
@@ -72,9 +74,9 @@ npm_version = version.gsub(/\./).with_index { |s, i| i >= 2 ? "-" : s }
 
     task gem => %w(update_versions pkg) do
       cmd = ""
-      cmd << "cd #{framework} && " unless framework == "rails"
-      cmd << "bundle exec rake package && " unless framework == "rails"
-      cmd << "gem build #{gemspec} && mv #{framework}-#{version}.gem #{root}/pkg/"
+      cmd += "cd #{framework} && " unless framework == "rails"
+      cmd += "bundle exec rake package && " unless framework == "rails"
+      cmd += "gem build #{gemspec} && mv #{framework}-#{version}.gem #{root}/pkg/"
       sh cmd
     end
 
@@ -104,7 +106,7 @@ namespace :changelog do
       current_contents = File.read(fname)
 
       header = "## Rails #{version} (#{Date.today.strftime('%B %d, %Y')}) ##\n\n"
-      header << "*   No changes.\n\n\n" if current_contents =~ /\A##/
+      header += "*   No changes.\n\n\n" if current_contents =~ /\A##/
       contents = header + current_contents
       File.open(fname, "wb") { |f| f.write contents }
     end

--- a/tools/console
+++ b/tools/console
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require "bundler"
 Bundler.setup
 

--- a/tools/profile
+++ b/tools/profile
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 # Profile require calls giving information about the time and the files that are called
 # when loading the provided file.
 #

--- a/tools/test.rb
+++ b/tools/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $: << File.expand_path("test", COMPONENT_ROOT)
 
 require "bundler"

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   # Returns the version of the currently loaded Rails as a <tt>Gem::Version</tt>
   def self.gem_version


### PR DESCRIPTION
### Summary

Follow up of https://github.com/rails/rails/pull/30211#issuecomment-322034559.

Extends Style/FrozenStringLiteralComment RuboCop rule to guides/, tasks/, tools/, ci/ and, root files.

Also, This PR fixes "can not modify frozen String" error caused by the following commands.

- rake build
- rake changelog:header

### Other Information

I think that the tasks of enable frozen string literal will end if #29891 (Railties) is resolved.
