### PR TITLE
Add `require: false` option to bcrypt in app's Gemfile

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -33,7 +33,7 @@ module ActiveModel
       #
       # Add bcrypt (~> 3.1.7) to Gemfile to use #has_secure_password:
       #
-      #   gem 'bcrypt', '~> 3.1.7'
+      #   gem 'bcrypt', '~> 3.1.7', require: false
       #
       # Example using Active Record (which automatically includes ActiveModel::SecurePassword):
       #

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -19,7 +19,7 @@ ruby <%= "'#{RUBY_VERSION}'" -%>
 <% end -%>
 
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+# gem 'bcrypt', '~> 3.1.7', require: false
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development


### PR DESCRIPTION
### Summary

- Add `require: false` option to bcrypt in application Gemfile. Because on calling `has_secure_password` method, then it call `require 'bcrypt'` (_[Ref](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/secure_password.rb#L59-L64)_).
- Modify docs described about bcrypt in ActiveModel.