### PR TITLE
In Action View Overview guide, remove reference to custom helpers

### DIFF
--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -7,7 +7,7 @@ After reading this guide, you will know:
 
 * What Action View is and how to use it with Rails.
 * How best to use templates, partials, and layouts.
-* What helpers are provided by Action View and how to make your own.
+* What helpers are provided by Action View.
 * How to use localized views.
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

Removing this reference to custom view helpers in the "After reading this guide" section because I don't see any corresponding text in the guide's body. I couldn't find it in the file history either, so I imagine it was always a todo.