### PR TITLE
_normalize_render expect to use return values

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -112,6 +112,7 @@ module AbstractController
     end
 
     def _process_variant(options)
+      options
     end
 
     def _set_html_content_type # :nodoc:
@@ -124,7 +125,7 @@ module AbstractController
     # :api: private
     def _normalize_render(*args, &block)
       options = _normalize_args(*args, &block)
-      _process_variant(options)
+      options = _process_variant(options)
       options = _normalize_options(options)
       options
     end

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -125,7 +125,7 @@ module AbstractController
     def _normalize_render(*args, &block)
       options = _normalize_args(*args, &block)
       _process_variant(options)
-      _normalize_options(options)
+      options = _normalize_options(options)
       options
     end
 

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -58,6 +58,7 @@ module ActionController
         if defined?(request) && !request.nil? && request.variant.present?
           options[:variant] = request.variant
         end
+        options
       end
 
       def _render_in_priorities(options)

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -98,7 +98,7 @@ module ActionController
           options[:status] = Rack::Utils.status_code(options[:status])
         end
 
-        super(options)
+        super
       end
 
       def _normalize_text(options)

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -97,7 +97,7 @@ module ActionController
           options[:status] = Rack::Utils.status_code(options[:status])
         end
 
-        super
+        super(options)
       end
 
       def _normalize_text(options)

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -87,7 +87,7 @@ module ActionController
 
       # Normalize both text and status options.
       def _normalize_options(options)
-        _normalize_text(options)
+        options = _normalize_text(options)
 
         if options[:html]
           options[:html] = ERB::Util.html_escape(options[:html])
@@ -106,6 +106,7 @@ module ActionController
             options[format] = options[format].to_text
           end
         end
+        options
       end
 
       # Process controller specific options, as status, content-type and location.

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -346,7 +346,7 @@ module ActionView
     end
 
     def _normalize_options(options) # :nodoc:
-      options = super(options)
+      options = super
 
       if _include_layout?(options)
         layout = options.delete(:layout) { :default }

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -346,12 +346,14 @@ module ActionView
     end
 
     def _normalize_options(options) # :nodoc:
-      super
+      options = super(options)
 
       if _include_layout?(options)
         layout = options.delete(:layout) { :default }
         options[:layout] = _layout_for_option(layout)
       end
+
+      options
     end
 
     attr_internal_writer :action_has_layout


### PR DESCRIPTION
Clarifies the behavior of methods delegated to by `_normalize_render`. Previously:
- only some methods return an options hash (return value cannot be depended on)
- only some callers depend on return values (callers know about implementation)

This made it a bit confusing when I was overriding `_normalize_options` in my own project and `super` [unexpectedly returned a Proc](https://github.com/rails/rails/blob/master/actionview/lib/action_view/layouts.rb#L353).

This PR changes `_normalize_options`, `_normalize_text`, and `_process_variant` to _always_ return options and insists that their callers depend on this return value. Although options are still mutated in-place, the callers no longer need knowledge of this.

A solution was previously attempted in https://github.com/rails/rails/pull/30551. Thanks for the comments @kamipo and @tenderlove, and I hope this helps! 💛💚💙💜❤️ 