### PR TITLE
Introduce ActiveStorage::Blob#representation

### DIFF
--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -65,6 +65,10 @@ class ActiveStorage::Variant
     service.url key, expires_in: expires_in, disposition: disposition, filename: blob.filename, content_type: blob.content_type
   end
 
+  # Returns the receiving variant. Allows ActiveStorage::Variant and ActiveStorage::Preview instances to be duck-typed.
+  def image
+    self
+  end
 
   private
     def processed?

--- a/activestorage/test/models/preview_test.rb
+++ b/activestorage/test/models/preview_test.rb
@@ -7,6 +7,7 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
   test "previewing a PDF" do
     blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
     preview = blob.preview(resize: "640x280").processed
+
     assert preview.image.attached?
     assert_equal "report.png", preview.image.filename.to_s
     assert_equal "image/png", preview.image.content_type
@@ -19,6 +20,7 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
   test "previewing an MP4 video" do
     blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
     preview = blob.preview(resize: "640x280").processed
+
     assert preview.image.attached?
     assert_equal "video.png", preview.image.filename.to_s
     assert_equal "image/png", preview.image.content_type

--- a/activestorage/test/models/representation_test.rb
+++ b/activestorage/test/models/representation_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::RepresentationTest < ActiveSupport::TestCase
+  test "representing an image" do
+    blob = create_file_blob
+    representation = blob.representation(resize: "100x100").processed
+
+    image = read_image(representation.image)
+    assert_equal 100, image.width
+    assert_equal 67, image.height
+  end
+
+  test "representing a PDF" do
+    blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+    representation = blob.representation(resize: "640x280").processed
+
+    image = read_image(representation.image)
+    assert_equal 612, image.width
+    assert_equal 792, image.height
+  end
+
+  test "representing an MP4 video" do
+    blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
+    representation = blob.representation(resize: "640x280").processed
+
+    image = read_image(representation.image)
+    assert_equal 640, image.width
+    assert_equal 480, image.height
+  end
+
+  test "representing an unrepresentable blob" do
+    blob = create_blob
+
+    assert_raises ActiveStorage::Blob::UnrepresentableError do
+      blob.representation resize: "100x100"
+    end
+  end
+end


### PR DESCRIPTION
You often want to display a thumbnail for a file of indeterminate type. This method returns an `ActiveStorage::Preview` instance for a previewable blob or an `ActiveStorage::Variant` instance for an image blob, making it easier to do that.