### PR TITLE
[WIP] ActiveStorage: Add remote_url option

### DIFF
--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -23,8 +23,11 @@ class User < ApplicationRecord
   has_one_attached :avatar
 end
 
-# Attach an avatar to the user.
+# Attach an avatar to the user with a local file.
 user.avatar.attach(io: File.open("/path/to/face.jpg"), filename: "face.jpg", content_type: "image/jpg")
+
+# Attach an avatar to the user from a remote file.
+user.avatar.attach(remote_url: "https://example.com/doc.png", filename: "face.jpg", content_type: "image/jpg")
 
 # Does the user have an avatar?
 user.avatar.attached? # => true

--- a/activestorage/lib/active_storage/attached.rb
+++ b/activestorage/lib/active_storage/attached.rb
@@ -32,6 +32,12 @@ module ActiveStorage
           nil
         end
       end
+
+      def download_remote_file(attachable)
+        # raise DownloadError unless /^https?/.match(attachable[:remote_url]).present?
+        remote_file = Net::HTTP.get_response(URI.parse(attachable[:remote_url]))
+        file = StringIO.new(remote_file.body)
+      end
   end
 end
 

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -19,8 +19,14 @@ module ActiveStorage
     #   document.images.attach(params[:signed_blob_id]) # Signed reference to blob from direct upload
     #   document.images.attach(io: File.open("/path/to/racecar.jpg"), filename: "racecar.jpg", content_type: "image/jpg")
     #   document.images.attach([ first_blob, second_blob ])
+    #   document.images.attach(remote_url: "https://example.com/doc.png", filename: "doc.png", content_type: "image/jpg")
     def attach(*attachables)
       attachables.flatten.collect do |attachable|
+        if attachable[:remote_url].present?
+          remote_file = download_remote_file(attachable)
+          attachable[:io] = remote_file
+          attachable.delete(:remote_url)
+        end
         attachments.create!(name: name, blob: create_blob_from(attachable))
       end
     end

--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -20,10 +20,16 @@ module ActiveStorage
     #   person.avatar.attach(params[:signed_blob_id]) # Signed reference to blob from direct upload
     #   person.avatar.attach(io: File.open("/path/to/face.jpg"), filename: "face.jpg", content_type: "image/jpg")
     #   person.avatar.attach(avatar_blob) # ActiveStorage::Blob object
+    #   person.avatar.attach(remote_url: "https://example.com/face.png", filename: "face.jpg", content_type: "image/jpg")
     def attach(attachable)
       if attached? && dependent == :purge_later
         replace attachable
       else
+        if attachable[:remote_url].present?
+          remote_file = download_remote_file(attachable)
+          attachable[:io] = remote_file
+          attachable.delete(:remote_url)
+        end
         write_attachment create_attachment_from(attachable)
       end
     end


### PR DESCRIPTION
### Allow uploads from remote urls

By passing a url through the remote_url option, it is possible to attach a remote file. 
Feedback would be greatly appreciated. 

I have 2 questions:
- should I make a dedicated class for remote files ? (will be useful to extend it in the future) 
- where should I define error classes ? I at least need a DownloadError class. 

