### PR TITLE
Always load `:posts` and `:comments` fixtures not to be affected

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1711,6 +1711,7 @@ class TestAutosaveAssociationWithTouch < ActiveRecord::TestCase
 end
 
 class TestAutosaveAssociationOnAHasManyAssociationWithInverse < ActiveRecord::TestCase
+  fixtures :posts, :comments
   class Post < ActiveRecord::Base
     has_many :comments, inverse_of: :post
   end


### PR DESCRIPTION
### Summary

Always load `:posts` and `:comments` fixtures not to be affected by other tests like `DelegationRelationTest#test_delegates_to_formatted_s_to_Array` which just loads `:comments`

Fixes #30380

```ruby
$ bin/test test/cases/relation/delegation_test.rb test/cases/autosave_association_test.rb --seed 63190 -n "/^(?:ActiveRecord::DelegationRelationTest#(?:test_delegates_to_formatted_s_to_Array)|TestAutosaveAssociationOnAHasManyAssociationWithInverse#(?:test_after_save_callback_with_autosave))$/"
Using sqlite3
Run options: --seed 63190 -n "/^(?:ActiveRecord::DelegationRelationTest#(?:test_delegates_to_formatted_s_to_Array)|TestAutosaveAssociationOnAHasManyAssociationWithInverse#(?:test_after_save_callback_with_autosave))$/"

.F

Finished in 0.121607s, 16.4465 runs/s, 16.4465 assertions/s.

  1) Failure:
TestAutosaveAssociationOnAHasManyAssociationWithInverse#test_after_save_callback_with_autosave [/home/yahonda/git/rails/activerecord/test/cases/autosave_association_test.rb:1732]:
Expected: 1
  Actual: 3

2 runs, 2 assertions, 1 failures, 0 errors, 0 skips
$
```

### Other Information

* Here are the part of `debug.log` for `comments` table when it fails.

```sql
  Fixture Delete (0.3ms)  DELETE FROM "comments"
  Fixture Insert (0.2ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (1, 1, 'Thank you for the welcome', 'Comment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (2, 1, 'Thank you again for the welcome', 'Comment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (3, 2, 'Don''t think too hard', 'SpecialComment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (5, 4, 'Very Special type', 'VerySpecialComment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (6, 4, 'Special type', 'SpecialComment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (7, 4, 'Special type 2', 'SpecialComment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (8, 4, 'Normal type', 'Comment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (9, 5, 'Normal type', 'Comment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (10, 5, 'Special Type', 'SpecialComment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (11, 7, 'go crazy', 'SpecialComment')
  Fixture Insert (0.2ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (12, 4, 'Sub special comment', 'SubSpecialComment')
  SQL (0.2ms)  INSERT INTO "comments" ("post_id", "body") VALUES (?, ?)  [["post_id", 1], ["body", "..."]]
```

Expected number of rows is 1 but actual ones is 3 because there are two external rows whrere `post_id` = `1` inserted by fixture insert.

```sql
  Fixture Insert (0.2ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (1, 1, 'Thank you for the welcome', 'Comment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (2, 1, 'Thank you again for the welcome', 'Comment')
  SQL (0.2ms)  INSERT INTO "comments" ("post_id", "body") VALUES (?, ?)  [["post_id", 1], ["body", "..."]]
```

* With this fix

```sql
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (1, 1, 'Thank you for the welcome', 'Comment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (2, 1, 'Thank you again for the welcome', 'Comment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (3, 2, 'Don''t think too hard', 'SpecialComment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (5, 4, 'Very Special type', 'VerySpecialComment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (6, 4, 'Special type', 'SpecialComment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (7, 4, 'Special type 2', 'SpecialComment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (8, 4, 'Normal type', 'Comment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (9, 5, 'Normal type', 'Comment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (10, 5, 'Special Type', 'SpecialComment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (11, 7, 'go crazy', 'SpecialComment')
  Fixture Insert (0.1ms)  INSERT INTO "comments" ("id", "post_id", "body", "type") VALUES (12, 4, 'Sub special comment', 'SubSpecialComment')
  SQL (0.1ms)  INSERT INTO "comments" ("post_id", "body") VALUES (?, ?)  [["post_id", 12], ["body", "..."]]
```

`:comments` fixture does not affect to newly inserted rows whose `post_id` is `12` by `test_after_save_callback_with_autosave`
