### PR TITLE
Add option to skip Rails' custom Minitest reporter.

### DIFF
--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -26,7 +26,7 @@ module Minitest
       options[:color] = value
     end
 
-    opts.on("-s", "--skip-rails-reporter", "Skip Rails' custom Minitest reporter") do |value|
+    opts.on("--skip-rails-reporter", "Skip Rails' custom Minitest reporter") do |value|
       options[:skip_reporter] = value
     end
 

--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -26,6 +26,10 @@ module Minitest
       options[:color] = value
     end
 
+    opts.on("-s", "--skip-rails-reporter", "Skip Rails' custom Minitest reporter") do |value|
+      options[:skip_reporter] = value
+    end
+
     options[:color] = true
     options[:output_inline] = true
   end
@@ -37,6 +41,8 @@ module Minitest
       # Plugin can run without Rails loaded, check before filtering.
       Minitest.backtrace_filter = ::Rails.backtrace_cleaner if ::Rails.respond_to?(:backtrace_cleaner)
     end
+
+    return if options[:skip_reporter]
 
     # Replace progress reporter for colors.
     reporter.reporters.delete_if { |reporter| reporter.kind_of?(SummaryReporter) || reporter.kind_of?(ProgressReporter) }

--- a/railties/test/test_unit/reporter_test.rb
+++ b/railties/test/test_unit/reporter_test.rb
@@ -155,6 +155,13 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     end
   end
 
+  test "skips Rails custom reporting" do
+    skip_reporter = Rails::TestUnitReporter.new @output, skip_reporter: true
+    skip_reporter.record(failed_test)
+
+    assert_no_match "bin/rails", @output.string
+  end
+
   private
     def assert_rerun_snippet_count(snippet_count)
       assert_equal snippet_count, @output.string.scan(%r{^bin/rails test }).size


### PR DESCRIPTION
### Summary

Add an option for skipping Rails' custom Minitest reporter.

Due to how Minitest loads plugins (alphabetical order), is really hard to control how reporters will be configured. Take the following scenario:

- I want to use a custom reporter available through the gem [minitest-utils](https://rubygems.org/gems/minitest-utils).
- Minitest will load plugins using `Gem.find_files('minitest/*_plugin.rb')`, so this will always return Rails' plugin as the last one from the list.
- Running tests will result in duplicated output (even though `minitest-utils` clears the existing reporters).

With the change proposed by this PR, one can run tests like `rails test --skip-reporter`. This approach is somewhat inspired by [minitest/pride](https://github.com/seattlerb/minitest/blob/ca6a71ca901016db09a5ad466b4adea4b52a504a/lib/minitest/pride_plugin.rb#L5-L7), which is enabled by `--pride`.

Please also check #30555, which adds this feature to master/5.2.0.