### PR TITLE
Adapters bubble up gem version mismatches for their dependencies

### DIFF
--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -25,13 +25,26 @@ module ActionCable
       # Also makes sure proper dependencies are required.
       def pubsub_adapter
         adapter = (cable.fetch("adapter") { "redis" })
+
+        # Require the adapter itself and give useful feedback about
+        #   1. Missing adapter gems and
+        #   2. Adapter gems' missing dependencies.
         path_to_adapter = "action_cable/subscription_adapter/#{adapter}"
         begin
           require path_to_adapter
-        rescue Gem::LoadError => e
-          raise Gem::LoadError, "Specified '#{adapter}' for Action Cable pubsub adapter, but the gem is not loaded. Add `gem '#{e.name}'` to your Gemfile (and ensure its version is at the minimum required by Action Cable)."
         rescue LoadError => e
-          raise LoadError, "Could not load '#{path_to_adapter}'. Make sure that the adapter in config/cable.yml is valid. If you use an adapter other than 'postgresql' or 'redis' add the necessary adapter gem to the Gemfile.", e.backtrace
+          # We couldn't require the adapter itself. Raise an exception that
+          # points out config typos and missing gems.
+          if e.path == path_to_adapter
+            # We can assume that a non-builtin adapter was specified, so it's
+            # either misspelled or missing from Gemfile.
+            raise e.class, "Could not load the '#{adapter}' Action Cable pubsub adapter. Ensure that the adapter is spelled correctly in config/cable.yml and that you've added the necessary adapter gem to your Gemfile.", e.backtrace
+
+          # Bubbled up from the adapter require. Prefix the exception message
+          # with some guidance about how to address it and reraise.
+          else
+            raise e.class, "Error loading the '#{adapter}' Action Cable pubsub adapter. Missing a gem it depends on? #{e.message}", e.backtrace
+          end
         end
 
         adapter = adapter.camelize

--- a/activerecord/lib/active_record/connection_adapters/connection_specification.rb
+++ b/activerecord/lib/active_record/connection_adapters/connection_specification.rb
@@ -183,13 +183,25 @@ module ActiveRecord
 
           raise(AdapterNotSpecified, "database configuration does not specify adapter") unless spec.key?(:adapter)
 
+          # Require the adapter itself and give useful feedback about
+          #   1. Missing adapter gems and
+          #   2. Adapter gems' missing dependencies.
           path_to_adapter = "active_record/connection_adapters/#{spec[:adapter]}_adapter"
           begin
             require path_to_adapter
-          rescue Gem::LoadError => e
-            raise Gem::LoadError, "Specified '#{spec[:adapter]}' for database adapter, but the gem is not loaded. Add `gem '#{e.name}'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord)."
           rescue LoadError => e
-            raise LoadError, "Could not load '#{path_to_adapter}'. Make sure that the adapter in config/database.yml is valid. If you use an adapter other than 'mysql2', 'postgresql' or 'sqlite3' add the necessary adapter gem to the Gemfile.", e.backtrace
+            # We couldn't require the adapter itself. Raise an exception that
+            # points out config typos and missing gems.
+            if e.path == path_to_adapter
+              # We can assume that a non-builtin adapter was specified, so it's
+              # either misspelled or missing from Gemfile.
+              raise e.class, "Could not load the '#{spec[:adapter]}' Active Record adapter. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile.", e.backtrace
+
+            # Bubbled up from the adapter require. Prefix the exception message
+            # with some guidance about how to address it and reraise.
+            else
+              raise e.class, "Error loading the '#{spec[:adapter]}' Action Record adapter. Missing a gem it depends on? #{e.message}", e.backtrace
+            end
           end
 
           adapter_method = "#{spec[:adapter]}_connection"

--- a/activerecord/test/cases/connection_specification/resolver_test.rb
+++ b/activerecord/test/cases/connection_specification/resolver_test.rb
@@ -19,7 +19,7 @@ module ActiveRecord
             spec "ridiculous://foo?encoding=utf8"
           end
 
-          assert_match "Could not load 'active_record/connection_adapters/ridiculous_adapter'", error.message
+          assert_match "Could not load the 'ridiculous' Active Record adapter. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile.", error.message
         end
 
         # The abstract adapter is used simply to bypass the bit of code that


### PR DESCRIPTION
Deal with #30527, misleading error when an optional adapter fails to load its required dependencies.

Distinguish missing adapter gems from load errors within the adapter
    
* When the adapter is missing, raise an exception that points out config typos and missing Gemfile entries. (We can assume that a non-builtin adapter was used since these are always available.)
* When loading an adapter raises a LoadError, prefix its error message to indicate that the adapter is likely missing an optional dependency.

References #30748.