### PR TITLE
Remove #to_hash deprecation message when params are permitted:

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -289,7 +289,7 @@ module ActionController
     #   safe_params = params.permit(:name)
     #   safe_params.to_hash # => {"name"=>"Senjougahara Hitagi"}
     def to_hash
-      if self.class.raise_on_unfiltered_parameters
+      if self.class.raise_on_unfiltered_parameters || permitted?
         to_h.to_hash
       else
         message = <<-DEPRECATE.squish

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -366,6 +366,12 @@ class ParametersPermitTest < ActiveSupport::TestCase
     end
   end
 
+  test "#to_hash when params are permitted" do
+    assert_not_deprecated do
+      assert_equal({ "person" => { "age" => "32" } }, @params.permit(person: [:age]).to_hash)
+    end
+  end
+
   test "to_hash raises UnfilteredParameters on unfiltered params if raise_on_unfiltered_parameters is true" do
     begin
       old_value = ActionController::Parameters.raise_on_unfiltered_parameters
@@ -382,12 +388,8 @@ class ParametersPermitTest < ActiveSupport::TestCase
   test "to_hash returns converted hash on permitted params" do
     @params.permit!
 
-    assert_deprecated do
-      assert_instance_of Hash, @params.to_hash
-    end
-    assert_deprecated do
-      assert_not_kind_of ActionController::Parameters, @params.to_hash
-    end
+    assert_instance_of Hash, @params.to_hash
+    assert_not_kind_of ActionController::Parameters, @params.to_hash
   end
 
   test "to_hash returns converted hash when .permit_all_parameters is set" do
@@ -395,15 +397,9 @@ class ParametersPermitTest < ActiveSupport::TestCase
       ActionController::Parameters.permit_all_parameters = true
       params = ActionController::Parameters.new(crab: "Senjougahara Hitagi")
 
-      assert_deprecated do
-        assert_instance_of Hash, params.to_hash
-      end
-      assert_deprecated do
-        assert_not_kind_of ActionController::Parameters, params.to_hash
-      end
-      assert_deprecated do
-        assert_equal({ "crab" => "Senjougahara Hitagi" }, params.to_hash)
-      end
+      assert_instance_of Hash, params.to_hash
+      assert_not_kind_of ActionController::Parameters, params.to_hash
+      assert_equal({ "crab" => "Senjougahara Hitagi" }, params.to_hash)
     ensure
       ActionController::Parameters.permit_all_parameters = false
     end


### PR DESCRIPTION
Hello rails team 👋 

Remove #to_hash deprecation message when params are permitted:

- `#to_hash` deprecation makes things a bit tricky for a developer to find out what in their app they need to modify in order to safely turn on the `raise_on_unfiltered_parameters` flag in production. The message is the same whether the params are permitted or not
- Removed the deprecation message when `#to_hash` gets called on a permitted params

cc/ @dylanahsmith @rafaelfranca 