### PR TITLE
Add :nodoc: to activerecord [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -44,7 +44,7 @@ module ActiveRecord
         json:        { name: "json" },
       }
 
-      class StatementPool < ConnectionAdapters::StatementPool
+      class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
         private def dealloc(stmt)
           stmt[:stmt].close
         end

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -110,7 +110,7 @@ module ActiveRecord
 
       private
 
-        module StraightReversions
+        module StraightReversions # :nodoc:
           private
             { transaction:       :transaction,
               execute_block:     :execute_block,

--- a/activerecord/lib/active_record/scoping.rb
+++ b/activerecord/lib/active_record/scoping.rb
@@ -11,23 +11,23 @@ module ActiveRecord
       include Named
     end
 
-    module ClassMethods
-      def current_scope(skip_inherited_scope = false) # :nodoc:
+    module ClassMethods # :nodoc:
+      def current_scope(skip_inherited_scope = false)
         ScopeRegistry.value_for(:current_scope, self, skip_inherited_scope)
       end
 
-      def current_scope=(scope) #:nodoc:
+      def current_scope=(scope)
         ScopeRegistry.set_value_for(:current_scope, self, scope)
       end
 
       # Collects attributes from scopes that should be applied when creating
       # an AR instance for the particular class this is called on.
-      def scope_attributes # :nodoc:
+      def scope_attributes
         all.scope_for_create
       end
 
       # Are there attributes associated with this scope?
-      def scope_attributes? # :nodoc:
+      def scope_attributes?
         current_scope
       end
     end


### PR DESCRIPTION
### Summary

Added `:nodoc:` to classes or modules which have only private methods.