### PR TITLE
Support multiple versions arguments for `gem` method of Generators

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support multiple versions arguments for `gem` method of Generators.
+
+    *Yoshiyuki Hirano*
+
 *   Add `--skip-yarn` option to the plugin generator.
 
     *bogdanvlviv*

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -13,17 +13,22 @@ module Rails
       #
       #   gem "rspec", group: :test
       #   gem "technoweenie-restful-authentication", lib: "restful-authentication", source: "http://gems.github.com/"
-      #   gem "rails", "3.0", git: "git://github.com/rails/rails"
+      #   gem "rails", "3.0", git: "https://github.com/rails/rails"
+      #   gem "RedCloth", ">= 4.1.0", "< 4.2.0"
       def gem(*args)
         options = args.extract_options!
-        name, version = args
+        name, *versions = args
 
         # Set the message to be shown in logs. Uses the git repo if one is given,
         # otherwise use name (version).
         parts, message = [ quote(name) ], name.dup
-        if version ||= options.delete(:version)
-          parts   << quote(version)
-          message << " (#{version})"
+
+        if versions = versions.any? ? versions : options.delete(:version)
+          _versions = Array(versions)
+          _versions.each do |version|
+            parts << quote(version)
+          end
+          message << " (#{_versions.join(", ")})"
         end
         message = options[:git] if options[:git]
 

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -71,10 +71,17 @@ class ActionsTest < Rails::Generators::TestCase
 
   def test_gem_with_version_should_include_version_in_gemfile
     run_generator
+    action :gem, "rspec", ">= 2.0.0.a5"
+    action :gem, "RedCloth", ">= 4.1.0", "< 4.2.0"
+    action :gem, "nokogiri", version: ">= 1.4.2"
+    action :gem, "faker", version: [">= 0.1.0", "< 0.3.0"]
 
-    action :gem, "rspec", ">=2.0.0.a5"
-
-    assert_file "Gemfile", /gem 'rspec', '>=2.0.0.a5'/
+    assert_file "Gemfile" do |content|
+      assert_match(/gem 'rspec', '>= 2\.0\.0\.a5'/, content)
+      assert_match(/gem 'RedCloth', '>= 4\.1\.0', '< 4\.2\.0'/, content)
+      assert_match(/gem 'nokogiri', '>= 1\.4\.2'/, content)
+      assert_match(/gem 'faker', '>= 0\.1\.0', '< 0\.3\.0'/, content)
+    end
   end
 
   def test_gem_should_insert_on_separate_lines


### PR DESCRIPTION
### Summary

It seems that `gem` method is supported only single version.
So I've modified it, and added test cases.