### PR TITLE
Fixing nginx configuration added missing semicolon

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1004,7 +1004,7 @@ Once you've configured the application server, you must proxy requests to it by 
 
 ```
 upstream application_server {
-  server 0.0.0.0:8080
+  server 0.0.0.0:8080;
 }
 
 server {


### PR DESCRIPTION
### Summary
Nginx configuration had a missing semicolon, added by this pull request.