### PR TITLE
Fix duplicate aliases when combining inner/left joins dependencies

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -90,8 +90,8 @@ module ActiveRecord
       #    associations # => [:appointments]
       #    joins # =>  []
       #
-      def initialize(base, table, associations, joins, eager_loading: true)
-        @alias_tracker = AliasTracker.create_with_joins(base.connection, base.table_name, joins)
+      def initialize(base, table, associations, joins, eager_loading: true, alias_tracker: nil)
+        @alias_tracker = alias_tracker || AliasTracker.create_with_joins(base.connection, base.table_name, joins)
         @eager_loading = eager_loading
         tree = self.class.make_tree associations
         @join_root = JoinBase.new(base, table, build(tree, base))

--- a/activerecord/test/cases/associations/left_outer_join_association_test.rb
+++ b/activerecord/test/cases/associations/left_outer_join_association_test.rb
@@ -20,9 +20,10 @@ class LeftOuterJoinAssociationTest < ActiveRecord::TestCase
     assert_nothing_raised do
       queries = capture_sql do
         Person.left_outer_joins(agents: { agents: :agents })
-              .left_outer_joins(agents: { agents: { primary_contact: :agents } }).to_a
+              .left_outer_joins(agents: { agents: { primary_contact: :agents } })
+              .joins(:agents).to_a
       end
-      assert queries.any? { |sql| /agents_people_4/i.match?(sql) }
+      assert queries.any? { |sql| /agents_people_5/i.match?(sql) }
     end
   end
 


### PR DESCRIPTION
This fixes a duplicate aliases query generation issue when combining `Relation#joins()` and `Relaction#left_outer_joins()` that have common join dependencies.
Fixes #30504 

Considering the following schema:

```
class User < ActiveRecord::Base
  has_many :posts
end

class Post < ActiveRecord::Base
  has_many :comments
end
```

Any of the following query will fail with ambiguous column (sqlite) or duplicate alias (postgresql):
```
User.joins(:posts).left_outer_joins(:posts).count
User.joins(:posts).left_outer_joins(:posts => :comments).count

# Both end up generating duplicate aliases for posts, eg:
# SELECT COUNT(*) FROM "users" INNER JOIN "posts" ON "posts"."user_id" = "users"."id" 
# LEFT OUTER JOIN "posts" ON "posts"."user_id" = "users"."id"
```

The issue seems to be that alias tracking/assignment is done per join type (JoinDependency) and not across all the joins of a query.
To work around this issue, this updates JoinDependency to be optionally built with an external alias tracker which is used to share alias tracking between the inner/left join dependencies at arel query building time. It's not clear to me if we shouldn't just make this stricter and always provide an AliasTracker to JoinDependency.
