### PR TITLE
Use __callee__ to pass alias instead of original method name

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -441,7 +441,7 @@ module ActiveRecord
     #   => SELECT "users".* FROM "users" LEFT OUTER JOIN "posts" ON "posts"."user_id" = "users"."id"
     #
     def left_outer_joins(*args)
-      check_if_method_has_arguments!(:left_outer_joins, args)
+      check_if_method_has_arguments!(__callee__, args)
 
       args.compact!
       args.flatten!


### PR DESCRIPTION
### Summary

`left_joins` is alias for `left_outer_joins` in ActiveRecord::QueryMethods.
I think passing `__callee__` to `check_if_method_has_arguments!` makes more friendly error message for the users.

Before

```
> Article.left_joins
ArgumentError: The method .left_outer_joins() must contain arguments.
```

After

```
> Article.left_joins
ArgumentError: The method .left_joins() must contain arguments.
```

### Other Information

none
