### PR TITLE
Change :github git source for bug report templates

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -9,6 +9,7 @@ end
 
 gemfile(true) do
   source "https://rubygems.org"
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
   # Activate the gem you are reporting the issue against.
   gem "rails", "5.1.0"
 end

--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -9,6 +9,7 @@ end
 
 gemfile(true) do
   source "https://rubygems.org"
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
   gem "rails", github: "rails/rails"
   gem "arel", github: "rails/arel"
 end

--- a/guides/bug_report_templates/active_job_gem.rb
+++ b/guides/bug_report_templates/active_job_gem.rb
@@ -9,6 +9,7 @@ end
 
 gemfile(true) do
   source "https://rubygems.org"
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
   # Activate the gem you are reporting the issue against.
   gem "activejob", "5.1.0"
 end

--- a/guides/bug_report_templates/active_job_master.rb
+++ b/guides/bug_report_templates/active_job_master.rb
@@ -9,6 +9,7 @@ end
 
 gemfile(true) do
   source "https://rubygems.org"
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
   gem "rails", github: "rails/rails"
   gem "arel", github: "rails/arel"
 end

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -9,6 +9,7 @@ end
 
 gemfile(true) do
   source "https://rubygems.org"
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
   # Activate the gem you are reporting the issue against.
   gem "activerecord", "5.1.0"
   gem "sqlite3"

--- a/guides/bug_report_templates/active_record_master.rb
+++ b/guides/bug_report_templates/active_record_master.rb
@@ -9,6 +9,7 @@ end
 
 gemfile(true) do
   source "https://rubygems.org"
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
   gem "rails", github: "rails/rails"
   gem "arel", github: "rails/arel"
   gem "sqlite3"

--- a/guides/bug_report_templates/active_record_migrations_gem.rb
+++ b/guides/bug_report_templates/active_record_migrations_gem.rb
@@ -9,6 +9,7 @@ end
 
 gemfile(true) do
   source "https://rubygems.org"
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
   # Activate the gem you are reporting the issue against.
   gem "activerecord", "5.1.0"
   gem "sqlite3"

--- a/guides/bug_report_templates/active_record_migrations_master.rb
+++ b/guides/bug_report_templates/active_record_migrations_master.rb
@@ -9,6 +9,7 @@ end
 
 gemfile(true) do
   source "https://rubygems.org"
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
   gem "rails", github: "rails/rails"
   gem "arel", github: "rails/arel"
   gem "sqlite3"

--- a/guides/bug_report_templates/benchmark.rb
+++ b/guides/bug_report_templates/benchmark.rb
@@ -9,6 +9,7 @@ end
 
 gemfile(true) do
   source "https://rubygems.org"
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
   gem "rails", github: "rails/rails"
   gem "arel", github: "rails/arel"
   gem "benchmark-ips"

--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -9,6 +9,7 @@ end
 
 gemfile(true) do
   source "https://rubygems.org"
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
   # Activate the gem you are reporting the issue against.
   gem "activesupport", "5.1.0"
 end

--- a/guides/bug_report_templates/generic_master.rb
+++ b/guides/bug_report_templates/generic_master.rb
@@ -9,6 +9,7 @@ end
 
 gemfile(true) do
   source "https://rubygems.org"
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
   gem "rails", github: "rails/rails"
   gem "arel", github: "rails/arel"
 end


### PR DESCRIPTION
:github source uses `git://` url by default, `https://` is recommended.
See http://bundler.io/v1.15/guides/git.html#security

We do the same in our `Gemfile` and templates.