### PR TITLE
Add assert_enqueued_email_with to ActionMailer::TestHelper

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `assert_enqueued_email_with` test helper.
+
+        assert_enqueued_email_with ContactMailer, :welcome do
+          ContactMailer.welcome.deliver_later
+        end
+    
+    *Mikkel Malmberg*
+
 *   Allow Action Mailer classes to configure their delivery job.
 
         class MyMailer < ApplicationMailer

--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -93,6 +93,48 @@ module ActionMailer
       assert_enqueued_jobs number, only: [ ActionMailer::DeliveryJob, ActionMailer::Parameterized::DeliveryJob ], &block
     end
 
+    # Asserts that a specific email has been enqueued, optionally
+    # matching arguments.
+    #
+    #   def test_email
+    #     ContactMailer.welcome.deliver_later
+    #     assert_enqueued_email_with ContactMailer, :welcome
+    #   end
+    #
+    #   def test_email_with_arguments
+    #     ContactMailer.welcome("Hello", "Goodbye").deliver_later
+    #     assert_enqueued_email_with ContactMailer, :welcome, args: ["Hello", "Goodbye"]
+    #   end
+    #
+    # If a block is passed, that block should cause the specified email
+    # to be enqueued.
+    #
+    #   def test_email_in_block
+    #     assert_enqueued_email_with ContactMailer, :welcome do
+    #       ContactMailer.welcome.deliver_later
+    #     end
+    #   end
+    #
+    # If `args` is provided as a Hash, a parameterized email is matched.
+    #
+    #   def test_parameterized_email
+    #     assert_enqueued_email_with ContactMailer, :welcome,
+    #       args: {email: 'user@example.com} do
+    #       ContactMailer.with(email: 'user@example.com').welcome.deliver_later
+    #     end
+    #   end
+    def assert_enqueued_email_with(mailer, method, args: nil, queue: "mailers", &block)
+      if args.is_a? Hash
+        job = ActionMailer::Parameterized::DeliveryJob
+        args = [mailer.to_s, method.to_s, "deliver_now", args]
+      else
+        job = ActionMailer::DeliveryJob
+        args = [mailer.to_s, method.to_s, "deliver_now", *args]
+      end
+
+      assert_enqueued_with(job: job, args: args, queue: queue, &block)
+    end
+
     # Asserts that no emails are enqueued for later delivery.
     #
     #   def test_no_emails

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -10,6 +10,18 @@ class TestHelperMailer < ActionMailer::Base
       to: "test@example.com",
       from: "tester@example.com"
   end
+
+  def test_args(recipient, name)
+    mail body: render(inline: "Hello, #{name}"),
+      to: recipient,
+      from: "tester@example.com"
+  end
+
+  def test_parameter_args
+    mail body: render(inline: "All is #{params[:all]}"),
+      to: "test@example.com",
+      from: "tester@example.com"
+  end
 end
 
 class TestHelperMailerTest < ActionMailer::TestCase
@@ -206,6 +218,36 @@ class TestHelperMailerTest < ActionMailer::TestCase
     end
 
     assert_match(/0 .* but 1/, error.message)
+  end
+
+  def test_assert_enqueued_email_with
+    assert_nothing_raised do
+      assert_enqueued_email_with TestHelperMailer, :test do
+        silence_stream($stdout) do
+          TestHelperMailer.test.deliver_later
+        end
+      end
+    end
+  end
+
+  def test_assert_enqueued_email_with_args
+    assert_nothing_raised do
+      assert_enqueued_email_with TestHelperMailer, :test_args, args: ["some_email", "some_name"] do
+        silence_stream($stdout) do
+          TestHelperMailer.test_args("some_email", "some_name").deliver_later
+        end
+      end
+    end
+  end
+
+  def test_assert_enqueued_email_with_parameterized_args
+    assert_nothing_raised do
+      assert_enqueued_email_with TestHelperMailer, :test_parameter_args, args: { all: "good" } do
+        silence_stream($stdout) do
+          TestHelperMailer.with(all: "good").test_parameter_args.deliver_later
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
### Summary

A proposal to add `assert_enqueued_email_with` to ActionMailer::TestHelper. We already have `assert_enqueued_email(amount)` and although that certainly is sufficient for most cases it's sometimes nice to be a little bit more specific in what you're expecting.

~I couldn't get the test suite to run without an exception that I couldn't diagnose so I hope this passes CI.~
~Got the suite to run with `bundle exec` 🙄~
@kaspth eventually told me about `bin/test`. Is this documented anywhere? 😄

~Should probably add a test case for something with arguments as well.~
Added a test with arguments. Added support for parameterized emails.