### PR TITLE
Singularize like pluralize

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -84,14 +84,15 @@ class String
   #   'posts'.with_count(1)            # => "post"
   #   'post'.with_count(2)             # => "posts"
   #   'posts'.with_count(2)            # => "posts"
-  #   'octopi'.with_count(2)           # => "octopus"
+  #   'octopi'.with_count(1)           # => "octopus"
   #   'sheep'.with_count(2)            # => "sheep"
   #   'word'.with_count(2)             # => "word"
-  #   'the blue mailmen'.with_count(2) # => "the blue mailman"
+  #   'the blue mailmen'.with_count(1) # => "the blue mailman"
+  #   'green woman'.with_count(2)  _   # => "green women"
   #   'CamelOctopi'.with_count(1)      # => "CamelOctopus"
   #   'apples'.with_count(1)           # => "apple"
   #   'apples'.with_count(2)           # => "apples"
-  #   'leyes'.with_count(:es)          # => "ley"
+  #   'leyes'.with_count(1, :es)       # => "ley"
   #   'leyes'.with_count(2, :es)       # => "leyes"
   def with_count(count, locale = :en)
     if count == 1

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -41,6 +41,10 @@ class String
 
   # The reverse of +pluralize+, returns the singular form of a word in a string.
   #
+  # If the optional parameter +count+ is specified,
+  # the singular form will be returned if <tt>count == 1</tt>.
+  # For any other value of +count+ the plural will be returned.
+  #
   # If the optional parameter +locale+ is specified,
   # the word will be singularized as a word of that language.
   # By default, this parameter is set to <tt>:en</tt>.
@@ -52,9 +56,17 @@ class String
   #   'word'.singularize             # => "word"
   #   'the blue mailmen'.singularize # => "the blue mailman"
   #   'CamelOctopi'.singularize      # => "CamelOctopus"
+  #   'apples'.singularize(1)        # => "apple"
+  #   'apples'.singularize(2)        # => "apples"
   #   'leyes'.singularize(:es)       # => "ley"
-  def singularize(locale = :en)
-    ActiveSupport::Inflector.singularize(self, locale)
+  #   'leyes'.singularize(2, :es)    # => "leyes"
+  def singularize(count = 1, locale = :en)
+    count, locale = 1, count if count.is_a?(Symbol)
+    if count != 1
+      dup
+    else
+      ActiveSupport::Inflector.singularize(self, locale)
+    end
   end
 
   # +constantize+ tries to find a declared constant with the name specified

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -69,6 +69,38 @@ class String
     end
   end
 
+  # Returns either the plural or the singular form of the word in the string.
+  #
+  # If the optional parameter +count+ is specified,
+  # the singular form will be returned if <tt>count == 1</tt>.
+  # For any other value of +count+ the plural will be returned.
+  #
+  # If the optional parameter +locale+ is specified,
+  # the word will be singularized as a word of that language.
+  # By default, this parameter is set to <tt>:en</tt>.
+  # You must define your own inflection rules for languages other than English.
+  #
+  #   'post'.with_count(1)             # => "post"
+  #   'posts'.with_count(1)            # => "post"
+  #   'post'.with_count(2)             # => "posts"
+  #   'posts'.with_count(2)            # => "posts"
+  #   'octopi'.with_count(2)           # => "octopus"
+  #   'sheep'.with_count(2)            # => "sheep"
+  #   'word'.with_count(2)             # => "word"
+  #   'the blue mailmen'.with_count(2) # => "the blue mailman"
+  #   'CamelOctopi'.with_count(1)      # => "CamelOctopus"
+  #   'apples'.with_count(1)           # => "apple"
+  #   'apples'.with_count(2)           # => "apples"
+  #   'leyes'.with_count(:es)          # => "ley"
+  #   'leyes'.with_count(2, :es)       # => "leyes"
+  def with_count(count, locale = :en)
+    if count == 1
+      ActiveSupport::Inflector.singularize(self, locale)
+    else
+      ActiveSupport::Inflector.pluralize(self, locale)
+    end
+  end
+
   # +constantize+ tries to find a declared constant with the name specified
   # in the string. It raises a NameError when the name is not in CamelCase
   # or is not initialized.  See ActiveSupport::Inflector.constantize

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -433,6 +433,13 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal("sociedad", "sociedades".singularize(:es))
     assert_equal("sociedade", "sociedades".singularize)
 
+    assert_equal("hijos", "hijo".with_count(2, :es))
+    assert_equal("luces", "luz".with_count(2, :es))
+    assert_equal("luzs", "luz".with_count(2))
+
+    assert_equal("sociedad", "sociedades".with_count(1, :es))
+    assert_equal("sociedade", "sociedades".with_count(1))
+
     assert_equal("los", "el".pluralize(:es))
     assert_equal("els", "el".pluralize)
 


### PR DESCRIPTION
### Summary

- Makes `String#singularize` similar to `String#pluralize` by adding a `count` argument.
- Adds new `String#with_count` which is like a combination of singularize and pluralize. It makes working with words easier by eliminating the need to know what plurality it was originally.