### PR TITLE
Make rfc, content type, set cookie, location constants private

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -124,6 +124,8 @@ module ActionDispatch
       HTTP_METHOD_LOOKUP[method] = method.underscore.to_sym
     }
 
+    private_constant :RFC2616, :RFC2518, :RFC3253, :RFC3648, :RFC3744, :RFC5323, :RFC4791, :RFC5789
+
     # Returns the HTTP \method that the application should see.
     # In the case where the \method was overridden by a middleware
     # (for instance, if a HEAD request was converted to a GET,

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -83,6 +83,8 @@ module ActionDispatch # :nodoc:
     LOCATION     = "Location".freeze
     NO_CONTENT_CODES = [100, 101, 102, 204, 205, 304]
 
+    private_constant :CONTENT_TYPE, :SET_COOKIE, :LOCATION, :NO_CONTENT_CODES
+
     cattr_accessor :default_charset, default: "utf-8"
     cattr_accessor :default_headers
 


### PR DESCRIPTION
These constants should not be used outside their corresponding class so they should be private.