### PR TITLE
activerecord: Fix deprecated behaviour of changed_attributes

### DIFF
--- a/activerecord/lib/active_record/attribute_mutation_tracker.rb
+++ b/activerecord/lib/active_record/attribute_mutation_tracker.rb
@@ -2,6 +2,8 @@ module ActiveRecord
   class AttributeMutationTracker # :nodoc:
     OPTION_NOT_GIVEN = Object.new
 
+    attr_reader :attributes
+
     def initialize(attributes)
       @attributes = attributes
       @forced_changes = Set.new
@@ -70,7 +72,7 @@ module ActiveRecord
     # Workaround for Ruby 2.2 "private attribute?" warning.
     protected
 
-      attr_reader :attributes, :forced_changes, :deprecated_forced_changes
+      attr_reader :forced_changes, :deprecated_forced_changes
 
     private
 


### PR DESCRIPTION
cc @sgrif

### Problem

Pull request https://github.com/rails/rails/pull/25337 made some breaking changes to the way changed_attributes works for rails 5.1, but the PR was only supposed to deprecate using it in after
callbacks.

The problem was that `forget_attribute_assignments` in `changes_internally_applied` disconnected `mutation_tracker` from the current attributes, so didn't receive any changes made to it in after callbacks.

### Solution

To preserve the deprecated behaviour, changes are applied to `mutation_tracker` when `changed_attributes` is called or after a save nested in an after_(create/update/save) callback.