### PR TITLE
Add `datalist` option to text_field helpers

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -368,6 +368,7 @@ module ActionView
           tag_builder.content_tag_string(:option, text, html_attributes)
         end.join("\n").html_safe
       end
+      alias options_for_datalist options_for_select
 
       # Returns a string of option tags that have been compiled by iterating over the +collection+ and assigning
       # the result of a call to the +value_method+ as the option value and the +text_method+ as the option text.

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -207,7 +207,7 @@ module ActionView
         output = tag(:input, { "type" => "text", "name" => name, "id" => sanitize_to_id(name), "value" => value }.update(options))
 
         if option_tags
-          output.safe_concat(content_tag(:datalist, option_tags, { "id" => options["list"] }))
+          output.safe_concat(content_tag(:datalist, option_tags, "id" => options["list"]))
         end
 
         output

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -163,6 +163,7 @@ module ActionView
       # * <tt>:size</tt> - The number of visible characters that will fit in the input.
       # * <tt>:maxlength</tt> - The maximum number of characters that the browser will allow the user to enter.
       # * <tt>:placeholder</tt> - The text contained in the field by default which is removed when the field receives focus.
+      # * <tt>:datalist</tt> - A collection of datalist options to associate with the input.
       # * Any other key creates standard HTML attributes for the tag.
       #
       # ==== Examples
@@ -189,8 +190,27 @@ module ActionView
       #
       #   text_field_tag 'ip', '0.0.0.0', maxlength: 15, size: 20, class: "ip-input"
       #   # => <input class="ip-input" id="ip" maxlength="15" name="ip" size="20" type="text" value="0.0.0.0" />
+      #
+      #   text_field_tag "title", nil, datalist: options_for_datalist(@titles)
+      #   # => <input id="title" name="title" type="text" list="title_list" /><datalist id="title_list"><option value="Developer">Developer</option></datalist>
+      #
+      #   text_field_tag 'title', nil, datalist: options_for_datalist(@titles), list: 'list-of-titles'
+      #   # => <input id="title" name="title" type="text" list="list-of-titles" /><datalist id="list-of-titles"><option value="Developer">Developer</option></datalist>
       def text_field_tag(name, value = nil, options = {})
-        tag :input, { "type" => "text", "name" => name, "id" => sanitize_to_id(name), "value" => value }.update(options.stringify_keys)
+        options = options.stringify_keys
+        option_tags = options.delete("datalist")
+
+        if option_tags
+          options["list"] = options.fetch("list") { "#{options['id'] || sanitize_to_id(name)}_list" }
+        end
+
+        output = tag(:input, { "type" => "text", "name" => name, "id" => sanitize_to_id(name), "value" => value }.update(options))
+
+        if option_tags
+          output.safe_concat(content_tag(:datalist, option_tags, { "id" => options["list"] }))
+        end
+
+        output
       end
 
       # Creates a label element. Accepts a block.

--- a/actionview/lib/action_view/helpers/tags/text_field.rb
+++ b/actionview/lib/action_view/helpers/tags/text_field.rb
@@ -14,7 +14,21 @@ module ActionView
           options["type"] ||= field_type
           options["value"] = options.fetch("value") { value_before_type_cast } unless field_type == "file"
           add_default_name_and_id(options)
-          tag("input", options)
+
+          datalist_values = options.delete("datalist")
+
+          if datalist_values
+            options["list"] = options.fetch("list") { "#{options["id"]}_list" if options["id"] }
+          end
+
+          output = tag("input", options)
+
+          if datalist_values
+            option_tags = options_for_datalist(datalist_values)
+            output += content_tag("datalist", option_tags, { "id" => options["list"] }.reject{ |_,v| v.blank? })
+          end
+
+          output
         end
 
         class << self

--- a/actionview/lib/action_view/helpers/tags/text_field.rb
+++ b/actionview/lib/action_view/helpers/tags/text_field.rb
@@ -25,7 +25,7 @@ module ActionView
 
           if datalist_values
             option_tags = options_for_datalist(datalist_values)
-            output += content_tag("datalist", option_tags, { "id" => options["list"] }.reject{ |_,v| v.blank? })
+            output += content_tag("datalist", option_tags, { "id" => options["list"] }.reject { |_, v| v.blank? })
           end
 
           output

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -492,7 +492,7 @@ class FormHelperTest < ActionView::TestCase
   def test_text_field_with_array_datalist_and_label
     assert_dom_equal(
       '<input id="post_cost" name="post[cost]" list="post_cost_list" type="text" /><datalist id="post_cost_list"><option label="Uno" value="One">One</option></datalist>',
-      text_field(:post, :cost, datalist: [["One", label: 'Uno']])
+      text_field(:post, :cost, datalist: [["One", label: "Uno"]])
     )
   end
 
@@ -506,7 +506,7 @@ class FormHelperTest < ActionView::TestCase
   def test_text_field_with_datalist_and_list_attribute
     assert_dom_equal(
       '<input id="post_cost" name="post[cost]" list="datalist_id" type="text" /><datalist id="datalist_id"></datalist>',
-      text_field(:post, :cost, datalist: [], list: 'datalist_id')
+      text_field(:post, :cost, datalist: [], list: "datalist_id")
     )
   end
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -468,6 +468,55 @@ class FormHelperTest < ActionView::TestCase
     end
   end
 
+  def test_text_field_with_nil_datalist
+    assert_dom_equal(
+      '<input id="post_cost" name="post[cost]" type="text" />',
+      text_field(:post, :cost, datalist: nil)
+    )
+  end
+
+  def test_text_field_with_empty_datalist
+    assert_dom_equal(
+      '<input id="post_cost" name="post[cost]" list="post_cost_list" type="text" /><datalist id="post_cost_list"></datalist>',
+      text_field(:post, :cost, datalist: [])
+    )
+  end
+
+  def test_text_field_with_array_datalist
+    assert_dom_equal(
+      '<input id="post_cost" name="post[cost]" list="post_cost_list" type="text" /><datalist id="post_cost_list"><option value="One">One</option></datalist>',
+      text_field(:post, :cost, datalist: ["One"])
+    )
+  end
+
+  def test_text_field_with_array_datalist_and_label
+    assert_dom_equal(
+      '<input id="post_cost" name="post[cost]" list="post_cost_list" type="text" /><datalist id="post_cost_list"><option label="Uno" value="One">One</option></datalist>',
+      text_field(:post, :cost, datalist: [["One", label: 'Uno']])
+    )
+  end
+
+  def test_text_field_with_hash_datalist
+    assert_dom_equal(
+      '<input id="post_cost" name="post[cost]" list="post_cost_list" type="text" /><datalist id="post_cost_list"><option value="1">One</option></datalist>',
+      text_field(:post, :cost, datalist: { "One" => 1 })
+    )
+  end
+
+  def test_text_field_with_datalist_and_list_attribute
+    assert_dom_equal(
+      '<input id="post_cost" name="post[cost]" list="datalist_id" type="text" /><datalist id="datalist_id"></datalist>',
+      text_field(:post, :cost, datalist: [], list: 'datalist_id')
+    )
+  end
+
+  def test_text_field_with_datalist_and_without_list_or_id_attribute
+    assert_dom_equal(
+      '<input name="post[cost]" type="text" /><datalist></datalist>',
+      text_field(:post, :cost, datalist: [], skip_default_ids: true)
+    )
+  end
+
   def test_text_field
     assert_dom_equal(
       '<input id="post_title" name="post[title]" type="text" value="Hello World" />',

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -438,7 +438,7 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_text_field_tag_with_datalist_option_and_list_attribute
-    actual = text_field_tag 'title', nil, datalist: options_for_datalist(["Developer"]), list: 'list-of-titles'
+    actual = text_field_tag "title", nil, datalist: options_for_datalist(["Developer"]), list: "list-of-titles"
     expected = %(<input id="title" name="title" type="text" list="list-of-titles" /><datalist id="list-of-titles"><option value="Developer">Developer</option></datalist>)
     assert_dom_equal expected, actual
   end

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -431,6 +431,18 @@ class FormTagHelperTest < ActionView::TestCase
     assert_match VALID_HTML_ID, input_elem["id"]
   end
 
+  def test_text_field_tag_with_datalist_option
+    actual = text_field_tag "title", nil, datalist: options_for_datalist(["Developer"])
+    expected = %(<input id="title" name="title" type="text" list="title_list" /><datalist id="title_list"><option value="Developer">Developer</option></datalist>)
+    assert_dom_equal expected, actual
+  end
+
+  def test_text_field_tag_with_datalist_option_and_list_attribute
+    actual = text_field_tag 'title', nil, datalist: options_for_datalist(["Developer"]), list: 'list-of-titles'
+    expected = %(<input id="title" name="title" type="text" list="list-of-titles" /><datalist id="list-of-titles"><option value="Developer">Developer</option></datalist>)
+    assert_dom_equal expected, actual
+  end
+
   def test_label_tag_without_text
     actual = label_tag "title"
     expected = %(<label for="title">Title</label>)


### PR DESCRIPTION
### Summary

This is a new PR to try and add support for associating a [HTML datalist](https://www.w3.org/wiki/HTML/Elements/datalist) with a given input, by passing a `datalist` option to the form helper and form tag helper methods.

For example:

```ruby
form.text_field(:post, :cost, datalist: ["One"], list: 'list-of-costs')
=> <input id="post_cost" name="post[cost]" list="list-of-costs" type="text" /><datalist id="list-of-costs"><option value="One">One</option></datalist>
```

and:

```ruby
text_field_tag "title", nil, datalist: options_for_datalist(["Developer"], list: 'list-of-titles)
=> <input id="title" name="title" type="text" list="list-of-titles" /><datalist id="list-of-titles"><option value="Developer">Developer</option></datalist>
```

The implementation uses the value of `list` attribute of the input, as the `id` of the datalist, but if not specified, it attempts to create a `list` attribute based on the `id` of the input.

For example

```ruby
form.text_field(:post, :cost, datalist: ["One"])
=> <input id="post_cost" name="post[cost]" list="post_cost_list" type="text" /><datalist id="post_cost_list"><option value="One">One</option></datalist>
```

I guess there is a risk in this approach, that the generated `list` attribute is already an existing `id` in the DOM. 

But I think when building more complex forms using `form_for` and `fields_for`, where default `id` values are generated for us, making the developer come up with unique `list` values for every input is maybe a little risky also.

In cases where an input is not given a `list` attribute, and the `id` is suppressed, such as the `form_with` behaviour, the datalist is still rendered, even though the function of the datalist may not work, it hopefully allows the developer to spot the issue when inspecting the DOM.

For example:

```ruby
  form.text_field(:post, :cost, datalist: [], skip_default_ids: true)
  => <input name="post[cost]" type="text" /><datalist></datalist>
```

With [browsers starting to support datalist](https://demo.agektmr.com/datalist/) for multiple input types - we can also pass the `datalist` option to those field helpers and field tag helpers that sub-class or delegate to the text field implementations.

For example:

```ruby
color_field_tag "color", nil, datalist: options_for_datalist(%w(Red Green Blue))
=> <input type="color" name="color" id="color" list="color_list" /><datalist id="color_list"><option value="Red">Red</option><option value="Green">Green</option><option value="Blue">Blue</option></datalist>

range_field_tag "rating", nil, datalist: options_for_datalist([1,2,3,4,5])
=> <input type="range" name="rating" id="rating" list="rating_list" /><datalist id="rating_list"><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option><option value="5">5</option></datalist>

number_field_tag "units", nil, datalist: options_for_datalist([1, 5, 10])
=> <input type="number" name="units" id="units" list="units_list" /><datalist id="units_list"<option value="1">1</option><option value="5">5</option><option value="10">10</option></datalist>
```

And finally, the method `options_for_datalist` is simply an alias to `options_for_select`, so we can pass through attributes to the datalist options, such as `label`, as we can now using `options_for_select`.

For example:

```ruby
  text_field_tag "title", nil, datalist: options_for_datalist([["Developer", "Coder"]], list: 'list-of-titles)
=> <input id="title" name="title" type="text" list="list-of-titles" /><datalist id="list-of-titles"><option value="Developer" label="Coder">Developer</option></datalist>
```

and:

```ruby
  form.text_field(:post, :cost, datalist: [["One", label: 'Uno']])
  => <input id="post_cost" name="post[cost]" list="post_cost_list" type="text" /><datalist id="post_cost_list"><option label="Uno" value="One">One</option></datalist>
```
  
### Other Information

Previously, #26398 was opened to create new form helper and form tag helper methods for datalists and the text type input.