### PR TITLE
Include Mutex_m into GeneratedAttributeMethods instead of extending instance

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -33,7 +33,9 @@ module ActiveRecord
 
     BLACKLISTED_CLASS_METHODS = %w(private public protected allocate new name parent superclass)
 
-    class GeneratedAttributeMethods < Module; end # :nodoc:
+    class GeneratedAttributeMethods < Module #:nodoc:
+      include Mutex_m
+    end
 
     module ClassMethods
       def inherited(child_class) #:nodoc:
@@ -42,7 +44,7 @@ module ActiveRecord
       end
 
       def initialize_generated_modules # :nodoc:
-        @generated_attribute_methods = GeneratedAttributeMethods.new { extend Mutex_m }
+        @generated_attribute_methods = GeneratedAttributeMethods.new
         @attribute_methods_generated = false
         include @generated_attribute_methods
 

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -999,6 +999,11 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal ["title"], model.accessed_fields
   end
 
+  test "generated attribute methods ancestors have correct class" do
+    mod = Topic.send(:generated_attribute_methods)
+    assert_match %r(GeneratedAttributeMethods), mod.inspect
+  end
+
   private
 
     def new_topic_like_ar_class(&block)


### PR DESCRIPTION
### Summary

An instance of the `GeneratedAttributeMethods` class is included into every AR model as a module on which to define attribute methods (with `define_attribute_methods`). It is therefore quite an important module in a model's ancestors, but currently it is quite hard to distinguish from other modules.

Here's an example of an ancestor chain:

```ruby
Post.ancestors                                             
=> [#<Post:0x0055a11cadbbb0>(id: integer, ...),                                                                                   
 #<Module:0x0055a11cadb4d0>,                                                                  
 #<#<Class:0x0055a11cadbae8>:0x0055a11cadbb60>,
 ActiveRecord::Base,                                                                          
 ActiveRecord::Suppressor,
 ActiveRecord::SecureToken,
 ActiveRecord::Store,
...
```

The module instance is the third ancestor, `#<#<Class:...>`, but it has no name because currently, the module is [extended with the `Mutex_m` module](https://github.com/rails/rails/blob/d20f4b73bd65a4c679aa31fb95795148d7799ae7/activerecord/lib/active_record/attribute_methods.rb#L46-L52) before being included:

```ruby
def initialize_generated_modules # :nodoc:
  @generated_attribute_methods = GeneratedAttributeMethods.new { extend Mutex_m }
  @attribute_methods_generated = false
  include @generated_attribute_methods

  super
end
```

The ancestor chain does not show the module instance because the class has been dynamically extended. However, if instead we *include* `Mutex_m` into the `GeneratedAttributeMethods` class when it is first defined (as I do in this PR), then we can see these modules clearly in the ancestor chain:

```ruby
Post.ancestors                                             
=> [#<Post:0x0055c524819068>(id: integer, ...),                                                                                   
 #<Module:0x0055c524818f50>,                   
 #<ActiveRecord::AttributeMethods::GeneratedAttributeMethods:0x0055c524818ff0>,
 ActiveRecord::Base,
 ActiveRecord::Suppressor,
 ActiveRecord::SecureToken,
 ActiveRecord::Store,
...
```

Although this is a small change, I think the visibility of the module in the ancestor chain is valuable for debugging and generally understanding where methods are being defined.