### PR TITLE
make documentation consistent with  KeyError message 

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -24,7 +24,7 @@ module ActiveSupport
   # To raise an exception when the value is blank, append a
   # bang to the key name, like:
   #
-  #   h.dog! # => raises KeyError: key not found: :dog
+  #   h.dog! # => raises KeyError: :dog is blank
   #
   class OrderedOptions < Hash
     alias_method :_get, :[] # preserve the original #[] method
@@ -46,7 +46,7 @@ module ActiveSupport
         bangs = name_string.chomp!("!")
 
         if bangs
-          fetch(name_string.to_sym).presence || raise(KeyError.new("#{name_string} is blank."))
+          fetch(name_string.to_sym).presence || raise(KeyError.new(":#{name_string} is blank"))
         else
           self[name_string]
         end

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1049,7 +1049,7 @@ If you want an exception to be raised when some key is blank, use the bang
 version:
 
 ```ruby
-Rails.application.credentials.some_api_key! # => raises KeyError: key not found: :some_api_key
+Rails.application.credentials.some_api_key! # => raises KeyError: :some_api_key is blank
 ```
 
 Additional Resources


### PR DESCRIPTION
The error being raised in the bang method (eg: `h.dog!`) when the key `dog` does not exist is currently of the form:-
`KeyError: dog is blank.`
This is inconsistent with the documentation within this class (and other classes where `KeyError` is raised) which clearly states error should be of the form:-
`KeyError: key not found: :dog`
This has been fixed.

EDIT:

It was concluded that it is the documentation that needed fix and it has been updated.