### PR TITLE
Fix document on 'alias_attribute'

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/aliasing.rb
+++ b/activesupport/lib/active_support/core_ext/module/aliasing.rb
@@ -4,7 +4,9 @@ class Module
   # Allows you to make aliases for attributes, which includes
   # getter, setter, and a predicate.
   #
-  #   class Content < ActiveRecord::Base
+  #   require 'active_support/core_ext/module/aliasing.rb'
+  #
+  #   class Content
   #     # has a title attribute
   #   end
   #

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -535,7 +535,9 @@ Extensions to `Module`
 Model attributes have a reader, a writer, and a predicate. You can alias a model attribute having the corresponding three methods defined for you in one shot. As in other aliasing methods, the new name is the first argument, and the old name is the second (one mnemonic is that they go in the same order as if you did an assignment):
 
 ```ruby
-class User < ApplicationRecord
+require 'active_support/core_ext/module/aliasing.rb'
+
+class User
   # You can refer to the email column as "login".
   # This can be meaningful for authentication code.
   alias_attribute :login, :email


### PR DESCRIPTION
## Summary

If you call `alias_attribute` in a class that inherits the `ActiveRecord::Base`.
like that:


```ruby
class Post < ActiveRecord::Base
  alias_attribute :clicks, :number_of_readings
  binding.pry
end
```

The method defined in the `ActiveModel::AttributeMethods::ClassMethods` module is called.
like that:

<details>
<summary> pry result </summary>

```pry
[9] pry(Post)> $ alias_attribute

From: /Users/fukudayukihiro/RubymineProjects/rails-issue/vendor/bundle/ruby/2.4.0/bundler/gems/rails-83bfe0758363/activemodel/lib/active_model/attribute_methods.rb @ line 208:
Owner: ActiveModel::AttributeMethods::ClassMethods
Visibility: public
Number of lines: 8

def alias_attribute(new_name, old_name)
  self.attribute_aliases = attribute_aliases.merge(new_name.to_s => old_name.to_s)
  attribute_method_matchers.each do |matcher|
    matcher_new = matcher.method_name(new_name).to_s
    matcher_old = matcher.method_name(old_name).to_s
    define_proxy_call false, self, matcher_new, matcher_old
  end
end

```

</details>

---

So, To call the `alias_attribute` method defined in `active_support / core_ext / module / aliasing.rb`, For example, you need to do as follows:


```ruby
require 'active_support/core_ext/module/aliasing.rb'

class Comment
  attr_accessor :number_of_readings
  alias_attribute :clicks, :number_of_readings
  binding.pry
end

```

<details>
<summary> pry result </summary>

```pry
[1] pry(Comment)> $ alias_attribute

From: /Users/fukudayukihiro/RubymineProjects/rails-issue/vendor/bundle/ruby/2.4.0/bundler/gems/rails-83bfe0758363/activesupport/lib/active_support/core_ext/module/aliasing.rb @ line 21:
Owner: Module
Visibility: public
Number of lines: 10

def alias_attribute(new_name, old_name)
  # The following reader methods use an explicit `self` receiver in order to
  # support aliases that start with an uppercase letter. Otherwise, they would
  # be resolved as constants instead.
  module_eval <<-STR, __FILE__, __LINE__ + 1
    def #{new_name}; self.#{old_name}; end          # def subject; self.title; end
    def #{new_name}?; self.#{old_name}?; end        # def subject?; self.title?; end
    def #{new_name}=(v); self.#{old_name} = v; end  # def subject=(v); self.title = v; end
  STR
end
```

</details>

---

The following is actually a ruby ​​script I tried.

<details>
<summary>more read ...</summary>

```ruby
# frozen_string_literal: true

begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", github: "rails/rails"
  gem "arel", github: "rails/arel"
  gem "sqlite3"
  gem "pry"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.integer :number_of_reading
  end
end

class Post < ActiveRecord::Base
  alias_attribute :clicks, :number_of_reading
  binding.pry
end


require 'active_support/core_ext/module/aliasing.rb'

class Comment
  attr_accessor :number_of_readings
  alias_attribute :clicks, :number_of_readings
  binding.pry
end

```

</details>

## System configuration

### Rails version:
- Rails 5.1.1

### Ruby version:
- ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin14]