### PR TITLE
Fix `can't modify frozen String` error in `XmlMini_JDOM`

### DIFF
--- a/activesupport/lib/active_support/xml_mini/jdom.rb
+++ b/activesupport/lib/active_support/xml_mini/jdom.rb
@@ -169,7 +169,7 @@ module ActiveSupport
       # element::
       #   XML element to be checked.
       def empty_content?(element)
-        text = ""
+        text = "".dup
         child_nodes = element.child_nodes
         (0...child_nodes.length).each do |i|
           item = child_nodes.item(i)


### PR DESCRIPTION
Without this, `XmlMini_JDOM` raises an error as follwing:

```
RuntimeError: can't modify frozen String
    org/jruby/RubyString.java:2264:in `concat'
    activesupport/lib/active_support/xml_mini/jdom.rb:177:in `block in empty_content?'
    org/jruby/RubyRange.java:485:in `each'
    activesupport/lib/active_support/xml_mini/jdom.rb:174:in `empty_content?'
    activesupport/lib/active_support/xml_mini/jdom.rb:86:in `collapse'
    activesupport/lib/active_support/xml_mini/jdom.rb:66:in `merge_element!'
    activesupport/lib/active_support/xml_mini/jdom.rb:84:in `block in collapse'
    org/jruby/RubyRange.java:485:in `each'
    activesupport/lib/active_support/xml_mini/jdom.rb:82:in `collapse'
    activesupport/lib/active_support/xml_mini/jdom.rb:66:in `merge_element!'
    activesupport/lib/active_support/xml_mini/jdom.rb:51:in `parse'
    activesupport/lib/active_support/xml_mini.rb:101:in `parse'
```

We already have tests about `XmlMini_JDOM`. But it is not running in CI.
https://github.com/rails/rails/blob/master/activesupport/test/xml_mini/jdom_engine_test.rb

