### PR TITLE
Fixes ActiveSupport::Cache::FileStore#cleanup bug which prevented it from removing expired entries

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -39,9 +39,8 @@ module ActiveSupport
       def cleanup(options = nil)
         options = merged_options(options)
         search_dir(cache_path) do |fname|
-          key = file_path_key(fname)
-          entry = read_entry(key, options)
-          delete_entry(key, options) if entry && entry.expired?
+          entry = read_entry(fname, options)
+          delete_entry(fname, options) if entry && entry.expired?
         end
       end
 

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -118,6 +118,7 @@ class FileStoreTest < ActiveSupport::TestCase
       assert_not @cache.exist?("foo")
       assert @cache.exist?("baz")
       assert @cache.exist?("quux")
+      assert_equal 2, Dir.glob(File.join(cache_dir, "**")).size
     end
   end
 


### PR DESCRIPTION
### Summary

`ActiveSupport::Cache::FileStore#cleanup` implementation was silently failing to remove expired entries from the cache storage directory. This was due to the implementation itself failing to read the entry properly during the `cleanup` call:

```ruby
def cleanup(options = nil)
  options = merged_options(options)
  search_dir(cache_path) do |fname|
    key = file_path_key(fname)
    entry = read_entry(key, options)
    delete_entry(key, options) if entry && entry.expired?
  end
end
```

The `read_entry` method here should receive the actual `fname` instead of `key` to retrieve this entry, otherwise it will just return `nil` and never calls `delete_entry`.

This was already reported [here](https://github.com/rails/rails/issues/30788).
