### PR TITLE
Update Autoloading and Reloading Constants guide [ci skip]

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -475,12 +475,21 @@ it is (edited):
 ```
 $ bin/rails r 'puts ActiveSupport::Dependencies.autoload_paths'
 .../app/assets
+.../app/channels
 .../app/controllers
+.../app/controllers/concerns
 .../app/helpers
+.../app/jobs
 .../app/mailers
 .../app/models
-.../app/controllers/concerns
 .../app/models/concerns
+.../activestorage/app/assets
+.../activestorage/app/controllers
+.../activestorage/app/javascript
+.../activestorage/app/jobs
+.../activestorage/app/models
+.../actioncable/app/assets
+.../actionview/app/assets
 .../test/mailers/previews
 ```
 


### PR DESCRIPTION
### Summary

It seems result of `ActiveSupport::Dependencies.autoload_paths` is old. So I've updated it.

This is actual logs:

```bash
$ bundle exec rails r 'puts ActiveSupport::Dependencies.autoload_paths'
/Users/yhirano/my_app/app/assets
/Users/yhirano/my_app/app/channels
/Users/yhirano/my_app/app/controllers
/Users/yhirano/my_app/app/controllers/concerns
/Users/yhirano/my_app/app/helpers
/Users/yhirano/my_app/app/jobs
/Users/yhirano/my_app/app/mailers
/Users/yhirano/my_app/app/models
/Users/yhirano/my_app/app/models/concerns
/Users/yhirano/my_app/vendor/bundle/bundler/gems/rails-332049d1161b/activestorage/app/assets
/Users/yhirano/my_app/vendor/bundle/bundler/gems/rails-332049d1161b/activestorage/app/controllers
/Users/yhirano/my_app/vendor/bundle/bundler/gems/rails-332049d1161b/activestorage/app/javascript
/Users/yhirano/my_app/vendor/bundle/bundler/gems/rails-332049d1161b/activestorage/app/jobs
/Users/yhirano/my_app/vendor/bundle/bundler/gems/rails-332049d1161b/activestorage/app/models
/Users/yhirano/my_app/vendor/bundle/bundler/gems/rails-332049d1161b/actioncable/app/assets
/Users/yhirano/my_app/vendor/bundle/bundler/gems/rails-332049d1161b/actionview/app/assets
/Users/yhirano/my_app/test/mailers/previews
```