### PR TITLE
Update MIT licenses link [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,4 @@ Everyone interacting in Rails and its sub-projects' codebases, issue trackers, c
 
 ## License
 
-Ruby on Rails is released under the [MIT License](http://www.opensource.org/licenses/MIT).
+Ruby on Rails is released under the [MIT License](https://opensource.org/licenses/MIT).

--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -549,7 +549,7 @@ Source code can be downloaded as part of the Rails project on GitHub
 
 Action Cable is released under the MIT license:
 
-* http://www.opensource.org/licenses/MIT
+* https://opensource.org/licenses/MIT
 
 
 ## Support

--- a/actionmailer/README.rdoc
+++ b/actionmailer/README.rdoc
@@ -157,7 +157,7 @@ Source code can be downloaded as part of the Rails project on GitHub
 
 Action Mailer is released under the MIT license:
 
-* http://www.opensource.org/licenses/MIT
+* https://opensource.org/licenses/MIT
 
 
 == Support

--- a/actionpack/README.rdoc
+++ b/actionpack/README.rdoc
@@ -39,7 +39,7 @@ Source code can be downloaded as part of the Rails project on GitHub
 
 Action Pack is released under the MIT license:
 
-* http://www.opensource.org/licenses/MIT
+* https://opensource.org/licenses/MIT
 
 
 == Support

--- a/actionview/README.rdoc
+++ b/actionview/README.rdoc
@@ -20,7 +20,7 @@ Source code can be downloaded as part of the Rails project on GitHub
 
 Action View is released under the MIT license:
 
-* http://www.opensource.org/licenses/MIT
+* https://opensource.org/licenses/MIT
 
 
 == Support

--- a/activejob/README.md
+++ b/activejob/README.md
@@ -108,7 +108,7 @@ Source code can be downloaded as part of the Rails project on GitHub
 
 Active Job is released under the MIT license:
 
-* http://www.opensource.org/licenses/MIT
+* https://opensource.org/licenses/MIT
 
 
 ## Support

--- a/activemodel/README.rdoc
+++ b/activemodel/README.rdoc
@@ -246,7 +246,7 @@ Source code can be downloaded as part of the Rails project on GitHub
 
 Active Model is released under the MIT license:
 
-* http://www.opensource.org/licenses/MIT
+* https://opensource.org/licenses/MIT
 
 
 == Support

--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -162,7 +162,7 @@ This would also define the following accessors: <tt>Product#name</tt> and
 == Philosophy
 
 Active Record is an implementation of the object-relational mapping (ORM)
-pattern[http://www.martinfowler.com/eaaCatalog/activeRecord.html] by the same
+pattern[https://www.martinfowler.com/eaaCatalog/activeRecord.html] by the same
 name described by Martin Fowler:
 
   "An object that wraps a row in a database table or view,
@@ -199,7 +199,7 @@ Source code can be downloaded as part of the Rails project on GitHub:
 
 Active Record is released under the MIT license:
 
-* http://www.opensource.org/licenses/MIT
+* https://opensource.org/licenses/MIT
 
 
 == Support

--- a/activesupport/README.rdoc
+++ b/activesupport/README.rdoc
@@ -21,7 +21,7 @@ Source code can be downloaded as part of the Rails project on GitHub:
 
 Active Support is released under the MIT license:
 
-* http://www.opensource.org/licenses/MIT
+* https://opensource.org/licenses/MIT
 
 
 == Support

--- a/railties/RDOC_MAIN.rdoc
+++ b/railties/RDOC_MAIN.rdoc
@@ -1,7 +1,7 @@
 == Welcome to \Rails
 
 \Rails is a web-application framework that includes everything needed to create
-database-backed web applications according to the {Model-View-Controller (MVC)}[http://en.wikipedia.org/wiki/Model-view-controller] pattern.
+database-backed web applications according to the {Model-View-Controller (MVC)}[https://en.wikipedia.org/wiki/Model-view-controller] pattern.
 
 Understanding the MVC pattern is key to understanding \Rails. MVC divides your application
 into three layers, each with a specific responsibility.
@@ -70,4 +70,4 @@ to proceed. {Join us}[http://contributors.rubyonrails.org]!
 
 == License
 
-Ruby on \Rails is released under the {MIT License}[http://www.opensource.org/licenses/MIT].
+Ruby on \Rails is released under the {MIT License}[https://opensource.org/licenses/MIT].

--- a/railties/README.rdoc
+++ b/railties/README.rdoc
@@ -23,7 +23,7 @@ Source code can be downloaded as part of the Rails project on GitHub
 
 Railties is released under the MIT license:
 
-* http://www.opensource.org/licenses/MIT
+* https://opensource.org/licenses/MIT
 
 == Support
 
@@ -38,4 +38,3 @@ Bug reports can be filed for the Ruby on Rails project here:
 Feature requests should be discussed on the rails-core mailing list here:
 
 * https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core
-

--- a/railties/lib/rails/generators/rails/plugin/templates/README.md
+++ b/railties/lib/rails/generators/rails/plugin/templates/README.md
@@ -25,4 +25,4 @@ $ gem install <%= name %>
 Contribution directions go here.
 
 ## License
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
### Summary

It looks links for MIT licenses are old (302 Url). I've fixed it.