### PR TITLE
Do not depend on the return value of _normalize_options

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -97,7 +97,7 @@ module AbstractController
     # Normalize options.
     # :api: plugin
     def _normalize_options(options)
-      options
+      # noop
     end
 
     # Process extra options.

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -139,7 +139,8 @@ module ActionView
       # Normalize options.
       # :api: private
       def _normalize_options(options)
-        options = super(options)
+        super
+
         if options[:partial] == true
           options[:partial] = action_name
         end
@@ -149,7 +150,6 @@ module ActionView
         end
 
         options[:template] ||= (options[:action] || action_name).to_s
-        options
       end
   end
 end


### PR DESCRIPTION
Hey all!

This change clarifies the expected behavior of `#_normalize_options`. Since the current implementation is vulnerable to bugs, I think it's more than just a [cosmetic change](https://github.com/rails/rails/pull/13771#issuecomment-32746700). But I'll be happy with whatever y'all decide. 😸

Hope this helps and thanks for maintaining Rails!!! 💛💚💙💜❤️ 

### Summary
Currently, when `#_normalize_options` is overridden, it always modifies the passed `options` in place, but _sometimes_ it acts as if it should pass the `options` back. This made it a bit confusing when I was overriding this method in my own project and `super` [unexpectedly returned a Proc](https://github.com/rails/rails/blob/master/actionview/lib/action_view/layouts.rb#L353).

This PR makes it clear that `#_normalize_options` is a command method that modifies `options` in-place and that the return values should _not_ be depended on.

#### Original Code for Reference:

[actionpack/lib/abstract_controller/rendering.rb:99](https://github.com/rails/rails/blob/master/actionpack/lib/abstract_controller/rendering.rb#L99-L101)
``` ruby
def _normalize_options(options)
  options
end
```

[actionview/lib/action_view/rendering.rb:141](https://github.com/rails/rails/blob/master/actionview/lib/action_view/rendering.rb#L141-L153)
``` ruby
def _normalize_options(options)
  options = super(options)
  if options[:partial] == true
    options[:partial] = action_name
  end

  if (options.keys & [:partial, :file, :template]).empty?
    options[:prefixes] ||= _prefixes
  end

  options[:template] ||= (options[:action] || action_name).to_s
  options
end
```

[actionview/lib/action_view/layouts.rb:348](https://github.com/rails/rails/blob/master/actionview/lib/action_view/layouts.rb#L348-L355)
``` ruby
def _normalize_options(options) # :nodoc:
  super

  if _include_layout?(options)
    layout = options.delete(:layout) { :default }
    options[:layout] = _layout_for_option(layout)
  end
end
```

[actionpack/lib/action_controller/metal/rendering.rb:89](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/rendering.rb#L89-L101)
``` ruby
def _normalize_options(options)
  _normalize_text(options)

  if options[:html]
    options[:html] = ERB::Util.html_escape(options[:html])
  end

  if options[:status]
    options[:status] = Rack::Utils.status_code(options[:status])
  end

  super
end
```