### PR TITLE
Remove obsolete explanation about passing string to `:if` and `:unless` [ci skip]

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -892,7 +892,7 @@ Conditional Validation
 
 Sometimes it will make sense to validate an object only when a given predicate
 is satisfied. You can do that by using the `:if` and `:unless` options, which
-can take a symbol, a string, a `Proc` or an `Array`. You may use the `:if`
+can take a symbol, a `Proc` or an `Array`. You may use the `:if`
 option when you want to specify when the validation **should** happen. If you
 want to specify when the validation **should not** happen, then you may use the
 `:unless` option.


### PR DESCRIPTION
This is a follow up to https://github.com/rails/rails/pull/28058.

Passing String is already oblsote since https://github.com/rails/rails/pull/27608
