### PR TITLE
Move `test_index_is_created_for_both_timestamps` to `TimestampsWithou…

### DIFF
--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -446,17 +446,6 @@ class TimestampTest < ActiveRecord::TestCase
     toy = Toy.first
     assert_equal ["created_at", "updated_at"], toy.send(:all_timestamp_attributes_in_model)
   end
-
-  def test_index_is_created_for_both_timestamps
-    ActiveRecord::Base.connection.create_table(:foos, force: true) do |t|
-      t.timestamps null: true, index: true
-    end
-
-    indexes = ActiveRecord::Base.connection.indexes("foos")
-    assert_equal ["created_at", "updated_at"], indexes.flat_map(&:columns).sort
-  ensure
-    ActiveRecord::Base.connection.drop_table(:foos)
-  end
 end
 
 class TimestampsWithoutTransactionTest < ActiveRecord::TestCase
@@ -474,5 +463,16 @@ class TimestampsWithoutTransactionTest < ActiveRecord::TestCase
       assert_nil post.created_at
       assert_nil post.updated_at
     end
+  end
+
+  def test_index_is_created_for_both_timestamps
+    ActiveRecord::Base.connection.create_table(:foos, force: true) do |t|
+      t.timestamps null: true, index: true
+    end
+
+    indexes = ActiveRecord::Base.connection.indexes("foos")
+    assert_equal ["created_at", "updated_at"], indexes.flat_map(&:columns).sort
+  ensure
+    ActiveRecord::Base.connection.drop_table(:foos)
   end
 end


### PR DESCRIPTION
### Summary

Move `test_index_is_created_for_both_timestamps` to `TimestampsWithoutTransactionTest`

This commit addresses these failures when the backend RDBMS executes implicit commit for DDL like MySQL and Oracle.

```ruby
$ ARCONN=mysql2 bin/test test/cases/integration_test.rb test/cases/timestamp_test.rb --seed 58225 -n '/^(?:TimestampTest#(?:test_index_is_created_for_both_timestamps)|IntegrationTest#(?:test_cache_key_for_newer_updated_at|test_cache_key_format_for_existing_record_with_updated_at|test_cache_key_format_for_existing_record_with_updated_at_and_custom_cache_timestamp_format))$/' -v
Using mysql2
Run options: --seed 58225 -n "/^(?:TimestampTest#(?:test_index_is_created_for_both_timestamps)|IntegrationTest#(?:test_cache_key_for_newer_updated_at|test_cache_key_format_for_existing_record_with_updated_at|test_cache_key_format_for_existing_record_with_updated_at_and_custom_cache_timestamp_format))$/" -v

TimestampTest#test_index_is_created_for_both_timestamps = 0.19 s = .
IntegrationTest#test_cache_key_format_for_existing_record_with_updated_at = 0.05 s = F
IntegrationTest#test_cache_key_format_for_existing_record_with_updated_at_and_custom_cache_timestamp_format = 0.02 s = F
IntegrationTest#test_cache_key_for_newer_updated_at = 0.01 s = F

Finished in 0.272880s, 14.6585 runs/s, 14.6585 assertions/s.

  1) Failure:
IntegrationTest#test_cache_key_format_for_existing_record_with_updated_at [/home/yahonda/git/rails/activerecord/test/cases/integration_test.rb:111]:
--- expected
+++ actual
@@ -1 +1 @@
-"developers/1-20170717135609430848"
+"developers/1-20170817135609283207"

  2) Failure:
IntegrationTest#test_cache_key_format_for_existing_record_with_updated_at_and_custom_cache_timestamp_format [/home/yahonda/git/rails/activerecord/test/cases/integration_test.rb:116]:
--- expected
+++ actual
@@ -1 +1 @@
-"cached_developers/1-20170717135609"
+"cached_developers/1-20170817135609"

  3) Failure:
IntegrationTest#test_cache_key_for_newer_updated_at [/home/yahonda/git/rails/activerecord/test/cases/integration_test.rb:147]:
--- expected
+++ actual
@@ -1 +1 @@
-"developers/1-20170717145609430848"
+"developers/1-20170817135609283207"

4 runs, 4 assertions, 3 failures, 0 errors, 0 skips
$
```

`ActiveRecord::TestCase::TimestampTest#test_index_is_created_for_both_timestamps`
calls`ActiveRecord::TestCase::TimestampTest#setup` which updates `updated_at` column value.

```ruby
    @developer = Developer.first
    ... snip ...
    @developer.update_columns(updated_at: Time.now.prev_month)
```

This transaction expected to be rolled back, but if the backend RDBMS like MySQL perfomes
implicit commit when DDL executed, this transacion is committed by `create table` statement
inside `ActiveRecord::TestCase::TimestampTest#test_index_is_created_for_both_timestamps`.

It causes these failures above which expect `update_at` column value is not changed(rollbacked).

