### PR TITLE
Add Documentation For Duration Support & Expiry Meta Data  Added to Signed / Encrypted Cookies

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,24 @@
+*  Cookies `:expires` option supports `ActiveSupport::Duration` object.
+    
+        cookies[:user_name] = { value: "assain", expires: 1.hour }
+        cookies[:key] = { value: "a yummy cookie", expires: 6.months }
+
+    Pull Request: #30121
+
+    *Assain Jaleel*
+
+*  Enforce signed/encrypted cookie expiry server side.
+
+    Rails can thwart attacks by malicious clients that don't honor a cookie's expiry.
+
+    It does so by stashing the expiry within the written cookie and relying on the
+    signing/encrypting to vouch that it hasn't been tampered with. Then on a
+    server-side read, the expiry is verified and any expired cookie is discarded.
+
+    Pull Request: #30121
+
+    *Assain Jaleel*
+
 *   Make `take_failed_screenshot` work within engine.
 
     Fixes #30405.

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -83,7 +83,10 @@ module ActionDispatch
   #   cookies[:lat_lon] = JSON.generate([47.68, -122.37])
   #
   #   # Sets a cookie that expires in 1 hour.
-  #   cookies[:login] = { value: "XJ-122", expires: 1.hour.from_now }
+  #   cookies[:login] = { value: "XJ-122", expires: 1.hour }
+  #
+  #   # Sets a cookie that expires at a specific time.
+  #   cookies[:login] = { value: "XJ-122", expires: Time.utc(2020, 10, 15, 5) }
   #
   #   # Sets a signed cookie, which prevents users from tampering with its value.
   #   # The cookie is signed by your app's `secrets.secret_key_base` value.
@@ -100,7 +103,7 @@ module ActionDispatch
   #   cookies.permanent[:login] = "XJ-122"
   #
   #   # You can also chain these methods:
-  #   cookies.permanent.signed[:login] = "XJ-122"
+  #   cookies.signed.permanent[:login] = "XJ-122"
   #
   # Examples of reading:
   #
@@ -118,7 +121,7 @@ module ActionDispatch
   #
   #  cookies[:name] = {
   #    value: 'a yummy cookie',
-  #    expires: 1.year.from_now,
+  #    expires: 1.year,
   #    domain: 'domain.com'
   #  }
   #
@@ -144,7 +147,7 @@ module ActionDispatch
   # * <tt>:tld_length</tt> - When using <tt>:domain => :all</tt>, this option can be used to explicitly
   #   set the TLD length when using a short (<= 3 character) domain that is being interpreted as part of a TLD.
   #   For example, to share cookies between user1.lvh.me and user2.lvh.me, set <tt>:tld_length</tt> to 1.
-  # * <tt>:expires</tt> - The time at which this cookie expires, as a \Time object.
+  # * <tt>:expires</tt> - The time at which this cookie expires, as a \Time or ActiveSupport::Duration object.
   # * <tt>:secure</tt> - Whether this cookie is only transmitted to HTTPS servers.
   #   Default is +false+.
   # * <tt>:httponly</tt> - Whether this cookie is accessible via scripting or


### PR DESCRIPTION
This PR is an addendum to #30121 with the following additions:
* Documentation for duration support added to `:expires` option of cookies. 
* Changelog entries for the duration support and expiry meta data added to signed/encrypted cookies.