### PR TITLE
Timestamps in schema migration

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1041,7 +1041,7 @@ module ActiveRecord
         end
 
         unless migrated.include?(version)
-          execute "INSERT INTO #{sm_table} (version) VALUES (#{quote(version)})"
+          execute "INSERT INTO #{sm_table} (version, created_at, updated_at) VALUES (#{quote(version)}, #{quote(Time.now.to_s)}, #{quote(Time.now.to_s)})"
         end
 
         inserting = (versions - migrated).select { |v| v < version }
@@ -1351,12 +1351,12 @@ module ActiveRecord
           sm_table = quote_table_name(ActiveRecord::SchemaMigration.table_name)
 
           if versions.is_a?(Array)
-            sql = "INSERT INTO #{sm_table} (version) VALUES\n".dup
-            sql << versions.map { |v| "(#{quote(v)})" }.join(",\n")
+            sql = "INSERT INTO #{sm_table} (version, created_at, updated_at) VALUES\n".dup
+            sql << versions.map { |v| "(#{quote(v)}, #{quote(Time.now.to_s)}, #{quote(Time.now.to_s)})" }.join(",\n")
             sql << ";\n\n"
             sql
           else
-            "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions)});"
+            "INSERT INTO #{sm_table} (version, created_at, updated_at) VALUES (#{quote(versions)}, #{quote(Time.now.to_s)}, #{quote(Time.now.to_s)});"
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1041,7 +1041,7 @@ module ActiveRecord
         end
 
         unless migrated.include?(version)
-          execute "INSERT INTO #{sm_table} (version, created_at, updated_at) VALUES (#{quote(version)}, #{quote(Time.now.to_s)}, #{quote(Time.now.to_s)})"
+          execute "INSERT INTO #{sm_table} (version, created_at, updated_at) VALUES (#{quote(version)}, #{now}, #{now})"
         end
 
         inserting = (versions - migrated).select { |v| v < version }
@@ -1352,11 +1352,11 @@ module ActiveRecord
 
           if versions.is_a?(Array)
             sql = "INSERT INTO #{sm_table} (version, created_at, updated_at) VALUES\n".dup
-            sql << versions.map { |v| "(#{quote(v)}, #{quote(Time.now.to_s)}, #{quote(Time.now.to_s)})" }.join(",\n")
+            sql << versions.map { |v| "(#{quote(v)}, #{now}, #{now})" }.join(",\n")
             sql << ";\n\n"
             sql
           else
-            "INSERT INTO #{sm_table} (version, created_at, updated_at) VALUES (#{quote(versions)}, #{quote(Time.now.to_s)}, #{quote(Time.now.to_s)});"
+            "INSERT INTO #{sm_table} (version, created_at, updated_at) VALUES (#{quote(versions)}, #{now}, #{now});"
           end
         end
 
@@ -1366,6 +1366,15 @@ module ActiveRecord
 
         def quoted_scope(name = nil, type: nil)
           raise NotImplementedError
+        end
+
+        def now
+          if self.class.name.match(/Mysql/)
+            # stripping Timezone suffix
+            quote(Time.now.to_s[0..-7])
+          else
+            quote(Time.now.to_s)
+          end
         end
     end
   end

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -23,11 +23,19 @@ module ActiveRecord
       end
 
       def create_table
-        unless table_exists?
+        if table_exists?
+          unless column_names.include?("created_at")
+            connection.add_column(table_name, "created_at", :datetime, null: false, default: -> { 'CURRENT_TIMESTAMP' })
+          end
+          unless column_names.include?("updated_at")
+            connection.add_column(table_name, "updated_at", :datetime, null: false, default: -> { 'CURRENT_TIMESTAMP' })
+          end
+        else
           version_options = connection.internal_string_options_for_primary_key
 
           connection.create_table(table_name, id: false) do |t|
             t.string :version, version_options
+            t.timestamps
           end
         end
       end

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -24,11 +24,11 @@ module ActiveRecord
 
       def create_table
         if table_exists?
-          unless column_names.include?("created_at")
-            connection.add_column(table_name, "created_at", :datetime, null: false, default: -> { 'CURRENT_TIMESTAMP' })
+          unless column_names.include?('created_at')
+            connection.add_column(table_name, 'created_at', :datetime, null: false, default: -> { 'CURRENT_TIMESTAMP' })
           end
-          unless column_names.include?("updated_at")
-            connection.add_column(table_name, "updated_at", :datetime, null: false, default: -> { 'CURRENT_TIMESTAMP' })
+          unless column_names.include?('updated_at')
+            connection.add_column(table_name, 'updated_at', :datetime, null: false, default: -> { 'CURRENT_TIMESTAMP' })
           end
         else
           version_options = connection.internal_string_options_for_primary_key


### PR DESCRIPTION
### Summary

I have many apps deployed in multiple production environment at different point in time.
not only I need to know what migration were migrated, but I'd like to know when the migration occurred.

thus, I am adding the commonly standard created_at/updated_at to the schema_migration table

