### PR TITLE
Remove unused `before_filters`

### DIFF
--- a/actionpack/lib/action_controller/metal/testing.rb
+++ b/actionpack/lib/action_controller/metal/testing.rb
@@ -12,11 +12,5 @@ module ActionController
         self.params = nil
       end
     end
-
-    module ClassMethods
-      def before_filters
-        _process_action_callbacks.find_all { |x| x.kind == :before }.map(&:name)
-      end
-    end
   end
 end


### PR DESCRIPTION
This method added by 1008511. It is unnecessary because it is no longer called by 19c3495.

