### PR TITLE
Skip validation on specific context with except

### DIFF
--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -56,14 +56,8 @@ module ActiveModel
         def before_validation(*args, &block)
           options = args.extract_options!
 
-          if options.key?(:on)
-            options = options.dup
-            options[:on] = Array(options[:on])
-            options[:if] = Array(options[:if])
-            options[:if].unshift ->(o) {
-              !(options[:on] & Array(o.validation_context)).empty?
-            }
-          end
+          raise ArgumentError, "You cannot specify both :on and :except" if %i(on except).all? { |k| options.key?(k) }
+          options = ActiveModel::Validations.convert_on_and_except(options)
 
           set_callback(:validation, :before, *args, options, &block)
         end
@@ -99,13 +93,8 @@ module ActiveModel
           options = options.dup
           options[:prepend] = true
 
-          if options.key?(:on)
-            options[:on] = Array(options[:on])
-            options[:if] = Array(options[:if])
-            options[:if].unshift ->(o) {
-              !(options[:on] & Array(o.validation_context)).empty?
-            }
-          end
+          raise ArgumentError, "You cannot specify both :on and :except" if %i(on except).all? { |k| options.key?(k) }
+          options = ActiveModel::Validations.convert_on_and_except(options)
 
           set_callback(:validation, :after, *args, options, &block)
         end

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -77,6 +77,7 @@ module ActiveModel
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:except</tt> - Specifies the contexts where this validation is inactive. Same arguments as :on.
       # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,
@@ -98,7 +99,7 @@ module ActiveModel
       #   validates :token, length: 24, strict: TokenLengthException
       #
       #
-      # Finally, the options +:if+, +:unless+, +:on+, +:allow_blank+, +:allow_nil+, +:strict+
+      # Finally, the options +:if+, +:unless+, +:on+, +:except+, +:allow_blank+, +:allow_nil+, +:strict+
       # and +:message+ can be given to one specific validator, as a hash:
       #
       #   validates :password, presence: { if: :password_required?, message: 'is forgotten.' }, confirmation: true
@@ -108,6 +109,7 @@ module ActiveModel
 
         raise ArgumentError, "You need to supply at least one attribute" if attributes.empty?
         raise ArgumentError, "You need to supply at least one validation" if validations.empty?
+        raise ArgumentError, "You cannot specify both :on and :except" if %i(on except).all? { |k| defaults.key?(k) }
 
         defaults[:attributes] = attributes
 
@@ -154,7 +156,7 @@ module ActiveModel
       # When creating custom validators, it might be useful to be able to specify
       # additional default keys. This can be done by overwriting this method.
       def _validates_default_keys
-        [:if, :unless, :on, :allow_blank, :allow_nil, :strict]
+        [:if, :unless, :on, :except, :allow_blank, :allow_nil, :strict]
       end
 
       def _parse_validates_options(options)

--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -162,4 +162,12 @@ class ValidatesTest < ActiveModel::TestCase
     assert_not_predicate topic, :valid?
     assert_equal ["Y U NO CONFIRM"], topic.errors[:title_confirmation]
   end
+
+  def test_validate_with_on_and_except_options
+    error = assert_raises(ArgumentError) do
+      Topic.validates :title, presence: true, on: :test, except: :test1
+    end
+    message = "You cannot specify both :on and :except"
+    assert_equal message, error.message
+  end
 end

--- a/activemodel/test/cases/validations/validations_context_test.rb
+++ b/activemodel/test/cases/validations/validations_context_test.rb
@@ -67,4 +67,13 @@ class ValidationsContextTest < ActiveModel::TestCase
     assert_includes topic.errors[:base], ERROR_MESSAGE
     assert_includes topic.errors[:base], ANOTHER_ERROR_MESSAGE
   end
+
+  test "with a class that adds errors except on context and validating a model with that context" do
+    Topic.validates_with(ValidatorThatAddsErrors, except: :context1)
+    topic = Topic.new
+
+    assert topic.valid?(:context1), "Validation doesn't run on context1 if 'except' is set to context1"
+    assert topic.invalid?, "Validation does run without context"
+    assert_includes topic.errors[:base], ERROR_MESSAGE
+  end
 end

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -172,7 +172,7 @@ class ValidationsTest < ActiveModel::TestCase
       # A common mistake -- we meant to call 'validates'
       Topic.validate :title, presence: true
     end
-    message = "Unknown key: :presence. Valid keys are: :on, :if, :unless, :prepend. Perhaps you meant to call `validates` instead of `validate`?"
+    message = "Unknown key: :presence. Valid keys are: :on, :except, :if, :unless, :prepend. Perhaps you meant to call `validates` instead of `validate`?"
     assert_equal message, error.message
   end
 


### PR DESCRIPTION
### Summary

This PR allows a model to specify the `except` keyword on validations. When set, the validation will not run in the specified context. The implementation does the same thing that the `on` keyword does (add a new `if` clause) and just inverts the condition.

`validates` raises if both `:on` and `:except` are specified.

Example:
```
class Person
  include ActiveModel::Validations

  attr_reader :name, :title
  validates :name, presence: true, on: :test
  validates :title, presence: true, except: :test
end

person = Person.new
person.valid?(:test)   # => false
person.errors.messages # => {:name=>["can't be blank"]}