### PR TITLE
Omit additional removing `config/cable.yml` 

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -395,7 +395,6 @@ module Rails
 
       def delete_action_cable_files_skipping_action_cable
         if options[:skip_action_cable]
-          remove_file "config/cable.yml"
           remove_file "app/assets/javascripts/cable.js"
           remove_dir "app/channels"
         end


### PR DESCRIPTION
`config/cable.yml` is never created if `--skip-action-cable` is given
