### PR TITLE
Fix third-party system libraries list in ActiveStorage::Preview [ci skip]

### DIFF
--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -23,8 +23,8 @@
 #
 # The built-in previewers rely on third-party system libraries:
 #
-#   * {ffmpeg}[https://www.ffmpeg.org]
-#   * {mupdf}[https://mupdf.com]
+# * {ffmpeg}[https://www.ffmpeg.org]
+# * {mupdf}[https://mupdf.com]
 #
 # These libraries are not provided by Rails. You must install them yourself to use the built-in previewers. Before you
 # install and use third-party software, make sure you understand the licensing implications of doing so.


### PR DESCRIPTION
### Summary

I removed needless indentation in the document of [ActiveStorage::Preview](http://edgeapi.rubyonrails.org/files/activestorage/app/models/active_storage/preview_rb.html).

#### Before

it seems that there are interpreted as code :(

![image](https://user-images.githubusercontent.com/15371677/31142451-4d03e60e-a8b5-11e7-8d8a-4cbda24cfcb2.png)

#### After

There are interpreted as the list :)

![image](https://user-images.githubusercontent.com/15371677/31142466-582a2372-a8b5-11e7-8cbe-3270ef07038c.png)