### PR TITLE
Apply frozen_string_literal magic comment to template files

### DIFF
--- a/actioncable/lib/rails/generators/channel/templates/application_cable/channel.rb
+++ b/actioncable/lib/rails/generators/channel/templates/application_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/actioncable/lib/rails/generators/channel/templates/application_cable/connection.rb
+++ b/actioncable/lib/rails/generators/channel/templates/application_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/actioncable/lib/rails/generators/channel/templates/channel.rb
+++ b/actioncable/lib/rails/generators/channel/templates/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing do -%>
 class <%= class_name %>Channel < ApplicationCable::Channel
   def subscribed

--- a/actionmailer/lib/rails/generators/mailer/templates/application_mailer.rb
+++ b/actionmailer/lib/rails/generators/mailer/templates/application_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing do -%>
 class ApplicationMailer < ActionMailer::Base
   default from: 'from@example.com'

--- a/actionmailer/lib/rails/generators/mailer/templates/mailer.rb
+++ b/actionmailer/lib/rails/generators/mailer/templates/mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing do -%>
 class <%= class_name %>Mailer < ApplicationMailer
 <% actions.each do |action| -%>

--- a/activerecord/lib/rails/generators/active_record/application_record/templates/application_record.rb
+++ b/activerecord/lib/rails/generators/active_record/application_record/templates/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing do -%>
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true

--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     create_table :<%= table_name %><%= primary_key_type %> do |t|

--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
 <%- if migration_action == 'add' -%>
   def change

--- a/activerecord/lib/rails/generators/active_record/model/templates/model.rb
+++ b/activerecord/lib/rails/generators/active_record/model/templates/model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing do -%>
 class <%= class_name %> < <%= parent_class_name.classify %>
 <% attributes.select(&:reference?).each do |attribute| -%>

--- a/activerecord/lib/rails/generators/active_record/model/templates/module.rb
+++ b/activerecord/lib/rails/generators/active_record/model/templates/module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing do -%>
 module <%= class_path.map(&:camelize).join('::') %>
   def self.table_name_prefix

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 

--- a/railties/lib/rails/generators/rails/app/templates/config.ru
+++ b/railties/lib/rails/generators/rails/app/templates/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_5_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_5_2.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 #
 # This file contains migration options to ease your Rails 5.2 upgrade.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/wrap_parameters.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/wrap_parameters.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/railties/lib/rails/generators/rails/app/templates/db/seeds.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/db/seeds.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
 #

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -380,6 +380,8 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     run_generator ["account", "supplier:references{required}"]
 
     expected_file = <<-FILE.strip_heredoc
+    # frozen_string_literal: true
+
     class Account < ApplicationRecord
       belongs_to :supplier, required: true
     end
@@ -391,6 +393,8 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     run_generator ["account", "supplier:references{required,polymorphic}"]
 
     expected_file = <<-FILE.strip_heredoc
+    # frozen_string_literal: true
+
     class Account < ApplicationRecord
       belongs_to :supplier, polymorphic: true, required: true
     end
@@ -402,6 +406,8 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     run_generator ["account", "supplier:references{polymorphic.required}"]
 
     expected_file = <<-FILE.strip_heredoc
+    # frozen_string_literal: true
+
     class Account < ApplicationRecord
       belongs_to :supplier, polymorphic: true, required: true
     end
@@ -453,6 +459,8 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   def test_token_option_adds_has_secure_token
     run_generator ["user", "token:token", "auth_token:token"]
     expected_file = <<-FILE.strip_heredoc
+    # frozen_string_literal: true
+
     class User < ApplicationRecord
       has_secure_token
       has_secure_token :auth_token


### PR DESCRIPTION
### Summary

This PR applies `frozen_string_literal` magic comment to a template files that missing `frozen_string_literal` magic comment in the Ruby files generated using generator.

This aims to unify that `frozen_string_literal` magic comment is used for the generated code.

Related PR #29655.