### PR TITLE
Add paths to docs for Active Storage

### DIFF
--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -69,6 +69,7 @@ module Rails
         "activestorage" => {
           include: %w(
             README.md
+            app/**/active_storage/**/*.rb
             lib/active_storage/**/*.rb
           )
         },


### PR DESCRIPTION
Active Storage is a mountable engine. So I've added app path to docs paths.