### PR TITLE
Delegate :rindex, :slice, :rotate(missing) to 'records'

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -39,9 +39,9 @@ module ActiveRecord
     # for each different klass, and the delegations are compiled into that subclass only.
 
     delegate :to_xml, :encode_with, :length, :each, :uniq, :to_ary, :join,
-             :[], :&, :|, :+, :-, :sample, :reverse, :compact, :in_groups, :in_groups_of,
+             :[], :&, :|, :+, :-, :sample, :reverse, :rotate, :compact, :in_groups, :in_groups_of,
              :to_sentence, :to_formatted_s, :as_json,
-             :shuffle, :split, :index, to: :records
+             :shuffle, :split, :slice, :index, :rindex, to: :records
 
     delegate :table_name, :quoted_table_name, :primary_key, :quoted_primary_key,
              :connection, :columns_hash, to: :klass

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -10,8 +10,8 @@ module ActiveRecord
       :+, :-, :|, :&, :[], :shuffle,
       :all?, :collect, :compact, :detect, :each, :each_cons, :each_with_index,
       :exclude?, :find_all, :flat_map, :group_by, :include?, :length,
-      :map, :none?, :one?, :partition, :reject, :reverse,
-      :sample, :second, :sort, :sort_by, :third,
+      :map, :none?, :one?, :partition, :reject, :reverse, :rotate,
+      :sample, :second, :sort, :sort_by, :slice, :third, :index, :rindex,
       :to_ary, :to_set, :to_xml, :to_yaml, :join,
       :in_groups, :in_groups_of, :to_sentence, :to_formatted_s, :as_json
     ]


### PR DESCRIPTION
Add missing array methods to delegate to records