### PR TITLE
Fixed broken `bundle exec rake install`

### DIFF
--- a/activestorage/Rakefile
+++ b/activestorage/Rakefile
@@ -11,4 +11,6 @@ Rake::TestTask.new do |test|
   test.warning = false
 end
 
+task :package
+
 task default: :test


### PR DESCRIPTION
I want to try to use edge rails.
But rake install is broken by activestorage.
I fixed it.