### PR TITLE
Implement change_table_comment and change_column_comment

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -311,6 +311,11 @@ module ActiveRecord
         execute("ALTER TABLE #{quote_table_name(table_name)} #{sqls}")
       end
 
+      def change_table_comment(table_name, comment) #:nodoc:
+        comment = "" if comment.nil?
+        execute("ALTER TABLE #{quote_table_name(table_name)} COMMENT #{quote(comment)}")
+      end
+
       # Renames a table.
       #
       # Example:
@@ -363,6 +368,11 @@ module ActiveRecord
         end
 
         change_column table_name, column_name, column.sql_type, null: null
+      end
+
+      def change_column_comment(table_name, column_name, comment) #:nodoc:
+        column = column_for(table_name, column_name)
+        change_column table_name, column_name, column.sql_type, comment: comment
       end
 
       def change_column(table_name, column_name, type, options = {}) #:nodoc:

--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -142,5 +142,27 @@ if ActiveRecord::Base.connection.supports_comments?
       assert_match %r[t\.string\s+"absent_comment"\n], output
       assert_no_match %r[t\.string\s+"absent_comment", comment:\n], output
     end
+
+    def test_change_table_comment
+      @connection.change_table_comment :commenteds, "Edited table comment"
+      assert_equal "Edited table comment", @connection.table_comment("commenteds")
+    end
+
+    def test_change_table_comment_to_nil
+      @connection.change_table_comment :commenteds, nil
+      assert @connection.table_comment("commenteds").blank?
+    end
+
+    def test_change_column_comment
+      @connection.change_column_comment :commenteds, :name, "Edited column comment"
+      column = Commented.columns_hash["name"]
+      assert_equal "Edited column comment", column.comment
+    end
+
+    def test_change_column_comment_to_nil
+      @connection.change_column_comment :commenteds, :name, nil
+      column = Commented.columns_hash["name"]
+      assert_nil column.comment
+    end
   end
 end


### PR DESCRIPTION
Implement change_table_comment and change_column_comment for MySql.
The two methods were defined in PR https://github.com/rails/rails/pull/22911 but only implemented for PostgreSQL.