### PR TITLE
42 compatibility - use int instead of bigint

### DIFF
--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -171,7 +171,7 @@ module ActiveRecord
             class << t
               prepend TableDefinition
             end
-            t
+            super
           end
 
           def index_name_for_remove(table_name, options = {})

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -71,6 +71,9 @@ module ActiveRecord
 
         assert_not connection.index_exists?(:more_testings, :foo_id)
         assert_not connection.index_exists?(:more_testings, :bar_id)
+
+        legacy_ref = connection.columns(:more_testings).find { |c| c.name == "foo_id" }
+        assert_not legacy_ref.bigint?
       ensure
         connection.drop_table :more_testings rescue nil
       end


### PR DESCRIPTION
### Summary
```
class AddProjectsWithSettings < ActiveRecord::Migration[4.2]
    create_table :projects

    create_table :settings do |t|
      t.references :project, index: true, foreign_key: true
    end
end
```
creating a reference fails, because default primary key type for version [4.2] is an integer, but references tries to use a bigint

master
```
projects.id => :integer
settings.project_id => :bigint
```

expected
```
projects.id => :integer
settings.project_id => :integer
```

Rails version
4.2.x - ok
5.1.4 - ok
master - fails

### Other Information

related commit
https://github.com/rails/rails/commit/14db455156cf822f1af738f24528200ae19efc1c#diff-21d4fbe002689dc4b0ab29f021585457