### PR TITLE
Use https instead of http for kindle task

### DIFF
--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -24,7 +24,7 @@ namespace :guides do
       ruby "rails_guides.rb"
     end
 
-    desc "Generate .mobi file. The kindlegen executable must be in your PATH. You can get it for free from http://www.amazon.com/gp/feature.html?docId=1000765211"
+    desc "Generate .mobi file. The kindlegen executable must be in your PATH. You can get it for free from https://www.amazon.com/gp/feature.html?docId=1000765211"
     task kindle: :encoding do
       require "kindlerb"
       unless Kindlerb.kindlegen_available?

--- a/guides/source/kindle/rails_guides.opf.erb
+++ b/guides/source/kindle/rails_guides.opf.erb
@@ -4,15 +4,12 @@
 <metadata>
   <meta name="cover" content="cover" />
   <dc-metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-
-       <dc:title>Ruby on Rails Guides (<%= @version || "master@#{@edge[0, 7]}" %>)</dc:title>
-
-  	<dc:language>en-us</dc:language>
-  	<dc:creator>Ruby on Rails</dc:creator>
-  	<dc:publisher>Ruby on Rails</dc:publisher>
-  	<dc:subject>Reference</dc:subject>
-  	<dc:date><%= Time.now.strftime('%Y-%m-%d') %></dc:date>
-
+    <dc:title>Ruby on Rails Guides (<%= @version || "master@#{@edge[0, 7]}" %>)</dc:title>
+    <dc:language>en-us</dc:language>
+    <dc:creator>Ruby on Rails</dc:creator>
+    <dc:publisher>Ruby on Rails</dc:publisher>
+    <dc:subject>Reference</dc:subject>
+    <dc:date><%= Time.now.strftime('%Y-%m-%d') %></dc:date>
     <dc:description>These guides are designed to make you immediately productive with Rails, and to help you understand how all of the pieces fit together.</dc:description>
   </dc-metadata>
   <x-metadata>
@@ -46,7 +43,7 @@
 </spine>
 
 <guide>
-	<reference type="toc" title="Table of Contents" href="toc.html"></reference>
+  <reference type="toc" title="Table of Contents" href="toc.html"></reference>
 </guide>
 
 </package>

--- a/guides/source/kindle/toc.html.erb
+++ b/guides/source/kindle/toc.html.erb
@@ -14,7 +14,7 @@ Ruby on Rails Guides
         <% if document['work_in_progress']%>(WIP)<% end %>
       </li>
     <% end %>
-  </ul>  
+  </ul>
 <% end %>
 <hr />
 <ul>

--- a/guides/source/kindle/toc.ncx.erb
+++ b/guides/source/kindle/toc.ncx.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE ncx PUBLIC "-//NISO//DTD ncx 2005-1//EN"
-	"http://www.daisy.org/z3986/2005/ncx-2005-1.dtd">
+    "http://www.daisy.org/z3986/2005/ncx-2005-1.dtd">
 
 <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1" xml:lang="en-US">
 <head>


### PR DESCRIPTION
### Summary

Use https instead of http for kindle task, and...

- Removed trailing spaces.
- Removed empty lines.
- Replaced hard tabs with soft tabs.

If you regard this request as cosmetic change, please feel free to close it. Thanks.