### PR TITLE
return XMLHttpRequest instance from Rails.ajax()

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
@@ -27,6 +27,7 @@ Rails.ajax = (options) ->
     xhr.send(options.data)
   else
     fire(document, 'ajaxStop') # to be compatible with jQuery.ajax
+  xhr
 
 prepareOptions = (options) ->
   options.url = options.url or location.href


### PR DESCRIPTION
useful for, e.g., implementing autocomplete features and canceling requests:

```coffee
xhr = null
autocomplete = ->
  xhr?.abort()
  xhr = Rails.ajax()
  # ...

document.querySelector('.autocompletable-field').addEventListener 'keypress', ->
  setTimeout autocomplete, 250
```