### PR TITLE
Update link in The Asset Pipeline guide [ci skip]

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -154,7 +154,7 @@ environments. You can enable or disable it in your configuration through the
 
 More reading:
 
-* [Optimize caching](http://code.google.com/speed/page-speed/docs/caching.html)
+* [Optimize caching](https://developers.google.com/speed/docs/insights/LeverageBrowserCaching)
 * [Revving Filenames: don't use querystring](http://www.stevesouders.com/blog/2008/08/23/revving-filenames-dont-use-querystring/)
 
 


### PR DESCRIPTION
### Summary

Currently, it seems that the link for http://code.google.com/speed/page-speed/docs/caching.html redirects to https://developers.google.com/speed/docs/insights/LeverageBrowserCaching. So I've fixed it in guide.