### PR TITLE
Remove not used gems by default [ci skip]

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -116,8 +116,6 @@ A standard Rails application depends on several gems, specifically:
 * mail
 * mime-types
 * rack
-* rack-cache
-* rack-mount
 * rack-test
 * rails
 * railties


### PR DESCRIPTION
`rack-mount` switched to journey with 5f0b37c.
Also, `rack-cache` will not be used unless you explicitly specify it.

Ref:
https://github.com/rails/rails/commit/037e50ec39c7c3d58a102a6584e2740652420d1d
https://github.com/rails/rails/commit/1fc795468525d8622cdca474a54c8310a514aa46
