### PR TITLE
Use `ActiveJob::Base.queue_adapter_name` to get adapter name

### DIFF
--- a/activejob/test/support/integration/test_case_helpers.rb
+++ b/activejob/test/support/integration/test_case_helpers.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/string/inflections"
 require "support/integration/jobs_manager"
 
 module TestCaseHelpers
@@ -30,8 +29,7 @@ module TestCaseHelpers
     end
 
     def adapter_is?(*adapter_class_symbols)
-      adapter = ActiveJob::Base.queue_adapter.class.name.demodulize.chomp("Adapter").underscore
-      adapter_class_symbols.map(&:to_s).include? adapter
+      adapter_class_symbols.map(&:to_s).include? ActiveJob::Base.queue_adapter_name
     end
 
     def wait_for_jobs_to_finish_for(seconds = 60)


### PR DESCRIPTION
Since 673606a, it holds adapter name.