### PR TITLE
Remove unused `UnknownController` class

### DIFF
--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -34,9 +34,6 @@ module ActionController
   class NotImplemented < MethodNotAllowed #:nodoc:
   end
 
-  class UnknownController < ActionControllerError #:nodoc:
-  end
-
   class MissingFile < ActionControllerError #:nodoc:
   end
 


### PR DESCRIPTION
`UnknownController` was added in b1999be, but it is not used anywhere.
