### PR TITLE
Call `to_s` before calling `gsub` in `ActiveRecord::Sanitization.sanitize_sql_like`

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -133,7 +133,7 @@ module ActiveRecord
         #   # => "snake!_cased!_string"
         def sanitize_sql_like(string, escape_character = "\\") # :doc:
           pattern = Regexp.union(escape_character, "%", "_")
-          string.gsub(pattern) { |x| [escape_character, x].join }
+          string.to_s.gsub(pattern) { |x| [escape_character, x].join }
         end
 
         # Accepts an array of conditions. The array has each value

--- a/activerecord/test/cases/sanitize_test.rb
+++ b/activerecord/test/cases/sanitize_test.rb
@@ -70,6 +70,11 @@ class SanitizeTest < ActiveRecord::TestCase
     assert_equal "normal string 42", Binary.send(:sanitize_sql_like, "normal string 42", "!")
   end
 
+  def test_sanitize_sql_like_with_not_string_argument
+    assert_equal "1", Binary.send(:sanitize_sql_like, 1)
+    assert_equal "", Binary.send(:sanitize_sql_like, nil)
+  end
+
   def test_sanitize_sql_like_example_use_case
     searchable_post = Class.new(Post) do
       def self.search(term)


### PR DESCRIPTION
### Summary

In `ActiveRecord::Sanitization.sanitize_sql_like`,  add `to_s`  before `gsub` so that if argument is not string object.

In current specification, `ActiveRecord::Sanitization.sanitize_sql_like` call `gsub` to this method argument directly. So if without string object is passed as 1st argument `NoMethodError` is raised.

```ruby
ActiveRecord::Base.send(:sanitize_sql_like, 1) # => NoMethodError: undefined method `gsub' for 1:Integer
```

### Background

Of course I know a main use case of this method is to sanitize **String** object to set safely into where sql statement. So basically I think user should take care  if the query is string object before calling this method.

But same as `where` method can receive Integer value for varchar column and convert to string, I think it's not strange that  `sanitize_sql_like` also convert a query to string.

```ruby
2.4.1 :008 > Post
 => Post(id: integer, content: string, created_at: datetime, updated_at: datetime)
2.4.1 :009 > Post.where(content: 1).to_sql
 => "SELECT \"posts\".* FROM \"posts\" WHERE \"posts\".\"content\" = '1'"
```

I do not know well about ActiveRecord::Sanitization argument validation policy. So it may be wrong that I implement an argument sanitization, like this . If so, I will close this PR.

