### PR TITLE
Remove `include FileUtils` from bin templates

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -1,5 +1,4 @@
 require 'fileutils'
-include FileUtils
 
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)
@@ -8,7 +7,7 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir APP_ROOT do
+FileUtils.chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
@@ -24,7 +23,7 @@ chdir APP_ROOT do
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')
-  #   cp 'config/database.yml.sample', 'config/database.yml'
+  #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
   # end
 
   puts "\n== Preparing database =="

--- a/railties/lib/rails/generators/rails/app/templates/bin/update.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/update.tt
@@ -1,5 +1,4 @@
 require 'fileutils'
-include FileUtils
 
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)
@@ -8,7 +7,7 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir APP_ROOT do
+FileUtils.chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 


### PR DESCRIPTION
## Summary

When creating a new Rails application with `rails new`, a top-level `include` is used in two files `bin/setup` and `bin/update`.

This PR makes `FileUtils` an explicit receiver instead of a top-level `include`. This change removes the top-level `include` affecting `Object` from the templates of a Rails application created with `rails new`.

By writing `include FileUtils` at the top level, it can call abbreviated methods like `chdir`, `cp` and others, but here it seems that there is not much merit. These are templates for short scripts of processes, but I think that it is preferable not to affect `Object`.

## Other Information

I found it by investigating a Rails applications when making https://github.com/bbatsov/rubocop/pull/4840.
