### PR TITLE
Add accept-charset to the output of form_with in JS guide [ci skip]

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -174,7 +174,7 @@ passing the `:local` option `form_with`.
 This will generate the following HTML:
 
 ```html
-<form action="/articles" method="post" data-remote="true">
+<form action="/articles" accept-charset="UTF-8" method="post" data-remote="true">
   ...
 </form>
 ```


### PR DESCRIPTION
### Summary

In Working with JavaScript in Rails guide, I found the difference between actual and guide, and added `accept-charset="UTF-8"` to the output of `form_with`.