### PR TITLE
Handle the highest priority exceptions in the cause chain

### DIFF
--- a/actionpack/test/controller/rescue_test.rb
+++ b/actionpack/test/controller/rescue_test.rb
@@ -294,7 +294,7 @@ class RescueControllerTest < ActionController::TestCase
 
   test "rescue when wrapper has more specific handler than cause" do
     get :exception_with_more_specific_handler_for_wrapper
-    assert_response :forbidden
+    assert_response :unprocessable_entity
   end
 
   test "rescue when cause has more specific handler than wrapper" do


### PR DESCRIPTION
Change to handle the highest priority exception in the exception cause chain.
`rescue_from` handler that are defined later have higher priority.
The priority does not depend on outside or inside of composition relation by `Exception#cause`.

Fixes #29739