### PR TITLE
Define Setter methods in ActiveStorage::Attached::Macros

### DIFF
--- a/activestorage/lib/active_storage/attached/macros.rb
+++ b/activestorage/lib/active_storage/attached/macros.rb
@@ -32,6 +32,10 @@ module ActiveStorage
         def #{name}
           @active_storage_attached_#{name} ||= ActiveStorage::Attached::One.new("#{name}", self, dependent: #{dependent == :purge_later ? ":purge_later" : "false"})
         end
+
+        def #{name}=(attachable)
+          #{name}.attach(attachable)
+        end
       CODE
 
       has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record
@@ -72,6 +76,10 @@ module ActiveStorage
       class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}
           @active_storage_attached_#{name} ||= ActiveStorage::Attached::Many.new("#{name}", self, dependent: #{dependent == :purge_later ? ":purge_later" : "false"})
+        end
+
+        def #{name}=(*attachables)
+          #{name}.attach(*attachables)
         end
       CODE
 

--- a/activestorage/test/models/attachments_test.rb
+++ b/activestorage/test/models/attachments_test.rb
@@ -15,8 +15,18 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     assert_equal "funky.jpg", @user.avatar.filename.to_s
   end
 
+  test "attach existing blob via setter" do
+    @user.avatar = create_blob(filename: "funky.jpg")
+    assert_equal "funky.jpg", @user.avatar.filename.to_s
+  end
+
   test "attach existing sgid blob" do
     @user.avatar.attach create_blob(filename: "funky.jpg").signed_id
+    assert_equal "funky.jpg", @user.avatar.filename.to_s
+  end
+
+  test "attach existing sgid blob via setter" do
+    @user.avatar = create_blob(filename: "funky.jpg").signed_id
     assert_equal "funky.jpg", @user.avatar.filename.to_s
   end
 
@@ -25,9 +35,20 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     assert_equal "town.jpg", @user.avatar.filename.to_s
   end
 
+  test "attach new blob from a Hash via setter" do
+    @user.avatar = { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg" }
+    assert_equal "town.jpg", @user.avatar.filename.to_s
+  end
+
   test "attach new blob from an UploadedFile" do
     file = file_fixture "racecar.jpg"
     @user.avatar.attach Rack::Test::UploadedFile.new file
+    assert_equal "racecar.jpg", @user.avatar.filename.to_s
+  end
+
+  test "attach new blob from an UploadedFile via setter" do
+    file = file_fixture "racecar.jpg"
+    @user.avatar = Rack::Test::UploadedFile.new file
     assert_equal "racecar.jpg", @user.avatar.filename.to_s
   end
 
@@ -105,10 +126,27 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     assert_equal "wonky.jpg", @user.highlights.second.filename.to_s
   end
 
+  test "attach existing blobs via setter" do
+    @user.highlights = [create_blob(filename: "funky.jpg"), create_blob(filename: "wonky.jpg")]
+
+    assert_equal "funky.jpg", @user.highlights.first.filename.to_s
+    assert_equal "wonky.jpg", @user.highlights.second.filename.to_s
+  end
+
   test "attach new blobs" do
     @user.highlights.attach(
       { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg" },
       { io: StringIO.new("IT"), filename: "country.jpg", content_type: "image/jpg" })
+
+    assert_equal "town.jpg", @user.highlights.first.filename.to_s
+    assert_equal "country.jpg", @user.highlights.second.filename.to_s
+  end
+
+  test "attach new blobs via setter" do
+    @user.highlights = [
+      { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg" },
+      { io: StringIO.new("IT"), filename: "country.jpg", content_type: "image/jpg" }
+    ]
 
     assert_equal "town.jpg", @user.highlights.first.filename.to_s
     assert_equal "country.jpg", @user.highlights.second.filename.to_s


### PR DESCRIPTION
### Summary

Currently,  `ActiveStorage::Attached::Macros.has_one_attached` or `ActiveStorage::Attached::Macros.has_many_attached` defines only getter methods (e.g. #avatar).

But if it is able to define setter methods (e.g. #avatar=), when it assigns multiple attributes with Strong Parameters, it'll be more convenient :)

#### Background views

```html+erb
<%= form_with(model: user, local: true) do |form| %>
  <div class="field">
    <%= form.label :name %>
    <%= form.text_field :name, id: :user_name %>
  </div>

  <div class="field">
    <%= form.label :avatar %>
    <%= form.file_field :avatar, id: :user_avatar %>
  </div>

  <div class="actions">
    <%= form.submit %>
  </div>
<% end %>
```

#### Before: when it doesn't define setter methods

```ruby
class UsersController < ApplicationController
  def create
    @user = User.new(user_params)

    if @user.save
      @user.avatar.attach(params[:user][:avatar])
      redirect_to @user, notice: 'User was successfully created.'
    else
      render :new
    end
  end
  private
    def user_params
      params.require(:user).permit(:name)
    end
end
```

#### After: when It defines setter methods

```ruby
class UsersController < ApplicationController
  def create
    @user = User.new(user_params)

    if @user.save
      redirect_to @user, notice: 'User was successfully created.'
    else
      render :new
    end
  end
  private
    def user_params
      params.require(:user).permit(:name, :avatar)
    end
end
```