### PR TITLE
Add Action Cable notifications to instrument guide [ci skip]

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -466,6 +466,45 @@ Active Job
 | `:adapter`   | QueueAdapter object processing the job |
 | `:job`       | Job object                             |
 
+Action Cable
+------------
+
+### perform_action.action_cable
+
+| Key              | Value                     |
+| ---------------- | ------------------------- |
+| `:channel_class` | Name of the channel class |
+| `:action`        | The action                |
+| `:data`          | A hash of data            |
+
+### transmit.action_cable
+
+| Key              | Value                     |
+| ---------------- | ------------------------- |
+| `:channel_class` | Name of the channel class |
+| `:data`          | A hash of data            |
+| `:via`           | Via                       |
+
+### transmit_subscription_confirmation.action_cable
+
+| Key              | Value                     |
+| ---------------- | ------------------------- |
+| `:channel_class` | Name of the channel class |
+
+### transmit_subscription_rejection.action_cable
+
+| Key              | Value                     |
+| ---------------- | ------------------------- |
+| `:channel_class` | Name of the channel class |
+
+### broadcast.action_cable
+
+| Key             | Value                |
+| --------------- | -------------------- |
+| `:broadcasting` | A named broadcasting |
+| `:message`      | A hash of message    |
+| `:coder`        | The coder            |
+
 Active Storage
 --------------
 


### PR DESCRIPTION
### Summary

I Added `*.action_cable` notifications to Active Support Instrumentation Guide.

### Source

- [perform_action.action_cable](https://github.com/rails/rails/blob/master/actioncable/lib/action_cable/channel/base.rb#L166-L169)
- [transmit.action_cable](https://github.com/rails/rails/blob/master/actioncable/lib/action_cable/channel/base.rb#L214-L217)
- [transmit_subscription_confirmation.action_cable](https://github.com/rails/rails/blob/master/actioncable/lib/action_cable/channel/base.rb#L284)
- [transmit_subscription_rejection.action_cable](https://github.com/rails/rails/blob/master/actioncable/lib/action_cable/channel/base.rb#L299)
- [broadcast.action_cable](https://github.com/rails/rails/blob/master/actioncable/lib/action_cable/server/broadcasting.rb#L45-L49)

### Generated guide

![](https://user-images.githubusercontent.com/15371677/31550918-dfa86eca-b06d-11e7-8c5a-36305e27a9ac.png)

![](https://user-images.githubusercontent.com/15371677/31550959-002f0168-b06e-11e7-892a-bb2c7354d81e.png)
