### PR TITLE
Fix typo in 'find_in_batches' example

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -414,7 +414,7 @@ end
 `find_in_batches` works on model classes, as seen above, and also on relations:
 
 ```ruby
-Invoice.pending.find_in_batches do |invoice|
+Invoice.pending.find_in_batches do |invoices|
   pending_invoices_export.add_invoices(invoices)
 end
 ```


### PR DESCRIPTION
### Summary

The documentation of find_in_batches used 'invoice' as parameter name but in the block uses 'invoices'. For the given example, invoices (plural) makes more sense, since the parameter holds a list of objects instead of a single object.