### PR TITLE
Use `Rails.initialize!` instead of `Rails.application.initialize!`

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -561,7 +561,7 @@ The rest of `config/application.rb` defines the configuration for the
 `Rails::Application` which will be used once the application is fully
 initialized. When `config/application.rb` has finished loading Rails and defined
 the application namespace, we go back to `config/environment.rb`. Here, the
-application is initialized with `Rails.application.initialize!`, which is
+application is initialized with `Rails.initialize!`, which is
 defined in `rails/application.rb`.
 
 ### `railties/lib/rails/application.rb`

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use `Rails.initialize!` instead of `Rails.application.initialize!`
+
+    *Yoshiyuki Hirano*
+
 *   Add `--skip-yarn` option to the plugin generator.
 
     *bogdanvlviv*

--- a/railties/lib/rails/generators/rails/app/templates/config/environment.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/environment.rb
@@ -4,4 +4,4 @@
 require_relative 'application'
 
 # Initialize the Rails application.
-Rails.application.initialize!
+Rails.initialize!

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -435,7 +435,7 @@ module ApplicationTests
 
     test "initialization on the assets group should set assets_dir" do
       require "#{app_path}/config/application"
-      Rails.application.initialize!(:assets)
+      Rails.initialize!(:assets)
       assert_not_nil Rails.application.config.action_controller.assets_dir
     end
 

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -126,7 +126,7 @@ class LoadingTest < ActiveSupport::TestCase
 
   test "initialize cant be called twice" do
     require "#{app_path}/config/environment"
-    assert_raise(RuntimeError) { Rails.application.initialize! }
+    assert_raise(RuntimeError) { Rails.initialize! }
   end
 
   test "reload constants on development" do

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -53,7 +53,7 @@ module ApplicationTests
           config.middleware.use SuperMiddleware
         end
 
-        Rails.application.initialize!
+        Rails.initialize!
       RUBY
 
       assert_match("SuperMiddleware", Dir.chdir(app_path) { `bin/rails middleware` })

--- a/railties/test/application/url_generation_test.rb
+++ b/railties/test/application/url_generation_test.rb
@@ -22,7 +22,7 @@ module ApplicationTests
         config.eager_load = false
       end
 
-      Rails.application.initialize!
+      Rails.initialize!
 
       class ::ApplicationController < ActionController::Base
       end


### PR DESCRIPTION
### Summary

- `Rails` delegates `.initialize!` method to `.application` ([here](https://github.com/rails/rails/blob/master/railties/lib/rails.rb#L43)).
- It seems that it doesn't need to call `.initialize!` via `Rails.application`.