### PR TITLE
Mention bin/test in contribution guides

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -302,21 +302,21 @@ $ bundle exec rake test
 
 #### For a Particular Component
 
-You can run tests only for a particular component (e.g. Action Pack). For example,
-to run Action Mailer tests:
+To test a particular component (e.g. Action Pack) every component has a dedicated
+`bin/test` script. For example, to run Action Mailer tests:
 
 ```bash
 $ cd actionmailer
-$ bundle exec rake test
+$ bin/test
 ```
 
 #### Running a Single Test
 
-You can run a single test through ruby. For instance:
+You can run a single test using `bin/test`. For instance:
 
 ```bash
 $ cd actionmailer
-$ bundle exec ruby -w -Itest test/mail_layout_test.rb -n test_explicit_class_layout
+$ bin/test test/mail_layout_test.rb -n test_explicit_class_layout
 ```
 
 The `-n` option allows you to run a single method instead of the whole


### PR DESCRIPTION
The guides don't mention `bin/test`. As a (very) new contributor, I needed @kaspth to [tell me](https://twitter.com/kaspth/status/912044653960220673) to do so.

I had some **troubles with ActiveRecord** though. As I understand it, it's the only lib with special instructions adding the `--adapter` argument. I couldn't get it to work though. `bin/test -a mysql2` just ran it with sqlite3. `ARCONN=mysql2 bin/test` did pick it up. I still need to describe how to:

- Run `bin/test` for ActiveRecord with a single adapter
- Run `bin/test` for ActiveRecord with every adapter

I looked at how CI runs them and it looks like they use the rake tasks. So we could also just keep the AR-docs as they are.

Any tips are greatly appreciated and I will update this accordingly.

I was also unsure if I should add a short explanation as to why we have this special setup. But I couldn't decide if it was important for newcomers or just an unnecessary detail?