### PR TITLE
Make `restart` and `dev:cache` tasks work when customizing pid file path

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -126,6 +126,7 @@ module Rails
         desc: "Specifies the PID file."
       class_option "dev-caching", aliases: "-C", type: :boolean, default: nil,
         desc: "Specifies whether to perform caching in development."
+      class_option "restart", type: :boolean, default: nil, hide: true
 
       def initialize(args = [], local_options = {}, config = {})
         @original_options = local_options
@@ -136,6 +137,7 @@ module Rails
 
       def perform
         set_application_directory!
+        prepare_restart
         Rails::Server.new(server_options).tap do |server|
           # Require application after server sets environment to propagate
           # the --environment option.
@@ -222,7 +224,7 @@ module Rails
         end
 
         def restart_command
-          "bin/rails server #{@server} #{@original_options.join(" ")}"
+          "bin/rails server #{@server} #{@original_options.join(" ")} --restart"
         end
 
         def pid
@@ -231,6 +233,10 @@ module Rails
 
         def self.banner(*)
           "rails server [puma, thin etc] [options]"
+        end
+
+        def prepare_restart
+          FileUtils.rm_f(options[:pid]) if options[:restart]
         end
     end
   end

--- a/railties/lib/rails/dev_caching.rb
+++ b/railties/lib/rails/dev_caching.rb
@@ -19,7 +19,6 @@ module Rails
         end
 
         FileUtils.touch "tmp/restart.txt"
-        FileUtils.rm_f("tmp/pids/server.pid")
       end
 
       def enable_by_argument(caching)

--- a/railties/lib/rails/tasks/restart.rake
+++ b/railties/lib/rails/tasks/restart.rake
@@ -5,6 +5,5 @@ task :restart do
   verbose(false) do
     mkdir_p "tmp"
     touch "tmp/restart.txt"
-    rm_f "tmp/pids/server.pid"
   end
 end

--- a/railties/test/application/rake/dev_test.rb
+++ b/railties/test/application/rake/dev_test.rb
@@ -32,12 +32,16 @@ module ApplicationTests
         end
       end
 
-      test "dev:cache removes server.pid also" do
+      test "dev:cache touches tmp/restart.txt" do
         Dir.chdir(app_path) do
-          FileUtils.mkdir_p("tmp/pids")
-          FileUtils.touch("tmp/pids/server.pid")
           `rails dev:cache`
-          assert_not File.exist?("tmp/pids/server.pid")
+          assert File.exist?("tmp/restart.txt")
+
+          prev_mtime = File.mtime("tmp/restart.txt")
+          sleep(1)
+          `rails dev:cache`
+          curr_mtime = File.mtime("tmp/restart.txt")
+          assert_not_equal prev_mtime, curr_mtime
         end
       end
     end

--- a/railties/test/application/rake/restart_test.rb
+++ b/railties/test/application/rake/restart_test.rb
@@ -35,15 +35,6 @@ module ApplicationTests
           assert File.exist?("tmp/restart.txt")
         end
       end
-
-      test "rails restart removes server.pid also" do
-        Dir.chdir(app_path) do
-          FileUtils.mkdir_p("tmp/pids")
-          FileUtils.touch("tmp/pids/server.pid")
-          `bin/rails restart`
-          assert_not File.exist?("tmp/pids/server.pid")
-        end
-      end
     end
   end
 end

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -190,7 +190,7 @@ class Rails::ServerTest < ActiveSupport::TestCase
     ARGV.replace args
 
     options = parse_arguments(args)
-    expected = "bin/rails server  -p 4567 -b 127.0.0.1 -c dummy_config.ru -d -e test -P tmp/server.pid -C"
+    expected = "bin/rails server  -p 4567 -b 127.0.0.1 -c dummy_config.ru -d -e test -P tmp/server.pid -C --restart"
 
     assert_equal expected, options[:restart_cmd]
   ensure


### PR DESCRIPTION
Originally, it hard-coded pid file path. It can not be removed when customizing pid file path.
But rake task can not get pid file path. Therefore, do not remove file in rake task, only file that tell them that restart is in progress are created, and pid file remove in server command.

Fixes #29306
