### PR TITLE
Fix spaces in the comment block [ci skip]

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -21,7 +21,7 @@ class SourceAnnotationExtractor
     end
 
     # Registers additional directories to be included
-    #  SourceAnnotationExtractor::Annotation.register_directories("spec","another")
+    #   SourceAnnotationExtractor::Annotation.register_directories("spec", "another")
     def self.register_directories(*dirs)
       directories.push(*dirs)
     end


### PR DESCRIPTION
### Summary

Added spaces to the comment block in `SourceAnnotationExtractor`.