### PR TITLE
Remove association(true) references from docs [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -850,7 +850,7 @@ module ActiveRecord
       #   project.milestones             # fetches milestones from the database
       #   project.milestones.size        # uses the milestone cache
       #   project.milestones.empty?      # uses the milestone cache
-      #   project.milestones(true).size  # fetches milestones from the database
+      #   project.milestones.reload.size # fetches milestones from the database
       #   project.milestones             # uses the milestone cache
       #
       # == Eager loading of associations

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1072,7 +1072,6 @@ module ActiveRecord
       end
 
       # Reloads the collection from the database. Returns +self+.
-      # Equivalent to <tt>collection(true)</tt>.
       #
       #   class Person < ActiveRecord::Base
       #     has_many :pets
@@ -1085,9 +1084,6 @@ module ActiveRecord
       #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
       #
       #   person.pets.reload # fetches pets from the database
-      #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
-      #
-      #   person.pets(true)  # fetches pets from the database
       #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
       def reload
         proxy_association.reload


### PR DESCRIPTION
Passing `true` to force an association to reload its records from the database was deprecated in 5.0 (by https://github.com/rails/rails/pull/20888) and removed in 5.1 (by https://github.com/rails/rails/commit/09cac8c67afdc4b2a1c6ae07931ddc082629b277).