### PR TITLE
Use `add_runtime_dependency` in gemspec.

### DIFF
--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |s|
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actioncable/CHANGELOG.md"
   }
 
-  s.add_dependency "actionpack", version
+  s.add_runtime_dependency "actionpack", version
 
-  s.add_dependency "nio4r",            "~> 2.0"
-  s.add_dependency "websocket-driver", "~> 0.6.1"
+  s.add_runtime_dependency "nio4r",            "~> 2.0"
+  s.add_runtime_dependency "websocket-driver", "~> 0.6.1"
 end

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -26,10 +26,10 @@ Gem::Specification.new do |s|
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionmailer/CHANGELOG.md"
   }
 
-  s.add_dependency "actionpack", version
-  s.add_dependency "actionview", version
-  s.add_dependency "activejob", version
+  s.add_runtime_dependency "actionpack", version
+  s.add_runtime_dependency "actionview", version
+  s.add_runtime_dependency "activejob", version
 
-  s.add_dependency "mail", ["~> 2.5", ">= 2.5.4"]
-  s.add_dependency "rails-dom-testing", "~> 2.0"
+  s.add_runtime_dependency "mail", ["~> 2.5", ">= 2.5.4"]
+  s.add_runtime_dependency "rails-dom-testing", "~> 2.0"
 end

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -26,13 +26,13 @@ Gem::Specification.new do |s|
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionpack/CHANGELOG.md"
   }
 
-  s.add_dependency "activesupport", version
+  s.add_runtime_dependency "activesupport", version
 
-  s.add_dependency "rack",      "~> 2.0"
-  s.add_dependency "rack-test", ">= 0.6.3"
-  s.add_dependency "rails-html-sanitizer", "~> 1.0", ">= 1.0.2"
-  s.add_dependency "rails-dom-testing", "~> 2.0"
-  s.add_dependency "actionview", version
+  s.add_runtime_dependency "rack",      "~> 2.0"
+  s.add_runtime_dependency "rack-test", ">= 0.6.3"
+  s.add_runtime_dependency "rails-html-sanitizer", "~> 1.0", ">= 1.0.2"
+  s.add_runtime_dependency "rails-dom-testing", "~> 2.0"
+  s.add_runtime_dependency "actionview", version
 
   s.add_development_dependency "activemodel", version
 end

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -26,12 +26,12 @@ Gem::Specification.new do |s|
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/actionview/CHANGELOG.md"
   }
 
-  s.add_dependency "activesupport", version
+  s.add_runtime_dependency "activesupport", version
 
-  s.add_dependency "builder",       "~> 3.1"
-  s.add_dependency "erubi",         "~> 1.4"
-  s.add_dependency "rails-html-sanitizer", "~> 1.0", ">= 1.0.3"
-  s.add_dependency "rails-dom-testing", "~> 2.0"
+  s.add_runtime_dependency "builder",       "~> 3.1"
+  s.add_runtime_dependency "erubi",         "~> 1.4"
+  s.add_runtime_dependency "rails-html-sanitizer", "~> 1.0", ">= 1.0.3"
+  s.add_runtime_dependency "rails-dom-testing", "~> 2.0"
 
   s.add_development_dependency "actionpack",  version
   s.add_development_dependency "activemodel", version

--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activejob/CHANGELOG.md"
   }
 
-  s.add_dependency "activesupport", version
-  s.add_dependency "globalid", ">= 0.3.6"
+  s.add_runtime_dependency "activesupport", version
+  s.add_runtime_dependency "globalid", ">= 0.3.6"
 end

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activemodel/CHANGELOG.md"
   }
 
-  s.add_dependency "activesupport", version
+  s.add_runtime_dependency "activesupport", version
 end

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |s|
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activerecord/CHANGELOG.md"
   }
 
-  s.add_dependency "activesupport", version
-  s.add_dependency "activemodel",   version
+  s.add_runtime_dependency "activesupport", version
+  s.add_runtime_dependency "activemodel",   version
 
-  s.add_dependency "arel", "9.0.0.alpha"
+  s.add_runtime_dependency "arel", "9.0.0.alpha"
 end

--- a/activestorage/activestorage.gemspec
+++ b/activestorage/activestorage.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activestorage/CHANGELOG.md"
   }
 
-  s.add_dependency "actionpack", version
-  s.add_dependency "activerecord", version
+  s.add_runtime_dependency "actionpack", version
+  s.add_runtime_dependency "activerecord", version
 end

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |s|
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/activesupport/CHANGELOG.md"
   }
 
-  s.add_dependency "i18n",       "~> 0.7"
-  s.add_dependency "tzinfo",     "~> 1.1"
-  s.add_dependency "minitest",   "~> 5.1"
-  s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
+  s.add_runtime_dependency "i18n",       "~> 0.7"
+  s.add_runtime_dependency "tzinfo",     "~> 1.1"
+  s.add_runtime_dependency "minitest",   "~> 5.1"
+  s.add_runtime_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
 end

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1387,7 +1387,7 @@ traditional `gem install`, specify it inside the `Gem::Specification` block
 inside the `.gemspec` file in the engine:
 
 ```ruby
-s.add_dependency "moo"
+s.add_runtime_dependency "moo"
 ```
 
 To specify a dependency that should only be installed as a development

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -20,17 +20,17 @@ Gem::Specification.new do |s|
 
   s.files = ["README.md"]
 
-  s.add_dependency "activesupport", version
-  s.add_dependency "actionpack",    version
-  s.add_dependency "actionview",    version
-  s.add_dependency "activemodel",   version
-  s.add_dependency "activerecord",  version
-  s.add_dependency "actionmailer",  version
-  s.add_dependency "activejob",     version
-  s.add_dependency "actioncable",   version
-  s.add_dependency "activestorage", version
-  s.add_dependency "railties",      version
+  s.add_runtime_dependency "activesupport", version
+  s.add_runtime_dependency "actionpack",    version
+  s.add_runtime_dependency "actionview",    version
+  s.add_runtime_dependency "activemodel",   version
+  s.add_runtime_dependency "activerecord",  version
+  s.add_runtime_dependency "actionmailer",  version
+  s.add_runtime_dependency "activejob",     version
+  s.add_runtime_dependency "actioncable",   version
+  s.add_runtime_dependency "activestorage", version
+  s.add_runtime_dependency "railties",      version
 
-  s.add_dependency "bundler",         ">= 1.3.0"
-  s.add_dependency "sprockets-rails", ">= 2.0.0"
+  s.add_runtime_dependency "bundler",         ">= 1.3.0"
+  s.add_runtime_dependency "sprockets-rails", ">= 2.0.0"
 end

--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  <%= '# ' if options.dev? || options.edge? -%>s.add_dependency "rails", "<%= Array(rails_version_specifier).join('", "') %>"
+  <%= '# ' if options.dev? || options.edge? -%>s.add_runtime_dependency "rails", "<%= Array(rails_version_specifier).join('", "') %>"
 <% unless options[:skip_active_record] -%>
 
   s.add_development_dependency "<%= gem_for_database[0] %>"

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -30,12 +30,12 @@ Gem::Specification.new do |s|
     "changelog_uri"   => "https://github.com/rails/rails/blob/v#{version}/railties/CHANGELOG.md"
   }
 
-  s.add_dependency "activesupport", version
-  s.add_dependency "actionpack",    version
+  s.add_runtime_dependency "activesupport", version
+  s.add_runtime_dependency "actionpack",    version
 
-  s.add_dependency "rake", ">= 0.8.7"
-  s.add_dependency "thor", ">= 0.18.1", "< 2.0"
-  s.add_dependency "method_source"
+  s.add_runtime_dependency "rake", ">= 0.8.7"
+  s.add_runtime_dependency "thor", ">= 0.18.1", "< 2.0"
+  s.add_runtime_dependency "method_source"
 
   s.add_development_dependency "actionview", version
 end


### PR DESCRIPTION
Preferred method for Gem Specification is [`add_runtime_dependency`](http://ruby-doc.org/stdlib-2.4.1//libdoc/rubygems/rdoc/Gem/Specification.html#method-i-add_runtime_dependency).
`add_dependency` is an alias and is confusing because does not convey the environment, and in fact is not even mentioned in [RubyGems Guide Specification Reference](http://guides.rubygems.org/specification-reference/#add_runtime_dependency). Changing this will assure consistency with  [POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment).