### PR TITLE
Fix actionmailer lambda default

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Bring back proc with arity of 1 in ActionMailer::Base.default proc
+    since it was supported in Rails 5.0 but not deprecated.
+
+    *Jimmy Bourassa*
+
 *   Allow Action Mailer classes to configure their delivery job.
 
         class MyMailer < ApplicationMailer

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -889,13 +889,23 @@ module ActionMailer
         default_values = self.class.default.map do |key, value|
           [
             key,
-            value.is_a?(Proc) ? instance_exec(&value) : value
+            compute_default(value)
           ]
         end.to_h
 
         headers_with_defaults = headers.reverse_merge(default_values)
         headers_with_defaults[:subject] ||= default_i18n_subject
         headers_with_defaults
+      end
+
+      def compute_default(value)
+        return value unless value.is_a?(Proc)
+
+        if value.arity == 1
+          instance_exec(self, &value)
+        else
+          instance_exec(&value)
+        end
       end
 
       def assign_headers_to_message(message, headers)

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -726,6 +726,15 @@ class BaseTest < ActiveSupport::TestCase
     assert(ProcMailer.welcome["x-has-to-proc"].to_s == "symbol")
   end
 
+  test "proc default values can have arity of 1 where arg is a mailer instance" do
+    assert_equal(ProcMailer.welcome['X-Lambda-Arity-1-arg'].to_s, "complex_value")
+    assert_equal(ProcMailer.welcome['X-Lambda-Arity-1-self'].to_s, "complex_value")
+  end
+
+  test "proc default values with fixed arity of 0 can be called" do
+    assert_equal("0", ProcMailer.welcome["X-Lambda-Arity-0"].to_s)
+  end
+
   test "we can call other defined methods on the class as needed" do
     mail = ProcMailer.welcome
     assert_equal("Thanks for signing up this afternoon", mail.subject)

--- a/actionmailer/test/mailers/proc_mailer.rb
+++ b/actionmailer/test/mailers/proc_mailer.rb
@@ -4,10 +4,17 @@ class ProcMailer < ActionMailer::Base
   default to: "system@test.lindsaar.net",
           "X-Proc-Method" => Proc.new { Time.now.to_i.to_s },
           subject: Proc.new { give_a_greeting },
-          "x-has-to-proc" => :symbol
+          "x-has-to-proc" => :symbol,
+          "X-Lambda-Arity-0" => ->() { "0" },
+          "X-Lambda-Arity-1-arg" => ->(arg) { arg.computed_value },
+          "X-Lambda-Arity-1-self" => ->(_) { self.computed_value }
 
   def welcome
     mail
+  end
+
+  def computed_value
+    "complex_value"
   end
 
   private


### PR DESCRIPTION
PR #29270 changed the number of arguments that gets passed to Procs defined in `ActionMail::Base.default`, thus introducing a breaking change. This change impacted Devise (plataformatec/devise#4604).

With this PR, Procs can have an arity of 0 or 1. I added a deprecation for Procs with arity of 1 because it doesn't really make sense to keep this around – I brought it back for the sake of deprecating it before it is removed.

--------

 [This](https://github.com/rails/rails/pull/27825/files#diff-df5a757beffcee1e175f7a82362a1800L891) is where the breaking change was introduced:

```diff
-            value.is_a?(Proc) ? instance_eval(&value) : value
+            value.is_a?(Proc) ? instance_exec(&value) : value
```

`instance_eval` passes `self` to the block, but `instance_exec` does not. In Rails < 5.1, this was the "correct" way, but it now crashes in 5.1. This breaking change was not caught by the test suite because the Proc were not defined with the `lambda` syntax. I added a test case for that as well.

Thoughts?