### PR TITLE
Use the default Capybara registered puma server configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rake", ">= 11.1"
 # be loaded after loading the test library.
 gem "mocha", "~> 0.14", require: false
 
-gem "capybara", "~> 2.13"
+gem "capybara", "~> 2.15"
 
 gem "rack-cache", "~> 1.2"
 gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -490,7 +490,7 @@ DEPENDENCIES
   blade-sauce_labs_plugin
   bootsnap (>= 1.1.0)
   byebug
-  capybara (~> 2.13)
+  capybara (~> 2.15)
   coffee-rails
   dalli (>= 2.2.1)
   delayed_job

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*  Use Capybara registered `:puma` server config.
+
+    The Capybara registered `:puma` server ensures the puma server is run in process so
+    connection sharing and open request detection work correctly by default.
+
+    *Thomas Walpole*
+
 *  Cookies `:expires` option supports `ActiveSupport::Duration` object.
 
         cookies[:user_name] = { value: "assain", expires: 1.hour }

--- a/actionpack/lib/action_dispatch/system_testing/server.rb
+++ b/actionpack/lib/action_dispatch/system_testing/server.rb
@@ -12,29 +12,17 @@ module ActionDispatch
       self.silence_puma = false
 
       def run
-        register
         setup
       end
 
       private
-        def register
-          Capybara.register_server :rails_puma do |app, port, host|
-            Rack::Handler::Puma.run(
-              app,
-              Port: port,
-              Threads: "0:1",
-              Silent: self.class.silence_puma
-            )
-          end
-        end
-
         def setup
           set_server
           set_port
         end
 
         def set_server
-          Capybara.server = :rails_puma
+          Capybara.server = :puma, { Silent: self.class.silence_puma }
         end
 
         def set_port

--- a/actionpack/test/dispatch/system_testing/server_test.rb
+++ b/actionpack/test/dispatch/system_testing/server_test.rb
@@ -9,10 +9,6 @@ class ServerTest < ActiveSupport::TestCase
     ActionDispatch::SystemTesting::Server.new.run
   end
 
-  test "initializing the server port" do
-    assert_includes Capybara.servers, :rails_puma
-  end
-
   test "port is always included" do
     assert Capybara.always_include_port, "expected Capybara.always_include_port to be true"
   end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   <%- if depends_on_system_test? -%>
   # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '~> 2.13'
+  gem 'capybara', '~> 2.15'
   gem 'selenium-webdriver'
   <%- end -%>
 end


### PR DESCRIPTION
The `puma_rails` "server" registered by Rails for system tests doesn't force Puma into "in process" mode.  This means if the user happens to have a `config/puma.rb` configuration file which is configuring puma in cluster mode for production it will also run Puma in cluster mode for tests.  Since cluster mode runs Puma in new processes it defeats the connection sharing needed for transactional testing, and prevents Capybara from being able to monitor open connections at the end of tests.

This PR changes the behavior to just use the default Capybara registered  `puma` "server" which does pass the needed options, and I don't really see the benefit of Rails registering its own "server" config.
