### PR TITLE
Fix order of Active Storage DiskService URL parameters

### DIFF
--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -66,7 +66,7 @@ module ActiveStorage
               verified_key_with_expiration,
               filename: filename, disposition: disposition, content_type: content_type
           else
-            "/rails/active_storage/disk/#{verified_key_with_expiration}/#{filename}?disposition=#{disposition}&content_type=#{content_type}"
+            "/rails/active_storage/disk/#{verified_key_with_expiration}/#{filename}?content_type=#{content_type}&disposition=#{disposition}"
           end
 
         payload[:url] = generated_url

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -8,7 +8,7 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
   include ActiveStorage::Service::SharedServiceTests
 
   test "url generation" do
-    assert_match(/rails\/active_storage\/disk\/.*\/avatar\.png\?.+disposition=inline/,
+    assert_match(/rails\/active_storage\/disk\/.*\/avatar\.png\?content_type=image%2Fpng&disposition=inline/,
       @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: "inline; filename=\"avatar.png\"", filename: "avatar.png", content_type: "image/png"))
   end
 end


### PR DESCRIPTION
### Summary

`content_type` parameter is before `disposition` parameter. This PR will order in that way.
