### PR TITLE
Separate out railties tests into two Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,8 @@ env:
   global:
     - "JRUBY_OPTS='--dev -J-Xmx1024M'"
   matrix:
-    - "GEM=railties"
+    - "GEM=railties:with_application"
+    - "GEM=railties:no_application"
     - "GEM=ap,ac"
     - "GEM=am,amo,as,av,aj,ast"
     - "GEM=as PRESERVE_TIMEZONES=1"

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -154,13 +154,19 @@ if ENV["GEM"] == "aj:integration"
   ENV["QUE_DATABASE_URL"] = "postgres://postgres@localhost/active_jobs_que_int_test"
 end
 
+if ENV["GEM"] == "railties:with_application"
+  ENV["TEST_DIRS"] = "application"
+elsif ENV["GEM"] == "railties:no_application"
+  ENV["SKIP_TEST_DIRS"] = "application"
+end
+
 results = {}
 
 ENV["GEM"].split(",").each do |gem|
   [false, true].each do |isolated|
     next if ENV["TRAVIS_PULL_REQUEST"] && ENV["TRAVIS_PULL_REQUEST"] != "false" && isolated
     next if RUBY_VERSION < "2.4" && isolated
-    next if gem == "railties" && isolated
+    next if gem.include?("railties") && isolated
     next if gem == "ac" && isolated
     next if gem == "ac:integration" && isolated
     next if gem == "aj:integration" && isolated

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -13,7 +13,17 @@ namespace :test do
   task :isolated do
     dirs = (ENV["TEST_DIR"] || ENV["TEST_DIRS"] || "**").split(",")
     test_files = dirs.map { |dir| "test/#{dir}/*_test.rb" }
-    Dir[*test_files].each do |file|
+    test_files = Dir[*test_files]
+
+    skip_dirs = (ENV["SKIP_TEST_DIR"] || ENV["SKIP_TEST_DIRS"] || "").split(",")
+
+    if !skip_dirs.empty?
+      test_files.reject! do |filename|
+        skip_dirs.any? { |skip_dir| filename.include?(skip_dir) }
+      end
+    end
+
+    test_files.each do |file|
       next true if file.include?("fixtures")
       dash_i = [
         "test",


### PR DESCRIPTION
### Summary

`railties` is notorious among Rails contributors for its long build times with Travis CI. [One recent build](https://travis-ci.org/rails/rails/builds/265702197) even took upwards of one hour to complete. IMHO the way forward here is to split up the railties job into two parts, one running `test/application/`, and the other running all other tests.

`test/application/` contains 43/114 of the total test classes and 552/1444 of the total tests (about 38% of both), so it is a sizable portion of the overall railties job.

Below are the build times once I separated out of the jobs. Note that I am comparing [this Rails master build](https://travis-ci.org/rails/rails/builds/265666623) (the most recent Travis CI build before I created my branch) and [this branch build](https://travis-ci.org/maclover7/jonrails/builds/265729907).

With one job:

2.2.7, 41 min 43 sec, 2503 sec
2.3.4, 28 min 34 sec, 1714 sec
2.4.1, 36 min 43 sec, 2203 sec

With two jobs (times below are the two builds added together):

2.2.7, 32 min 45 sec, 1966 sec, -21.45%
2.3.4, 35 min 00 sec, 2100 sec, +22.52%
2.4.1, 26 min 26 sec, 1586 sec, -28.00%

Average change from one build to two: -8.97%

Although the 2.3.4 build goes up, the 2.2.7 and 2.4.1 builds both get about a 20-30% speed improvement, which is fairly substantial. Some more work can probably be done here, but this is a decent first attempt at solving this.

### Other Information

There is probably some other tuning that can be done here, but I am also concerned about how this may impact Travis CI. If we continue to extract out separate build jobs, while the actual run time may be smaller, the enqueue time maybe longer, since we are requesting more resources from Travis. It may be worth trying to run some railties tests alongside other components, as a way to avoid this problem, although that opens up another can of worms itself.

I've also been looking through some of the railties tests themselves, and I _think_ some of them should be able to move to their respective components, and not live in railties. That's kind of a wider topic, but also something that should possibly be on the table

Lots of things to consider here 😢 