### PR TITLE
Make `ActiveRecord::Base.find_or_*` methods compatible with virtual attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Make `ActiveRecord::Base.find_or_*` methods compatible with virtual attributes
+
+    `ActiveRecord::Base.create` is compatible with virtual attributes:
+    a common use case is passing them in the arguments hash so that
+    callbacks that need them have access to them.
+
+    Based on this behavior one might expect the `ActiveRecord::Base.find_or_*`
+    methods: (find_or_create_by, find_or_create_by!, and find_or_initialize_by)
+    to work the same way, but that is not the case.
+
+    Instead, the `ActiveRecord::Base.find_or_*` methods blow up when
+    passed virtual attributes, as they attempt to generate SQL select
+    statements with the virtual attributes assumed to be column names.
+
+    This fixes that, and the `ActiveRecord::Base.find_or_*` methods now
+    behave how you would expect them to, given the behavior of
+    `ActiveRecord::Base.create`.
+
 *   Add new error class `TransactionTimeout` for MySQL adapter which will be raised
     when lock wait time expires.
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -213,20 +213,20 @@ module ActiveRecord
     #  end
     #
     def find_or_create_by(attributes, &block)
-      find_by(attributes) || create(attributes, &block)
+      find_by_with_virtual_attributes(attributes) || create(attributes, &block)
     end
 
     # Like #find_or_create_by, but calls
     # {create!}[rdoc-ref:Persistence::ClassMethods#create!] so an exception
     # is raised if the created record is invalid.
     def find_or_create_by!(attributes, &block)
-      find_by(attributes) || create!(attributes, &block)
+      find_by_with_virtual_attributes(attributes) || create!(attributes, &block)
     end
 
     # Like #find_or_create_by, but calls {new}[rdoc-ref:Core#new]
     # instead of {create}[rdoc-ref:Persistence::ClassMethods#create].
     def find_or_initialize_by(attributes, &block)
-      find_by(attributes) || new(attributes, &block)
+      find_by_with_virtual_attributes(attributes) || new(attributes, &block)
     end
 
     # Runs EXPLAIN on the query or queries triggered by this relation and

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -82,6 +82,29 @@ module ActiveRecord
       nil
     end
 
+    # Like #find_by, except compatible with virtual attributes: if you pass
+    # in virtual attributes it does not use them to general the SQL SELECT query,
+    # and instead sets those virtual attributes on the resulting active record object.
+    def find_by_with_virtual_attributes(arg, *args)
+      symbolized_column_names = column_names.map(&:to_sym)
+      database_attributes, virtual_attributes = {}, {}
+
+      arg.each do |attribute, value|
+        if symbolized_column_names.include?(attribute)
+          database_attributes[attribute] = value
+        else
+          virtual_attributes[attribute] = value
+        end
+      end
+
+      record = find_by(database_attributes, *args)
+
+      return nil if record.nil?
+
+      record.assign_attributes(virtual_attributes)
+      record
+    end
+
     # Like #find_by, except that if no record is found, raises
     # an ActiveRecord::RecordNotFound error.
     def find_by!(arg, *args)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1334,6 +1334,29 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal bird, Bird.find_or_create_by(name: "bob")
   end
 
+  class BirdWithVirtualAttribute < Bird
+    attribute :virtual_attribute
+  end
+
+  def test_find_or_create_by_with_virtual_attributes
+    bird = BirdWithVirtualAttribute.find_or_create_by(name: "bob", virtual_attribute: "foo")
+    assert_equal "foo", bird.virtual_attribute
+
+    bird = BirdWithVirtualAttribute.find_or_create_by(name: "bob", virtual_attribute: "foo")
+    assert_equal "foo", bird.virtual_attribute
+  end
+
+  def test_find_or_initialize_by_with_virtual_attributes
+    bird = BirdWithVirtualAttribute.find_or_initialize_by(name: "bob", virtual_attribute: "foo")
+    assert_equal "foo", bird.virtual_attribute
+
+    bird = BirdWithVirtualAttribute.create!(name: "bob", virtual_attribute: "foo")
+    assert_equal "foo", bird.virtual_attribute
+
+    bird = BirdWithVirtualAttribute.find_or_initialize_by(name: "bob", virtual_attribute: "foo")
+    assert_equal "foo", bird.virtual_attribute
+  end
+
   def test_find_or_create_by_with_create_with
     assert_nil Bird.find_by(name: "bob")
 


### PR DESCRIPTION
`ActiveRecord::Base.create` is compatible with virtual attributes:
a common use case is passing them in the arguments hash so that
callbacks that need them have access to them.

Based on this behavior one might expect the `ActiveRecord::Base.find_or_*`
methods: (find_or_create_by, find_or_create_by!, and find_or_initialize_by)
to work the same way, but that is not the case.

Instead, the `ActiveRecord::Base.find_or_*` methods blow up when
passed virtual attributes, as they attempt to generate SQL select
statements with the virtual attributes assumed to be column names.

This fixes that, and the `ActiveRecord::Base.find_or_*` methods now
behave how you would expect them to, given the behavior of
`ActiveRecord::Base.create`.
