### PR TITLE
Fix formatting of `Time.use_zone` [ci skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -55,10 +55,10 @@ class Time
     #     end
     #   end
     #
-    #  NOTE: This won't affect any <tt>ActiveSupport::TimeWithZone</tt>
-    #  objects that have already been created, e.g. any model timestamp
-    #  attributes that have been read before the block will remain in
-    #  the application's default timezone.
+    # NOTE: This won't affect any <tt>ActiveSupport::TimeWithZone</tt>
+    # objects that have already been created, e.g. any model timestamp
+    # attributes that have been read before the block will remain in
+    # the application's default timezone.
     def use_zone(time_zone)
       new_zone = find_zone!(time_zone)
       begin


### PR DESCRIPTION
**before**

![before](https://user-images.githubusercontent.com/987638/31168686-29d1618a-a931-11e7-8891-53f89198ad29.png)


**after**

![after](https://user-images.githubusercontent.com/987638/31168690-2b5a8432-a931-11e7-97ae-e0ab2372182c.png)
