### PR TITLE
Remove unused require in ActiveStorage::Variation

### DIFF
--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/object/inclusion"
-
 # A set of transformations that can be applied to a blob to create a variant. This class is exposed via
 # the ActiveStorage::Blob#variant method and should rarely be used directly.
 #


### PR DESCRIPTION
### Summary

It looks that `Object#in?` and `Object#presence_in?` are no longer used in `ActiveStorage::Variation`.