### PR TITLE
Ensure `1 AS one` for SQL Server with Calculations

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -391,7 +391,7 @@ module ActiveRecord
       def build_count_subquery(relation, column_name, distinct)
         relation.select_values = [
           if column_name == :all
-            distinct ? table[Arel.star] : Arel.sql("1")
+            distinct ? table[Arel.star] : Arel.sql(FinderMethods::ONE_AS_ONE)
           else
             column_alias = Arel.sql("count_column")
             aggregate_column(column_name).as(column_alias)


### PR DESCRIPTION
During the work done in https://github.com/rails/rails/pull/29848 a regression was caused for SQL Server where derived tables need to create references to column names. For example, this simple calculation example fails, with VS Code screenshot to latest SQL Server on Linux connection.

```sql
SELECT COUNT(*)
FROM ( SELECT 1 ) count
```

![screen shot 2017-09-22 at 9 31 54 pm](https://user-images.githubusercontent.com/2381/30768977-7a39ce98-9fde-11e7-9f29-b655cce644dd.png)

The fix is simple, we can use `1 AS one` which is even referenced in a const already but in another module. Open to alternatives if the usage is not ideal. Also, it would be super cool if this could be applied to 5-1-stable since v5.1.4 is now broken for us. Thanks so much for whomever's time on this too. Thanks y'all!!!

cc @kamipo 