### PR TITLE
Fix line filtering when running tests via `ruby -Itest [...]`

### DIFF
--- a/railties/lib/rails/plugin/test.rb
+++ b/railties/lib/rails/plugin/test.rb
@@ -2,6 +2,7 @@
 
 require_relative "../test_unit/runner"
 require_relative "../test_unit/reporter"
+require_relative "../test_unit/line_filtering"
 
 Rails::TestUnitReporter.executable = "bin/test"
 


### PR DESCRIPTION
### Summary

Resolves one issue related to https://github.com/rails/rails/issues/29899, created (AFAICT) by [moving the minitest logic into plugin](https://github.com/rails/rails/commit/0d72489b2a08487f71dd4230846c01a5d99ef35f), and therefore not eagerly loading it.

This PR fixes tests execution to accept line filters again when Rails are not loaded, f.e. `rails/test file_test.rb:4` (note the number).

### Other Information

I ran into this while updating RoR to version 5.1.3 in Fedora.

Railties tests run without the patch result in Failure: 
```
PluginTestRunnerTest#test_mix_files_and_line_filters [test/generators/plugin_test_runner_test.rb:48]:
Expected /2\ runs,\ 2\ assertions/ to match "Run options: --seed 4097\n\n# Running:\n\n.PostTest\n.AccountTest\n.\n\nFinished in 0.011165s, 268.7031 runs/s, 268.7031 assertions/s.\n3 runs, 3 assertions, 0 failures, 0 errors, 0 skips\n".
bin/rails test test/generators/plugin_test_runner_test.rb:28
```