### PR TITLE
Fix bug, :uuid type with a function as default ignored `null: false`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -21,6 +21,7 @@ module ActiveRecord
           column = options.fetch(:column) { return super }
           if column.type == :uuid && options[:default] =~ /\(\)/
             sql << " DEFAULT #{options[:default]}"
+            sql << " NOT NULL" if options[:null] == false
           else
             super
           end

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -258,6 +258,28 @@ class PostgresqlUUIDTestNilDefault < ActiveRecord::TestCase
   end
 end
 
+class PostgresqlUUIDTestNotNull < ActiveRecord::TestCase
+  include PostgresqlUUIDHelper
+  include SchemaDumpingHelper
+
+  setup do
+    enable_extension!('uuid-ossp', connection)
+
+    connection.create_table "uuid_data_type" do |t|
+      t.uuid 'guid', default: "uuid_generate_v4()", null: false
+    end
+  end
+
+  teardown do
+    drop_table "uuid_data_type"
+  end
+
+  def test_allows_not_null
+    schema = dump_table_schema("uuid_data_type")
+    assert_match(/\bt\.uuid "guid", default: "uuid_generate_v4\(\)", null: false/, schema)
+  end
+end
+
 class PostgresqlUUIDTestInverseOf < ActiveRecord::TestCase
   include PostgresqlUUIDHelper
 


### PR DESCRIPTION
### Summary

Fixes bug (no issues found on GitHub) on 4-2

Creating a uuid column with a default function, e.g. `uuid_generate_v4()` **and** not nullable `null: false` would ignore the "NOT NULL". This fixes restores that functionality. Yeah, it's on the 4-2 branch, but some of us are stragglers.