### PR TITLE
Raises error when #truncate receives non-string

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -92,14 +92,18 @@ module ActionView
       #   truncate("Once upon a time in a world far far away") { link_to "Continue", "#" }
       #   # => "Once upon a time in a wo...<a href="#">Continue</a>"
       def truncate(text, options = {}, &block)
-        if text
-          length  = options.fetch(:length, 30)
+        return unless text
 
-          content = text.truncate(length, options)
-          content = options[:escape] == false ? content.html_safe : ERB::Util.html_escape(content)
-          content << capture(&block) if block_given? && text.length > length
-          content
+        unless text.is_a?(String)
+          raise ArgumentError, "can't truncate other than String, got #{text.class}"
         end
+
+        length  = options.fetch(:length, 30)
+
+        content = text.truncate(length, options)
+        content = options[:escape] == false ? content.html_safe : ERB::Util.html_escape(content)
+        content << capture(&block) if block_given? && text.length > length
+        content
       end
 
       # Highlights one or more +phrases+ everywhere in +text+ by inserting it into

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -91,6 +91,12 @@ class TextHelperTest < ActionView::TestCase
     assert_equal "Hello Wor...", truncate("Hello World!!", length: 12)
   end
 
+  def test_truncate_raises_error_when_non_string_is_passed
+    e = assert_raises(ArgumentError) { truncate(123456789) }
+    klass = RUBY_VERSION > "2.4" ? Integer : Fixnum
+    assert_equal "can't truncate other than String, got #{klass}", e.message
+  end
+
   def test_truncate_should_use_default_length_of_30
     str = "This is a string that will go longer then the default truncate length of 30"
     assert_equal str[0...27] + "...", truncate(str)


### PR DESCRIPTION
Currently `ActionView::Helpers::TextHelper#truncate` raises error with following message when it receives non-string:

```
ArgumentError: wrong number of arguments (given 2, expected 0..1)
```

It is hard to understand what is wrong from this message.

This issue can resolve by calling `#to_s` in `#truncate`, but I thought that allowing many types is risky.
So I specify it accepts only string.