### PR TITLE
Fix issue #30658 by checking explicitly for 'null' referrer

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -414,11 +414,21 @@ module ActionController #:nodoc:
         allow_forgery_protection
       end
 
+      NULL_ORIGIN_MESSAGE = <<-MSG.strip_heredoc
+        The browser returned a 'null' origin for a request with origin-based forgery protection turned on. This usually
+        means you have the 'no-referrer' Referrer-Policy header enabled, or that you the request came from a site that
+        refused to give its origin. This makes it impossible for Rails to verify the source of the requests. Likely the
+        best solution is to change your referrer policy to something less strict like same-origin or strict-same-origin.
+        If you cannot change the referrer policy, you can disable origin checking with the
+        Rails.application.config.action_controller.forgery_protection_origin_check setting.
+      MSG
+
       # Checks if the request originated from the same origin by looking at the
       # Origin header.
       def valid_request_origin? # :doc:
         if forgery_protection_origin_check
           # We accept blank origin headers because some user agents don't send it.
+          raise InvalidAuthenticityToken, NULL_ORIGIN_MESSAGE if request.origin == "null"
           request.origin.nil? || request.origin == request.base_url
         else
           true

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -446,6 +446,19 @@ module RequestForgeryProtectionTests
     end
   end
 
+  def test_should_raise_for_post_with_null_origin
+    forgery_protection_origin_check do
+      session[:_csrf_token] = @token
+      @controller.stub :form_authenticity_token, @token do
+        exception = assert_raises(ActionController::InvalidAuthenticityToken) do
+          @request.set_header "HTTP_ORIGIN", "null"
+          post :index, params: { custom_authenticity_token: @token }
+        end
+        assert_match "The browser returned a 'null' origin for a request", exception.message
+      end
+    end
+  end
+
   def test_should_block_post_with_origin_checking_and_wrong_origin
     old_logger = ActionController::Base.logger
     logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new


### PR DESCRIPTION
### Summary

Currently, when a POST request with request forgery checking enabled occurs, Rails checks the 
`request.origin` to see if it is either `nil` (not sent) or equal to the expected origin. As mentioned in 
issue #30658, Chrome has begun serving a referrer of `null` when `no-referrer` is specified in the
referrer policy header. Because of this, all authenticity-checking POST requests originating on a 
page with `no-referrer` enabled will fail. This PR adds code that checks for the explicit string "null"
in the referrer and allows it through.
