### PR TITLE
4-2-stable: Fix datetime with precision for mysql adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -282,6 +282,14 @@ module ActiveRecord
         0
       end
 
+      def quoted_date(value)
+        if supports_datetime_with_precision? && value.acts_like?(:time) && value.respond_to?(:usec)
+          "#{super}.#{sprintf("%06d", value.usec)}"
+        else
+          super
+        end
+      end
+
       # REFERENTIAL INTEGRITY ====================================
 
       def disable_referential_integrity #:nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -74,14 +74,6 @@ module ActiveRecord
         @connection.escape(string)
       end
 
-      def quoted_date(value)
-        if supports_datetime_with_precision? && value.acts_like?(:time) && value.respond_to?(:usec)
-          "#{super}.#{sprintf("%06d", value.usec)}"
-        else
-          super
-        end
-      end
-
       #--
       # CONNECTION MANAGEMENT ====================================
       #++

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -282,6 +282,10 @@ module ActiveRecord
               super
             end
           end
+
+          def has_precision?
+            precision || 0
+          end
         end
 
         class Time < Type::Time # :nodoc:
@@ -328,8 +332,11 @@ module ActiveRecord
 
       def initialize_type_map(m) # :nodoc:
         super
-        m.register_type %r(datetime)i, Fields::DateTime.new
         m.register_type %r(time)i,     Fields::Time.new
+        m.register_type(%r(datetime)i) do |sql_type|
+          precision = extract_precision(sql_type)
+          Fields::DateTime.new(precision: precision)
+        end
       end
 
       def exec_without_stmt(sql, name = 'SQL') # :nodoc:

--- a/activerecord/test/cases/adapters/mysql/datetime_test.rb
+++ b/activerecord/test/cases/adapters/mysql/datetime_test.rb
@@ -74,7 +74,7 @@ if mysql_56?
       result = results.find do |result_hash|
         result_hash["column_name"] == column_name
       end
-      result && result["datetime_precision"]
+      result && result["datetime_precision"].to_i
     end
 
     def activerecord_column_option(tablename, column_name, option)

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -47,8 +47,7 @@ end
 
 def mysql_56?
   current_adapter?(:MysqlAdapter, :Mysql2Adapter) &&
-    ActiveRecord::Base.connection.send(:version) >= '5.6.0' &&
-    ActiveRecord::Base.connection.send(:version) < '5.7.0'
+    ActiveRecord::Base.connection.send(:version) >= '5.6.0'
 end
 
 def mysql_enforcing_gtid_consistency?

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -46,7 +46,7 @@ def in_memory_db?
 end
 
 def mysql_56?
-  current_adapter?(:MysqlAdapter, :Mysql2Adapter) &&
+  current_adapter?(:Mysql2Adapter) &&
     ActiveRecord::Base.connection.send(:version) >= '5.6.0'
 end
 


### PR DESCRIPTION
It will pass isolated test (test per file), but somehow created
`t.datetime :written_on, precision: 6` causes any side effects and CI
will be failed only mysql adapter.

For example, the failures on `attribute_methods_test.rb` is due to caching `emulate_booleans = false`'s boolean type, it will be fixed by adding `Topic.reset_column_information`.

https://travis-ci.org/rails/rails/jobs/276872277#L823-L836

But if added `Topic.reset_column_information`, it will cause new failures `test_preserving_time_objects_with_time_with_zone_conversion_to_default_timezone_{utc,local}` in `base_test.rb`.

So I decided to skip datetime with precision tests for mysql adapter
since the adapter has already been removed after 5.0, it is not worth to
fix the side effects in 4-2-stable.