### PR TITLE
Use tt in doc for ActiveRecord [ci skip]

### DIFF
--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -103,8 +103,8 @@ module ActiveModel
     #     end
     #   end
     #
-    # NOTE: +method_name+ passed to `define_model_callbacks` must not end with
-    # `!`, `?` or `=`.
+    # NOTE: +method_name+ passed to define_model_callbacks must not end with
+    # <tt>!</tt>, <tt>?</tt> or <tt>=</tt>.
     def define_model_callbacks(*callbacks)
       options = callbacks.extract_options!
       options = {

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -94,7 +94,7 @@ module ActiveRecord
       end
 
       # Did this attribute change when we last saved? This method can be invoked
-      # as `saved_change_to_name?` instead of `saved_change_to_attribute?("name")`.
+      # as +saved_change_to_name?+ instead of <tt>saved_change_to_attribute?("name")</tt>.
       # Behaves similarly to +attribute_changed?+. This method is useful in
       # after callbacks to determine if the call to save changed a certain
       # attribute.
@@ -117,8 +117,8 @@ module ActiveRecord
       # Behaves similarly to +attribute_change+. This method is useful in after
       # callbacks, to see the change in an attribute that just occurred
       #
-      # This method can be invoked as `saved_change_to_name` in instead of
-      # `saved_change_to_attribute("name")`
+      # This method can be invoked as +saved_change_to_name+ in instead of
+      # <tt>saved_change_to_attribute("name")</tt>
       def saved_change_to_attribute(attr_name)
         mutations_before_last_save.change_to_attribute(attr_name)
       end
@@ -131,7 +131,7 @@ module ActiveRecord
         mutations_before_last_save.original_value(attr_name)
       end
 
-      # Did the last call to `save` have any changes to change?
+      # Did the last call to +save+ have any changes to change?
       def saved_changes?
         mutations_before_last_save.any_changes?
       end
@@ -141,37 +141,37 @@ module ActiveRecord
         mutations_before_last_save.changes
       end
 
-      # Alias for `attribute_changed?`
+      # Alias for +attribute_changed?+
       def will_save_change_to_attribute?(attr_name, **options)
         mutations_from_database.changed?(attr_name, **options)
       end
 
-      # Alias for `attribute_change`
+      # Alias for +attribute_change+
       def attribute_change_to_be_saved(attr_name)
         mutations_from_database.change_to_attribute(attr_name)
       end
 
-      # Alias for `attribute_was`
+      # Alias for +attribute_was+
       def attribute_in_database(attr_name)
         mutations_from_database.original_value(attr_name)
       end
 
-      # Alias for `changed?`
+      # Alias for +changed?+
       def has_changes_to_save?
         mutations_from_database.any_changes?
       end
 
-      # Alias for `changes`
+      # Alias for +changes+
       def changes_to_save
         mutations_from_database.changes
       end
 
-      # Alias for `changed`
+      # Alias for +changed+
       def changed_attribute_names_to_save
         changes_to_save.keys
       end
 
-      # Alias for `changed_attributes`
+      # Alias for +changed_attributes+
       def attributes_in_database
         changes_to_save.transform_values(&:first)
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -76,7 +76,7 @@ module ActiveRecord
       ##
       # :singleton-method:
       # Indicates whether boolean values are stored in sqlite3 databases as 1
-      # and 0 or 't' and 'f'. Leaving `ActiveRecord::ConnectionAdapters::SQLite3Adapter.represent_boolean_as_integer`
+      # and 0 or 't' and 'f'. Leaving <tt>ActiveRecord::ConnectionAdapters::SQLite3Adapter.represent_boolean_as_integer</tt>
       # set to false is deprecated. SQLite databases have used 't' and 'f' to
       # serialize boolean values and must have old data converted to 1 and 0
       # (its native boolean serialization) before setting this flag to true.
@@ -85,7 +85,7 @@ module ActiveRecord
       #   ExampleModel.where("boolean_column = 't'").update_all(boolean_column: 1)
       #   ExampleModel.where("boolean_column = 'f'").update_all(boolean_column: 0)
       # for all models and all boolean columns, after which the flag must be set
-      # to true by adding the following to your application.rb file:
+      # to true by adding the following to your <tt>application.rb</tt> file:
       #
       #   Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
       class_attribute :represent_boolean_as_integer, default: false

--- a/activerecord/lib/active_record/define_callbacks.rb
+++ b/activerecord/lib/active_record/define_callbacks.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  # This module exists because `ActiveRecord::AttributeMethods::Dirty` needs to
-  # define callbacks, but continue to have its version of `save` be the super
-  # method of `ActiveRecord::Callbacks`. This will be removed when the removal
+  # This module exists because ActiveRecord::AttributeMethods::Dirty needs to
+  # define callbacks, but continue to have its version of +save+ be the super
+  # method of ActiveRecord::Callbacks. This will be removed when the removal
   # of deprecated code removes this need.
   module DefineCallbacks
     extend ActiveSupport::Concern

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -147,7 +147,7 @@ module ActiveRecord
   # unwanted inter-test dependencies. Methods used by multiple fixtures should be defined in a module
   # that is included in ActiveRecord::FixtureSet.context_class.
   #
-  # - define a helper method in `test_helper.rb`
+  # - define a helper method in <tt>test_helper.rb</tt>
   #     module FixtureFileHelpers
   #       def file_sha(path)
   #         Digest::SHA2.hexdigest(File.read(Rails.root.join('test/fixtures', path)))

--- a/activerecord/lib/active_record/no_touching.rb
+++ b/activerecord/lib/active_record/no_touching.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
-      # Lets you selectively disable calls to `touch` for the
+      # Lets you selectively disable calls to +touch+ for the
       # duration of a block.
       #
       # ==== Examples

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -353,7 +353,7 @@ module ActiveRecord
     # Wrapper around #increment that writes the update to the database.
     # Only +attribute+ is updated; the record itself is not saved.
     # This means that any other modified attributes will still be dirty.
-    # Validations and callbacks are skipped. Supports the `touch` option from
+    # Validations and callbacks are skipped. Supports the +touch+ option from
     # +update_counters+, see that for more.
     # Returns +self+.
     def increment!(attribute, by = 1, touch: nil)
@@ -374,7 +374,7 @@ module ActiveRecord
     # Wrapper around #decrement that writes the update to the database.
     # Only +attribute+ is updated; the record itself is not saved.
     # This means that any other modified attributes will still be dirty.
-    # Validations and callbacks are skipped. Supports the `touch` option from
+    # Validations and callbacks are skipped. Supports the +touch+ option from
     # +update_counters+, see that for more.
     # Returns +self+.
     def decrement!(attribute, by = 1, touch: nil)


### PR DESCRIPTION
### Summary

I found wrong format of rdoc in docs for ActiveModel, ActiveRecord. And I've corrected it.