### PR TITLE
Use tt in doc for action_mailer [ci skip]

### DIFF
--- a/actionmailer/lib/action_mailer/rescuable.rb
+++ b/actionmailer/lib/action_mailer/rescuable.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActionMailer #:nodoc:
-  # Provides `rescue_from` for mailers. Wraps mailer action processing,
+  # Provides +rescue_from+ for mailers. Wraps mailer action processing,
   # mail job processing, and mail delivery.
   module Rescuable
     extend ActiveSupport::Concern


### PR DESCRIPTION
### Summary

I've found wrong format in the [doc](http://edgeapi.rubyonrails.org/classes/ActionMailer/Rescuable.html) of `ActionMailer::Rescuable`. So I've fixed it.