### PR TITLE
Retain positions of preloaded records on AR::Relation

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -668,13 +668,14 @@ module ActiveRecord
                 else
                   rows = connection.select_all(relation.arel, "SQL")
                   join_dependency.instantiate(rows, &block)
-                end.freeze
+                end
               end
             else
-              klass.find_by_sql(arel, &block).freeze
+              klass.find_by_sql(arel, &block)
             end
 
           retain_positionals if keep_preloaded_positions?
+          @records.freeze
 
           preload = preload_values
           preload += includes_values unless eager_loading?

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -674,6 +674,8 @@ module ActiveRecord
               klass.find_by_sql(arel, &block).freeze
             end
 
+          retain_positionals
+
           preload = preload_values
           preload += includes_values unless eager_loading?
           preloader = nil
@@ -696,6 +698,13 @@ module ActiveRecord
           end
         else
           yield
+        end
+      end
+
+      def retain_positionals
+        unless @offsets.empty?
+          unpositioned = @records.reject { |r| @offsets.values.include?(r) }.each
+          @records = @records.size.times.map { |i| @offsets[i] || unpositioned.next }
         end
       end
 

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -178,6 +178,20 @@ class NamedScopingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_to_a_should_retain_preloaded_positions
+    topics = Topic.order('random()')
+    second = topics.second
+    fourth = topics.fourth
+    assert_equal second, topics.to_a.second
+    assert_equal fourth, topics.to_a.fourth
+  end
+
+  def test_to_a_should_retain_first_position
+    topics = Topic.order('random()')
+    first = topics.first
+    assert_not_equal first, topics.to_a.last
+  end
+
   def test_empty_should_not_load_results
     topics = Topic.base
     assert_queries(2) do


### PR DESCRIPTION
ActiveRecord Relations load specific single record positions to answer `first`,
`second`, `last`, etc. These positions are currently overloaded on `to_a` which
loads all records.

This change re-orders the full result list on `to_a` to reflect any specific
positionals we have already loaded.

Full spec: https://gist.github.com/matthewd/041bb43bc131f09a133bb7c7fee1fd4b