### PR TITLE
Use released `sidekiq` instead of master version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem "bootsnap", ">= 1.1.0", require: false
 group :job do
   gem "resque", require: false
   gem "resque-scheduler", github: "jeremy/resque-scheduler", branch: "redis-rb-4.0", require: false
-  gem "sidekiq", github: "mperham/sidekiq", require: false
+  gem "sidekiq", require: false
   gem "sucker_punch", require: false
   gem "delayed_job", require: false
   gem "queue_classic", github: "QueueClassic/queue_classic", branch: "master", require: false, platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,16 +35,6 @@ GIT
       websocket
 
 GIT
-  remote: https://github.com/mperham/sidekiq.git
-  revision: 6332b9f8a316cf1000246701e40e108d16fed6d4
-  specs:
-    sidekiq (5.0.5)
-      concurrent-ruby (~> 1.0)
-      connection_pool (~> 2.2, >= 2.2.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.4, < 5)
-
-GIT
   remote: https://github.com/rails/arel.git
   revision: 42510bf71472e2e35d9becb546edd05562672344
   specs:
@@ -424,6 +414,11 @@ GEM
     sequel (4.49.0)
     serverengine (1.5.11)
       sigdump (~> 0.2.2)
+    sidekiq (5.0.5)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.4, < 5)
     sigdump (0.2.4)
     signet (0.7.3)
       addressable (~> 2.3)
@@ -544,7 +539,7 @@ DEPENDENCIES
   sass-rails!
   sdoc!
   sequel
-  sidekiq!
+  sidekiq
   sneakers
   sprockets-export
   sqlite3 (~> 1.3.6)


### PR DESCRIPTION
The sidekiq 5.0.5 includes redis-rb 4.0 support.
Ref: https://github.com/mperham/sidekiq/blob/90db3b84208cbb73a50d1a77a1dea97d3490ce70/Changes.md#505