### PR TITLE
Fix increment! of aliased attributes

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Add method `canonical_attribute_name` for `ActiveModel::AttributeMethods` to give the original name when provided an alias, or the name itself otherwise.
+
+    *Lisa Ugray*
+
 *   Add method `#merge!` for `ActiveModel::Errors`.
 
     *Jahfer Husain*

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -224,6 +224,16 @@ module ActiveModel
         attribute_aliases[name.to_s]
       end
 
+      # Returns the canonical name for the attribute +name+: the original name
+      # if +name+ is an alias, or +name+ as a string if it's not an alias
+      def canonical_attribute_name(name)
+        if attribute_alias?(name)
+          attribute_alias(name)
+        else
+          name.to_s
+        end
+      end
+
       # Declares the attributes that should be prefixed and suffixed by
       # <tt>ActiveModel::AttributeMethods</tt>.
       #

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -192,6 +192,16 @@ class AttributeMethodsTest < ActiveModel::TestCase
     end
   end
 
+  test "#canonical_attribute_name gives the original attribute name" do
+    klass = Class.new(ModelWithAttributes) do
+      define_attribute_methods :foo
+      alias_attribute :bar, :foo
+    end
+
+    assert_equal "foo", klass.canonical_attribute_name(:bar)
+    assert_equal "foo", klass.canonical_attribute_name(:foo)
+  end
+
   test "#alias_attribute works with attributes with spaces in their names" do
     begin
       ModelWithAttributesWithSpaces.define_attribute_methods(:'foo bar')

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `ActiveRecord::Persistence#increment!` now accepts attribute aliases
+
+    Fixes #30279.
+
+    *Lisa Ugray* and *Wanderson Policarpo*
+
 *   Use given algorithm while removing index from database.
 
     Fixes #24190.

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -202,6 +202,7 @@ module ActiveRecord
         end
 
         def clear_attribute_change(attr_name)
+          attr_name = self.class.canonical_attribute_name(attr_name)
           mutation_tracker.forget_change(attr_name)
           mutations_from_database.forget_change(attr_name)
         end

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -102,7 +102,8 @@ module ActiveRecord
 
         updates = counters.map do |counter_name, value|
           operator = value < 0 ? "-" : "+"
-          quoted_column = connection.quote_column_name(counter_name)
+          column_name = canonical_attribute_name(counter_name)
+          quoted_column = connection.quote_column_name(column_name)
           "#{quoted_column} = COALESCE(#{quoted_column}, 0) #{operator} #{value.abs}"
         end
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -452,7 +452,7 @@ module ActiveRecord
     # Returns +self+.
     def increment!(attribute, by = 1, touch: nil)
       increment(attribute, by)
-      change = public_send(attribute) - (attribute_in_database(attribute.to_s) || 0)
+      change = send(attribute) - (send("#{attribute}_in_database") || 0)
       self.class.update_counters(id, attribute => change, touch: touch)
       clear_attribute_change(attribute) # eww
       self

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -128,6 +128,14 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
+  test "update aliased counter" do
+    Topic.alias_attribute(:replies_count_alias, :replies_count)
+    assert_equal 1, @topic.replies_count
+
+    Topic.update_counters(@topic.id, replies_count_alias: 1)
+    assert_equal 2, @topic.reload.replies_count
+  end
+
   test "update counters of multiple records" do
     t1, t2 = topics(:first, :second)
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -126,6 +126,15 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal 53, accounts(:signals37, :reload).credit_limit
   end
 
+  def test_increment_aliased_attribute
+    assert_equal 50, accounts(:signals37).available_credit
+    accounts(:signals37).increment! :available_credit
+    assert_equal 51, accounts(:signals37, :reload).available_credit
+
+    accounts(:signals37).increment(:available_credit).increment!(:available_credit)
+    assert_equal 53, accounts(:signals37, :reload).available_credit
+  end
+
   def test_increment_nil_attribute
     assert_nil topics(:first).parent_id
     topics(:first).increment! :parent_id


### PR DESCRIPTION
### Summary

Resolves an issue when incrementing an aliased attribute where `ActiveRecord` tries to update the column based on the aliased name, not the original name and an error is raised because the aliased column does not exist.

Fixes https://github.com/rails/rails/issues/30279.