### PR TITLE
Ensure `HashWithIndifferentAccess#transform_keys` to return `HashWithIndifferentAccess`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Return an instance of `HashWithIndifferentAccess` from `HashWithIndifferentAccess#transform_keys`.
+
+    *Yuji Yaginuma*
+
 *   Add key rotation support to `MessageEncryptor` and `MessageVerifier`
 
     This change introduces a `rotate` method to both the `MessageEncryptor` and

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -306,6 +306,11 @@ module ActiveSupport
       dup.tap { |hash| hash.transform_values!(*args, &block) }
     end
 
+    def transform_keys(*args, &block)
+      return to_enum(:transform_keys) unless block_given?
+      dup.tap { |hash| hash.transform_keys!(*args, &block) }
+    end
+
     def compact
       dup.tap(&:compact!)
     end

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -399,6 +399,13 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings
   end
 
+  def test_indifferent_transform_keys
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).transform_keys { |k| k * 2 }
+
+    assert_equal({ "aa" => 1, "bb" => 2 }, hash)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
   def test_indifferent_compact
     hash_contain_nil_value = @strings.merge("z" => nil)
     hash = ActiveSupport::HashWithIndifferentAccess.new(hash_contain_nil_value)


### PR DESCRIPTION
Currently, `#transform_values`, `#select` and `#reject` return instance of `HashWithIndifferentAccess`. But `#transform_keys` returns instance of Hash. This behavior is a bit confusing.

I think that `HashWithIndifferentAccess#transform_keys` should also return instance of `HashWithIndifferentAccess` as well as other methods.
