### PR TITLE
Add local option to Message form [ci skip]

### DIFF
--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -63,7 +63,7 @@ end
 ```
 
 ```erb
-<%= form_with model: @message do |form| %>
+<%= form_with model: @message, local: true do |form| %>
   <%= form.text_field :title, placeholder: "Title" %><br>
   <%= form.text_area :content %><br><br>
 


### PR DESCRIPTION
## Summary

* `MessagesController` redirects to `GET /message/:id`.
* It looks it don't expect XHR request.
* `form_with` behaves for XHR by default.
* I've added `local: true` option to `form_with`.
