### PR TITLE
Backport fix for through_scope association on STI tables

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -74,12 +74,17 @@ module ActiveRecord
 
         def through_scope
           scope = through_reflection.klass.unscoped
+          values = reflection_scope.values
 
           if options[:source_type]
             scope.where! reflection.foreign_type => options[:source_type]
           else
             unless reflection_scope.where_values.empty?
-              scope.includes_values = Array(reflection_scope.values[:includes] || options[:source])
+              if includes = values[:includes]
+                scope.includes!(source_reflection.name => includes)
+              else
+                scope.includes!(source_reflection.name)
+              end
               scope.where_values    = reflection_scope.values[:where]
               scope.bind_values     = reflection_scope.bind_values
             end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -510,6 +510,14 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal [comments(:does_it_hurt)], assert_no_queries { author.special_post_comments }
   end
 
+  def test_preloading_has_many_through_with_implicit_source
+    authors = Author.includes(:very_special_comments).to_a
+    assert_no_queries do
+      special_comment_authors = authors.map { |author| [author.name, author.very_special_comments.size] }
+      assert_equal [["David", 1], ["Mary", 0], ["Bob", 0]], special_comment_authors
+    end
+  end
+
   def test_eager_with_has_many_through_an_sti_join_model_with_conditions_on_both
     author = Author.all.merge!(:includes => :special_nonexistant_post_comments, :order => 'authors.id').first
     assert_equal [], author.special_nonexistant_post_comments

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -19,7 +19,7 @@ class Author < ActiveRecord::Base
   end
   has_many :comments_containing_the_letter_e, :through => :posts, :source => :comments
   has_many :comments_with_order_and_conditions, -> { order('comments.body').where("comments.body like 'Thank%'") }, :through => :posts, :source => :comments
-  has_many :comments_with_include, -> { includes(:post) }, :through => :posts, :source => :comments
+  has_many :comments_with_include, -> { includes(:post).where(posts: { type: "Post" }) }, :through => :posts, :source => :comments
 
   has_many :first_posts
   has_many :comments_on_first_posts, -> { order('posts.id desc, comments.id asc') }, :through => :first_posts, :source => :comments


### PR DESCRIPTION
`values[:includes]` in `reflection_scope` is not compatible with `through_scope`

Without this fix, preloading `:comments_with_include` will cause the
following error:

```
% bundle exec ruby -w -Itest test/cases/associations/eager_test.rb -n test_eager_with_has_many_through_join_model_with_include
Using sqlite3
Run options: -n test_eager_with_has_many_through_join_model_with_include --seed 1502

E

Error:
EagerAssociationTest#test_eager_with_has_many_through_join_model_with_include:
ActiveRecord::AssociationNotFoundError: Association named 'post' was not found on Post; perhaps you misspelled it?
```

### Summary

This is a backport of the fix merged here: https://github.com/rails/rails/commit/82bfe3bf115e7d4d6f5f5b40f8ab32a61148da67

