### PR TITLE
Don't reference deleted file secrets.yml

### DIFF
--- a/railties/lib/rails/secrets.rb
+++ b/railties/lib/rails/secrets.rb
@@ -42,7 +42,6 @@ module Rails
 
       def template
         <<-end_of_template.strip_heredoc
-          # See `secrets.yml` for tips on generating suitable keys.
           # production:
           #   external_api_key: 1466aac22e6a869134be3d09b9e89232fc2c2289
 


### PR DESCRIPTION
Since #30067 Rails apps do not include a `config/secrets.yml` file
anymore so that file should not be referenced anymore.

The file was deleted in https://github.com/rails/rails/commit/f8c249b by @dhh.