### PR TITLE
Fix `can't modify frozen String` error in `DBConsole`

### DIFF
--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -75,7 +75,7 @@ module Rails
         args += ["-P", "#{config['password']}"] if config["password"]
 
         if config["host"]
-          host_arg = "#{config['host']}"
+          host_arg = "#{config['host']}".dup
           host_arg << ":#{config['port']}" if config["port"]
           args += ["-S", host_arg]
         end

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -206,6 +206,12 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     assert_equal ["sqlplus", "user/secret@db"], dbconsole.find_cmd_and_exec_args
   end
 
+  def test_sqlserver
+    start(adapter: "sqlserver", database: "db", username: "user", password: "secret", host: "localhost", port: 1433)
+    assert_not aborted
+    assert_equal ["sqsh", "-D", "db", "-U", "user", "-P", "secret", "-S", "localhost:1433"], dbconsole.find_cmd_and_exec_args
+  end
+
   def test_unknown_command_line_client
     start(adapter: "unknown", database: "db")
     assert aborted


### PR DESCRIPTION
Without this, `dbconsole` raises an error as follwing:

```
RuntimeError: can't modify frozen String
    railties/lib/rails/commands/dbconsole/dbconsole_command.rb:79:in `start'
```