### PR TITLE
Remove unnecessary `to_i` for old sqlite3 adapter

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -518,8 +518,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_sum_expression
-    # Oracle adapter returns floating point value 636.0 after SUM
-    if current_adapter?(:OracleAdapter)
+    if current_adapter?(:SQLite3Adapter, :Mysql2Adapter, :PostgreSQLAdapter, :OracleAdapter)
       assert_equal 636, Account.sum("2 * credit_limit")
     else
       assert_equal 636, Account.sum("2 * credit_limit").to_i

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -302,14 +302,10 @@ class QueryCacheTest < ActiveRecord::TestCase
     end
   end
 
-  def test_cache_does_not_wrap_string_results_in_arrays
+  def test_cache_does_not_wrap_results_in_arrays
     Task.cache do
-      # Oracle adapter returns count() as Integer or Float
-      if current_adapter?(:OracleAdapter)
-        assert_kind_of Numeric, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
-      elsif current_adapter?(:SQLite3Adapter, :Mysql2Adapter, :PostgreSQLAdapter)
-        # Future versions of the sqlite3 adapter will return numeric
-        assert_instance_of 0.class, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
+      if current_adapter?(:SQLite3Adapter, :Mysql2Adapter, :PostgreSQLAdapter, :OracleAdapter)
+        assert_equal 2, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
       else
         assert_instance_of String, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
       end


### PR DESCRIPTION
### Summary

Remove unnecessary `to_i` for old sqlite3 adapter and `if current_adapter?(:OracleAdapter)` condition

`to_i` was added for SQLite3 adapter which did not handle number
but sqlite3 gem already supports it then `to_i` is unnecessary.
Considering other bundled adapters(mysql2 and postgresql) and Oracle enhanced adapter,
all adapter already return number(integer) for this test.

### Other Information

"future proofing the sqlite3 adapter code"
https://github.com/rails/rails/commit/beda2d43d6ac5c3435fc2fba0cbd108c20fe1c67

"Refactor calculation test to remove unneeded SQLite special case."
https://github.com/rails/rails/commit/47d568ed3fc701934ebe80b276f3d8bf6951c93f

"no need to to_i, sqlite does that for us"
https://github.com/rails/rails/commit/6cf44a1bd64ba10497742d70ad78fe68faa16e99