### PR TITLE
App generator should be fail if it is given invalid options `--api` and `--webpack`

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -246,6 +246,10 @@ module Rails
           raise Error, "Invalid value for --database option. Supported for preconfiguration are: #{DATABASES.join(", ")}."
         end
 
+        if options[:api] && options[:webpack]
+          raise Error, "Invalid options are supplied. Please use either --api or --webpack."
+        end
+
         # Force sprockets and yarn to be skipped when generating API only apps.
         # Can't modify options hash as it's frozen by default.
         if options[:api]

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -63,6 +63,11 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_generator_if_webpack_is_given
+    stderr_output = capture(:stderr) { run_generator [destination_root, "--api", "--webpack=webpack"] }
+    assert_equal(stderr_output, "Invalid options are supplied. Please use either --api or --webpack.\n")
+  end
+
   def test_app_update_does_not_generate_unnecessary_config_files
     run_generator
 


### PR DESCRIPTION
### Summary

When it was given `--api` and `--webpack` options, app_generator is better to raise error.