### PR TITLE
Use `deep_merge!` to keep nested values in shared secrets

### DIFF
--- a/railties/lib/rails/secrets.rb
+++ b/railties/lib/rails/secrets.rb
@@ -27,8 +27,8 @@ module Rails
           require "erb"
 
           secrets = YAML.load(ERB.new(preprocess(path)).result) || {}
-          all_secrets.merge!(secrets["shared"].deep_symbolize_keys) if secrets["shared"]
-          all_secrets.merge!(secrets[env].deep_symbolize_keys) if secrets[env]
+          all_secrets.deep_merge!(secrets["shared"].deep_symbolize_keys) if secrets["shared"]
+          all_secrets.deep_merge!(secrets[env].deep_symbolize_keys) if secrets[env]
         end
       end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -619,14 +619,20 @@ module ApplicationTests
       app_file "config/secrets.yml", <<-YAML
         shared:
           api_key: 3b7cd727
+          vars:
+            foo: foo123
+            bar: bar123
 
         development:
           api_key: abc12345
+          vars:
+            bar: bar456
       YAML
 
       app "development"
 
       assert_equal "abc12345", app.secrets.api_key
+      assert_equal({ foo: "foo123", bar: "bar456" }, app.secrets.vars)
     end
 
     test "blank config/secrets.yml does not crash the loading process" do


### PR DESCRIPTION
### Summary

Currently, nested values in shared secrets will be replaced with environment or encrypted secrets.
This PR fixes nested values that other secrets don't have will be kept.

### Example

```
# secrets.yml
shared:
  vars:
    foo: foo123
    bar: bar123
 
development:
  vars:
    bar: bar456
```

```
# Before
Rails.application.secrets.vars #=> {:bar=>"bar456"}

# After
Rails.application.secrets.vars #=> {:foo=>"foo123", :bar=>"bar456"}
```