### PR TITLE
activerecord: Remove a redundant mutation tracker

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -228,7 +228,7 @@ module ActiveRecord
     def becomes(klass)
       became = klass.new
       became.instance_variable_set("@attributes", @attributes)
-      became.instance_variable_set("@mutation_tracker", @mutation_tracker) if defined?(@mutation_tracker)
+      became.instance_variable_set("@mutations_from_database", @mutations_from_database) if defined?(@mutations_from_database)
       became.instance_variable_set("@changed_attributes", attributes_changed_by_setter)
       became.instance_variable_set("@new_record", new_record?)
       became.instance_variable_set("@destroyed", destroyed?)


### PR DESCRIPTION
cc @sgrif

Pull request https://github.com/rails/rails/pull/25337 added an extra mutation tracker to preserve the old `changes` behaviour, but now that `changes` behaves the same way as `changes_to_save` (https://github.com/rails/rails/commit/020abadf047997cb3df18a59d210dfe4406cf166), we don't need both `@mutation_tracker` and `@mutations_from_database`.  In fact, the only time they reference a different object is within `changes_applied` where it made the assignment `@mutations_from_database = AttributeMutationTracker.new(@attributes)` but then it called `clear_mutation_trackers` which set both `@mutation_tracker` and `@mutations_from_database`` to `nil`.

This PR removes `@mutation_tracker` and instead just uses `@mutations_from_database`.
