### PR TITLE
Run CodeClimate with the latest Rubocop

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,7 @@
 engines:
   rubocop:
     enabled: true
+    channel: rubocop-0-49
 
 ratings:
   paths:


### PR DESCRIPTION
### Summary

This change updates Rubocop analysis in CodeClimate to the latest version of 0.49.1.

The CodeClimate CLI got the change here: https://github.com/codeclimate/codeclimate/commit/29bf51747aedbcf4db669ed87ac4e8521107cc1b

