### PR TITLE
Add ability to serialize Proc argument

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -69,6 +69,8 @@ module ActiveJob
           result = serialize_hash(argument)
           result[SYMBOL_KEYS_KEY] = symbol_keys
           result
+        when Proc
+          serialize_argument(argument.call)
         else
           raise SerializationError.new("Unsupported argument type: #{argument.class.name}")
         end


### PR DESCRIPTION
### Summary

after updating from rails 4.1.9 to 4.2.8 I got an issues that if I use deliver_later for ActionMailer::Base object and put proc as an argument to mail rendering method I got an exception `SerializationError`.

To fix this I decide to update serialize_argument method.

### Other Information


Thanks for contributing to Rails!
