### PR TITLE
Make test runner work with AR test tool

### DIFF
--- a/activerecord/bin/test
+++ b/activerecord/bin/test
@@ -1,6 +1,12 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+adapter_index = ARGV.index("--adapter") || ARGV.index("-a")
+if adapter_index
+  ARGV.delete_at(adapter_index)
+  ENV["ARCONN"] = ARGV.delete_at(adapter_index).strip
+end
+
 COMPONENT_ROOT = File.expand_path("..", __dir__)
 require_relative "../../tools/test"
 
@@ -17,4 +23,5 @@ module Minitest
   end
 end
 
+Minitest.load_plugins
 Minitest.extensions.unshift "active_record"


### PR DESCRIPTION
Since #29572, test runner will be loaded as minitest's plugin.
Therefore, if specify a value in `Minitest.extensions` before the Minitest initialization process, the extension will not load and the test runner will not work.
https://github.com/seattlerb/minitest/blob/44eee51ed9716c789c7cea8a90c131cf736b8915/lib/minitest.rb#L86

**before**

![before](https://user-images.githubusercontent.com/987638/29481433-35b7f3fe-84bc-11e7-8ab3-5cf38a327fda.png)

**after**

![after](https://user-images.githubusercontent.com/987638/29481435-35e40b4c-84bc-11e7-9258-53a464f05814.png)
