### PR TITLE
Add TransactionTimeout for MySQL error code 1205

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -630,6 +630,7 @@ module ActiveRecord
         ER_LOCK_DEADLOCK        = 1213
         ER_CANNOT_ADD_FOREIGN   = 1215
         ER_CANNOT_CREATE_TABLE  = 1005
+        ER_LOCK_WAIT_TIMEOUT    = 1205
 
         def translate_exception(exception, message)
           case error_number(exception)
@@ -653,6 +654,8 @@ module ActiveRecord
             NotNullViolation.new(message)
           when ER_LOCK_DEADLOCK
             Deadlocked.new(message)
+          when ER_LOCK_WAIT_TIMEOUT
+            TransactionTimeout.new(message)
           else
             super
           end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -334,4 +334,9 @@ module ActiveRecord
   # +reverse_order+ to automatically reverse.
   class IrreversibleOrderError < ActiveRecordError
   end
+
+  # TransactionTimeout will be raised when lock wait timeout expires.
+  # Wait time value is set by innodb_lock_wait_timeout.
+  class TransactionTimeout < StatementInvalid
+  end
 end

--- a/activerecord/test/cases/adapters/mysql2/transaction_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/transaction_test.rb
@@ -59,5 +59,11 @@ module ActiveRecord
         end
       end
     end
+
+    test "raises TransactionTimeout when mysql raises ER_LOCK_WAIT_TIMEOUT" do
+      assert_raises(ActiveRecord::TransactionTimeout) do
+        ActiveRecord::Base.connection.execute("SIGNAL SQLSTATE 'HY000' SET MESSAGE_TEXT = 'Testing error', MYSQL_ERRNO = 1205;")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

This PR adds `TransactionTimedout` error to the MySQL adapter. `Message: Lock wait timeout exceeded; try restarting transaction` (MySQL error 1205) will be easier to rescue.

https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html#error_er_lock_wait_timeout

cc @rafaelfranca 