### PR TITLE
Add `.travis.yml` to the plugin generator

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `.travis.yml` to the plugin generator
+
+    *Yoshiyuki Hirano*
+
 *   Optimize indentation for generator actions.
 
     *Yoshiyuki Hirano*

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -56,6 +56,10 @@ module Rails
       template "gitignore", ".gitignore"
     end
 
+    def travis
+      template "travis.yml", ".travis.yml"
+    end
+
     def lib
       template "lib/%namespaced_name%.rb"
       template "lib/tasks/%namespaced_name%_tasks.rake"
@@ -210,6 +214,7 @@ task default: :test
         build(:rakefile)
         build(:gemspec)   unless options[:skip_gemspec]
         build(:license)
+        build(:travis)
         build(:gitignore) unless options[:skip_git]
         build(:gemfile)   unless options[:skip_gemfile]
       end

--- a/railties/lib/rails/generators/rails/plugin/templates/travis.yml
+++ b/railties/lib/rails/generators/rails/plugin/templates/travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: ruby
+rvm:
+  - <%= RUBY_VERSION %>
+before_install: gem install bundler -v <%= Bundler::VERSION %>

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -5,6 +5,7 @@ require "rails/engine/updater"
 
 DEFAULT_PLUGIN_FILES = %w(
   .gitignore
+  .travis.yml
   Gemfile
   Rakefile
   README.md
@@ -60,6 +61,10 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   def test_generating_without_options
     run_generator
     assert_file "README.md", /Bukkits/
+    assert_file ".travis.yml" do |content|
+      assert_match(/- #{RUBY_VERSION}/, content)
+      assert_match(/before_install: gem install bundler -v #{Bundler::VERSION}/, content)
+    end
     assert_no_file "config/routes.rb"
     assert_no_file "app/assets/config/bukkits_manifest.js"
     assert_file "test/test_helper.rb" do |content|


### PR DESCRIPTION
### Summary

- Added `.travis.yml` same as bunder's one to the plugin generator.
- I think that the plugin generator is similar to `bundle gem` command. And we often manage plugin with isolate repository. Therefore it's convenient for us to be generated `.travis.yml` by default.