### PR TITLE
Update Action Mailer doc [ci skip]

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -59,7 +59,7 @@ module ActionMailer
   # The hash passed to the mail method allows you to specify any header that a <tt>Mail::Message</tt>
   # will accept (any valid email header including optional fields).
   #
-  # The mail method, if not passed a block, will inspect your views and send all the views with
+  # The +mail+ method, if not passed a block, will inspect your views and send all the views with
   # the same name as the method, so the above action would send the +welcome.text.erb+ view
   # file as well as the +welcome.html.erb+ view file in a +multipart/alternative+ email.
   #
@@ -138,7 +138,7 @@ module ActionMailer
   # You can also define a <tt>default_url_options</tt> method on individual mailers to override these
   # default settings per-mailer.
   #
-  # By default when <tt>config.force_ssl</tt> is true, URLs generated for hosts will use the HTTPS protocol.
+  # By default when <tt>config.force_ssl</tt> is +true+, URLs generated for hosts will use the HTTPS protocol.
   #
   # = Sending mail
   #
@@ -316,7 +316,7 @@ module ActionMailer
   #
   # = Callbacks
   #
-  # You can specify callbacks using before_action and after_action for configuring your messages.
+  # You can specify callbacks using <tt>before_action</tt> and <tt>after_action</tt> for configuring your messages.
   # This may be useful, for example, when you want to add default inline attachments for all
   # messages sent out by a certain mailer class:
   #

--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -4,7 +4,7 @@ require "delegate"
 
 module ActionMailer
   # The <tt>ActionMailer::MessageDelivery</tt> class is used by
-  # <tt>ActionMailer::Base</tt> when creating a new mailer.
+  # ActionMailer::Base when creating a new mailer.
   # <tt>MessageDelivery</tt> is a wrapper (+Delegator+ subclass) around a lazy
   # created <tt>Mail::Message</tt>. You can get direct access to the
   # <tt>Mail::Message</tt>, deliver the email or schedule the email to be sent

--- a/actionmailer/lib/action_mailer/preview.rb
+++ b/actionmailer/lib/action_mailer/preview.rb
@@ -17,7 +17,7 @@ module ActionMailer
       #
       #     config.action_mailer.show_previews = true
       #
-      # Defaults to true for development environment
+      # Defaults to +true+ for development environment
       #
       mattr_accessor :show_previews, instance_writer: false
 
@@ -33,7 +33,7 @@ module ActionMailer
 
       # Register an Interceptor which will be called before mail is previewed.
       # Either a class or a string can be passed in as the Interceptor. If a
-      # string is passed in it will be <tt>constantize</tt>d.
+      # string is passed in it will be constantized.
       def register_preview_interceptor(interceptor)
         preview_interceptor = \
           case interceptor
@@ -81,12 +81,12 @@ module ActionMailer
         public_instance_methods(false).map(&:to_s).sort
       end
 
-      # Returns true if the email exists.
+      # Returns +true+ if the email exists.
       def email_exists?(email)
         emails.include?(email)
       end
 
-      # Returns true if the preview exists.
+      # Returns +true+ if the preview exists.
       def exists?(preview)
         all.any? { |p| p.preview_name == preview }
       end


### PR DESCRIPTION
### Summary

- Markup as typewriter format.
- Enable link to `ActionMailer::Base` from `ActionMailer::MessageDelivery`.