### PR TITLE
Don't expose `write_attribute_without_type_cast`

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -62,12 +62,6 @@ module ActiveRecord
         clear_mutation_trackers
       end
 
-      def write_attribute_without_type_cast(attr_name, *) # :nodoc:
-        result = super
-        clear_attribute_change(attr_name)
-        result
-      end
-
       def clear_attribute_changes(attr_names) # :nodoc:
         super
         attr_names.each do |attr_name|
@@ -183,6 +177,11 @@ module ActiveRecord
       end
 
       private
+        def write_attribute_without_type_cast(attr_name, _)
+          result = super
+          clear_attribute_change(attr_name)
+          result
+        end
 
         def mutation_tracker
           unless defined?(@mutation_tracker)


### PR DESCRIPTION
`write_attribute_without_type_cast` is defined as a private method in
`AttributeMethods::Write`, but `AttributeMethods::Dirty` overrode it as
a public method. It should be kept the original visibility.