### PR TITLE
Deprecate secret token

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Deprecate cookies.secret_token
+
+    The architecture for signed and encrypted cookies had a big upgrade
+    between Rails 3 and Rails 4. To avoid disruptions, a set of "smart"
+    cookie jars were added (#9909) so that developers could upgrade Rails
+    version without affecting users with "legacy" cookies in their browsers.
+
+    Since Rails 4 is now four years old, it is fair to assume that most apps
+    do not need these legacy cookie jars anymore. Deprecation warnings have
+    been added tp help developers upgrade their applications accordingly.
+
+    *claudiob*
+
 *   Deprecate `ActionDispatch::TestResponse` response aliases
 
     `#success?`, `#missing?` & `#error?` are not supported by the actual

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -50,7 +50,14 @@ module ActionDispatch
     end
 
     def secret_token
-      get_header Cookies::SECRET_TOKEN
+      secret_token = get_header Cookies::SECRET_TOKEN
+      if secret_token
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+         cookies.secret_token is deprecated and will be removed in Rails 6.0.
+         Please use cookies.secret_key_base instead.
+        MSG
+      end
+      secret_token
     end
 
     def secret_key_base

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -694,8 +694,10 @@ class CookiesTest < ActionController::TestCase
   def test_signed_uses_signed_cookie_jar_if_only_secret_token_is_set
     @request.env["action_dispatch.secret_token"] = "b3c631c314c0bbca50c1b2843150fe33"
     @request.env["action_dispatch.secret_key_base"] = nil
-    get :set_signed_cookie
-    assert_kind_of ActionDispatch::Cookies::SignedCookieJar, cookies.signed
+    ActiveSupport::Deprecation.silence do
+      get :set_signed_cookie
+      assert_kind_of ActionDispatch::Cookies::SignedCookieJar, cookies.signed
+    end
   end
 
   def test_signed_uses_signed_cookie_jar_if_only_secret_key_base_is_set
@@ -708,15 +710,19 @@ class CookiesTest < ActionController::TestCase
   def test_signed_uses_upgrade_legacy_signed_cookie_jar_if_both_secret_token_and_secret_key_base_are_set
     @request.env["action_dispatch.secret_token"] = "b3c631c314c0bbca50c1b2843150fe33"
     @request.env["action_dispatch.secret_key_base"] = "c3b95688f35581fad38df788add315ff"
-    get :set_signed_cookie
-    assert_kind_of ActionDispatch::Cookies::UpgradeLegacySignedCookieJar, cookies.signed
+    ActiveSupport::Deprecation.silence do
+      get :set_signed_cookie
+      assert_kind_of ActionDispatch::Cookies::UpgradeLegacySignedCookieJar, cookies.signed
+    end
   end
 
   def test_signed_or_encrypted_uses_signed_cookie_jar_if_only_secret_token_is_set
     @request.env["action_dispatch.secret_token"] = "b3c631c314c0bbca50c1b2843150fe33"
     @request.env["action_dispatch.secret_key_base"] = nil
-    get :get_encrypted_cookie
-    assert_kind_of ActionDispatch::Cookies::SignedCookieJar, cookies.signed_or_encrypted
+    ActiveSupport::Deprecation.silence do
+      get :get_encrypted_cookie
+      assert_kind_of ActionDispatch::Cookies::SignedCookieJar, cookies.signed_or_encrypted
+    end
   end
 
   def test_signed_or_encrypted_uses_encrypted_cookie_jar_if_only_secret_key_base_is_set
@@ -729,8 +735,10 @@ class CookiesTest < ActionController::TestCase
   def test_signed_or_encrypted_uses_upgrade_legacy_encrypted_cookie_jar_if_both_secret_token_and_secret_key_base_are_set
     @request.env["action_dispatch.secret_token"] = "b3c631c314c0bbca50c1b2843150fe33"
     @request.env["action_dispatch.secret_key_base"] = "c3b95688f35581fad38df788add315ff"
-    get :get_encrypted_cookie
-    assert_kind_of ActionDispatch::Cookies::UpgradeLegacyEncryptedCookieJar, cookies.signed_or_encrypted
+    ActiveSupport::Deprecation.silence do
+      get :get_encrypted_cookie
+      assert_kind_of ActionDispatch::Cookies::UpgradeLegacyEncryptedCookieJar, cookies.signed_or_encrypted
+    end
   end
 
   def test_encrypted_uses_encrypted_cookie_jar_if_only_secret_key_base_is_set
@@ -743,8 +751,10 @@ class CookiesTest < ActionController::TestCase
   def test_encrypted_uses_upgrade_legacy_encrypted_cookie_jar_if_both_secret_token_and_secret_key_base_are_set
     @request.env["action_dispatch.secret_token"] = "b3c631c314c0bbca50c1b2843150fe33"
     @request.env["action_dispatch.secret_key_base"] = "c3b95688f35581fad38df788add315ff"
-    get :get_encrypted_cookie
-    assert_kind_of ActionDispatch::Cookies::UpgradeLegacyEncryptedCookieJar, cookies.encrypted
+    ActiveSupport::Deprecation.silence do
+      get :get_encrypted_cookie
+      assert_kind_of ActionDispatch::Cookies::UpgradeLegacyEncryptedCookieJar, cookies.encrypted
+    end
   end
 
   def test_legacy_signed_cookie_is_read_and_transparently_upgraded_by_signed_cookie_jar_if_both_secret_token_and_secret_key_base_are_set
@@ -754,7 +764,7 @@ class CookiesTest < ActionController::TestCase
     legacy_value = ActiveSupport::MessageVerifier.new("b3c631c314c0bbca50c1b2843150fe33").generate(45)
 
     @request.headers["Cookie"] = "user_id=#{legacy_value}"
-    get :get_signed_cookie
+    ActiveSupport::Deprecation.silence { get :get_signed_cookie }
 
     assert_equal 45, @controller.send(:cookies).signed[:user_id]
 
@@ -773,7 +783,7 @@ class CookiesTest < ActionController::TestCase
     legacy_value = ActiveSupport::MessageVerifier.new("b3c631c314c0bbca50c1b2843150fe33").generate("bar")
 
     @request.headers["Cookie"] = "foo=#{legacy_value}"
-    get :get_encrypted_cookie
+    ActiveSupport::Deprecation.silence { get :get_encrypted_cookie }
 
     assert_equal "bar", @controller.send(:cookies).encrypted[:foo]
 
@@ -792,7 +802,7 @@ class CookiesTest < ActionController::TestCase
     legacy_value = ActiveSupport::MessageVerifier.new("b3c631c314c0bbca50c1b2843150fe33", serializer: JSON).generate(45)
 
     @request.headers["Cookie"] = "user_id=#{legacy_value}"
-    get :get_signed_cookie
+    ActiveSupport::Deprecation.silence { get :get_signed_cookie }
 
     assert_equal 45, @controller.send(:cookies).signed[:user_id]
 
@@ -810,7 +820,7 @@ class CookiesTest < ActionController::TestCase
     legacy_value = ActiveSupport::MessageVerifier.new("b3c631c314c0bbca50c1b2843150fe33", serializer: JSON).generate("bar")
 
     @request.headers["Cookie"] = "foo=#{legacy_value}"
-    get :get_encrypted_cookie
+    ActiveSupport::Deprecation.silence { get :get_encrypted_cookie }
 
     assert_equal "bar", @controller.send(:cookies).encrypted[:foo]
 
@@ -829,7 +839,7 @@ class CookiesTest < ActionController::TestCase
     legacy_value = ActiveSupport::MessageVerifier.new("b3c631c314c0bbca50c1b2843150fe33", serializer: JSON).generate(45)
 
     @request.headers["Cookie"] = "user_id=#{legacy_value}"
-    get :get_signed_cookie
+    ActiveSupport::Deprecation.silence { get :get_signed_cookie }
 
     assert_equal 45, @controller.send(:cookies).signed[:user_id]
 
@@ -847,7 +857,7 @@ class CookiesTest < ActionController::TestCase
     legacy_value = ActiveSupport::MessageVerifier.new("b3c631c314c0bbca50c1b2843150fe33", serializer: JSON).generate("bar")
 
     @request.headers["Cookie"] = "foo=#{legacy_value}"
-    get :get_encrypted_cookie
+    ActiveSupport::Deprecation.silence { get :get_encrypted_cookie }
 
     assert_equal "bar", @controller.send(:cookies).encrypted[:foo]
 
@@ -866,7 +876,7 @@ class CookiesTest < ActionController::TestCase
     legacy_value = ActiveSupport::MessageVerifier.new("b3c631c314c0bbca50c1b2843150fe33").generate(45)
 
     @request.headers["Cookie"] = "user_id=#{legacy_value}"
-    get :get_signed_cookie
+    ActiveSupport::Deprecation.silence { get :get_signed_cookie }
 
     assert_equal 45, @controller.send(:cookies).signed[:user_id]
 
@@ -884,7 +894,7 @@ class CookiesTest < ActionController::TestCase
     legacy_value = ActiveSupport::MessageVerifier.new("b3c631c314c0bbca50c1b2843150fe33").generate("bar")
 
     @request.headers["Cookie"] = "foo=#{legacy_value}"
-    get :get_encrypted_cookie
+    ActiveSupport::Deprecation.silence { get :get_encrypted_cookie }
 
     assert_equal "bar", @controller.send(:cookies).encrypted[:foo]
 
@@ -900,7 +910,7 @@ class CookiesTest < ActionController::TestCase
     @request.env["action_dispatch.secret_key_base"] = "c3b95688f35581fad38df788add315ff"
 
     @request.headers["Cookie"] = "user_id=45"
-    get :get_signed_cookie
+    ActiveSupport::Deprecation.silence { get :get_signed_cookie }
 
     assert_nil @controller.send(:cookies).signed[:user_id]
     assert_nil @response.cookies["user_id"]
@@ -911,7 +921,7 @@ class CookiesTest < ActionController::TestCase
     @request.env["action_dispatch.secret_key_base"] = "c3b95688f35581fad38df788add315ff"
 
     @request.headers["Cookie"] = "foo=baz"
-    get :get_encrypted_cookie
+    ActiveSupport::Deprecation.silence { get :get_encrypted_cookie }
 
     assert_nil @controller.send(:cookies).encrypted[:foo]
     assert_nil @response.cookies["foo"]

--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -19,7 +19,6 @@ require "action_controller/railtie"
 class TestApp < Rails::Application
   config.root = __dir__
   config.session_store :cookie_store, key: "cookie_store_key"
-  secrets.secret_token    = "secret_token"
   secrets.secret_key_base = "secret_key_base"
 
   config.logger = Logger.new($stdout)

--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -17,7 +17,6 @@ require "action_controller/railtie"
 
 class TestApp < Rails::Application
   config.root = __dir__
-  secrets.secret_token    = "secret_token"
   secrets.secret_key_base = "secret_key_base"
 
   config.logger = Logger.new($stdout)

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Deprecate secret_token
+
+    The architecture for secrets had a big upgrade between Rails 3 and Rails 4,
+    when the default changed from using `secret_token` to `secret_key_base`.
+
+    `secret_token` has been deprecated for four years but is still in place
+    to support apps that were created before Rails 4 (e.g., to still be able
+    to read the legacy cookies of their older users). Deprecation warnings have
+    been added to help developers upgrade their applications accordingly.
+
+    *claudiob*
+
 *   Add `--skip-yarn` option to the plugin generator.
 
     *bogdanvlviv*

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -178,6 +178,10 @@ module Rails
           key_generator = ActiveSupport::KeyGenerator.new(secrets.secret_key_base, iterations: 1000)
           ActiveSupport::CachingKeyGenerator.new(key_generator)
         else
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+           secrets.secret_token is deprecated and will be removed in Rails 6.0.
+           Please use secrets.secret_key_base instead.
+          MSG
           ActiveSupport::LegacyKeyGenerator.new(secrets.secret_token)
         end
     end
@@ -511,6 +515,11 @@ module Rails
 
         if secrets.secret_token.blank?
           raise "Missing `secret_key_base` for '#{Rails.env}' environment, set this value in `config/secrets.yml`"
+        else
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+           secrets.secret_token is deprecated and will be removed in Rails 6.0.
+           Please use secrets.secret_key_base instead.
+          MSG
         end
       end
     end


### PR DESCRIPTION
This is another take on #30138 where secret_token is more strongly deprecated rather than removed, following comments by @dhh and @rafaelfranca on Campfire.

I have created three commits to deal separately with Action Pack, Guides, and Railties.

I'm not 100% sure about this PR… let me know if that's what you meant by "stronger deprecation in 5.2". Thanks!
