### PR TITLE
Fix cookie key rotation tests

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -608,7 +608,7 @@ module ActionDispatch
         end
 
         if upgrade_legacy_hmac_aes_cbc_cookies?
-          secret = request.key_generator.generate_key(request.encrypted_cookie_salt)
+          secret = request.key_generator.generate_key(request.encrypted_cookie_salt, ActiveSupport::MessageEncryptor.key_len("aes-256-cbc"))
           sign_secret = request.key_generator.generate_key(request.encrypted_signed_cookie_salt)
 
           @encryptor.rotate secret, sign_secret, cipher: "aes-256-cbc", digest: digest, serializer: SERIALIZER

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -301,8 +301,6 @@ module ApplicationTests
     end
 
     test "session upgrading from AES-CBC-HMAC encryption to AES-GCM encryption" do
-      skip "@kaspth will fix this"
-
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
           get ':controller(/:action)'


### PR DESCRIPTION
### Summary

This commit removes a few skips and fixes up a couple tests related to the cookies middleware key rotation. There is also a small fix in this commit for the cookies middleware that properly truncates AES CBC encryption keys to 32-bytes.

### Other Information

/r? @kaspth 