### PR TITLE
Fix MySQL strict mode warning

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -770,7 +770,8 @@ module ActiveRecord
               sql_mode = "REPLACE(#{sql_mode}, 'STRICT_ALL_TABLES', '')"
               sql_mode = "REPLACE(#{sql_mode}, 'TRADITIONAL', '')"
             end
-            sql_mode = "CONCAT(#{sql_mode}, ',NO_AUTO_VALUE_ON_ZERO')"
+            extra_sql_modes = %w(NO_AUTO_VALUE_ON_ZERO NO_ZERO_DATE NO_ZERO_IN_DATE ERROR_FOR_DIVISION_BY_ZERO)
+            sql_mode = "CONCAT(#{sql_mode}, ',#{extra_sql_modes.join(',')}')"
           end
           sql_mode_assignment = "@@SESSION.sql_mode = #{sql_mode}, " if sql_mode
 

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -122,7 +122,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
 
   def test_mysql_default_in_strict_mode
     result = @connection.select_value("SELECT @@SESSION.sql_mode")
-    assert_match %r(STRICT_ALL_TABLES), result
+    assert_match %r(STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO), result
   end
 
   def test_mysql_strict_mode_disabled


### PR DESCRIPTION
Without this, MySQL 5.7.8 and later raises an warning.

```
MysqlWarning: 'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and
  'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict
  mode. They will be merged with strict mode in a future release.
```

ERROR_FOR_DIVISION_BY_ZERO, NO_ZERO_DATE, and NO_ZERO_IN_DATE can be
used separately from strict mode, however it is intended that they be
used together. A warning occurs if they are enabled without also
enabling strict mode or vice versa.