### PR TITLE
Don't use Active Support where it is not needed.

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -49,7 +49,7 @@ module ActionDispatch
 
     # Default to 180 days, the low end for https://www.ssllabs.com/ssltest/
     # and greater than the 18-week requirement for browser preload lists.
-    HSTS_EXPIRES_IN = 180.days.to_i
+    HSTS_EXPIRES_IN = 15552000
 
     def self.default_hsts_options
       { expires: HSTS_EXPIRES_IN, subdomains: true, preload: false }


### PR DESCRIPTION
This code has been changed with https://github.com/rails/rails/pull/30735/files#diff-8e5f6b33c191ad6dec07f3288345a13fL47.

However, `active_support/time` is not load automatically, so if use Action Pack alone, `days` method can not use and an error occurs.
In this case, I think that there is no problem by specifying a value with Integer.


