### PR TITLE
Remove unnecessary Include parameter in rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,7 +82,6 @@ Style/MethodDefParentheses:
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always
-  Include:
   Exclude:
     - 'railties/**/*'
     - 'actionview/test/**/*.builder'


### PR DESCRIPTION
I forgot to delete at #30230 💦 