### PR TITLE
AbstractController::Base.action_methods refactoring

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -117,9 +117,9 @@ module ActionCable
             # All public instance methods of this class, including ancestors
             methods = (public_instance_methods(true) -
               # Except for public instance methods of Base and its ancestors
-              ActionCable::Channel::Base.public_instance_methods(true) +
-              # Be sure to include shadowed public instance methods of this class
-              public_instance_methods(false)).uniq.map(&:to_s)
+              (ActionCable::Channel::Base.public_instance_methods(true) -
+                # Be sure to keep shadowed public instance methods of this class
+                public_instance_methods(false))).map(&:to_s)
             methods.to_set
           end
         end

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -76,9 +76,9 @@ module AbstractController
           # All public instance methods of this class, including ancestors
           methods = (public_instance_methods(true) -
             # Except for public instance methods of Base and its ancestors
-            internal_methods +
-            # Be sure to include shadowed public instance methods of this class
-            public_instance_methods(false)).uniq.map(&:to_s)
+            (internal_methods -
+              # Be sure to keep shadowed public instance methods of this class
+              public_instance_methods(false))).map(&:to_s)
 
           methods.to_set
         end


### PR DESCRIPTION
Consider the example:
``` ruby
all_days     = ["Mon.", "Tue.", "Wed.", "Thu.", "Fri.", "Sat.", "Sun."] # all days of the week
working_days = ["Mon.", "Tue.", "Wed.", "Thu.", "Fri."] # all week days except for weekends
# weekends = ["Sat.", "Sun."] # weekends
holidays     = ["Wed.", "Sun."] # for instance
```
 

In order to find all days off (which are weekends and holidays), I would do the following:
```
# take all days except for working days that are not holidays
days_off = all_days - (working_days - holidays)
```

There is another way I would never do it:
```
# take all days except for all working days but then return back holidays since they are days off too
days_off = all_days - working_days + holidays

# then remove duplicates, since holidays may happen to be weekends
days_off = days_off.uniq
```

So, in this PR I made Rails go the first way ) 
