### PR TITLE
Fixed bug introduced in this PR #30524

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1185,7 +1185,7 @@ module ActiveRecord
       end
 
       Relation::SINGLE_VALUE_METHODS.each do |value|
-        DEFAULT_VALUES[value] = nil if DEFAULT_VALUES[value].nil?
+        DEFAULT_VALUES[value] = nil
       end
 
       def default_value_for(name)


### PR DESCRIPTION
The code is not like the original one, the Relation::SINGLE_VALUE_METHODS values
are nil. This error was introduced in this PR #30524 
