### PR TITLE
Fix typo in `allow_failure` argument [ci skip]

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -235,7 +235,7 @@ module TestHelpers
 
     # Invoke a bin/rails command inside the app
     #
-    # allow_failures:: true to return normally if the command exits with
+    # allow_failure:: true to return normally if the command exits with
     #   a non-zero status. By default, this method will raise.
     # stderr:: true to pass STDERR output straight to the "real" STDERR.
     #   By default, the STDERR and STDOUT of the process will be


### PR DESCRIPTION
Ref: https://github.com/rails/rails/blob/3be123ba26cad461a80d7d680819e71c1388a241/railties/test/isolation/abstract_unit.rb#L243
