### PR TITLE
Fix checking for template variants when using the ActionView::FixtureResolver

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -6,6 +6,10 @@
 
     *John Hawthorn*
 
+*   Fix `ActionView::FixtureResolver` so that it handles template variants correctly.
+
+    *Edward Rudd*
+
 
 ## Rails 6.0.0.beta3 (March 11, 2019) ##
 

--- a/actionview/lib/action_view/testing/resolvers.rb
+++ b/actionview/lib/action_view/testing/resolvers.rb
@@ -25,8 +25,8 @@ module ActionView #:nodoc:
 
       def query(path, exts, _, locals)
         query = +""
-        EXTENSIONS.each_key do |ext|
-          query << "(" << exts[ext].map { |e| e && Regexp.escape(".#{e}") }.join("|") << "|)"
+        EXTENSIONS.each do |ext, prefix|
+          query << "(" << exts[ext].map { |e| e && Regexp.escape("#{prefix}#{e}") }.join("|") << "|)"
         end
         query = /^(#{Regexp.escape(path)})#{query}$/
 

--- a/actionview/test/template/testing/fixture_resolver_test.rb
+++ b/actionview/test/template/testing/fixture_resolver_test.rb
@@ -17,4 +17,14 @@ class FixtureResolverTest < ActiveSupport::TestCase
     assert_equal "arbitrary/path", templates.first.virtual_path
     assert_nil templates.first.format
   end
+
+  def test_should_match_templates_with_variants
+    resolver = ActionView::FixtureResolver.new("arbitrary/path.html+variant.erb" => "this text")
+    templates = resolver.find_all("path", "arbitrary", false, locale: [], formats: [:html], variants: [:variant], handlers: [:erb])
+    assert_equal 1, templates.size, "expected one template"
+    assert_equal "this text",       templates.first.source
+    assert_equal "arbitrary/path",  templates.first.virtual_path
+    assert_equal [:html],           templates.first.formats
+    assert_equal ["variant"],       templates.first.variants
+  end
 end

--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Added documentation about the `variants` option to `render`
+
+    *Edward Rudd*
+
+
 ## Rails 6.0.0.beta3 (March 11, 2019) ##
 
 *   No changes.

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -296,6 +296,7 @@ Calls to the `render` method generally accept five options:
 * `:location`
 * `:status`
 * `:formats`
+* `:variants`
 
 ##### The `:content_type` Option
 
@@ -416,6 +417,44 @@ render formats: [:json, :xml]
 ```
 
 If a template with the specified format does not exist an `ActionView::MissingTemplate` error is raised.
+
+##### The `:variants` Option
+
+This tells rails to look for template variations of the same format.
+You can specify a list of variants by passing the `:variants` option with a symbol or an array. 
+
+An example of use would be this.
+
+```ruby
+# called in HomeController#index
+render variants: [:mobile, :desktop]
+```
+
+With this set of variants Rails will look for the following set of templates and use the first that exists.
+
+- `app/views/home/index.html+mobile.erb`
+- `app/views/home/index.html+desktop.erb`
+- `app/views/home/index.html.erb`
+
+If a template with the specified format does not exist an `ActionView::MissingTemplate` error is raised.
+
+Instead of setting the variant on the render call you may also set it on the request object in your controller action.
+
+```ruby
+def index
+  request.variant = determine_variant
+end
+
+private
+
+def determine_variant
+  variant = nil 
+  # some code to determine the variant(s) to use
+  variant = :mobile if session[:use_mobile]
+  
+  variant    
+end
+```
 
 #### Finding Layouts
 


### PR DESCRIPTION
### Summary
The ActionView::FixtureResolver does not handle resolving templates that use variants correctly. it used a fixed "." separator instead of using the configured "+" separator, thus would never match the correct template when variants were used in a test.   The issue has been there since Rails 4.1 (when variants were introduces) until even the current master.
