### PR TITLE
Simplify variant tests

### DIFF
--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -20,12 +20,10 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     assert_equal 67, image.height
   end
 
-  test "resized and monochrome variation" do
-    variant = @blob.variant(resize: "100x100", monochrome: true).processed
+  test "monochrome variation" do
+    variant = @blob.variant(monochrome: true).processed
 
     image = read_image_variant(variant)
-    assert_equal 100, image.width
-    assert_equal 67, image.height
     assert_match(/Gray/, image.colorspace)
   end
 

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -8,9 +8,12 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     @blob = create_image_blob filename: "racecar.jpg"
   end
 
+  test "service_url" do
+    assert_match(/racecar\.jpg/, @blob.variant({}).service_url)
+  end
+
   test "resized variation" do
     variant = @blob.variant(resize: "100x100").processed
-    assert_match(/racecar\.jpg/, variant.service_url)
 
     image = read_image_variant(variant)
     assert_equal 100, image.width
@@ -19,7 +22,6 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "resized and monochrome variation" do
     variant = @blob.variant(resize: "100x100", monochrome: true).processed
-    assert_match(/racecar\.jpg/, variant.service_url)
 
     image = read_image_variant(variant)
     assert_equal 100, image.width

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -28,4 +28,12 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     assert_equal 67, image.height
     assert_match(/Gray/, image.colorspace)
   end
+
+  test "rotate variation" do
+    variant = @blob.variant(rotate: "-90").processed
+
+    image = read_image_variant(variant)
+    assert_equal 2736, image.width
+    assert_equal 4104, image.height
+  end
 end


### PR DESCRIPTION
- remove duplicate assertions for `#service_url`
- not to test `resize` variant again
- add tests for `rotate` variant because it might be used very often

thanks :)