### PR TITLE
Verify credentials format before saving

### DIFF
--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -22,6 +22,12 @@ module ActiveSupport
       ""
     end
 
+    def write(contents)
+      deserialize(contents)
+
+      super
+    end
+
     def config
       @config ||= deserialize(read).deep_symbolize_keys
     end
@@ -36,7 +42,7 @@ module ActiveSupport
       end
 
       def deserialize(config)
-        config.present? ? YAML.load(config) : {}
+        config.present? ? YAML.load(config, content_path) : {}
       end
   end
 end

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -51,6 +51,14 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     assert_equal "things", @credentials[:new]
   end
 
+  test "raise error when writing an invalid format value" do
+    assert_raise(Psych::SyntaxError) do
+      @credentials.change do |config_file|
+        config_file.write "login: *login\n  username: dummy"
+      end
+    end
+  end
+
   test "raises key error when accessing config via bang method" do
     assert_raise(KeyError) { @credentials.something! }
   end


### PR DESCRIPTION
Currently, credentials does not check the format when saving. As a result, incorrect data as yaml is also saved.
If credentials is used in config files., an error will occur in credential yaml parsing before edit, and will not be able to edit it.
In order to prevent this, verify the format when saving.
Related: #30851

r? @kaspth 