### PR TITLE
Fix default of `String#to_time` [ci skip]

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1752,7 +1752,7 @@ The methods `to_date`, `to_time`, and `to_datetime` are basically convenience wr
 "2010-07-27 23:42:00".to_time(:local) # => 2010-07-27 23:42:00 +0200
 ```
 
-Default is `:utc`.
+Default is `:local`.
 
 Please refer to the documentation of `Date._parse` for further details.
 


### PR DESCRIPTION
The default of `String#to_time` is `:local` since b79adc4.
