### PR TITLE
PERF: Recover `ActiveRecord::pluck` performance.

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1172,21 +1172,24 @@ module ActiveRecord
       end
       alias having_clause_factory where_clause_factory
 
+      DEFAULT_VALUES = {
+        create_with: FROZEN_EMPTY_HASH,
+        readonly: false,
+        where: Relation::WhereClause.empty,
+        having: Relation::WhereClause.empty,
+        from: Relation::FromClause.empty
+      }
+
+      Relation::MULTI_VALUE_METHODS.each do |value|
+        DEFAULT_VALUES[value] ||= FROZEN_EMPTY_ARRAY
+      end
+
+      Relation::SINGLE_VALUE_METHODS.each do |value|
+        DEFAULT_VALUES[value] = nil if DEFAULT_VALUES[value].nil?
+      end
+
       def default_value_for(name)
-        case name
-        when :create_with
-          FROZEN_EMPTY_HASH
-        when :readonly
-          false
-        when :where, :having
-          Relation::WhereClause.empty
-        when :from
-          Relation::FromClause.empty
-        when *Relation::MULTI_VALUE_METHODS
-          FROZEN_EMPTY_ARRAY
-        when *Relation::SINGLE_VALUE_METHODS
-          nil
-        else
+        DEFAULT_VALUES.fetch(name) do
           raise ArgumentError, "unknown relation value #{name.inspect}"
         end
       end


### PR DESCRIPTION
### Summary

I'm seeing a performance regression when using pluck with a scope. One thing I noticed when profiling with `ruby-prof` is that `Symbol#===` was taking quite abit of time.

![screenshot from 2017-09-05 17-26-50](https://user-images.githubusercontent.com/4335742/30054692-78b189a8-925f-11e7-8fea-e51e204ee155.png)

#### Benchmark script used

```ruby
require 'active_record'
require 'benchmark/ips'

ActiveRecord::Base.establish_connection(ENV.fetch('DATABASE_URL'))
ActiveRecord::Migration.verbose = false

ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
    t.string :name, :email
    t.timestamps null: false
  end
end

attributes = {
  name: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
  email: 'foobar@email.com'
}

class User < ActiveRecord::Base; end

1000.times do
  User.create!(attributes)
end

Benchmark.ips do |x|
  x.config(time: 10, warmup: 2)

  x.report('pluck 1 column') do
    User.pluck(:id)
  end

  x.report('pluck 2 columns') do
    User.pluck(:id, :email)
  end

  x.report('pluck 1 column with scope') do
    User.where(id: 1000).pluck(:id)
  end

  x.report('pluck 2 columns with scope') do
    User.where(id: 1000).pluck(:id, :email)
  end
end
```

#### Rails 4.2.9

```
Calculating -------------------------------------
      pluck 1 column   122.000  i/100ms
     pluck 2 columns    74.000  i/100ms
pluck 1 column with scope
                       615.000  i/100ms
pluck 2 columns with scope
                       515.000  i/100ms
-------------------------------------------------
      pluck 1 column      1.272k (± 3.9%) i/s -     12.810k
     pluck 2 columns    750.096  (± 3.3%) i/s -      7.548k
pluck 1 column with scope
                          6.074k (± 4.1%) i/s -     60.885k
pluck 2 columns with scope
                          5.158k (± 2.7%) i/s -     52.015k
```

#### Rails 5.1.3

```
Calculating -------------------------------------
      pluck 1 column   126.000  i/100ms
     pluck 2 columns    78.000  i/100ms
pluck 1 column with scope
                       457.000  i/100ms
pluck 2 columns with scope
                       434.000  i/100ms
-------------------------------------------------
      pluck 1 column      1.266k (± 2.1%) i/s -     12.726k
     pluck 2 columns    795.061  (± 3.0%) i/s -      7.956k
pluck 1 column with scope
                          4.660k (± 2.1%) i/s -     46.614k
pluck 2 columns with scope
                          4.355k (± 2.3%) i/s -     43.834k
```

#### Rails Master

```
Calculating -------------------------------------
      pluck 1 column   126.000  i/100ms
     pluck 2 columns    78.000  i/100ms
pluck 1 column with scope
                       539.000  i/100ms
pluck 2 columns with scope
                       481.000  i/100ms
-------------------------------------------------
      pluck 1 column      1.308k (± 3.4%) i/s -     13.104k
     pluck 2 columns    798.604  (± 2.8%) i/s -      8.034k
pluck 1 column with scope
                          5.530k (± 3.4%) i/s -     55.517k
pluck 2 columns with scope
                          4.914k (± 2.7%) i/s -     49.543k
```

#### Rails Master with Patch

```
Calculating -------------------------------------
      pluck 1 column   139.000  i/100ms
     pluck 2 columns    79.000  i/100ms
pluck 1 column with scope
                       580.000  i/100ms
pluck 2 columns with scope
                       526.000  i/100ms
-------------------------------------------------
      pluck 1 column      1.337k (± 3.0%) i/s -     13.483k
     pluck 2 columns    806.776  (± 2.7%) i/s -      8.137k
pluck 1 column with scope
                          5.924k (± 4.1%) i/s -     59.160k
pluck 2 columns with scope
                          5.276k (± 3.1%) i/s -     53.126k
```