### PR TITLE
Allow usage of strings as locals for partial renderer

### DIFF
--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -363,7 +363,7 @@ module ActionView
         @options = options
         @block   = block
 
-        @locals  = options[:locals] || {}
+        @locals  = options[:locals] ? options[:locals].symbolize_keys : {}
         @details = extract_details(options)
 
         prepend_formats(options[:formats])

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -489,6 +489,10 @@ class TestController < ApplicationController
     render partial: "customer", locals: { customer: Customer.new("david") }
   end
 
+  def partial_with_string_locals
+    render partial: "customer", locals: { "customer" => Customer.new("david") }
+  end
+
   def partial_with_form_builder
     render partial: ActionView::Helpers::FormBuilder.new(:post, nil, view_context, {})
   end
@@ -1166,6 +1170,11 @@ class RenderTest < ActionController::TestCase
 
   def test_partial_with_locals
     get :partial_with_locals
+    assert_equal "Hello: david", @response.body
+  end
+
+  def test_partial_with_string_locals
+    get :partial_with_string_locals
     assert_equal "Hello: david", @response.body
   end
 


### PR DESCRIPTION
I tried to pass variables generated in some other place to partial locals like this:

```ruby
class TestController < ApplicationController
  def index
    render partial: 'test', layout: false, locals: { MyClass.name.underscore => 'my_value' }
  end
end
```

And found that in this case I won't get a `undefined local variable or method` exception and my local variable `my_class` would be equal to `nil`. Looks like this variable "exists" but value is not set because key is not a symbol in `locals` hash.

If it wasn't on purpose then I suggest to use `symbolize_keys` for locals in partial renderer.