### PR TITLE
redis-rb 4.0 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,8 +61,8 @@ gem "bootsnap", ">= 1.1.0", require: false
 # Active Job.
 group :job do
   gem "resque", require: false
-  gem "resque-scheduler", require: false
-  gem "sidekiq", require: false
+  gem "resque-scheduler", github: "jeremy/resque-scheduler", branch: "redis-rb-4.0", require: false
+  gem "sidekiq", github: "mperham/sidekiq", require: false
   gem "sucker_punch", require: false
   gem "delayed_job", require: false
   gem "queue_classic", github: "QueueClassic/queue_classic", branch: "master", require: false, platforms: :ruby
@@ -82,7 +82,10 @@ group :cable do
 
   gem "em-hiredis", require: false
   gem "hiredis", require: false
-  gem "redis", require: false
+  gem "redis", "~> 4.0", require: false
+
+  # For Redis 4.0 support. Unreleased 9cb81bf.
+  gem "redis-namespace", github: "resque/redis-namespace"
 
   gem "websocket-client-simple", github: "matthewd/websocket-client-simple", branch: "close-race", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,17 @@ GIT
       pg (>= 0.17, < 0.20)
 
 GIT
+  remote: https://github.com/jeremy/resque-scheduler.git
+  revision: 5efd21bb7ee4b326d9c0d26fccad10fc59dd51f0
+  branch: redis-rb-4.0
+  specs:
+    resque-scheduler (4.3.0)
+      mono_logger (~> 1.0)
+      redis (>= 3.3, < 5)
+      resque (~> 1.26)
+      rufus-scheduler (~> 3.2)
+
+GIT
   remote: https://github.com/matthewd/rb-inotify.git
   revision: 856730aad4b285969e8dd621e44808a7c5af4242
   branch: close-handling
@@ -22,6 +33,16 @@ GIT
     websocket-client-simple (0.3.0)
       event_emitter
       websocket
+
+GIT
+  remote: https://github.com/mperham/sidekiq.git
+  revision: 6332b9f8a316cf1000246701e40e108d16fed6d4
+  specs:
+    sidekiq (5.0.5)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.4, < 5)
 
 GIT
   remote: https://github.com/rails/arel.git
@@ -40,6 +61,13 @@ GIT
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+
+GIT
+  remote: https://github.com/resque/redis-namespace.git
+  revision: 1403f511f6ae1ec9a8f330298a4cacf73fb10afc
+  specs:
+    redis-namespace (1.5.3)
+      redis (>= 3.0.4)
 
 GIT
   remote: https://github.com/robin850/sdoc.git
@@ -361,9 +389,7 @@ GEM
     rb-fsevent (0.10.2)
     rdoc (5.1.0)
     redcarpet (3.2.3)
-    redis (3.3.3)
-    redis-namespace (1.5.3)
-      redis (~> 3.0, >= 3.0.4)
+    redis (4.0.1)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -374,11 +400,6 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    resque-scheduler (4.3.0)
-      mono_logger (~> 1.0)
-      redis (~> 3.3)
-      resque (~> 1.26)
-      rufus-scheduler (~> 3.2)
     retriable (3.1.1)
     rubocop (0.49.1)
       parallel (~> 1.10)
@@ -403,11 +424,6 @@ GEM
     sequel (4.49.0)
     serverengine (1.5.11)
       sigdump (~> 0.2.2)
-    sidekiq (5.0.4)
-      concurrent-ruby (~> 1.0)
-      connection_pool (~> 2.2, >= 2.2.0)
-      rack-protection (>= 1.5.0)
-      redis (~> 3.3, >= 3.3.3)
     sigdump (0.2.4)
     signet (0.7.3)
       addressable (~> 2.3)
@@ -520,14 +536,15 @@ DEPENDENCIES
   rake (>= 11.1)
   rb-inotify!
   redcarpet (~> 3.2.3)
-  redis
+  redis (~> 4.0)
+  redis-namespace!
   resque
-  resque-scheduler
+  resque-scheduler!
   rubocop (>= 0.47)
   sass-rails!
   sdoc!
   sequel
-  sidekiq
+  sidekiq!
   sneakers
   sprockets-export
   sqlite3 (~> 1.3.6)

--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support redis-rb 4.0.
+
+    *Jeremy Daer*
+
 *   Hash long stream identifiers when using PostgreSQL adapter.
 
     PostgreSQL has a limit on identifiers length (63 chars, [docs](https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)).

--- a/actioncable/lib/action_cable/subscription_adapter/evented_redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/evented_redis.rb
@@ -3,7 +3,7 @@
 require "thread"
 
 gem "em-hiredis", "~> 0.3.0"
-gem "redis", "~> 3.0"
+gem "redis", ">= 3", "< 5"
 require "em-hiredis"
 require "redis"
 

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -2,7 +2,7 @@
 
 require "thread"
 
-gem "redis", "~> 3.0"
+gem "redis", ">= 3", "< 5"
 require "redis"
 
 module ActionCable
@@ -76,7 +76,7 @@ module ActionCable
 
           def listen(conn)
             conn.without_reconnect do
-              original_client = conn.client
+              original_client = conn.respond_to?(:_client) ? conn._client : conn.client
 
               conn.subscribe("_action_cable_internal") do |on|
                 on.subscribe do |chan, count|

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support redis-rb 4.0.
+
+    *Jeremy Daer*
+
 *   Change logging instrumentation to log errors when a job raises an exception.
 
     Fixes #26848.

--- a/activejob/test/support/integration/adapters/resque.rb
+++ b/activejob/test/support/integration/adapters/resque.rb
@@ -3,7 +3,7 @@
 module ResqueJobsManager
   def setup
     ActiveJob::Base.queue_adapter = :resque
-    Resque.redis = Redis::Namespace.new "active_jobs_int_test", redis: Redis.connect(url: "redis://:password@127.0.0.1:6379/12", thread_safe: true)
+    Resque.redis = Redis::Namespace.new "active_jobs_int_test", redis: Redis.new(url: "redis://:password@127.0.0.1:6379/12", thread_safe: true)
     Resque.logger = Rails.logger
     unless can_run?
       puts "Cannot run integration tests for resque. To be able to run integration tests for resque you need to install and start redis.\n"
@@ -41,11 +41,8 @@ module ResqueJobsManager
   end
 
   def can_run?
-    begin
-      Resque.redis.client.connect
-    rescue
-      return false
-    end
-    true
+    Resque.redis.ping == "PONG"
+  rescue
+    false
   end
 end

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Gemfile for new apps: upgrade redis-rb from ~> 3.0 to 4.0.
+
+    *Jeremy Daer*
+
 *   Add `mini_magick` to default `Gemfile` as comment.
 
     *Yoshiyuki Hirano*

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -369,7 +369,7 @@ module Rails
         return [] if options[:skip_action_cable]
         comment = "Use Redis adapter to run Action Cable in production"
         gems = []
-        gems << GemfileEntry.new("redis", "~> 3.0", comment, {}, true)
+        gems << GemfileEntry.new("redis", "~> 4.0", comment, {}, true)
         gems
       end
 


### PR DESCRIPTION
* Loosen Redis version dep to `>= 3.3, < 5`
* Bump redis-namespace for looser Redis version dep
* Avoid using the underlying `redis.client` directly
* Use `Redis.new` instead of `Redis.connect`

Pending gem releases for [Sidekiq](https://github.com/mperham/sidekiq/pull/3618), [redis-namespace](https://github.com/resque/redis-namespace/pull/136), and [resque-scheduler](https://github.com/resque/resque-scheduler/pull/620).

Fixes #30527