### PR TITLE
Use tt in doc for ActiveSupport and Railties [skip ci]

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -85,7 +85,7 @@ module ActiveSupport #:nodoc:
     # handles the new constants.
     #
     # If child.rb is being autoloaded, its constants will be added to
-    # autoloaded_constants. If it was being `require`d, they will be discarded.
+    # autoloaded_constants. If it was being required, they will be discarded.
     #
     # This is handled by walking back up the watch stack and adding the constants
     # found by child.rb to the list of original constants in parent.rb.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -151,7 +151,7 @@ module Rails
       end
 
       # Loads and returns the entire raw configuration of database from
-      # values stored in `config/database.yml`.
+      # values stored in <tt>config/database.yml</tt>.
       def database_configuration
         path = paths["config/database"].existent.first
         yaml = Pathname.new(path) if path

--- a/railties/lib/rails/command/actions.rb
+++ b/railties/lib/rails/command/actions.rb
@@ -3,9 +3,9 @@
 module Rails
   module Command
     module Actions
-      # Change to the application's path if there is no config.ru file in current directory.
-      # This allows us to run `rails server` from other directories, but still get
-      # the main config.ru and properly set the tmp directory.
+      # Change to the application's path if there is no <tt>config.ru</tt> file in current directory.
+      # This allows us to run <tt>rails server</tt> from other directories, but still get
+      # the main <tt>config.ru</tt> and properly set the <tt>tmp</tt> directory.
       def set_application_directory!
         Dir.chdir(File.expand_path("../..", APP_PATH)) unless File.exist?(File.expand_path("config.ru"))
       end

--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -112,8 +112,8 @@ module Rails
         # Default file root to place extra files a command might need, placed
         # one folder above the command file.
         #
-        # For a `Rails::Command::TestCommand` placed in `rails/command/test_command.rb`
-        # would return `rails/test`.
+        # For a Rails::Command::TestCommand placed in <tt>rails/command/test_command.rb</tt>
+        # would return <tt>rails/test</tt>.
         def default_command_root
           path = File.expand_path(File.join("../commands", command_root_namespace), __dir__)
           path if File.exist?(path)


### PR DESCRIPTION
### Summary

I found wrong format of rdoc in docs for ActiveSupport and Railties. And I've corrected it.
