### PR TITLE
Define skip callbacks on `#define_model_callbacks`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Define skip callbacks on `#define_model_callbacks`
+
+    *Yoshiyuki Hirano*
+
 *   Add method `#merge!` for `ActiveModel::Errors`.
 
     *Jahfer Husain*

--- a/activemodel/test/cases/callbacks_test.rb
+++ b/activemodel/test/cases/callbacks_test.rb
@@ -52,10 +52,21 @@ class CallbacksTest < ActiveModel::TestCase
     end
   end
 
+  class ModelCallbacksChild < ModelCallbacks
+    skip_before_create :before_create
+  end
+
   test "complete callback chain" do
     model = ModelCallbacks.new
     model.create
     assert_equal model.callbacks, [ :before_create, :before_around_create, :create,
+                                    :after_around_create, :after_create, :final_callback]
+  end
+
+  test "skip callback chain" do
+    model = ModelCallbacksChild.new
+    model.create
+    assert_equal model.callbacks, [ :before_around_create, :create,
                                     :after_around_create, :after_create, :final_callback]
   end
 


### PR DESCRIPTION
### Summary

When it registered callback methods (e.g. `before_create`, `around_upate`) through `ActiveModel::Callbacks#define_model_callbacks`, then it isn't registered `skip_*_#{callback}` methods (e.g. `skip_before_create`, `skip_around_update`). I think it's inconvenient. I wished resolve it, So I made this pull request.

In particular, when some parent class that has many callbacks defined through `ActiveModel::Callbacks` exists, I think it's not convenient that we cannot skip callbacks on implement its subclasses.