### PR TITLE
Use `require_relative` instead of `require` 

### DIFF
--- a/activestorage/lib/active_storage/attached.rb
+++ b/activestorage/lib/active_storage/attached.rb
@@ -35,6 +35,6 @@ module ActiveStorage
   end
 end
 
-require "active_storage/attached/one"
-require "active_storage/attached/many"
-require "active_storage/attached/macros"
+require_relative "attached/one"
+require_relative "attached/many"
+require_relative "attached/macros"


### PR DESCRIPTION
### Summary

* There is no advantage to use autoload there.
* Those files needs to be eager loaded at boot time.
* Prefer `require_relative` over `relative` for performance.