### PR TITLE
Enable `hstore` extention disabled at the end of `test_migrate_enable_and_disable_extension`

### DIFF
--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -295,6 +295,8 @@ module ActiveRecord
 
         migration2.migrate(:down)
         assert_equal false, Horse.connection.extension_enabled?("hstore")
+      ensure
+        enable_extension!("hstore", ActiveRecord::Base.connection)
       end
     end
 


### PR DESCRIPTION
### Summary

Enable `hstore` extention disabled at the end of `InvertibleMigrationTest#test_migrate_enable_and_disable_extension`
to avoid failure of `PostgresqlArrayTest#test_schema_dump_with_shorthand`
which expects `hstore` extension enabled.

This pull request addresses `PostgresqlArrayTest#test_schema_dump_with_shorthand` failure reported at https://travis-ci.org/rails/rails/jobs/289390069

### Steps to reproduce

```ruby
$ ARCONN=postgresql bin/test test/cases/adapters/postgresql/extension_migration_test.rb test/cases/invertible_migration_test.rb test/cases/adapters/postgresql/array_test.rb --seed 42296 -n "/^(?:PostgresqlExtensionMigrationTest#(?:test_enable_extension_migration_ignores_prefix_and_suffix)|ActiveRecord::InvertibleMigrationTest#(?:test_migrate_enable_and_disable_extension)|PostgresqlArrayTest#(?:test_schema_dump_with_shorthand))$/"
Using postgresql
Run options: --seed 42296 -n "/^(?:PostgresqlExtensionMigrationTest#(?:test_enable_extension_migration_ignores_prefix_and_suffix)|ActiveRecord::InvertibleMigrationTest#(?:test_migrate_enable_and_disable_extension)|PostgresqlArrayTest#(?:test_schema_dump_with_shorthand))$/"

# Running:

..unknown OID 411199: failed to recognize type of 'hstores'. It will be treated as String.
F

Finished in 0.722768s, 4.1507 runs/s, 9.6850 assertions/s.

  1) Failure:
PostgresqlArrayTest#test_schema_dump_with_shorthand [/home/yahonda/git/rails/activerecord/test/cases/adapters/postgresql/array_test.rb:150]:
Expected /t\.string\s+"tags",\s+limit: 255,\s+array: true/ to match "# This file is auto-generated from the current state of the database. Instead\n# of editing this file, please use the migrations feature of Active Record to\n# incrementally modify your database, and then regenerate this schema definition.\n#\n# Note that this schema.rb definition is the authoritative source for your\n# database schema. If you need to create the application database on another\n# system, you should be using db:schema:load, not running all the migrations\n# from scratch. The latter is a flawed and unsustainable approach (the more migrations\n# you'll amass, the slower it'll run and the greater likelihood for issues).\n#\n# It's strongly recommended that you check this file into your version control system.\n\nActiveRecord::Schema.define(version: 0) do\n\n  # These are extensions that must be enabled in order to support this database\n  enable_extension \"hstore\"\n  enable_extension \"ltree\"\n  enable_extension \"pgcrypto\"\n  enable_extension \"plpgsql\"\n  enable_extension \"uuid-ossp\"\n\n# Could not dump table \"pg_arrays\" because of following StandardError\n#   Unknown type 'hstore' for column 'hstores'\n\nend\n".

3 runs, 7 assertions, 1 failures, 0 errors, 0 skips
$
```