### PR TITLE
Testing actioncable against websocket-driver 0.7.0

### DIFF
--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_dependency "actionpack", version
 
   s.add_dependency "nio4r",            "~> 2.0"
-  s.add_dependency "websocket-driver", "~> 0.6.1"
+  s.add_dependency "websocket-driver", "~> 0.7.0"
 end

--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_dependency "actionpack", version
 
   s.add_dependency "nio4r",            "~> 2.0"
-  s.add_dependency "websocket-driver", "~> 0.7.0"
+  s.add_dependency "websocket-driver", ">= 0.6.1"
 end


### PR DESCRIPTION
This PR is just to cause a CI run, but if people want to use it as a starting point for discussion, that's fine too.

The changelog for websocket-driver 0.7.0 does not mention any breaking changes.

```
0.7.0 / 2017-09-11

Add ping and pong to the set of events users can listen to
```

