### PR TITLE
Return correct exit status of ujs test

### DIFF
--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -46,7 +46,7 @@ namespace :test do
       end
 
       system("npm run lint && bundle exec ruby ../ci/qunit-selenium-runner.rb http://localhost:4567/")
-      status = $?.to_i
+      status = $?.exitstatus
     ensure
       Process.kill("KILL", pid) if pid
       FileUtils.rm_rf("log")


### PR DESCRIPTION
The `Process::Status#to_i` returns the bits in stat. If need exit status,
need to use `#exitstatus`.
Ref: https://ruby-doc.org/core-2.4.0/Process/Status.html#method-i-to_i
