### PR TITLE
Do not create credentials in dummy application

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -159,7 +159,7 @@ module Rails
     end
 
     def master_key
-      return if options[:pretend]
+      return if options[:pretend] || options[:dummy_app]
 
       require_relative "../master_key/master_key_generator"
 
@@ -169,7 +169,7 @@ module Rails
     end
 
     def credentials
-      return if options[:pretend]
+      return if options[:pretend] || options[:dummy_app]
 
       require_relative "../credentials/credentials_generator"
 

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -99,6 +99,7 @@ task default: :test
       opts[:skip_listen] = true
       opts[:skip_git] = true
       opts[:skip_turbolinks] = true
+      opts[:dummy_app] = true
 
       invoke Rails::Generators::AppGenerator,
         [ File.expand_path(dummy_path, destination_root) ], opts

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -475,6 +475,8 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_no_file "test/dummy/Gemfile"
     assert_no_file "test/dummy/public/robots.txt"
     assert_no_file "test/dummy/README.md"
+    assert_no_file "test/dummy/config/master.key"
+    assert_no_file "test/dummy/config/credentials.yml.enc"
     assert_no_directory "test/dummy/lib/tasks"
     assert_no_directory "test/dummy/test"
     assert_no_directory "test/dummy/vendor"


### PR DESCRIPTION
Because dummy application is only for use test, so credentials is unnecessary.

r? @kaspth 