### PR TITLE
Add render options in action_controller/renderer for api docs [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -71,6 +71,18 @@ module ActionController
     end
 
     # Render templates with any options from ActionController::Base#render_to_string.
+    #
+    # The primary options are:
+    # * <tt>:partial</tt> - See <tt>ActionView::PartialRenderer</tt> for details.
+    # * <tt>:file</tt> - Renders an explicit template file. Add <tt>:locals</tt> to pass in, if so desired.
+    # * <tt>:inline</tt> - Renders an inline template.
+    # * <tt>:plain</tt> - Renders provided text and sets the content type as <tt>text/plain</tt>.
+    # * <tt>:html</tt> - Renders the provided HTML safe string, otherwise
+    #   performs HTML escape on the string first. Sets the content type as <tt>text/html</tt>.
+    # * <tt>:body</tt> - Renders provided text and sets content type of <tt>text/plain</tt>.
+    #
+    # If no <tt>options</tt> hash is passed or if <tt>:update</tt> is specified, the default is
+    # to render a partial and use the second parameter as the locals hash.
     def render(*args)
       raise "missing controller" unless controller
 


### PR DESCRIPTION
Added render options as described in issue #28484. I continued from the pr https://github.com/rails/rails/pull/28784. I removed `text` as requested by @rafaelfrance since its no longer a valid option, and moved the render options to `ActionController::Rendering#render` as suggested in the previous pr. Are there any other options missing?
