### PR TITLE
Allow symbol list for ignored_columns

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -115,20 +115,6 @@ module ActiveRecord
     # If true, the default table name for a Product class will be "products". If false, it would just be "product".
     # See table_name for the full rules on table/class naming. This is true, by default.
 
-    ##
-    # :singleton-method: ignored_columns
-    # :call-seq: ignored_columns
-    #
-    # The list of columns names the model should ignore. Ignored columns won't have attribute
-    # accessors defined, and won't be referenced in SQL queries.
-
-    ##
-    # :singleton-method: ignored_columns=
-    # :call-seq: ignored_columns=(columns)
-    #
-    # Sets the columns names the model should ignore. Ignored columns won't have attribute
-    # accessors defined, and won't be referenced in SQL queries.
-
     included do
       mattr_accessor :primary_key_prefix_type, instance_writer: false
 
@@ -138,9 +124,9 @@ module ActiveRecord
       class_attribute :internal_metadata_table_name, instance_accessor: false, default: "ar_internal_metadata"
       class_attribute :protected_environments, instance_accessor: false, default: [ "production" ]
       class_attribute :pluralize_table_names, instance_writer: false, default: true
-      class_attribute :ignored_columns, instance_accessor: false, default: [].freeze
 
       self.inheritance_column = "type"
+      self.ignored_columns = [].freeze
 
       delegate :type_for_attribute, to: :class
 
@@ -269,6 +255,22 @@ module ActiveRecord
       def inheritance_column=(value)
         @inheritance_column = value.to_s
         @explicit_inheritance_column = true
+      end
+
+      # The list of columns names the model should ignore. Ignored columns won't have attribute
+      # accessors defined, and won't be referenced in SQL queries.
+      def ignored_columns
+        if defined?(@ignored_columns)
+          @ignored_columns
+        else
+          superclass.ignored_columns
+        end
+      end
+
+      # Sets the columns names the model should ignore. Ignored columns won't have attribute
+      # accessors defined, and won't be referenced in SQL queries.
+      def ignored_columns=(columns)
+        @ignored_columns = columns.map(&:to_s)
       end
 
       def sequence_name

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1445,6 +1445,7 @@ class BasicsTest < ActiveRecord::TestCase
     assert_includes cache_columns.keys, "first_name"
     assert_not_includes Developer.columns_hash.keys, "first_name"
     assert_not_includes SubDeveloper.columns_hash.keys, "first_name"
+    assert_not_includes SymbolIgnoredDeveloper.columns_hash.keys, "first_name"
   end
 
   test "ignored columns have no attribute methods" do
@@ -1454,6 +1455,9 @@ class BasicsTest < ActiveRecord::TestCase
     refute SubDeveloper.new.respond_to?(:first_name)
     refute SubDeveloper.new.respond_to?(:first_name=)
     refute SubDeveloper.new.respond_to?(:first_name?)
+    refute SymbolIgnoredDeveloper.new.respond_to?(:first_name)
+    refute SymbolIgnoredDeveloper.new.respond_to?(:first_name=)
+    refute SymbolIgnoredDeveloper.new.respond_to?(:first_name?)
   end
 
   test "ignored columns don't prevent explicit declaration of attribute methods" do
@@ -1463,5 +1467,13 @@ class BasicsTest < ActiveRecord::TestCase
     assert SubDeveloper.new.respond_to?(:last_name)
     assert SubDeveloper.new.respond_to?(:last_name=)
     assert SubDeveloper.new.respond_to?(:last_name?)
+    assert SymbolIgnoredDeveloper.new.respond_to?(:last_name)
+    assert SymbolIgnoredDeveloper.new.respond_to?(:last_name=)
+    assert SymbolIgnoredDeveloper.new.respond_to?(:last_name?)
+  end
+
+  test "ignored columns are stored as an array of string" do
+    assert_equal(%w(first_name last_name), Developer.ignored_columns)
+    assert_equal(%w(first_name last_name), SymbolIgnoredDeveloper.ignored_columns)
   end
 end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -90,6 +90,14 @@ end
 class SubDeveloper < Developer
 end
 
+class SymbolIgnoredDeveloper < ActiveRecord::Base
+  self.table_name = "developers"
+  self.ignored_columns = [:first_name, :last_name]
+
+  attr_accessor :last_name
+  define_attribute_method "last_name"
+end
+
 class AuditLog < ActiveRecord::Base
   belongs_to :developer, validate: true
   belongs_to :unvalidated_developer, class_name: "Developer"


### PR DESCRIPTION
### Summary


`ActiveRecord::ModelSchema.ignored_columns` is used to except columns on loading schema. This works for a list of string, but doesn't works for a list of symbol(just "ignored"). This pull request enable to use a list of symbol for `ignored_columns`.

before:

```
self.ignored_columns = [:page_view] # This behaves like `[]`
```

after:

```
self.ignored_columns = [:page_view] # This behaves like `['page_view']`
```

### Background

`ignored_columns` excepts the columns from schema cache, so is often used in the purpose of deleting some columns without stopping the application. Currently, when a user mistakes that `ignored_columns` accepts `Array<Symbol>`, the column deletion causes many application errros.

So it's better to do any of the following.

* `ignored_columns` behaves "indifferent"(doesn't distinct symbol from string) on loading schema. 
* `ignored_columns=` checks the type of elements.
* `ignored_columns=` convert the type of elements to string.