### PR TITLE
Add test case for `font_url`

### DIFF
--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -305,6 +305,24 @@ class AssetTagHelperTest < ActionView::TestCase
     %(font_path("font.ttf?123")) => %(/fonts/font.ttf?123)
   }
 
+  FontUrlToTag = {
+    %(font_url("font.eot")) => %(http://www.example.com/fonts/font.eot),
+    %(font_url("font.eot#iefix")) => %(http://www.example.com/fonts/font.eot#iefix),
+    %(font_url("font.woff")) => %(http://www.example.com/fonts/font.woff),
+    %(font_url("font.ttf")) => %(http://www.example.com/fonts/font.ttf),
+    %(font_url("font.ttf?123")) => %(http://www.example.com/fonts/font.ttf?123),
+    %(font_url("font.ttf", host: "http://assets.example.com")) => %(http://assets.example.com/fonts/font.ttf)
+  }
+
+  UrlToFontToTag = {
+    %(url_to_font("font.eot")) => %(http://www.example.com/fonts/font.eot),
+    %(url_to_font("font.eot#iefix")) => %(http://www.example.com/fonts/font.eot#iefix),
+    %(url_to_font("font.woff")) => %(http://www.example.com/fonts/font.woff),
+    %(url_to_font("font.ttf")) => %(http://www.example.com/fonts/font.ttf),
+    %(url_to_font("font.ttf?123")) => %(http://www.example.com/fonts/font.ttf?123),
+    %(url_to_font("font.ttf", host: "http://assets.example.com")) => %(http://assets.example.com/fonts/font.ttf)
+  }
+
   def test_autodiscovery_link_tag_with_unknown_type_but_not_pass_type_option_key
     assert_raise(ArgumentError) do
       auto_discovery_link_tag(:xml)
@@ -545,6 +563,14 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_font_path
     FontPathToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_font_url
+    FontUrlToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_url_to_font_alias_for_font_url
+    UrlToFontToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
 
   def test_video_audio_tag_does_not_modify_options


### PR DESCRIPTION
Since test of `font_url` was not in Action View's test suite, so it added.