### PR TITLE
Allow reuse of NumberConverter instances

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -117,21 +117,23 @@ module ActiveSupport
       }
 
       def self.convert(number, options)
-        new(number, options).execute
+        new(options).execute(number)
       end
 
-      def initialize(number, options)
-        @number = number
-        @opts   = options.symbolize_keys
+      def initialize(*args)
+        raise ArgumentError if args.size > 2
+
+        @opts = args.extract_options!.symbolize_keys
+        @number = args.shift
       end
 
-      def execute
+      def execute(number = self.number)
         if !number
           nil
-        elsif validate_float? && !valid_float?
+        elsif validate_float? && !valid_float?(number)
           number
         else
-          convert
+          convert(number)
         end
       end
 
@@ -174,7 +176,7 @@ module ActiveSupport
           key.split(".").reduce(DEFAULTS) { |defaults, k| defaults[k.to_sym] }
         end
 
-        def valid_float?
+        def valid_float?(number)
           Float(number)
         rescue ArgumentError, TypeError
           false

--- a/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
@@ -7,8 +7,8 @@ module ActiveSupport
     class NumberToCurrencyConverter < NumberConverter # :nodoc:
       self.namespace = :currency
 
-      def convert
-        number = self.number.to_s.strip
+      def convert(number = self.number)
+        number = number.to_s.strip
         format = options[:format]
 
         if number.to_f.negative?
@@ -16,11 +16,15 @@ module ActiveSupport
           number = absolute_value(number)
         end
 
-        rounded_number = NumberToRoundedConverter.convert(number, options)
+        rounded_number = number_to_rounded_converter.execute(number)
         format.gsub("%n".freeze, rounded_number).gsub("%u".freeze, options[:unit])
       end
 
       private
+
+        def number_to_rounded_converter
+          @number_to_rounded_converter ||= NumberToRoundedConverter.new(options)
+        end
 
         def absolute_value(number)
           number.respond_to?(:abs) ? number.abs : number.sub(/\A-/, "")

--- a/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
@@ -7,13 +7,13 @@ module ActiveSupport
 
       DEFAULT_DELIMITER_REGEX = /(\d)(?=(\d\d\d)+(?!\d))/
 
-      def convert
-        parts.join(options[:separator])
+      def convert(number = self.number)
+        parts(number).join(options[:separator])
       end
 
       private
 
-        def parts
+        def parts(number)
           left, right = number.to_s.split(".".freeze)
           left.gsub!(delimiter_pattern) do |digit_to_delimit|
             "#{digit_to_delimit}#{options[:delimiter]}"

--- a/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
@@ -8,46 +8,50 @@ module ActiveSupport
       self.namespace      = :human
       self.validate_float = true
 
-      def convert
-        @number = Float(number)
+      def convert(number = self.number)
+        number = Float(number)
 
         # for backwards compatibility with those that didn't add strip_insignificant_zeros to their locale files
         unless options.key?(:strip_insignificant_zeros)
           options[:strip_insignificant_zeros] = true
         end
 
-        if smaller_than_base?
+        if smaller_than_base?(number)
           number_to_format = number.to_i.to_s
         else
-          human_size = number / (base**exponent)
-          number_to_format = NumberToRoundedConverter.convert(human_size, options)
+          human_size = number / (base**exponent(number))
+          number_to_format = number_to_rounded_converter.execute(human_size)
         end
-        conversion_format.gsub("%n".freeze, number_to_format).gsub("%u".freeze, unit)
+        conversion_format.gsub("%n".freeze, number_to_format).gsub("%u".freeze, unit(number))
       end
 
       private
+
+        def number_to_rounded_converter
+          @number_to_rounded_converter ||= NumberToRoundedConverter.new(options)
+        end
 
         def conversion_format
           translate_number_value_with_default("human.storage_units.format", locale: options[:locale], raise: true)
         end
 
-        def unit
-          translate_number_value_with_default(storage_unit_key, locale: options[:locale], count: number.to_i, raise: true)
+        def unit(number)
+          translate_number_value_with_default(storage_unit_key(number), locale: options[:locale], count: number.to_i, raise: true)
         end
 
-        def storage_unit_key
-          key_end = smaller_than_base? ? "byte" : STORAGE_UNITS[exponent]
+        def storage_unit_key(number)
+          key_end = smaller_than_base?(number) ? "byte" : STORAGE_UNITS[exponent(number)]
           "human.storage_units.units.#{key_end}"
         end
 
-        def exponent
+        def exponent(number)
           max = STORAGE_UNITS.size - 1
           exp = (Math.log(number) / Math.log(base)).to_i
           exp = max if exp > max # avoid overflow for the highest unit
           exp
         end
 
-        def smaller_than_base?
+        def smaller_than_base?(number)
           number.to_i < base
         end
 

--- a/activesupport/lib/active_support/number_helper/number_to_percentage_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_percentage_converter.rb
@@ -5,10 +5,16 @@ module ActiveSupport
     class NumberToPercentageConverter < NumberConverter # :nodoc:
       self.namespace = :percentage
 
-      def convert
-        rounded_number = NumberToRoundedConverter.convert(number, options)
+      def convert(number = self.number)
+        rounded_number = number_to_rounded_converter.execute(number)
         options[:format].gsub("%n".freeze, rounded_number)
       end
+
+      private
+
+        def number_to_rounded_converter
+          @number_to_rounded_converter ||= NumberToRoundedConverter.new(options)
+        end
     end
   end
 end

--- a/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
@@ -3,7 +3,7 @@
 module ActiveSupport
   module NumberHelper
     class NumberToPhoneConverter < NumberConverter #:nodoc:
-      def convert
+      def convert(number = self.number)
         str = country_code(opts[:country_code]).dup
         str << convert_to_phone_number(number.to_s.strip)
         str << phone_ext(opts[:extension])

--- a/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
@@ -6,13 +6,12 @@ module ActiveSupport
       self.namespace      = :precision
       self.validate_float = true
 
-      def convert
-        helper = RoundingHelper.new(options)
-        rounded_number = helper.round(number)
+      def convert(number = self.number)
+        rounded_number = rounding_helper.round(number)
 
         if precision = options[:precision]
           if options[:significant] && precision > 0
-            digits = helper.digit_count(rounded_number)
+            digits = rounding_helper.digit_count(rounded_number)
             precision -= digits
             precision = 0 if precision < 0 # don't let it be negative
           end
@@ -31,14 +30,18 @@ module ActiveSupport
           formatted_string = rounded_number
         end
 
-        delimited_number = NumberToDelimitedConverter.convert(formatted_string, options)
+        delimited_number = number_to_delimited_converter.execute(formatted_string)
         format_number(delimited_number)
       end
 
       private
 
-        def calculate_rounded_number(multiplier)
-          (number / BigDecimal.new(multiplier.to_f.to_s)).round * multiplier
+        def rounding_helper
+          @rounding_helper ||= RoundingHelper.new(options)
+        end
+
+        def number_to_delimited_converter
+          @number_to_delimited_converter ||= NumberToDelimitedConverter.new(options)
         end
 
         def digit_count(number)

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -406,6 +406,20 @@ module ActiveSupport
           assert_equal "x", number_helper.number_to_human("x")
         end
       end
+
+      def test_number_helpers_reuse_converter
+        [
+          NumberToCurrencyConverter, NumberToDelimitedConverter,
+          NumberToHumanConverter, NumberToHumanSizeConverter,
+          NumberToPercentageConverter, NumberToPhoneConverter,
+          NumberToRoundedConverter
+        ].each do |converter_class|
+          converter = converter_class.new(1_000)
+          assert_equal(converter.execute, converter.execute(1_000))
+          assert_not_equal(converter.execute, converter.execute(2_000))
+          assert_not_equal(converter.execute(2_000), converter.execute(3_000))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

This PR makes it possible to reuse subclasses of `NumberConverter`. On pages with thousands of calls to helpers like `number_to_currency`, this can make a big difference in render time. I wrote the code in such a way that either the old calling convention for `NumberConverter.new(number, options)` or the new calling convention of `NumberConverter.new(options)` can be used.

### Other Information

I started a thread on the `rails-core` list about this, but I didn't get any response.