### PR TITLE
[activesupport] Update links to use https instead of http [ci skip]

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -14,7 +14,7 @@ require_relative "../core_ext/array/extract_options"
 module ActiveSupport
   module Cache
     # A cache store implementation which stores data in Memcached:
-    # http://memcached.org/
+    # https://memcached.org
     #
     # This is currently the most popular cache store for production websites.
     #

--- a/activesupport/lib/active_support/core_ext/digest/uuid.rb
+++ b/activesupport/lib/active_support/core_ext/digest/uuid.rb
@@ -14,7 +14,7 @@ module Digest
     # Using Digest::MD5 generates version 3 UUIDs; Digest::SHA1 generates version 5 UUIDs.
     # uuid_from_hash always generates the same UUID for a given name and namespace combination.
     #
-    # See RFC 4122 for details of UUID at: http://www.ietf.org/rfc/rfc4122.txt
+    # See RFC 4122 for details of UUID at: https://www.ietf.org/rfc/rfc4122.txt
     def self.uuid_from_hash(hash_class, uuid_namespace, name)
       if hash_class == Digest::MD5
         version = 3

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -133,7 +133,7 @@ module ActiveSupport
     class << self
       # Creates a new Duration from string formatted according to ISO 8601 Duration.
       #
-      # See {ISO 8601}[http://en.wikipedia.org/wiki/ISO_8601#Durations] for more information.
+      # See {ISO 8601}[https://en.wikipedia.org/wiki/ISO_8601#Durations] for more information.
       # This method allows negative parts to be present in pattern.
       # If invalid string is provided, it will raise +ActiveSupport::Duration::ISO8601Parser::ParsingError+.
       def parse(iso8601duration)

--- a/activesupport/lib/active_support/duration/iso8601_parser.rb
+++ b/activesupport/lib/active_support/duration/iso8601_parser.rb
@@ -7,7 +7,7 @@ module ActiveSupport
   class Duration
     # Parses a string formatted according to ISO 8601 Duration into the hash.
     #
-    # See {ISO 8601}[http://en.wikipedia.org/wiki/ISO_8601#Durations] for more information.
+    # See {ISO 8601}[https://en.wikipedia.org/wiki/ISO_8601#Durations] for more information.
     #
     # This parser allows negative parts to be present in pattern.
     class ISO8601Parser # :nodoc:

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -119,13 +119,13 @@ module ActiveSupport
     end
 
     # Encrypt and sign a message. We need to sign the message in order to avoid
-    # padding attacks. Reference: http://www.limited-entropy.com/padding-oracle-attacks.
+    # padding attacks. Reference: https://www.limited-entropy.com/padding-oracle-attacks/.
     def encrypt_and_sign(value, expires_at: nil, expires_in: nil, purpose: nil)
       verifier.generate(_encrypt(value, expires_at: expires_at, expires_in: expires_in, purpose: purpose))
     end
 
     # Decrypt and verify a message. We need to verify the message in order to
-    # avoid padding attacks. Reference: http://www.limited-entropy.com/padding-oracle-attacks.
+    # avoid padding attacks. Reference: https://www.limited-entropy.com/padding-oracle-attacks/.
     def decrypt_and_verify(data, purpose: nil)
       _decrypt(verifier.verify(data), purpose)
     end


### PR DESCRIPTION
### Summary

- Update links to use `https` instead of `http` in activesupport.
- All changes are only in comment blocks. So I've skipped CI.