### PR TITLE
Add error on foreign key for non-reference column

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -407,6 +407,7 @@ module ActiveRecord
 
       private
         def create_column_definition(name, type, options)
+          raise ArgumentError, "You can't add foreign_key for non-reference column #{name}" if options[:foreign_key]
           ColumnDefinition.new(name, type, options)
         end
 

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -16,6 +16,14 @@ if ActiveRecord::Base.connection.supports_foreign_keys_in_create?
           @connection.drop_table "testing_parents", if_exists: true
         end
 
+        test "foreign keys can't be created for non-reference column" do
+          @connection.create_table :testings do |t|
+            assert_raises(ArgumentError) do
+              t.integer :testing_parent_id, foreign_key: true
+            end
+          end
+        end
+
         test "foreign keys can be created with the table" do
           @connection.create_table :testings do |t|
             t.references :testing_parent, foreign_key: true


### PR DESCRIPTION
### Summary

Seems like it's a common mistake to add `foreign_key` for non-reference column (proofs:
[[1]](<https://github.com/search?l=Ruby&p=1&q=+%22id%2C+foreign_key%3A+true%22&type=Code&utf8=%E2%9C%93>), [[2]](<https://github.com/search?utf8=%E2%9C%93&q=+%22id%2C+index%3A+true%2C+foreign_key%3A+true%22&type=Code>)). I think it will be better to notify about such mistakes. 
