### PR TITLE
Remove Active Storage duplicated classes from the API site

### DIFF
--- a/railties/lib/rails/api/generator.rb
+++ b/railties/lib/rails/api/generator.rb
@@ -6,8 +6,11 @@ class RDoc::Generator::API < RDoc::Generator::SDoc # :nodoc:
   RDoc::RDoc.add_generator self
 
   def generate_class_tree_level(classes, visited = {})
-    # Only process core extensions on the first visit.
+    # Only process core extensions on the first visit and remove
+    # Active Storage duplicated classes that are at the top level
+    # since they aren't nested under a definition of the `ActiveStorage` module.
     if visited.empty?
+      classes = classes.reject { |klass| active_storage?(klass) }
       core_exts, classes = classes.partition { |klass| core_extension?(klass) }
 
       super.unshift([ "Core extensions", "", "", build_core_ext_subtree(core_exts, visited) ])
@@ -26,5 +29,9 @@ class RDoc::Generator::API < RDoc::Generator::SDoc # :nodoc:
 
     def core_extension?(klass)
       klass.name != "ActiveSupport" && klass.in_files.any? { |file| file.absolute_name.include?("core_ext") }
+    end
+
+    def active_storage?(klass)
+      klass.name != "ActiveStorage" && klass.in_files.all? { |file| file.absolute_name.include?("active_storage") }
     end
 end


### PR DESCRIPTION
Hello,

Since cb5af0d7, some classes that are under Active Storage are now part of the API site.

However, these classes aren't nested under a definition of the `ActiveStorage` module but rather name-spaced under it like `ActiveStorage::Foo`.

Thus, these classes are present both under the ActiveStorage label and at the root of the site's sidebar so we have to strip out duplicates.

Have a nice day !