### PR TITLE
Remove useless explanation in engines.md [ci skip]

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1515,12 +1515,12 @@ To hook into the initialization process of one of the following classes use the 
 
 These are the available configuration hooks. They do not hook into any particular framework, instead they run in context of the entire application.
 
-| Hook                   | Use Case                                                                              |
-| ---------------------- | ------------------------------------------------------------------------------------- |
-| `before_configuration` | First configurable block to run. Called before any initializers are run.              |
-| `before_initialize`    | Second configurable block to run. Called before frameworks initialize.                |
-| `before_eager_load`    | Third configurable block to run. Does not run if `config.cache_classes` set to false. |
-| `after_initialize`     | Last configurable block to run. Called after frameworks initialize.                   |
+| Hook                   | Use Case                                             |
+| ---------------------- | ---------------------------------------------------- |
+| `before_configuration` | Called before any initializers are run.              |
+| `before_initialize`    | Called before frameworks initialize.                 |
+| `before_eager_load`    | Does not run if `config.cache_classes` set to false. |
+| `after_initialize`     | Called after frameworks initialize.                  |
 
 ### Example
 


### PR DESCRIPTION
The explanations about triggered order are useless.
It could make reader confuse when it called.
The next sentences make it clear when these hook will be called.
Hence, we don't need these sentences.