### PR TITLE
`counter_cache` requires association class before `attr_readonly`

### DIFF
--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# `counter_cache` requires association class before `attr_readonly`.
+class Post < ActiveRecord::Base; end
+
 class Comment < ActiveRecord::Base
   scope :limit_by, lambda { |l| limit(l) }
   scope :containing_the_letter_e, -> { where("comments.body LIKE '%e%'") }


### PR DESCRIPTION
### Summary

This pull  request addresses the following failure. Refer #26370 #27575 for similar fixes.

```ruby
$ for i in sqlite3 mysql2 postgresql; do ARCONN=$i bin/test test/cases/associations/inverse_associations_test.rb test/cases/base_test.rb --seed 62853 -n "/^(?:InverseHasManyTests#(?:test_parent_instance_should_be_shared_with_newly_block_style_created_child)|BasicsTest#(?:test_readonly_attributes))$/" -v; done
```

```ruby
$ for i in sqlite3 mysql2 postgresql; do ARCONN=$i bin/test test/cases/associations/inverse_associations_test.rb test/cases/base_test.rb --seed 62853 -n "/^(?:InverseHasManyTests#(?:test_parent_instance_should_be_shared_with_newly_block_style_created_child)|BasicsTest#(?:test_readonly_attributes))$/" -v; done
Using sqlite3
Run options: --seed 62853 -n "/^(?:InverseHasManyTests#(?:test_parent_instance_should_be_shared_with_newly_block_style_created_child)|BasicsTest#(?:test_readonly_attributes))$/" -v

# Running:

InverseHasManyTests#test_parent_instance_should_be_shared_with_newly_block_style_created_child = 0.06 s = .
BasicsTest#test_readonly_attributes = 0.06 s = F

Finished in 0.129403s, 15.4556 runs/s, 46.3667 assertions/s.

  1) Failure:
BasicsTest#test_readonly_attributes [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:632]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Set: {"title", "comments_count"}>
+#<Set: {"title"}>


2 runs, 6 assertions, 1 failures, 0 errors, 0 skips
Using mysql2
Run options: --seed 62853 -n "/^(?:InverseHasManyTests#(?:test_parent_instance_should_be_shared_with_newly_block_style_created_child)|BasicsTest#(?:test_readonly_attributes))$/" -v

# Running:

InverseHasManyTests#test_parent_instance_should_be_shared_with_newly_block_style_created_child = 0.14 s = .
BasicsTest#test_readonly_attributes = 0.29 s = F

Finished in 0.430007s, 4.6511 runs/s, 13.9533 assertions/s.

  1) Failure:
BasicsTest#test_readonly_attributes [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:632]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Set: {"title", "comments_count"}>
+#<Set: {"title"}>


2 runs, 6 assertions, 1 failures, 0 errors, 0 skips
Using postgresql
Run options: --seed 62853 -n "/^(?:InverseHasManyTests#(?:test_parent_instance_should_be_shared_with_newly_block_style_created_child)|BasicsTest#(?:test_readonly_attributes))$/" -v

# Running:

InverseHasManyTests#test_parent_instance_should_be_shared_with_newly_block_style_created_child = 0.16 s = .
BasicsTest#test_readonly_attributes = 0.23 s = F

Finished in 0.398185s, 5.0228 runs/s, 15.0684 assertions/s.

  1) Failure:
BasicsTest#test_readonly_attributes [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:632]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Set: {"title", "comments_count"}>
+#<Set: {"title"}>


2 runs, 6 assertions, 1 failures, 0 errors, 0 skips
$
```
