### PR TITLE
Add `!connection.active_record` to instrument guide [ci skip]

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -288,6 +288,14 @@ INFO. The adapters will add their own data as well.
 }
 ```
 
+### !connection.active_record
+
+| Key              | Value                        |
+| ---------------- | ---------------------------- |
+| `:connection_id` | `self.object_id`             |
+| `:spec_name`     | Name of environment          |
+| `:config`        | Configuration of environment |
+
 Action Mailer
 -------------
 


### PR DESCRIPTION
### Summary

Added `!connection.active_record` to Active Support instrumentation guide. Source is [here](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L881-L901)