### PR TITLE
Update guide section styles [ci skip]

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -34,7 +34,8 @@ information (publishers), send data to an abstract class of recipients
 (subscribers), without specifying individual recipients. Action Cable uses this
 approach to communicate between the server and many clients.
 
-## Server-Side Components
+Server-Side Components
+----------------------
 
 ### Connections
 
@@ -135,7 +136,8 @@ class ChatChannel < ApplicationCable::Channel
 end
 ```
 
-## Client-Side Components
+Client-Side Components
+----------------------
 
 ### Connections
 
@@ -184,7 +186,8 @@ App.cable.subscriptions.create { channel: "ChatChannel", room: "1st Room" }
 App.cable.subscriptions.create { channel: "ChatChannel", room: "2nd Room" }
 ```
 
-## Client-Server Interactions
+Client-Server Interactions
+--------------------------
 
 ### Streams
 
@@ -351,7 +354,8 @@ The rebroadcast will be received by all connected clients, _including_ the
 client that sent the message. Note that params are the same as they were when
 you subscribed to the channel.
 
-## Full-Stack Examples
+Full-Stack Examples
+-------------------
 
 The following setup steps are common to both examples:
 
@@ -523,7 +527,8 @@ and unpacked for the data argument arriving to `received`.
 See the [rails/actioncable-examples](https://github.com/rails/actioncable-examples)
 repository for a full example of how to setup Action Cable in a Rails app and adding channels.
 
-## Configuration
+Configuration
+-------------
 
 Action Cable has two required configurations: a subscription adapter and allowed request origins.
 
@@ -545,6 +550,7 @@ production:
   url: redis://10.10.3.153:6381
   channel_prefix: appname_production
 ```
+
 #### Adapter Configuration
 
 Below is a list of the subscription adapters available for end users.
@@ -613,7 +619,8 @@ connections as you have workers. The default worker pool size is set to 4, so
 that means you have to make at least that available. You can change that in
 `config/database.yml` through the `pool` attribute.
 
-## Running Standalone Cable Servers
+Running Standalone Cable Servers
+--------------------------------
 
 ### In App
 
@@ -666,7 +673,8 @@ The WebSocket server doesn't have access to the session, but it has
 access to the cookies. This can be used when you need to handle
 authentication. You can see one way of doing that with Devise in this [article](http://www.rubytutorial.io/actioncable-devise-authentication).
 
-## Dependencies
+Dependencies
+------------
 
 Action Cable provides a subscription adapter interface to process its
 pubsub internals. By default, asynchronous, inline, PostgreSQL, evented
@@ -676,7 +684,8 @@ in new Rails applications is the asynchronous (`async`) adapter.
 The Ruby side of things is built on top of [websocket-driver](https://github.com/faye/websocket-driver-ruby),
 [nio4r](https://github.com/celluloid/nio4r), and [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby).
 
-## Deployment
+Deployment
+----------
 
 Action Cable is powered by a combination of WebSockets and threads. Both the
 framework plumbing and user-specified channel work are handled internally by

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1424,7 +1424,8 @@ Rails code can often be referenced on load of an application. Rails is responsib
 
 On Load hooks are the API that allow you to hook into this initialization process without violating the load contract with Rails. This will also mitigate boot performance degradation and avoid conflicts.
 
-## What are `on_load` hooks?
+What are `on_load` hooks?
+-------------------------
 
 Since Ruby is a dynamic language, some code will cause different Rails frameworks to load. Take this snippet for instance:
 
@@ -1442,11 +1443,13 @@ ActiveSupport.on_load(:active_record) { include MyActiveRecordHelper }
 
 This new snippet will only include `MyActiveRecordHelper` when `ActiveRecord::Base` is loaded.
 
-## How does it work?
+How does it work?
+-----------------
 
 In the Rails framework these hooks are called when a specific library is loaded. For example, when `ActionController::Base` is loaded, the `:action_controller_base` hook is called. This means that all `ActiveSupport.on_load` calls with `:action_controller_base` hooks will be called in the context of `ActionController::Base` (that means `self` will be an `ActionController::Base`).
 
-## Modifying code to use `on_load` hooks
+Modifying code to use `on_load` hooks
+-------------------------------------
 
 Modifying code is generally straightforward. If you have a line of code that refers to a Rails framework such as `ActiveRecord::Base` you can wrap that code in an `on_load` hook.
 
@@ -1486,7 +1489,8 @@ becomes
 ActiveSupport.on_load(:active_record) { self.include_root_in_json = true } # self refers to ActiveRecord::Base here
 ```
 
-## Available Hooks
+Available Hooks
+---------------
 
 These are the hooks you can use in your own code.
 
@@ -1511,7 +1515,8 @@ To hook into the initialization process of one of the following classes use the 
 | `ActiveSupport::TestCase`         | `active_support_test_case`           |
 | `i18n`                            | `i18n`                               |
 
-## Configuration hooks
+Configuration hooks
+-------------------
 
 These are the available configuration hooks. They do not hook into any particular framework, instead they run in context of the entire application.
 


### PR DESCRIPTION
### Summary

It seems that it would be better that unify [same heading section style](http://guides.rubyonrails.org/ruby_on_rails_guides_guidelines.html#headings) in guide. So I've unified it.