### PR TITLE
Add unpermitted_parameters hook to instrumentation guide [ci skip]

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -197,6 +197,12 @@ INFO. Additional keys may be added by the caller.
 }
 ```
 
+### unpermitted_parameters.action_controller
+
+| Key     | Value            |
+| ------- | ---------------- |
+| `:keys` | Unpermitted keys |
+
 Action View
 -----------
 


### PR DESCRIPTION
### Summary

Added `unpermitted_parameters.action_controller` notification to Active Support Instrumentation guide. Source is [here](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/strong_parameters.rb#L868-L869).