### PR TITLE
Add `mini_magick` to default `Gemfile` as comment

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `mini_magick` to default `Gemfile` as comment.
+
+    *Yoshiyuki Hirano*
+
 *   Derive `secret_key_base` from the app name in development and test environments.
 
     Spares away needless secret configs.

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -21,6 +21,9 @@ ruby <%= "'#{RUBY_VERSION}'" -%>
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
+# Use ActiveStorage variant
+# gem 'mini_magick', '~> 4.8'
+
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 


### PR DESCRIPTION
### Summary

* If we want to transform image on ActiveStorage, we should bundle `mini_magick`.
* I've added comment block to default `Gemfile` to be easier to install `mini_magick`.