### PR TITLE
Use tt in doc for ActionView [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -111,9 +111,9 @@ module ActionView
       #   <%= render_categorizable_events @person.events %>
       #
       # This marks every template in the directory as a dependency. To find those
-      # templates, the wildcard path must be absolutely defined from app/views or paths
+      # templates, the wildcard path must be absolutely defined from <tt>app/views</tt> or paths
       # otherwise added with +prepend_view_path+ or +append_view_path+.
-      # This way the wildcard for `app/views/recordings/events` would be `recordings/events/*` etc.
+      # This way the wildcard for <tt>app/views/recordings/events</tt> would be <tt>recordings/events/*</tt> etc.
       #
       # The pattern used to match explicit dependencies is <tt>/# Template Dependency: (\S+)/</tt>,
       # so it's important that you type it out just so.
@@ -133,14 +133,14 @@ module ActionView
       #
       # === Collection Caching
       #
-      # When rendering a collection of objects that each use the same partial, a `cached`
+      # When rendering a collection of objects that each use the same partial, a <tt>:cached</tt>
       # option can be passed.
       #
       # For collections rendered such:
       #
       #   <%= render partial: 'projects/project', collection: @projects, cached: true %>
       #
-      # The `cached: true` will make Action View's rendering read several templates
+      # The <tt>cached: true</tt> will make Action View's rendering read several templates
       # from cache at once instead of one call per template.
       #
       # Templates in the collection not already cached are written to cache.

--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -9,7 +9,7 @@ module ActionView
     # can be used in other parts of a template or layout file.
     #
     # It provides a method to capture blocks into variables through capture and
-    # a way to capture a block of markup for use in a layout through content_for.
+    # a way to capture a block of markup for use in a layout through {content_for}[rdoc-ref:ActionView::Helpers::CaptureHelper#content_for].
     module CaptureHelper
       # The capture method extracts part of a template as a String object.
       # You can then use this object anywhere in your templates, layout, or helpers.
@@ -44,7 +44,7 @@ module ActionView
         end
       end
 
-      # Calling content_for stores a block of markup in an identifier for later use.
+      # Calling <tt>content_for</tt> stores a block of markup in an identifier for later use.
       # In order to access this stored content in other templates, helper modules
       # or the layout, you would pass the identifier as an argument to <tt>content_for</tt>.
       #
@@ -110,7 +110,7 @@ module ActionView
       # That will place +script+ tags for your default set of JavaScript files on the page;
       # this technique is useful if you'll only be using these scripts in a few views.
       #
-      # Note that content_for concatenates (default) the blocks it is given for a particular
+      # Note that <tt>content_for</tt> concatenates (default) the blocks it is given for a particular
       # identifier in order. For example:
       #
       #   <% content_for :navigation do %>
@@ -127,7 +127,7 @@ module ActionView
       #
       #   <ul><%= content_for :navigation %></ul>
       #
-      # If the flush parameter is true content_for replaces the blocks it is given. For example:
+      # If the flush parameter is +true+ <tt>content_for</tt> replaces the blocks it is given. For example:
       #
       #   <% content_for :navigation do %>
       #     <li><%= link_to 'Home', action: 'index' %></li>
@@ -147,7 +147,7 @@ module ActionView
       #
       #   <% content_for :script, javascript_include_tag(:defaults) %>
       #
-      # WARNING: content_for is ignored in caches. So you shouldn't use it for elements that will be fragment cached.
+      # WARNING: <tt>content_for</tt> is ignored in caches. So you shouldn't use it for elements that will be fragment cached.
       def content_for(name, content = nil, options = {}, &block)
         if content || block_given?
           if block_given?
@@ -174,7 +174,7 @@ module ActionView
         result unless content
       end
 
-      # content_for? checks whether any content has been captured yet using `content_for`.
+      # <tt>content_for?</tt> checks whether any content has been captured yet using <tt>content_for</tt>.
       # Useful to render parts of your layout differently based on what is in your views.
       #
       #   <%# This is the layout %>

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -456,7 +456,7 @@ module ActionView
       # submit tag but it isn't supported in legacy browsers. However,
       # the button tag does allow for richer labels such as images and emphasis,
       # so this helper will also accept a block. By default, it will create
-      # a button tag with type `submit`, if type is not given.
+      # a button tag with type <tt>submit</tt>, if type is not given.
       #
       # ==== Options
       # * <tt>:data</tt> - This option can be used to add custom data attributes.

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -52,12 +52,12 @@ module ActionView
   #     <%= render partial: "ad", locals: { ad: ad } %>
   #   <% end %>
   #
-  # This would first render "advertiser/_account.html.erb" with @buyer passed in as the local variable +account+, then
-  # render "advertiser/_ad.html.erb" and pass the local variable +ad+ to the template for display.
+  # This would first render <tt>advertiser/_account.html.erb</tt> with <tt>@buyer</tt> passed in as the local variable +account+, then
+  # render <tt>advertiser/_ad.html.erb</tt> and pass the local variable +ad+ to the template for display.
   #
   # == The :as and :object options
   #
-  # By default <tt>ActionView::PartialRenderer</tt> doesn't have any local variables.
+  # By default ActionView::PartialRenderer doesn't have any local variables.
   # The <tt>:object</tt> option can be used to pass an object to the partial. For instance:
   #
   #   <%= render partial: "account", object: @buyer %>
@@ -85,7 +85,7 @@ module ActionView
   #
   #   <%= render partial: "ad", collection: @advertisements %>
   #
-  # This will render "advertiser/_ad.html.erb" and pass the local variable +ad+ to the template for display. An
+  # This will render <tt>advertiser/_ad.html.erb</tt> and pass the local variable +ad+ to the template for display. An
   # iteration object will automatically be made available to the template with a name of the form
   # +partial_name_iteration+. The iteration object has knowledge about which index the current object has in
   # the collection and the total size of the collection. The iteration object also has two convenience methods,
@@ -100,7 +100,7 @@ module ActionView
   #
   #   <%= render partial: "ad", collection: @advertisements, spacer_template: "ad_divider" %>
   #
-  # If the given <tt>:collection</tt> is +nil+ or empty, <tt>render</tt> will return nil. This will allow you
+  # If the given <tt>:collection</tt> is +nil+ or empty, <tt>render</tt> will return +nil+. This will allow you
   # to specify a text which will be displayed instead by using this form:
   #
   #   <%= render(partial: "ad", collection: @advertisements) || "There's no ad to be displayed" %>
@@ -114,18 +114,18 @@ module ActionView
   #
   #   <%= render partial: "advertisement/ad", locals: { ad: @advertisement } %>
   #
-  # This will render the partial "advertisement/_ad.html.erb" regardless of which controller this is being called from.
+  # This will render the partial <tt>advertisement/_ad.html.erb</tt> regardless of which controller this is being called from.
   #
-  # == \Rendering objects that respond to `to_partial_path`
+  # == \Rendering objects that respond to +to_partial_path+
   #
   # Instead of explicitly naming the location of a partial, you can also let PartialRenderer do the work
-  # and pick the proper path by checking `to_partial_path` method.
+  # and pick the proper path by checking +to_partial_path+ method.
   #
   #  # @account.to_partial_path returns 'accounts/account', so it can be used to replace:
   #  # <%= render partial: "accounts/account", locals: { account: @account} %>
   #  <%= render partial: @account %>
   #
-  #  # @posts is an array of Post instances, so every post record returns 'posts/post' on `to_partial_path`,
+  #  # @posts is an array of Post instances, so every post record returns 'posts/post' on +to_partial_path+,
   #  # that's why we can replace:
   #  # <%= render partial: "posts/post", collection: @posts %>
   #  <%= render partial: @posts %>
@@ -145,7 +145,7 @@ module ActionView
   #  # <%= render partial: "accounts/account", locals: { account: @account} %>
   #  <%= render @account %>
   #
-  #  # @posts is an array of Post instances, so every post record returns 'posts/post' on `to_partial_path`,
+  #  # @posts is an array of Post instances, so every post record returns 'posts/post' on +to_partial_path+,
   #  # that's why we can replace:
   #  # <%= render partial: "posts/post", collection: @posts %>
   #  <%= render @posts %>

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -310,13 +310,13 @@ module ActionView
   # ==== Examples
   #
   # Default pattern, loads views the same way as previous versions of rails, eg. when you're
-  # looking for `users/new` it will produce query glob: `users/new{.{en},}{.{html,js},}{.{erb,haml},}`
+  # looking for <tt>users/new</tt> it will produce query glob: <tt>users/new{.{en},}{.{html,js},}{.{erb,haml},}</tt>
   #
   #   FileSystemResolver.new("/path/to/views", ":prefix/:action{.:locale,}{.:formats,}{+:variants,}{.:handlers,}")
   #
   # This one allows you to keep files with different formats in separate subdirectories,
-  # eg. `users/new.html` will be loaded from `users/html/new.erb` or `users/new.html.erb`,
-  # `users/new.js` from `users/js/new.erb` or `users/new.js.erb`, etc.
+  # eg. <tt>users/new.html</tt> will be loaded from <tt>users/html/new.erb</tt> or <tt>users/new.html.erb</tt>,
+  # <tt>users/new.js</tt> from <tt>users/js/new.erb</tt> or <tt>users/new.js.erb</tt>, etc.
   #
   #   FileSystemResolver.new("/path/to/views", ":prefix/{:formats/,}:action{.:locale,}{.:formats,}{+:variants,}{.:handlers,}")
   #


### PR DESCRIPTION
### Summary

I found wrong format of rdoc in docs for ActionView. And I've corrected it.