### PR TITLE
Remove needless setup from `InfoTest`

### DIFF
--- a/railties/test/rails_info_test.rb
+++ b/railties/test/rails_info_test.rb
@@ -2,20 +2,7 @@
 
 require "abstract_unit"
 
-unless defined?(Rails) && defined?(Rails::Info)
-  module Rails
-    class Info; end
-  end
-end
-
-require "active_support/core_ext/kernel/reporting"
-
 class InfoTest < ActiveSupport::TestCase
-  def setup
-    Rails.send :remove_const, :Info
-    silence_warnings { load "rails/info.rb" }
-  end
-
   def test_property_with_block_swallows_exceptions_and_ignores_property
     assert_nothing_raised do
       Rails::Info.module_eval do


### PR DESCRIPTION
The `abstract_unit` loads `rails/all`. Therefore, `Rails` is definitely defined.
Also, since `Info` is autoloaded, do not need to explicitly load the file.
https://github.com/rails/rails/blob/3ede539357acc91e377611cea9dd5f30678e7b2a/railties/lib/rails.rb#L29
