### PR TITLE
Make automatically synchronize test schema work inside engine

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -581,7 +581,8 @@ module ActiveRecord
       def load_schema_if_pending!
         if ActiveRecord::Migrator.needs_migration? || !ActiveRecord::Migrator.any_migrations?
           # Roundtrip to Rake to allow plugins to hook into database initialization.
-          FileUtils.cd Rails.root do
+          root = defined?(ENGINE_ROOT) ? ENGINE_ROOT : Rails.root
+          FileUtils.cd(root) do
             current_config = Base.connection_config
             Base.clear_all_connections!
             system("bin/rails db:test:prepare")

--- a/railties/lib/rails/tasks/engine.rake
+++ b/railties/lib/rails/tasks/engine.rake
@@ -70,6 +70,9 @@ namespace :db do
 
   desc "Retrieves the current schema version number"
   app_task "version"
+
+  # desc 'Load the test schema'
+  app_task "test:prepare"
 end
 
 def find_engine_path(path)

--- a/railties/test/engine/test_test.rb
+++ b/railties/test/engine/test_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class Rails::Engine::TestTest < ActiveSupport::TestCase
+  setup do
+    @destination_root = Dir.mktmpdir("bukkits")
+    Dir.chdir(@destination_root) { `bundle exec rails plugin new bukkits --mountable` }
+  end
+
+  teardown do
+    FileUtils.rm_rf(@destination_root)
+  end
+
+  test "automatically synchronize test schema" do
+    Dir.chdir(plugin_path) do
+      # In order to confirm that migration files are loaded, generate multiple migration files.
+      `bin/rails generate model user name:string;
+       bin/rails generate model todo name:string;
+       RAILS_ENV=development bin/rails db:migrate`
+
+      output = `bin/rails test test/models/bukkits/user_test.rb`
+      assert_includes(output, "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips")
+    end
+  end
+
+  private
+    def plugin_path
+      "#{@destination_root}/bukkits"
+    end
+end


### PR DESCRIPTION
In Rails engine, migration files are in under `db/migrate` of engine.
Therefore, when rake task is executed in engine, `db/migrate` is automatically added to `DatabaseTasks.migrations_paths`.
https://github.com/rails/rails/blob/a18cf23a9cbcbeed61e8049442640c7153e0a8fb/activerecord/lib/active_record/railtie.rb#L39..L43

However, if execute the rake task under dummy app, migration files will not be loaded because engine's migration path setting process is not called.

Therefore, in order to load migration files correctly, it is necessary to execute rake task under engine.

Fixes #30765
