### PR TITLE
Fix broken link for Java xml [ci skip]

### DIFF
--- a/activesupport/lib/active_support/xml_mini/jdom.rb
+++ b/activesupport/lib/active_support/xml_mini/jdom.rb
@@ -40,7 +40,7 @@ module ActiveSupport
       else
         @dbf = DocumentBuilderFactory.new_instance
         # secure processing of java xml
-        # http://www.ibm.com/developerworks/xml/library/x-tipcfsx/index.html
+        # https://archive.is/9xcQQ
         @dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
         @dbf.setFeature("http://xml.org/sax/features/external-general-entities", false)
         @dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false)


### PR DESCRIPTION
I've fixed a broken link describes `Configure SAX parsers for secure processing`.
It is redirected to the error page from the original url.

I found same document in `www.ibm.com`. However I could not find it.
So I've replaced the original url with archived website's url.

Of course, if it is bad fix on the view of security, it might be better to remove the original comment block.