### PR TITLE
Simplify ActiveModel::Errors#generate_message

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -398,20 +398,18 @@ module ActiveModel
       type = options.delete(:message) if options[:message].is_a?(Symbol)
 
       if @base.class.respond_to?(:i18n_scope)
-        defaults = @base.class.lookup_ancestors.map do |klass|
-          [ :"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
-            :"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}" ]
+        i18n_scope = @base.class.i18n_scope.to_s
+        defaults = @base.class.lookup_ancestors.flat_map do |klass|
+          [ :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
+            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}" ]
         end
+        defaults << :"#{i18n_scope}.errors.messages.#{type}"
       else
         defaults = []
       end
 
-      defaults << :"#{@base.class.i18n_scope}.errors.messages.#{type}" if @base.class.respond_to?(:i18n_scope)
       defaults << :"errors.attributes.#{attribute}.#{type}"
       defaults << :"errors.messages.#{type}"
-
-      defaults.compact!
-      defaults.flatten!
 
       key = defaults.shift
       defaults = options.delete(:message) if options[:message]


### PR DESCRIPTION
### Summary

Besides making `ActiveModel::Errors#generate_message` easier to read, this PR also makes it faster for several reasons:

* We don't eval `@base.class.respond_to?(:i18n_scope)` twice
* We only eval `@base.class.i18n_scope` once
* We don't call `flatten!` because it's not needed anymore
* We don't call `compact!` because all elements are Symbols

### Other Information

```ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  @base = User
  attribute = :email
  type = :invalid

  x.report('before') do
    if @base.class.respond_to?(:i18n_scope)
      defaults = @base.class.lookup_ancestors.map do |klass|
        [ :"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
          :"#{@base.class.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}" ]
      end
    else
      defaults = []
    end

    defaults << :"#{@base.class.i18n_scope}.errors.messages.#{type}" if @base.class.respond_to?(:i18n_scope)
    defaults << :"errors.attributes.#{attribute}.#{type}"
    defaults << :"errors.messages.#{type}"

    defaults.compact!
    defaults.flatten!
  end

  x.report('after') do
    if @base.class.respond_to?(:i18n_scope)
      i18n_scope = @base.class.i18n_scope
      defaults = @base.class.lookup_ancestors.flat_map do |klass|
        [ :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
          :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}" ]
      end
      defaults << :"#{i18n_scope}.errors.messages.#{type}"
    else
      defaults = []
    end

    defaults << :"errors.attributes.#{attribute}.#{type}"
    defaults << :"errors.messages.#{type}"
  end

  x.compare!
end
__END__
Warming up --------------------------------------
              before    25.251k i/100ms
               after    43.075k i/100ms
Calculating -------------------------------------
              before    276.045k (± 8.2%) i/s -      1.389M in   5.064302s
               after    507.466k (± 6.5%) i/s -      2.541M in   5.028634s

Comparison:
               after:   507465.6 i/s
              before:   276044.9 i/s - 1.84x  slower
```
