### PR TITLE
Fix #18062: honor scope_attributes on build

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -53,8 +53,10 @@ module ActiveRecord
         end
 
         attrs = args.first || {}
-        attrs = attrs.to_h
-        attrs = attrs.stringify_keys.reverse_merge(scope_attributes).presence
+        attrs = attrs.to_h.stringify_keys
+        attrs = attrs.reverse_merge(scope_attributes)
+        attrs = attrs.reject { |_, value| value.nil? }
+        attrs = attrs.presence
         if has_attribute?(inheritance_column)
           subclass = subclass_from_attributes(attrs)
 

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -52,7 +52,7 @@ module ActiveRecord
           raise NotImplementedError, "#{self} is an abstract class and cannot be instantiated."
         end
 
-        attrs = args.first
+        attrs = scope_attributes.merge(args.first || {})
         if has_attribute?(inheritance_column)
           subclass = subclass_from_attributes(attrs)
 

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -52,7 +52,9 @@ module ActiveRecord
           raise NotImplementedError, "#{self} is an abstract class and cannot be instantiated."
         end
 
-        attrs = scope_attributes.merge(args.first || {})
+        attrs = args.first || {}
+        attrs = attrs.to_h
+        attrs = attrs.stringify_keys.reverse_merge(scope_attributes).presence
         if has_attribute?(inheritance_column)
           subclass = subclass_from_attributes(attrs)
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1118,7 +1118,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
       validates :post, presence: true
     end
 
-    comment = model.new
+    comment = model.new type: nil
     comment.post_id = 9223372036854775808 # out of range in the bigint
 
     assert_nil comment.post

--- a/activerecord/test/cases/associations/callbacks_test.rb
+++ b/activerecord/test/cases/associations/callbacks_test.rb
@@ -116,7 +116,7 @@ class AssociationCallbacksTest < ActiveRecord::TestCase
         new_dev = r.new_record?
       }
     end
-    rec = klass.create!
+    rec = klass.create!(type: nil)
     alice = Developer.new(name: "alice")
     rec.developers_with_callbacks << alice
     assert_equal alice, dev

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -280,6 +280,16 @@ class InheritanceTest < ActiveRecord::TestCase
     assert_equal Firm, firm.class
   end
 
+  def test_inheritance_build_with_base_class
+    company = Company.where(type: "Company").build
+    assert_equal Company, company.class
+  end
+
+  def test_inheritance_build_with_subclass
+    firm = Company.where(type: "Firm").build
+    assert_equal Firm, firm.class
+  end
+
   def test_new_with_abstract_class
     e = assert_raises(NotImplementedError) do
       AbstractCompany.new

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -411,7 +411,7 @@ class PersistenceTest < ActiveRecord::TestCase
         update_attribute("author_name", "David")
       end
     end
-    topic = klass.new
+    topic = klass.new(type: nil)
     topic.title = "Another New Topic"
     topic.save
 
@@ -424,7 +424,7 @@ class PersistenceTest < ActiveRecord::TestCase
     klass = Class.new(Topic) do
       def self.name; "Topic"; end
     end
-    topic = klass.create(title: "Another New Topic")
+    topic = klass.create(type: nil, title: "Another New Topic")
     assert_queries(0) do
       assert topic.update_attribute(:title, "Another New Topic")
     end


### PR DESCRIPTION
### Summary

* `Inheritance#build` does not take the current scope's attribute into
  account;
  * e.g. `Company.where(type: 'Firm').build` builds a `Company` instead
    of a `Firm`;
* I believe this behavior is unexpected, given that `Company.build(type: 'Firm')` builds a `Firm`;
* this inconsistency presents itself when having a `has_many` relationship with an STI-enabled model (e.g. `@company.customers.build` can fail);

### Other Information

* ref #18062
* based on (and supercedes) #18227