### PR TITLE
Faster and more readable implementation of Hash#deep_merge

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
@@ -21,20 +21,14 @@ class Hash
 
   # Same as +deep_merge+, but modifies +self+.
   def deep_merge!(other_hash, &block)
-    other_hash.each_pair do |current_key, other_value|
-      this_value = self[current_key]
-
-      self[current_key] = if this_value.is_a?(Hash) && other_value.is_a?(Hash)
-        this_value.deep_merge(other_value, &block)
+    merge!(other_hash) do |key, this_val, other_val|
+      if this_val.is_a?(Hash) && other_val.is_a?(Hash)
+        this_val.deep_merge(other_val, &block)
+      elsif block_given?
+        block.call(key, this_val, other_val)
       else
-        if block_given? && key?(current_key)
-          block.call(current_key, this_value, other_value)
-        else
-          other_value
-        end
+        other_val
       end
     end
-
-    self
   end
 end


### PR DESCRIPTION
### Summary

This is a re-implementation of `Hash#deep_merge`. Using Ruby's built-in optional block for `merge` to handle duplicate keys makes the code shorter and more readable, and since the block is only run when a duplicate key is encountered it also improves performance. Performance benefits fluctuate case by case and are felt more strongly when merging hashes with fewer duplicate keys. All tests pass after this change.

### Benchmark (MacOS 10.12.6, ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin16])

[In a gist](https://gist.github.com/msimonborg/532f49918e0cd723e6bdb6696b8588b7)

```
require 'active_support'
require 'benchmark/ips'

class Hash
  def new_deep_merge(other_hash, &block)
    dup.new_deep_merge!(other_hash, &block)
  end

  def new_deep_merge!(other, &block)
    merge!(other) do |key, old_val, new_val|
      if old_val.is_a?(Hash) && new_val.is_a?(Hash)
        old_val.new_deep_merge(new_val, &block)
      elsif block_given?
        block.call(key, old_val, new_val)
      else
        new_val
      end
    end
  end
end

h1 = { a: true, b: { c: [1, 2, 3] }, d: 1 }
h2 = { a: false, b: { c: [3, 4, 5] }, d: 2 }
h3 = { a: false, b: { x: [3, 4, 5] }, e: 2, f: { y: false } }
h4 = { e: 2, f: { y: false }, g: 'hi', h: true }

Benchmark.ips do |bm|
  bm.report('old_deep_merge_all_dupes') { h1.deep_merge(h2) }
  bm.report('new_deep_merge_all_dupes') { h1.new_deep_merge(h2) }
  bm.compare!
end

Benchmark.ips do |bm|
  bm.report('old_deep_merge_some_dupes') { h1.deep_merge(h3) }
  bm.report('new_deep_merge_some_dupes') { h1.new_deep_merge(h3) }
  bm.compare!
end

Benchmark.ips do |bm|
  bm.report('old_deep_merge_no_dupes') { h1.deep_merge(h4) }
  bm.report('new_deep_merge_no_dupes') { h1.new_deep_merge(h4) }
  bm.compare!
end

Warming up --------------------------------------
old_deep_merge_all_dupes
                        21.602k i/100ms
new_deep_merge_all_dupes
                        23.242k i/100ms
Calculating -------------------------------------
old_deep_merge_all_dupes
                        248.052k (± 3.3%) i/s -      1.253M in   5.056553s
new_deep_merge_all_dupes
                        264.029k (± 3.8%) i/s -      1.325M in   5.024762s

Comparison:
new_deep_merge_all_dupes:   264028.7 i/s
old_deep_merge_all_dupes:   248052.3 i/s - same-ish: difference falls within error

Warming up --------------------------------------
old_deep_merge_some_dupes
                        19.705k i/100ms
new_deep_merge_some_dupes
                        22.753k i/100ms
Calculating -------------------------------------
old_deep_merge_some_dupes
                        209.495k (± 5.0%) i/s -      1.064M in   5.092063s
new_deep_merge_some_dupes
                        249.642k (± 3.6%) i/s -      1.251M in   5.019540s

Comparison:
new_deep_merge_some_dupes:   249642.2 i/s
old_deep_merge_some_dupes:   209494.5 i/s - 1.19x  slower

Warming up --------------------------------------
old_deep_merge_no_dupes
                        30.064k i/100ms
new_deep_merge_no_dupes
                        40.112k i/100ms
Calculating -------------------------------------
old_deep_merge_no_dupes
                        330.682k (± 3.9%) i/s -      1.654M in   5.008077s
new_deep_merge_no_dupes
                        471.547k (± 3.2%) i/s -      2.367M in   5.023926s

Comparison:
new_deep_merge_no_dupes:   471547.3 i/s
old_deep_merge_no_dupes:   330682.5 i/s - 1.43x  slower
```