### PR TITLE
Use https in guide and comment [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -21,7 +21,7 @@ module ActionDispatch
         #                           This is the default value if the +CI+ environment variables
         #                           is defined.
         # * [+artifact+]            display the screenshot in the terminal, using the terminal
-        #                           artifact format (http://buildkite.github.io/terminal/inline-images/).
+        #                           artifact format (https://buildkite.github.io/terminal/inline-images/).
         def take_screenshot
           save_image
           puts display_image

--- a/actionview/test/ujs/public/vendor/qunit.js
+++ b/actionview/test/ujs/public/vendor/qunit.js
@@ -42,7 +42,7 @@ var QUnit,
 	 * with IE 7 (and prior) where Error.prototype.toString is
 	 * not properly implemented
 	 *
-	 * Based on http://es5.github.com/#x15.11.4.4
+	 * Based on https://es5.github.io/#x15.11.4.4
 	 *
 	 * @param {String|Error} error
 	 * @return {String} error message

--- a/activejob/lib/active_job/queue_adapters/async_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/async_adapter.rb
@@ -31,7 +31,7 @@ module ActiveJob
     # jobs. Since jobs share a single thread pool, long-running jobs will block
     # short-lived jobs. Fine for dev/test; bad for production.
     class AsyncAdapter
-      # See {Concurrent::ThreadPoolExecutor}[http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/ThreadPoolExecutor.html] for executor options.
+      # See {Concurrent::ThreadPoolExecutor}[https://ruby-concurrency.github.io/concurrent-ruby/Concurrent/ThreadPoolExecutor.html] for executor options.
       def initialize(**executor_options)
         @scheduler = Scheduler.new(**executor_options)
       end

--- a/guides/source/2_3_release_notes.md
+++ b/guides/source/2_3_release_notes.md
@@ -10,7 +10,7 @@ Rails 2.3 delivers a variety of new and improved features, including pervasive R
 Application Architecture
 ------------------------
 
-There are two major changes in the architecture of Rails applications: complete integration of the [Rack](http://rack.github.io/) modular web server interface, and renewed support for Rails Engines.
+There are two major changes in the architecture of Rails applications: complete integration of the [Rack](https://rack.github.io/) modular web server interface, and renewed support for Rails Engines.
 
 ### Rack Integration
 

--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -55,7 +55,7 @@ information.
 ### API Applications
 
 Rails can now be used to create slimmed down API only applications.
-This is useful for creating and serving APIs similar to [Twitter](https://dev.twitter.com) or [GitHub](http://developer.github.com) API, 
+This is useful for creating and serving APIs similar to [Twitter](https://dev.twitter.com) or [GitHub](https://developer.github.com) API, 
 that can be used to serve public facing, as well as, for custom applications.
 
 You can generate a new api Rails app using:
@@ -74,11 +74,11 @@ This will do three main things:
   Controller modules that provide functionalities primarily used by browser
   applications.
 - Configure the generators to skip generating views, helpers and assets when
-  you generate a new resource. 
+  you generate a new resource.
 
-The application provides a base for APIs, 
+The application provides a base for APIs,
 that can then be [configured to pull in functionality](api_app.html) as suitable for the application's needs.  
- 
+
 See the [Using Rails for API-only Applications](api_app.html) guide for more
 information.
 

--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -18,7 +18,7 @@ What is an API Application?
 
 Traditionally, when people said that they used Rails as an "API", they meant
 providing a programmatically accessible API alongside their web application.
-For example, GitHub provides [an API](http://developer.github.com) that you
+For example, GitHub provides [an API](https://developer.github.com) that you
 can use from your own custom clients.
 
 With the advent of client-side frameworks, more developers are using Rails to
@@ -94,7 +94,7 @@ Handled at the Action Pack layer:
   means not having to spend time thinking about how to model your API in terms
   of HTTP.
 - URL Generation: The flip side of routing is URL generation. A good API based
-  on HTTP includes URLs (see [the GitHub Gist API](http://developer.github.com/v3/gists/)
+  on HTTP includes URLs (see [the GitHub Gist API](https://developer.github.com/v3/gists/)
   for an example).
 - Header and Redirection Responses: `head :no_content` and
   `redirect_to user_url(current_user)` come in handy. Sure, you could manually

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -1069,7 +1069,7 @@ Customizing the Pipeline
 ### CSS Compression
 
 One of the options for compressing CSS is YUI. The [YUI CSS
-compressor](http://yui.github.io/yuicompressor/css.html) provides
+compressor](https://yui.github.io/yuicompressor/css.html) provides
 minification.
 
 The following line enables YUI compression, and requires the `yui-compressor`

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -164,7 +164,7 @@ NOTE: The instructions are for Rails > 4. The Redcarpet Gem doesn't work with JR
 Translation efforts we know about (various versions):
 
 * **Italian**: [https://github.com/rixlabs/docrails](https://github.com/rixlabs/docrails)
-* **Spanish**: [http://wiki.github.com/gramos/docrails](http://wiki.github.com/gramos/docrails)
+* **Spanish**: [https://wiki.github.com/gramos/docrails](https://wiki.github.com/gramos/docrails)
 * **Polish**: [https://github.com/apohllo/docrails/tree/master](https://github.com/apohllo/docrails/tree/master)
 * **French** : [https://github.com/railsfrance/docrails](https://github.com/railsfrance/docrails)
 * **Czech** : [https://github.com/rubyonrails-cz/docrails/tree/czech](https://github.com/rubyonrails-cz/docrails/tree/czech)
@@ -324,7 +324,7 @@ file.
 
 #### Testing Active Record
 
-First, create the databases you'll need. You can find a list of the required 
+First, create the databases you'll need. You can find a list of the required
 table names, usernames, and passwords in `activerecord/test/config.example.yml`.
 
 For MySQL and PostgreSQL, running the SQL statements `create database

--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -30,7 +30,7 @@ Ruby on Rails uses Git for source code control. The [Git homepage](https://git-s
 
 * [Try Git course](https://try.github.io/) is an interactive course that will teach you the basics.
 * The [official Documentation](https://git-scm.com/documentation) is pretty comprehensive and also contains some videos with the basics of Git.
-* [Everyday Git](http://schacon.github.io/git/everyday.html) will teach you just enough about Git to get by.
+* [Everyday Git](https://schacon.github.io/git/everyday.html) will teach you just enough about Git to get by.
 * [GitHub](https://help.github.com/) offers links to a variety of Git resources.
 * [Pro Git](https://git-scm.com/book) is an entire book about Git with a Creative Commons license.
 

--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -302,7 +302,7 @@ Resources
 
 ### Learning Rack
 
-* [Official Rack Website](http://rack.github.io)
+* [Official Rack Website](https://rack.github.io)
 * [Introducing Rack](http://chneukirchen.org/blog/archive/2007/02/introducing-rack.html)
 
 ### Understanding Middlewares

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1025,7 +1025,7 @@ Here is a list of common headers:
 * **X-Content-Type-Options:** _'nosniff' in Rails by default_ - stops the browser from guessing the MIME type of a file.
 * **X-Content-Security-Policy:** [A powerful mechanism for controlling which sites certain content types can be loaded from](http://w3c.github.io/webappsec/specs/content-security-policy/csp-specification.dev.html)
 * **Access-Control-Allow-Origin:** Used to control which sites are allowed to bypass same origin policies and send cross-origin requests.
-* **Strict-Transport-Security:** [Used to control if the browser is allowed to only access a site over a secure connection](http://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security)
+* **Strict-Transport-Security:** [Used to control if the browser is allowed to only access a site over a secure connection](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security)
 
 Environmental Security
 ----------------------
@@ -1060,7 +1060,7 @@ Additional Resources
 
 The security landscape shifts and it is important to keep up to date, because missing a new vulnerability can be catastrophic. You can find additional resources about (Rails) security here:
 
-* Subscribe to the Rails security [mailing list](http://groups.google.com/group/rubyonrails-security).
-* [Brakeman - Rails Security Scanner](http://brakemanscanner.org/) - To perform static security analysis for Rails applications.
+* Subscribe to the Rails security [mailing list](https://groups.google.com/forum/#!forum/rubyonrails-security).
+* [Brakeman - Rails Security Scanner](https://brakemanscanner.org/) - To perform static security analysis for Rails applications.
 * [Keep up to date on the other application layers](http://secunia.com/) (they have a weekly newsletter, too).
 * A [good security blog](https://www.owasp.org) including the [Cross-Site scripting Cheat Sheet](https://www.owasp.org/index.php/DOM_based_XSS_Prevention_Cheat_Sheet).


### PR DESCRIPTION
### Summary

- Replaced `http` with `https` (I checked all replaced url with web browser)
- Fixed Rail Security's url:
    - before `http://groups.google.com/group/rubyonrails-security`
    - after `https://groups.google.com/forum/#!forum/rubyonrails-security`