### PR TITLE
Change method of retrieving secret_key_base in secrets.yml to fix breakage.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/secrets.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/secrets.yml
@@ -29,4 +29,4 @@ test:
 # and move the `production:` environment over there.
 
 production:
-  secret_key_base: <%%= ENV["SECRET_KEY_BASE"] %>
+  secret_key_base: <%%= ENV.fetch("SECRET_KEY_BASE") %>


### PR DESCRIPTION
### Summary

Changed output of railties/lib/rails/generators/rails/app/templates/config/secrets.yml to produce reference to SECRET_KEY_BASE using ENV.fetch("SECRET_KEY_BASE") to replace current method of ENV["SECRET_KEY_BASE"] because that method of accessing SECRET_KEY_BASE no longer works on an actual production server (Linux) tested with Rails 5.1.4 and Ruby 2.5.0.

