### PR TITLE
Make increment! work with aliases

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add method `canonical_attribute_name` for `ActiveModel::AttributeMethods` to
+    give the original name when provided an alias, or the name itself otherwise.
+
+    *Lisa Ugray*
+
 *   Add method `#merge!` for `ActiveModel::Errors`.
 
     *Jahfer Husain*

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -224,6 +224,16 @@ module ActiveModel
         attribute_aliases[name.to_s]
       end
 
+      # Returns the canonical name for the attribute +name+: the original name
+      # if +name+ is an alias, or +name+ as a string if it's not an alias
+      def canonical_attribute_name(name)
+        if attribute_alias?(name)
+          attribute_alias(name)
+        else
+          name.to_s
+        end
+      end
+
       # Declares the attributes that should be prefixed and suffixed by
       # <tt>ActiveModel::AttributeMethods</tt>.
       #

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -191,6 +191,16 @@ class AttributeMethodsTest < ActiveModel::TestCase
     assert_not klass.attribute_alias?(:foo)
   end
 
+  test "#canonical_attribute_name gives the original attribute name" do
+    klass = Class.new(ModelWithAttributes) do
+      define_attribute_methods :foo
+      alias_attribute :bar, :foo
+    end
+
+    assert_equal "foo", klass.canonical_attribute_name(:bar)
+    assert_equal "foo", klass.canonical_attribute_name(:foo)
+  end
+
   test "#define_attribute_methods generates attribute methods with spaces in their names" do
     begin
       ModelWithAttributesWithSpaces.define_attribute_methods(:'foo bar')

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -181,6 +181,16 @@ class AttributeMethodsTest < ActiveModel::TestCase
     assert_equal({ "bar" => "foo" }, klass.attribute_aliases)
   end
 
+  test "#attribute_alias? identifies aliases" do
+    klass = Class.new(ModelWithAttributes) do
+      define_attribute_methods :foo
+      alias_attribute :bar, :foo
+    end
+
+    assert klass.attribute_alias?(:bar)
+    assert_not klass.attribute_alias?(:foo)
+  end
+
   test "#define_attribute_methods generates attribute methods with spaces in their names" do
     begin
       ModelWithAttributesWithSpaces.define_attribute_methods(:'foo bar')

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `ActiveRecord::Persistence#increment!` now accepts attribute aliases
+
+    *Lisa Ugray*
+
 *   Ensure `sum` honors `distinct` on `has_many :through` associations
 
     Fixes #16791.

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -202,6 +202,7 @@ module ActiveRecord
         end
 
         def clear_attribute_change(attr_name)
+          attr_name = self.class.canonical_attribute_name(attr_name)
           mutation_tracker.forget_change(attr_name)
           mutations_from_database.forget_change(attr_name)
         end

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -101,6 +101,7 @@ module ActiveRecord
         touch = counters.delete(:touch)
 
         updates = counters.map do |counter_name, value|
+          counter_name = canonical_attribute_name(counter_name)
           operator = value < 0 ? "-" : "+"
           quoted_column = connection.quote_column_name(counter_name)
           "#{quoted_column} = COALESCE(#{quoted_column}, 0) #{operator} #{value.abs}"

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -358,7 +358,7 @@ module ActiveRecord
     # Returns +self+.
     def increment!(attribute, by = 1, touch: nil)
       increment(attribute, by)
-      change = public_send(attribute) - (attribute_in_database(attribute.to_s) || 0)
+      change = send(attribute) - (send("#{attribute}_in_database") || 0)
       self.class.update_counters(id, attribute => change, touch: touch)
       clear_attribute_change(attribute) # eww
       self

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -123,6 +123,18 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal 1, topics(:first).parent_id
   end
 
+  def test_increment_bang_attribute_alias
+    begin
+      Account.alias_attribute(:credit_limit_alias, :credit_limit)
+
+      assert_equal 50, accounts(:signals37).credit_limit_alias
+      accounts(:signals37).increment! :credit_limit_alias
+      assert_equal 51, accounts(:signals37, :reload).credit_limit_alias
+    ensure
+      Account.undefine_attribute_methods
+    end
+  end
+
   def test_increment_attribute_by
     assert_equal 50, accounts(:signals37).credit_limit
     accounts(:signals37).increment! :credit_limit, 5


### PR DESCRIPTION
### Summary
Fixes #30279.

`increment!` should work with attribute aliases, just like `where` does.

### Other Information
Even though they both operate on database columns, the columns are often
understood as a special (persisted) case of attributes.