### PR TITLE
Improved logging of AJ's DelayedJob wrapper

### DIFF
--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -34,6 +34,10 @@ module ActiveJob
           @job_data = job_data
         end
 
+        def display_name
+          "#{job_data['job_class']} [#{job_data['job_id']}] from DelayedJob(#{job_data['queue_name']}) with arguments: #{job_data['arguments']}"
+        end
+
         def perform
           Base.execute(job_data)
         end

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -45,6 +45,13 @@ class QueuingTest < ActiveSupport::TestCase
     end
   end
 
+  test "should supply a wrapped class name to DelayedJob" do
+    skip unless adapter_is?(:delayed_job)
+    ::HelloJob.perform_later
+    job = Delayed::Job.first
+    assert_match(/HelloJob \[[0-9a-f-]+\] from DelayedJob\(default\) with arguments: \[\]/, job.name)
+  end
+
   test "resque JobWrapper should have instance variable queue" do
     skip unless adapter_is?(:resque)
     job = ::HelloJob.set(wait: 5.seconds).perform_later


### PR DESCRIPTION
### Summary

ActiveJob wraps every adapter into its own class, that is later passed into DelayedJob which is responsible for displaying all the logs.

This change improves the logging so we can easily trace executed jobs and see meaningful information in the logs.