### PR TITLE
Improve plugin generator codebase

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -87,14 +87,13 @@ task default: :test
 
     PASSTHROUGH_OPTIONS = [
       :skip_active_record, :skip_action_mailer, :skip_javascript, :skip_action_cable, :skip_sprockets, :database,
-      :javascript, :quiet, :pretend, :force, :skip
+      :javascript, :api, :quiet, :pretend, :force, :skip
     ]
 
     def generate_test_dummy(force = false)
       opts = (options || {}).slice(*PASSTHROUGH_OPTIONS)
       opts[:force] = force
       opts[:skip_bundle] = true
-      opts[:api] = options.api?
       opts[:skip_listen] = true
       opts[:skip_git] = true
       opts[:skip_turbolinks] = true

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -87,7 +87,7 @@ task default: :test
 
     PASSTHROUGH_OPTIONS = [
       :skip_active_record, :skip_action_mailer, :skip_javascript, :skip_action_cable, :skip_sprockets, :database,
-      :javascript, :api, :quiet, :pretend, :force, :skip
+      :javascript, :api, :quiet, :pretend, :skip
     ]
 
     def generate_test_dummy(force = false)


### PR DESCRIPTION
- Register `--api` option for plugin generator by `PASSTHROUGH_OPTIONS` constant
- Remove `:force` from PASSTHROUGH_OPTIONS for plugin generator
  - `:force` is setted inside the method `generate_test_dummy`