### PR TITLE
Respect quiet option in all process of `rails new` command

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -69,7 +69,7 @@ module Rails
 
     def version_control
       if !options[:skip_git] && !options[:pretend]
-        run "git init"
+        run "git init", capture: options[:quiet]
       end
     end
 
@@ -164,7 +164,7 @@ module Rails
       require_relative "../master_key/master_key_generator"
 
       after_bundle do
-        Rails::Generators::MasterKeyGenerator.new.add_master_key_file
+        Rails::Generators::MasterKeyGenerator.new([], quiet: options[:quiet]).add_master_key_file
       end
     end
 
@@ -174,7 +174,7 @@ module Rails
       require_relative "../credentials/credentials_generator"
 
       after_bundle do
-        Rails::Generators::CredentialsGenerator.new.add_credentials_file_silently
+        Rails::Generators::CredentialsGenerator.new([], quiet: options[:quiet]).add_credentials_file_silently
       end
     end
 

--- a/railties/lib/rails/generators/rails/master_key/master_key_generator.rb
+++ b/railties/lib/rails/generators/rails/master_key/master_key_generator.rb
@@ -13,15 +13,15 @@ module Rails
         unless MASTER_KEY_PATH.exist?
           key = ActiveSupport::EncryptedFile.generate_key
 
-          say "Adding #{MASTER_KEY_PATH} to store the master encryption key: #{key}"
-          say ""
-          say "Save this in a password manager your team can access."
-          say ""
-          say "If you lose the key, no one, including you, can access anything encrypted with it."
+          log "Adding #{MASTER_KEY_PATH} to store the master encryption key: #{key}"
+          log ""
+          log "Save this in a password manager your team can access."
+          log ""
+          log "If you lose the key, no one, including you, can access anything encrypted with it."
 
-          say ""
+          log ""
           create_file MASTER_KEY_PATH, key
-          say ""
+          log ""
 
           ignore_master_key_file
         end
@@ -31,15 +31,15 @@ module Rails
         def ignore_master_key_file
           if File.exist?(".gitignore")
             unless File.read(".gitignore").include?(key_ignore)
-              say "Ignoring #{MASTER_KEY_PATH} so it won't end up in Git history:"
-              say ""
+              log "Ignoring #{MASTER_KEY_PATH} so it won't end up in Git history:"
+              log ""
               append_to_file ".gitignore", key_ignore
-              say ""
+              log ""
             end
           else
-            say "IMPORTANT: Don't commit #{MASTER_KEY_PATH}. Add this to your ignore file:"
-            say key_ignore, :on_green
-            say ""
+            log "IMPORTANT: Don't commit #{MASTER_KEY_PATH}. Add this to your ignore file:"
+            log key_ignore, :on_green
+            log ""
           end
         end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -560,6 +560,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_match(/run  git init/, output)
   end
 
+  def test_quiet_option
+    output = run_generator [File.join(destination_root, "myapp"), "--quiet"]
+    assert_empty output
+  end
+
   def test_application_name_with_spaces
     path = File.join(destination_root, "foo bar")
 
@@ -737,7 +742,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     sequence = ["git init", "install", "exec spring binstub --all", "echo ran after_bundle"]
     @sequence_step ||= 0
-    ensure_bundler_first = -> command do
+    ensure_bundler_first = -> command, options = nil do
       assert_equal sequence[@sequence_step], command, "commands should be called in sequence #{sequence}"
       @sequence_step += 1
     end


### PR DESCRIPTION
If specify the `quiet` option, expect that no status will be shown.
However, some process show status. This suppresses all status output.