### PR TITLE
preloading polymorphic source on multi-level has_many through

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -28,9 +28,12 @@ module ActiveRecord
 
           middle_records = through_records.flat_map(&:last)
 
+          scope = reflection_scope
+          scope.merge!(preload_scope) if preload_scope
+
           preloaders = preloader.preload(middle_records,
                                          source_reflection.name,
-                                         reflection_scope)
+                                         scope)
 
           @preloaded_records = preloaders.flat_map(&:preloaded_records)
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1326,7 +1326,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   test "preloading a through association twice does not reset it" do
     members = Member.includes(current_membership: :club).includes(:club).to_a
     assert_no_queries {
-      assert_equal 3, members.map(&:current_membership).map(&:club).size
+      assert_equal 4, members.map(&:current_membership).map(&:club).size
     }
   end
 
@@ -1351,7 +1351,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
     members = Member.preload(:current_membership).includes(current_membership: :club).all.to_a
     assert_no_queries {
       members_with_membership = members.select(&:current_membership)
-      assert_equal 3, members_with_membership.map(&:current_membership).map(&:club).size
+      assert_equal 4, members_with_membership.map(&:current_membership).map(&:club).size
     }
   end
 

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -135,6 +135,19 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     clubs = Club.all.merge!(includes: :sponsored_member, where: ["name = ?", "Moustache and Eyebrow Fancier Club"]).to_a
     # Only the eyebrow fanciers club has a sponsored_member
     assert_not_nil assert_no_queries { clubs[0].sponsored_member }
+    assert_equal members(:groucho), clubs(:moustache_club).sponsored_member
+  end
+
+  def test_nested_has_one_through_polymorphic_with_source_type
+    assert_equal clubs(:sponsoring_club), members(:alan).sponsored_clubs.first
+  end
+
+  def test_nested_eager_has_one_through_polymorphic_with_source_type
+    alan_id = members(:alan).id
+    alan = Member.includes(:sponsored_clubs).where(id: alan_id).first
+    # Only the eyebrow fanciers club has a sponsored_member
+    assert_not_nil assert_no_queries { alan.sponsored_clubs }
+    assert_equal clubs(:sponsoring_club), alan.sponsored_clubs.first
   end
 
   def test_has_one_through_nonpreload_eagerloading

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "models/tag"
+require "models/account"
 require "models/tagging"
 require "models/post"
 require "models/rating"
@@ -21,7 +22,7 @@ require "models/car"
 class AssociationsJoinModelTest < ActiveRecord::TestCase
   self.use_transactional_tests = false unless supports_savepoints?
 
-  fixtures :posts, :authors, :author_addresses, :categories, :categorizations, :comments, :tags, :taggings, :author_favorites, :vertices, :items, :books,
+  fixtures :accounts, :posts, :authors, :author_addresses, :categories, :categorizations, :comments, :tags, :taggings, :author_favorites, :vertices, :items, :books,
     # Reload edges table from fixtures as otherwise repeated test was failing
     :edges
 
@@ -363,6 +364,17 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   def test_has_many_polymorphic_with_source_type
     # added sort by ID as otherwise Oracle select sometimes returned rows in different order
     assert_equal posts(:welcome, :thinking).sort_by(&:id), tags(:general).tagged_posts.sort_by(&:id)
+  end
+
+  def test_nested_has_many_through_polymorphic_with_source_type
+    assert_equal posts(:welcome, :thinking, :misc_by_bob, :misc_by_mary, :other_by_bob, :other_by_mary).sort_by(&:id), accounts(:signals37).tagged_posts.uniq.sort_by(&:id)
+  end
+
+  def test_preload_nested_has_many_through_polymorphic_with_source_type
+    account_id = accounts(:signals37).id
+    account = Account.includes(:tagged_posts).find(account_id)
+    assert_no_queries{ account.tagged_posts }
+    assert_equal posts(:welcome, :thinking, :misc_by_bob, :misc_by_mary, :other_by_bob, :other_by_mary).sort_by(&:id), account.tagged_posts.uniq.sort_by(&:id)
   end
 
   def test_has_many_polymorphic_associations_merges_through_scope

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -373,7 +373,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   def test_preload_nested_has_many_through_polymorphic_with_source_type
     account_id = accounts(:signals37).id
     account = Account.includes(:tagged_posts).find(account_id)
-    assert_no_queries{ account.tagged_posts }
+    assert_no_queries { account.tagged_posts }
     assert_equal posts(:welcome, :thinking, :misc_by_bob, :misc_by_mary, :other_by_bob, :other_by_mary).sort_by(&:id), account.tagged_posts.uniq.sort_by(&:id)
   end
 

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -394,7 +394,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   def test_has_one_through_has_one_through_with_belongs_to_source_reflection_preload_via_joins
     assert_includes_and_joins_equal(
       Member.where("categories.id" => categories(:technology).id),
-      [members(:blarpy_winkup)], :club_category
+      members(:alan, :blarpy_winkup), :club_category
     )
   end
 

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -393,8 +393,8 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_one_through_has_one_through_with_belongs_to_source_reflection_preload_via_joins
     assert_includes_and_joins_equal(
-      Member.where("categories.id" => categories(:technology).id),
-      members(:alan, :blarpy_winkup), :club_category
+      Member.where("categories.id" => categories(:technology).id).order(:id),
+      members(:blarpy_winkup, :alan), :club_category
     )
   end
 

--- a/activerecord/test/fixtures/clubs.yml
+++ b/activerecord/test/fixtures/clubs.yml
@@ -1,3 +1,6 @@
+sponsoring_club:
+  id: 1
+  name: Sponsoring club
 boring_club:
   name: Banana appreciation society
   category_id: 1

--- a/activerecord/test/fixtures/members.yml
+++ b/activerecord/test/fixtures/members.yml
@@ -9,3 +9,7 @@ some_other_guy:
 blarpy_winkup:
   id: 3
   name: Blarpy Winkup
+alan:
+  id: 4
+  name: Alan Turing
+  member_type_id: 1

--- a/activerecord/test/fixtures/memberships.yml
+++ b/activerecord/test/fixtures/memberships.yml
@@ -12,6 +12,20 @@ membership_of_favourite_club:
   favourite: true
   type: Membership
 
+alan_membership_of_crazy_club:
+  joined_on: <%= 3.weeks.ago.to_s(:db) %>
+  club: crazy_club
+  member_id: 4
+  favourite: true
+  type: CurrentMembership
+
+alan_membership_of_sponsoring_club:
+  joined_on: <%= 3.weeks.ago.to_s(:db) %>
+  club_id: 1
+  member_id: 4
+  favourite: true
+  type: CurrentMembership
+
 other_guys_membership:
   joined_on: <%= 4.weeks.ago.to_s(:db) %>
   club: boring_club

--- a/activerecord/test/fixtures/sponsors.yml
+++ b/activerecord/test/fixtures/sponsors.yml
@@ -10,3 +10,7 @@ crazy_club_sponsor_for_groucho:
   sponsor_club: crazy_club
   sponsorable_id: 3
   sponsorable_type: Member
+sponsor_club_sponsor_for_sponsor_club:
+  club_id: 1
+  sponsorable_id: 1
+  sponsorable_type: Club

--- a/activerecord/test/fixtures/tags.yml
+++ b/activerecord/test/fixtures/tags.yml
@@ -1,11 +1,14 @@
 general:
   id: 1
+  creator_id: 1
   name: General
 
 misc:
   id: 2
+  creator_id: 1
   name: Misc
 
 blue:
   id: 3
+  creator_id: 1
   name: Blue

--- a/activerecord/test/models/account.rb
+++ b/activerecord/test/models/account.rb
@@ -3,6 +3,10 @@
 class Account < ActiveRecord::Base
   belongs_to :firm, class_name: "Company"
   belongs_to :unautosaved_firm, foreign_key: "firm_id", class_name: "Firm", autosave: false
+  has_many :tags, foreign_key: :creator_id
+  has_many :taggings, through: :tags, source: :taggings
+  has_many :tagged_posts, through: :taggings, source: :taggable, source_type: "Post"
+
 
   alias_attribute :available_credit, :credit_limit
 

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -6,6 +6,7 @@ class Club < ActiveRecord::Base
   has_many :members, through: :memberships
   has_one :sponsor
   has_one :sponsored_member, through: :sponsor, source: :sponsorable, source_type: "Member"
+  has_many :sponsors
   belongs_to :category
 
   has_many :favourites, -> { where(memberships: { favourite: true }) }, through: :memberships, source: :member

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -28,6 +28,8 @@ class Member < ActiveRecord::Base
 
   has_many :current_memberships, -> { where favourite: true }
   has_many :clubs, through: :current_memberships
+  has_many :club_sponsors, through: :clubs, source: :sponsors
+  has_many :sponsored_clubs, through: :club_sponsors, source_type: "Club", source: :sponsorable
 
   has_many :tenant_memberships
   has_many :tenant_clubs, through: :tenant_memberships, class_name: "Club", source: :club

--- a/activerecord/test/models/tag.rb
+++ b/activerecord/test/models/tag.rb
@@ -4,6 +4,7 @@ class Tag < ActiveRecord::Base
   has_many :taggings
   has_many :taggables, through: :taggings
   has_one  :tagging
+  belongs_to :creator,class_name: "Account"
 
   has_many :tagged_posts, through: :taggings, source: "taggable", source_type: "Post"
 end

--- a/activerecord/test/models/tag.rb
+++ b/activerecord/test/models/tag.rb
@@ -4,7 +4,7 @@ class Tag < ActiveRecord::Base
   has_many :taggings
   has_many :taggables, through: :taggings
   has_one  :tagging
-  belongs_to :creator,class_name: "Account"
+  belongs_to :creator, class_name: "Account"
 
   has_many :tagged_posts, through: :taggings, source: "taggable", source_type: "Post"
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -836,6 +836,7 @@ ActiveRecord::Schema.define do
 
   create_table :tags, force: true do |t|
     t.column :name, :string
+    t.column :creator_id, :integer
     t.column :taggings_count, :integer, default: 0
   end
 


### PR DESCRIPTION
### Summary

Solution for #30242 

Reproduction step provided by @CicholGricenchos

```
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", github: "rails/rails"
  gem "arel", github: "rails/arel"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :hotels, force: true do |t|
  end
  create_table :departments, force: true do |t|
    t.integer :hotel_id
  end
  create_table :cake_designers, force: true do |t|
  end
  create_table :drink_designers, force: true do |t|
  end
  create_table :chefs, force: true do |t|
    t.integer :employable_id
    t.string :employable_type
    t.integer :department_id
    t.string :employable_list_type
    t.integer :employable_list_id
  end
end

class Hotel < ActiveRecord::Base
  has_many :departments
  has_many :chefs, through: :departments
  has_many :cake_designers, source_type: "CakeDesigner", source: :employable, through: :chefs
  has_many :drink_designers, source_type: "DrinkDesigner", source: :employable, through: :chefs
end

class Department < ActiveRecord::Base
  has_many :chefs
  belongs_to :hotel
end

class Chef < ActiveRecord::Base
  belongs_to :employable, polymorphic: true
  has_many :recipes
end

class CakeDesigner < ActiveRecord::Base
  has_one :chef, as: :employable
end

class DrinkDesigner < ActiveRecord::Base
  has_one :chef, as: :employable
end

class BugTest < Minitest::Test
  def test_preloading_polymorphic_source_on_two_level_has_many_through
    hotel = Hotel.create!
    department = hotel.departments.create!
    cake_designer = CakeDesigner.create!
    drink_designer = DrinkDesigner.create!
    department.chefs.create!(employable: cake_designer)
    department.chefs.create!(employable: drink_designer)

    found_cake_designers = Hotel.preload(:cake_designers).find(hotel.id).cake_designers

    assert_equal 1, found_cake_designers.size
    assert_equal cake_designer, found_cake_designers.first
  end
end

```
