### PR TITLE
Clear mail after test

### DIFF
--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -14,7 +14,6 @@ class MessageDeliveryTest < ActiveSupport::TestCase
     ActionMailer::Base.deliver_later_queue_name = :test_queue
     ActionMailer::Base.delivery_method = :test
     ActiveJob::Base.logger = Logger.new(nil)
-    ActionMailer::Base.deliveries.clear
     ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
     ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
 
@@ -25,6 +24,8 @@ class MessageDeliveryTest < ActiveSupport::TestCase
   end
 
   teardown do
+    ActionMailer::Base.deliveries.clear
+
     ActiveJob::Base.logger = @previous_logger
     ActionMailer::Base.delivery_method = @previous_delivery_method
     ActionMailer::Base.deliver_later_queue_name = @previous_deliver_later_queue_name
@@ -60,8 +61,6 @@ class MessageDeliveryTest < ActiveSupport::TestCase
   def test_should_enqueue_and_run_correctly_in_activejob
     @mail.deliver_later!
     assert_equal 1, ActionMailer::Base.deliveries.size
-  ensure
-    ActionMailer::Base.deliveries.clear
   end
 
   test "should enqueue the email with :deliver_now delivery method" do


### PR DESCRIPTION
If clear it before the test, the mail of the last executed test will not be correctly cleared.
Therefore, executing the test with seed below will result in an error.

```
./bin/test -w --seed 55480
Run options: --seed 55480

# Running:

...........................................................................................................................................................F

Failure:
MailDeliveryTest#test_does_not_increment_the_deliveries_collection_on_error [/home/yaginuma/program/rails/master_y_yagi/rails/actionmailer/test/delivery_methods_test.rb:221]:
--- expected
+++ actual
@@ -1 +1 @@
-[]
+[#<Mail::Message:47011389364640, Multipart: false, Headers: <Date: Mon, 14 Aug 2017 07:48:40 +0900>, <From: test-sender@test.com>, <To: test-receiver@test.com>, <Message-ID: <5990d748ea5b2_29342ac1af8bcf40886f7@yaginuma.mail>>, <Subject: Test Subject>, <Mime-Version: 1.0>, <Content-Type: text/plain>, <Content-Transfer-Encoding: 7bit>>]

bin/test test/delivery_methods_test.rb:216
```