### PR TITLE
Change namespace of Active Storage rake task

### DIFF
--- a/activestorage/lib/tasks/activestorage.rake
+++ b/activestorage/lib/tasks/activestorage.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-namespace :activestorage do
+namespace :active_storage do
   desc "Copy over the migration needed to the application"
   task install: :environment do
     Rake::Task["active_storage:install:migrations"].invoke


### PR DESCRIPTION
### Summary

The following is a display of the result of `rake -T` using the Active Storage application.

```Console
% bin/rake -T
rake about                              # List versions of all Rails frameworks and the environment
rake active_storage:install:migrations  # Copy migrations from active_storage to application
rake activestorage:install              # Copy over the migration needed to the application
rake app:template                       # Applies the template supplied by LOCATION=(/path/to/template) or URL

(snip)
```

The namespace of `active_storage:install:migrations` and` activestorage:install` are different. This PR unifies the namespace of Active Storage rake task to `active_storage`.

The namespace of `active_storage:install:migrations` depends on `Engine#railtie_name`.

https://github.com/rails/rails/blob/0789d093f3473dd9bc95e387cc519072760a6759/railties/lib/rails/engine.rb#L627-L630

So I think that the change target is namespace defined by activestorage.rake.