### PR TITLE
Pass missing name attribute to execute_hook

### DIFF
--- a/activesupport/lib/active_support/lazy_load_hooks.rb
+++ b/activesupport/lib/active_support/lazy_load_hooks.rb
@@ -40,7 +40,7 @@ module ActiveSupport
     # * <tt>:run_once</tt> - Given +block+ will run only once.
     def on_load(name, options = {}, &block)
       @loaded[name].each do |base|
-        execute_hook(base, options, block)
+        execute_hook(name, base, options, block)
       end
 
       @load_hooks[name] << [block, options]
@@ -49,7 +49,7 @@ module ActiveSupport
     def run_load_hooks(name, base = Object)
       @loaded[name] << base
       @load_hooks[name].each do |hook, options|
-        execute_hook(base, options, hook)
+        execute_hook(name, base, options, hook)
       end
     end
 
@@ -63,7 +63,7 @@ module ActiveSupport
         end
       end
 
-      def execute_hook(base, options, block)
+      def execute_hook(name, base, options, block)
         with_execution_control(name, block, options[:run_once]) do
           if options[:yield]
             block.call(base)

--- a/activesupport/test/lazy_load_hooks_test.rb
+++ b/activesupport/test/lazy_load_hooks_test.rb
@@ -22,14 +22,19 @@ class LazyLoadHooksTest < ActiveSupport::TestCase
 
   def test_basic_hook_with_two_registrations_only_once
     i = 0
-    ActiveSupport.on_load(:basic_hook_with_two_once, run_once: true) do
+    block = proc { i += incr }
+    ActiveSupport.on_load(:basic_hook_with_two_once, run_once: true, &block)
+    ActiveSupport.on_load(:basic_hook_with_two_once) do
       i += incr
     end
-    assert_equal 0, i
+
+    ActiveSupport.on_load(:different_hook, run_once: true, &block)
+    ActiveSupport.run_load_hooks(:different_hook, FakeContext.new(2))
+    assert_equal 2, i
     ActiveSupport.run_load_hooks(:basic_hook_with_two_once, FakeContext.new(2))
-    assert_equal 2, i
+    assert_equal 6, i
     ActiveSupport.run_load_hooks(:basic_hook_with_two_once, FakeContext.new(5))
-    assert_equal 2, i
+    assert_equal 11, i
   end
 
   def test_hook_registered_after_run


### PR DESCRIPTION
### Summary
This PR fixes commit 10bf93ef92a70ae511036134290bf0e2de184b5c created to solve issue #30025.

**Problem:**
`execute_hook` should receive now the attribute `name` in order to be able to provide it to `with_execution_control`.

**Solution:**
Added `name` to `execute_hook`'s attribute list so it can be provided to `with_execution_control`.

Bug was discovered by @kaspth 