### PR TITLE
Bump PostgreSQL version to the latest version 9.6 at Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
   - memcached
 
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"
 
 bundler_args: --without test --jobs 3 --retry 3
 before_install:


### PR DESCRIPTION
### Summary

Travis CI new default Ubuntu Trusty supports 9.6
https://docs.travis-ci.com/user/database-setup/#Using-a-different-PostgreSQL-Version