### PR TITLE
Do not install unused gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ group :job do
   gem "backburner", require: false
   #TODO: add qu after it support Rails 5.1
   # gem 'qu-rails', github: "bkeepers/qu", branch: "master", require: false
-  gem "qu-redis", require: false
+  # gem "qu-redis", require: false
   gem "delayed_job_active_record", require: false
   gem "sequel", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,12 +336,6 @@ GEM
     psych (2.2.4)
     public_suffix (2.0.5)
     puma (3.9.1)
-    qu (0.2.0)
-      multi_json
-    qu-redis (0.2.0)
-      qu (= 0.2.0)
-      redis-namespace
-      simple_uuid
     que (0.14.0)
     racc (1.4.14)
     rack (2.0.3)
@@ -415,7 +409,6 @@ GEM
       faraday (~> 0.9)
       jwt (~> 1.5)
       multi_json (~> 1.10)
-    simple_uuid (0.4.0)
     sinatra (2.0.0)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -515,7 +508,6 @@ DEPENDENCIES
   pg (>= 0.18.0)
   psych (~> 2.0)
   puma
-  qu-redis
   que
   queue_classic!
   racc (>= 1.4.6)


### PR DESCRIPTION
`qu-redis` is need for qu adapter integration test.
However, since 8ecc5ab, que adapter integration test has not been executed, it is unnecessary now.

