### PR TITLE
Convert AttributeMethodMatcher to Module Builder

### DIFF
--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -32,6 +32,7 @@ module ActiveModel
 
   autoload :AttributeAssignment
   autoload :AttributeMethods
+  autoload :AttributeMethodMatcher
   autoload :BlockValidator, "active_model/validator"
   autoload :Callbacks
   autoload :Conversion

--- a/activemodel/lib/active_model/attribute_method_matcher.rb
+++ b/activemodel/lib/active_model/attribute_method_matcher.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "concurrent/map"
+
+module ActiveModel
+  class AttributeMethodMatcher < Module
+    NAME_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?=]?\z/
+    CALL_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?]?\z/
+
+    attr_reader :prefix, :suffix, :method_missing_target, :method_names
+    AttributeMethodMatch = Struct.new(:target, :attr_name, :method_name)
+
+    def initialize(options = {})
+      @prefix, @suffix = options.fetch(:prefix, ""), options.fetch(:suffix, "")
+      @regex = /^(?:#{Regexp.escape(@prefix)})(.*)(?:#{Regexp.escape(@suffix)})$/
+      @method_missing_target = "#{@prefix}attribute#{@suffix}"
+      @method_name = "#{prefix}%s#{suffix}"
+      @method_names = []
+      define_method_missing
+    end
+
+    def included(model_class)
+      model_class.include AttributeMissingMethods
+    end
+
+    def inspect
+      "<#{self.class.name}: #{@regex.inspect}>"
+    end
+
+    def define_attribute_methods(*attr_names)
+      attr_names.each { |attr_name| define_attribute_method(attr_name) }
+    end
+
+    def define_attribute_method(attr_name)
+      name = method_name(attr_name)
+      unless instance_method_already_implemented?(name)
+        generate_method = "define_method_#{method_missing_target}"
+
+        if respond_to?(generate_method, true)
+          send(generate_method, attr_name.to_s)
+        else
+          method_names << name.to_sym
+          define_proxy_call true, name, method_missing_target, attr_name.to_s
+        end
+      end
+    end
+
+    def undefine_attribute_methods
+      (method_names & instance_methods(false)).each(&method(:undef_method))
+      method_names.clear
+      matchers_cache.clear
+    end
+
+    def alias_attribute(new_name, old_name)
+      define_proxy_call false, method_name(new_name), method_name(old_name)
+    end
+
+    def match(method_name)
+      matchers_cache.compute_if_absent(method_name) do
+        if (@regex =~ method_name) && (method_name != :attributes)
+          AttributeMethodMatch.new(method_missing_target, $1, method_name.to_s)
+        end
+      end
+    end
+
+    def apply(klass)
+      klass.include self
+    end
+
+    private
+
+    def define_method_missing
+      matcher = self
+
+      define_method :method_missing do |method_name, *arguments, &method_block|
+        if (match = matcher.match(method_name.to_s)) &&
+            method_name != :attributes &&
+            attribute_method?(match.attr_name) &&
+            !respond_to_without_attributes?(method_name, true)
+          attribute_missing(match, *arguments, &method_block)
+        else
+          super(method_name, *arguments, &method_block)
+        end
+      end
+
+      define_method :respond_to? do |method_name, include_private_methods = false|
+        if super(method_name, include_private_methods)
+          true
+        elsif !include_private_methods && super(method_name, true)
+          false
+        else
+          (match = matcher.match(method_name.to_s)) &&
+            (method_name != :attributes) &&
+            attribute_method?(match.attr_name) || false
+        end
+      end
+    end
+
+    def matchers_cache
+      @matchers_cache ||= Concurrent::Map.new(initial_capacity: 4)
+    end
+
+    def method_name(attr_name)
+      @method_name % attr_name
+    end
+
+    def define_proxy_call(include_private, name, send, *extra)
+      defn = if NAME_COMPILABLE_REGEXP.match?(name)
+        "def #{name}(*args)"
+      else
+        "define_method(:'#{name}') do |*args|"
+      end
+
+      extra = (extra.map!(&:inspect) << "*args").join(", ".freeze)
+
+      target = if CALL_COMPILABLE_REGEXP.match?(send)
+        "#{"self." unless include_private}#{send}(#{extra})"
+      else
+        "send(:'#{send}', #{extra})"
+      end
+
+      module_eval <<-RUBY, __FILE__, __LINE__ + 1
+        #{defn}
+          #{target}
+        end
+      RUBY
+    end
+
+    def instance_method_already_implemented?(method_name)
+      method_defined?(method_name)
+    end
+
+    module AttributeMissingMethods
+      # +attribute_missing+ is like +method_missing+, but for attributes. When
+      # +method_missing+ is called we check to see if there is a matching
+      # attribute method. If so, we tell +attribute_missing+ to dispatch the
+      # attribute. This method can be overloaded to customize the behavior.
+      def attribute_missing(match, *args, &block)
+        __send__(match.target, match.attr_name, *args, &block)
+      end
+
+      alias :respond_to_without_attributes? :respond_to?
+
+      private
+
+      def attribute_method?(attr_name)
+        respond_to_without_attributes?(:attributes) && attributes.include?(attr_name)
+      end
+
+      def missing_attribute(attr_name, stack)
+        raise ActiveModel::MissingAttributeError, "missing attribute: #{attr_name}", stack
+      end
+
+      def _read_attribute(attr)
+        __send__(attr)
+      end
+    end
+  end
+end

--- a/activemodel/lib/active_model/attribute_method_matcher.rb
+++ b/activemodel/lib/active_model/attribute_method_matcher.rb
@@ -15,7 +15,7 @@ module ActiveModel
       @regex = /^(?:#{Regexp.escape(@prefix)})(.*)(?:#{Regexp.escape(@suffix)})$/
       @method_missing_target = "#{@prefix}attribute#{@suffix}"
       @method_name = "#{prefix}%s#{suffix}"
-      @method_names = []
+      @method_names = Set.new
       define_method_missing
     end
 
@@ -33,13 +33,13 @@ module ActiveModel
 
     def define_attribute_method(attr_name)
       name = method_name(attr_name)
+      method_names << name.to_sym
       unless instance_method_already_implemented?(name)
         generate_method = "define_method_#{method_missing_target}"
 
         if respond_to?(generate_method, true)
           send(generate_method, attr_name.to_s)
         else
-          method_names << name.to_sym
           define_proxy_call true, name, method_missing_target, attr_name.to_s
         end
       end

--- a/activemodel/lib/active_model/attribute_method_matcher.rb
+++ b/activemodel/lib/active_model/attribute_method_matcher.rb
@@ -68,92 +68,90 @@ module ActiveModel
     end
 
     private
+      def define_method_missing
+        matcher = self
 
-    def define_method_missing
-      matcher = self
+        define_method :method_missing do |method_name, *arguments, &method_block|
+          if (match = matcher.match(method_name.to_s)) &&
+              method_name != :attributes &&
+              attribute_method?(match.attr_name) &&
+              !respond_to_without_attributes?(method_name, true)
+            attribute_missing(match, *arguments, &method_block)
+          else
+            super(method_name, *arguments, &method_block)
+          end
+        end
 
-      define_method :method_missing do |method_name, *arguments, &method_block|
-        if (match = matcher.match(method_name.to_s)) &&
-            method_name != :attributes &&
-            attribute_method?(match.attr_name) &&
-            !respond_to_without_attributes?(method_name, true)
-          attribute_missing(match, *arguments, &method_block)
+        define_method :respond_to? do |method_name, include_private_methods = false|
+          if super(method_name, include_private_methods)
+            true
+          elsif !include_private_methods && super(method_name, true)
+            false
+          else
+            (match = matcher.match(method_name.to_s)) &&
+              (method_name != :attributes) &&
+              attribute_method?(match.attr_name) || false
+          end
+        end
+      end
+
+      def matchers_cache
+        @matchers_cache ||= Concurrent::Map.new(initial_capacity: 4)
+      end
+
+      def method_name(attr_name)
+        @method_name % attr_name
+      end
+
+      def define_proxy_call(include_private, name, send, *extra)
+        defn = if NAME_COMPILABLE_REGEXP.match?(name)
+          "def #{name}(*args)"
         else
-          super(method_name, *arguments, &method_block)
+          "define_method(:'#{name}') do |*args|"
         end
-      end
 
-      define_method :respond_to? do |method_name, include_private_methods = false|
-        if super(method_name, include_private_methods)
-          true
-        elsif !include_private_methods && super(method_name, true)
-          false
+        extra = (extra.map!(&:inspect) << "*args").join(", ".freeze)
+
+        target = if CALL_COMPILABLE_REGEXP.match?(send)
+          "#{"self." unless include_private}#{send}(#{extra})"
         else
-          (match = matcher.match(method_name.to_s)) &&
-            (method_name != :attributes) &&
-            attribute_method?(match.attr_name) || false
+          "send(:'#{send}', #{extra})"
         end
-      end
-    end
 
-    def matchers_cache
-      @matchers_cache ||= Concurrent::Map.new(initial_capacity: 4)
-    end
-
-    def method_name(attr_name)
-      @method_name % attr_name
-    end
-
-    def define_proxy_call(include_private, name, send, *extra)
-      defn = if NAME_COMPILABLE_REGEXP.match?(name)
-        "def #{name}(*args)"
-      else
-        "define_method(:'#{name}') do |*args|"
+        module_eval <<-RUBY, __FILE__, __LINE__ + 1
+          #{defn}
+            #{target}
+          end
+        RUBY
       end
 
-      extra = (extra.map!(&:inspect) << "*args").join(", ".freeze)
-
-      target = if CALL_COMPILABLE_REGEXP.match?(send)
-        "#{"self." unless include_private}#{send}(#{extra})"
-      else
-        "send(:'#{send}', #{extra})"
+      def instance_method_already_implemented?(method_name)
+        method_defined?(method_name)
       end
 
-      module_eval <<-RUBY, __FILE__, __LINE__ + 1
-        #{defn}
-          #{target}
+      module AttributeMissingMethods
+        # +attribute_missing+ is like +method_missing+, but for attributes. When
+        # +method_missing+ is called we check to see if there is a matching
+        # attribute method. If so, we tell +attribute_missing+ to dispatch the
+        # attribute. This method can be overloaded to customize the behavior.
+        def attribute_missing(match, *args, &block)
+          __send__(match.target, match.attr_name, *args, &block)
         end
-      RUBY
-    end
 
-    def instance_method_already_implemented?(method_name)
-      method_defined?(method_name)
-    end
+        alias :respond_to_without_attributes? :respond_to?
 
-    module AttributeMissingMethods
-      # +attribute_missing+ is like +method_missing+, but for attributes. When
-      # +method_missing+ is called we check to see if there is a matching
-      # attribute method. If so, we tell +attribute_missing+ to dispatch the
-      # attribute. This method can be overloaded to customize the behavior.
-      def attribute_missing(match, *args, &block)
-        __send__(match.target, match.attr_name, *args, &block)
+        private
+          def attribute_method?(attr_name)
+            respond_to_without_attributes?(:attributes) && attributes.include?(attr_name)
+          end
+
+          def missing_attribute(attr_name, stack)
+            raise ActiveModel::MissingAttributeError, "missing attribute: #{attr_name}", stack
+          end
+
+          def _read_attribute(attr)
+            __send__(attr)
+          end
       end
-
-      alias :respond_to_without_attributes? :respond_to?
-
-      private
-
-      def attribute_method?(attr_name)
-        respond_to_without_attributes?(:attributes) && attributes.include?(attr_name)
-      end
-
-      def missing_attribute(attr_name, stack)
-        raise ActiveModel::MissingAttributeError, "missing attribute: #{attr_name}", stack
-      end
-
-      def _read_attribute(attr)
-        __send__(attr)
-      end
-    end
   end
 end

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -317,10 +317,9 @@ module ActiveModel
       end
 
       private
-
-      def instance_method_already_implemented?(method_name)
-        attribute_method_matchers.any? { |matcher| matcher.method_defined?(method_name) }
-      end
+        def instance_method_already_implemented?(method_name)
+          attribute_method_matchers.any? { |matcher| matcher.method_defined?(method_name) }
+        end
     end
   end
 end

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "concurrent/map"
-
 module ActiveModel
   # Raised when an attribute is not defined.
   #
@@ -65,15 +63,17 @@ module ActiveModel
   module AttributeMethods
     extend ActiveSupport::Concern
 
-    NAME_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?=]?\z/
-    CALL_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?]?\z/
-
     included do
       class_attribute :attribute_aliases, instance_writer: false, default: {}
-      class_attribute :attribute_method_matchers, instance_writer: false, default: [ ClassMethods::AttributeMethodMatcher.new ]
+      matcher = attribute_method_matcher_class.new.tap { |m| m.apply(self) }
+      class_attribute :attribute_method_matchers, instance_writer: false, default: [ matcher ]
     end
 
     module ClassMethods
+      def attribute_method_matcher_class
+        ActiveModel::AttributeMethodMatcher
+      end
+
       # Declares a method available for all attributes with the given prefix.
       # Uses +method_missing+ and <tt>respond_to?</tt> to rewrite the method.
       #
@@ -106,7 +106,9 @@ module ActiveModel
       #   person.clear_name
       #   person.name          # => nil
       def attribute_method_prefix(*prefixes)
-        self.attribute_method_matchers += prefixes.map! { |prefix| AttributeMethodMatcher.new prefix: prefix }
+        self.attribute_method_matchers += prefixes.map! do |prefix|
+          attribute_method_matcher_class.new(prefix: prefix).tap { |m| m.apply(self) }
+        end
         undefine_attribute_methods
       end
 
@@ -141,7 +143,9 @@ module ActiveModel
       #   person.name          # => "Bob"
       #   person.name_short?   # => true
       def attribute_method_suffix(*suffixes)
-        self.attribute_method_matchers += suffixes.map! { |suffix| AttributeMethodMatcher.new suffix: suffix }
+        self.attribute_method_matchers += suffixes.map! do |suffix|
+          attribute_method_matcher_class.new(suffix: suffix).tap { |m| m.apply(self) }
+        end
         undefine_attribute_methods
       end
 
@@ -177,7 +181,9 @@ module ActiveModel
       #   person.reset_name_to_default!
       #   person.name                         # => 'Default Name'
       def attribute_method_affix(*affixes)
-        self.attribute_method_matchers += affixes.map! { |affix| AttributeMethodMatcher.new prefix: affix[:prefix], suffix: affix[:suffix] }
+        self.attribute_method_matchers += affixes.map! do |affix|
+          attribute_method_matcher_class.new(prefix: affix[:prefix], suffix: affix[:suffix]).tap { |m| m.apply(self) }
+        end
         undefine_attribute_methods
       end
 
@@ -207,11 +213,7 @@ module ActiveModel
       #   person.nickname_short? # => true
       def alias_attribute(new_name, old_name)
         self.attribute_aliases = attribute_aliases.merge(new_name.to_s => old_name.to_s)
-        attribute_method_matchers.each do |matcher|
-          matcher_new = matcher.method_name(new_name).to_s
-          matcher_old = matcher.method_name(old_name).to_s
-          define_proxy_call false, self, matcher_new, matcher_old
-        end
+        attribute_method_matchers.each { |matcher| matcher.alias_attribute(new_name, old_name) }
       end
 
       # Is +new_name+ an alias?
@@ -249,7 +251,9 @@ module ActiveModel
       #     end
       #   end
       def define_attribute_methods(*attr_names)
-        attr_names.flatten.each { |attr_name| define_attribute_method(attr_name) }
+        attribute_method_matchers.each do |matcher|
+          matcher.define_attribute_methods(*(attr_names.flatten))
+        end
       end
 
       # Declares an attribute that should be prefixed and suffixed by
@@ -281,22 +285,7 @@ module ActiveModel
       #   person.name = 'Bob'
       #   person.name        # => "Bob"
       #   person.name_short? # => true
-      def define_attribute_method(attr_name)
-        attribute_method_matchers.each do |matcher|
-          method_name = matcher.method_name(attr_name)
-
-          unless instance_method_already_implemented?(method_name)
-            generate_method = "define_method_#{matcher.method_missing_target}"
-
-            if respond_to?(generate_method, true)
-              send(generate_method, attr_name.to_s)
-            else
-              define_proxy_call true, generated_attribute_methods, method_name, matcher.method_missing_target, attr_name.to_s
-            end
-          end
-        end
-        attribute_method_matchers_cache.clear
-      end
+      alias_method :define_attribute_method, :define_attribute_methods
 
       # Removes all the previously dynamically defined methods from the class.
       #
@@ -322,157 +311,16 @@ module ActiveModel
       #
       #   person.name_short? # => NoMethodError
       def undefine_attribute_methods
-        generated_attribute_methods.module_eval do
-          instance_methods.each { |m| undef_method(m) }
+        attribute_method_matchers.each do |matcher|
+          matcher.undefine_attribute_methods
         end
-        attribute_method_matchers_cache.clear
       end
 
       private
-        def generated_attribute_methods
-          @generated_attribute_methods ||= Module.new.tap { |mod| include mod }
-        end
 
-        def instance_method_already_implemented?(method_name)
-          generated_attribute_methods.method_defined?(method_name)
-        end
-
-        # The methods +method_missing+ and +respond_to?+ of this module are
-        # invoked often in a typical rails, both of which invoke the method
-        # +matched_attribute_method+. The latter method iterates through an
-        # array doing regular expression matches, which results in a lot of
-        # object creations. Most of the time it returns a +nil+ match. As the
-        # match result is always the same given a +method_name+, this cache is
-        # used to alleviate the GC, which ultimately also speeds up the app
-        # significantly (in our case our test suite finishes 10% faster with
-        # this cache).
-        def attribute_method_matchers_cache
-          @attribute_method_matchers_cache ||= Concurrent::Map.new(initial_capacity: 4)
-        end
-
-        def attribute_method_matchers_matching(method_name)
-          attribute_method_matchers_cache.compute_if_absent(method_name) do
-            # Must try to match prefixes/suffixes first, or else the matcher with no prefix/suffix
-            # will match every time.
-            matchers = attribute_method_matchers.partition(&:plain?).reverse.flatten(1)
-            matchers.map { |method| method.match(method_name) }.compact
-          end
-        end
-
-        # Define a method `name` in `mod` that dispatches to `send`
-        # using the given `extra` args. This falls back on `define_method`
-        # and `send` if the given names cannot be compiled.
-        def define_proxy_call(include_private, mod, name, send, *extra)
-          defn = if NAME_COMPILABLE_REGEXP.match?(name)
-            "def #{name}(*args)"
-          else
-            "define_method(:'#{name}') do |*args|"
-          end
-
-          extra = (extra.map!(&:inspect) << "*args").join(", ".freeze)
-
-          target = if CALL_COMPILABLE_REGEXP.match?(send)
-            "#{"self." unless include_private}#{send}(#{extra})"
-          else
-            "send(:'#{send}', #{extra})"
-          end
-
-          mod.module_eval <<-RUBY, __FILE__, __LINE__ + 1
-            #{defn}
-              #{target}
-            end
-          RUBY
-        end
-
-        class AttributeMethodMatcher #:nodoc:
-          attr_reader :prefix, :suffix, :method_missing_target
-
-          AttributeMethodMatch = Struct.new(:target, :attr_name, :method_name)
-
-          def initialize(options = {})
-            @prefix, @suffix = options.fetch(:prefix, ""), options.fetch(:suffix, "")
-            @regex = /^(?:#{Regexp.escape(@prefix)})(.*)(?:#{Regexp.escape(@suffix)})$/
-            @method_missing_target = "#{@prefix}attribute#{@suffix}"
-            @method_name = "#{prefix}%s#{suffix}"
-          end
-
-          def match(method_name)
-            if @regex =~ method_name
-              AttributeMethodMatch.new(method_missing_target, $1, method_name)
-            end
-          end
-
-          def method_name(attr_name)
-            @method_name % attr_name
-          end
-
-          def plain?
-            prefix.empty? && suffix.empty?
-          end
-        end
-    end
-
-    # Allows access to the object attributes, which are held in the hash
-    # returned by <tt>attributes</tt>, as though they were first-class
-    # methods. So a +Person+ class with a +name+ attribute can for example use
-    # <tt>Person#name</tt> and <tt>Person#name=</tt> and never directly use
-    # the attributes hash -- except for multiple assignments with
-    # <tt>ActiveRecord::Base#attributes=</tt>.
-    #
-    # It's also possible to instantiate related objects, so a <tt>Client</tt>
-    # class belonging to the +clients+ table with a +master_id+ foreign key
-    # can instantiate master through <tt>Client#master</tt>.
-    def method_missing(method, *args, &block)
-      if respond_to_without_attributes?(method, true)
-        super
-      else
-        match = matched_attribute_method(method.to_s)
-        match ? attribute_missing(match, *args, &block) : super
+      def instance_method_already_implemented?(method_name)
+        attribute_method_matchers.any? { |matcher| matcher.method_defined?(method_name) }
       end
     end
-
-    # +attribute_missing+ is like +method_missing+, but for attributes. When
-    # +method_missing+ is called we check to see if there is a matching
-    # attribute method. If so, we tell +attribute_missing+ to dispatch the
-    # attribute. This method can be overloaded to customize the behavior.
-    def attribute_missing(match, *args, &block)
-      __send__(match.target, match.attr_name, *args, &block)
-    end
-
-    # A +Person+ instance with a +name+ attribute can ask
-    # <tt>person.respond_to?(:name)</tt>, <tt>person.respond_to?(:name=)</tt>,
-    # and <tt>person.respond_to?(:name?)</tt> which will all return +true+.
-    alias :respond_to_without_attributes? :respond_to?
-    def respond_to?(method, include_private_methods = false)
-      if super
-        true
-      elsif !include_private_methods && super(method, true)
-        # If we're here then we haven't found among non-private methods
-        # but found among all methods. Which means that the given method is private.
-        false
-      else
-        !matched_attribute_method(method.to_s).nil?
-      end
-    end
-
-    private
-      def attribute_method?(attr_name)
-        respond_to_without_attributes?(:attributes) && attributes.include?(attr_name)
-      end
-
-      # Returns a struct representing the matching attribute method.
-      # The struct's attributes are prefix, base and suffix.
-      def matched_attribute_method(method_name)
-        matches = self.class.send(:attribute_method_matchers_matching, method_name)
-        matches.detect { |match| attribute_method?(match.attr_name) }
-      end
-
-      def missing_attribute(attr_name, stack)
-        raise ActiveModel::MissingAttributeError, "missing attribute: #{attr_name}", stack
-      end
-
-      def _read_attribute(attr)
-        __send__(attr)
-      end
   end
 end

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -117,15 +117,22 @@ class AttributeMethodsTest < ActiveModel::TestCase
   end
 
   test "#define_attribute_method does not generate attribute method if already defined in attribute module" do
-    klass = Class.new(ModelWithAttributes)
-    klass.send(:generated_attribute_methods).module_eval do
-      def foo
-        "<3"
+    begin
+      klass = Class.new(ModelWithAttributes)
+      matcher = klass.ancestors.find { |mod|
+        mod.is_a?(ActiveModel::AttributeMethodMatcher)
+      }
+      matcher.module_eval do
+        def foo
+          "<3"
+        end
       end
-    end
-    klass.define_attribute_method(:foo)
+      klass.define_attribute_method(:foo)
 
-    assert_equal "<3", klass.new.foo
+      assert_equal "<3", klass.new.foo
+    ensure
+      klass.undefine_attribute_methods
+    end
   end
 
   test "#define_attribute_method generates a method that is already defined on the host" do

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -84,6 +84,7 @@ module ActiveRecord
     autoload :Associations
     autoload :AttributeAssignment
     autoload :AttributeMethods
+    autoload :AttributeMethodMatcher
     autoload :AutosaveAssociation
 
     autoload :LegacyYamlAdapter

--- a/activerecord/lib/active_record/attribute_method_matcher.rb
+++ b/activerecord/lib/active_record/attribute_method_matcher.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "mutex_m"
+
+module ActiveRecord
+  class AttributeMethodMatcher < ActiveModel::AttributeMethodMatcher
+    include Mutex_m
+
+    def initialize(*)
+      super
+      @attribute_methods_generated = false
+    end
+
+    def included(model_class)
+      super
+      @model_class = model_class
+    end
+
+    # Generates all the attribute related methods for columns in the database
+    # accessors, mutators and query methods.
+    def define_attribute_methods(*attr_names)
+      return false if @attribute_methods_generated
+      # Use a mutex; we don't want two threads simultaneously trying to define
+      # attribute methods.
+      synchronize do
+        return false if @attribute_methods_generated
+        super(*attr_names)
+        @attribute_methods_generated = true
+      end
+    end
+
+    def undefine_attribute_methods # :nodoc:
+      synchronize do
+        super if @attribute_methods_generated
+        @attribute_methods_generated = false
+      end
+    end
+
+    def apply(klass)
+      super unless klass == Base
+    end
+
+    def plain?
+      prefix.empty? && suffix.empty?
+    end
+
+    private
+
+    # We want to generate the methods via module_eval rather than
+    # define_method, because define_method is slower on dispatch.
+    # Evaluating many similar methods may use more memory as the instruction
+    # sequences are duplicated and cached (in MRI).  define_method may
+    # be slower on dispatch, but if you're careful about the closure
+    # created, then define_method will consume much less memory.
+    #
+    # But sometimes the database might return columns with
+    # characters that are not allowed in normal method names (like
+    # 'my_column(omg)'. So to work around this we first define with
+    # the __temp__ identifier, and then use alias method to rename
+    # it to what we want.
+    #
+    # We are also defining a constant to hold the frozen string of
+    # the attribute name. Using a constant means that we do not have
+    # to allocate an object on each call to the attribute method.
+    # Making it frozen means that it doesn't get duped when used to
+    # key the @attributes in read_attribute.
+    def define_method_attribute(name)
+      safe_name = name.unpack("h*".freeze).first
+      temp_method = "__temp__#{safe_name}"
+
+      ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
+
+      module_eval <<-STR, __FILE__, __LINE__ + 1
+        def #{temp_method}
+          name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
+          sync_with_transaction_state if name == self.class.primary_key
+          _read_attribute(name) { |n| missing_attribute(n, caller) }
+        end
+      STR
+
+      alias_method name, temp_method
+      undef_method temp_method
+    end
+
+    def define_method_attribute=(name)
+      safe_name = name.unpack("h*".freeze).first
+      ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
+
+      module_eval <<-STR, __FILE__, __LINE__ + 1
+        def __temp__#{safe_name}=(value)
+          name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
+          sync_with_transaction_state if name == self.class.primary_key
+          _write_attribute(name, value)
+        end
+        alias_method #{(name + '=').inspect}, :__temp__#{safe_name}=
+        undef_method :__temp__#{safe_name}=
+      STR
+    end
+
+    def instance_method_already_implemented?(method_name)
+      @model_class && @model_class.instance_method_already_implemented?(method_name)
+    end
+  end
+end

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "mutex_m"
-
 module ActiveRecord
   # = Active Record Attribute Methods
   module AttributeMethods
@@ -9,7 +7,7 @@ module ActiveRecord
     include ActiveModel::AttributeMethods
 
     included do
-      initialize_generated_modules
+      self.attribute_method_matchers = [ attribute_method_matcher_class.new ]
       include Read
       include Write
       include BeforeTypeCast
@@ -33,43 +31,25 @@ module ActiveRecord
 
     BLACKLISTED_CLASS_METHODS = %w(private public protected allocate new name parent superclass)
 
-    class GeneratedAttributeMethods < Module #:nodoc:
-      include Mutex_m
-    end
-
     module ClassMethods
-      def inherited(child_class) #:nodoc:
-        child_class.initialize_generated_modules
-        super
+      def attribute_method_matcher_class
+        ActiveRecord::AttributeMethodMatcher
       end
 
-      def initialize_generated_modules # :nodoc:
-        @generated_attribute_methods = GeneratedAttributeMethods.new
-        @attribute_methods_generated = false
-        include @generated_attribute_methods
-
+      def inherited(child_class) #:nodoc:
+        if self == Base
+          child_class.attribute_method_matchers =
+            attribute_method_matchers.partition(&:plain?).flatten(1).map do |matcher|
+              matcher.dup.tap { |mod| child_class.include(mod) }
+            end
+        end
         super
       end
 
       # Generates all the attribute related methods for columns in the database
       # accessors, mutators and query methods.
       def define_attribute_methods # :nodoc:
-        return false if @attribute_methods_generated
-        # Use a mutex; we don't want two threads simultaneously trying to define
-        # attribute methods.
-        generated_attribute_methods.synchronize do
-          return false if @attribute_methods_generated
-          superclass.define_attribute_methods unless self == base_class
-          super(attribute_names)
-          @attribute_methods_generated = true
-        end
-      end
-
-      def undefine_attribute_methods # :nodoc:
-        generated_attribute_methods.synchronize do
-          super if defined?(@attribute_methods_generated) && @attribute_methods_generated
-          @attribute_methods_generated = false
-        end
+        super(attribute_names)
       end
 
       # Raises an ActiveRecord::DangerousAttributeError exception when an
@@ -97,7 +77,7 @@ module ActiveRecord
           # If ThisClass < ... < SomeSuperClass < ... < Base and SomeSuperClass
           # defines its own attribute method, then we don't want to overwrite that.
           defined = method_defined_within?(method_name, superclass, Base) &&
-            ! superclass.instance_method(method_name).owner.is_a?(GeneratedAttributeMethods)
+            ! superclass.instance_method(method_name).owner.is_a?(attribute_method_matcher_class)
           defined || super
         end
       end

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -3,51 +3,6 @@
 module ActiveRecord
   module AttributeMethods
     module Read
-      extend ActiveSupport::Concern
-
-      module ClassMethods # :nodoc:
-        private
-
-          # We want to generate the methods via module_eval rather than
-          # define_method, because define_method is slower on dispatch.
-          # Evaluating many similar methods may use more memory as the instruction
-          # sequences are duplicated and cached (in MRI).  define_method may
-          # be slower on dispatch, but if you're careful about the closure
-          # created, then define_method will consume much less memory.
-          #
-          # But sometimes the database might return columns with
-          # characters that are not allowed in normal method names (like
-          # 'my_column(omg)'. So to work around this we first define with
-          # the __temp__ identifier, and then use alias method to rename
-          # it to what we want.
-          #
-          # We are also defining a constant to hold the frozen string of
-          # the attribute name. Using a constant means that we do not have
-          # to allocate an object on each call to the attribute method.
-          # Making it frozen means that it doesn't get duped when used to
-          # key the @attributes in read_attribute.
-          def define_method_attribute(name)
-            safe_name = name.unpack("h*".freeze).first
-            temp_method = "__temp__#{safe_name}"
-
-            ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
-            sync_with_transaction_state = "sync_with_transaction_state" if name == primary_key
-
-            generated_attribute_methods.module_eval <<-STR, __FILE__, __LINE__ + 1
-              def #{temp_method}
-                #{sync_with_transaction_state}
-                name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
-                _read_attribute(name) { |n| missing_attribute(n, caller) }
-              end
-            STR
-
-            generated_attribute_methods.module_eval do
-              alias_method name, temp_method
-              undef_method temp_method
-            end
-          end
-      end
-
       # Returns the value of the attribute identified by <tt>attr_name</tt> after
       # it has been typecast (for example, "2004-12-12" in a date column is cast
       # to a date object, like Date.new(2004, 12, 12)).

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -9,26 +9,6 @@ module ActiveRecord
         attribute_method_suffix "="
       end
 
-      module ClassMethods # :nodoc:
-        private
-
-          def define_method_attribute=(name)
-            safe_name = name.unpack("h*".freeze).first
-            ActiveRecord::AttributeMethods::AttrNames.set_name_cache safe_name, name
-            sync_with_transaction_state = "sync_with_transaction_state" if name == primary_key
-
-            generated_attribute_methods.module_eval <<-STR, __FILE__, __LINE__ + 1
-              def __temp__#{safe_name}=(value)
-                name = ::ActiveRecord::AttributeMethods::AttrNames::ATTR_#{safe_name}
-                #{sync_with_transaction_state}
-                _write_attribute(name, value)
-              end
-              alias_method #{(name + '=').inspect}, :__temp__#{safe_name}=
-              undef_method :__temp__#{safe_name}=
-            STR
-          end
-      end
-
       # Updates the attribute identified by <tt>attr_name</tt> with the
       # specified +value+. Empty strings for Integer and Float columns are
       # turned into +nil+.

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -156,6 +156,7 @@ module ActiveRecord
       def inherited(child_class) # :nodoc:
         # initialize cache at class definition for thread safety
         child_class.initialize_find_by_cache
+        child_class.initialize_generated_modules
         super
       end
 

--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -38,6 +38,7 @@ module ActiveRecord
       end
 
       def test_define_attribute_methods
+        skip "implementation changed, need to update test"
         instance = @klass.new
 
         @klass.attribute_names.each do |name|
@@ -52,6 +53,7 @@ module ActiveRecord
       end
 
       def test_attribute_methods_generated?
+        skip "implementation changed, need to update test"
         assert_not @klass.method_defined?(:one)
         @klass.define_attribute_methods
         assert @klass.method_defined?(:one)

--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -38,7 +38,6 @@ module ActiveRecord
       end
 
       def test_define_attribute_methods
-        skip "implementation changed, need to update test"
         instance = @klass.new
 
         @klass.attribute_names.each do |name|
@@ -53,7 +52,6 @@ module ActiveRecord
       end
 
       def test_attribute_methods_generated?
-        skip "implementation changed, need to update test"
         assert_not @klass.method_defined?(:one)
         @klass.define_attribute_methods
         assert @klass.method_defined?(:one)

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -19,14 +19,8 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   fixtures :topics, :developers, :companies, :computers
 
   def setup
-    @old_matchers = ActiveRecord::Base.send(:attribute_method_matchers).dup
     @target = Class.new(ActiveRecord::Base)
     @target.table_name = "topics"
-  end
-
-  teardown do
-    ActiveRecord::Base.send(:attribute_method_matchers).clear
-    ActiveRecord::Base.send(:attribute_method_matchers).concat(@old_matchers)
   end
 
   test "attribute_for_inspect with a string" do
@@ -999,11 +993,6 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal ["title"], model.accessed_fields
   end
 
-  test "generated attribute methods ancestors have correct class" do
-    mod = Topic.send(:generated_attribute_methods)
-    assert_match %r(GeneratedAttributeMethods), mod.inspect
-  end
-
   private
 
     def new_topic_like_ar_class(&block)
@@ -1012,7 +1001,9 @@ class AttributeMethodsTest < ActiveRecord::TestCase
         class_eval(&block)
       end
 
-      assert_empty klass.send(:generated_attribute_methods).instance_methods(false)
+      klass.attribute_method_matchers.each do |matcher|
+        assert_empty matcher.instance_methods - [:respond_to?, :method_missing]
+      end
       klass
     end
 


### PR DESCRIPTION
This is quite a large and substantial refactor of two core modules, `ActiveModel::AttributeMethods` and `ActiveRecord::AttributeMethods`. The inspiration for this PR is [this blog post](http://dejimata.com/2017/5/20/the-ruby-module-builder-pattern) on the module builder pattern which I wrote a few months ago (the end of the post discusses a change to AM::AttributeMethods which is almost the same to the one here). I had intended only to change ActiveModel, but the two modules are so heavily coupled that it was impossible to change one without the other.

I have tried to make the *absolute minimal* changes to achieve the goal of de-coupling described below, and wherever possible I have moved methods without actually altering their logic.

There are still some points to discuss and more tests to write, so this is not a finished PR; for now I'd just like to get some feedback on the general idea and current implementation.

### Summary

ActiveModel and ActiveRecord provide a [simple mechanism](http://api.rubyonrails.org/classes/ActiveModel/AttributeMethods.html) for defining prefixed/suffixed/affixed attribute methods, whereby you call a class method like `attribute_method_prefix` (etc) with a prefix (or suffix/affix), then call `define_attribute_methods` to actually define the attribute methods.

Under the hood, calling one of these class methods creates an instance of a class `AttributeMethodMatcher` which stores the prefix and/or suffix, and appends the instance onto a class attribute `attribute_method_matchers`. (Similar for defining aliases.)

https://github.com/shioyama/rails/blob/5668dc6b1863ef43be8f8ef0fb1d5db913085fb3/activemodel/lib/active_model/attribute_methods.rb#L387-L412

When you actually call an attribute method (i.e. a method with a prefix/suffix), AR/AM dispatches to a handler using one of two mechanisms:
- AM::AttributeMethods [overrides `method_missing`](https://github.com/shioyama/rails/blob/5668dc6b1863ef43be8f8ef0fb1d5db913085fb3/activemodel/lib/active_model/attribute_methods.rb#L425-L432) to dispatch calls for a method (say) `reset_foo_to_default!` to `reset_attribute_to_default!("foo")`, *if* `foo` is a key on the hash stored in the hash returned by the `attributes` method. (This one is actually not very well documented.)
- In addition, by calling `define_attribute_methods`, you can convert these prefixes/suffixes/affixes into actual methods, which are defined on instances of an anonymous module (in ActiveModel) or instances of a named module `GeneratedAttributeMethods` (in ActiveRecord).

While it works, there are a few problems with the current implementation, the major one being that the components (attribute method matchers on the class, instance methods on generated attribute methods, etc.) are heavily coupled to each other, making it hard to read the code and even harder to extend it. This is even more clear when you look at how heavily coupled AR::AttributeMethods is to the internals of AM::AttributeMethods.

I recently wrote a [blog post](http://dejimata.com/2017/5/20/the-ruby-module-builder-pattern) where (toward the end of the post) I discuss the problems with this approach. This PR is an attempt to implement what I describe in the post.

The basic concept here is to convert the matcher class `ActiveModel::ClassMethods::AttributeMethodMatcher` into a subclass of `Module`, which I've promoted in namespace to `ActiveModel::AttributeMethodMatcher`. Since the matcher has the prefix and/or suffix, you can define the `method_missing`/`respond_to?` overrides, *and also define* attribute methods (and aliases) themselves on the matcher and *include* it into the class. Coupling is vastly reduced since everything is encapsulated in one place.

The first commit in this PR does this in AM, which is quite a simple change and passes tests easily. The hard part is to make this work in ActiveRecord, since AR currently overrides private methods like `generated_attribute_methods`.

However, what is pleasantly surprising is that making a similar change in AR also yields cleaner code. Whereas currently AR::AttributeMethods has to override many methods in AM::AttributeMethods, here the customization happens instead by *subclassing* `ActiveModel::AttributeMethodMatcher` (the class which generates the matcher modules). By doing this, a number of the private methods added to the model class are instead moved to the matcher module, avoiding namespace pollution and keeping the implementation more encapsulated.

Concretely, the following AR methods are moved out of the model class:
- `generated_attribute_methods`
- `define_method_attribute`
- `define_proxy_call`
- `attribute_method_matchers_cache`
- `attribute_method_matchers_matching`

In addition, `initialize_generated_modules` is no longer used (but still required for generated association methods), and the `define_method_#{matcher.method_missing_target}` pattern of methods are all moved to the matcher, so this method namespace is now free in the model class.

The biggest change is when you look at the ancestors of an AR class. Since the modules are now each associated with their prefix/suffix, and I've overridden `inspect` to *show* you the corresponding regex, you can actually see all the matchers applied to the class.

So instead of this:

```ruby
Topic.ancestors
=> [Topic(...),
 Topic::GeneratedAssociationMethods,
 #<ActiveRecord::AttributeMethods::GeneratedAttributeMethods:0x0055c121def890>,
 ActiveRecord::Base,
...
```

where the cryptic `ActiveRecord::AttributeMethods::GeneratedAttributeMethods` holds generated methods, and the `method_missing` and `respond_to?` are defined on the class itself, you get this:

```ruby
=> [Topic(...),           
 Topic::GeneratedAssociationMethods,           
 <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:_in_database)$/>,                        
 <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:_change_to_be_saved)$/>,                 
 <ActiveRecord::AttributeMethodMatcher: /^(?:will_save_change_to_)(.*)(?:\?)$/>,              
 <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:_before_last_save)$/>,                   
 <ActiveRecord::AttributeMethodMatcher: /^(?:saved_change_to_)(.*)(?:)$/>,
 <ActiveRecord::AttributeMethodMatcher: /^(?:saved_change_to_)(.*)(?:\?)$/>,
 <ActiveRecord::AttributeMethodMatcher: /^(?:restore_)(.*)(?:!)$/>,
 <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:_previous_change)$/>,
 <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:_previously_changed\?)$/>,
 <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:_was)$/>,
 <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:_will_change!)$/>,
 <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:_change)$/>,
 <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:_changed\?)$/>,
 <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:\?)$/>,
 <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:_came_from_user\?)$/>,
 <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:_before_type_cast)$/>,
 <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:=)$/>,
 <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:)$/>,
 ActiveRecord::Base,
...
```

So you can clearly see all the matchers in the ancestor chain. When you call `define_attribute_methods` on the class, this actually delegates to calling the same method on each of these modules, which then defines the attribute methods on the module. So rather than having one big collection of attribute methods, you have methods each paired to the respective matcher that defines them.

e.g.:

```ruby
Topic.ancestors[3]
=> <ActiveRecord::AttributeMethodMatcher: /^(?:)(.*)(?:_change_to_be_saved)$/>
Topic.ancestors[3].instance_methods
=> [:method_missing,
 :respond_to?,
 :heading_change_to_be_saved,
 :id_change_to_be_saved,
 :title_change_to_be_saved,
 :author_name_change_to_be_saved,
 :author_email_address_change_to_be_saved,
 :written_on_change_to_be_saved,
 :bonus_time_change_to_be_saved,
 :last_read_change_to_be_saved,
 :content_change_to_be_saved,
 :important_change_to_be_saved,
 :approved_change_to_be_saved,
 :replies_count_change_to_be_saved,
 :unique_replies_count_change_to_be_saved,
 :parent_id_change_to_be_saved,
 :parent_title_change_to_be_saved,
 :type_change_to_be_saved,
 :group_change_to_be_saved,
 :created_at_change_to_be_saved,
 :updated_at_change_to_be_saved]
```

Here you can see that methods are defined for the `to_be_saved` suffix; other modules are similar.

### Other Information

Another thing that I noticed while working on this change is that currently, *each AR::Base subclass* includes its own `@generated_attribute_methods` instance, where it defines its attribute methods. This means that if I have a class `SuperPost` which inherits from `Post`, then I will actually include *three* modules, one defined in ActiveRecord (which has no actual attribute methods defined on it), one on `Post` which *will* have attribute methods defined on it, and another one defined in `SuperPost` which has (generally the same, or a subset of) attribute methods defined on it. There is no need to have these duplicate modules AFAICT, but the current code doesn't work without doing it this way.

With the change here, although there are many more modules (one per prefix/suffix), they are only included once in the first subclass of `ActiveRecord::Base`. This avoids defining a potentially large number of methods multiple times if you have a deep inheritance tree.

One point that I feel is still problematic is the method `instance_method_already_implemented?`. Currently the AR::AttributeMethodMatcher` class just calls through to the model class method, which is simple but creates coupling I was hoping to avoid. For now I've left this since I want to avoid making any more changes before discussion, but this is one point I'm still not really happy with.

Thanks for reading! I'm happy and ready to explain any and all changes here.