### PR TITLE
Address `test_after_save_callback_with_autosave` failure

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1724,6 +1724,10 @@ class TestAutosaveAssociationOnAHasManyAssociationWithInverse < ActiveRecord::Te
     end
   end
 
+  def setup
+    Comment.delete_all
+  end
+
   def test_after_save_callback_with_autosave
     post = Post.new(title: "Test", body: "...")
     comment = post.comments.build(body: "...")


### PR DESCRIPTION
### Summary

Address `test_after_save_callback_with_autosave` failure
when other `AutomaticInverseFindingTests` load `:comments` fixture
but does not load `:posts` reported at https://travis-ci.org/rails/rails/jobs/267948502

Refer #30385 for the similar issue