### PR TITLE
Preload digest/sha2 to avoid thread safe error.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -2,7 +2,7 @@
 
 require_relative "../../migration/join_table"
 require "active_support/core_ext/string/access"
-require "digest"
+require "digest/sha2"
 
 module ActiveRecord
   module ConnectionAdapters # :nodoc:

--- a/activesupport/lib/active_support/security_utils.rb
+++ b/activesupport/lib/active_support/security_utils.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "digest"
+require "digest/sha2"
 
 module ActiveSupport
   module SecurityUtils


### PR DESCRIPTION
### Summary

I got this error in production using Puma in multi-threaded mode:

```
RuntimeError: Digest::Base cannot be directly inherited in Ruby
from active_support/security_utils.rb:23:in `variable_size_secure_compare'
from active_support/security_utils.rb:23:in `hexdigest'
from active_support/security_utils.rb:23:in `digest'
```

Looks like Digest uses `const_missing` to load Digest::SHA256 (https://github.com/ruby/ruby/blob/trunk/ext/digest/lib/digest.rb#L8)

### Other information

- https://bugs.ruby-lang.org/issues/9494
- https://github.com/ruby/ruby/commit/c02fa39463a0c6bf698b01bc610135604aca2ff4