### PR TITLE
Remove unnecessary require statement

### DIFF
--- a/actioncable/lib/action_cable/connection/stream.rb
+++ b/actioncable/lib/action_cable/connection/stream.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
-
 module ActionCable
   module Connection
     #--

--- a/actioncable/lib/action_cable/connection/stream_event_loop.rb
+++ b/actioncable/lib/action_cable/connection/stream_event_loop.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "nio"
-require "thread"
 
 module ActionCable
   module Connection

--- a/actioncable/lib/action_cable/subscription_adapter/evented_redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/evented_redis.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
-
 gem "em-hiredis", "~> 0.3.0"
 gem "redis", "~> 3.0"
 require "em-hiredis"

--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -2,7 +2,6 @@
 
 gem "pg", "~> 0.18"
 require "pg"
-require "thread"
 require "digest/sha1"
 
 module ActionCable

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
-
 gem "redis", "~> 3.0"
 require "redis"
 

--- a/actioncable/test/subscription_adapter/evented_redis_test.rb
+++ b/actioncable/test/subscription_adapter/evented_redis_test.rb
@@ -31,7 +31,6 @@ class EventedRedisAdapterTest < ActionCable::TestCase
 
   def test_slow_eventmachine
     require "eventmachine"
-    require "thread"
 
     lock = Mutex.new
 

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -2,7 +2,6 @@
 
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/kernel/singleton_class"
-require "thread"
 
 module ActionView
   # = Action View Template

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -4,7 +4,6 @@ require "pathname"
 require "active_support/core_ext/class"
 require "active_support/core_ext/module/attribute_accessors"
 require_relative "../template"
-require "thread"
 require "concurrent/map"
 
 module ActionView

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
 require "concurrent/map"
 require "monitor"
 

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
 require "cases/helper"
 require "models/person"
 require "models/job"

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -8,7 +8,6 @@ require_relative "core_ext/kernel/reporting"
 require_relative "core_ext/kernel/singleton_class"
 require_relative "core_ext/string/filters"
 require_relative "deprecation"
-require "thread"
 
 module ActiveSupport
   # Callbacks are code hooks that are run at key points in an object's life cycle.

--- a/activesupport/lib/active_support/concurrency/share_lock.rb
+++ b/activesupport/lib/active_support/concurrency/share_lock.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
 require "monitor"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "set"
-require "thread"
 require "concurrent/map"
 require "pathname"
 require_relative "core_ext/module/aliasing"

--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -3,8 +3,6 @@
 module ActiveSupport
   module Testing
     module Isolation
-      require "thread"
-
       def self.included(klass) #:nodoc:
         klass.class_eval do
           parallelize_me!

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -4,7 +4,6 @@ require_relative "railtie"
 require_relative "engine/railties"
 require "active_support/core_ext/module/delegation"
 require "pathname"
-require "thread"
 
 module Rails
   # <tt>Rails::Engine</tt> allows you to wrap a specific Rails application or subset of


### PR DESCRIPTION
## Summary

This PR removes unnecessary require statement.
The following features are unnecessary because they are already loaded.

```console
% ruby -ve 'p $LOADED_FEATURES.reject { |x| %r|/| =~ x }'
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-darwin13]
["enumerator.so", "thread.rb", "rational.so", "complex.so"]
```

The same features has already been loaded in Ruby 2.2.2.
