### PR TITLE
Don't expose Active Storage routes

### DIFF
--- a/activestorage/config/routes.rb
+++ b/activestorage/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get "/rails/active_storage/blobs/:signed_id/*filename" => "active_storage/blobs#show", as: :rails_service_blob
+  get "/rails/active_storage/blobs/:signed_id/*filename" => "active_storage/blobs#show", as: :rails_service_blob, internal: true
 
   direct :rails_blob do |blob|
     route_for(:rails_service_blob, blob.signed_id, blob.filename)
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   resolve("ActiveStorage::Attachment") { |attachment| route_for(:rails_blob, attachment.blob) }
 
 
-  get "/rails/active_storage/variants/:signed_blob_id/:variation_key/*filename" => "active_storage/variants#show", as: :rails_blob_variation
+  get "/rails/active_storage/variants/:signed_blob_id/:variation_key/*filename" => "active_storage/variants#show", as: :rails_blob_variation, internal: true
 
   direct :rails_variant do |variant|
     signed_blob_id = variant.blob.signed_id
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
   resolve("ActiveStorage::Variant") { |variant| route_for(:rails_variant, variant) }
 
 
-  get  "/rails/active_storage/disk/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_service
-  put  "/rails/active_storage/disk/:encoded_token" => "active_storage/disk#update", as: :update_rails_disk_service
-  post "/rails/active_storage/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
+  get  "/rails/active_storage/disk/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_service, internal: true
+  put  "/rails/active_storage/disk/:encoded_token" => "active_storage/disk#update", as: :update_rails_disk_service, internal: true
+  post "/rails/active_storage/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads, internal: true
 end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -133,13 +133,8 @@ module ApplicationTests
 
       output = rails("routes")
       assert_equal <<-MESSAGE.strip_heredoc, output
-                         Prefix Verb URI Pattern                                                                       Controller#Action
-                           cart GET  /cart(.:format)                                                                   cart#show
-             rails_service_blob GET  /rails/active_storage/blobs/:signed_id/*filename(.:format)                        active_storage/blobs#show
-           rails_blob_variation GET  /rails/active_storage/variants/:signed_blob_id/:variation_key/*filename(.:format) active_storage/variants#show
-             rails_disk_service GET  /rails/active_storage/disk/:encoded_key/*filename(.:format)                       active_storage/disk#show
-      update_rails_disk_service PUT  /rails/active_storage/disk/:encoded_token(.:format)                               active_storage/disk#update
-           rails_direct_uploads POST /rails/active_storage/direct_uploads(.:format)                                    active_storage/direct_uploads#create
+                         Prefix Verb URI Pattern     Controller#Action
+                           cart GET  /cart(.:format) cart#show
       MESSAGE
     end
 
@@ -174,18 +169,14 @@ module ApplicationTests
 
       output = rails("routes", "-g", "show", allow_failure: true)
       assert_equal <<-MESSAGE.strip_heredoc, output
-                         Prefix Verb URI Pattern                                                                       Controller#Action
-                           cart GET  /cart(.:format)                                                                   cart#show
-             rails_service_blob GET  /rails/active_storage/blobs/:signed_id/*filename(.:format)                        active_storage/blobs#show
-           rails_blob_variation GET  /rails/active_storage/variants/:signed_blob_id/:variation_key/*filename(.:format) active_storage/variants#show
-             rails_disk_service GET  /rails/active_storage/disk/:encoded_key/*filename(.:format)                       active_storage/disk#show
+                         Prefix Verb URI Pattern     Controller#Action
+                           cart GET  /cart(.:format) cart#show
       MESSAGE
 
       output = rails("routes", "-g", "POST")
       assert_equal <<-MESSAGE.strip_heredoc, output
-                         Prefix Verb URI Pattern                                    Controller#Action
-                                POST /cart(.:format)                                cart#create
-           rails_direct_uploads POST /rails/active_storage/direct_uploads(.:format) active_storage/direct_uploads#create
+                         Prefix Verb URI Pattern     Controller#Action
+                                POST /cart(.:format) cart#create
       MESSAGE
 
       output = rails("routes", "-g", "basketballs")
@@ -242,12 +233,11 @@ module ApplicationTests
       RUBY
 
       assert_equal <<-MESSAGE.strip_heredoc, rails("routes")
-                         Prefix Verb URI Pattern                                                                       Controller#Action
-             rails_service_blob GET  /rails/active_storage/blobs/:signed_id/*filename(.:format)                        active_storage/blobs#show
-           rails_blob_variation GET  /rails/active_storage/variants/:signed_blob_id/:variation_key/*filename(.:format) active_storage/variants#show
-             rails_disk_service GET  /rails/active_storage/disk/:encoded_key/*filename(.:format)                       active_storage/disk#show
-      update_rails_disk_service PUT  /rails/active_storage/disk/:encoded_token(.:format)                               active_storage/disk#update
-           rails_direct_uploads POST /rails/active_storage/direct_uploads(.:format)                                    active_storage/direct_uploads#create
+        You don't have any routes defined!
+
+        Please add some routes in config/routes.rb.
+
+        For more information about routes, see the Rails guide: http://guides.rubyonrails.org/routing.html.
       MESSAGE
     end
 
@@ -261,13 +251,8 @@ module ApplicationTests
       output = Dir.chdir(app_path) { `bin/rake --rakefile Rakefile routes` }
 
       assert_equal <<-MESSAGE.strip_heredoc, output
-                         Prefix Verb URI Pattern                                                                       Controller#Action
-                           cart GET  /cart(.:format)                                                                   cart#show
-             rails_service_blob GET  /rails/active_storage/blobs/:signed_id/*filename(.:format)                        active_storage/blobs#show
-           rails_blob_variation GET  /rails/active_storage/variants/:signed_blob_id/:variation_key/*filename(.:format) active_storage/variants#show
-             rails_disk_service GET  /rails/active_storage/disk/:encoded_key/*filename(.:format)                       active_storage/disk#show
-      update_rails_disk_service PUT  /rails/active_storage/disk/:encoded_token(.:format)                               active_storage/disk#update
-           rails_direct_uploads POST /rails/active_storage/direct_uploads(.:format)                                    active_storage/direct_uploads#create
+                         Prefix Verb URI Pattern     Controller#Action
+                           cart GET  /cart(.:format) cart#show
       MESSAGE
     end
 


### PR DESCRIPTION
These routes are only used internally in Active Storage, and it seems that there is no need for the user to directly use them.

Therefore, I think that routes should not be exposed to users.