### PR TITLE
Added support for managing custom encrypted files from cli.

### DIFF
--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "active_support"
+require "pathname"
+
+module Rails
+  module Command
+    class EncryptedCommand < Rails::Command::Base # :nodoc:
+      class_option :key, aliases: "-k", type: :string,
+        default: "config/master.key", desc: "Path to the key for encryption"
+
+      no_commands do
+        def help
+          say "Usage:\n  #{self.class.banner}"
+          say ""
+        end
+      end
+
+      def edit(file_path)
+        file_path = Pathname.new(file_path)
+        key_path  = Pathname.new(options[:key])
+
+        require_application_and_environment!
+
+        ensure_editor_available || (return)
+        ensure_encryption_key_has_been_added(key_path)
+        ensure_encrypted_file_have_been_added(file_path, key_path)
+
+        change_encrypted_file_in_system_editor(file_path, key_path)
+
+        say "File encrypted and saved."
+      rescue Interrupt
+        say "Aborted changing file: nothing saved."
+      rescue ActiveSupport::EncryptedFile::MissingKeyError => error
+        say error.message
+      end
+
+      def show(file_path)
+        file_path = Pathname.new(file_path)
+        key_path  = Pathname.new(options[:key])
+
+        require_application_and_environment!
+        encrypted_file = encrypted_file(file_path, key_path)
+
+        say encrypted_file.content_path.exist? ? encrypted_file.read :
+          "File '#{file_path}' does not exist. Use bin/rails encrypted:edit #{file_path} to change that."
+      end
+
+      private
+        def ensure_editor_available
+          if ENV["EDITOR"].to_s.empty?
+            say "No $EDITOR to open file in. Assign one like this:"
+            say ""
+            say %(EDITOR="mate --wait" bin/rails encrypted:edit)
+            say ""
+            say "For editors that fork and exit immediately, it's important to pass a wait flag,"
+            say "otherwise the credentials will be saved immediately with no chance to edit."
+
+            false
+          else
+            true
+          end
+        end
+
+        def ensure_encryption_key_has_been_added(key_path)
+          master_key_generator.add_master_key_file(key_path)
+          master_key_generator.ignore_master_key_file(key_path)
+        end
+
+        def ensure_encrypted_file_have_been_added(file_path, key_path)
+          encrypted_file_generator.add_encrypted_file_silently(file_path, key_path)
+        end
+
+        def change_encrypted_file_in_system_editor(file_path, key_path)
+          encrypted_file(file_path, key_path).change do |tmp_path|
+            system("#{ENV["EDITOR"]} #{tmp_path}")
+          end
+        end
+
+        def encrypted_file(file_path, key_path)
+          ActiveSupport::EncryptedFile.new \
+            content_path: file_path,
+            key_path: key_path,
+            env_key: "RAILS_MASTER_KEY"
+        end
+
+        def master_key_generator
+          require "rails/generators"
+          require "rails/generators/rails/master_key/master_key_generator"
+
+          Rails::Generators::MasterKeyGenerator.new
+        end
+
+        def encrypted_file_generator
+          require "rails/generators"
+          require "rails/generators/rails/encrypted_file/encrypted_file_generator"
+
+          Rails::Generators::EncryptedFileGenerator.new
+        end
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/encrypted_file/encrypted_file_generator.rb
+++ b/railties/lib/rails/generators/rails/encrypted_file/encrypted_file_generator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails/generators/base"
+require "active_support/encrypted_file"
+
+module Rails
+  module Generators
+    class EncryptedFileGenerator < Base
+      def add_encrypted_file(file_path, key_path)
+        unless File.exist?(file_path)
+          say "Adding #{file_path} to store encrypted content."
+          say ""
+          say "The following content has been encrypted with the encryption key:"
+          say ""
+          say template, :on_green
+          say ""
+
+          add_encrypted_file_silently(file_path, key_path)
+
+          say "You can edit encrypted file with `bin/rails encrypted:edit #{file_path}`."
+          say ""
+        end
+      end
+
+      def add_encrypted_file_silently(file_path, key_path, template = encrypted_file_template)
+        unless File.exist?(file_path)
+          setup = { content_path: file_path, key_path: key_path, env_key: "RAILS_MASTER_KEY" }
+          ActiveSupport::EncryptedFile.new(setup).write(template)
+        end
+      end
+
+      private
+        def encrypted_file_template
+          "# aws:\n#  access_key_id: 123\n#  secret_access_key: 345\n\n"
+        end
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/master_key/master_key_generator.rb
+++ b/railties/lib/rails/generators/rails/master_key/master_key_generator.rb
@@ -9,44 +9,46 @@ module Rails
     class MasterKeyGenerator < Base
       MASTER_KEY_PATH = Pathname.new("config/master.key")
 
-      def add_master_key_file
-        unless MASTER_KEY_PATH.exist?
+      def add_master_key_file(key_path = MASTER_KEY_PATH)
+        unless key_path.exist?
           key = ActiveSupport::EncryptedFile.generate_key
 
-          log "Adding #{MASTER_KEY_PATH} to store the master encryption key: #{key}"
+          log "Adding #{key_path} to store the master encryption key: #{key}"
           log ""
           log "Save this in a password manager your team can access."
           log ""
           log "If you lose the key, no one, including you, can access anything encrypted with it."
 
           log ""
-          add_master_key_file_silently key
+          add_master_key_file_silently(key, key_path)
           log ""
         end
       end
 
-      def add_master_key_file_silently(key = nil)
-        create_file MASTER_KEY_PATH, key || ActiveSupport::EncryptedFile.generate_key
+      def add_master_key_file_silently(key = nil, key_path = MASTER_KEY_PATH)
+        create_file key_path, key || ActiveSupport::EncryptedFile.generate_key
       end
 
-      def ignore_master_key_file
+      def ignore_master_key_file(key_path = MASTER_KEY_PATH)
+        ignore = key_ignore(key_path)
+
         if File.exist?(".gitignore")
-          unless File.read(".gitignore").include?(key_ignore)
-            log "Ignoring #{MASTER_KEY_PATH} so it won't end up in Git history:"
+          unless File.read(".gitignore").include?(ignore)
+            log "Ignoring #{key_path} so it won't end up in Git history:"
             log ""
-            append_to_file ".gitignore", key_ignore
+            append_to_file ".gitignore", ignore
             log ""
           end
         else
-          log "IMPORTANT: Don't commit #{MASTER_KEY_PATH}. Add this to your ignore file:"
-          log key_ignore, :on_green
+          log "IMPORTANT: Don't commit #{key_path}. Add this to your ignore file:"
+          log ignore, :on_green
           log ""
         end
       end
 
       private
-        def key_ignore
-          [ "", "# Ignore master key for decrypting credentials and more.", "/#{MASTER_KEY_PATH}", "" ].join("\n")
+        def key_ignore(key_path)
+          [ "", "# Ignore master key for decrypting credentials and more.", "/#{key_path}", "" ].join("\n")
         end
     end
   end

--- a/railties/test/commands/encrypted_test.rb
+++ b/railties/test/commands/encrypted_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "env_helpers"
+require "rails/command"
+require "rails/commands/encrypted/encrypted_command"
+
+class Rails::Command::EncryptedCommandTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation, EnvHelpers
+
+  setup :build_app
+  teardown :teardown_app
+
+  test "edit without editor gives hint" do
+    assert_match "No $EDITOR to open file in", run_edit_command("config/tokens.yml.enc", editor: "")
+  end
+
+  test "edit encrypted file" do
+    # Run twice to ensure file can be reread after first edit pass.
+    2.times do
+      assert_match(/access_key_id: 123/, run_edit_command("config/tokens.yml.enc"))
+    end
+  end
+
+  test "edit command does not add master key to gitignore when already exist" do
+    run_edit_command("config/tokens.yml.enc")
+
+    Dir.chdir(app_path) do
+      gitignore = File.read(".gitignore")
+      assert_equal 1, gitignore.scan(%r|config/master\.key|).length
+    end
+  end
+
+  test "edit encrypts file with custom key" do
+    run_edit_command("config/tokens.yml.enc", key: "config/tokens.key")
+
+    Dir.chdir(app_path) do
+      assert File.exists?("config/tokens.yml.enc")
+      assert File.exists?("config/tokens.key")
+
+      gitignore = File.read(".gitignore")
+      assert_equal 1, gitignore.scan(%r|config/tokens\.key|).length
+    end
+
+    assert_match(/access_key_id: 123/, run_edit_command("config/tokens.yml.enc", key: "config/tokens.key"))
+  end
+
+  test "show encrypted file with custom key" do
+    run_edit_command("config/tokens.yml.enc", key: "config/tokens.key")
+
+    assert_match(/access_key_id: 123/, run_show_command("config/tokens.yml.enc", key: "config/tokens.key"))
+  end
+
+  private
+    def run_edit_command(file, editor: "cat", key: nil)
+      args = [file]
+      args.push("--key", key) if key
+
+      switch_env("EDITOR", editor) do
+        rails "encrypted:edit", args
+      end
+    end
+
+    def run_show_command(file, key: nil)
+      args = [file]
+      args.push("--key", key) if key
+
+      rails "encrypted:show", args
+    end
+end


### PR DESCRIPTION
One can now generate/edit file by
~`bin/rails credentials:edit config/staging-credentials.yml.enc --key config/staging.key`~
`bin/rails encrypted:edit config/staging-credentials.yml.enc --key config/staging.key`

and display it by

~`bin/rails credentials:show config/staging-credentials.yml.enc --key config/staging.key`~
`bin/rails encrypted:show config/staging-credentials.yml.enc --key config/staging.key`

When `--key` option is omitted then default `config/master.key` is used.

This is a follow up to https://github.com/rails/rails/pull/29909

/cc @dhh and @kaspth as you introduced encrypted files