### PR TITLE
WIP: Raises ArgumentError when picked candidate from compute_type in Activ…

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -378,6 +378,15 @@ module ActiveRecord
       # instead. This allows plugins to hook into association object creation.
       def klass
         @klass ||= compute_class(class_name)
+
+        unless @klass.respond_to?(:table_name)
+          raise ArgumentError, <<-MSG.squish
+            Rails could not find a valid model for #{class_name} association.
+            Please provide the :class_name option on the association declaration
+          MSG
+        end
+
+        @klass
       end
 
       def compute_class(name)


### PR DESCRIPTION
### Summary

When candidate picked in `compute_type` from `ActiveRecord::Inheritance` is not a valid ActiveRecord model we should raise an Argument Error asking to specify the `class_name` option.

Closes https://github.com/rails/rails/issues/15811