### PR TITLE
Make master key added to gitignore the same value as when creating appplication

### DIFF
--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -53,7 +53,6 @@ module Rails
 
         def ensure_master_key_has_been_added
           master_key_generator.add_master_key_file
-          master_key_generator.ignore_master_key_file
         end
 
         def ensure_credentials_have_been_added

--- a/railties/lib/rails/generators/rails/app/templates/gitignore
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore
@@ -7,9 +7,6 @@
 # Ignore bundler config.
 /.bundle
 
-# Ignore master key for decrypting credentials and more.
-/config/master.key
-
 <% if sqlite3? -%>
 # Ignore the default SQLite database.
 /db/*.sqlite3

--- a/railties/lib/rails/generators/rails/master_key/master_key_generator.rb
+++ b/railties/lib/rails/generators/rails/master_key/master_key_generator.rb
@@ -22,6 +22,8 @@ module Rails
           say ""
           add_master_key_file_silently key
           say ""
+
+          ignore_master_key_file
         end
       end
 
@@ -29,24 +31,24 @@ module Rails
         create_file MASTER_KEY_PATH, key || ActiveSupport::EncryptedFile.generate_key
       end
 
-      def ignore_master_key_file
-        if File.exist?(".gitignore")
-          unless File.read(".gitignore").include?(key_ignore)
-            say "Ignoring #{MASTER_KEY_PATH} so it won't end up in Git history:"
-            say ""
-            append_to_file ".gitignore", key_ignore
+      private
+        def ignore_master_key_file
+          if File.exist?(".gitignore")
+            unless File.read(".gitignore").include?(key_ignore)
+              say "Ignoring #{MASTER_KEY_PATH} so it won't end up in Git history:"
+              say ""
+              append_to_file ".gitignore", key_ignore
+              say ""
+            end
+          else
+            say "IMPORTANT: Don't commit #{MASTER_KEY_PATH}. Add this to your ignore file:"
+            say key_ignore, :on_green
             say ""
           end
-        else
-          say "IMPORTANT: Don't commit #{MASTER_KEY_PATH}. Add this to your ignore file:"
-          say key_ignore, :on_green
-          say ""
         end
-      end
 
-      private
         def key_ignore
-          [ "", "# Ignore master key for decrypting credentials and more.", MASTER_KEY_PATH, "" ].join("\n")
+          [ "", "# Ignore master key for decrypting credentials and more.", "/#{MASTER_KEY_PATH}", "" ].join("\n")
         end
     end
   end

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "env_helpers"
+require "rails/command"
+require "rails/commands/credentials/credentials_command"
+
+class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation, EnvHelpers
+
+  setup { build_app }
+
+  teardown { teardown_app }
+
+  test "edit command does not add master key to gitignore when already exist" do
+    run_edit_command
+
+    Dir.chdir(app_path) do
+      gitignore = File.read(".gitignore")
+      assert_equal 1, gitignore.scan(%r|config/master\.key|).length
+    end
+  end
+
+  private
+    def run_edit_command(editor: "cat")
+      switch_env("EDITOR", editor) do
+        rails "credentials:edit"
+      end
+    end
+end


### PR DESCRIPTION
For gitignore generated by `rails new`, key with a leading slash is specified.
https://github.com/rails/rails/blob/69f976b859cae7f9d050152103da018b7f5dda6d/railties/lib/rails/generators/rails/app/templates/gitignore#L11

Therefore, when executing `credentials:edit`, also need leading slack.
In order to avoid such a difference, fixed to use same method for `rails new` and `credentials:edit`.