### PR TITLE
Fix broken doc layout for action_view [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/active_model_helper.rb
+++ b/actionview/lib/action_view/helpers/active_model_helper.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/enumerable"
 
 module ActionView
   # = Active Model Helpers
-  module Helpers
+  module Helpers #:nodoc:
     module ActiveModelHelper
     end
 

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -4,7 +4,7 @@ require "zlib"
 
 module ActionView
   # = Action View Asset URL Helpers
-  module Helpers
+  module Helpers #:nodoc:
     # This module provides methods for generating asset paths and
     # urls.
     #

--- a/actionview/lib/action_view/helpers/atom_feed_helper.rb
+++ b/actionview/lib/action_view/helpers/atom_feed_helper.rb
@@ -4,7 +4,7 @@ require "set"
 
 module ActionView
   # = Action View Atom Feed Helpers
-  module Helpers
+  module Helpers #:nodoc:
     module AtomFeedHelper
       # Adds easy defaults to writing Atom feeds with the Builder template engine (this does not work on ERB or any other
       # template languages).

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -2,7 +2,7 @@
 
 module ActionView
   # = Action View Cache Helper
-  module Helpers
+  module Helpers #:nodoc:
     module CacheHelper
       # This helper exposes a method for caching fragments of a view
       # rather than an entire action or page. This technique is useful

--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -4,7 +4,7 @@ require "active_support/core_ext/string/output_safety"
 
 module ActionView
   # = Action View Capture Helper
-  module Helpers
+  module Helpers #:nodoc:
     # CaptureHelper exposes methods to let you extract generated markup which
     # can be used in other parts of a template or layout file.
     #

--- a/actionview/lib/action_view/helpers/controller_helper.rb
+++ b/actionview/lib/action_view/helpers/controller_helper.rb
@@ -3,7 +3,7 @@
 require "active_support/core_ext/module/attr_internal"
 
 module ActionView
-  module Helpers
+  module Helpers #:nodoc:
     # This module keeps all methods and behavior in ActionView
     # that simply delegates to the controller.
     module ControllerHelper #:nodoc:

--- a/actionview/lib/action_view/helpers/csrf_helper.rb
+++ b/actionview/lib/action_view/helpers/csrf_helper.rb
@@ -2,7 +2,7 @@
 
 module ActionView
   # = Action View CSRF Helper
-  module Helpers
+  module Helpers #:nodoc:
     module CsrfHelper
       # Returns meta tags "csrf-param" and "csrf-token" with the name of the cross-site
       # request forgery protection parameter and token, respectively.

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -9,7 +9,7 @@ require "active_support/core_ext/object/acts_like"
 require "active_support/core_ext/object/with_options"
 
 module ActionView
-  module Helpers
+  module Helpers #:nodoc:
     # = Action View Date Helpers
     #
     # The Date Helper primarily creates select/option tags for different kinds of dates and times or date and time

--- a/actionview/lib/action_view/helpers/debug_helper.rb
+++ b/actionview/lib/action_view/helpers/debug_helper.rb
@@ -4,7 +4,7 @@ module ActionView
   # = Action View Debug Helper
   #
   # Provides a set of methods for making it easier to debug Rails objects.
-  module Helpers
+  module Helpers #:nodoc:
     module DebugHelper
       include TagHelper
 

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -14,7 +14,7 @@ require "active_support/core_ext/string/inflections"
 
 module ActionView
   # = Action View Form Helpers
-  module Helpers
+  module Helpers #:nodoc:
     # Form helpers are designed to make working with resources much easier
     # compared to using vanilla HTML.
     #

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -9,7 +9,7 @@ require "active_support/core_ext/array/wrap"
 
 module ActionView
   # = Action View Form Option Helpers
-  module Helpers
+  module Helpers #:nodoc:
     # Provides a number of methods for turning different kinds of containers into a set of option tags.
     #
     # The <tt>collection_select</tt>, <tt>select</tt> and <tt>time_zone_select</tt> methods take an <tt>options</tt> parameter, a hash:

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -7,7 +7,7 @@ require "active_support/core_ext/module/attribute_accessors"
 
 module ActionView
   # = Action View Form Tag Helpers
-  module Helpers
+  module Helpers #:nodoc:
     # Provides a number of methods for creating form tags that don't rely on an Active Record object assigned to the template like
     # FormHelper does. Instead, you provide the names and values manually.
     #

--- a/actionview/lib/action_view/helpers/javascript_helper.rb
+++ b/actionview/lib/action_view/helpers/javascript_helper.rb
@@ -3,7 +3,7 @@
 require_relative "tag_helper"
 
 module ActionView
-  module Helpers
+  module Helpers #:nodoc:
     module JavaScriptHelper
       JS_ESCAPE_MAP = {
         '\\'    => '\\\\',

--- a/actionview/lib/action_view/helpers/record_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/record_tag_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActionView
-  module Helpers
+  module Helpers #:nodoc:
     module RecordTagHelper
       def div_for(*) # :nodoc:
         raise NoMethodError, "The `div_for` method has been removed from " \

--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActionView
-  module Helpers
+  module Helpers #:nodoc:
     # = Action View Rendering
     #
     # Implements methods that allow rendering from a view context.

--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -5,7 +5,7 @@ require "rails-html-sanitizer"
 
 module ActionView
   # = Action View Sanitize Helpers
-  module Helpers
+  module Helpers #:nodoc:
     # The SanitizeHelper module provides a set of methods for scrubbing text of undesired HTML elements.
     # These helper methods extend Action View making them callable within your template files.
     module SanitizeHelper

--- a/actionview/lib/action_view/helpers/tags.rb
+++ b/actionview/lib/action_view/helpers/tags.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActionView
-  module Helpers
+  module Helpers #:nodoc:
     module Tags #:nodoc:
       extend ActiveSupport::Autoload
 

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -6,7 +6,7 @@ require "i18n/exceptions"
 
 module ActionView
   # = Action View Translation Helpers
-  module Helpers
+  module Helpers #:nodoc:
     module TranslationHelper
       extend ActiveSupport::Concern
 

--- a/actionview/lib/action_view/template/handlers.rb
+++ b/actionview/lib/action_view/template/handlers.rb
@@ -2,7 +2,7 @@
 
 module ActionView #:nodoc:
   # = Action View Template Handlers
-  class Template
+  class Template #:nodoc:
     module Handlers #:nodoc:
       autoload :Raw, "action_view/template/handlers/raw"
       autoload :ERB, "action_view/template/handlers/erb"

--- a/actionview/lib/action_view/template/html.rb
+++ b/actionview/lib/action_view/template/html.rb
@@ -2,7 +2,7 @@
 
 module ActionView #:nodoc:
   # = Action View HTML Template
-  class Template
+  class Template #:nodoc:
     class HTML #:nodoc:
       attr_accessor :type
 

--- a/actionview/lib/action_view/template/text.rb
+++ b/actionview/lib/action_view/template/text.rb
@@ -2,7 +2,7 @@
 
 module ActionView #:nodoc:
   # = Action View Text Template
-  class Template
+  class Template #:nodoc:
     class Text #:nodoc:
       attr_accessor :type
 

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -3,7 +3,7 @@
 require "active_support/core_ext/module/attribute_accessors"
 
 module ActionView
-  class Template
+  class Template #:nodoc:
     class Types
       class Type
         SET = Struct.new(:symbols).new([ :html, :text, :js, :css, :xml, :json ])


### PR DESCRIPTION
### Summary

I've found broken layout in doc for ActionView:

- http://edgeapi.rubyonrails.org/classes/ActionView/Helpers.html
- http://edgeapi.rubyonrails.org/classes/ActionView/Template.html

I think the cause of broken is some of classes/modules don't give `:nodoc:` annotation. So I've added them.