### PR TITLE
Fix file missing in activestorage's example code [ci skip]

### DIFF
--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -24,7 +24,7 @@ class User < ApplicationRecord
 end
 
 # Attach an avatar to the user.
-user.avatar.attach(io: File.open("~/face.jpg"), filename: "avatar.jpg", content_type: "image/jpg")
+user.avatar.attach(io: File.open("/path/to/face.jpg"), filename: "face.jpg", content_type: "image/jpg")
 
 # Does the user have an avatar?
 user.avatar.attached? # => true

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -17,7 +17,7 @@ module ActiveStorage
     #
     #   document.images.attach(params[:images]) # Array of ActionDispatch::Http::UploadedFile objects
     #   document.images.attach(params[:signed_blob_id]) # Signed reference to blob from direct upload
-    #   document.images.attach(io: File.open("~/racecar.jpg"), filename: "racecar.jpg", content_type: "image/jpg")
+    #   document.images.attach(io: File.open("/path/to/racecar.jpg"), filename: "racecar.jpg", content_type: "image/jpg")
     #   document.images.attach([ first_blob, second_blob ])
     def attach(*attachables)
       attachables.flatten.collect do |attachable|

--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -18,7 +18,7 @@ module ActiveStorage
     #
     #   person.avatar.attach(params[:avatar]) # ActionDispatch::Http::UploadedFile object
     #   person.avatar.attach(params[:signed_blob_id]) # Signed reference to blob from direct upload
-    #   person.avatar.attach(io: File.open("~/face.jpg"), filename: "face.jpg", content_type: "image/jpg")
+    #   person.avatar.attach(io: File.open("/path/to/face.jpg"), filename: "face.jpg", content_type: "image/jpg")
     #   person.avatar.attach(avatar_blob) # ActiveStorage::Blob object
     def attach(attachable)
       if attached? && dependent == :purge_later


### PR DESCRIPTION
### Summary

* File.open("~/face.jpg") raise error:
    ```
    Errno::ENOENT: No such file or directory @ rb_sysopen - ~/face.jpg
    ```
* ~It seems that it should call `File.open(File.expand_path("~/face.jpg"))`.~
* I've changed to `File.open("/path/to/face.jpg")` (`File.expand_path` is too complex.)