### PR TITLE
Fix "warning: assigned but unused variable - message"

### DIFF
--- a/railties/test/generators/argv_scrubber_test.rb
+++ b/railties/test/generators/argv_scrubber_test.rb
@@ -82,9 +82,8 @@ module Rails
         file.puts "--hello --world"
         file.flush
 
-        message = nil
         scrubber = Class.new(ARGVScrubber) {
-          define_method(:puts) { |msg| message = msg }
+          define_method(:puts) { |msg| }
         }.new ["new", "--rc=#{file.path}"]
         args = scrubber.prepare!
         assert_equal ["--hello", "--world"], args


### PR DESCRIPTION
Ruby 2.5 warns about this. Ref: https://travis-ci.org/rails/rails/jobs/286338999
