### PR TITLE
Remove needless `silence_warnings`

### DIFF
--- a/railties/test/application/asset_debugging_test.rb
+++ b/railties/test/application/asset_debugging_test.rb
@@ -9,10 +9,7 @@ module ApplicationTests
     include Rack::Test::Methods
 
     def setup
-      # FIXME: shush Sass warning spam, not relevant to testing Railties
-      Kernel.silence_warnings do
-        build_app(initializers: true)
-      end
+      build_app(initializers: true)
 
       app_file "app/assets/javascripts/application.js", "//= require_tree ."
       app_file "app/assets/javascripts/xmlhr.js", "function f1() { alert(); }"
@@ -34,11 +31,6 @@ module ApplicationTests
 
     def teardown
       teardown_app
-    end
-
-    # FIXME: shush Sass warning spam, not relevant to testing Railties
-    def get(*)
-      Kernel.silence_warnings { super }
     end
 
     test "assets are concatenated when debug is off and compile is off either if debug_assets param is provided" do

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -62,10 +62,7 @@ module ApplicationTests
 
       add_to_env_config "development", "config.assets.digest = false"
 
-      # FIXME: shush Sass warning spam, not relevant to testing Railties
-      Kernel.silence_warnings do
-        require "#{app_path}/config/environment"
-      end
+      require "#{app_path}/config/environment"
 
       get "/assets/demo.js"
       assert_equal 'a = "/assets/rails.png";', last_response.body.strip

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -56,10 +56,7 @@ module TestHelpers
       @app ||= begin
         ENV["RAILS_ENV"] = env
 
-        # FIXME: shush Sass warning spam, not relevant to testing Railties
-        Kernel.silence_warnings do
-          require "#{app_path}/config/environment"
-        end
+        require "#{app_path}/config/environment"
 
         Rails.application
       end


### PR DESCRIPTION
Since ff30db1, warning is not shown.

I confirmed that there is no same FIXME in `git grep "Sass warning"`.
