### PR TITLE
Fix after commit on update callback with optimistic locking

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -79,7 +79,10 @@ module ActiveRecord
 
         def _update_record(attribute_names = self.attribute_names)
           return super unless locking_enabled?
-          return 0 if attribute_names.empty?
+          if attribute_names.empty?
+            @_trigger_update_callback = true
+            return 0
+          end
 
           begin
             lock_col = self.class.locking_column
@@ -101,7 +104,9 @@ module ActiveRecord
               end.to_h
             )
 
-            unless affected_rows == 1
+            if affected_rows == 1
+              @_trigger_update_callback = true
+            else
               raise ActiveRecord::StaleObjectError.new(self, "update")
             end
 

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -28,6 +28,13 @@ class ReadonlyNameShip < Ship
   attr_readonly :name
 end
 
+class CallbackPerson < ActiveRecord::Base
+  self.table_name = "people"
+  attr_reader :after_commit_on_update_called
+
+  after_commit(on: :update) { @after_commit_on_update_called = true }
+end
+
 class OptimisticLockingTest < ActiveRecord::TestCase
   fixtures :people, :legacy_things, :references, :string_key_objects, :peoples_treasures
 
@@ -425,6 +432,21 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     t2 = YAML.load(YAML.dump(t1))
 
     assert_equal t1.attributes, t2.attributes
+  end
+
+  def test_after_commit_on_update_with_lock_column
+    person = CallbackPerson.find(1)
+    assert !person.after_commit_on_update_called
+    person.first_name = "Michelle"
+    person.save
+    assert person.after_commit_on_update_called
+  end
+
+  def test_after_commit_on_update_with_no_changes_and_lock_column
+    person = CallbackPerson.find(1)
+    assert !person.after_commit_on_update_called
+    person.save
+    assert person.after_commit_on_update_called
   end
 end
 


### PR DESCRIPTION
When using optimistic locking, the `after_commit on: update` callback wasn't firing.  

The commit https://github.com/rails/rails/commit/371c083fb0620efebf7bd0188a66486403e12ecc added a new mechanism that set the @_trigger_update_callback instance variable to true when the `after_commit on: :update` callback should be fired.

Optimistic locking overrides the normal _update_record method so we need to properly set the @_trigger_update_callback instance variable in there as well.  The `after_commit on: :destroy` method calls super so we don't have to worry about that one.

Fixes https://github.com/rails/rails/issues/30779
