### PR TITLE
Fixed nested where for associations with different class_name

### DIFF
--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -52,7 +52,7 @@ module ActiveRecord
         return self
       elsif association && !association.polymorphic?
         association_klass = association.klass
-        arel_table = association_klass.arel_table.alias(table_name)
+        arel_table = association_klass.arel_table
       else
         type_caster = TypeCaster::Connection.new(klass, table_name)
         association_klass = nil

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -90,6 +90,21 @@ module ActiveRecord
       assert_equal expected.to_sql, actual.to_sql
     end
 
+    def test_belongs_to_nested_where_with_different_class_name
+      actual = Post.joins(:creator).where(creator: { id: [1, 2] })
+      expected = Post.joins(:author).where(author: { id: [1, 2] })
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+    def test_has_many_nested_where_with_different_class_name
+      actual = Author.joins(:other_posts).where(other_posts: { id: [1, 2] })
+      expected = Author.joins(:posts).where(posts: { id: [1, 2] })
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+
     def test_belongs_to_nested_where_with_relation
       author = authors(:david)
 

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -27,6 +27,8 @@ class Post < ActiveRecord::Base
   scope :locked, -> { lock }
 
   belongs_to :author
+  belongs_to :creator, class_name: "Author", foreign_key: :author_id
+
   belongs_to :readonly_author, -> { readonly }, class_name: "Author", foreign_key: :author_id
 
   belongs_to :author_with_posts, -> { includes(:posts) }, class_name: "Author", foreign_key: :author_id


### PR DESCRIPTION
### Summary
Reproduction Steps

```
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"
  # Activate the gem you are reporting the issue against.
  gem "activerecord", "5.0.5"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# Ensure backward compatibility with Minitest 4
Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
  end

  create_table :posts, force: true do |t|
    t.references :user
  end
end

class User < ActiveRecord::Base
  has_many :posts
  has_many :my_posts, class_name: 'Post'
end

class Post < ActiveRecord::Base
end


class BugTest < Minitest::Test
  def test_joins_scopes
    has_many_actual = User.joins(:my_posts).where(my_posts: {id: [1,2]})
    has_many_expected = User.joins(:posts).where(posts: {id: [1,2]})

    assert_equal has_many_actual.to_sql, has_many_expected.to_sql   
  end
end
```
we need to consider association name in nested where rather than table name otherwise it will lead to issue like #30278.
