### PR TITLE
Reformat implicit render exception

### DIFF
--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -22,6 +22,12 @@ module ActionController
     end
   end
 
+  class MissingExactTemplate < ActionControllerError #:nodoc:
+    def initialize(message)
+      super(message)
+    end
+  end
+
   class ActionController::UrlGenerationError < ActionControllerError #:nodoc:
   end
 

--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -44,15 +44,9 @@ module ActionController
         message = "#{self.class.name}\##{action_name} is missing a template " \
           "for this request format and variant.\n\n" \
           "request.formats: #{request.formats.map(&:to_s).inspect}\n" \
-          "request.variant: #{request.variant.inspect}\n\n" \
-          "NOTE! For XHR/Ajax or API requests, this action would normally " \
-          "respond with 204 No Content: an empty white screen. Since you're " \
-          "loading it in a web browser, we assume that you expected to " \
-          "actually render a template, not nothing, so we're showing an " \
-          "error to be extra-clear. If you expect 204 No Content, carry on. " \
-          "That's what you'll get from an XHR or API request. Give it a shot."
+          "request.variant: #{request.variant.inspect}\n\n"
 
-        raise ActionController::UnknownFormat, message
+        raise ActionController::MissingExactTemplate, message
       else
         logger.info "No template found for #{self.class.name}\##{action_name}, rendering head :no_content" if logger
         super

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -22,10 +22,11 @@ module ActionDispatch
     )
 
     cattr_accessor :rescue_templates, default: Hash.new("diagnostics").merge!(
-      "ActionView::MissingTemplate"         => "missing_template",
-      "ActionController::RoutingError"      => "routing_error",
-      "AbstractController::ActionNotFound"  => "unknown_action",
-      "ActionView::Template::Error"         => "template_error"
+      "ActionView::MissingTemplate"            => "missing_template",
+      "ActionController::RoutingError"         => "routing_error",
+      "ActionController::MissingExactTemplate" => "missing_exact_template",
+      "AbstractController::ActionNotFound"     => "unknown_action",
+      "ActionView::Template::Error"            => "template_error"
     )
 
     attr_reader :backtrace_cleaner, :exception, :line_number, :file

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exact_template.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exact_template.html.erb
@@ -1,0 +1,29 @@
+<header>
+  <h1>Missing Exact Template Error</h1>
+</header>
+<div id="container">
+  <h2>
+    <%= h @exception.message %>
+    NOTE! For XHR/Ajax or API requests, this action would normally
+    respond with 204 No Content: an empty white screen. Since you're
+    loading it in a web browser, we assume that you expected to
+    actually render a template, not nothing, so we're showing an
+    error to be extra-clear. If you expect 204 No Content, carry on.
+    That's what you'll get from an XHR or API request. Give it a shot.
+  </h2>
+  <%= render template: "rescues/_trace" %>
+
+  <% if @routes_inspector %>
+    <h2>
+      Routes
+    </h2>
+
+    <p>
+      Routes match in priority from top to bottom
+    </p>
+
+    <%= @routes_inspector.format(ActionDispatch::Routing::HtmlTableFormatter.new(self)) %>
+  <% end %>
+
+  <%= render template: "rescues/_request_and_response" %>
+</div>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exat_template.text.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exat_template.text.erb
@@ -1,0 +1,10 @@
+Missing Exact Template Error
+
+<%= @exception.message %>
+NOTE! For XHR/Ajax or API requests, this action would normally
+respond with 204 No Content: an empty white screen. Since you're
+loading it in a web browser, we assume that you expected to
+actually render a template, not nothing, so we're showing an
+error to be extra-clear. If you expect 204 No Content, carry on.
+That's what you'll get from an XHR or API request. Give it a shot.
+<%= render template: "rescues/_trace", format: :text %>

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -658,13 +658,13 @@ class RespondToControllerTest < ActionController::TestCase
   end
 
   def test_variant_without_implicit_rendering_from_browser
-    assert_raises(ActionController::UnknownFormat) do
+    assert_raises(ActionController::MissingExactTemplate) do
       get :variant_without_implicit_template_rendering, params: { v: :does_not_matter }
     end
   end
 
   def test_variant_variant_not_set_and_without_implicit_rendering_from_browser
-    assert_raises(ActionController::UnknownFormat) do
+    assert_raises(ActionController::MissingExactTemplate) do
       get :variant_without_implicit_template_rendering
     end
   end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -650,7 +650,7 @@ class ImplicitRenderTest < ActionController::TestCase
   tests ImplicitRenderTestController
 
   def test_implicit_no_content_response_as_browser
-    assert_raises(ActionController::UnknownFormat) do
+    assert_raises(ActionController::MissingExactTemplate) do
       get :empty_action
     end
   end


### PR DESCRIPTION
### Summary

Created a new error subclass, for the errors raised in the `ActionController:: ImplicitRender`
Added views to display the error message
Fixes #29280 


