### PR TITLE
Remove unused methods from `RenderPartialWithRecordIdentificationController`

### DIFF
--- a/actionview/test/activerecord/render_partial_with_record_identification_test.rb
+++ b/actionview/test/activerecord/render_partial_with_record_identification_test.rb
@@ -17,19 +17,9 @@ class RenderPartialWithRecordIdentificationController < ActionController::Base
     render partial: Reply.base
   end
 
-  def render_with_has_many_through_association
-    @developer = Developer.first
-    render partial: @developer.topics
-  end
-
   def render_with_has_one_association
     @company = Company.find(1)
     render partial: @company.mascot
-  end
-
-  def render_with_belongs_to_association
-    @reply = Reply.find(1)
-    render partial: @reply.topic
   end
 
   def render_with_record


### PR DESCRIPTION
These methods no longer used since a3da293.
