### PR TITLE
Use __dir__  in activestorage/

### DIFF
--- a/activestorage/test/database/setup.rb
+++ b/activestorage/test/database/setup.rb
@@ -3,5 +3,5 @@
 require_relative "create_users_migration"
 
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
-ActiveRecord::Migrator.migrate File.expand_path("../../../db/migrate", __FILE__)
+ActiveRecord::Migrator.migrate File.expand_path("../../db/migrate", __dir__)
 ActiveStorageCreateUsers.migrate(:up)

--- a/activestorage/test/dummy/bin/bundle
+++ b/activestorage/test/dummy/bin/bundle
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 load Gem.bin_path("bundler", "bundle")

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
+require_relative "dummy/config/environment.rb"
 
 require "bundler/setup"
 require "active_support"

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -23,7 +23,7 @@ Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
 require "yaml"
 SERVICE_CONFIGURATIONS = begin
-  erb = ERB.new(Pathname.new(File.expand_path("../service/configurations.yml", __FILE__)).read)
+  erb = ERB.new(Pathname.new(File.expand_path("service/configurations.yml", __dir__)).read)
   configuration = YAML.load(erb.result) || {}
   configuration.deep_symbolize_keys
 rescue Errno::ENOENT
@@ -38,7 +38,7 @@ ActiveStorage::Service.logger = ActiveSupport::Logger.new(nil)
 ActiveStorage.verifier = ActiveSupport::MessageVerifier.new("Testing")
 
 class ActiveSupport::TestCase
-  self.file_fixture_path = File.expand_path("../fixtures/files", __FILE__)
+  self.file_fixture_path = File.expand_path("fixtures/files", __dir__)
 
   private
     def create_blob(data: "Hello world!", filename: "hello.txt", content_type: "text/plain")


### PR DESCRIPTION
- Define path with \_\_dir\_\_ in activestorage/ 
  Related to #29176

-  Use `require_relative` instead of `require` with full path in activestorage/
    Related to #29417

Would be great to keep consistency ActiveStorage codebase with Rails, since ActiveStorage is part of Rails.
/cc @georgeclaghorn 