### PR TITLE
Allow for partial durations via `/` operator

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Restores functionality to `Duration` to allow for partial times
+
+    Previously in Rails 5.0.2 dividing a duration would return a partial duration
+    such as `Time.now.ago(1.days / 2)` returning half a day ago. Starting in
+    Rails 5.1.0, this functionality was lost, but now the functionality is back.
+    Fixes #30546.
+
+    *Kevin M. Hall*
+
 *   Deprecate `secrets.secret_token`.
 
     The architecture for secrets had a big upgrade between Rails 3 and Rails 4,

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -266,11 +266,11 @@ module ActiveSupport
     # Divides this Duration by a Numeric and returns a new Duration.
     def /(other)
       if Scalar === other
-        Duration.new(value / other.value, parts.map { |type, number| [type, number / other.value] })
+        Duration.new(value / other.value, parts.map { |type, number| [type, number / other.value.to_f] })
       elsif Duration === other
         value / other.value
       elsif Numeric === other
-        Duration.new(value / other, parts.map { |type, number| [type, number / other] })
+        Duration.new(value / other, parts.map { |type, number| [type, number / other.to_f] })
       else
         raise_type_error(other)
       end

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -73,6 +73,16 @@ class NumericExtTimeAndDateTimeTest < ActiveSupport::TestCase
     assert_equal Time.utc(2005, 2, 28, 15, 15, 10), Time.utc(2004, 2, 29, 15, 15, 10) + 1.year
     assert_equal DateTime.civil(2005, 2, 28, 15, 15, 10), DateTime.civil(2004, 2, 29, 15, 15, 10) + 1.year
   end
+
+  def test_partial_days
+    assert_equal @now - 0.5.days, @now.ago(1.day / 2)
+    assert_equal @now - 8.hours, @now.ago(1.day / 3)
+    assert_equal @now - 0.25.days, @now.ago(1.day / 4)
+    assert_equal @now - 4.hours, @now.ago(1.day / 6)
+    assert_equal @now - 1.hour, @now.ago(1.day / 24)
+    assert_equal @now - 0.5.days, @now.ago(2.days / 4)
+    assert_equal @now - 0.5.days, @now.ago(1.day / ActiveSupport::Duration::Scalar.new(2))
+  end
 end
 
 class NumericExtDateTest < ActiveSupport::TestCase


### PR DESCRIPTION
### Summary

Previously durations could be divided and would return partial durations,
but in Rails 5.1 dividing a duration such as

    1.day / 2

would return a duration of 0 instead of 0.5 days. This change restores
that functionality by forcing the divisor to a float, which allows for
the partial duration to be returned. Also updated Duration::Scalar to
behave the same way. Fixes #30546.

### Other Information

I wasn't sure if I should do the same `.to_f` change for the Duration `elsif` block. I've never done `1.day / 2.hours` or anything similar, so not sure about that particular test case.