### PR TITLE
Add Rails::Generators::PoroModelGenerator

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `Rails::Generators::PoroModelGenerator`.
+
+    Creates a model as Plain Old Ruby Object:
+
+      $ bin/rails generate poro_model address
+
+    *Yoshiyuki Hirano*
+
 *   Add `mini_magick` to default `Gemfile` as comment.
 
     *Yoshiyuki Hirano*

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Enable ModelGenerator `--no-orm` option to create PORO model
+
+    Creates a model as Plain Old Ruby Object:
+
+      $ bin/rails generate model address --no-orm
+
+    *Yoshiyuki Hirano*
+
 *   Add `Rails::Generators::PoroModelGenerator`.
 
     Creates a model as Plain Old Ruby Object:

--- a/railties/lib/rails/generators/rails/model/USAGE
+++ b/railties/lib/rails/generators/rails/model/USAGE
@@ -112,3 +112,10 @@ Examples:
             Fixtures:   test/fixtures/admin/accounts.yml
             Migration:  db/migrate/XXX_create_admin_accounts.rb
 
+    `rails generate model address --no-orm`
+
+        Creates an Address model as Plain Old Ruby Object.
+
+            Model:      app/models/address.rb
+            Test:       test/models/address_test.rb
+

--- a/railties/lib/rails/generators/rails/model/model_generator.rb
+++ b/railties/lib/rails/generators/rails/model/model_generator.rb
@@ -9,6 +9,10 @@ module Rails
 
       argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
       hook_for :orm, required: true, desc: "ORM to be invoked"
+
+      def invoke_poro_model
+        invoke(:poro_model, [name]) unless options.orm
+      end
     end
   end
 end

--- a/railties/lib/rails/generators/rails/poro_model/USAGE
+++ b/railties/lib/rails/generators/rails/poro_model/USAGE
@@ -1,0 +1,15 @@
+Description:
+    Stubs out a new model as Plain Old Ruby Object.
+    Pass the model name, either CamelCased or under_scored.
+
+    To create a model within a module, specify the model name as a
+    path like 'parent_module/model_name'.
+
+Example:
+    `rails generate poro_model address`
+
+        Creates an Address model as Plain Old Ruby Object.
+
+            Model:      app/models/address.rb
+            Test:       test/models/address_test.rb
+

--- a/railties/lib/rails/generators/rails/poro_model/poro_model_generator.rb
+++ b/railties/lib/rails/generators/rails/poro_model/poro_model_generator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../../model_helpers"
+
+module Rails
+  module Generators
+    class PoroModelGenerator < NamedBase # :nodoc:
+      include Rails::Generators::ModelHelpers
+
+      def create_model_file
+        template "model.rb", File.join("app/models", class_path, "#{file_name}.rb")
+      end
+
+      hook_for :test_framework
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/poro_model/templates/model.rb
+++ b/railties/lib/rails/generators/rails/poro_model/templates/model.rb
@@ -1,0 +1,4 @@
+<% module_namespacing do -%>
+class <%= class_name %>
+end
+<% end -%>

--- a/railties/lib/rails/generators/test_unit/poro_model/poro_model_generator.rb
+++ b/railties/lib/rails/generators/test_unit/poro_model/poro_model_generator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "../../test_unit"
+
+module TestUnit # :nodoc:
+  module Generators # :nodoc:
+    class PoroModelGenerator < Base # :nodoc:
+      check_class_collision suffix: "Test"
+
+      def create_test_file
+        template "unit_test.rb", File.join("test/models", class_path, "#{file_name}_test.rb")
+      end
+    end
+  end
+end

--- a/railties/lib/rails/generators/test_unit/poro_model/templates/unit_test.rb
+++ b/railties/lib/rails/generators/test_unit/poro_model/templates/unit_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+<% module_namespacing do -%>
+class <%= class_name %>Test < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end
+<% end -%>

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -31,6 +31,12 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_file "app/models/account.rb", /class Account < ApplicationRecord/
   end
 
+  def test_model_with_no_orm_option
+    run_generator ["address", "--no-orm"]
+    assert_file "app/models/address.rb", /class Address/
+    assert_no_migration "db/migrate/create_addresses.rb"
+  end
+
   def test_model_with_parent_option
     run_generator ["account", "--parent", "Admin::Account"]
     assert_file "app/models/account.rb", /class Account < Admin::Account/

--- a/railties/test/generators/poro_model_generator_test.rb
+++ b/railties/test/generators/poro_model_generator_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "generators/generators_test_helper"
+require "rails/generators/rails/poro_model/poro_model_generator"
+
+class PoroModelGeneratorTest < Rails::Generators::TestCase
+  include GeneratorsTestHelper
+
+  def test_help_shows_invoked_generators_options
+    content = run_generator ["--help"]
+    assert_match(/Stubs out a new model as Plain Old Ruby Object/, content)
+    assert_match(/rails generate poro_model address/, content)
+  end
+
+  def test_plural_names_are_singularized
+    run_generator ["accounts"]
+    assert_file "app/models/account.rb", /class Account/
+  end
+
+  def test_model_with_namespace
+    run_generator ["Admin::Gallery::Image"]
+    assert_file "app/models/admin/gallery/image.rb", /class Admin::Gallery::Image/
+  end
+end


### PR DESCRIPTION
### Summary

* This generator is used when we want to generate a model which don't need Active Record (as Plain Old Ruby Object).
* In almost use cases that I expect, it's executed through the command as `bin/rails g model Money --no-orm`.

### Examples

```
$ bin/rails g model Address --no-orm --pretend
      create  app/models/address.rb
      invoke  test_unit
      create    test/models/address_test.rb
```

```
$ bin/rails g poro_model Address --pretend
      create  app/models/address.rb
      invoke  test_unit
      create    test/models/address_test.rb
```

### Generated codes

There are so simple, but I feel that it's troublesome a little to create manually :(

```ruby
class Address
end
```

```ruby
require 'test_helper'

class AddressTest < ActiveSupport::TestCase
  # test "the truth" do
  #   assert true
  # end
end
```
