### PR TITLE
[actionpack] Update links to use https link instead of http [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -228,7 +228,7 @@ module ActionController
     #   expires_in 3.hours, public: true, must_revalidate: true
     #
     # This method will overwrite an existing Cache-Control header.
-    # See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html for more possibilities.
+    # See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html for more possibilities.
     #
     # The method will also ensure an HTTP Date header for client compatibility.
     def expires_in(seconds, options = {})

--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -56,14 +56,14 @@ module ActionController #:nodoc:
       #
       # Read about the other Content-* HTTP headers if you'd like to
       # provide the user with more information (such as Content-Description) in
-      # http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11.
+      # https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11.
       #
       # Also be aware that the document may be cached by proxies and browsers.
       # The Pragma and Cache-Control headers declare how the file may be cached
       # by intermediaries. They default to require clients to validate with
       # the server before releasing cached responses. See
-      # http://www.mnot.net/cache_docs/ for an overview of web caching and
-      # http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
+      # https://www.mnot.net/cache_docs/ for an overview of web caching and
+      # https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
       # for the Cache-Control header spec.
       def send_file(path, options = {}) #:doc:
         raise MissingFile, "Cannot read file #{path}" unless File.file?(path) && File.readable?(path)

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -31,7 +31,7 @@ module ActionController
     #   redirect_to post_url(@post), status: 301
     #   redirect_to action: 'atom', status: 302
     #
-    # The status code can either be a standard {HTTP Status code}[http://www.iana.org/assignments/http-status-codes] as an
+    # The status code can either be a standard {HTTP Status code}[https://www.iana.org/assignments/http-status-codes] as an
     # integer, or a symbol representing the downcased, underscored and symbolized description.
     # Note that the status code must be a 3xx HTTP code, or redirection will not occur.
     #
@@ -95,7 +95,7 @@ module ActionController
       # The scheme name consist of a letter followed by any combination of
       # letters, digits, and the plus ("+"), period ("."), or hyphen ("-")
       # characters; and is terminated by a colon (":").
-      # See http://tools.ietf.org/html/rfc3986#section-3.1
+      # See https://tools.ietf.org/html/rfc3986#section-3.1
       # The protocol relative scheme starts with a double slash "//".
       when /\A([a-z][a-z\d\-+\.]*:|\/\/).*/i
         options

--- a/actionpack/lib/action_dispatch/http/mime_types.rb
+++ b/actionpack/lib/action_dispatch/http/mime_types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Build list of Mime types for HTTP responses
-# http://www.iana.org/assignments/media-types/
+# https://www.iana.org/assignments/media-types/
 
 Mime::Type.register "text/html", :html, %w( application/xhtml+xml ), %w( xhtml )
 Mime::Type.register "text/plain", :text, [], %w(txt)
@@ -28,7 +28,7 @@ Mime::Type.register "application/x-yaml", :yaml, %w( text/yaml ), %w(yml yaml)
 Mime::Type.register "multipart/form-data", :multipart_form
 Mime::Type.register "application/x-www-form-urlencoded", :url_encoded_form
 
-# http://www.ietf.org/rfc/rfc4627.txt
+# https://www.ietf.org/rfc/rfc4627.txt
 # http://www.json.org/JSONRequest.html
 Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest )
 

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -98,14 +98,14 @@ module ActionDispatch
     end
 
     # List of HTTP request methods from the following RFCs:
-    # Hypertext Transfer Protocol -- HTTP/1.1 (http://www.ietf.org/rfc/rfc2616.txt)
-    # HTTP Extensions for Distributed Authoring -- WEBDAV (http://www.ietf.org/rfc/rfc2518.txt)
-    # Versioning Extensions to WebDAV (http://www.ietf.org/rfc/rfc3253.txt)
-    # Ordered Collections Protocol (WebDAV) (http://www.ietf.org/rfc/rfc3648.txt)
-    # Web Distributed Authoring and Versioning (WebDAV) Access Control Protocol (http://www.ietf.org/rfc/rfc3744.txt)
-    # Web Distributed Authoring and Versioning (WebDAV) SEARCH (http://www.ietf.org/rfc/rfc5323.txt)
-    # Calendar Extensions to WebDAV (http://www.ietf.org/rfc/rfc4791.txt)
-    # PATCH Method for HTTP (http://www.ietf.org/rfc/rfc5789.txt)
+    # Hypertext Transfer Protocol -- HTTP/1.1 (https://www.ietf.org/rfc/rfc2616.txt)
+    # HTTP Extensions for Distributed Authoring -- WEBDAV (https://www.ietf.org/rfc/rfc2518.txt)
+    # Versioning Extensions to WebDAV (https://www.ietf.org/rfc/rfc3253.txt)
+    # Ordered Collections Protocol (WebDAV) (https://www.ietf.org/rfc/rfc3648.txt)
+    # Web Distributed Authoring and Versioning (WebDAV) Access Control Protocol (https://www.ietf.org/rfc/rfc3744.txt)
+    # Web Distributed Authoring and Versioning (WebDAV) SEARCH (https://www.ietf.org/rfc/rfc5323.txt)
+    # Calendar Extensions to WebDAV (https://www.ietf.org/rfc/rfc4791.txt)
+    # PATCH Method for HTTP (https://www.ietf.org/rfc/rfc5789.txt)
     RFC2616 = %w(OPTIONS GET HEAD POST PUT DELETE TRACE CONNECT)
     RFC2518 = %w(PROPFIND PROPPATCH MKCOL COPY MOVE LOCK UNLOCK)
     RFC3253 = %w(VERSION-CONTROL REPORT CHECKOUT CHECKIN UNCHECKOUT MKWORKSPACE UPDATE LABEL MERGE BASELINE-CONTROL MKACTIVITY)

--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -27,7 +27,7 @@ module ActionDispatch
         end
 
         # URI path and fragment escaping
-        # http://tools.ietf.org/html/rfc3986
+        # https://tools.ietf.org/html/rfc3986
         class UriEncoder # :nodoc:
           ENCODE   = "%%%02X".freeze
           US_ASCII = Encoding::US_ASCII

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -12,7 +12,7 @@ module ActionDispatch
   # by @gingerlime. A more detailed explanation of the algorithm is given
   # at GetIp#calculate_ip.
   #
-  # Some Rack servers concatenate repeated headers, like {HTTP RFC 2616}[http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2]
+  # Some Rack servers concatenate repeated headers, like {HTTP RFC 2616}[https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2]
   # requires. Some Rack servers simply drop preceding headers, and only report
   # the value that was {given in the last header}[http://andre.arko.net/2011/12/26/repeated-headers-and-ruby-web-servers].
   # If you are behind multiple proxy servers (like NGINX to HAProxy to Unicorn)
@@ -31,7 +31,7 @@ module ActionDispatch
     # The default trusted IPs list simply includes IP addresses that are
     # guaranteed by the IP specification to be private addresses. Those will
     # not be the ultimate client IP in production, and so are discarded. See
-    # http://en.wikipedia.org/wiki/Private_network for details.
+    # https://en.wikipedia.org/wiki/Private_network for details.
     TRUSTED_PROXIES = [
       "127.0.0.1",      # localhost IPv4
       "::1",            # localhost IPv6

--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -94,7 +94,7 @@ module ActionDispatch
         end
       end
 
-      # http://tools.ietf.org/html/rfc6797#section-6.1
+      # https://tools.ietf.org/html/rfc6797#section-6.1
       def build_hsts_header(hsts)
         value = "max-age=#{hsts[:expires].to_i}".dup
         value << "; includeSubDomains" if hsts[:subdomains]

--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -16,7 +16,7 @@ module ActionDispatch
         # You can set the +RAILS_SYSTEM_TESTING_SCREENSHOT+ environment variable to
         # control the output. Possible values are:
         # * [+inline+ (default)]    display the screenshot in the terminal using the
-        #                           iTerm image protocol (http://iterm2.com/documentation-images.html).
+        #                           iTerm image protocol (https://iterm2.com/documentation-images.html).
         # * [+simple+]              only display the screenshot path.
         #                           This is the default value if the +CI+ environment variables
         #                           is defined.


### PR DESCRIPTION
### Summary

- Update links to use `https` instead of `http` in actionpack.
- All changes are only in comment blocks. So I've skipped CI.