### PR TITLE
We need to raise an exception with a helpful error message

### DIFF
--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -45,6 +45,7 @@ module ActiveRecord
           foreign_key  = has_many_association.foreign_key.to_s
           child_class  = has_many_association.klass
           reflection   = child_class._reflections.values.find { |e| e.belongs_to? && e.foreign_key.to_s == foreign_key && e.options[:counter_cache].present? }
+          raise ArgumentError, "'counter_cache: true declaration is missing in the model" if reflection.nil?
           counter_name = reflection.counter_cache_column
 
           updates = { counter_name.to_sym => object.send(counter_association).count(:all) }


### PR DESCRIPTION
#If you forget to define the `counter_cache: true` in the model, you will get this error:

```
rake aborted!
NoMethodError: undefined method `counter_cache_column' for nil:NilClass
```

we need to raise an exception with a helpful error message like this:

```
raise ArgumentError, "'counter_cache: true declaration is missing in the model" if reflection.nil?
```