### PR TITLE
Use nil Logger for tests

### DIFF
--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -32,7 +32,7 @@ end
 
 require "tmpdir"
 ActiveStorage::Blob.service = ActiveStorage::Service::DiskService.new(root: Dir.mktmpdir("active_storage_tests"))
-ActiveStorage::Service.logger = ActiveSupport::Logger.new(STDOUT)
+ActiveStorage::Service.logger = ActiveSupport::Logger.new(nil)
 
 ActiveStorage.verifier = ActiveSupport::MessageVerifier.new("Testing")
 


### PR DESCRIPTION
### Summary

Makes tests much more quietly, as opposed to the enormous amount of
logging that appears right now. This setting is used in AJ, as well as
other frameworks.

Output from test run:

```
# Running:

.........................................................

Finished in 3.003355s, 18.9788 runs/s, 45.2827 assertions/s.
57 runs, 136 assertions, 0 failures, 0 errors, 0 skips
```