### PR TITLE
CI against Ruby 2.3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ env:
 
 rvm:
   - 2.2.7
-  - 2.3.4
+  - 2.3.5
   - 2.4.1
   - ruby-head
 
@@ -66,7 +66,7 @@ matrix:
       services:
         - memcached
         - rabbitmq
-    - rvm: 2.3.4
+    - rvm: 2.3.5
       env: "GEM=aj:integration"
       services:
         - memcached
@@ -81,15 +81,15 @@ matrix:
       services:
         - memcached
         - rabbitmq
-    - rvm: 2.3.4
+    - rvm: 2.3.5
       env:
         - "GEM=ar:mysql2 MYSQL=mariadb"
       addons:
         mariadb: 10.2
-    - rvm: 2.3.4
+    - rvm: 2.3.5
       env:
         - "GEM=ar:sqlite3_mem"
-    - rvm: 2.3.4
+    - rvm: 2.3.5
       env:
         - "GEM=ar:postgresql POSTGRES=9.2"
       addons:


### PR DESCRIPTION
### Summary

https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-3-5-released/