### PR TITLE
Read and clear ENV["RAILS_MASTER_KEY"]

### DIFF
--- a/railties/lib/rails/secrets.rb
+++ b/railties/lib/rails/secrets.rb
@@ -37,7 +37,7 @@ module Rails
       end
 
       def key
-        ENV["RAILS_MASTER_KEY"] || read_key_file || handle_missing_key
+        read_key_from_env || read_key_file || handle_missing_key
       end
 
       def template
@@ -77,6 +77,10 @@ module Rails
       private
         def handle_missing_key
           raise MissingKeyError
+        end
+
+        def read_key_from_env
+          @env_rails_master_key ||= ENV.delete("RAILS_MASTER_KEY")
         end
 
         def read_key_file

--- a/railties/test/secrets_test.rb
+++ b/railties/test/secrets_test.rb
@@ -54,6 +54,18 @@ class Rails::SecretsTest < ActiveSupport::TestCase
     end
   end
 
+  test "reading from ENV variable and then clearing it" do
+    run_secrets_generator do
+      begin
+        ENV["RAILS_MASTER_KEY"] = "00112233445566778899aabbccddeeff"
+
+        assert_equal "00112233445566778899aabbccddeeff", Rails::Secrets.key
+      ensure
+        assert_nil ENV["RAILS_MASTER_KEY"]
+      end
+    end
+  end
+
   test "reading from key file" do
     run_secrets_generator do
       File.binwrite("config/secrets.yml.key", "00112233445566778899aabbccddeeff")


### PR DESCRIPTION
### Summary

After reading ENV["RAILS_MASTER_KEY"], this variable is cleared to prevent attackers with access to ENV from stealing secrets.

This was reported in issue #30338 

### Other Information

I decided to open this PR after asking [here](https://github.com/rails/rails/pull/30067#issuecomment-324426268) if it made sense to implement this within #30067
