### PR TITLE
Fix asset pipeline guide

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -283,10 +283,10 @@ You can view the search path by inspecting
 `Rails.application.config.assets.paths` in the Rails console.
 
 Besides the standard `assets/*` paths, additional (fully qualified) paths can be
-added to the pipeline in `config/application.rb`. For example:
+added to the pipeline in `config/initializers/assets.rb`. For example:
 
 ```ruby
-config.assets.paths << Rails.root.join("lib", "videoplayer", "flash")
+Rails.application.config.assets.paths << Rails.root.join("lib", "videoplayer", "flash")
 ```
 
 Paths are traversed in the order they occur in the search path. By default,


### PR DESCRIPTION
The guide is saying to add the extra assets paths in the `config/application.rb` file, the correct one is `config/initializers/assets.rb`.

In the `assets.rb` has a comment explaining that:
```
# Add additional assets to the asset load path
# Rails.application.config.assets.paths << Emoji.images_path
```