### PR TITLE
Ignore files already deleted on GCS file deletions

### DIFF
--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -35,7 +35,11 @@ module ActiveStorage
 
     def delete(key)
       instrument :delete, key do
-        file_for(key).try(:delete)
+        begin
+          file_for(key).try(:delete)
+        rescue Google::Cloud::NotFoundError
+          # Ignore files already deleted
+        end
       end
     end
 


### PR DESCRIPTION
### Summary

This PR avoids raising errors when trying to delete files in Google Cloud Storage that were already deleted. This is currently handled for most situations:
https://github.com/rails/rails/blob/c2b2a8c74fcd2e32996641503ed029c8f7484b00/activestorage/lib/active_storage/service/gcs_service.rb#L36-L40

`file_for` returns `nil` when the file doesn't exist, so the `delete` won't be attempted and everything would be fine. However, there is an interesting race condition we have been running into:
- `file_for` sends a `GET` request to `googleapis` to fetch an existing file, returned from `file_for`
- That file is deleted from GCS in parallel after this, but before our `delete` call sends the `DELETE` request for that same file
- This last request will get a 404 from `googleapis`, that in turn will raise `Google::Cloud::NotFoundError`. 

The change here simply ignores this error, independently on where it happens (`file_for` or `delete`). It's similar to what 
Relying on the GET request issued first to fetch the file we want to
delete is not enough to avoid this error. If the file is deleted after
our GET request but before the DELETE request we'll get a NotFound error
that after all means that the file is already deleted, so it can be
safely ignored.

### Other Information

I have also reviewed the other services that currently exist in `ActiveStorage`, in case the same change could be needed there:

- `DiskService` already [takes care](https://github.com/rails/rails/blob/c2b2a8c74fcd2e32996641503ed029c8f7484b00/activestorage/lib/active_storage/service/disk_service.rb#L45-L47) of this. 
- `S3Service` is fine because of the way the [`DELETE object` operation works](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html). A 204 response is always returned, with information about the deletion in the response's custom headers. The Ruby AWS SDK doesn't raise any exceptions depending on this (see [here](https://github.com/aws/aws-sdk-ruby/blob/9ea447b7e9e57e27bb7924aca40a5bf0c3265a94/gems/aws-sdk-s3/lib/aws-sdk-s3/object.rb#L471-L478) and [here](https://github.com/aws/aws-sdk-ruby/blob/9ea447b7e9e57e27bb7924aca40a5bf0c3265a94/gems/aws-sdk-s3/lib/aws-sdk-s3/client.rb#L1218-L1221)). 
- `AzureStorageService` already [takes care](https://github.com/rails/rails/blob/c2b2a8c74fcd2e32996641503ed029c8f7484b00/activestorage/lib/active_storage/service/azure_storage_service.rb#L48-L50) of this as well. Perhaps it could be improved to use a less generic error, though. 

