### PR TITLE
Remove outdated comment [ci skip]

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -330,7 +330,7 @@ module ActionView
         locals = @locals - Module::RUBY_RESERVED_KEYWORDS
         locals = locals.grep(/\A@?(?![A-Z0-9])(?:[[:alnum:]_]|[^\0-\177])+\z/)
 
-        # Double assign to suppress the dreaded 'assigned but unused variable' warning
+        # Assign for the same variable is to suppress unused variable warning
         locals.each_with_object("".dup) { |key, code| code << "#{key} = local_assigns[:#{key}]; #{key} = #{key};" }
       end
 


### PR DESCRIPTION
We do not use double assign since 61f92f8bc5fa0b486fc56f249fa23f1102e79759.

