### PR TITLE
show tags on errors

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -86,10 +86,11 @@ module ActionDispatch
       trace = wrapper.framework_trace if trace.empty?
 
       ActiveSupport::Deprecation.silence do
-        message = "\n#{exception.class} (#{exception.message}):\n"
-        message << exception.annoted_source_code.to_s if exception.respond_to?(:annoted_source_code)
-        message << "  " << trace.join("\n  ")
-        logger.fatal("#{message}\n\n")
+        messages = ["#{exception.class} (#{exception.message}):"]
+        messages << exception.annoted_source_code.to_s if exception.respond_to?(:annoted_source_code)
+        messages += trace
+
+        messages.each { |line| logger.fatal line }
       end
     end
 


### PR DESCRIPTION
### Summary
solves https://github.com/rails/rails/issues/30572
supports logging errors with log_tags
