### PR TITLE
Encourage html-safe API in layouts/rendering guide

### DIFF
--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -232,14 +232,14 @@ You can send an HTML string back to the browser by using the `:html` option to
 `render`:
 
 ```ruby
-render html: "<strong>Not Found</strong>".html_safe
+render html: helpers.tag.strong('Not Found')
 ```
 
 TIP: This is useful when you're rendering a small snippet of HTML code.
 However, you might want to consider moving it to a template file if the markup
 is complex.
 
-NOTE: When using `html:` option, HTML entities will be escaped if the string is not marked as HTML safe by using `html_safe` method.
+NOTE: When using `html:` option, HTML entities will be escaped if the string is not composed with `html_safe`-aware APIs.
 
 #### Rendering JSON
 


### PR DESCRIPTION
This is a second pass at https://github.com/rails/rails/pull/30576 /cc @georgeclaghorn

### Summary

While the code example was not unsafe, it encourages the use of confusingly unsafe APIs
(specifically `html_safe`). We have a safe alternative and we should encourage people to use
it.

I don't know if there is an open issue for this, but a quick search doesn't reveal one. 

### Other Information

> Finally, if your pull request affects documentation or any non-code
> changes, guidelines for those changes are [available
> here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)
 
I've added:

> composed with `html_safe`-aware APIs`

I'm not sure if the language is OK or whether or not it should link to https://github.com/rails/rails/blob/b9ecb5797b97ba557a70efd66d2ff2c22501723f/guides/source/active_support_core_extensions.md#output-safety for more details. 
