### PR TITLE
Remove duplicated `join_id_for`

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -512,7 +512,7 @@ module ActiveRecord
       alias :check_eager_loadable! :check_preloadable!
 
       def join_id_for(owner) # :nodoc:
-        owner[active_record_primary_key]
+        owner[join_foreign_key]
       end
 
       def through_reflection
@@ -750,10 +750,6 @@ module ActiveRecord
         end
       end
 
-      def join_id_for(owner) # :nodoc:
-        owner[foreign_key]
-      end
-
       def join_foreign_key
         foreign_key
       end
@@ -780,7 +776,7 @@ module ActiveRecord
     # Holds all the metadata about a :through association as it was specified
     # in the Active Record class.
     class ThroughReflection < AbstractReflection #:nodoc:
-      delegate :foreign_key, :foreign_type, :association_foreign_key,
+      delegate :foreign_key, :foreign_type, :association_foreign_key, :join_id_for,
                :active_record_primary_key, :type, :get_join_keys, to: :source_reflection
 
       def initialize(delegate_reflection)
@@ -941,10 +937,6 @@ module ActiveRecord
 
       def through_options
         through_reflection.options
-      end
-
-      def join_id_for(owner) # :nodoc:
-        source_reflection.join_id_for(owner)
       end
 
       def check_validity!


### PR DESCRIPTION
The primary key on the owner record is abstracted as `join_foreign_key`.