### PR TITLE
Add missing require in AM::AttributeAssignment

### DIFF
--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/hash/keys"
+require_relative "forbidden_attributes_protection"
 
 module ActiveModel
   module AttributeAssignment


### PR DESCRIPTION
Fixes uninitialized constant error.