### PR TITLE
Remove hard tabs

### DIFF
--- a/actionmailer/README.rdoc
+++ b/actionmailer/README.rdoc
@@ -52,7 +52,7 @@ generated would look like this:
   Subject: [Signed up] Welcome david@loudthinking.com
   Mime-Version: 1.0
   Content-Type: text/plain;
-  	charset="US-ASCII";
+   charset="US-ASCII";
   Content-Transfer-Encoding: 7bit
 
   Hello there,

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -50,7 +50,7 @@ SQL
   ActiveRecord::Base.connection.execute <<-SQL
 CREATE PROCEDURE ten() SQL SECURITY INVOKER
 BEGIN
-	select 10;
+  select 10;
 END
 SQL
 

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -308,7 +308,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
     run_generator [ "admin/role" ], behavior: :revoke
 
     # Model
-    assert_file "app/models/test_app/admin.rb"	# ( should not be remove )
+    assert_file "app/models/test_app/admin.rb" # ( should not be remove )
     assert_no_file "app/models/test_app/admin/role.rb"
     assert_no_file "test/models/test_app/admin/role_test.rb"
     assert_no_file "test/fixtures/test_app/admin/roles.yml"
@@ -375,7 +375,7 @@ class NamespacedScaffoldGeneratorTest < NamespacedGeneratorTestCase
     run_generator [ "admin/user/special/role" ], behavior: :revoke
 
     # Model
-    assert_file "app/models/test_app/admin/user/special.rb"	# ( should not be remove )
+    assert_file "app/models/test_app/admin/user/special.rb" # ( should not be remove )
     assert_no_file "app/models/test_app/admin/user/special/role.rb"
     assert_no_file "test/models/test_app/admin/user/special/role_test.rb"
     assert_no_file "test/fixtures/test_app/admin/user/special/roles.yml"


### PR DESCRIPTION
### Summary

I found hard tabs are in actionmailer, activerecord and railstie.
And I've replaced them with spaces.

As for actionmailer, I've confirmed actual logs that use spaces.