### PR TITLE
rails-ujs: Update README

### DIFF
--- a/actionview/app/assets/javascripts/README.md
+++ b/actionview/app/assets/javascripts/README.md
@@ -1,5 +1,4 @@
-Ruby on Rails unobtrusive scripting adapter.
-========================================
+# Ruby on Rails unobtrusive scripting adapter
 
 This unobtrusive scripting support file is developed for the Ruby on Rails framework, but is not strictly tied to any specific backend. You can drop this into any application to:
 
@@ -8,51 +7,47 @@ This unobtrusive scripting support file is developed for the Ruby on Rails frame
 - make forms or hyperlinks submit data asynchronously with Ajax;
 - have submit buttons become automatically disabled on form submit to prevent double-clicking.
 
-These features are achieved by adding certain ["data" attributes][data] to your HTML markup. In Rails, they are added by the framework's template helpers.
+These features are achieved by adding certain [`data` attributes][data] to your HTML markup. In Rails, they are added by the framework's template helpers.
 
-Requirements
-------------
+## Optional prerequisites
 
-- HTML5 doctype (optional).
+Note that the `data` attributes this library adds are a feature of HTML5. If you're not targeting HTML5, these attributes may make your HTML to fail [validation][validator]. However, this shouldn't create any issues for web browsers or other user agents.
 
-If you don't use HTML5, adding "data" attributes to your HTML4 or XHTML pages might make them fail [W3C markup validation][validator]. However, this shouldn't create any issues for web browsers or other user agents.
+## Installation
 
-Installation using npm
-------------
+### NPM
 
-Run `npm install rails-ujs --save` to install the rails-ujs package.
+    npm install rails-ujs --save
+    
+### Yarn
+    
+    yarn add rails-ujs
 
-Installation using Yarn
-------------
+## Usage
 
-Run `yarn add rails-ujs` to install the rails-ujs package.
+### Asset pipeline
 
-Usage
-------------
-
-Require `rails-ujs` in your application.js manifest.
+In a conventional Rails application that uses the asset pipeline, require `rails-ujs` in your `application.js` manifest:
 
 ```javascript
 //= require rails-ujs
 ```
 
-Usage with yarn
-------------
+### ES2015+
 
-When using with the Webpacker gem or your preferred JavaScript bundler, just
-add the following to your main JS file and compile.
+If you're using the Webpacker gem or some other JavaScript bundler, add the following to your main JS file:
 
 ```javascript
 import Rails from 'rails-ujs';
 Rails.start()
 ```
 
-How to run tests
-------------
+## How to run tests
 
 Run `bundle exec rake ujs:server` first, and then run the web tests by visiting http://localhost:4567 in your browser.
 
 ## License
+
 rails-ujs is released under the [MIT License](MIT-LICENSE).
 
 [data]: http://www.w3.org/TR/html5/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes "Embedding custom non-visible data with the data-* attributes"


### PR DESCRIPTION
Make various wording tweaks to cater to users who are viewing the README
on NPM. Notably, don't highlight Yarn specifically in the installation
instructions -- even though this is the preferred tool of choice
especially in the Ruby community, some people still use NPM (and,
really, ES2015+ syntax has nothing to do with NPM or Yarn).
