### PR TITLE
Fix test name for daemon option test

### DIFF
--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -22,13 +22,13 @@ class Rails::ServerTest < ActiveSupport::TestCase
     assert_nil options[:server]
   end
 
-  def test_server_option_with_daemon
+  def test_daemon_with_option
     args = ["-d"]
     options = parse_arguments(args)
     assert_equal true, options[:daemonize]
   end
 
-  def test_server_option_without_daemon
+  def test_daemon_without_option
     args = []
     options = parse_arguments(args)
     assert_equal false, options[:daemonize]


### PR DESCRIPTION
In this test file, "server option" refers to the server used to start Rails(e.g. `puma`, `thin`).
But this test, "server option" is not specified. Therefore, I think that
it is incorrect that `server_option` is included in the test name.

