### PR TITLE
Appropriately request to unset and set cookie for different sub-domains

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -394,7 +394,7 @@ module ActionDispatch
         if @cookies[name.to_s] != value || options[:expires]
           @cookies[name.to_s] = value
           @set_cookies[name.to_s] = options
-          @delete_cookies.delete(name.to_s)
+          @delete_cookies.delete(name.to_s) if same_domain_or_no_domain?(name.to_s)
         end
 
         value
@@ -457,6 +457,16 @@ module ActionDispatch
 
         def write_cookie?(cookie)
           request.ssl? || !cookie[:secure] || always_write_cookie
+        end
+
+        def same_domain_or_no_domain?(name)
+          delete_cookie = @delete_cookies[name]
+          return true if delete_cookie.blank?
+
+          set_cookie = @set_cookies[name]
+          return true if set_cookie.blank?
+
+          set_cookie[:domain] == delete_cookie[:domain]
         end
     end
 

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -275,6 +275,27 @@ class CookiesTest < ActionController::TestCase
       head :ok
     end
 
+    def delete_and_set_cookie_with_same_name_different_domain
+      cookies.delete(:user_name, domain: :all)
+      cookies[:user_name] = { value: "shayonj", expires: 1.year.from_now, domain: "foo.bar.com" }
+
+      head :ok
+    end
+
+    def delete_and_set_cookie_with_same_name_and_domain
+      cookies.delete(:user_name, domain: ".bar.com")
+      cookies[:user_name] = { value: "shayonj", expires: 1.year.from_now, domain: ".bar.com" }
+
+      head :ok
+    end
+
+    def delete_and_set_cookie_with_same_name_and_domain_with_ip
+      cookies.delete(:user_name, domain: "10.1.1.1.1")
+      cookies[:user_name] = { value: "shayonj", expires: 1.year.from_now, domain: "10.1.1.1.1" }
+
+      head :ok
+    end
+
     def encrypted_cookie
       cookies.encrypted["foo"]
     end
@@ -628,9 +649,40 @@ class CookiesTest < ActionController::TestCase
     assert_equal 100, @controller.send(:cookies).signed[:remember_me]
   end
 
+  def test_deleting_cookie_and_setting_new_one_with_same_name_but_different_domain
+    @request.host = "foo.bar.com"
+    cookies[:user_name] = { value: "shayonOld", expires: 1.year.from_now, domain: "bar.com" }
+
+    response = get :delete_and_set_cookie_with_same_name_different_domain
+
+    assert_match(%r(user_name=; domain=.bar.com;), response.headers["Set-Cookie"])
+    assert_match(%r(user_name=shayonj; domain=foo.bar.com;), response.headers["Set-Cookie"])
+  end
+
+  def test_deleting_cookie_and_setting_new_one_with_same_name_and_same_domain
+    @request.host = "bar.com"
+    cookies[:user_name] = { value: "shayonOld", expires: 1.year.from_now, domain: "bar.com" }
+
+    response = get :delete_and_set_cookie_with_same_name_and_domain
+
+    assert_no_match(%r(user_name=; domain=.bar.com;), response.headers["Set-Cookie"])
+    assert_match(%r(user_name=shayonj; domain=.bar.com;), response.headers["Set-Cookie"])
+  end
+
+  def test_deleting_cookie_and_setting_new_one_with_same_name_and_domain_with_ip
+    @request.host = "10.1.1.1.1"
+    cookies[:user_name] = { value: "shayonOld", expires: 1.year.from_now, domain: "10.1.1.1.1" }
+
+    response = get :delete_and_set_cookie_with_same_name_and_domain_with_ip
+
+    assert_no_match(%r(user_name=;), response.headers["Set-Cookie"])
+    assert_match(%r(user_name=shayonj; domain=10.1.1.1.1;), response.headers["Set-Cookie"])
+  end
+
   def test_delete_and_set_cookie
     request.cookies[:user_name] = "Joe"
     get :delete_and_set_cookie
+    assert_no_match(%r(user_name=;), @response.headers["Set-Cookie"])
     assert_cookie_header "user_name=david; path=/; expires=Mon, 10 Oct 2005 05:00:00 -0000"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end


### PR DESCRIPTION
### Summary

Currently if we were to delete a cookie and set a same cookie but with a
different sub domain, only the new cookie gets set. The cookie that is marked
for removal is still persisted. For example:

```ruby
cookies.delete(:foo, domain: "bar.com")

cookies[:foo] = { value: "bar", expires: 1.year.from_now, domain: "xyz.bar.com" }
```

In the above scenario, single `Set-Cookie` header is sent for `xyz.bar.com`.
Which leaves the earlier cookie persisted in browser, because technically, those
are two different domains.

This may not be a very common use case, but is helpful when working with
legacy cookie and introducing new sub domains.

Hence, this PR. Where, in such a scenario we now send two `Set-Cookie` headers.
One to remove/unset the old cookie and the other to set the new cookie
value on new domain.

I have added new tests and extended an existing test to make sure existing
behaviors are persisted.