### PR TITLE
Remove unnecessary `allow_failure: true` option

### DIFF
--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -166,7 +166,7 @@ module ApplicationTests
         end
       RUBY
 
-      output = rails("routes", "-g", "show", allow_failure: true)
+      output = rails("routes", "-g", "show")
       assert_equal <<-MESSAGE.strip_heredoc, output
                          Prefix Verb URI Pattern     Controller#Action
                            cart GET  /cart(.:format) cart#show


### PR DESCRIPTION
`routes` task always returns zero to status, so status is not to non-zeno.
Ref: https://github.com/rails/rails/blob/b1867c480dd5476948ff0492ea2f91e2c2fcb04b/railties/lib/rails/tasks/routes.rake#L30