### PR TITLE
remove clone call from dirty attribute module

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/hash_with_indifferent_access"
-require "active_support/core_ext/object/duplicable"
 
 module ActiveModel
   # == Active \Model \Dirty
@@ -239,11 +238,8 @@ module ActiveModel
       # Handles <tt>*_will_change!</tt> for +method_missing+.
       def attribute_will_change!(attr)
         return if attribute_changed?(attr)
-
-        begin
+        if respond_to?(attr)
           value = _read_attribute(attr)
-          value = value.duplicable? ? value.dup : value
-        rescue TypeError, NoMethodError
         end
 
         set_attribute_was(attr, value)

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -242,7 +242,7 @@ module ActiveModel
 
         begin
           value = _read_attribute(attr)
-          value = value.duplicable? ? value.clone : value
+          value = value.duplicable? ? value.dup : value
         rescue TypeError, NoMethodError
         end
 

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -40,6 +40,10 @@ class DirtyTest < ActiveModel::TestCase
       @size = val
     end
 
+    def invalid_attr
+      attribute_will_change!(:foobar)
+    end
+
     def save
       changes_applied
     end
@@ -218,5 +222,11 @@ class DirtyTest < ActiveModel::TestCase
     assert @model.changed?
     assert_equal "Dmitry", @model.name
     assert_equal "White", @model.color
+  end
+
+  test "invalid attribute_will_change call" do
+    @model.invalid_attr
+    # TODO: this probably should be `refute`, but that would change some behaviour
+    assert @model.changed?
   end
 end


### PR DESCRIPTION
### How did I find this?

I was debugging the following error in our Rails 4.1 upgrade: `RuntimeError: can't modify frozen Array`. Then I got to the `Dirty#attribute_will_change!` method where I saw it was doing a `clone` instead of a `dup`, even if it was checking for `duplicable?`, which is a check against the `dup` method. [See this was done](https://github.com/rails/rails/commit/f97dae5ebe2f19273d3f92e5ea9baba788c8e89f#diff-aaddd42c7feb0834b1b5c66af69814d3R100) LONG time ago, by @josh.

### The problem
The reason it raised for me on Rails 4.1, is that after that `clone`, it will push the value to a `HashWithIndifferentAccess`, which [will mutate the value](
https://github.com/rails/rails/blob/0cad778c2605a5204a05a9f1dbd3344e39f248d8/activesupport/lib/active_support/hash_with_indifferent_access.rb#L264) when it is an array.
However, when trying to simulate that error on latest master, I couldn't, because the HWIA was [changed](https://github.com/rails/rails/commit/584931d749bfdd8553740bdcc6e4fef2c18ec523) to make up for the frozen case.

### The fix 
https://github.com/arthurnn/rails/commit/45f5fd9c44545535ca733471aa0ddb07eae0abae
I thought, just changing the method to `dup` instead of `clone` was the right thing to do, even if there is nothing broken really, but it would be more semantically correct.

### The other fix
After changing the method, I start thinking why we need to dup/clone the value in the first place. I couldn't find an answer for that, and decided to remove the clone/dup all together. In the end, that will save us some memory allocations.
And, `Dirty` module is not mutating the value at all, so it should not need to clone it.

### The other problem
See the `TODO` on my test case. 
The current behaviour will mark the object as changed, even if we mark an invalid attribute as changed. That seems odd, but I didn't want to change much behaviour, and didn't fix that part. I just left the same behaviour as it is right now, and documented that in a test case.

### Is this backwards compatible?
Kinda, yes and no. Now `changed_attributes` will hold a reference to the value itself. I guess that is ok though. 

I almost didn't send the patch, because it is actually not fixing anything and just avoiding some allocations, and the trade off is a possible, small, incompatibility. But, anyways, you folks can tell me what you think.



