### PR TITLE
Enable links in Active Storage docs [ci skip]

### DIFF
--- a/activestorage/app/models/active_storage/filename.rb
+++ b/activestorage/app/models/active_storage/filename.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Encapsulates a string representing a filename to provide convenience access to parts of it and a sanitized version.
-# This is what's returned by `ActiveStorage::Blob#filename`. A Filename instance is comparable so it can be used for sorting.
+# This is what's returned by ActiveStorage::Blob#filename. A Filename instance is comparable so it can be used for sorting.
 class ActiveStorage::Filename
   include Comparable
 

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -3,7 +3,7 @@
 require "active_support/core_ext/object/inclusion"
 
 # A set of transformations that can be applied to a blob to create a variant. This class is exposed via
-# the `ActiveStorage::Blob#variant` method and should rarely be used directly.
+# the ActiveStorage::Blob#variant method and should rarely be used directly.
 #
 # In case you do need to use this directly, it's instantiated using a hash of transformations where
 # the key is the command and the value is the arguments. Example:


### PR DESCRIPTION
### Summary

Enable links in docs for ActiveStorage.
And I've confirmed them after generating docs on local.