### PR TITLE
Update Rails I18n API guide [ci skip]

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -105,7 +105,7 @@ This means, that in the `:en` locale, the key _hello_ will map to the _Hello wor
 
 The I18n library will use **English** as a **default locale**, i.e. if a different locale is not set, `:en` will be used for looking up translations.
 
-NOTE: The i18n library takes a **pragmatic approach** to locale keys (after [some discussion](http://groups.google.com/group/rails-i18n/browse_thread/thread/14dede2c7dbe9470/80eec34395f64f3c?hl=en)), including only the _locale_ ("language") part, like `:en`, `:pl`, not the _region_ part, like `:en-US` or `:en-GB`, which are traditionally used for separating "languages" and "regional setting" or "dialects". Many international applications use only the "language" element of a locale such as `:cs`, `:th` or `:es` (for Czech, Thai and Spanish). However, there are also regional differences within different language groups that may be important. For instance, in the `:en-US` locale you would have $ as a currency symbol, while in `:en-GB`, you would have £. Nothing stops you from separating regional and other settings in this way: you just have to provide full "English - United Kingdom" locale in a `:en-GB` dictionary. Few gems such as [Globalize3](https://github.com/globalize/globalize) may help you implement it.
+NOTE: The i18n library takes a **pragmatic approach** to locale keys (after [some discussion](https://groups.google.com/forum/#!topic/rails-i18n/FN7eLH2-lHA)), including only the _locale_ ("language") part, like `:en`, `:pl`, not the _region_ part, like `:en-US` or `:en-GB`, which are traditionally used for separating "languages" and "regional setting" or "dialects". Many international applications use only the "language" element of a locale such as `:cs`, `:th` or `:es` (for Czech, Thai and Spanish). However, there are also regional differences within different language groups that may be important. For instance, in the `:en-US` locale you would have $ as a currency symbol, while in `:en-GB`, you would have £. Nothing stops you from separating regional and other settings in this way: you just have to provide full "English - United Kingdom" locale in a `:en-GB` dictionary. Few gems such as [Globalize3](https://github.com/globalize/globalize) may help you implement it.
 
 The **translations load path** (`I18n.load_path`) is an array of paths to files that will be loaded automatically. Configuring this path allows for customization of translations directory structure and file naming scheme.
 
@@ -313,7 +313,7 @@ In general, this approach is far less reliable than using the language header an
 WARNING: You may be tempted to store the chosen locale in a _session_ or a *cookie*. However, **do not do this**. The locale should be transparent and a part of the URL. This way you won't break people's basic assumptions about the web itself: if you send a URL to a friend, they should see the same page and content as you. A fancy word for this would be that you're being [*RESTful*](https://en.wikipedia.org/wiki/Representational_State_Transfer). Read more about the RESTful approach in [Stefan Tilkov's articles](https://www.infoq.com/articles/rest-introduction). Sometimes there are exceptions to this rule and those are discussed below.
 
 Internationalization and Localization
------------------------------------
+-------------------------------------
 
 OK! Now you've initialized I18n support for your Ruby on Rails application and told it which locale to use and how to preserve it between requests.
 
@@ -371,7 +371,7 @@ end
 
 ```html+erb
 # app/views/home/index.html.erb
-<h1><%=t :hello_world %></h1>
+<h1><%= t :hello_world %></h1>
 <p><%= flash[:notice] %></p>
 ```
 
@@ -430,12 +430,12 @@ en:
 ```
 
 ```ruby
-I18n.t 'success.true' # => 'True!'
-I18n.t 'success.on' # => 'On!'
+I18n.t 'success.true'  # => 'True!'
+I18n.t 'success.on'    # => 'On!'
 I18n.t 'success.false' # => 'False!'
 I18n.t 'failure.false' # => Translation Missing
-I18n.t 'failure.off' # => Translation Missing
-I18n.t 'failure.true' # => Translation Missing
+I18n.t 'failure.off'   # => Translation Missing
+I18n.t 'failure.true'  # => Translation Missing
 ```
 
 ### Passing Variables to Translations
@@ -502,7 +502,7 @@ OK! Now let's add a timestamp to the view, so we can demo the **date/time locali
 
 ```erb
 # app/views/home/index.html.erb
-<h1><%=t :hello_world %></h1>
+<h1><%= t :hello_world %></h1>
 <p><%= flash[:notice] %></p>
 <p><%= l Time.now, format: :short %></p>
 ```
@@ -1050,7 +1050,7 @@ The Simple backend shipped with Active Support allows you to store translations 
 
 For example a Ruby Hash providing translations can look like this:
 
-```yaml
+```ruby
 {
   pt: {
     foo: {
@@ -1187,7 +1187,7 @@ If you find your own locale (language) missing from our [example translations da
 Resources
 ---------
 
-* [Google group: rails-i18n](http://groups.google.com/group/rails-i18n) - The project's mailing list.
+* [Google group: rails-i18n](https://groups.google.com/forum/#!forum/rails-i18n) - The project's mailing list.
 * [GitHub: rails-i18n](https://github.com/svenfuchs/rails-i18n) - Code repository and issue tracker for the rails-i18n project. Most importantly you can find lots of [example translations](https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale) for Rails that should work for your application in most cases.
 * [GitHub: i18n](https://github.com/svenfuchs/i18n) - Code repository and issue tracker for the i18n gem.
 


### PR DESCRIPTION
### Summary

- Modified Google group's Url on L108 and L1090.
- Changed language for syntax highlight from `yaml` to `ruby` on L1053.
- Added spaces between `=` and method name on L374 and L505.