### PR TITLE
Use credentials, not secrets, for Active Storage

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -400,7 +400,7 @@ Rails.application.config.session_store :cookie_store, key: '_your_app_session', 
 Rails sets up (for the CookieStore) a secret key used for signing the session data in `config/credentials.yml.enc`. This can be changed with `bin/rails credentials:edit`.
 
 ```ruby
-# amazon:
+# aws:
 #   access_key_id: 123
 #   secret_access_key: 345
 

--- a/railties/lib/rails/generators/rails/app/templates/config/storage.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/storage.yml
@@ -6,10 +6,10 @@ local:
   service: Disk
   root: <%%= Rails.root.join("storage") %>
 
-# Use rails secrets:edit to set the AWS secrets (as shared:aws:access_key_id|secret_access_key)
+# Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3
-#   access_key_id: <%%= Rails.application.secrets.dig(:aws, :access_key_id) %>
+#   access_key_id: <%%= Rails.application.credentials.dig(:aws, :access_key_id) %>
 #   secret_access_key: <%%= Rails.application.secrets.dig(:aws, :secret_access_key) %>
 #   region: us-east-1
 #   bucket: your_own_bucket
@@ -21,12 +21,12 @@ local:
 #   keyfile: <%%= Rails.root.join("path/to/gcs.keyfile") %>
 #   bucket: your_own_bucket
 
-# Use rails secrets:edit to set the Azure Storage secret (as shared:azure_storage:storage_access_key)
+# Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
 # microsoft:
 #   service: AzureStorage
 #   path: your_azure_storage_path
 #   storage_account_name: your_account_name
-#   storage_access_key: <%%= Rails.application.secrets.dig(:azure_storage, :storage_access_key) %>
+#   storage_access_key: <%%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
 #   container: your_container_name
 
 # mirror:

--- a/railties/lib/rails/generators/rails/credentials/credentials_generator.rb
+++ b/railties/lib/rails/generators/rails/credentials/credentials_generator.rb
@@ -37,7 +37,7 @@ module Rails
 
       private
         def credentials_template
-          "# amazon:\n#  access_key_id: 123\n#  secret_access_key: 345\n\n" +
+          "# aws:\n#  access_key_id: 123\n#  secret_access_key: 345\n\n" +
           "# Used as the base secret for all MessageVerifiers in Rails, including the one protecting cookies.\n" +
           "secret_key_base: #{SecureRandom.hex(64)}"
         end


### PR DESCRIPTION
According to #30067 (@dhh / @kaspth) :

> This PR will deprecate secrets.yml* and instead adopt
> config/credentials.yml.enc to signify what these secrets are specifically
> for: Keeping API keys, database passwords, and any other integration
> credentials in one place.

Therefore the examples for Active Storage should indicate `Rails.application.credentials` and not `Rails.application.secrets`.

Additionally, the template for the credentials file should have an `aws` key, and not an `amazon` key, since that's what the example config/storage.yml file expects.
