### PR TITLE
Fix `can't modify frozen String` error in AC::Rendering

### DIFF
--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -42,7 +42,7 @@ module ActionController
     def render_to_string(*)
       result = super
       if result.respond_to?(:each)
-        string = ""
+        string = "".dup
         result.each { |r| string << r }
         string
       else

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -606,6 +606,18 @@ class MetalRenderTest < ActionController::TestCase
   end
 end
 
+class ActionControllerRenderTest < ActionController::TestCase
+  class MinimalController < ActionController::Metal
+    include AbstractController::Rendering
+    include ActionController::Rendering
+  end
+
+  def test_direct_render_to_string_with_body
+    mc = MinimalController.new
+    assert_equal "Hello world!", mc.render_to_string(body: ["Hello world!"])
+  end
+end
+
 class ActionControllerBaseRenderTest < ActionController::TestCase
   def test_direct_render_to_string
     ac = ActionController::Base.new()


### PR DESCRIPTION
### Summary

This PR will change the code introduced with the following commit.

https://github.com/rails/rails/commit/c27fde26166f71ec68a7fb501435b656f436a687

There is one thing I'm troubled about. I can not indicate a test case. Because I can not understand the arguments of `render_to_string` method for the `result.respond_to?(:each)` to return `true`.
On the other hand, a test case where `result.respond_to?(:each)` to return `false` is already existing as below.

https://github.com/rails/rails/blob/v5.1.4.rc1/actionpack/test/controller/render_test.rb#L607-L612

However, when the condition is `true`, this code is obvious that `can not modify frozen String` error will occur, this PR fix it.
