### PR TITLE
Fix indentation in the template for secrets

### DIFF
--- a/railties/lib/rails/secrets.rb
+++ b/railties/lib/rails/secrets.rb
@@ -44,7 +44,7 @@ module Rails
         <<-end_of_template.strip_heredoc
           # See `secrets.yml` for tips on generating suitable keys.
           # production:
-          #  external_api_key: 1466aac22e6a869134be3d09b9e89232fc2c2289
+          #   external_api_key: 1466aac22e6a869134be3d09b9e89232fc2c2289
 
         end_of_template
       end

--- a/railties/test/generators/encrypted_secrets_generator_test.rb
+++ b/railties/test/generators/encrypted_secrets_generator_test.rb
@@ -17,8 +17,8 @@ class EncryptedSecretsGeneratorTest < Rails::Generators::TestCase
     assert_file "config/secrets.yml.key", /\w+/
 
     assert File.exist?("config/secrets.yml.enc")
-    assert_no_match(/production:\n#  external_api_key: \w+/, IO.binread("config/secrets.yml.enc"))
-    assert_match(/production:\n#  external_api_key: \w+/, Rails::Secrets.read)
+    assert_no_match(/# production:\n#   external_api_key: \w+/, IO.binread("config/secrets.yml.enc"))
+    assert_match(/# production:\n#   external_api_key: \w+/, Rails::Secrets.read)
   end
 
   def test_appends_to_gitignore

--- a/railties/test/secrets_test.rb
+++ b/railties/test/secrets_test.rb
@@ -47,7 +47,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
         ENV["RAILS_MASTER_KEY"] = IO.binread("config/secrets.yml.key").strip
         FileUtils.rm("config/secrets.yml.key")
 
-        assert_match "production:\n#  external_api_key", Rails::Secrets.read
+        assert_match "# production:\n#   external_api_key:", Rails::Secrets.read
       ensure
         ENV["RAILS_MASTER_KEY"] = old_key
       end
@@ -69,7 +69,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
       Rails::Secrets.read_for_editing do |tmp_path|
         decrypted_path = tmp_path
 
-        assert_match(/production:\n#  external_api_key/, File.read(tmp_path))
+        assert_match(/# production:\n#   external_api_key/, File.read(tmp_path))
 
         File.write(tmp_path, "Empty streets, empty nights. The Downtown Lights.")
       end


### PR DESCRIPTION
### Summary

In YAML format, it is expected 2 spaces for its indentation, but it is given only 1 space.