### PR TITLE
Backport changelog links

### DIFF
--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |s|
   s.files        = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*"]
   s.require_path = "lib"
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actioncable",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actioncable/CHANGELOG.md"
+  }
+
   s.add_dependency "actionpack", version
 
   s.add_dependency "nio4r",            "~> 2.0"

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -19,6 +19,11 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actionmailer",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionmailer/CHANGELOG.md"
+  }
+
   s.add_dependency "actionpack", version
   s.add_dependency "actionview", version
   s.add_dependency "activejob", version

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -19,6 +19,11 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actionpack",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionpack/CHANGELOG.md"
+  }
+
   s.add_dependency "activesupport", version
 
   s.add_dependency "rack",      "~> 2.0"

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -19,6 +19,11 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/actionview",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionview/CHANGELOG.md"
+  }
+
   s.add_dependency "activesupport", version
 
   s.add_dependency "builder",       "~> 3.1"

--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |s|
   s.files        = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*"]
   s.require_path = "lib"
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activejob",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activejob/CHANGELOG.md"
+  }
+
   s.add_dependency "activesupport", version
   s.add_dependency "globalid", ">= 0.3.6"
 end

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -18,5 +18,10 @@ Gem::Specification.new do |s|
   s.files        = Dir["CHANGELOG.md", "MIT-LICENSE", "README.rdoc", "lib/**/*"]
   s.require_path = "lib"
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activemodel",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activemodel/CHANGELOG.md"
+  }
+
   s.add_dependency "activesupport", version
 end

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -21,6 +21,11 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w(README.rdoc)
   s.rdoc_options.concat ["--main",  "README.rdoc"]
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activerecord",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activerecord/CHANGELOG.md"
+  }
+
   s.add_dependency "activesupport", version
   s.add_dependency "activemodel",   version
 

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -20,6 +20,11 @@ Gem::Specification.new do |s|
 
   s.rdoc_options.concat ["--encoding",  "UTF-8"]
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/activesupport",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activesupport/CHANGELOG.md"
+  }
+
   s.add_dependency "i18n",       "~> 0.7"
   s.add_dependency "tzinfo",     "~> 1.1"
   s.add_dependency "minitest",   "~> 5.1"

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -23,6 +23,11 @@ Gem::Specification.new do |s|
 
   s.rdoc_options << "--exclude" << "."
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/rails/tree/v#{version}/railties",
+    "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/railties/CHANGELOG.md"
+  }
+
   s.add_dependency "activesupport", version
   s.add_dependency "actionpack",    version
 


### PR DESCRIPTION
Backports #29650 and #29588. Means we'll get the changelog links on future `5.1.x` releases.