### PR TITLE
Confirm escaped already for avoid duplicate escape when adding anchor param

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -88,7 +88,11 @@ module ActionDispatch
 
         def add_anchor(path, anchor)
           if anchor
-            path << "##{Journey::Router::Utils.escape_fragment(anchor.to_param)}"
+            param = anchor.to_param
+            unless Journey::Router::Utils.escaped_fragment?(param)
+              param = Journey::Router::Utils.escape_fragment(param)
+            end
+            path << "##{param}"
           end
         end
 

--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -50,12 +50,24 @@ module ActionDispatch
             escape(fragment, FRAGMENT)
           end
 
+          def escaped_fragment?(fragment)
+            escaped?(fragment, FRAGMENT)
+          end
+
           def escape_path(path)
             escape(path, PATH)
           end
 
+          def escaped_path?(path)
+            escaped?(path, PATH)
+          end
+
           def escape_segment(segment)
             escape(segment, SEGMENT)
+          end
+
+          def escaped_segment?(segment)
+            escaped?(segment, SEGMENT)
           end
 
           def unescape_uri(uri)
@@ -66,6 +78,10 @@ module ActionDispatch
           private
             def escape(component, pattern)
               component.gsub(pattern) { |unsafe| percent_encode(unsafe) }.force_encoding(US_ASCII)
+            end
+
+            def escaped?(component, pattern)
+              component.gsub(ESCAPED, "") !~ pattern
             end
 
             def percent_encode(unsafe)
@@ -81,12 +97,24 @@ module ActionDispatch
           ENCODER.escape_path(path.to_s)
         end
 
+        def self.escaped_path?(path)
+          ENCODER.escaped_path?(path.to_s)
+        end
+
         def self.escape_segment(segment)
           ENCODER.escape_segment(segment.to_s)
         end
 
+        def self.escaped_segment?(segment)
+          ENCODER.escaped_segment?(segment.to_s)
+        end
+
         def self.escape_fragment(fragment)
           ENCODER.escape_fragment(fragment.to_s)
+        end
+
+        def self.escaped_fragment?(fragment)
+          ENCODER.escaped_fragment?(fragment.to_s)
         end
 
         # Replaces any escaped sequences with their unescaped representations.

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -88,6 +88,12 @@ module AbstractController
         )
       end
 
+      def test_anchor_should_not_escape_escaped_pchar
+        assert_equal("/c/a#%23anchor",
+          W.new.url_for(only_path: true, controller: "c", action: "a", anchor: Struct.new(:to_param).new("%23anchor"))
+        )
+      end
+
       def test_anchor_should_not_escape_safe_pchar
         assert_equal("/c/a#name=user&email=user@domain.com",
           W.new.url_for(only_path: true, controller: "c", action: "a", anchor: Struct.new(:to_param).new("name=user&email=user@domain.com"))

--- a/actionpack/test/journey/router/utils_test.rb
+++ b/actionpack/test/journey/router/utils_test.rb
@@ -10,12 +10,27 @@ module ActionDispatch
           assert_equal "a/b%20c+d%25", Utils.escape_path("a/b c+d%")
         end
 
+        def test_path_escaped?
+          assert_equal false, Utils.escaped_path?("a/b c+d%")
+          assert_equal true, Utils.escaped_path?(Utils.escape_path("a/b c+d%"))
+        end
+
         def test_segment_escape
           assert_equal "a%2Fb%20c+d%25", Utils.escape_segment("a/b c+d%")
         end
 
+        def test_segment_escaped?
+          assert_equal false, Utils.escaped_segment?("a/b c+d%")
+          assert_equal true, Utils.escaped_segment?(Utils.escape_segment("a/b c+d%"))
+        end
+
         def test_fragment_escape
           assert_equal "a/b%20c+d%25?e", Utils.escape_fragment("a/b c+d%?e")
+        end
+
+        def test_fragment_escaped?
+          assert_equal false, Utils.escaped_fragment?("a/b c+d%?e")
+          assert_equal true, Utils.escaped_fragment?(Utils.escape_fragment("a/b c+d%?e"))
         end
 
         def test_uri_unescape


### PR DESCRIPTION
### Summary

When generating URL included anchor, example code is

```rb
users_path({anchor: {mail: 'foo@example.com'}})
=> "/users#mail=foo%2540example.com"
```
but in this case `foo%2540example.com` is duplicate escaped.
Correctly it should be as follows

```rb
users_path({anchor: {mail: 'foo@example.com'}})
=> "/users#mail=foo%40example.com"
```

In this pull request, skip escape when already escaped for avoid duplicate escape when adding anchor param.

### Other Information
Add 3 checking methods for each escapes but not used `Journey::Router::Utils.escaped_path?` and `Journey::Router::Utils.escaped_segment?` in this pull request.