### PR TITLE
Fix `can't modify frozen String` error in an AR test

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -288,11 +288,11 @@ module ActiveRecord
       def test_log_invalid_encoding
         error = assert_raises RuntimeError do
           @connection.send :log, "SELECT 'ы' FROM DUAL" do
-            raise "ы".force_encoding(Encoding::ASCII_8BIT)
+            raise "ы".dup.force_encoding(Encoding::ASCII_8BIT)
           end
         end
 
-        assert_not_nil error.message
+        assert_equal "ы", error.message
       end
     end
   end


### PR DESCRIPTION
### Summary

Follow up of rails/rails#29732.

This `test_log_invalid_encoding` test was returning `can't modify frozen String` error, not the expected error message.

The following is result of adding the assertion `assert_equal "ы", error.message` to `test_log_invalid_encoding` test.

```console
% be ruby -w -Itest test/cases/adapter_test.rb -n test_log_invalid_encoding
Using sqlite3
Run options: -n test_log_invalid_encoding --seed 3397

# Running:

F

Failure:
ActiveRecord::AdapterTest#test_log_invalid_encoding [test/cases/adapter_test.rb:295]:
--- expected
+++ actual
@@ -1 +1,2 @@
-"ы"
+# encoding: ASCII-8BIT
+"can't modify frozen String"

bin/rails test test/cases/adapter_test.rb:288

.........

Finished in 0.167510s, 173.1241 runs/s, 513.4025 assertions/s.
29 runs, 86 assertions, 1 failures, 0 errors, 0 skips
```

This PR fixes `can't modify frozen String` error using `String#dup`. Also change to the assertion to be compared with the expected error message.