### PR TITLE
Refactor max-age seconds

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -19,7 +19,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}"
+      'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -15,7 +15,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.seconds.to_i}"
+    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
   }
 
   # Show full error reports and disable caching.


### PR DESCRIPTION
### Summary

We don't need to call `seconds`. So I've removed needless `seconds` method.

`#to_i` always returns the number of seconds that this Duration represents ([ref](http://api.rubyonrails.org/classes/ActiveSupport/Duration.html#method-i-to_i)).

```
[1] pry(main)> 2.days.to_i
172800
[2] pry(main)> 2.days.seconds.to_i
172800
[3] pry(main)> 1.hour.to_i
3600
[4] pry(main)> 1.hour.seconds.to_i
3600
```