### PR TITLE
Add enum `#{pluralized_name}_labels` class method

### DIFF
--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -488,4 +488,9 @@ class EnumTest < ActiveRecord::TestCase
   test "data type of Enum type" do
     assert_equal :integer, Book.type_for_attribute("status").type
   end
+
+  test "get enum labels" do
+    assert_equal %w(proposed written published), Book.statuses_labels
+    assert_equal %w(unread reading read forgotten), Book.read_statuses_labels
+  end
 end


### PR DESCRIPTION
### Summary

_Proposal_

This PR adds a new class method in order to get enum labels. At the moment, it's possible to get the labels through the enum `Hash`:

```ruby
Book.statuses.keys
# => ["proposed", "written", "published"]
```

This generates a new array every time it's called:

```ruby
Book.statuses.keys.object_id
# => 70259822444720
Book.statuses.keys.object_id
# => 70259822416460
```

This proposal adds a new way to get the labels (being always the same object):

```ruby
Book.statuses_labels
# => ["proposed", "written", "published"]
Book.statuses_labels.object_id
# => 70259793942700
Book.statuses_labels.object_id
# => 70259793942700
```

Any feedback would be appreciated

### Benchmark

_Using Ruby 2.3.3_

```
Calculating -------------------------------------
      .statuses.keys      3.147  (± 0.0%) i/s -     16.000  in   5.087741s
    .statuses_labels     12.669  (± 0.0%) i/s -     64.000  in   5.057873s

Comparison:
    .statuses_labels:       12.7 i/s
      .statuses.keys:        3.1 i/s - 4.03x  slower
```