### PR TITLE
Improve railties' tests

### DIFF
--- a/railties/test/application/dbconsole_test.rb
+++ b/railties/test/application/dbconsole_test.rb
@@ -19,21 +19,19 @@ module ApplicationTests
     end
 
     def test_use_value_defined_in_environment_file_in_database_yml
-      Dir.chdir(app_path) do
-        app_file "config/database.yml", <<-YAML
-          development:
-             database: <%= Rails.application.config.database %>
-             adapter: sqlite3
-             pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-             timeout: 5000
-        YAML
+      app_file "config/database.yml", <<-YAML
+        development:
+           database: <%= Rails.application.config.database %>
+           adapter: sqlite3
+           pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+           timeout: 5000
+      YAML
 
-        app_file "config/environments/development.rb", <<-RUBY
-          Rails.application.configure do
-            config.database = "db/development.sqlite3"
-          end
-        RUBY
-      end
+      app_file "config/environments/development.rb", <<-RUBY
+        Rails.application.configure do
+          config.database = "db/development.sqlite3"
+        end
+      RUBY
 
       master, slave = PTY.open
       spawn_dbconsole(slave)
@@ -43,22 +41,20 @@ module ApplicationTests
     end
 
     def test_respect_environment_option
-      Dir.chdir(app_path) do
-        app_file "config/database.yml", <<-YAML
-          default: &default
-            adapter: sqlite3
-            pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-            timeout: 5000
+      app_file "config/database.yml", <<-YAML
+        default: &default
+          adapter: sqlite3
+          pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+          timeout: 5000
 
-          development:
-            <<: *default
-            database: db/development.sqlite3
+        development:
+          <<: *default
+          database: db/development.sqlite3
 
-          production:
-            <<: *default
-            database: db/production.sqlite3
-        YAML
-      end
+        production:
+          <<: *default
+          database: db/production.sqlite3
+      YAML
 
       master, slave = PTY.open
       spawn_dbconsole(slave, "-e production")

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -300,7 +300,7 @@ class LoadingTest < ActiveSupport::TestCase
       end
     MIGRATION
 
-    Dir.chdir(app_path) { `rake db:migrate` }
+    rails("db:migrate")
     require "#{rails_root}/config/environment"
 
     get "/title"
@@ -314,7 +314,7 @@ class LoadingTest < ActiveSupport::TestCase
       end
     MIGRATION
 
-    Dir.chdir(app_path) { `rake db:migrate` }
+    rails("db:migrate")
 
     get "/body"
     assert_equal "BODY", last_response.body

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -15,69 +15,63 @@ module ApplicationTests
       end
 
       test "running migrations with given scope" do
-        Dir.chdir(app_path) do
-          rails "generate", "model", "user", "username:string", "password:string"
+        rails "generate", "model", "user", "username:string", "password:string"
 
-          app_file "db/migrate/01_a_migration.bukkits.rb", <<-MIGRATION
-            class AMigration < ActiveRecord::Migration::Current
-            end
-          MIGRATION
+        app_file "db/migrate/01_a_migration.bukkits.rb", <<-MIGRATION
+          class AMigration < ActiveRecord::Migration::Current
+          end
+        MIGRATION
 
-          output = rails("db:migrate", "SCOPE=bukkits")
-          assert_no_match(/create_table\(:users\)/, output)
-          assert_no_match(/CreateUsers/, output)
-          assert_no_match(/add_column\(:users, :email, :string\)/, output)
+        output = rails("db:migrate", "SCOPE=bukkits")
+        assert_no_match(/create_table\(:users\)/, output)
+        assert_no_match(/CreateUsers/, output)
+        assert_no_match(/add_column\(:users, :email, :string\)/, output)
 
-          assert_match(/AMigration: migrated/, output)
+        assert_match(/AMigration: migrated/, output)
 
-          output = rails("db:migrate", "SCOPE=bukkits", "VERSION=0")
-          assert_no_match(/drop_table\(:users\)/, output)
-          assert_no_match(/CreateUsers/, output)
-          assert_no_match(/remove_column\(:users, :email\)/, output)
+        output = rails("db:migrate", "SCOPE=bukkits", "VERSION=0")
+        assert_no_match(/drop_table\(:users\)/, output)
+        assert_no_match(/CreateUsers/, output)
+        assert_no_match(/remove_column\(:users, :email\)/, output)
 
-          assert_match(/AMigration: reverted/, output)
-        end
+        assert_match(/AMigration: reverted/, output)
       end
 
       test "migration with empty version" do
-        Dir.chdir(app_path) do
-          output = rails("db:migrate", "VERSION=", allow_failure: true)
-          assert_match(/Empty VERSION provided/, output)
+        output = rails("db:migrate", "VERSION=", allow_failure: true)
+        assert_match(/Empty VERSION provided/, output)
 
-          output = rails("db:migrate:redo", "VERSION=", allow_failure: true)
-          assert_match(/Empty VERSION provided/, output)
+        output = rails("db:migrate:redo", "VERSION=", allow_failure: true)
+        assert_match(/Empty VERSION provided/, output)
 
-          output = rails("db:migrate:up", "VERSION=", allow_failure: true)
-          assert_match(/VERSION is required/, output)
+        output = rails("db:migrate:up", "VERSION=", allow_failure: true)
+        assert_match(/VERSION is required/, output)
 
-          output = rails("db:migrate:up", allow_failure: true)
-          assert_match(/VERSION is required/, output)
+        output = rails("db:migrate:up", allow_failure: true)
+        assert_match(/VERSION is required/, output)
 
-          output = rails("db:migrate:down", "VERSION=", allow_failure: true)
-          assert_match(/VERSION is required - To go down one migration, use db:rollback/, output)
+        output = rails("db:migrate:down", "VERSION=", allow_failure: true)
+        assert_match(/VERSION is required - To go down one migration, use db:rollback/, output)
 
-          output = rails("db:migrate:down", allow_failure: true)
-          assert_match(/VERSION is required - To go down one migration, use db:rollback/, output)
-        end
+        output = rails("db:migrate:down", allow_failure: true)
+        assert_match(/VERSION is required - To go down one migration, use db:rollback/, output)
       end
 
       test "model and migration generator with change syntax" do
-        Dir.chdir(app_path) do
-          rails "generate", "model", "user", "username:string", "password:string"
-          rails "generate", "migration", "add_email_to_users", "email:string"
+        rails "generate", "model", "user", "username:string", "password:string"
+        rails "generate", "migration", "add_email_to_users", "email:string"
 
-          output = rails("db:migrate")
-          assert_match(/create_table\(:users\)/, output)
-          assert_match(/CreateUsers: migrated/, output)
-          assert_match(/add_column\(:users, :email, :string\)/, output)
-          assert_match(/AddEmailToUsers: migrated/, output)
+        output = rails("db:migrate")
+        assert_match(/create_table\(:users\)/, output)
+        assert_match(/CreateUsers: migrated/, output)
+        assert_match(/add_column\(:users, :email, :string\)/, output)
+        assert_match(/AddEmailToUsers: migrated/, output)
 
-          output = rails("db:rollback", "STEP=2")
-          assert_match(/drop_table\(:users\)/, output)
-          assert_match(/CreateUsers: reverted/, output)
-          assert_match(/remove_column\(:users, :email, :string\)/, output)
-          assert_match(/AddEmailToUsers: reverted/, output)
-        end
+        output = rails("db:rollback", "STEP=2")
+        assert_match(/drop_table\(:users\)/, output)
+        assert_match(/CreateUsers: reverted/, output)
+        assert_match(/remove_column\(:users, :email, :string\)/, output)
+        assert_match(/AddEmailToUsers: reverted/, output)
       end
 
       test "migration status when schema migrations table is not present" do
@@ -86,93 +80,85 @@ module ApplicationTests
       end
 
       test "migration status" do
-        Dir.chdir(app_path) do
-          rails "generate", "model", "user", "username:string", "password:string"
-          rails "generate", "migration", "add_email_to_users", "email:string"
-          rails "db:migrate"
+        rails "generate", "model", "user", "username:string", "password:string"
+        rails "generate", "migration", "add_email_to_users", "email:string"
+        rails "db:migrate"
 
-          output = rails("db:migrate:status")
+        output = rails("db:migrate:status")
 
-          assert_match(/up\s+\d{14}\s+Create users/, output)
-          assert_match(/up\s+\d{14}\s+Add email to users/, output)
+        assert_match(/up\s+\d{14}\s+Create users/, output)
+        assert_match(/up\s+\d{14}\s+Add email to users/, output)
 
-          rails "db:rollback", "STEP=1"
-          output = rails("db:migrate:status")
+        rails "db:rollback", "STEP=1"
+        output = rails("db:migrate:status")
 
-          assert_match(/up\s+\d{14}\s+Create users/, output)
-          assert_match(/down\s+\d{14}\s+Add email to users/, output)
-        end
+        assert_match(/up\s+\d{14}\s+Create users/, output)
+        assert_match(/down\s+\d{14}\s+Add email to users/, output)
       end
 
       test "migration status without timestamps" do
         add_to_config("config.active_record.timestamped_migrations = false")
 
-        Dir.chdir(app_path) do
-          rails "generate", "model", "user", "username:string", "password:string"
-          rails "generate", "migration", "add_email_to_users", "email:string"
-          rails "db:migrate"
+        rails "generate", "model", "user", "username:string", "password:string"
+        rails "generate", "migration", "add_email_to_users", "email:string"
+        rails "db:migrate"
 
-          output = rails("db:migrate:status")
+        output = rails("db:migrate:status")
 
-          assert_match(/up\s+\d{3,}\s+Create users/, output)
-          assert_match(/up\s+\d{3,}\s+Add email to users/, output)
+        assert_match(/up\s+\d{3,}\s+Create users/, output)
+        assert_match(/up\s+\d{3,}\s+Add email to users/, output)
 
-          rails "db:rollback", "STEP=1"
-          output = rails("db:migrate:status")
+        rails "db:rollback", "STEP=1"
+        output = rails("db:migrate:status")
 
-          assert_match(/up\s+\d{3,}\s+Create users/, output)
-          assert_match(/down\s+\d{3,}\s+Add email to users/, output)
-        end
+        assert_match(/up\s+\d{3,}\s+Create users/, output)
+        assert_match(/down\s+\d{3,}\s+Add email to users/, output)
       end
 
       test "migration status after rollback and redo" do
-        Dir.chdir(app_path) do
-          rails "generate", "model", "user", "username:string", "password:string"
-          rails "generate", "migration", "add_email_to_users", "email:string"
-          rails "db:migrate"
+        rails "generate", "model", "user", "username:string", "password:string"
+        rails "generate", "migration", "add_email_to_users", "email:string"
+        rails "db:migrate"
 
-          output = rails("db:migrate:status")
+        output = rails("db:migrate:status")
 
-          assert_match(/up\s+\d{14}\s+Create users/, output)
-          assert_match(/up\s+\d{14}\s+Add email to users/, output)
+        assert_match(/up\s+\d{14}\s+Create users/, output)
+        assert_match(/up\s+\d{14}\s+Add email to users/, output)
 
-          rails "db:rollback", "STEP=2"
-          output = rails("db:migrate:status")
+        rails "db:rollback", "STEP=2"
+        output = rails("db:migrate:status")
 
-          assert_match(/down\s+\d{14}\s+Create users/, output)
-          assert_match(/down\s+\d{14}\s+Add email to users/, output)
+        assert_match(/down\s+\d{14}\s+Create users/, output)
+        assert_match(/down\s+\d{14}\s+Add email to users/, output)
 
-          rails "db:migrate:redo"
-          output = rails("db:migrate:status")
+        rails "db:migrate:redo"
+        output = rails("db:migrate:status")
 
-          assert_match(/up\s+\d{14}\s+Create users/, output)
-          assert_match(/up\s+\d{14}\s+Add email to users/, output)
-        end
+        assert_match(/up\s+\d{14}\s+Create users/, output)
+        assert_match(/up\s+\d{14}\s+Add email to users/, output)
       end
 
       test "migration status after rollback and forward" do
-        Dir.chdir(app_path) do
-          rails "generate", "model", "user", "username:string", "password:string"
-          rails "generate", "migration", "add_email_to_users", "email:string"
-          rails "db:migrate"
+        rails "generate", "model", "user", "username:string", "password:string"
+        rails "generate", "migration", "add_email_to_users", "email:string"
+        rails "db:migrate"
 
-          output = rails("db:migrate:status")
+        output = rails("db:migrate:status")
 
-          assert_match(/up\s+\d{14}\s+Create users/, output)
-          assert_match(/up\s+\d{14}\s+Add email to users/, output)
+        assert_match(/up\s+\d{14}\s+Create users/, output)
+        assert_match(/up\s+\d{14}\s+Add email to users/, output)
 
-          rails "db:rollback", "STEP=2"
-          output = rails("db:migrate:status")
+        rails "db:rollback", "STEP=2"
+        output = rails("db:migrate:status")
 
-          assert_match(/down\s+\d{14}\s+Create users/, output)
-          assert_match(/down\s+\d{14}\s+Add email to users/, output)
+        assert_match(/down\s+\d{14}\s+Create users/, output)
+        assert_match(/down\s+\d{14}\s+Add email to users/, output)
 
-          rails "db:forward", "STEP=2"
-          output = rails("db:migrate:status")
+        rails "db:forward", "STEP=2"
+        output = rails("db:migrate:status")
 
-          assert_match(/up\s+\d{14}\s+Create users/, output)
-          assert_match(/up\s+\d{14}\s+Add email to users/, output)
-        end
+        assert_match(/up\s+\d{14}\s+Create users/, output)
+        assert_match(/up\s+\d{14}\s+Add email to users/, output)
       end
 
       test "raise error on any move when current migration does not exist" do
@@ -209,50 +195,45 @@ module ApplicationTests
       test "migration status after rollback and redo without timestamps" do
         add_to_config("config.active_record.timestamped_migrations = false")
 
-        Dir.chdir(app_path) do
-          rails "generate", "model", "user", "username:string", "password:string"
-          rails "generate", "migration", "add_email_to_users", "email:string"
-          rails "db:migrate"
+        rails "generate", "model", "user", "username:string", "password:string"
+        rails "generate", "migration", "add_email_to_users", "email:string"
+        rails "db:migrate"
 
-          output = rails("db:migrate:status")
+        output = rails("db:migrate:status")
 
-          assert_match(/up\s+\d{3,}\s+Create users/, output)
-          assert_match(/up\s+\d{3,}\s+Add email to users/, output)
+        assert_match(/up\s+\d{3,}\s+Create users/, output)
+        assert_match(/up\s+\d{3,}\s+Add email to users/, output)
 
-          rails "db:rollback", "STEP=2"
-          output = rails("db:migrate:status")
+        rails "db:rollback", "STEP=2"
+        output = rails("db:migrate:status")
 
-          assert_match(/down\s+\d{3,}\s+Create users/, output)
-          assert_match(/down\s+\d{3,}\s+Add email to users/, output)
+        assert_match(/down\s+\d{3,}\s+Create users/, output)
+        assert_match(/down\s+\d{3,}\s+Add email to users/, output)
 
-          rails "db:migrate:redo"
-          output = rails("db:migrate:status")
+        rails "db:migrate:redo"
+        output = rails("db:migrate:status")
 
-          assert_match(/up\s+\d{3,}\s+Create users/, output)
-          assert_match(/up\s+\d{3,}\s+Add email to users/, output)
-        end
+        assert_match(/up\s+\d{3,}\s+Create users/, output)
+        assert_match(/up\s+\d{3,}\s+Add email to users/, output)
       end
 
       test "running migrations with not timestamp head migration files" do
-        Dir.chdir(app_path) do
+        app_file "db/migrate/1_one_migration.rb", <<-MIGRATION
+          class OneMigration < ActiveRecord::Migration::Current
+          end
+        MIGRATION
 
-          app_file "db/migrate/1_one_migration.rb", <<-MIGRATION
-            class OneMigration < ActiveRecord::Migration::Current
-            end
-          MIGRATION
+        app_file "db/migrate/02_two_migration.rb", <<-MIGRATION
+          class TwoMigration < ActiveRecord::Migration::Current
+          end
+        MIGRATION
 
-          app_file "db/migrate/02_two_migration.rb", <<-MIGRATION
-            class TwoMigration < ActiveRecord::Migration::Current
-            end
-          MIGRATION
+        rails "db:migrate"
 
-          rails "db:migrate"
+        output = rails("db:migrate:status")
 
-          output = rails("db:migrate:status")
-
-          assert_match(/up\s+001\s+One migration/, output)
-          assert_match(/up\s+002\s+Two migration/, output)
-        end
+        assert_match(/up\s+001\s+One migration/, output)
+        assert_match(/up\s+002\s+Two migration/, output)
       end
 
       test "schema generation when dump_schema_after_migration is set" do

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -101,6 +101,7 @@ module ApplicationTests
       add_to_config <<-RUBY
         rake_tasks do
           task do_nothing: :environment do
+            puts 'There is nothing'
           end
         end
       RUBY
@@ -113,10 +114,8 @@ module ApplicationTests
         raise 'should not be pre-required for rake even eager_load=true'
       RUBY
 
-      Dir.chdir(app_path) do
-        assert system("bin/rails do_nothing RAILS_ENV=production"),
-               "should not be pre-required for rake even eager_load=true"
-      end
+      output = rails("do_nothing", "RAILS_ENV=production")
+      assert_match "There is nothing", output
     end
 
     def test_code_statistics_sanity
@@ -294,9 +293,8 @@ module ApplicationTests
 
     def test_scaffold_tests_pass_by_default
       rails "generate", "scaffold", "user", "username:string", "password:string"
-      output = Dir.chdir(app_path) do
-        `RAILS_ENV=test bin/rails db:migrate test`
-      end
+      with_rails_env("test") { rails("db:migrate") }
+      output = rails("test")
 
       assert_match(/7 runs, 9 assertions, 0 failures, 0 errors/, output)
       assert_no_match(/Errors running/, output)
@@ -313,9 +311,8 @@ module ApplicationTests
       RUBY
 
       rails "generate", "scaffold", "user", "username:string", "password:string"
-      output = Dir.chdir(app_path) do
-        `RAILS_ENV=test bin/rails db:migrate test`
-      end
+      with_rails_env("test") { rails("db:migrate") }
+      output = rails("test")
 
       assert_match(/5 runs, 7 assertions, 0 failures, 0 errors/, output)
       assert_no_match(/Errors running/, output)
@@ -325,9 +322,8 @@ module ApplicationTests
       rails "generate", "model", "Product"
       rails "generate", "model", "Cart"
       rails "generate", "scaffold", "LineItems", "product:references", "cart:belongs_to"
-      output = Dir.chdir(app_path) do
-        `RAILS_ENV=test bin/rails db:migrate test`
-      end
+      with_rails_env("test") { rails("db:migrate") }
+      output = rails("test")
 
       assert_match(/7 runs, 9 assertions, 0 failures, 0 errors/, output)
       assert_no_match(/Errors running/, output)

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -333,9 +333,7 @@ module ApplicationTests
       add_to_config "config.active_record.schema_format = :sql"
       rails "generate", "scaffold", "user", "username:string"
       rails "db:migrate"
-      output = with_rails_env("test") do
-        rails "db:test:prepare", "--trace"
-      end
+      output = rails("db:test:prepare", "--trace")
       assert_match(/Execute db:test:load_structure/, output)
     end
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -40,7 +40,7 @@ module ApplicationTests
       with_rails_env "test" do
         rails "generate", "model", "product", "name:string"
         rails "db:create", "db:migrate"
-        output = Dir.chdir(app_path) { rails("db:test:prepare", "test") }
+        output = rails("db:test:prepare", "test")
 
         refute_match(/ActiveRecord::ProtectedEnvironmentError/, output)
       end
@@ -372,14 +372,12 @@ module ApplicationTests
     end
 
     def test_copy_templates
-      Dir.chdir(app_path) do
-        rails "app:templates:copy"
-        %w(controller mailer scaffold).each do |dir|
-          assert File.exist?(File.join(app_path, "lib", "templates", "erb", dir))
-        end
-        %w(controller helper scaffold_controller assets).each do |dir|
-          assert File.exist?(File.join(app_path, "lib", "templates", "rails", dir))
-        end
+      rails "app:templates:copy"
+      %w(controller mailer scaffold).each do |dir|
+        assert File.exist?(File.join(app_path, "lib", "templates", "erb", dir))
+      end
+      %w(controller helper scaffold_controller assets).each do |dir|
+        assert File.exist?(File.join(app_path, "lib", "templates", "rails", dir))
       end
     end
 

--- a/railties/test/application/server_test.rb
+++ b/railties/test/application/server_test.rb
@@ -42,7 +42,7 @@ module ApplicationTests
         pid = Process.spawn("#{app_path}/bin/rails server -P tmp/dummy.pid", in: slave, out: slave, err: slave)
         assert_output("Listening", master)
 
-        Dir.chdir(app_path) { system("bin/rails restart") }
+        rails("restart")
 
         assert_output("Restarting", master)
         assert_output("Inherited", master)


### PR DESCRIPTION
- Remove redundant execution of `Dir.chdir(app_path) { }` in railties' tests
- <strike>Improve RakeTest#test_not_protected_when_previous_migration_was_not_production</strike>
  - <strike>Allow failure for `db:test:prepare` to ensure the test woun't raise error:
     `RuntimeError: rails command failed (1): bin/rails db:test:prepare 2>&1`</strike>
  - <strike>Prevent redundant execution of `bin/rails test` inside the test</strike>
</strike>

- Invoke rails command inside the railties' test app with TestHelpers::Generation#rails
  See #30520
- Improve RakeTest#test_db_test_prepare_when_using_sql_format
  - Remove redundant setting `RAILS_ENV` for `db:test:prepare`.
    `db:test:prepare` doesn't require it.

/cc @matthewd 