### PR TITLE
Add `with_attached_*` scope to `has_one_attached` macro

### DIFF
--- a/activestorage/lib/active_storage/attached/macros.rb
+++ b/activestorage/lib/active_storage/attached/macros.rb
@@ -12,6 +12,10 @@ module ActiveStorage
     # There is no column defined on the model side, Active Storage takes
     # care of the mapping between your records and the attachment.
     #
+    # To avoid N+1 queries, you can include the attached blobs in your query like so:
+    #
+    #   User.with_attached_avatar
+    #
     # Under the covers, this relationship is implemented as a +has_one+ association to a
     # ActiveStorage::Attachment record and a +has_one-through+ association to a
     # ActiveStorage::Blob record. These associations are available as +avatar_attachment+
@@ -32,6 +36,8 @@ module ActiveStorage
 
       has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record
       has_one :"#{name}_blob", through: :"#{name}_attachment", class_name: "ActiveStorage::Blob", source: :blob
+
+      scope :"with_attached_#{name}", -> { includes("#{name}_attachment": :blob) }
 
       if dependent == :purge_later
         before_destroy { public_send(name).purge_later }

--- a/activestorage/test/models/attachments_test.rb
+++ b/activestorage/test/models/attachments_test.rb
@@ -84,6 +84,19 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     end
   end
 
+  test "find with attached blob" do
+    records = %w[alice bob].map do |name|
+      User.create!(name: name).tap do |user|
+        user.avatar.attach create_blob(filename: "#{name}.jpg")
+      end
+    end
+
+    users = User.where(id: records.map(&:id)).with_attached_avatar.all
+
+    assert_equal "alice.jpg", users.first.avatar.filename.to_s
+    assert_equal "bob.jpg", users.second.avatar.filename.to_s
+  end
+
 
   test "attach existing blobs" do
     @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "wonky.jpg")


### PR DESCRIPTION
### Summary

To avoid N+1 queries, added `with_attached_*` scope to `has_one_attached` macro.