### PR TITLE
Remove unnecessary method call

### DIFF
--- a/activestorage/app/models/active_storage/filename.rb
+++ b/activestorage/app/models/active_storage/filename.rb
@@ -11,7 +11,7 @@ class ActiveStorage::Filename
 
   # Filename.new("racecar.jpg").base # => "racecar"
   def base
-    File.basename @filename, extension_with_delimiter
+    File.basename @filename, ".*"
   end
 
   # Filename.new("racecar.jpg").extension_with_delimiter # => ".jpg"


### PR DESCRIPTION
### Summary
Just pass `".*"` as a second parameter for `File.basename`,
instead of calling `ActiveStrage::Filename#extension_with_delimiter`.