### PR TITLE
Optimize routes indentation

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Optimize routes indentation.
+
+    *Yoshiyuki Hirano*
+
 *   Optimize indentation for generator actions.
 
     *Yoshiyuki Hirano*

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -244,7 +244,7 @@ module Rails
         sentinel = /\.routes\.draw do\s*\n/m
 
         in_root do
-          inject_into_file "config/routes.rb", "  #{routing_code}\n", after: sentinel, verbose: false, force: false
+          inject_into_file "config/routes.rb", optimize_indentation(routing_code, 2), after: sentinel, verbose: false, force: false
         end
       end
 

--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -13,12 +13,8 @@ module Rails
       end
 
       def add_routes
-        unless options[:skip_routes]
-          actions.reverse_each do |action|
-            # route prepends two spaces onto the front of the string that is passed, this corrects that.
-            route indent(generate_routing_code(action), 2)[2..-1]
-          end
-        end
+        return if options[:skip_routes]
+        route generate_routing_code(actions)
       end
 
       hook_for :template_engine, :test_framework, :helper, :assets
@@ -26,11 +22,12 @@ module Rails
       private
 
         # This method creates nested route entry for namespaced resources.
-        # For eg. rails g controller foo/bar/baz index
+        # For eg. rails g controller foo/bar/baz index show
         # Will generate -
         # namespace :foo do
         #   namespace :bar do
         #     get 'baz/index'
+        #     get 'baz/show'
         #   end
         # end
         def generate_routing_code(action)
@@ -47,7 +44,9 @@ module Rails
 
           # Create route
           #     get 'baz/index'
-          lines << indent(%{get '#{file_name}/#{action}'\n}, depth * 2)
+          actions.each do |action|
+            lines << indent(%{get '#{file_name}/#{action}'\n}, depth * 2)
+          end
 
           # Create `end` ladder
           #   end

--- a/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
+++ b/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
@@ -15,37 +15,32 @@ module Rails
       def add_resource_route
         return if options[:actions].present?
 
-        # iterates over all namespaces and opens up blocks
-        regular_class_path.each_with_index do |namespace, index|
-          write("namespace :#{namespace} do", index + 1)
+        depth = 0
+        lines = []
+
+        # Create 'namespace' ladder
+        # namespace :foo do
+        #   namespace :bar do
+        regular_class_path.each do |ns|
+          lines << indent("namespace :#{ns} do\n", depth * 2)
+          depth += 1
         end
 
         # inserts the primary resource
-        write("resources :#{file_name.pluralize}", route_length + 1)
+        # Create route
+        #     resources 'products'
+        lines << indent(%{resources :#{file_name.pluralize}\n}, depth * 2)
 
-        # ends blocks
-        regular_class_path.each_index do |index|
-          write("end", route_length - index)
+        # Create `end` ladder
+        #   end
+        # end
+        until depth.zero?
+          depth -= 1
+          lines << indent("end\n", depth * 2)
         end
 
-        # route prepends two spaces onto the front of the string that is passed, this corrects that.
-        # Also it adds a \n to the end of each line, as route already adds that
-        # we need to correct that too.
-        route route_string[2..-2]
+        route lines.join
       end
-
-      private
-        def route_string
-          @route_string ||= ""
-        end
-
-        def write(str, indent)
-          route_string << "#{"  " * indent}#{str}\n"
-        end
-
-        def route_length
-          regular_class_path.length
-        end
     end
   end
 end

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -100,4 +100,11 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
       assert_match(/^  namespace :admin do\n    get 'dashboard\/index'\n  end$/, route)
     end
   end
+
+  def test_namespaced_routes_with_multiple_actions_are_created_in_routes
+    run_generator ["admin/dashboard", "index", "show"]
+    assert_file "config/routes.rb" do |route|
+      assert_match(/^  namespace :admin do\n    get 'dashboard\/index'\n    get 'dashboard\/show'\n  end$/, route)
+    end
+  end
 end


### PR DESCRIPTION
### Summary

1. Optimize routes indentation for actions of generator.
2. Refactor ControllerGenerator when it given multiple actions:

    #### Command

    ```
    $ bin/rails g controller foo/bar/baz index show
    ```

    #### Before

    ```ruby
    namespace :foo do
      namespace :bar do
        get 'baz/index'
      end
    end

    namespace :foo do
      namespace :bar do
        get 'baz/show'
      end
    end
    ```
    #### After

    ```ruby
    namespace :foo do
      namespace :bar do
        get 'baz/index'
        get 'baz/show'
      end
    end
    ```
