### PR TITLE
Fix formatting in ActionDispatch::SSL middleware docs

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -1,50 +1,55 @@
 # frozen_string_literal: true
 
 module ActionDispatch
-  # This middleware is added to the stack when `config.force_ssl = true`, and is passed
-  # the options set in `config.ssl_options`. It does three jobs to enforce secure HTTP
+  # This middleware is added to the stack when <tt>config.force_ssl = true</tt>, and is passed
+  # the options set in +config.ssl_options+. It does three jobs to enforce secure HTTP
   # requests:
   #
-  #   1. TLS redirect: Permanently redirects http:// requests to https://
-  #      with the same URL host, path, etc. Enabled by default. Set `config.ssl_options`
-  #      to modify the destination URL
-  #      (e.g. `redirect: { host: "secure.widgets.com", port: 8080 }`), or set
-  #      `redirect: false` to disable this feature.
+  # 1. <b>TLS redirect</b>: Permanently redirects +http://+ requests to +https://+
+  #    with the same URL host, path, etc. Enabled by default. Set +config.ssl_options+
+  #    to modify the destination URL
+  #    (e.g. <tt>redirect: { host: "secure.widgets.com", port: 8080 }</tt>), or set
+  #    <tt>redirect: false</tt> to disable this feature.
   #
-  #   2. Secure cookies: Sets the `secure` flag on cookies to tell browsers they
-  #      mustn't be sent along with http:// requests. Enabled by default. Set
-  #      `config.ssl_options` with `secure_cookies: false` to disable this feature.
+  #    Requests can opt-out of redirection with +exclude+:
   #
-  #   3. HTTP Strict Transport Security (HSTS): Tells the browser to remember
-  #      this site as TLS-only and automatically redirect non-TLS requests.
-  #      Enabled by default. Configure `config.ssl_options` with `hsts: false` to disable.
+  #      config.ssl_options = { redirect: { exclude: -> request { request.path =~ /healthcheck/ } } }
   #
-  # Set `config.ssl_options` with `hsts: { … }` to configure HSTS:
-  #   * `expires`: How long, in seconds, these settings will stick. The minimum
-  #     required to qualify for browser preload lists is `18.weeks`. Defaults to
-  #     `180.days` (recommended).
-  #   * `subdomains`: Set to `true` to tell the browser to apply these settings
-  #     to all subdomains. This protects your cookies from interception by a
-  #     vulnerable site on a subdomain. Defaults to `true`.
-  #   * `preload`: Advertise that this site may be included in browsers'
-  #     preloaded HSTS lists. HSTS protects your site on every visit *except the
-  #     first visit* since it hasn't seen your HSTS header yet. To close this
-  #     gap, browser vendors include a baked-in list of HSTS-enabled sites.
-  #     Go to https://hstspreload.appspot.com to submit your site for inclusion.
-  #     Defaults to `false`.
+  # 2. <b>Secure cookies</b>: Sets the +secure+ flag on cookies to tell browsers they
+  #    must not be sent along with +http://+ requests. Enabled by default. Set
+  #    +config.ssl_options+ with <tt>secure_cookies: false</tt> to disable this feature.
   #
-  # To turn off HSTS, omitting the header is not enough. Browsers will remember the
-  # original HSTS directive until it expires. Instead, use the header to tell browsers to
-  # expire HSTS immediately. Setting `hsts: false` is a shortcut for
-  # `hsts: { expires: 0 }`.
+  # 3. <b>HTTP Strict Transport Security (HSTS)</b>: Tells the browser to remember
+  #    this site as TLS-only and automatically redirect non-TLS requests.
+  #    Enabled by default. Configure +config.ssl_options+ with <tt>hsts: false</tt> to disable.
   #
-  # Requests can opt-out of redirection with `exclude`:
+  #    Set +config.ssl_options+ with <tt>hsts: { ... }</tt> to configure HSTS:
   #
-  #    config.ssl_options = { redirect: { exclude: -> request { request.path =~ /healthcheck/ } } }
+  #    * +expires+: How long, in seconds, these settings will stick. The minimum
+  #      required to qualify for browser preload lists is 18 weeks. Defaults to
+  #      180 days (recommended).
+  #
+  #    * +subdomains+: Set to +true+ to tell the browser to apply these settings
+  #      to all subdomains. This protects your cookies from interception by a
+  #      vulnerable site on a subdomain. Defaults to +true+.
+  #
+  #    * +preload+: Advertise that this site may be included in browsers'
+  #      preloaded HSTS lists. HSTS protects your site on every visit <i>except the
+  #      first visit</i> since it hasn't seen your HSTS header yet. To close this
+  #      gap, browser vendors include a baked-in list of HSTS-enabled sites.
+  #      Go to https://hstspreload.org to submit your site for inclusion.
+  #      Defaults to +false+.
+  #
+  #    To turn off HSTS, omitting the header is not enough. Browsers will remember the
+  #    original HSTS directive until it expires. Instead, use the header to tell browsers to
+  #    expire HSTS immediately. Setting <tt>hsts: false</tt> is a shortcut for
+  #    <tt>hsts: { expires: 0 }</tt>.
   class SSL
+    # :stopdoc:
+
     # Default to 180 days, the low end for https://www.ssllabs.com/ssltest/
     # and greater than the 18-week requirement for browser preload lists.
-    HSTS_EXPIRES_IN = 15552000
+    HSTS_EXPIRES_IN = 180.days.to_i
 
     def self.default_hsts_options
       { expires: HSTS_EXPIRES_IN, subdomains: true, preload: false }


### PR DESCRIPTION
Before: https://monosnap.com/file/J6xewF0tYpm6dC9nSTe82ddsHAOcM5.png

After: https://monosnap.com/file/0tCYicLXNqRHAEMDb81u0aLb3gH9Wf.png

[ci skip]