### PR TITLE
Improve error message when assign wrong attributes to model

### DIFF
--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -27,7 +27,7 @@ module ActiveModel
     #   cat.status # => 'sleeping'
     def assign_attributes(new_attributes)
       if !new_attributes.respond_to?(:stringify_keys)
-        raise ArgumentError, "When assigning attributes, you must pass a hash as an argument."
+        raise ArgumentError, "When assigning attributes, you must pass a hash as an argument, #{new_attributes.class} passed."
       end
       return if new_attributes.empty?
 

--- a/activemodel/test/cases/attribute_assignment_test.rb
+++ b/activemodel/test/cases/attribute_assignment_test.rb
@@ -100,9 +100,11 @@ class AttributeAssignmentTest < ActiveModel::TestCase
   end
 
   test "an ArgumentError is raised if a non-hash-like object is passed" do
-    assert_raises(ArgumentError) do
+    err = assert_raises(ArgumentError) do
       Model.new(1)
     end
+
+    assert_equal("When assigning attributes, you must pass a hash as an argument, Integer passed.", err.message)
   end
 
   test "forbidden attributes cannot be used for mass assignment" do


### PR DESCRIPTION
### Summary

Include class name in `ArgumentError` message for a more precise understanding of the error 

