### PR TITLE
Implement H2 Early Hints for Rails

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add ability to enable Early Hints for HTTP/2
+
+    If supported by the server, and enabled in Puma this allows H2 Early Hints to be used.
+
+    The `javascript_include_tag` and the `stylesheet_link_tag` automatically add Early Hints if requested.
+
+    *Eileen M. Uchitelle*, *Aaron Patterson*
+
 *   Simplify cookies middleware with key rotation support
 
     Use the `rotate` method for both `MessageEncryptor` and

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -199,6 +199,23 @@ module ActionDispatch
       @headers ||= Http::Headers.new(self)
     end
 
+    # Early Hints is an HTTP/2 status code that indicates hints to help a client start
+    # making preparations for processing the final response.
+    #
+    # If the env contains +rack.early_hints+ then the server accepts HTTP2 push for Link headers.
+    #
+    # The +send_early_hints+ method accepts an hash of links as follows:
+    #
+    #   send_early_hints("Link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload")
+    #
+    # If you are using +javascript_include_tag+ or +stylesheet_link_tag+ the
+    # Early Hints headers are included by default if supported.
+    def send_early_hints(links)
+      return unless env["rack.early_hints"]
+
+      env["rack.early_hints"].call(links)
+    end
+
     # Returns a +String+ with the last requested path including their params.
     #
     #    # get '/foo'

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1304,3 +1304,18 @@ class RequestFormData < BaseRequestTest
     assert !request.form_data?
   end
 end
+
+class EarlyHintsRequestTest < BaseRequestTest
+  def setup
+    super
+    @env["rack.early_hints"] = lambda { |links| links }
+    @request = stub_request
+  end
+
+  test "when early hints is set in the env link headers are sent" do
+    early_hints = @request.send_early_hints("Link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload")
+    expected_hints = { "Link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload" }
+
+    assert_equal expected_hints, early_hints
+  end
+end

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -19,6 +19,7 @@ class AssetTagHelperTest < ActionView::TestCase
       def ssl?() false end
       def host_with_port() "localhost" end
       def base_url() "http://www.example.com" end
+      def send_early_hints(links) end
     end.new
 
     @controller.request = @request
@@ -653,7 +654,9 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
     @controller = BasicController.new
     @controller.config.relative_url_root = "/collaboration/hieraki"
 
-    @request = Struct.new(:protocol, :base_url).new("gopher://", "gopher://www.example.com")
+    @request = Struct.new(:protocol, :base_url) do
+      def send_early_hints(links); end
+    end.new("gopher://", "gopher://www.example.com")
     @controller.request = @request
   end
 

--- a/actionview/test/template/javascript_helper_test.rb
+++ b/actionview/test/template/javascript_helper_test.rb
@@ -6,11 +6,15 @@ class JavaScriptHelperTest < ActionView::TestCase
   tests ActionView::Helpers::JavaScriptHelper
 
   attr_accessor :output_buffer
+  attr_reader :request
 
   setup do
     @old_escape_html_entities_in_json = ActiveSupport.escape_html_entities_in_json
     ActiveSupport.escape_html_entities_in_json = true
     @template = self
+    @request = Class.new do
+      def send_early_hints(links) end
+    end.new
   end
 
   def teardown

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -127,6 +127,7 @@ module Rails
       class_option "dev-caching", aliases: "-C", type: :boolean, default: nil,
         desc: "Specifies whether to perform caching in development."
       class_option "restart", type: :boolean, default: nil, hide: true
+      class_option "early_hints", type: :boolean, default: nil, desc: "Enables HTTP/2 early hints."
 
       def initialize(args = [], local_options = {}, config = {})
         @original_options = local_options
@@ -161,7 +162,8 @@ module Rails
             daemonize:             options[:daemon],
             pid:                   pid,
             caching:               options["dev-caching"],
-            restart_cmd:           restart_command
+            restart_cmd:           restart_command,
+            early_hints:           early_hints
           }
         end
       end
@@ -225,6 +227,10 @@ module Rails
 
         def restart_command
           "bin/rails server #{@server} #{@original_options.join(" ")} --restart"
+        end
+
+        def early_hints
+          options[:early_hints]
         end
 
         def pid

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -81,6 +81,18 @@ class Rails::ServerTest < ActiveSupport::TestCase
     assert_equal false, options[:caching]
   end
 
+  def test_early_hints_with_option
+    args = ["--early-hints"]
+    options = parse_arguments(args)
+    assert_equal true, options[:early_hints]
+  end
+
+  def test_early_hints_is_nil_by_default
+    args = []
+    options = parse_arguments(args)
+    assert_nil options[:early_hints]
+  end
+
   def test_log_stdout
     with_rack_env nil do
       with_rails_env nil do


### PR DESCRIPTION
When puma/puma#1403 is merged Puma will support the Early Hints status
code for sending assets before a request has finished.

While the Early Hints spec is still in draft, this PR prepares Rails to
allowing this status code.

If the proxy server supports Early Hints, it will send H2 pushes to the
client.

This PR adds a method for setting Early Hints Link headers via Rails,
and also automatically sends Early Hints if supported from the
`stylesheet_link_tag` and the `javascript_include_tag`.

Once puma supports Early Hints the `--early-hints` argument can be
passed to the server to enable this. Note that for Early Hints to work
in the browser the requirements are 1) a proxy that can handle H2,
and 2) HTTPS.

To start the server with Early Hints enabled pass `--early-hints` to `rails s`.

This has been verified to work with h2o, Puma, and Rails with Chrome.

The commit adds a new option to the rails server to enable early hints
for Puma.

Early Hints spec:
https://tools.ietf.org/html/draft-ietf-httpbis-early-hints-04

cc/ @tenderlove who I worked with on this feature

---
In the screenshot below you can see the pushes from early hints.

![screen shot 2017-09-26 at 1 26 57 pm](https://user-images.githubusercontent.com/1080678/30984877-aa914620-a45c-11e7-82b5-523d0b13fa75.png)
