### PR TITLE
Update azure-core to 0.1.11 to fix rails-dev-box

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,9 +127,10 @@ GEM
     aws-sdk-resources (2.10.27)
       aws-sdk-core (= 2.10.27)
     aws-sigv4 (1.0.1)
-    azure-core (0.1.10)
+    azure-core (0.1.11)
       faraday (~> 0.9)
       faraday_middleware (~> 0.10)
+      nokogiri (~> 1.6)
     azure-storage (0.12.3.preview)
       azure-core (~> 0.1)
       faraday (~> 0.9)
@@ -217,7 +218,7 @@ GEM
     eventmachine (1.2.5-x64-mingw32)
     eventmachine (1.2.5-x86-mingw32)
     execjs (2.7.0)
-    faraday (0.13.0)
+    faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
@@ -543,4 +544,4 @@ DEPENDENCIES
   websocket-client-simple!
 
 BUNDLED WITH
-   1.15.3
+   1.15.4


### PR DESCRIPTION
rails-dev-box was failing to install gems with a filesystem permission
error. The issue was introduced when azure-core was bumped from 0.1.9 to
0.1.10 in d2f493c7ed7a95f48730aecdcfbcc7bbee30921b. azure-core has [fixed the build problem](https://github.com/Azure/azure-ruby-asm-core/commit/536c3fc21cc48c292959cc10a9e5551e165aa0ed) and
released a new version, 0.1.11 with the fix.

This change is just to run `bundle update azure-core` to pick up that
fix.
