### PR TITLE
Cache regexps generated from acronym_regex

### DIFF
--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -763,7 +763,7 @@ class RequestMethod < BaseRequestTest
 
   test "post uneffected by local inflections" do
     existing_acronyms = ActiveSupport::Inflector.inflections.acronyms.dup
-    existing_acronym_regex = ActiveSupport::Inflector.inflections.acronym_regex.dup
+    assert_deprecated { ActiveSupport::Inflector.inflections.acronym_regex.dup }
     begin
       ActiveSupport::Inflector.inflections do |inflect|
         inflect.acronym "POS"

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -777,7 +777,7 @@ class RequestMethod < BaseRequestTest
       # Reset original acronym set
       ActiveSupport::Inflector.inflections do |inflect|
         inflect.send(:instance_variable_set, "@acronyms", existing_acronyms)
-        inflect.send(:instance_variable_set, "@acronym_regex", existing_acronym_regex)
+        inflect.send(:define_acronym_regex_patterns)
       end
     end
   end

--- a/activesupport/lib/active_support/deprecation/constant_accessor.rb
+++ b/activesupport/lib/active_support/deprecation/constant_accessor.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/inflector/methods"
-
 module ActiveSupport
   class Deprecation
     # DeprecatedConstantAccessor transforms a constant into a deprecated one by
@@ -29,6 +27,8 @@ module ActiveSupport
     #        ["Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune"]
     module DeprecatedConstantAccessor
       def self.included(base)
+        require "active_support/inflector/methods"
+
         extension = Module.new do
           def const_missing(missing_const_name)
             if class_variable_defined?(:@@_deprecated_constants)

--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/inflector/methods"
 require "active_support/core_ext/regexp"
 
 module ActiveSupport
@@ -125,6 +124,8 @@ module ActiveSupport
     #        ["Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune"]
     class DeprecatedConstantProxy < DeprecationProxy
       def initialize(old_const, new_const, deprecator = ActiveSupport::Deprecation.instance, message: "#{old_const} is deprecated! Use #{new_const} instead.")
+        require "active_support/inflector/methods"
+
         @old_const = old_const
         @new_const = new_const
         @deprecator = deprecator

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -66,17 +66,21 @@ module ActiveSupport
         @__instance__[locale] ||= new
       end
 
-      attr_reader :plurals, :singulars, :uncountables, :humans, :acronyms, :acronym_regex
+      attr_reader :plurals, :singulars, :uncountables, :humans,
+                  :acronyms, :acronym_regex
+      attr_reader :acronyms_camelize_regex, :acronyms_underscore_regex # :nodoc:
 
       def initialize
-        @plurals, @singulars, @uncountables, @humans, @acronyms, @acronym_regex = [], [], Uncountables.new, [], {}, /(?=a)b/
+        @plurals, @singulars, @uncountables, @humans, @acronyms = [], [], Uncountables.new, [], {}
+        define_acronym_regex_patterns
       end
 
       # Private, for the test suite.
       def initialize_dup(orig) # :nodoc:
-        %w(plurals singulars uncountables humans acronyms acronym_regex).each do |scope|
+        %w(plurals singulars uncountables humans acronyms).each do |scope|
           instance_variable_set("@#{scope}", orig.send(scope).dup)
         end
+        define_acronym_regex_patterns
       end
 
       # Specifies a new acronym. An acronym must be specified as it will appear
@@ -130,7 +134,7 @@ module ActiveSupport
       #   camelize 'mcdonald'   # => 'McDonald'
       def acronym(word)
         @acronyms[word.downcase] = word
-        @acronym_regex = /#{@acronyms.values.join("|")}/
+        define_acronym_regex_patterns
       end
 
       # Specifies a new pluralization rule and its replacement. The rule can
@@ -225,6 +229,14 @@ module ActiveSupport
           instance_variable_set "@#{scope}", []
         end
       end
+
+      private
+
+        def define_acronym_regex_patterns
+          @acronym_regex             = @acronyms.empty? ? /(?=a)b/ : /#{@acronyms.values.join("|")}/
+          @acronyms_camelize_regex   = /^(?:#{@acronym_regex}(?=\b|[A-Z_])|\w)/
+          @acronyms_underscore_regex = /(?:(?<=([A-Za-z\d]))|\b)(#{@acronym_regex})(?=\b|[^a-z])/
+        end
     end
 
     # Yields a singleton instance of Inflector::Inflections so you can specify

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -4,6 +4,7 @@ require "concurrent/map"
 require "active_support/core_ext/array/prepend_and_append"
 require "active_support/core_ext/regexp"
 require "active_support/i18n"
+require "active_support/deprecation"
 
 module ActiveSupport
   module Inflector
@@ -66,8 +67,9 @@ module ActiveSupport
         @__instance__[locale] ||= new
       end
 
-      attr_reader :plurals, :singulars, :uncountables, :humans,
-                  :acronyms, :acronym_regex
+      attr_reader :plurals, :singulars, :uncountables, :humans, :acronyms, :acronym_regex
+      deprecate :acronym_regex
+
       attr_reader :acronyms_camelize_regex, :acronyms_underscore_regex # :nodoc:
 
       def initialize

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -71,7 +71,7 @@ module ActiveSupport
       if uppercase_first_letter
         string = string.sub(/^[a-z\d]*/) { |match| inflections.acronyms[match] || match.capitalize }
       else
-        string = string.sub(/^(?:#{inflections.acronym_regex}(?=\b|[A-Z_])|\w)/) { |match| match.downcase }
+        string = string.sub(inflections.acronyms_camelize_regex) { |match| match.downcase }
       end
       string.gsub!(/(?:_|(\/))([a-z\d]*)/i) { "#{$1}#{inflections.acronyms[$2] || $2.capitalize}" }
       string.gsub!("/".freeze, "::".freeze)
@@ -92,7 +92,7 @@ module ActiveSupport
     def underscore(camel_cased_word)
       return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
       word = camel_cased_word.to_s.gsub("::".freeze, "/".freeze)
-      word.gsub!(/(?:(?<=([A-Za-z\d]))|\b)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1 && '_'.freeze }#{$2.downcase}" }
+      word.gsub!(inflections.acronyms_underscore_regex) { "#{$1 && '_'.freeze }#{$2.downcase}" }
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2'.freeze)
       word.gsub!(/([a-z\d])([A-Z])/, '\1_\2'.freeze)
       word.tr!("-".freeze, "_".freeze)

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -224,6 +224,12 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal("json_html_api", ActiveSupport::Inflector.underscore("JSONHTMLAPI"))
   end
 
+  def test_acronym_regexp_is_deprecated
+    assert_deprecated do
+      ActiveSupport::Inflector.inflections.acronym_regex
+    end
+  end
+
   def test_underscore
     CamelToUnderscore.each do |camel, underscore|
       assert_equal(underscore, ActiveSupport::Inflector.underscore(camel))


### PR DESCRIPTION
Summary
-------

The following line from `String#camelize`:

```ruby
string = string.sub(/^(?:#{inflections.acronym_regex}(?=\b|[A-Z_])|\w)/) { |match| match.downcase }
```

and the following line from `String#camelize`:

```ruby
word.gsub!(/(?:(?<=([A-Za-z\d]))|\b)(#{inflections.acronym_regex})(?=\b|[^a-z])/) { "#{$1 && '_'.freeze }#{$2.downcase}" }#{$2.downcase}" }
```

Both generate the same regexep in the first part of the `.sub`/`.gsub` method calls every time the function is called, creating an extra object allocation each time.  The value of `acronym_regex` only changes if the user decides add an acronym to the current set of inflections and apends another string on the the regexp generated here, but beyond that it remains relatively static.

This has been around since acronym support was introduced back in 2011 in https://github.com/rails/rails/pull/1648.

To avoid re-generating these strings every time these methods are called, cache the values of these regular expressions in the `ActiveSupport::Inflector::Inflections` instance, making it so these regular expressions are only generated once, or when the acronym's are added to.


Other Information
-----------------

Benchmarks against this code, and the most recently released version of `activesupport` can be run using this gist:

https://gist.github.com/NickLaMuro/a91406e512a59c5b676f110ce968680b

When running it using the following for the current version of `ActiveSupport`, and the changes after this patch, there were 20% less object allocations, and the script ran 20% - 30% faster.  Sample output can be found below:


**Before:**

```console
$ ruby test_acronym_fixes.rb --install-gems --silent-bundler
Total allocated: 59551503 bytes (510009 objects)
Total retained:  320 bytes (2 objects)

allocated memory by gem
-----------------------------------
  44970885  activesupport-5.1.4
  14580618  other

allocated memory by file
-----------------------------------
  41770716  /Users/nicklamuro/.gem/ruby/2.3.5/gems/activesupport-5.1.4/lib/active_support/inflector/methods.rb
  14580618  test_acronym_fixes.rb
   3200169  /Users/nicklamuro/.gem/ruby/2.3.5/gems/activesupport-5.1.4/lib/active_support/core_ext/regexp.rb

allocated memory by location
-----------------------------------
  19500040  /Users/nicklamuro/.gem/ruby/2.3.5/gems/activesupport-5.1.4/lib/active_support/inflector/methods.rb:93
   9780169  /Users/nicklamuro/.gem/ruby/2.3.5/gems/activesupport-5.1.4/lib/active_support/inflector/methods.rb:95
   8090169  test_acronym_fixes.rb:84
   7690169  /Users/nicklamuro/.gem/ruby/2.3.5/gems/activesupport-5.1.4/lib/active_support/inflector/methods.rb:74


Timings
-------
real    0m5.346s
user    0m5.210s
sys     0m0.130s
cuser   0m0.000s
csys    0m0.000s

Memory used MB: 429.05859375
```


**After:**

```console
$ ruby test_acronym_fixes.rb --install-gems --silent-bundler --local
Total allocated: 40051632 bytes (420009 objects)
Total retained:  320 bytes (2 objects)

allocated memory by gem
-----------------------------------
  25471014  activesupport/lib
  14580618  other

allocated memory by file
-----------------------------------
  22270845  /Users/nicklamuro/code/public_forks/rails-dev-box/rails/activesupport/lib/active_support/inflector/methods.rb
  14580618  test_acronym_fixes.rb
   3200169  /Users/nicklamuro/code/public_forks/rails-dev-box/rails/activesupport/lib/active_support/core_ext/regexp.rb

allocated memory by location
-----------------------------------
   9780169  /Users/nicklamuro/code/public_forks/rails-dev-box/rails/activesupport/lib/active_support/inflector/methods.rb:99
   8090169  test_acronym_fixes.rb:84
   7690169  /Users/nicklamuro/code/public_forks/rails-dev-box/rails/activesupport/lib/active_support/inflector/methods.rb:77
   6490449  test_acronym_fixes.rb:83


Timings
-------
real    0m4.309s
user    0m4.210s
sys     0m0.090s
cuser   0m0.000s
csys    0m0.000s

Memory used MB: 364.76953125
```