### PR TITLE
[ci skip] Mailer fixtures in Testing guide.

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -950,7 +950,7 @@ In order to test that your mailer is working as expected, you can use unit tests
 
 For the purposes of unit testing a mailer, fixtures are used to provide an example of how the output _should_ look. Because these are example emails, and not Active Record data like the other fixtures, they are kept in their own subdirectory apart from the other fixtures. The name of the directory within `test/fixtures` directly corresponds to the name of the mailer. So, for a mailer named `UserMailer`, the fixtures should reside in `test/fixtures/user_mailer` directory.
 
-When you generated your mailer, the generator creates stub fixtures for each of the mailers actions. If you didn't use the generator you'll have to make those files yourself.
+If you generated your mailer, the generator does not create stub fixtures for the mailers actions. You'll have to create those files yourself as described above.
 
 #### The Basic Test Case
 


### PR DESCRIPTION
### Summary

Apply changes from commit #29064  that address issue #29051 and update guide to clarify that mailer fixtures are not created when using the mailer generator.

This is to Bring 4-2-stable up to date with latest edge rails.

### Other Information

Attempted to use a patch from my original commit to master to backport these changes as per the [docs](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#older-versions-of-ruby-on-rails) but the patch failed because it did not apply correctly.