### PR TITLE
Remove needless test case from namespaced_generator_test

### DIFF
--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -152,7 +152,6 @@ class NamespacedMailerGeneratorTest < NamespacedGeneratorTestCase
     assert_file "app/mailers/test_app/notifier_mailer.rb" do |mailer|
       assert_match(/module TestApp/, mailer)
       assert_match(/class NotifierMailer < ApplicationMailer/, mailer)
-      assert_no_match(/default from: "from@example.com"/, mailer)
     end
   end
 


### PR DESCRIPTION
### Summary

- Since #17646, we have been to generate mailer class inherited from ApplicationMailer class. 
- `default from: "from@example.com"` is generated in ApplicationMailer class, it is clearly not generated in its subclasses. So I've removed its test case (This is the [template](https://github.com/rails/rails/blob/master/actionmailer/lib/rails/generators/mailer/templates/mailer.rb#L1-L17) for mailer class).