### PR TITLE
Allow BlobsController to return file response instead of redirect

### DIFF
--- a/activestorage/app/controllers/active_storage/blobs_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs_controller.rb
@@ -7,8 +7,7 @@
 class ActiveStorage::BlobsController < ActionController::Base
   def show
     if blob = find_signed_blob
-      expires_in 5.minutes # service_url defaults to 5 minutes
-      redirect_to blob.service_url(disposition: disposition_param)
+      params[:no_redirect] ? data_response(blob) : redirect_response(blob)
     else
       head :not_found
     end
@@ -21,5 +20,23 @@ class ActiveStorage::BlobsController < ActionController::Base
 
     def disposition_param
       params[:disposition].presence_in(%w( inline attachment )) || "inline"
+    end
+
+    def filename_param
+      params[:filename].presence || File.basename(@service_url)
+    end
+
+    def type_param
+      params[:type].presence || Mime::Type.lookup_by_extension(File.extname(@service_url).split(".").last).to_s
+    end
+
+    def data_response(blob)
+      @service_url = blob.service_url(disposition: "inline")
+      send_data open(@service_url).read, disposition: disposition_param, filename: filename_param, type: type_param
+    end
+
+    def redirect_response(blob)
+      expires_in 5.minutes # service_url defaults to 5 minutes
+      redirect_to blob.service_url(disposition: disposition_param)
     end
 end


### PR DESCRIPTION
### Summary

This is my attempt at a PR in response to #30431. Please bear with me as this is my first real code PR for Rails and I'm not totally familiar with the conventions yet.

Effectively this allows you to have your server respond with the files you have stored through ActiveStorage rather than returning a redirect to that location. The reason this is helpful is because if you put a CDN in front of your app (like CloudFront) it will only cache the 301 redirect (which expires after 5 minutes). This allows your CDN to cache the actual file content and serve it at it's own discretion instead.

### Other Information

It would be great if you have any feedback on whether this is the sort of thing you'd be interested in including and also how I could improve the code to fall better inline with the framework's conventions.