### PR TITLE
Make it same title in index and page [ci skip]

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -72,7 +72,7 @@
       url: active_support_core_extensions.html
       description: This guide documents the Ruby core extensions defined in Active Support.
     -
-      name: Rails Internationalization API
+      name: Rails Internationalization (I18n) API
       url: i18n.html
       description: This guide covers how to add internationalization to your applications. Your application will be able to translate content to different languages, change pluralization rules, use correct date formats for each country, and so on.
     -
@@ -104,7 +104,7 @@
       url: command_line.html
       description: This guide covers the command line tools provided by Rails.
     -
-      name: Asset Pipeline
+      name: The Asset Pipeline
       url: asset_pipeline.html
       description: This guide documents the asset pipeline.
     -
@@ -151,7 +151,7 @@
       url: rails_on_rack.html
       description: This guide covers Rails integration with Rack and interfacing with other Rack components.
     -
-      name: Creating and Customizing Rails Generators
+      name: Creating and Customizing Rails Generators & Templates
       url: generators.html
       description: This guide covers the process of adding a brand new generator to your extension or providing an alternative to an element of a built-in Rails generator (such as providing alternative test stubs for the scaffold generator).
     -
@@ -178,7 +178,7 @@
   name: Maintenance Policy
   documents:
     -
-      name: Maintenance Policy
+      name: Maintenance Policy for Ruby on Rails
       url: maintenance_policy.html
       description: What versions of Ruby on Rails are currently supported, and when to expect new versions.
 -

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -1,7 +1,7 @@
 **DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON http://guides.rubyonrails.org.**
 
-Form Helpers
-============
+Action View Form Helpers
+========================
 
 Forms in web applications are an essential interface for user input. However, form markup can quickly become tedious to write and maintain because of the need to handle form control naming and its numerous attributes. Rails does away with this complexity by providing view helpers for generating form markup. However, since these helpers have different use cases, developers need to know the differences between the helper methods before putting them to use.
 

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1,7 +1,7 @@
 **DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON http://guides.rubyonrails.org.**
 
-Ruby on Rails Security Guide
-============================
+Securing Rails Applications
+===========================
 
 This manual describes common security problems in web applications and how to avoid them with Rails.
 

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1,7 +1,7 @@
 **DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON http://guides.rubyonrails.org.**
 
-A Guide to Testing Rails Applications
-=====================================
+Testing Rails Applications
+==========================
 
 This guide covers built-in mechanisms in Rails for testing your application.
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -1,7 +1,7 @@
 **DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON http://guides.rubyonrails.org.**
 
-A Guide for Upgrading Ruby on Rails
-===================================
+Upgrading Ruby on Rails
+=======================
 
 This guide provides steps to be followed when you upgrade your applications to a newer version of Ruby on Rails. These steps are also available in individual release guides.
 


### PR DESCRIPTION
### Summary

I found some different title between index of guide and the page of guide.
So I fixed to make them same title.

If the title is different between index and page, I choose more specific one (`Action View Form Helpers`, `Securing Rails Application`, `Testing Rails Applications` and `Upgrading Ruby on Rails` were chosen from index's title).