### PR TITLE
`rails routes --all` will also show hidden internal routes

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -61,9 +61,9 @@ module ActionDispatch
         @routes = routes
       end
 
-      def format(formatter, filter = nil)
+      def format(formatter, filter: nil, show_internal: false)
         routes_to_display = filter_routes(normalize_filter(filter))
-        routes = collect_routes(routes_to_display)
+        routes = collect_routes(routes_to_display, show_internal)
         if routes.none?
           formatter.no_routes(collect_routes(@routes))
           return formatter.result
@@ -101,10 +101,14 @@ module ActionDispatch
           end
         end
 
-        def collect_routes(routes)
-          routes.collect do |route|
+        def collect_routes(routes, show_internal = false)
+          routes = routes.collect do |route|
             RouteWrapper.new(route)
-          end.reject(&:internal?).collect do |route|
+          end
+
+          routes.reject!(&:internal?) unless show_internal
+
+          routes.collect do |route|
             collect_engine_routes(route)
 
             { name: route.name,

--- a/railties/lib/rails/tasks/routes.rake
+++ b/railties/lib/rails/tasks/routes.rake
@@ -2,13 +2,14 @@
 
 require "optparse"
 
-desc "Print out all defined routes in match order, with names. Target specific controller with -c option, or grep routes using -g option"
+desc "Print out all defined routes in match order, with names. Target specific controller with -c option, or grep routes using -g option. Show internal routes with -a option."
 task routes: :environment do
   all_routes = Rails.application.routes.routes
   require "action_dispatch/routing/inspector"
   inspector = ActionDispatch::Routing::RoutesInspector.new(all_routes)
 
   routes_filter = nil
+  show_internal = false
 
   OptionParser.new do |opts|
     opts.banner = "Usage: rails routes [options]"
@@ -23,9 +24,17 @@ task routes: :environment do
       routes_filter = pattern
     end
 
+    opts.on("-a", "--all", "Show all routes including internal") do
+      show_internal = true
+    end
+
   end.parse!(ARGV.reject { |x| x == "routes" })
 
-  puts inspector.format(ActionDispatch::Routing::ConsoleFormatter.new, routes_filter)
+  puts inspector.format(
+    ActionDispatch::Routing::ConsoleFormatter.new,
+    filter: routes_filter,
+    show_internal: show_internal
+  )
 
   exit 0 # ensure extra arguments aren't interpreted as Rake tasks
 end


### PR DESCRIPTION
### Summary

`rails routes --all` new switch that will show all the routes including hidden internal ones. Like asset routes, mailer previews and the reason I needed it: active storage. Also I learned that `rails/info` is a thing. Who knew.

### Other Information

There's an issue with ActiveStorage appending routes instead of prepending. I could not see for sure until this change. I'll work on the fix for ActiveStorage next.
