### PR TITLE
Remove frozen_string_literal comment from activestorage's migration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,6 +88,7 @@ Style/FrozenStringLiteralComment:
     - 'actionview/test/**/*.ruby'
     - 'actionpack/test/**/*.builder'
     - 'actionpack/test/**/*.ruby'
+    - 'activestorage/db/migrate/**/*.rb'
 
 # Use `foo {}` not `foo{}`.
 Layout/SpaceBeforeBlockBraces:

--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class CreateActiveStorageTables < ActiveRecord::Migration[5.1]
   def change
     create_table :active_storage_blobs do |t|


### PR DESCRIPTION
The activestorage's migration is used as template for apps

Related to #30348
/cc @koic