### PR TITLE
activerecord: Fix saved_changes for saves nested in after callbacks

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -63,7 +63,7 @@ module ActiveRecord
       end
 
       def changes_internally_applied # :nodoc:
-        @mutations_before_last_save = mutation_tracker
+        @mutations_before_last_save = mutations_from_database
         forget_attribute_assignments
         @mutations_from_database = AttributeMutationTracker.new(@attributes)
       end
@@ -71,7 +71,8 @@ module ActiveRecord
       def changes_applied # :nodoc:
         @previous_mutation_tracker = mutation_tracker
         @changed_attributes = ActiveSupport::HashWithIndifferentAccess.new
-        clear_mutation_trackers
+        @mutation_tracker = nil
+        @mutations_from_database = nil
       end
 
       def clear_changes_information # :nodoc:


### PR DESCRIPTION
cc @sgrif 

### Problem

The behaviour of `saved_changes` is different between rails 5.1 and rails master in an after_(create/update/save) callback for a save nested within an after_(create/update/save) callback.  On rails 5.1 it was returning the changes for the outermost save in the callbacks for the nested save.  The behaviour on rails master matches how `saved_changes` was initially described in https://github.com/rails/rails/pull/25337#issuecomment-225166796, which is that it returns a "Hash of all changes in last save".

There is also a related problem after the double save after it returns, where `saved_changes` would be empty rather than having the changes for the last save.

### Solution

Avoid using `mutation_tracker` for the `saved_changes`, since that mutation tracker is for the deprecated changed_attributes behaviour, which changes after all the callbacks rather than at the start of the after_(create/update/save) callbacks.  By using `mutations_from_database` instead, we avoid the differences between rails 5.1 and rails master.

Similarly, we shouldn't be resetting `@mutations_before_last_save = nil` after all the callbacks in `changes_applied` since that doesn't match the rails master behaviour which doesn't do anything after all the callbacks, only at the start of the after callbacks.  This way `saved_changes` still references the last save after `save` returns.