### PR TITLE
Properly build array of non basic objects by dedicated predicate handler

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -56,6 +56,10 @@ module ActiveRecord
       Arel::Nodes::BindParam.new(attr)
     end
 
+    def basic_object?(value)
+      handler_for(value).is_a?(BasicObjectHandler)
+    end
+
     protected
 
       attr_reader :table

--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -12,7 +12,7 @@ module ActiveRecord
 
         values = value.map { |x| x.is_a?(Base) ? x.id : x }
         nils, values = values.partition(&:nil?)
-        ranges, values = values.partition { |v| v.is_a?(Range) }
+        values, others = values.partition { |v| predicate_builder.basic_object?(v) }
 
         values_predicate =
           case values.length
@@ -29,7 +29,7 @@ module ActiveRecord
           values_predicate = values_predicate.or(predicate_builder.build(attribute, nil))
         end
 
-        array_predicates = ranges.map { |range| predicate_builder.build(attribute, range) }
+        array_predicates = others.map { |other| predicate_builder.build(attribute, other) }
         array_predicates.unshift(values_predicate)
         array_predicates.inject(&:or)
       end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -741,6 +741,18 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal [1, 2, 6, 7, 8], Comment.where(id: [1..2, 6..8]).to_a.map(&:id).sort
   end
 
+  def test_find_on_hash_conditions_with_array_of_arrays
+    assert_equal [1, 2, 6, 7, 8], Comment.where(id: [[1, 2], [6, 7, 8]]).to_a.map(&:id).sort
+  end
+
+  def test_find_on_hash_conditions_with_array_of_sets
+    assert_equal [1, 2, 6, 7, 8], Comment.where(id: [[1, 2].to_set, [6, 7, 8].to_set]).to_a.map(&:id).sort
+  end
+
+  def test_find_on_hash_conditions_with_array_of_relations
+    assert_equal [1, 2, 6, 7, 8], Comment.where(id: [Comment.where(id: 1..2), Comment.where(id: 6..8)]).to_a.map(&:id).sort
+  end
+
   def test_find_on_multiple_hash_conditions
     assert Topic.where(author_name: "David", title: "The First Topic", replies_count: 1, approved: false).find(1)
     assert_raise(ActiveRecord::RecordNotFound) { Topic.where(author_name: "David", title: "The First Topic", replies_count: 1, approved: true).find(1) }

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -5,14 +5,22 @@ require "models/topic"
 
 module ActiveRecord
   class PredicateBuilderTest < ActiveRecord::TestCase
-    def test_registering_new_handlers
+    def setup
       Topic.predicate_builder.register_handler(Regexp, proc do |column, value|
-        Arel::Nodes::InfixOperation.new("~", column, Arel.sql(value.source))
+        Arel::Nodes::InfixOperation.new("~", column, Arel::Nodes.build_quoted(value.source))
       end)
+    end
 
-      assert_match %r{["`]topics["`]\.["`]title["`] ~ rails}i, Topic.where(title: /rails/).to_sql
-    ensure
+    def teardown
       Topic.reset_column_information
+    end
+
+    def test_registering_new_handlers
+      assert_match %r{["`]topics["`]\.["`]title["`] ~ 'rails'}i, Topic.where(title: /rails/).to_sql
+    end
+
+    def test_array_of_new_handlers_values
+      assert_match %r{["`]topics["`]\.["`]title["`] ~ 'ruby' OR ["`]topics["`]\.["`]title["`] ~ 'rails'}i, Topic.where(title: [/ruby/, /rails/]).to_sql
     end
   end
 end


### PR DESCRIPTION
Otherwise the behavior will be undefined (actually incorrect).