### PR TITLE
Add strict argument checking to ActiveRecord callbacks

### DIFF
--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -127,26 +127,28 @@ module ActiveModel
     private
 
       def _define_before_model_callback(klass, callback)
-        klass.define_singleton_method("before_#{callback}") do |*args, &block|
-          set_callback(:"#{callback}", :before, *args, &block)
+        klass.define_singleton_method("before_#{callback}") do |*args, **options, &block|
+          options.assert_valid_keys :if, :unless, :prepend
+          set_callback(:"#{callback}", :before, *args, **options, &block)
         end
       end
 
       def _define_around_model_callback(klass, callback)
-        klass.define_singleton_method("around_#{callback}") do |*args, &block|
-          set_callback(:"#{callback}", :around, *args, &block)
+        klass.define_singleton_method("around_#{callback}") do |*args, **options, &block|
+          options.assert_valid_keys :if, :unless, :prepend
+          set_callback(:"#{callback}", :around, *args, **options, &block)
         end
       end
 
       def _define_after_model_callback(klass, callback)
-        klass.define_singleton_method("after_#{callback}") do |*args, &block|
-          options = args.extract_options!
+        klass.define_singleton_method("after_#{callback}") do |*args, **options, &block|
+          options.assert_valid_keys :if, :unless, :prepend
           options[:prepend] = true
           conditional = ActiveSupport::Callbacks::Conditionals::Value.new { |v|
             v != false
           }
           options[:if] = Array(options[:if]) << conditional
-          set_callback(:"#{callback}", :after, *(args << options), &block)
+          set_callback(:"#{callback}", :after, *args, **options, &block)
         end
       end
   end

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -476,4 +476,27 @@ class CallbacksTest < ActiveRecord::TestCase
     child.save
     assert child.after_save_called
   end
+
+  def test_on_isnt_allowed
+    exception = assert_raises ArgumentError do
+      Class.new(ActiveRecord::Base) do
+        before_save(on: :create) {}
+      end
+    end
+    assert_equal "Unknown key: :on. Valid keys are: :if, :unless, :prepend", exception.message
+
+    exception = assert_raises ArgumentError do
+      Class.new(ActiveRecord::Base) do
+        around_save(on: :create) {}
+      end
+    end
+    assert_equal "Unknown key: :on. Valid keys are: :if, :unless, :prepend", exception.message
+
+    exception = assert_raises ArgumentError do
+      Class.new(ActiveRecord::Base) do
+        after_save(on: :create) {}
+      end
+    end
+    assert_equal "Unknown key: :on. Valid keys are: :if, :unless, :prepend", exception.message
+  end
 end


### PR DESCRIPTION
### Summary

This fixes #17622 by adding strict argument checking to ActiveRecord callbacks.

This ends up adding it to all save-related callbacks defined in `ActiveRecord::DefineCallbacks`, including e.g. `after_create`. Which should be fine: they didn't support `:on` in the first place.

### Other Information

Should this go in the changelog? It seems like it should be backported to 5.0.