### PR TITLE
Add headless chrome driver to System Tests

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add headless chrome support to System Tests.
+
+    *Yuji Yaginuma*
+
 *   Add ability to enable Early Hints for HTTP/2
 
     If supported by the server, and enabled in Puma this allows H2 Early Hints to be used.

--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -121,6 +121,8 @@ module ActionDispatch
     #
     #   driven_by :selenium, using: :firefox
     #
+    #   driven_by :selenium, using: :headless_chrome
+    #
     #   driven_by :selenium, screen_size: [800, 800]
     def self.driven_by(driver, using: :chrome, screen_size: [1400, 1400], options: {})
       self.driver = SystemTesting::Driver.new(driver, using: using, screen_size: screen_size, options: options)

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -31,8 +31,24 @@ module ActionDispatch
           end
         end
 
+        def browser_options
+          if @browser == :headless_chrome
+            browser_options = Selenium::WebDriver::Chrome::Options.new
+            browser_options.args << "--headless"
+            browser_options.args << "--disable-gpu"
+
+            @options.merge(options: browser_options)
+          else
+            @options
+          end
+        end
+
+        def browser
+          @browser == :headless_chrome ? :chrome : @browser
+        end
+
         def register_selenium(app)
-          Capybara::Selenium::Driver.new(app, { browser: @browser }.merge(@options)).tap do |driver|
+          Capybara::Selenium::Driver.new(app, { browser: browser }.merge(browser_options)).tap do |driver|
             driver.browser.manage.window.size = Selenium::WebDriver::Dimension.new(*@screen_size)
           end
         end

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -449,3 +449,7 @@ end
 class DrivenBySeleniumWithChrome < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome
 end
+
+class DrivenBySeleniumWithHeadlessChrome < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_chrome
+end

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -17,6 +17,14 @@ class DriverTest < ActiveSupport::TestCase
     assert_equal ({ url: "http://example.com/wd/hub" }), driver.instance_variable_get(:@options)
   end
 
+  test "initializing the driver with a headless chrome" do
+    driver = ActionDispatch::SystemTesting::Driver.new(:selenium, using: :headless_chrome, screen_size: [1400, 1400], options: { url: "http://example.com/wd/hub" })
+    assert_equal :selenium, driver.instance_variable_get(:@name)
+    assert_equal :headless_chrome, driver.instance_variable_get(:@browser)
+    assert_equal [1400, 1400], driver.instance_variable_get(:@screen_size)
+    assert_equal ({ url: "http://example.com/wd/hub" }), driver.instance_variable_get(:@options)
+  end
+
   test "initializing the driver with a poltergeist" do
     driver = ActionDispatch::SystemTesting::Driver.new(:poltergeist, screen_size: [1400, 1400], options: { js_errors: false })
     assert_equal :poltergeist, driver.instance_variable_get(:@name)

--- a/actionpack/test/dispatch/system_testing/system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/system_test_case_test.rb
@@ -22,6 +22,12 @@ class SetDriverToSeleniumTest < DrivenBySeleniumWithChrome
   end
 end
 
+class SetDriverToSeleniumHeadlessChromeTest < DrivenBySeleniumWithHeadlessChrome
+  test "uses selenium headless chrome" do
+    assert_equal :selenium, Capybara.current_driver
+  end
+end
+
 class SetHostTest < DrivenByRackTest
   test "sets default host" do
     assert_equal "http://127.0.0.1", Capybara.app_host


### PR DESCRIPTION
Currently, Headless Chrome seems to be stable, I think there is no problem in using it for testing. 
Therefore, I think that it is good to add to the driver that System test supports by default.

r? @eileencodes 