### PR TITLE
Remove unused `FixtureTemplate` class

### DIFF
--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -4,17 +4,6 @@ require "abstract_unit"
 require "fileutils"
 require "action_view/dependency_tracker"
 
-class FixtureTemplate
-  attr_reader :source, :handler
-
-  def initialize(template_path)
-    @source = File.read(template_path)
-    @handler = ActionView::Template.handler_for_extension(:erb)
-  rescue Errno::ENOENT
-    raise ActionView::MissingTemplate.new([], "", [], true, [])
-  end
-end
-
 class FixtureFinder < ActionView::LookupContext
   FIXTURES_DIR = File.expand_path("../fixtures/digestor", __dir__)
 


### PR DESCRIPTION
`FixtureTemplate` is no longer used since 3d7892d.
