### PR TITLE
Remove unsued `jquery-rails`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem "mocha", require: false
 gem "capybara", "~> 2.15"
 
 gem "rack-cache", "~> 1.2"
-gem "jquery-rails"
 gem "coffee-rails"
 gem "sass-rails", github: "rails/sass-rails", branch: "5-0-stable"
 gem "turbolinks", "~> 5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,10 +290,6 @@ GEM
     httpclient (2.8.3)
     i18n (0.8.6)
     jmespath (1.3.1)
-    jquery-rails (4.3.1)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     json (2.1.0)
     jwt (1.5.6)
     kindlerb (1.2.0)
@@ -510,7 +506,6 @@ DEPENDENCIES
   erubis (~> 2.7.0)
   google-cloud-storage (~> 1.3)
   hiredis
-  jquery-rails
   json (>= 2.0.0)
   kindlerb (~> 1.2.0)
   libxml-ruby


### PR DESCRIPTION
This has been added by 8f8cb1baa3b5609969805fcdd7295f3d7de2bd6b. But now it is unnecessary because it is not used in the test.
