### PR TITLE
Add process.action_mailer notification to Instrument guide [ci skip]

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -337,6 +337,22 @@ Action Mailer
 }
 ```
 
+### process.action_mailer
+
+| Key           | Value                    |
+| ------------- | ------------------------ |
+| `:mailer`     | Name of the mailer class |
+| `:action`     | The action               |
+| `:args`       | The arguments            |
+
+```ruby
+{
+  mailer: "Notification",
+  action: "welcome_email",
+  args: []
+}
+```
+
 Active Support
 --------------
 


### PR DESCRIPTION
I Added `process.action_mailer` notification to Active Support Instrumentation guide.

The implementation of `ActionMailer::Base#process` is [here](https://github.com/rails/rails/blob/master/actionmailer/lib/action_mailer/base.rb#L599-L610). 