### PR TITLE
Fix typo in "Ambiguous route definition" error message

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1851,7 +1851,7 @@ module ActionDispatch
             path_types.fetch(String, []).each do |_path|
               route_options = options.dup
               if _path && option_path
-                raise ArgumentError, "Ambiguous route definition. Both :path and the route path where specified as strings."
+                raise ArgumentError, "Ambiguous route definition. Both :path and the route path were specified as strings."
               end
               to = get_to_from_path(_path, to, route_options[:action])
               decomposed_match(_path, controller, route_options, _path, to, via, formatted, anchor, options_constraints)


### PR DESCRIPTION
This PR fixes a typo in the "Ambiguous route definition" error message for ActionDispatch. Partly addresses issue brought up in #30321.