### PR TITLE
Accept trailing slashes in bin/rails test paths.

### DIFF
--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -61,7 +61,7 @@ module Rails
         private
           def extract_filters(argv)
             # Extract absolute and relative paths but skip -n /.*/ regexp filters.
-            argv.select { |arg| arg =~ %r%^/?\w+/% && !arg.end_with?("/") }.map do |path|
+            argv.select { |arg| arg =~ %r%^/?\w+/% && (!arg.end_with?("/") || !arg.start_with?("/")) }.map do |path|
               case
               when path =~ /(:\d+)+$/
                 file, *lines = path.split(":")

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -164,6 +164,17 @@ module ApplicationTests
       end
     end
 
+    def test_run_folder_with_trailing_slash
+      create_test_file :models, "foo"
+      create_test_file :models, "bar"
+      create_test_file :controllers, "foobar_controller"
+      run_test_command("test/models/").tap do |output|
+        assert_match "FooTest", output
+        assert_match "BarTest", output
+        assert_match "2 runs, 2 assertions, 0 failures", output
+      end
+    end
+
     def test_run_named_test
       app_file "test/unit/chu_2_koi_test.rb", <<-RUBY
         require 'test_helper'
@@ -268,8 +279,21 @@ module ApplicationTests
     def test_run_multiple_folders
       create_test_file :models, "account"
       create_test_file :controllers, "accounts_controller"
+      create_test_file :helpers, "foo_helper"
 
       run_test_command("test/models test/controllers").tap do |output|
+        assert_match "AccountTest", output
+        assert_match "AccountsControllerTest", output
+        assert_match "2 runs, 2 assertions, 0 failures, 0 errors, 0 skips", output
+      end
+    end
+
+    def test_run_multiple_folders_with_trailing_slashes
+      create_test_file :models, "account"
+      create_test_file :controllers, "accounts_controller"
+      create_test_file :helpers, "foo_helper"
+
+      run_test_command("test/models/ test/controllers/").tap do |output|
         assert_match "AccountTest", output
         assert_match "AccountsControllerTest", output
         assert_match "2 runs, 2 assertions, 0 failures, 0 errors, 0 skips", output


### PR DESCRIPTION
### Summary

07d84b7c8db5b85f7521cfc5d2028ed973d9a14b accidentally made it so that
paths with trailing slashes are ignored by bin/rails test. This is a bit
annoying, as Bash auto-complete adds a trailing slash for directory
names.

This commit fixes the bug and adds relevant tests.

### Other Information

This is an (unintended, I assume) behavior change between Rails 5.1.2 and Rails 5.1.4, so I think this should be backported to 5-1-stable. I'd be happy to submit a separate PR for that, after this goes through code review.