### PR TITLE
Add newline before `git_source` in Gemfile templates

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby <%= "'#{RUBY_VERSION}'" -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 <% if options[:skip_gemspec] -%>


### PR DESCRIPTION
Related to a151d8ad89a3d353160d85945ab9ad44cb9e6f7a, https://github.com/rails/rails/pull/30726#issuecomment-332452556
/cc @kamipo @kaspth 