### PR TITLE
Break long variant filenames into path chunks

### DIFF
--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -50,7 +50,7 @@ class ActiveStorage::Variant
 
   # Returns a combination key of the blob and the variation that together identifies a specific variant.
   def key
-    "variants/#{blob.key}/#{variation.key}"
+    "variants/#{blob.key}/#{Digest::SHA256.hexdigest(variation.key)}"
   end
 
   # Returns the URL of the variant on the service. This URL is intended to be short-lived for security and not used directly

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -26,4 +26,9 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     assert_equal 67, image.height
     assert_match(/Gray/, image.colorspace)
   end
+
+  test "service_url doesn't grow in length despite long variant options" do
+    variant = @blob.variant(font: "a" * 10_000).processed
+    assert_operator variant.service_url.length, :<, 500
+  end
 end


### PR DESCRIPTION
### Summary

If a variant has a large set of options associated with it, the generated filename will be too long, causing Errno::ENAMETOOLONG to be raised. This change adds intermediary paths that retain the uniqueness of the variant while not raising the aforementioned error until the overall 1024 path limit is exceeded. Fixes #30662.

### Other Information

Initially I was worried about needing to join the chunked paths in order to be able to decode the data back into the variant information. I'm no longer sure if that's a valid use-case. Any insight as to the validity of this belief would be useful. Also all this code basically came from @marcusg, the reporter.