### PR TITLE
Make bang version work with `InheritableOptions`

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -46,7 +46,7 @@ module ActiveSupport
         bangs = name_string.chomp!("!")
 
         if bangs
-          fetch(name_string.to_sym).presence || raise(KeyError.new(":#{name_string} is blank"))
+          self[name_string].presence || raise(KeyError.new(":#{name_string} is blank"))
         else
           self[name_string]
         end

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -102,4 +102,17 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     end
     assert_raises(KeyError) { a.non_existing_key! }
   end
+
+  def test_inheritable_options_with_bang
+    a = ActiveSupport::InheritableOptions.new(foo: :bar)
+
+    assert_nothing_raised { a.foo! }
+    assert_equal a.foo, a.foo!
+
+    assert_raises(KeyError) do
+      a.foo = nil
+      a.foo!
+    end
+    assert_raises(KeyError) { a.non_existing_key! }
+  end
 end


### PR DESCRIPTION
Currently, bang version does not work with `InheritableOptions`.
`InheritableOptions` treats the argument Hash as the default value.
However, `Hash#fetch` does not use the default value when key is not found, so can not get the default value. So in bang version, should use `Hash#[]` instead of `Hash#fetch`.
