### PR TITLE
Underscore unused block vars in ActionController::TestCase

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -599,8 +599,8 @@ module ActionController
       private
 
         def scrub_env!(env)
-          env.delete_if { |k, v| k =~ /^(action_dispatch|rack)\.request/ }
-          env.delete_if { |k, v| k =~ /^action_dispatch\.rescue/ }
+          env.delete_if { |k, _v| k =~ /^(action_dispatch|rack)\.request/ }
+          env.delete_if { |k, _v| k =~ /^action_dispatch\.rescue/ }
           env.delete "action_dispatch.request.query_parameters"
           env.delete "action_dispatch.request.request_parameters"
           env["rack.input"] = StringIO.new


### PR DESCRIPTION
Underscore unused block variables as per the [style guide](https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars).