### PR TITLE
Respect layout option when rendering collection

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Respect `layout` option when rendering a collection with a non-unique set
+    of partial paths.
+
+    *Steven Harman*
+
 *   Add `srcset` option to `image_tag` helper.
 
     *Roberto Miranda*

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -457,7 +457,7 @@ module ActionView
           path, as, counter, iteration = collection_data[index]
 
           if layout = @options[:layout]
-            layout = find_template(layout, keys + [as, counter, iteration])
+            layout = (cache[layout] ||= find_template(layout, keys + [as, counter, iteration]))
           end
 
           locals[as]        = object

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -456,12 +456,17 @@ module ActionView
           index = partial_iteration.index
           path, as, counter, iteration = collection_data[index]
 
+          if layout = @options[:layout]
+            layout = find_template(layout, keys + [as, counter, iteration])
+          end
+
           locals[as]        = object
           locals[counter]   = index
           locals[iteration] = partial_iteration
 
           template = (cache[path] ||= find_template(path, keys + [as, counter, iteration]))
           content = template.render(view, locals)
+          content = layout.render(view, locals) { content } if layout
           partial_iteration.iterate!
           content
         end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -367,6 +367,16 @@ module RenderTestCases
       @view.render(partial: "test/customer", layout: "test/b_layout_for_partial_with_object", object: Customer.new("Amazon"))
   end
 
+  def test_render_partial_with_layout_and_homogeneous_collection
+    assert_equal "<b>hi: Amazon</b><b>hi: Yahoo</b>",
+      @controller_view.render(partial: [ Customer.new("Amazon"), Customer.new("Yahoo") ], layout: "test/b_layout_for_partial", locals: { greeting: "hi" })
+  end
+
+  def test_render_partial_with_layout_and_heterogeneous_collection
+    assert_equal "<b>hi: Amazon</b><b>hi good customer: Yahoo1</b>",
+      @controller_view.render(partial: [ Customer.new("Amazon"), GoodCustomer.new("Yahoo") ], layout: "test/b_layout_for_partial", locals: { greeting: "hi" })
+  end
+
   def test_render_partial_with_empty_array_should_return_nil
     assert_nil @view.render(partial: [])
   end


### PR DESCRIPTION
When doing a partial render for a collection there is a layout option available. It is used to wrap each rendered partial. This works as expected in all cases (that I've found) except when the collection is heterogeneous - or at least when the objects in the collection result in a set of non-unique `to_partial_path` values.

A change back in 228f9910389cad7fe0dd7f2bd010fe654f794b37 caused this inconsistency. The comment there says the layout option is ignored for the shortcut `render @collection`, but makes no mention of the longer form. There has been much churn in this area in the years since that change, and it seems we ought to respect the option as it's consistent with the existing documentation, and other ways of calling this partial render.
