### PR TITLE
Set version in activestorage/package.json in proper format.

### DIFF
--- a/activestorage/package.json
+++ b/activestorage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activestorage",
-  "version": "5.2.0.alpha",
+  "version": "5.2.0-alpha",
   "description": "Attach cloud and local files in Rails applications",
   "main": "app/assets/javascripts/activestorage.js",
   "files": [


### PR DESCRIPTION
`5.2.0.alpha` => `5.2.0-alpha`

System versioning isn't compliant with npm.