### PR TITLE
delegate scope_for on PolymorphicReflection

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1002,7 +1002,7 @@ module ActiveRecord
     end
 
     class PolymorphicReflection < AbstractReflection # :nodoc:
-      delegate :klass, :scope, :plural_name, :type, :get_join_keys, to: :@reflection
+      delegate :klass, :scope, :plural_name, :type, :get_join_keys, :scope_for, to: :@reflection
 
       def initialize(reflection, previous_reflection)
         @reflection = reflection

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -425,6 +425,11 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
     assert authors.empty?
   end
 
+  def test_nested_has_many_through_with_scope_on_polymorphic_reflection
+    authors = Author.joins(:ordered_posts).where("posts.id" => posts(:misc_by_bob).id)
+    assert_equal [authors(:mary), authors(:bob)], authors.distinct.sort_by(&:id)
+  end
+
   def test_has_many_through_with_foreign_key_option_on_through_reflection
     assert_equal [posts(:welcome), posts(:authorless)], people(:david).agents_posts.order("posts.id")
     assert_equal [authors(:david)], references(:david_unicyclist).agents_posts_authors

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -101,10 +101,12 @@ class Author < ActiveRecord::Base
   has_many :taggings,        through: :posts, source: :taggings
   has_many :taggings_2,      through: :posts, source: :tagging
   has_many :tags,            through: :posts
+  has_many :ordered_tags,    through: :posts
   has_many :post_categories, through: :posts, source: :categories
   has_many :tagging_tags,    through: :taggings, source: :tag
 
   has_many :similar_posts, -> { distinct }, through: :tags, source: :tagged_posts
+  has_many :ordered_posts, -> { distinct }, through: :ordered_tags, source: :tagged_posts
   has_many :distinct_tags, -> { select("DISTINCT tags.*").order("tags.name") }, through: :posts, source: :tags
 
   has_many :tags_with_primary_key, through: :posts

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -115,6 +115,7 @@ class Post < ActiveRecord::Base
   has_many :misc_tags, -> { where tags: { name: "Misc" } }, through: :taggings, source: :tag
   has_many :funky_tags, through: :taggings, source: :tag
   has_many :super_tags, through: :taggings
+  has_many :ordered_tags, through: :taggings
   has_many :tags_with_primary_key, through: :taggings, source: :tag_with_primary_key
   has_one :tagging, as: :taggable
 

--- a/activerecord/test/models/tag.rb
+++ b/activerecord/test/models/tag.rb
@@ -12,4 +12,5 @@ class OrderedTag < Tag
   self.table_name = "tags"
 
   has_many :taggings, -> { order("taggings.id DESC") }, foreign_key: "tag_id"
+  has_many :tagged_posts, through: :taggings, source: "taggable", source_type: "Post"
 end

--- a/activerecord/test/models/tagging.rb
+++ b/activerecord/test/models/tagging.rb
@@ -8,6 +8,7 @@ class Tagging < ActiveRecord::Base
   belongs_to :tag, -> { includes(:tagging) }
   belongs_to :super_tag,   class_name: "Tag", foreign_key: "super_tag_id"
   belongs_to :invalid_tag, class_name: "Tag", foreign_key: "tag_id"
+  belongs_to :ordered_tag, class_name: "OrderedTag", foreign_key: "tag_id"
   belongs_to :blue_tag, -> { where tags: { name: "Blue" } }, class_name: "Tag", foreign_key: :tag_id
   belongs_to :tag_with_primary_key, class_name: "Tag", foreign_key: :tag_id, primary_key: :custom_primary_key
   belongs_to :taggable, polymorphic: true, counter_cache: :tags_count


### PR DESCRIPTION
### Summary
scope_for method is undefined on a PolymorphicReflection

```
Comment.eager_load(:post).to_sql
```

https://github.com/rails/rails/pull/30682/files#diff-1663e5f930ac83fef235d7e2aa5edf65L209

works fine on 5.1.4, but fails on master