### PR TITLE
Should escape regexp wildcard character `.`

### DIFF
--- a/activestorage/test/controllers/blobs_controller_test.rb
+++ b/activestorage/test/controllers/blobs_controller_test.rb
@@ -11,7 +11,7 @@ class ActiveStorage::BlobsControllerTest < ActionDispatch::IntegrationTest
   test "showing blob utilizes browser caching" do
     get rails_blob_url(@blob)
 
-    assert_redirected_to(/racecar.jpg/)
+    assert_redirected_to(/racecar\.jpg/)
     assert_equal "max-age=300, private", @response.headers["Cache-Control"]
   end
 end

--- a/activestorage/test/controllers/variants_controller_test.rb
+++ b/activestorage/test/controllers/variants_controller_test.rb
@@ -14,7 +14,7 @@ class ActiveStorage::VariantsControllerTest < ActionDispatch::IntegrationTest
       signed_blob_id: @blob.signed_id,
       variation_key: ActiveStorage::Variation.encode(resize: "100x100"))
 
-    assert_redirected_to(/racecar.jpg\?.*disposition=inline/)
+    assert_redirected_to(/racecar\.jpg\?.*disposition=inline/)
 
     image = read_image_variant(@blob.variant(resize: "100x100"))
     assert_equal 100, image.width

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -10,7 +10,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "resized variation" do
     variant = @blob.variant(resize: "100x100").processed
-    assert_match(/racecar.jpg/, variant.service_url)
+    assert_match(/racecar\.jpg/, variant.service_url)
 
     image = read_image_variant(variant)
     assert_equal 100, image.width
@@ -19,7 +19,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "resized and monochrome variation" do
     variant = @blob.variant(resize: "100x100", monochrome: true).processed
-    assert_match(/racecar.jpg/, variant.service_url)
+    assert_match(/racecar\.jpg/, variant.service_url)
 
     image = read_image_variant(variant)
     assert_equal 100, image.width


### PR DESCRIPTION
This PR is the same intention as #18586.