### PR TITLE
Use `String#delete` instead of `String#gsub`

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -80,7 +80,7 @@ module ActionDispatch
           end
 
           def inline_base64(path)
-            Base64.encode64(path).gsub("\n", "")
+            Base64.encode64(path).delete("\n")
           end
 
           def failed?


### PR DESCRIPTION
### Summary

I think that `String#delete` is better that arguments are less than `String#gsub`. And its meaning of code are more readable than before. So I've refactored it.