### PR TITLE
Change all OSX/OS X/Mac references to macOS

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -151,7 +151,7 @@ module ActiveRecord
     # When prompted, restart the PostgreSQL server with the
     # "-m fast" option or kill the individual connection assuming
     # you know the incantation to do that.
-    # To restart PostgreSQL 9.1 on OS X, installed via MacPorts, ...
+    # To restart PostgreSQL 9.1 on macOS, installed via MacPorts, ...
     # sudo su postgres -c "pg_ctl restart -D /opt/local/var/db/postgresql91/defaultdb/ -m fast"
     def test_reconnection_after_actual_disconnection_with_verify
       original_connection_pid = @connection.query("select pg_backend_pid()")

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -607,7 +607,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   # NOTE: this test seems to fail (changeset 1958) only on certain platforms,
-  # like OSX, and FreeBSD 5.4.
+  # like macOS, and FreeBSD 5.4.
   def test_fp_inaccuracy_ticket_1836
     midnight = Time.local(2005, 2, 21, 0, 0, 0)
     assert_equal midnight.midnight, (midnight + 1.hour + 0.000001).midnight

--- a/guides/assets/stylesheets/fixes.css
+++ b/guides/assets/stylesheets/fixes.css
@@ -1,5 +1,5 @@
 /*
-  Fix a rendering issue affecting WebKits on Mac.
+  Fix a rendering issue affecting WebKits on macOS.
   See https://github.com/lifo/docrails/issues#issue/16 for more information.
 */
 .syntaxhighlighter a,

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -633,9 +633,9 @@ $ cat config/database.yml
 #
 # Install the pg driver:
 #   gem install pg
-# On OS X with Homebrew:
+# On macOS with Homebrew:
 #   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On OS X with MacPorts:
+# On macOS with MacPorts:
 #   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
 # On Windows:
 #   gem install pg

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -726,7 +726,7 @@ The log files on www.attacker.com will read like this:
 GET http://www.attacker.com/_app_session=836c1c25278e5b321d6bea4f19cb57e2
 ```
 
-You can mitigate these attacks (in the obvious way) by adding the **httpOnly** flag to cookies, so that document.cookie may not be read by JavaScript. HTTP only cookies can be used from IE v6.SP1, Firefox v2.0.0.5, Opera 9.5, Safari 4 and Chrome 1.0.154 onwards. But other, older browsers (such as WebTV and IE 5.5 on Mac) can actually cause the page to fail to load. Be warned that cookies [will still be visible using Ajax](https://www.owasp.org/index.php/HTTPOnly#Browsers_Supporting_HttpOnly), though.
+You can mitigate these attacks (in the obvious way) by adding the **httpOnly** flag to cookies, so that document.cookie may not be read by JavaScript. HTTP only cookies can be used from IE v6.SP1, Firefox v2.0.0.5, Opera 9.5, Safari 4 and Chrome 1.0.154 onwards. But other, older browsers (such as WebTV and IE 5.5 on macOS) can actually cause the page to fail to load. Be warned that cookies [will still be visible using Ajax](https://www.owasp.org/index.php/HTTPOnly#Browsers_Supporting_HttpOnly), though.
 
 ##### Defacement
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -493,9 +493,9 @@ module Rails
           "/var/tmp/mysql.sock",                    # freebsd
           "/var/lib/mysql/mysql.sock",              # fedora
           "/opt/local/lib/mysql/mysql.sock",        # fedora
-          "/opt/local/var/run/mysqld/mysqld.sock",  # mac + darwinports + mysql
-          "/opt/local/var/run/mysql4/mysqld.sock",  # mac + darwinports + mysql4
-          "/opt/local/var/run/mysql5/mysqld.sock",  # mac + darwinports + mysql5
+          "/opt/local/var/run/mysqld/mysqld.sock",  # macOS + darwinports + mysql
+          "/opt/local/var/run/mysql4/mysqld.sock",  # macOS + darwinports + mysql4
+          "/opt/local/var/run/mysql5/mysqld.sock",  # macOS + darwinports + mysql5
           "/opt/lampp/var/mysql/mysql.sock"         # xampp for linux
         ].find { |f| File.exist?(f) } unless Gem.win_platform?
       end

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/ibm_db.yml
@@ -11,14 +11,14 @@
 #       export IBM_DB_LIB=/opt/ibm/db2/V9.7/lib32
 #       gem install ibm_db
 #
-#   On Mac OS X 10.5:
+#   On macOS 10.5:
 #       . /home/db2inst1/sqllib/db2profile
 #       export IBM_DB_INCLUDE=/opt/ibm/db2/V9.7/include
 #       export IBM_DB_LIB=/opt/ibm/db2/V9.7/lib32
 #       export ARCHFLAGS="-arch i386"
 #       gem install ibm_db
 #
-#   On Mac OS X 10.6:
+#   On macOS 10.6:
 #       . /home/db2inst1/sqllib/db2profile
 #       export IBM_DB_INCLUDE=/opt/ibm/db2/V9.7/include
 #       export IBM_DB_LIB=/opt/ibm/db2/V9.7/lib64

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
@@ -2,9 +2,9 @@
 #
 # Install the pg driver:
 #   gem install pg
-# On OS X with Homebrew:
+# On macOS with Homebrew:
 #   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On OS X with MacPorts:
+# On macOS with MacPorts:
 #   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
 # On Windows:
 #   gem install pg

--- a/railties/test/app_loader_test.rb
+++ b/railties/test/app_loader_test.rb
@@ -76,7 +76,7 @@ class AppLoaderTest < ActiveSupport::TestCase
 
         # Compare the realpath in case either of them has symlinks.
         #
-        # This happens in particular in Mac OS X, where @tmp starts
+        # This happens in particular on macOS, where @tmp starts
         # with "/var", and Dir.pwd with "/private/var", due to a
         # default system symlink var -> private/var.
         assert_equal File.realpath("#@tmp/foo"), File.realpath(Dir.pwd)


### PR DESCRIPTION
### Summary

Since Apple renamed the operating system, it makes sense for us to bring
our documentation and library code in line with that rename.

### Other Information

NOTE: I was going to directly commit the documentation changes to
master, and then PR the library code changes separately, but I figured
it was better for this change to happen together/all at once.