### PR TITLE
Yield with an error instance instead of error class

### DIFF
--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -49,7 +49,7 @@ module ActiveJob
             retry_job wait: determine_delay(wait), queue: queue, priority: priority
           else
             if block_given?
-              yield self, exception
+              yield self, error
             else
               logger.error "Stopped retrying #{self.class} due to a #{exception}, which reoccurred on #{executions} attempts. The original exception was #{error.cause.inspect}."
               raise error

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -61,7 +61,7 @@ class ExceptionsTest < ActiveJob::TestCase
   test "custom handling of job that exceeds retry attempts" do
     perform_enqueued_jobs do
       RetryJob.perform_later "CustomCatchError", 6
-      assert_equal "Dealt with a job that failed to retry in a custom way after 6 attempts", JobBuffer.last_value
+      assert_equal "Dealt with a job that failed to retry in a custom way after 6 attempts. Message: CustomCatchError", JobBuffer.last_value
     end
   end
 

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -17,7 +17,7 @@ class RetryJob < ActiveJob::Base
   retry_on ShortWaitTenAttemptsError, wait: 1.second, attempts: 10
   retry_on ExponentialWaitTenAttemptsError, wait: :exponentially_longer, attempts: 10
   retry_on CustomWaitTenAttemptsError, wait: ->(executions) { executions * 2 }, attempts: 10
-  retry_on(CustomCatchError) { |job, exception| JobBuffer.add("Dealt with a job that failed to retry in a custom way after #{job.arguments.second} attempts") }
+  retry_on(CustomCatchError) { |job, exception| JobBuffer.add("Dealt with a job that failed to retry in a custom way after #{job.arguments.second} attempts. Message: #{exception.message}") }
   discard_on DiscardableError
 
   def perform(raising, attempts)


### PR DESCRIPTION
The code comment says "This block is yielded with the job instance as the first and the error instance as the second parameter." so I think the block should be yielded with an actual error instance instead of error class