### PR TITLE
 Modify so that `preloader` isn't initialized each time `exec_queries` is called.

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -587,10 +587,9 @@ module ActiveRecord
 
           preload = preload_values
           preload += includes_values unless eager_loading?
-          preloader = nil
           preload.each do |associations|
-            preloader ||= build_preloader
-            preloader.preload @records, associations
+            @preloader_cache ||= build_preloader
+            @preloader_cache.preload @records, associations
           end
 
           @records.each(&:readonly!) if readonly_value


### PR DESCRIPTION
~~Fixed as `build_preloader` used in `ActiveRecord::Relation#exec_queries` was not working properly.~~

~~Fix this commit: #27030~~

1. `build_preloader` is an instance of `ActiveRecord::Associations::Preloader` class that does't hold instance variables.
2. `build_preloader.preload` doesn't manipulate instance variables other than `@records`.
3. The owner of `@records` is not a `build_preloader`.

For these 3 reasons, 
I think that it is not necessary to initialize `preloader` with `nil` each time `exec_queries` is called.

Modify this commit: #27030