### PR TITLE
Don't set the delivery_method to :test when the existing delivery_method is not either :smtp or :send_mail.

### DIFF
--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -90,8 +90,14 @@ module ActionMailer
         end
 
         def set_delivery_method(method)
-          @old_delivery_method = ActionMailer::Base.delivery_method
-          ActionMailer::Base.delivery_method = method
+          # This can happen in a scenario where `delivery_method` is not
+          # specified in the test environment.
+          if [:smtp, :sendmail].include? ActionMailer::Base.delivery_method
+            @old_delivery_method = ActionMailer::Base.delivery_method
+            ActionMailer::Base.delivery_method = method
+          else
+            @old_delivery_method = ActionMailer::Base.delivery_method
+          end
         end
 
         def restore_delivery_method

--- a/actionmailer/test/test_case_test.rb
+++ b/actionmailer/test/test_case_test.rb
@@ -26,6 +26,40 @@ class ClearTestDeliveriesMixinTest < ActiveSupport::TestCase
   end
 end
 
+class ChangeTestDeliveryTestWithNonSmtp < ActionMailer::TestCase
+  def before_setup
+    @original_delivery_method = ActionMailer::Base.delivery_method
+    ActionMailer::Base.delivery_method = :my_delivery_method
+    super
+  end
+
+  def test_delivery_method_change_when_non_smtp
+    assert_equal :my_delivery_method, ActionMailer::Base.delivery_method
+  end
+
+  def after_teardown
+    super
+    ActionMailer::Base.delivery_method = @original_delivery_method
+  end
+end
+
+class ChangeTestDeliveryTestWithSmtp < ActionMailer::TestCase
+  def before_setup
+    @original_delivery_method = ActionMailer::Base.delivery_method
+    ActionMailer::Base.delivery_method = :smtp
+    super
+  end
+
+  def test_delivery_method_change_when_smtp
+    assert_equal :test, ActionMailer::Base.delivery_method
+  end
+
+  def after_teardown
+    super
+    ActionMailer::Base.delivery_method = @original_delivery_method
+  end
+end
+
 class MailerDeliveriesClearingTest < ActionMailer::TestCase
   def before_setup
     ActionMailer::Base.deliveries << "better clear me, setup"


### PR DESCRIPTION
### Summary
In the scenarios where we have the test unit classes inheriting from `ActionMailer::TestCase` which explicitly sets the delivery_method to `:test` irrespective of the value specified in the test environment. 

I think this should not be case and since there are defaults provided for the test environments but there are cases where I don't want to use the `:test` as the delivery_method and use something like `:letter_opener` for example as a preferred delivery method.

### Other Information
Fixes #30665 

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!