### PR TITLE
ActionCable: use find method when unsubscribing

### DIFF
--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -43,7 +43,7 @@ module ActionCable
 
       def remove(data)
         logger.info "Unsubscribing from channel: #{data['identifier']}"
-        remove_subscription subscriptions[data["identifier"]]
+        remove_subscription find(data)
       end
 
       def remove_subscription(subscription)


### PR DESCRIPTION
### Summary

If a frontend for some reason tries to unsubscribe from a non existing action cable subscription, the following error is logged:

```
Could not execute command from ({"command"=>"unsubscribe", "identifier"=>"{\"channel\":\"SomeChannel\"}"}) [NoMethodError - undefined method `unsubscribe_from_channel' for nil:NilClass]:
/app/vendor/bundle/ruby/2.4.0/gems/actioncable-5.1.4/lib/action_cable/connection/subscriptions.rb:48:in `remove_subscription'
/app/vendor/bundle/ruby/2.4.0/gems/actioncable-5.1.4/lib/action_cable/connection/subscriptions.rb:44:in `remove'
/app/vendor/bundle/ruby/2.4.0/gems/actioncable-5.1.4/lib/action_cable/connection/subscriptions.rb:16:in `execute_command'
/app/vendor/bundle/ruby/2.4.0/gems/actioncable-5.1.4/lib/action_cable/connection/base.rb:85:in `dispatch_websocket_message' /app/vendor/bundle/ruby/2.4.0/gems/actioncable-5.1.4/lib/action_cable/server/worker.rb:58:in `block in invoke'
```

Instead, it will now properly log:

```
Could not execute command from ({"command"=>"unsubscribe", "identifier"=>"{\"channel\":\"SomeChannel\"}"}) [RuntimeError - Unable to find subscription with identifier: {"channel":"SomeChannel"}]:
/app/vendor/bundle/ruby/2.4.0/gems/actioncable-5.1.4/lib/action_cable/connection/subscriptions.rb:76:in `find'
/app/vendor/bundle/ruby/2.4.0/gems/actioncable-5.1.4/lib/action_cable/connection/subscriptions.rb:44:in `remove'
/app/vendor/bundle/ruby/2.4.0/gems/actioncable-5.1.4/lib/action_cable/connection/subscriptions.rb:16:in `execute_command'
/app/vendor/bundle/ruby/2.4.0/gems/actioncable-5.1.4/lib/action_cable/connection/base.rb:85:in `dispatch_websocket_message'
/app/vendor/bundle/ruby/2.4.0/gems/actioncable-5.1.4/lib/action_cable/server/worker.rb:58:in `block in invoke
```

It's a subtle difference but it helps a lot when debugging.
