### PR TITLE
Remove unused `NumberToRoundedConverter#digits_and_rounded_number`

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
@@ -37,18 +37,6 @@ module ActiveSupport
 
       private
 
-        def digits_and_rounded_number(precision)
-          if zero?
-            [1, 0]
-          else
-            digits = digit_count(number)
-            multiplier = 10**(digits - precision)
-            rounded_number = calculate_rounded_number(multiplier)
-            digits = digit_count(rounded_number) # After rounding, the number of digits may have changed
-            [digits, rounded_number]
-          end
-        end
-
         def calculate_rounded_number(multiplier)
           (number / BigDecimal.new(multiplier.to_f.to_s)).round * multiplier
         end


### PR DESCRIPTION
`digits_and_rounded_number` is unused since #26628