### PR TITLE
Don't allow failures for `ac:integration`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,6 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-9.1.13.0
-    - env: "GEM=ac:integration"
   fast_finish: true
 
 notifications:


### PR DESCRIPTION
Last few CI-builds on master branch show that it doesn't fail too frequently anymore!

Related to 333af12c00939d11d810e948e950dacf50748eb3

r? @matthewd 