### PR TITLE
Fix "warning: `*' interpreted as argument prefix"

### DIFF
--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     def test_payload_name_on_load
       Book.create(name: "test book")
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
-        event = ActiveSupport::Notifications::Event.new *args
+        event = ActiveSupport::Notifications::Event.new(*args)
         if event.payload[:sql].match "SELECT"
           assert_equal "Book Load", event.payload[:name]
         end
@@ -20,7 +20,7 @@ module ActiveRecord
 
     def test_payload_name_on_create
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
-        event = ActiveSupport::Notifications::Event.new *args
+        event = ActiveSupport::Notifications::Event.new(*args)
         if event.payload[:sql].match "INSERT"
           assert_equal "Book Create", event.payload[:name]
         end
@@ -32,7 +32,7 @@ module ActiveRecord
 
     def test_payload_name_on_update
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
-        event = ActiveSupport::Notifications::Event.new *args
+        event = ActiveSupport::Notifications::Event.new(*args)
         if event.payload[:sql].match "UPDATE"
           assert_equal "Book Update", event.payload[:name]
         end
@@ -45,7 +45,7 @@ module ActiveRecord
 
     def test_payload_name_on_update_all
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
-        event = ActiveSupport::Notifications::Event.new *args
+        event = ActiveSupport::Notifications::Event.new(*args)
         if event.payload[:sql].match "UPDATE"
           assert_equal "Book Update All", event.payload[:name]
         end
@@ -58,7 +58,7 @@ module ActiveRecord
 
     def test_payload_name_on_destroy
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
-        event = ActiveSupport::Notifications::Event.new *args
+        event = ActiveSupport::Notifications::Event.new(*args)
         if event.payload[:sql].match "DELETE"
           assert_equal "Book Destroy", event.payload[:name]
         end


### PR DESCRIPTION
This fixes following warning:

```
/home/travis/build/rails/rails/activerecord/test/cases/instrumentation_test.rb:11: warning: `*' interpreted as argument prefix
/home/travis/build/rails/rails/activerecord/test/cases/instrumentation_test.rb:23: warning: `*' interpreted as argument prefix
/home/travis/build/rails/rails/activerecord/test/cases/instrumentation_test.rb:35: warning: `*' interpreted as argument prefix
/home/travis/build/rails/rails/activerecord/test/cases/instrumentation_test.rb:48: warning: `*' interpreted as argument prefix
/home/travis/build/rails/rails/activerecord/test/cases/instrumentation_test.rb:61: warning: `*' interpreted as argument prefix
```
