### PR TITLE
Add missing round bracket in "Ruby on Rails 5.1 Release Notes" guide

### DIFF
--- a/guides/source/5_1_release_notes.md
+++ b/guides/source/5_1_release_notes.md
@@ -602,7 +602,7 @@ Please refer to the [Changelog][active-support] for detailed changes.
     ([Pull Request](https://github.com/rails/rails/pull/28157))
 
 *   Deprecated passing string to `:if` and `:unless` conditional options on `set_callback` and `skip_callback`.
-    ([Commit](https://github.com/rails/rails/commit/0952552)
+    ([Commit](https://github.com/rails/rails/commit/0952552))
 
 ### Notable changes
 


### PR DESCRIPTION
[ci skip]