### PR TITLE
Allow the use of AWS SDK v3 in Active Storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ group :cable do
 end
 
 group :storage do
-  gem "aws-sdk", "~> 2", require: false
+  gem "aws-sdk-s3", require: false
   gem "google-cloud-storage", "~> 1.3", require: false
   gem "azure-storage", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,13 +119,18 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     amq-protocol (2.2.0)
     ast (2.3.0)
-    aws-sdk (2.10.27)
-      aws-sdk-resources (= 2.10.27)
-    aws-sdk-core (2.10.27)
+    aws-partitions (1.20.0)
+    aws-sdk-core (3.3.0)
+      aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.27)
-      aws-sdk-core (= 2.10.27)
+    aws-sdk-kms (1.1.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.2.0)
+      aws-sdk-core (~> 3)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.1)
     azure-core (0.1.11)
       faraday (~> 0.9)
@@ -477,7 +482,7 @@ DEPENDENCIES
   activerecord-jdbcpostgresql-adapter (>= 1.3.0)
   activerecord-jdbcsqlite3-adapter (>= 1.3.0)
   arel!
-  aws-sdk (~> 2)
+  aws-sdk-s3
   azure-storage
   backburner
   bcrypt (~> 3.1.11)

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -54,7 +54,7 @@ module ActiveStorage
 
     def url(key, expires_in:, filename:, disposition:, content_type:)
       instrument :url, key do |payload|
-        generated_url = object_for(key).presigned_url :get, expires_in: expires_in,
+        generated_url = object_for(key).presigned_url :get, expires_in: expires_in.to_i,
           response_content_disposition: disposition,
           response_content_type: content_type
 
@@ -66,7 +66,7 @@ module ActiveStorage
 
     def url_for_direct_upload(key, expires_in:, content_type:, content_length:, checksum:)
       instrument :url, key do |payload|
-        generated_url = object_for(key).presigned_url :put, expires_in: expires_in,
+        generated_url = object_for(key).presigned_url :put, expires_in: expires_in.to_i,
           content_type: content_type, content_length: content_length, content_md5: checksum
 
         payload[:url] = generated_url

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "aws-sdk"
+require "aws-sdk-s3"
 require "active_support/core_ext/numeric/bytes"
 
 module ActiveStorage


### PR DESCRIPTION
In AWS SDK v3, gem is divided for each service.
Therefore, if only use S3, we only need `aws-sdk-s3`.