### PR TITLE
Explicitly require `test_unit/reporter`

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb
@@ -12,6 +12,7 @@ require "rails/test_help"
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
 <% unless engine? -%>
+require "rails/test_unit/reporter"
 Rails::TestUnitReporter.executable = 'bin/test'
 <% end -%>
 

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -105,6 +105,12 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
       capture(:stderr) { run_test_command("test/models/warnings_test.rb -w") })
   end
 
+  def test_run_rake_test
+    create_test_file "foo"
+    result = Dir.chdir(plugin_path) { `rake test TEST=test/foo_test.rb` }
+    assert_match "1 runs, 1 assertions, 0 failures", result
+  end
+
   private
     def plugin_path
       "#{@destination_root}/bukkits"


### PR DESCRIPTION
If the user used the `bin/test` to execute the test, this file is automatically loaded, so require is unnecessary.
https://github.com/rails/rails/blob/acea68de026ba657cb65c4dd0fc1f24ba67e1cf8/railties/lib/rails/plugin/test.rb#L4

However, when using `rake test`, an explicit require is required because the above file is not loaded.

Fixes #30516
