### PR TITLE
Don't run `webpacker:install` when `skip_bundle` is given

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -422,7 +422,7 @@ module Rails
       end
 
       def run_webpack
-        if !(webpack = options[:webpack]).nil?
+        if bundle_install? && !(webpack = options[:webpack]).nil?
           rails_command "webpacker:install"
           rails_command "webpacker:install:#{webpack}" unless webpack == "webpack"
         end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -609,6 +609,18 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["']$}
   end
 
+  def test_webpack
+    run_generator [destination_root, "--webpack=webpack"]
+    assert_gem "webpacker"
+  end
+
+  def test_webpack_when_skip_bundle_is_given
+    assert_not_called(generator([destination_root], skip_bundle: true, webpack: "webpack"), :rails_command) do
+      quietly { generator.invoke_all }
+      assert_gem "webpacker"
+    end
+  end
+
   def test_spring
     run_generator
     assert_gem "spring"


### PR DESCRIPTION
### Summary

If `rails new` command is given `--skip-bundle` option, it should not execute `webpacker:install` as same as `spring binstub --all`.