### PR TITLE
Retrive screenshot in relative path of current directory

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Make `take_failed_screenshot` work within engine.
+
+    Fixes #30405.
+
+    *Yuji Yaginuma*
+
 *   Deprecate `ActionDispatch::TestResponse` response aliases
 
     `#success?`, `#missing?` & `#error?` are not supported by the actual

--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -44,11 +44,15 @@ module ActionDispatch
           end
 
           def image_path
-            "tmp/screenshots/#{image_name}.png"
+            @image_path ||= absolute_image_path.relative_path_from(Pathname.pwd).to_s
+          end
+
+          def absolute_image_path
+            Rails.root.join("tmp/screenshots/#{image_name}.png")
           end
 
           def save_image
-            page.save_screenshot(Rails.root.join(image_path))
+            page.save_screenshot(absolute_image_path)
           end
 
           def output_type
@@ -69,10 +73,10 @@ module ActionDispatch
 
             case output_type
             when "artifact"
-              message << "\e]1338;url=artifact://#{image_path}\a\n"
+              message << "\e]1338;url=artifact://#{absolute_image_path}\a\n"
             when "inline"
-              name = inline_base64(File.basename(image_path))
-              image = inline_base64(File.read(image_path))
+              name = inline_base64(File.basename(absolute_image_path))
+              image = inline_base64(File.read(absolute_image_path))
               message << "\e]1337;File=name=#{name};height=400px;inline=1:#{image}\a\n"
             end
 

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -8,23 +8,29 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
   test "image path is saved in tmp directory" do
     new_test = DrivenBySeleniumWithChrome.new("x")
 
-    assert_equal "tmp/screenshots/x.png", new_test.send(:image_path)
+    Rails.stub :root, Pathname.getwd do
+      assert_equal "tmp/screenshots/x.png", new_test.send(:image_path)
+    end
   end
 
   test "image path includes failures text if test did not pass" do
     new_test = DrivenBySeleniumWithChrome.new("x")
 
-    new_test.stub :passed?, false do
-      assert_equal "tmp/screenshots/failures_x.png", new_test.send(:image_path)
+    Rails.stub :root, Pathname.getwd do
+      new_test.stub :passed?, false do
+        assert_equal "tmp/screenshots/failures_x.png", new_test.send(:image_path)
+      end
     end
   end
 
   test "image path does not include failures text if test skipped" do
     new_test = DrivenBySeleniumWithChrome.new("x")
 
-    new_test.stub :passed?, false do
-      new_test.stub :skipped?, true do
-        assert_equal "tmp/screenshots/x.png", new_test.send(:image_path)
+    Rails.stub :root, Pathname.getwd do
+      new_test.stub :passed?, false do
+        new_test.stub :skipped?, true do
+          assert_equal "tmp/screenshots/x.png", new_test.send(:image_path)
+        end
       end
     end
   end
@@ -36,11 +42,21 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
 
       new_test = DrivenBySeleniumWithChrome.new("x")
 
-      new_test.stub :passed?, false do
-        assert_match "\e]1338;url=artifact://tmp/screenshots/failures_x.png\a", new_test.send(:display_image)
+      Rails.stub :root, Pathname.getwd do
+        new_test.stub :passed?, false do
+          assert_match %r|url=artifact://.+?tmp/screenshots/failures_x\.png|, new_test.send(:display_image)
+        end
       end
     ensure
       ENV["RAILS_SYSTEM_TESTING_SCREENSHOT"] = original_output_type
+    end
+  end
+
+  test "image path returns the relative path from current directory" do
+    new_test = DrivenBySeleniumWithChrome.new("x")
+
+    Rails.stub :root, Pathname.getwd.join("..") do
+      assert_equal "../tmp/screenshots/x.png", new_test.send(:image_path)
     end
   end
 end


### PR DESCRIPTION
In Rails engine `Rails.root `returns the path of the dummy application.
Therefore, there is no `tmp` directly where the test is running, so can not get the screenshot.
For this reason, instead of directly specifying tmp, retrive screenshot by relative path from the current directory.

Fixes #30405
