### PR TITLE
Fix broken link to mysql docs in database.yml [ci skip]

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml
@@ -7,7 +7,7 @@
 # gem 'activerecord-jdbcmysql-adapter'
 #
 # And be sure to use new-style password hashing:
-#   http://dev.mysql.com/doc/refman/5.7/en/old-client.html
+#   https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html
 #
 default: &default
   adapter: mysql

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml
@@ -7,7 +7,7 @@
 #   gem 'mysql2'
 #
 # And be sure to use new-style password hashing:
-#   http://dev.mysql.com/doc/refman/5.7/en/old-client.html
+#   https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html
 #
 default: &default
   adapter: mysql2


### PR DESCRIPTION
### Summary

* A link which navigates to mysql 5.7 docs is broken:
    * If `http://dev.mysql.com/doc/refman/5.7/en/old-client.html` is clicked, then it redirect to the page of [common errors index](https://dev.mysql.com/doc/refman/5.6/en/old-client.html).
    * Perhaps, this is expected that navigates to the page like [this](https://dev.mysql.com/doc/refman/5.6/en/old-client.html) (v5.6).
* I've fixed a link to mysql docs. It navigates to [password-hasing.html](https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html) that describes password hashing.

This request is not for guide, but changes are for comment. So I've added `[ci skip]` to the commit message.