### PR TITLE
5-0-stable: Fix unscoping `default_scope` in STI associations

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -54,15 +54,13 @@ module ActiveRecord
             end
             scope_chain_index += 1
 
+            relation = ActiveRecord::Relation.create(klass, table, predicate_builder)
+            current_scope = klass.current_scope
+
             klass_scope =
-              if klass.current_scope && klass.current_scope.values.empty?
-                klass.unscoped
+              if current_scope && current_scope.empty_scope?
+                relation
               else
-                relation = ActiveRecord::Relation.create(
-                  klass,
-                  table,
-                  predicate_builder,
-                )
                 klass.send(:build_default_scope, relation)
               end
             scope_chain_items.concat [klass_scope].compact

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -130,6 +130,16 @@ module ActiveRecord
           @reflection_scope ||= reflection.scope_for(klass)
         end
 
+        def klass_scope
+          current_scope = klass.current_scope
+
+          if current_scope && current_scope.empty_scope?
+            klass.unscoped
+          else
+            klass.default_scoped
+          end
+        end
+
         def build_scope
           scope = klass.unscoped
 
@@ -166,7 +176,7 @@ module ActiveRecord
           end
 
           scope.unscope_values = Array(values[:unscope]) + Array(preload_values[:unscope])
-          klass.default_scoped.merge(scope)
+          klass_scope.merge(scope)
         end
       end
     end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -689,6 +689,10 @@ module ActiveRecord
       "#<#{self.class.name} [#{entries.join(', ')}]>"
     end
 
+    def empty_scope? # :nodoc:
+      @values == klass.unscoped.values
+    end
+
     protected
 
       def load_records(records)

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -397,6 +397,22 @@ class DefaultScopingTest < ActiveRecord::TestCase
                  Comment.joins(:post).to_a
   end
 
+  def test_sti_association_with_unscoped_not_affected_by_default_scope
+    post = posts(:thinking)
+    comments = [comments(:does_it_hurt)]
+
+    post.special_comments.update_all(deleted_at: Time.now)
+
+    assert_raises(ActiveRecord::RecordNotFound) { Post.joins(:special_comments).find(post.id) }
+    assert_equal [], post.special_comments
+
+    SpecialComment.unscoped do
+      assert_equal post, Post.joins(:special_comments).find(post.id)
+      assert_equal comments, Post.joins(:special_comments).find(post.id).special_comments
+      assert_equal comments, Post.eager_load(:special_comments).find(post.id).special_comments
+    end
+  end
+
   def test_default_scope_select_ignored_by_aggregations
     assert_equal DeveloperWithSelect.all.to_a.count, DeveloperWithSelect.count
   end

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -410,6 +410,8 @@ class DefaultScopingTest < ActiveRecord::TestCase
       assert_equal post, Post.joins(:special_comments).find(post.id)
       assert_equal comments, Post.joins(:special_comments).find(post.id).special_comments
       assert_equal comments, Post.eager_load(:special_comments).find(post.id).special_comments
+      assert_equal comments, Post.includes(:special_comments).find(post.id).special_comments
+      assert_equal comments, Post.preload(:special_comments).find(post.id).special_comments
     end
   end
 

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -53,6 +53,7 @@ class Comment < ActiveRecord::Base
 end
 
 class SpecialComment < Comment
+  default_scope { where(deleted_at: nil) }
 end
 
 class SubSpecialComment < SpecialComment

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -185,6 +185,7 @@ ActiveRecord::Schema.define do
     t.string :resource_id
     t.string :resource_type
     t.integer :developer_id
+    t.datetime :deleted_at
   end
 
   create_table :companies, force: true do |t|


### PR DESCRIPTION
Backported #29834.

Since 5c71000, it has lost to be able to unscope `default_scope` in STI
associations. This change will use `.empty_scope?` instead of
`.values.empty?` to regard as an empty scope if only have
`type_condition`.