### PR TITLE
Improve out-of-box experience with System tests including chromedriver-helper by default

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile
@@ -43,6 +43,8 @@ group :development, :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.15'
   gem 'selenium-webdriver'
+  # Easy installation and use of chromedriver to run system tests with Chrome
+  gem 'chromedriver-helper'
   <%- end -%>
 end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -412,6 +412,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile" do |content|
       assert_no_match(/capybara/, content)
       assert_no_match(/selenium-webdriver/, content)
+      assert_no_match(/chromedriver-helper/, content)
     end
 
     assert_no_directory("test")
@@ -422,6 +423,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile" do |content|
       assert_no_match(/capybara/, content)
       assert_no_match(/selenium-webdriver/, content)
+      assert_no_match(/chromedriver-helper/, content)
     end
 
     assert_directory("test")


### PR DESCRIPTION
### Summary

This includes [chromedriver-helper](https://github.com/flavorjones/chromedriver-helper) in default Gemfile, this gem installs the chromedriver executable in the user's gem path allowing to run the tests without installing anything else.

I think this will offer a better out-of-box experience to newcomers when running Rails system tests.

<img width="656" alt="screen shot 2017-10-18 at 10 20 35" src="https://user-images.githubusercontent.com/160941/31732260-7e1181f4-b3fd-11e7-9c10-acb54a7eb25a.png">





