### PR TITLE
Update activejob doc [ci skip]

### DIFF
--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -10,7 +10,7 @@ module ActiveJob
     # Includes the +perform_later+ method for job initialization.
     module ClassMethods
       # Push a job onto the queue. The arguments must be legal JSON types
-      # (string, int, float, nil, true, false, hash or array) or
+      # (+string+, +int+, +float+, +nil+, +true+, +false+, +hash+ or +array+) or
       # GlobalID::Identification instances. Arbitrary Ruby objects
       # are not supported.
       #


### PR DESCRIPTION
### Summary

Markup as typewriter format.

If this change is not worth for Rails, feel free to close this request.