### PR TITLE
Remove unused `new_credentials_configuration`

### DIFF
--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -54,12 +54,4 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
   test "raises key error when accessing config via bang method" do
     assert_raise(KeyError) { @credentials.something! }
   end
-
-  private
-    def new_credentials_configuration
-      ActiveSupport::EncryptedConfiguration.new \
-        config_path: @credentials_config_path,
-        key_path: @credentials_key_path,
-        env_key: "RAILS_MASTER_KEY"
-    end
 end


### PR DESCRIPTION
`new_credentials_configuration` is no longer used since 081a6ac6f7fd929798481f9ee333fb92b441356c.
