### PR TITLE
Fix `to_s(:db)` for range comprising of alphabets.

### DIFF
--- a/activesupport/lib/active_support/core_ext/range/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/range/conversions.rb
@@ -2,7 +2,13 @@
 
 module ActiveSupport::RangeWithFormat
   RANGE_FORMATS = {
-    db: Proc.new { |start, stop| "BETWEEN '#{start.to_s(:db)}' AND '#{stop.to_s(:db)}'" }
+    db: -> (start, stop) do
+      case start
+      when String then "BETWEEN '#{start}' AND '#{stop}'"
+      else
+        "BETWEEN '#{start.to_s(:db)}' AND '#{stop.to_s(:db)}'"
+      end
+    end
   }
 
   # Convert range to a formatted string. See RANGE_FORMATS for predefined formats.

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -16,6 +16,11 @@ class RangeTest < ActiveSupport::TestCase
     assert_equal "BETWEEN '2005-12-10 15:30:00' AND '2005-12-10 17:30:00'", date_range.to_s(:db)
   end
 
+  def test_to_s_with_alphabets
+    alphabet_range = ("a".."z")
+    assert_equal "BETWEEN 'a' AND 'z'", alphabet_range.to_s(:db)
+  end
+
   def test_to_s_with_numeric
     number_range = (1..100)
     assert_equal "BETWEEN '1' AND '100'", number_range.to_s(:db)


### PR DESCRIPTION
Calling `to_s(:db)` on the Range comprising of alphabets gives an `ArgumentError`.
The current fix checks for the type of `start` and `end` value in the formatter.