### PR TITLE
Fix broken doc for Active Record [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  # = Active Record Belongs To Association
   module Associations
+    # = Active Record Belongs To Association
     class BelongsToAssociation < SingularAssociation #:nodoc:
       def handle_dependency
         target.send(options[:dependent]) if load_target

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  # = Active Record Belongs To Polymorphic Association
   module Associations
+    # = Active Record Belongs To Polymorphic Association
     class BelongsToPolymorphicAssociation < BelongsToAssociation #:nodoc:
       def klass
         type = owner[reflection.foreign_type]

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  # = Active Record Has Many Association
   module Associations
+    # = Active Record Has Many Association
     # This is the proxy that handles a has many association.
     #
     # If the association has a <tt>:through</tt> option further specialization

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  # = Active Record Has Many Through Association
   module Associations
+    # = Active Record Has Many Through Association
     class HasManyThroughAssociation < HasManyAssociation #:nodoc:
       include ThroughAssociation
 

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  # = Active Record Has One Association
   module Associations
+    # = Active Record Has One Association
     class HasOneAssociation < SingularAssociation #:nodoc:
       include ForeignAssociation
 

--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  # = Active Record Has One Through Association
   module Associations
+    # = Active Record Has One Through Association
     class HasOneThroughAssociation < HasOneAssociation #:nodoc:
       include ThroughAssociation
 

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  # = Active Record Through Association
   module Associations
+    # = Active Record Through Association
     module ThroughAssociation #:nodoc:
       delegate :source_reflection, :through_reflection, to: :reflection
 


### PR DESCRIPTION
### Summary

Fix [broken doc](http://edgeapi.rubyonrails.org/classes/ActiveRecord/Associations.html) for Active Record.

I've regard [ActiveRecord::Associations::CollectionAssociation](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/collection_association.rb#L5) as a good case. And I've made others (e.g. [ActiveRecord::Associations::BelongsToAssociation](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/belongs_to_association.rb#L4)) change same as `ActiveRecord::Associations::CollectionAssociation`.