### PR TITLE
Fix `can't modify frozen String` error in `DatabaseTasks`

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -117,7 +117,7 @@ module ActiveRecord
         end
 
         def run_cmd_error(cmd, args, action)
-          msg = "failed to execute:\n"
+          msg = "failed to execute:\n".dup
           msg << "#{cmd} #{args.join(' ')}\n\n"
           msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"
           msg

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -73,7 +73,7 @@ module ActiveRecord
         end
 
         def run_cmd_error(cmd, args)
-          msg = "failed to execute:\n"
+          msg = "failed to execute:\n".dup
           msg << "#{cmd} #{args.join(' ')}\n\n"
           msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"
           msg

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -295,6 +295,16 @@ if current_adapter?(:PostgreSQLAdapter)
         end
       end
 
+      def test_structure_dump_execution_fails
+        filename = "awesome-file.sql"
+        Kernel.expects(:system).with("pg_dump", "-s", "-x", "-O", "-f", filename, "my-app-db").returns(nil)
+
+        e = assert_raise(RuntimeError) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+        end
+        assert_match("failed to execute:", e.message)
+      end
+
       private
         def with_dump_schemas(value, &block)
           old_dump_schemas = ActiveRecord::Base.dump_schemas


### PR DESCRIPTION
Without this, `db:structure:dump` task raises an error as follwing:

```
can't modify frozen String
activerecord/lib/active_record/tasks/sqlite_database_tasks.rb:77:in `run_cmd_error'
activerecord/lib/active_record/tasks/sqlite_database_tasks.rb:72:in `run_cmd'
activerecord/lib/active_record/tasks/sqlite_database_tasks.rb:52:in `structure_dump'
activerecord/lib/active_record/tasks/database_tasks.rb:219:in `structure_dump'
activerecord/lib/active_record/railties/databases.rake:279:in `block (3 levels) in <main>'
railties/lib/rails/commands/rake/rake_command.rb:23:in `block in perform'
railties/lib/rails/commands/rake/rake_command.rb:20:in `perform'
railties/lib/rails/command.rb:48:in `invoke'
railties/lib/rails/commands.rb:18:in `<main>'
```