### PR TITLE
Normalize/process Cache-Control headers consistently

### DIFF
--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -189,7 +189,8 @@ module ActionDispatch
           control.merge! cache_control
 
           if control.empty?
-            self._cache_control = DEFAULT_CACHE_CONTROL
+            # Let middleware handle default behavior
+            self._cache_control = nil
           elsif control[:no_cache]
             self._cache_control = NO_CACHE
             if control[:extras]

--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -167,9 +167,7 @@ module ActionDispatch
         end
 
         def handle_conditional_get!
-          if etag? || last_modified? || !@cache_control.empty?
-            set_conditional_cache_control!(@cache_control)
-          end
+          set_conditional_cache_control!(@cache_control)
         end
 
         DEFAULT_CACHE_CONTROL = "max-age=0, private, must-revalidate".freeze

--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -170,7 +170,6 @@ module ActionDispatch
           set_conditional_cache_control!(@cache_control)
         end
 
-        DEFAULT_CACHE_CONTROL = "max-age=0, private, must-revalidate".freeze
         NO_CACHE              = "no-cache".freeze
         PUBLIC                = "public".freeze
         PRIVATE               = "private".freeze

--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -196,7 +196,6 @@ module ActionDispatch
 
           if control.empty?
             # Let middleware handle default behavior
-            self._cache_control = nil
           elsif control[:no_cache]
             self._cache_control = NO_CACHE
             if control[:extras]

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -433,6 +433,7 @@ module ActionDispatch # :nodoc:
     def before_committed
       return if committed?
       assign_default_content_type_and_charset!
+      merge_and_normalize_cache_control!(@cache_control)
       handle_conditional_get!
       handle_no_content!
     end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -162,6 +162,17 @@ class TestController < ActionController::Base
     render action: "hello_world"
   end
 
+  def conditional_hello_with_expires_and_confliciting_cache_control_headers
+    response.headers["Cache-Control"] = "no-cache, must-revalidate"
+    expires_now
+    render action: "hello_world"
+  end
+
+  def conditional_hello_without_expires_and_confliciting_cache_control_headers
+    response.headers["Cache-Control"] = "no-cache, must-revalidate"
+    render action: "hello_world"
+  end
+
   def conditional_hello_with_bangs
     render action: "hello_world"
   end
@@ -366,6 +377,18 @@ class ExpiresInRenderTest < ActionController::TestCase
     get :conditional_hello_with_cache_control_headers
     assert_match(/no-cache/, @response.headers["Cache-Control"])
     assert_match(/no-transform/, @response.headers["Cache-Control"])
+  end
+
+  def test_expires_now_with_conflicting_cache_control_headers
+    get :conditional_hello_with_expires_and_confliciting_cache_control_headers
+    assert_match(/no-cache/, @response.headers["Cache-Control"])
+    refute_match(/must-revalidate/, @response.headers["Cache-Control"])
+  end
+
+  def test_no_expires_now_with_conflicting_cache_control_headers
+    get :conditional_hello_without_expires_and_confliciting_cache_control_headers
+    assert_match(/no-cache/, @response.headers["Cache-Control"])
+    refute_match(/must-revalidate/, @response.headers["Cache-Control"])
   end
 
   def test_date_header_when_expires_in

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -381,14 +381,12 @@ class ExpiresInRenderTest < ActionController::TestCase
 
   def test_expires_now_with_conflicting_cache_control_headers
     get :conditional_hello_with_expires_and_confliciting_cache_control_headers
-    assert_match(/no-cache/, @response.headers["Cache-Control"])
-    refute_match(/must-revalidate/, @response.headers["Cache-Control"])
+    assert_equal "no-cache", @response.headers["Cache-Control"]
   end
 
   def test_no_expires_now_with_conflicting_cache_control_headers
     get :conditional_hello_without_expires_and_confliciting_cache_control_headers
-    assert_match(/no-cache/, @response.headers["Cache-Control"])
-    refute_match(/must-revalidate/, @response.headers["Cache-Control"])
+    assert_equal "no-cache", @response.headers["Cache-Control"]
   end
 
   def test_date_header_when_expires_in


### PR DESCRIPTION
### Summary

In the existing logic, the `Cache-Control` header may or may not get normalized by additional logic depending on whether `response.cache_conrol` has been modified. This leads to inconsistent behavior, since sometimes `Cache-Control` can contain whatever a user sets and sometimes it gets
normalized, based on the logic inside of `set_conditional_cache_control!`. It seems like this normalization process should happen regardless to ensure consistent behavior.

### Other Information

I'm not super familiar with this bit of the codebase. It is not quite clear to me why the existing logic was conditionally called based on `etag?`, `last_modified?`, etc. The bulk of `set_conditional_cache_control!` seems to just normalize/merge the cache options found in existing headers and those found in the `cache_control` hash. I'm not quite clear why that would only be needed based  etags, last modified headers, etc. 

/cc 
@tenderlove - Since you seem to have a fair number of commits in this file. 
@raggi - Since https://github.com/rails/rails/pull/6776 changed some of the prior logic that didn't try to merge the header values and the `cache_control` hash. It is the merging (and normalization) that leads to some of the differences in behavior. 