### PR TITLE
Use typewriter in doc for Action Cable [ci skip]

### DIFF
--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -30,7 +30,7 @@ module ActionCable
         config.connection_class.call.new(self, env).process
       end
 
-      # Disconnect all the connections identified by `identifiers` on this server or any others via RemoteConnections.
+      # Disconnect all the connections identified by +identifiers+ on this server or any others via RemoteConnections.
       def disconnect(identifiers)
         remote_connections.where(identifiers).disconnect
       end


### PR DESCRIPTION
I've found backquotes are used in [doc](http://edgeapi.rubyonrails.org/classes/ActionCable/Server/Base.html#method-i-disconnect).