### PR TITLE
Add alias key to as_json [ci skip]

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Rails 4.1.16.2 (August 29, 2017) ##
+
+*	Add alias key to as_json
+
+	When I have 2 or more has_many associations, I want to use the second has_many association
+	name with content of first has_many associations.
+
+	Example:
+	  user = User.last
+	  user.as_json(include: { friends: { alias: :new_friends } }) # will produce:
+	  {"email"=>"david@example.com", "gender"=>"male", "name"=>"David", "new_friends"=>[]}
+
+    *Yoga Hapriana*
+
 ## Rails 4.1.16 (July 12, 2016) ##
 
 *   No changes.

--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -155,7 +155,9 @@ module ActiveModel
 
         includes.each do |association, opts|
           if records = send(association)
-            yield association, records, opts
+            alias_association = opts[:alias]
+            assoc = alias_association.present? ? alias_association : association
+            yield assoc, records, opts
           end
         end
       end

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -165,4 +165,10 @@ class SerializationTest < ActiveModel::TestCase
                            {"name"=>'Sue', "email"=>'sue@example.com', "gender"=>'female'}]}
     assert_equal expected, @user.serializable_hash(include: [{ address: {only: "street" } }, :friends])
   end
+
+  def test_method_serializable_hash_should_work_with_alias
+    @user.friends = []
+    expected = {"email"=>"david@example.com", "gender"=>"male", "name"=>"David", "new_friends"=>[]}
+    assert_equal expected, @user.serializable_hash(include: [friends: { alias: :new_friends }])
+  end
 end


### PR DESCRIPTION
When I have 2 or more has_many associations, I want to use the second has_many association
name with content of first has_many associations.

Example:
  user = User.last
  user.as_json(include: { friends: { alias: :new_friends } }) # will produce:
  {"email"=>"david@example.com", "gender"=>"male", "name"=>"David", "new_friends"=>[]}