### PR TITLE
Remove unused `source_type_info` in `RuntimeReflection`

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1085,15 +1085,16 @@ module ActiveRecord
         @reflection.constraints + [source_type_info]
       end
 
-      def source_type_info
-        type = @previous_reflection.foreign_type
-        source_type = @previous_reflection.options[:source_type]
-        lambda { |object| where(type => source_type) }
-      end
-
       def get_join_keys(association_klass)
         @reflection.get_join_keys(association_klass)
       end
+
+      private
+        def source_type_info
+          type = @previous_reflection.foreign_type
+          source_type = @previous_reflection.options[:source_type]
+          lambda { |object| where(type => source_type) }
+        end
     end
 
     class RuntimeReflection < PolymorphicReflection # :nodoc:
@@ -1110,10 +1111,6 @@ module ActiveRecord
 
       def constraints
         @reflection.constraints
-      end
-
-      def source_type_info
-        @reflection.source_type_info
       end
 
       def alias_candidate(name)


### PR DESCRIPTION
`source_type_info` is only used for `constraints` in
`PolymorphicReflection`.