### PR TITLE
ActiveRecord::Relation#== should never return nil

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -518,6 +518,8 @@ module ActiveRecord
         other.to_sql == to_sql
       when Array
         records == other
+      else
+        false
       end
     end
 


### PR DESCRIPTION
If you try to compare `ActiveRecord::Relation` with something other than `Associations::CollectionProxy`, `AssociationRelation`, itself or `Array` you will get `nil`. But I think it's common for `==` methods to return booleans.