### PR TITLE
Backport Capybara :puma defaults to 5.1.x

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Ensure dev and prod puma configs do not clobber `ActionDispatch::SystemTesting` defaults. Adds workers: 0 and daemon: false
+
+    *Max Schwenk*
+
 ## Rails 5.1.4 (September 07, 2017) ##
 
 *   Make `take_failed_screenshot` work within engine.

--- a/actionpack/lib/action_dispatch/system_testing/server.rb
+++ b/actionpack/lib/action_dispatch/system_testing/server.rb
@@ -21,6 +21,8 @@ module ActionDispatch
               app,
               Port: port,
               Threads: "0:1",
+              workers: 0,
+              daemon: false,
               Silent: self.class.silence_puma
             )
           end


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/pull/30638 fixed potential Puma configs in `config/puma.rb` overriding the desirable stack for SystemTests but could not be pulled into `5.1.x` because it required a Capybara upgrade. This just backports the fix to 5.1.x by manually copying over the missing options.

My first Rails PR, Railsbot is 😱  but I think for a backport this base branch is correct?

cc @twalpole 