### PR TITLE
Nested where query for customized-name associations

### DIFF
--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -46,7 +46,7 @@ module ActiveRecord
     end
 
     def associated_table(table_name)
-      association = klass._reflect_on_association(table_name) || klass._reflect_on_association(table_name.to_s.singularize)
+      association = table_to_assoc(table_name)
 
       if !association && table_name == arel_table.name
         return self
@@ -60,6 +60,18 @@ module ActiveRecord
       end
 
       TableMetadata.new(association_klass, arel_table, association)
+    end
+
+    def table_to_assoc(table_name)
+      klass._reflect_on_association(table_name) ||
+          klass._reflect_on_association(table_name.to_s.singularize) ||
+          klass.reflect_on_all_associations.detect do |assoc|
+            begin
+              assoc.table_name == table_name
+            rescue NameError
+              false
+            end
+          end
     end
 
     def polymorphic_association?

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -14,6 +14,9 @@ require "models/price_estimate"
 require "models/topic"
 require "models/treasure"
 require "models/vertex"
+require "models/guitar"
+require "models/person"
+require "models/company"
 
 module ActiveRecord
   class WhereTest < ActiveRecord::TestCase
@@ -86,6 +89,26 @@ module ActiveRecord
 
       expected = Post.where(comments: { parent_id: 1 }).joins(:comments)
       actual   = Post.where(comments: { parent: parent }).joins(:comments)
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+    def test_named_belongs_to_nested_where
+      number1_fan = Person.new
+      number1_fan.id = 1
+
+      expected = Guitar.where(people: { number1_fan_id: number1_fan.id }).joins(:player)
+      actual   = Guitar.where(people: { number1_fan: number1_fan }).joins(:player)
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
+
+    def test_named_has_many_nested_where
+      manufacturer = Company.new
+      manufacturer.id = 2
+
+      expected = Person.where(guitars: { company_id: manufacturer.id }).joins(:fancy_guitars)
+      actual = Person.where(guitars: { manufacturer: manufacturer }).joins(:fancy_guitars)
 
       assert_equal expected.to_sql, actual.to_sql
     end

--- a/activerecord/test/models/guitar.rb
+++ b/activerecord/test/models/guitar.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Guitar < ActiveRecord::Base
+  belongs_to :manufacturer, class_name: "Company", foreign_key: "company_id"
+  belongs_to :player, class_name: "Person", foreign_key: "person_id"
   has_many :tuning_pegs, index_errors: true
   accepts_nested_attributes_for :tuning_pegs
 end

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -38,6 +38,8 @@ class Person < ActiveRecord::Base
   has_many :agents_posts_authors, through: :agents_posts, source: :author
   has_many :essays, primary_key: "first_name", foreign_key: "writer_id"
 
+  has_many :fancy_guitars, class_name: "Guitar"
+
   scope :males,   -> { where(gender: "M") }
 end
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -369,6 +369,8 @@ ActiveRecord::Schema.define do
   end
 
   create_table :guitars, force: true do |t|
+    t.integer :company_id
+    t.integer :person_id
     t.string :color
   end
 


### PR DESCRIPTION
### Summary

There was a situation where we expected something like this would work.
(I changed the model names so it will fit the code change I have made.)

```ruby
# Models
class Guitar < AR
  belongs_to :manufacturer, class_name: "Company", foreign_key: "company_id"
  belongs_to :player, class_name: "Person", foreign_key: "person_id"
end

class Person < AR
  has_many :fancy_guitars, class_name: "Guitar"
end

class Company < AR
  has_many :guitars
end

# Query
manufacturer = Company.last
Person.where(guitars: { manufacturer: manufacturer }).joins(:fancy_guitars)
```

But the query does not work as below
```ruby
Person.where(guitars: { manufacturer: manufacturer }).joins(:fancy_guitars).to_sql
# expected
# => "SELECT \"people\".* FROM \"people\" INNER JOIN \"guitars\" ON \"guitars\".\"person_id\" = \"people\".\"id\" WHERE \"guitars\".\"company_id\" = 2"
# actual
# => "SELECT \"people\".* FROM \"people\" INNER JOIN \"guitars\" ON \"guitars\".\"person_id\" = \"people\".\"id\" WHERE \"guitars\".\"manufacturer\" = 2"
```

This happens when the association has customized name (`has_many :fancy_guitars, class_name: "Guitar"` instead of `has_many :guitars`)

I looked into it and it is because we pass table name to `klass._reflect_on_association`, where ideally we should pass association name instead here.
https://github.com/rails/rails/blob/e0d2207ab321145c117c6d615ce209c6f873605d/activerecord/lib/active_record/table_metadata.rb#L49

This PR will improve the situation above by adding additional effort to get correct association object.

### Other Information
This will work with `has_one` instead of `has_many` , too.
This will work with `includes` instead of `joins`, too.

(If we could use association name (`fancy_guitars` instead of `guitars` in the case above) for where method, we would be able to use it, but I saw the decision made not to go with association name for where method.)



