### PR TITLE
StreamingTemplateRenderer fails to forward I18n.locale in layouts

### DIFF
--- a/actionview/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionview/lib/action_view/renderer/streaming_template_renderer.rb
@@ -65,7 +65,9 @@ module ActionView
         yielder = lambda { |*name| view._layout_for(*name) }
 
         instrument(:template, identifier: template.identifier, layout: layout.try(:virtual_path)) do
+          outer_config = I18n.config
           fiber = Fiber.new do
+            I18n.config = outer_config
             if layout
               layout.render(view, locals, output, &yielder)
             else

--- a/actionview/test/fixtures/layouts/streaming_with_locale.erb
+++ b/actionview/test/fixtures/layouts/streaming_with_locale.erb
@@ -1,0 +1,2 @@
+layout.locale: <%= I18n.locale %>
+<%= yield %>

--- a/actionview/test/fixtures/test/streaming_with_locale.erb
+++ b/actionview/test/fixtures/test/streaming_with_locale.erb
@@ -1,0 +1,1 @@
+view.locale: <%= I18n.locale %>

--- a/actionview/test/template/streaming_render_test.rb
+++ b/actionview/test/template/streaming_render_test.rb
@@ -5,7 +5,7 @@ require "abstract_unit"
 class TestController < ActionController::Base
 end
 
-class FiberedTest < ActiveSupport::TestCase
+class SetupFiberedBase < ActiveSupport::TestCase
   def setup
     view_paths = ActionController::Base.view_paths
     @assigns = { secret: "in the sauce", name: nil }
@@ -25,7 +25,9 @@ class FiberedTest < ActiveSupport::TestCase
     end
     string
   end
+end
 
+class FiberedTest < SetupFiberedBase
   def test_streaming_works
     content = []
     body = render_body(template: "test/hello_world", layout: "layouts/yield")
@@ -109,5 +111,22 @@ class FiberedTest < ActiveSupport::TestCase
   def test_render_with_streaming_and_capture
     assert_equal "Yes, \n this works\n like a charm.",
       buffered_render(template: "test/streaming", layout: "layouts/streaming_with_capture")
+  end
+end
+
+class FiberedWithLocaleTest < SetupFiberedBase
+  def setup
+    @old_locale = I18n.locale
+    I18n.locale = "da"
+    super
+  end
+
+  def teardown
+    I18n.locale = @old_locale
+  end
+
+  def test_render_with_streaming_and_locale
+    assert_equal "layout.locale: da\nview.locale: da\n\n",
+      buffered_render(template: "test/streaming_with_locale", layout: "layouts/streaming_with_locale")
   end
 end


### PR DESCRIPTION
Hello,

I recently used the option ```render stream: true``` to render some actions ( Ruby 2.4.1p111 / Rails 5.1.3 ) 

We noticed that our layout failed to keep the current locale [I18n.locale]. After some explorations, here is what happens :
* the I18n gems stores the current config in a Thread.current[:local]
* the StreamingTemplateRenderer streams the response via a Fiber.resume pattern
* unfortunatelly the Fiber does not keeps the Thread.current[:i18n_config]

This commit includes a simple fix: keeping a reference of the I18n.config above the Fiber scope and re-applying this reference to I18n.config.

Here is a link to a gist (https://gist.github.com/mfo/e8e5d51fe52f6cacd33ea778b1ef6c6d) with other options : 
* FiberWithI18n -> copy the I18n.config from caller
* FiberWithLocalsFromCallerThread -> copy all caller's threads local vars within the Fiber locals hash [it's a bit overkill but it may be useful for other gems/parts of rails]
* you can switch implementations from the gist (and fails the test using normal Fiber class)


