### PR TITLE
Fix `can't modify frozen String` error in `display_image`

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -65,7 +65,7 @@ module ActionDispatch
           end
 
           def display_image
-            message = "[Screenshot]: #{image_path}\n"
+            message = "[Screenshot]: #{image_path}\n".dup
 
             case output_type
             when "artifact"

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -28,6 +28,21 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "display_image return artifact format when specify RAILS_SYSTEM_TESTING_SCREENSHOT environment" do
+    begin
+      original_output_type = ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"]
+      ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] = "artifact"
+
+      new_test = DrivenBySeleniumWithChrome.new("x")
+
+      new_test.stub :passed?, false do
+        assert_match "\e]1338;url=artifact://tmp/screenshots/failures_x.png\a", new_test.send(:display_image)
+      end
+    ensure
+      ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] = original_output_type
+    end
+  end
 end
 
 class RackTestScreenshotsTest < DrivenByRackTest


### PR DESCRIPTION
Without this, `display_image` raises an error as follwing:

```
RuntimeError: can't modify frozen String
    rails/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:72:in `display_image'
    rails/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb:40:in `block (2 levels) in <class:ScreenshotHelperTest>'
```

