### PR TITLE
Update RDOC_MAIN.rdoc [ci skip]

### DIFF
--- a/railties/RDOC_MAIN.rdoc
+++ b/railties/RDOC_MAIN.rdoc
@@ -1,35 +1,50 @@
 == Welcome to \Rails
 
-\Rails is a web-application framework that includes everything needed to create
-database-backed web applications according to the {Model-View-Controller (MVC)}[https://en.wikipedia.org/wiki/Model-view-controller] pattern.
+\Rails is a web-application framework that includes everything needed to
+create database-backed web applications according to the
+{Model-View-Controller (MVC)}[http://en.wikipedia.org/wiki/Model-view-controller]
+pattern.
 
-Understanding the MVC pattern is key to understanding \Rails. MVC divides your application
-into three layers, each with a specific responsibility.
+Understanding the MVC pattern is key to understanding \Rails. MVC divides your
+application into three layers, each with a specific responsibility.
 
-The View layer is composed of "templates" that are responsible for providing
-appropriate representations of your application's resources. Templates
-can come in a variety of formats, but most view templates are \HTML with embedded Ruby
-code (.erb files).
+The <em>Model layer</em> represents your domain model (such as Account, Product,
+Person, Post, etc.) and encapsulates the business logic that is specific to
+your application. In \Rails, database-backed model classes are derived from
+ActiveRecord::Base. Active Record allows you to present the data from
+database rows as objects and embellish these data objects with business logic
+methods. You can read more about Active Record in its {README}[link:files/activerecord/README_rdoc.html].
+Although most \Rails models are backed by a database, models can also be ordinary
+Ruby classes, or Ruby classes that implement a set of interfaces as provided by
+the Active Model module. You can read more about Active Model in its {README}[link:files/activemodel/README_rdoc.html].
 
-The Model layer represents your domain model (such as Account, Product, Person, Post)
-and encapsulates the business logic that is specific to your application. In \Rails,
-database-backed model classes are derived from ActiveRecord::Base. Active Record allows
-you to present the data from database rows as objects and embellish these data objects
-with business logic methods. Although most \Rails models are backed by a database, models
-can also be ordinary Ruby classes, or Ruby classes that implement a set of interfaces as
-provided by the ActiveModel module. You can read more about Active Record in its
-{README}[link:files/activerecord/README_rdoc.html].
+The <em>Controller layer</em> is responsible for handling incoming HTTP requests and
+providing a suitable response. Usually this means returning \HTML, but \Rails controllers
+can also generate XML, JSON, PDFs, mobile-specific views, and more. Controllers load and
+manipulate models, and render view templates in order to generate the appropriate HTTP response.
+In \Rails, incoming requests are routed by Action Dispatch to an appropriate controller, and
+controller classes are derived from ActionController::Base. Action Dispatch and Action Controller
+are bundled together in Action Pack. You can read more about Action Pack in its
+{README}[link:files/actionpack/README_rdoc.html].
 
-The Controller layer is responsible for handling incoming HTTP requests and providing a
-suitable response. Usually this means returning \HTML, but \Rails controllers can also
-generate XML, JSON, PDFs, mobile-specific views, and more. Controllers manipulate models
-and render view templates in order to generate the appropriate HTTP response.
+The <em>View layer</em> is composed of "templates" that are responsible for providing
+appropriate representations of your application's resources. Templates can
+come in a variety of formats, but most view templates are \HTML with embedded
+Ruby code (ERB files). Views are typically rendered to generate a controller response,
+or to generate the body of an email. In \Rails, View generation is handled by Action View.
+You can read more about Action View in its {README}[link:files/actionview/README_rdoc.html].
 
-In \Rails, the Controller and View layers are handled together by Action Pack.
-These two layers are bundled in a single package due to their heavy interdependence.
-This is unlike the relationship between Active Record and Action Pack, which are
-independent. Each of these packages can be used independently outside of \Rails. You
-can read more about Action Pack in its {README}[link:files/actionpack/README_rdoc.html].
+Active Record, Active Model, Action Pack, and Action View can each be used independently outside \Rails.
+In addition to that, \Rails also comes with Action Mailer ({README}[link:files/actionmailer/README_rdoc.html]), a library
+to generate and send emails; Active Job ({README}[link:files/activejob/README_md.html]), a
+framework for declaring jobs and making them run on a variety of queueing
+backends; Action Cable ({README}[link:files/actioncable/README_md.html]), a framework to
+integrate WebSockets with a \Rails application;
+Active Storage ({README}[link:files/activestorage/README_md.html]), a library to attach cloud
+and local files to \Rails applications;
+and Active Support ({README}[link:files/activesupport/README_rdoc.html]), a collection
+of utility classes and standard library extensions that are useful for \Rails,
+and may also be used independently outside \Rails.
 
 == Getting Started
 
@@ -45,28 +60,31 @@ can read more about Action Pack in its {README}[link:files/actionpack/README_rdo
 
 3. Change directory to +myapp+ and start the web server:
 
-    $ cd myapp; rails server
+    $ cd myapp
+    $ rails server
 
    Run with <tt>--help</tt> or <tt>-h</tt> for options.
 
-4. Go to http://localhost:3000 and you'll see:
-
-    "Yay! You’re on Rails!"
+4. Go to <tt>http://localhost:3000</tt> and you'll see: "Yay! You’re on \Rails!"
 
 5. Follow the guidelines to start developing your application. You may find the following resources handy:
 
-* The \README file created within your application.
-* {Getting Started with \Rails}[http://guides.rubyonrails.org/getting_started.html].
-* {Ruby on \Rails Tutorial}[https://www.railstutorial.org/book].
-* {Ruby on \Rails Guides}[http://guides.rubyonrails.org].
-* {The API Documentation}[http://api.rubyonrails.org].
+   * The \README file created within your application.
+   * {Getting Started with \Rails}[http://guides.rubyonrails.org/getting_started.html].
+   * {Ruby on \Rails Guides}[http://guides.rubyonrails.org].
+   * {The API Documentation}[http://api.rubyonrails.org].
+   * {Ruby on \Rails Tutorial}[https://www.railstutorial.org/book].
 
 == Contributing
 
-We encourage you to contribute to Ruby on \Rails! Please check out the {Contributing to Rails
-guide}[http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html] for guidelines about how
-to proceed. {Join us}[http://contributors.rubyonrails.org]!
+We encourage you to contribute to Ruby on \Rails! Please check out the
+{Contributing to Ruby on \Rails guide}[http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html] for guidelines about how to proceed. {Join us!}[http://contributors.rubyonrails.org]
 
+Trying to report a possible security vulnerability in \Rails? Please
+check out our {security policy}[http://rubyonrails.org/security/] for
+guidelines about how to proceed.
+
+Everyone interacting in \Rails and its sub-projects' codebases, issue trackers, chat rooms, and mailing lists is expected to follow the \Rails {code of conduct}[http://rubyonrails.org/conduct/].
 
 == License
 


### PR DESCRIPTION
### Summary

It seems that descriptions of [README for api](http://edgeapi.rubyonrails.org/files/railties/RDOC_MAIN_rdoc.html) are old a little. So I updated this. Almost of all descriptions referred from [README for repo](https://github.com/rails/rails/blob/master/README.md).

I've confirmed all links after running `bundle exec rake rdoc` on local.