### PR TITLE
Install JavaScript dependencies on bin/update

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/update.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/update.tt
@@ -15,6 +15,11 @@ chdir APP_ROOT do
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
+<% unless options.skip_yarn? -%>
+
+  # Install JavaScript dependencies if using Yarn
+  # system('bin/yarn')
+<% end -%>
 <% unless options.skip_active_record? -%>
 
   puts "\n== Updating database =="


### PR DESCRIPTION
### Summary

refs https://github.com/rails/rails/commit/c873746c506e193cf6294d8919d464997d54eadb

On above commit aimed to comment out the calling of `bin/yarn` but it was removed from `bin/update` in spite of remaining in `bin/setup`.

I think it is helpful to us who are using yarn if generated `bin/update` has this code.