### PR TITLE
Added test case for starting rails with daemon option

### DIFF
--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -22,6 +22,18 @@ class Rails::ServerTest < ActiveSupport::TestCase
     assert_nil options[:server]
   end
 
+  def test_server_option_with_daemon
+    args = ["-d"]
+    options = parse_arguments(args)
+    assert_equal true, options[:daemonize]
+  end
+
+  def test_server_option_without_daemon
+    args = []
+    options = parse_arguments(args)
+    assert_equal false, options[:daemonize]
+  end
+
   def test_server_option_without_environment
     args = ["thin"]
     with_rack_env nil do


### PR DESCRIPTION
### Summary

Currently there is no test for testing that daemon is set correctly when provided by the user when starting rails using `rails s -d`. The two test cases makes sure that the options[:daemonize] is set to true when the argument `-d` is given.