### PR TITLE
PERF: Partially recover some performance when preloading. 

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -50,20 +50,14 @@ module ActiveRecord
           end
 
           def owner_keys
-            unless defined?(@owner_keys)
-              @owner_keys = owners.map do |owner|
-                owner[owner_key_name]
-              end
-              @owner_keys.uniq!
-              @owner_keys.compact!
-            end
-            @owner_keys
+            @owner_keys ||= owners_by_key.keys
           end
 
           def owners_by_key
             unless defined?(@owners_by_key)
               @owners_by_key = owners.each_with_object({}) do |owner, h|
-                h[convert_key(owner[owner_key_name])] = owner
+                key = convert_key(owner[owner_key_name])
+                h[key] = owner if key
               end
             end
             @owners_by_key

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -17,13 +17,15 @@ module ActiveRecord
       # Returns the primary key value.
       def id
         sync_with_transaction_state
-        _read_attribute(self.class.primary_key) if self.class.primary_key
+        primary_key = self.class.primary_key
+        _read_attribute(primary_key) if primary_key
       end
 
       # Sets the primary key value.
       def id=(value)
         sync_with_transaction_state
-        _write_attribute(self.class.primary_key, value) if self.class.primary_key
+        primary_key = self.class.primary_key
+        _write_attribute(primary_key, value) if primary_key
       end
 
       # Queries the primary key value.

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -58,8 +58,9 @@ module ActiveRecord
           attr_name.to_s
         end
 
-        name = self.class.primary_key if name == "id".freeze && self.class.primary_key
-        sync_with_transaction_state if name == self.class.primary_key
+        primary_key = self.class.primary_key
+        name = primary_key if name == "id".freeze && primary_key
+        sync_with_transaction_state if name == primary_key
         _read_attribute(name, &block)
       end
 

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -39,8 +39,9 @@ module ActiveRecord
           attr_name.to_s
         end
 
-        name = self.class.primary_key if name == "id".freeze && self.class.primary_key
-        sync_with_transaction_state if name == self.class.primary_key
+        primary_key = self.class.primary_key
+        name = primary_key if name == "id".freeze && primary_key
+        sync_with_transaction_state if name == primary_key
         _write_attribute(name, value)
       end
 


### PR DESCRIPTION
Benchmark Script:
```
require 'active_record'
require 'benchmark/ips'

ActiveRecord::Base.establish_connection(ENV.fetch('DATABASE_URL'))
ActiveRecord::Migration.verbose = false

ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
    t.string :name, :email
    t.integer :topic_id
    t.timestamps null: false
  end

  create_table :topics, force: true do |t|
    t.string :title
    t.timestamps null: false
  end
end

attributes = {
  name: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
  email: 'foobar@email.com'
}

class Topic < ActiveRecord::Base
  has_many :users
end

class User < ActiveRecord::Base
  belongs_to :topic
end

100.times do
  User.create!(attributes)
end

users = User.first(50)

Topic.create!(title: 'This is a topic', users: users)

Benchmark.ips do |x|
  x.config(time: 10, warmup: 5)

  x.report("preload") do
    User.includes(:topic).all.to_a
  end
end
```

Before:
```
Calculating -------------------------------------
             preload    40.000  i/100ms
-------------------------------------------------
             preload    407.962  (± 1.5%) i/s -      4.080k
```

After:
```
alculating -------------------------------------
             preload    43.000  i/100ms
-------------------------------------------------
             preload    427.567  (± 1.6%) i/s -      4.300k
```