### PR TITLE
Add :nodoc: for ActiveRecord::AttributeMethods [ci skip]

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     module Read
       extend ActiveSupport::Concern
 
-      module ClassMethods
+      module ClassMethods # :nodoc:
         private
 
           # We want to generate the methods via module_eval rather than

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -62,7 +62,7 @@ module ActiveRecord
         class_attribute :time_zone_aware_types, instance_writer: false, default: [ :datetime, :time ]
       end
 
-      module ClassMethods
+      module ClassMethods # :nodoc:
         private
 
           def inherited(subclass)

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -9,7 +9,7 @@ module ActiveRecord
         attribute_method_suffix "="
       end
 
-      module ClassMethods
+      module ClassMethods # :nodoc:
         private
 
           def define_method_attribute=(name)


### PR DESCRIPTION
### Summary

I found ClassMethods which are not implemented public methods inside namespace of `ActiveRecord::AttributeMethods`. And I've added `:nodoc:` annotations to them.