### PR TITLE
Update payload names for `sql.active_record` instrumentation to be more descriptive.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Update payload names for `sql.active_record` instrumentation to be
+    more descriptive.
+
+    Fixes #30586.
+
+    *Jeremy Green*
+
 *   Add new error class `TransactionTimeout` for MySQL adapter which will be raised
     when lock wait time expires.
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -63,7 +63,7 @@ module ActiveRecord
 
       @klass.connection.insert(
         im,
-        "SQL",
+        "#{@klass} Create",
         primary_key || false,
         primary_key_value,
         nil,
@@ -86,7 +86,7 @@ module ActiveRecord
 
       @klass.connection.update(
         um,
-        "SQL",
+        "#{@klass} Update",
       )
     end
 
@@ -373,7 +373,7 @@ module ActiveRecord
         stmt.wheres = arel.constraints
       end
 
-      @klass.connection.update stmt, "SQL"
+      @klass.connection.update stmt, "#{@klass} Update All"
     end
 
     # Updates an object (or multiple objects) and saves it to the database, if validations pass.
@@ -503,7 +503,7 @@ module ActiveRecord
         stmt.wheres = arel.constraints
       end
 
-      affected = @klass.connection.delete(stmt, "SQL")
+      affected = @klass.connection.delete(stmt, "#{@klass} Destroy")
 
       reset
       affected

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/book"
+
+module ActiveRecord
+  class InstrumentationTest < ActiveRecord::TestCase
+    def test_payload_name_on_load
+      Book.create(name: "test book")
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        event = ActiveSupport::Notifications::Event.new *args
+        if event.payload[:sql].match "SELECT"
+          assert_equal "Book Load", event.payload[:name]
+        end
+      end
+      Book.first
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+
+    def test_payload_name_on_create
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        event = ActiveSupport::Notifications::Event.new *args
+        if event.payload[:sql].match "INSERT"
+          assert_equal "Book Create", event.payload[:name]
+        end
+      end
+      Book.create(name: "test book")
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+
+    def test_payload_name_on_update
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        event = ActiveSupport::Notifications::Event.new *args
+        if event.payload[:sql].match "UPDATE"
+          assert_equal "Book Update", event.payload[:name]
+        end
+      end
+      book = Book.create(name: "test book")
+      book.update_attribute(:name, "new name")
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+
+    def test_payload_name_on_update_all
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        event = ActiveSupport::Notifications::Event.new *args
+        if event.payload[:sql].match "UPDATE"
+          assert_equal "Book Update All", event.payload[:name]
+        end
+      end
+      Book.create(name: "test book")
+      Book.update_all(name: "new name")
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+
+    def test_payload_name_on_destroy
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        event = ActiveSupport::Notifications::Event.new *args
+        if event.payload[:sql].match "DELETE"
+          assert_equal "Book Destroy", event.payload[:name]
+        end
+      end
+      book = Book.create(name: "test book")
+      book.destroy
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+  end
+end


### PR DESCRIPTION
### Summary

This updates payload names of `sql.active_record` instrumentation for `create`, `update`, and `destroy` operations to match the pattern set up by `find` and `count` operations.

**Previous behavior:**

* When a `Book` is created the payload name was `"SQL"`.
* When a `Book` is updated the payload name was `"SQL"`.
* When a `Book` is deleted the payload name was `"SQL"`.

**New behavior:**

* When a `Book` is created the payload name is `"Book Create"`.
* When a `Book` is updated the payload name is `"Book Update"`.
* When a `Book` is deleted  the payload name is `"Book Delete"`.

Fixes #30586.

### Other Information

Thread from the rails core mailing list: https://groups.google.com/forum/#!topic/rubyonrails-core/yh9lg0nmvOQ