### PR TITLE
Support expires_in in ActiveSupport::Cache::MemCacheStore#increment and #decrement

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Support `expires_in` in `ActiveSupport::Cache::MemCacheStore#increment` and `#decrement`
+
+    `expires_in` option of `MemCacheStore` is now correctly passed to `Dalli::Client`
+    as `ttl`.
+
+    *Takumasa Ochi*
+
 *   Handle `TZInfo::AmbiguousTime` errors
 
     Make `ActiveSupport::TimeWithZone` match Ruby's handling of ambiguous

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -122,7 +122,7 @@ module ActiveSupport
         options = merged_options(options)
         instrument(:increment, name, amount: amount) do
           rescue_error_with nil do
-            @data.incr(normalize_key(name, options), amount)
+            @data.incr(normalize_key(name, options), amount, options[:expires_in])
           end
         end
       end
@@ -135,7 +135,7 @@ module ActiveSupport
         options = merged_options(options)
         instrument(:decrement, name, amount: amount) do
           rescue_error_with nil do
-            @data.decr(normalize_key(name, options), amount)
+            @data.decr(normalize_key(name, options), amount, options[:expires_in])
           end
         end
       end

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -57,6 +57,30 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     end
   end
 
+  def test_increment_expires_in
+    cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, raw: true)
+    cache.clear
+    assert_called_with cache.instance_variable_get(:@data), :incr, [
+      "foo",
+      1,
+      60
+    ] do
+      cache.increment("foo", 1, expires_in: 60)
+    end
+  end
+
+  def test_decrement_expires_in
+    cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, raw: true)
+    cache.clear
+    assert_called_with cache.instance_variable_get(:@data), :decr, [
+      "foo",
+      1,
+      60
+    ] do
+      cache.decrement("foo", 1, expires_in: 60)
+    end
+  end
+
   def test_local_cache_raw_values_with_marshal
     cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, raw: true)
     cache.clear


### PR DESCRIPTION
### Summary

Previously, `ActiveSupport::Cache::MemCacheStore#increment` and
`ActiveSupport::Cache::MemCacheStore#decrement` call `Dalli::Client#incr`
and `Dalli::Client#decr` as follows.

```ruby
@data.incr(normalize_key(name, options), amount)
@data.decr(normalize_key(name, options), amount)
```

However, considering the method arguments of `Dalli::Client`,
`options[:expires_in]` and default value for a not stored value
are not passed correctly.

* `Dalli::Client#incr(key, amt = 1, ttl = nil, default = nil)`
* `Dalli::Client#decr(key, amt = 1, ttl = nil, default = nil)`

c.f. https://github.com/petergoldstein/dalli/blob/f41bb9cf078246bd58a249cf09b1f56044e4662c/lib/dalli/client.rb#L169-L202

As a result, initial values for not stored values are not correctly set
despite the documentation saying `Calling it on a value not stored
with :raw will initialize that value to zero.`

c.f.
https://github.com/aeroastro/rails/blob/9befc197f926272abbba5a1ca1323ce4f15ebd10/activesupport/lib/active_support/cache/mem_cache_store.rb#L117-L120

Fortunately, since `ttl` is only applicable when the value is already set,
we have not encountered any bugs regarding `expires_in`.

By this patch, `ActiveSupport::Cache::MemCacheStore` will correctly handle
initialization of counters. Also, test on increment/decrement behavior will be
fixed.

### Other Information

P.S. Regarding this initialization, I have posted feature-request on the Google Group to initialize the not stored value to amount as if it is initialized to 0 **prior to the operation**.