### PR TITLE
Rename Active Storage install task

### DIFF
--- a/activestorage/lib/tasks/activestorage.rake
+++ b/activestorage/lib/tasks/activestorage.rake
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-namespace :active_storage do
-  desc "Copy over the migration needed to the application"
-  task install: :environment do
-    Rake::Task["active_storage:install:migrations"].invoke
+namespace :blob do
+  desc "Copy over the Active Storage migration needed to the application"
+  task migrations: :environment do
+    Rake::Task["railties:install:migrations"].invoke
   end
 end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -621,7 +621,7 @@ module Rails
     end
 
     rake_tasks do
-      next if is_a?(Rails::Application)
+      next if is_a?(Rails::Application) || railtie_name == "active_storage"
       next unless has_migrations?
 
       namespace railtie_name do


### PR DESCRIPTION
### Summary

This PR is based on the following discussion.

https://github.com/rails/rails/pull/30280#issuecomment-322794793.

There are two changes.

- Rename `active_storage:install` task to `blob:migrations` task
- Don't display `active_storage:install:migrations` task on `rake -T`

The following is the difference of the result of `rake -T` in an Active Storage application.

```diff
% bin/rake -T
 rake about                              # List versions of all Rails frameworks and the environment
-rake active_storage:install:migrations  # Copy migrations from active_storage to application
-rake activestorage:install              # Copy over the migration needed to the applicationrake app:template                       # Applies the template supplied by LOCATION=(/path/to/template) or URL
 rake app:update                         # Update configs and some other initially generated files (or use just update:configs or update:bin)
 rake assets:clean[keep]                 # Remove old compiled assets
 rake assets:clobber                     # Remove compiled assets
 rake assets:environment                 # Load asset compile environment
 rake assets:precompile                  # Compile all the assets named in config.assets.precompile
+rake blob:migrations                    # Copy over the Active Storage migration needed to the application

(snip)
```