### PR TITLE
Bring back overridable Rails.confirm dialogs

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/features/confirm.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/features/confirm.coffee
@@ -5,6 +5,10 @@
 Rails.handleConfirm = (e) ->
   stopEverything(e) unless allowAction(this)
 
+# Overridable at Rails.confirm, for use with custom dialogs.
+Rails.confirm = (message) ->
+  confirm(message)
+
 # For 'data-confirm' attribute:
 # - Fires `confirm` event
 # - Shows the confirmation dialog
@@ -20,7 +24,7 @@ allowAction = (element) ->
 
   answer = false
   if fire(element, 'confirm')
-    try answer = confirm(message)
+    try answer = Rails.confirm(message)
     callback = fire(element, 'confirm:complete', [answer])
 
   answer and callback


### PR DESCRIPTION
### Summary

My PR brings back overridable confirm dialogs, making it an overridable function `Rails.confirm` which was removed when Rails stopped using jQuery and all rails-ujs code was rewritten in pure javascript, as now is very difficult to implement custom dialogs and keeping it simple using `data-confirm` attributes.