### PR TITLE
Performance improvements related to string allocations

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -589,10 +589,16 @@ module ActionView
         end
 
         def add_method_to_attributes!(html_options, method)
-          if method && method.to_s.downcase != "get".freeze && html_options["rel".freeze] !~ /nofollow/
-            html_options["rel".freeze] = "#{html_options["rel".freeze]} nofollow".lstrip
+          @_method_downcase_cache ||= {}
+          downcased_method = @_method_downcase_cache[method] ||= method.to_s.downcase
+          if downcased_method && downcased_method != "get" && html_options["rel"] !~ /nofollow/
+            if html_options["rel"].present?
+              html_options["rel"] = "#{html_options["rel"]} nofollow"
+            else
+              html_options["rel"] = "nofollow"
+            end
           end
-          html_options["data-method".freeze] = method
+          html_options["data-method"] = downcased_method
         end
 
         def token_tag(token = nil, form_options: {})

--- a/activesupport/lib/active_support/core_ext/object/acts_like.rb
+++ b/activesupport/lib/active_support/core_ext/object/acts_like.rb
@@ -7,6 +7,15 @@ class Object
   # <tt>x.acts_like?(:date)</tt> to do duck-type-safe comparisons, since classes that
   # we want to act like Time simply need to define an <tt>acts_like_time?</tt> method.
   def acts_like?(duck)
-    respond_to? :"acts_like_#{duck}?"
+    case duck
+    when :time
+      respond_to? :acts_like_time?
+    when :date
+      respond_to? :acts_like_date?
+    when :string
+      respond_to? :acts_like_string?
+    else
+      respond_to? :"acts_like_#{duck}?"
+    end
   end
 end

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -208,11 +208,12 @@ module ActiveSupport
     #   dasherize('puni_puni') # => "puni-puni"
     def dasherize(underscored_word)
       @_dasherize_cache ||= {}
-      @_dasherize_cache[underscored_word] ||= if underscored_word.include?('_')
-                                                underscored_word.tr('_', '-')
-                                              else
-                                                underscored_word
-                                              end
+      @_dasherize_cache[underscored_word] ||=
+        if underscored_word.include?("_")
+          underscored_word.tr("_", "-")
+        else
+          underscored_word
+        end
     end
 
     # Removes the module part from the expression in the string.

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -207,7 +207,12 @@ module ActiveSupport
     #
     #   dasherize('puni_puni') # => "puni-puni"
     def dasherize(underscored_word)
-      underscored_word.tr("_".freeze, "-".freeze)
+      @_dasherize_cache ||= {}
+      @_dasherize_cache[underscored_word] ||= if underscored_word.include?('_')
+                                                underscored_word.tr('_', '-')
+                                              else
+                                                underscored_word
+                                              end
     end
 
     # Removes the module part from the expression in the string.


### PR DESCRIPTION
### Summary

Cache various string allocations that I discovered were the same string or similar strings, mostly while rendering links on a page in my app that has potentially 1000s of links.

### Details and Benchmarking info

`actionview/lib/action_view/helpers/url_helper.rb`
add_method_to_attributes!

Add a cache to save the "method.to_s.downcase" call.

This change prevents a string allocation for each time the method is
called, with performance changes within margin of error.

`activesupport/lib/active_support/core_ext/object/acts_like.rb`
acts_like?

Add a case statement to use direct symbols instead of string
interpolation for the three scenarios I found in the Rails codebase:
time, date, and string.

For time/date/string, this change prevents two string allocations for
each time the method is called and speeds up the method by ~2.7x.  For
other arguments, there is no memory difference and performance
difference is within margin of error.

`activesupport/lib/active_support/inflector/methods.rb`
dasherize

Add a cache to save the dasherized word so that we only generate the
string once.

This change prevents a string allocation for each time the method is
called, with a speed up of ~1.3x for small strings (5-10 chars) and
~2.4x for large strings (~50 chars)

`activesupport/lib/active_support/time_with_zone.rb`
zone

Add a cache for the stringified zone_identifier so that we only generate
a string once per zone.

This change prevents a string allocation for each time the method is
called, with performance changes within margin of error.

strftime

Add a cache for the gsubbed format so that we only generate a string
once per format.

This change prevents three string allocations and one IMEMO allocation
for each time the method is called, with performance changes between
margin of error and ~1.3x improvement.

Profiling code below
```ruby
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update
                your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", github: "rails/rails"
  gem "arel", github: "rails/arel"
  gem "benchmark-ips"
end

def allocate_count
  GC.disable
  before = ObjectSpace.count_objects
  yield
  after = ObjectSpace.count_objects
  after.each { |k,v| after[k] = v - before[k] }
  after[:T_HASH] -= 1 # probe effect - we created the before hash.
  GC.enable
  result = after.reject { |k,v| v == 0 }
  GC.start
  result
end

module ActiveSupport
  class TimeWithZone
    def fast_zone
      TimeWithZone.zone_identifier_cache[period.zone_identifier] ||=
        period.zone_identifier.to_s
    end

    def fast_strftime(format)
      format = TimeWithZone.strftime_format_cache[format] ||=
        format.gsub(/((?:\A|[^%])(?:%%)*)%Z/, "\\1#{zone}")
      getlocal(utc_offset).strftime(format)
    end

    private

    class << self
      def zone_identifier_cache
        @_zone_identifier_cache ||= {}
      end

      def strftime_format_cache
        @_strftime_format_cache ||= {}
      end
    end
  end

  module Inflector
    extend self
    def fast_dasherize(underscored_word)
      @_dasherize_cache ||= {}
      @_dasherize_cache[underscored_word] ||=
        if underscored_word.include?('_')
          underscored_word.tr('_', '-')
        else
          underscored_word
        end
    end
  end
end

class Object
  def fast_acts_like?(duck)
    case duck
    when :time
      respond_to? :acts_like_time?
    when :date
      respond_to? :acts_like_date?
    when :string
      respond_to? :acts_like_string?
    else
      respond_to? :"acts_like_#{duck}?"
    end
  end
end

def add_method_to_attributes!(html_options, method)
  if method && method.to_s.downcase != "get".freeze &&
      html_options["rel".freeze] !~ /nofollow/
    html_options["rel".freeze] =
      "#{html_options["rel".freeze]} nofollow".lstrip
  end
  html_options["data-method".freeze] = method
end

def fast_add_method_to_attributes!(html_options, method)
  @_method_downcase_cache ||= {}
  downcased_method = @_method_downcase_cache[method] ||=
    method.to_s.downcase
  if downcased_method && downcased_method != "get" &&
      html_options["rel"] !~ /nofollow/
    if html_options["rel"].present?
      html_options["rel"] = "#{html_options["rel"]} nofollow"
    else
      html_options["rel"] = "nofollow"
    end
  end
  html_options["data-method"] = downcased_method
end

puts
puts " add_method_to_attributes! ".center(80, '=')
puts

obj = ''.freeze

[
  [{}, 'GET'],
  [{'rel' => 'hi'}, 'GET'],
  [{}, 'DEL'],
  [{'rel' => 'hi'}, 'DEL']
].each do |html_options, method|
  puts " #{html_options} , #{method}".center(80, '=')

  puts " Memory Usage ".center(80, "=")
  puts

  puts "value.add_method_to_attributes!"
  puts allocate_count {
    1000.times { add_method_to_attributes!(html_options, method) }
  }

  puts "value.fast_add_method_to_attributes!"
  puts allocate_count {
    1000.times { fast_add_method_to_attributes!(html_options, method) }
  }

  puts
  puts " Benchmark.ips ".center(80, "=")
  puts

  Benchmark.ips do |x|
    x.report("add_method_to_attributes!") do
      add_method_to_attributes!(html_options, method)
    end
    x.report("fast_add_method_to_attributes!") do
      fast_add_method_to_attributes!(html_options, method)
    end
    x.compare!
  end
end

puts
puts " acts_like? ".center(80, '=')
puts

obj = ''.freeze

%i(time date string super_hacka).each do |type|
  puts " #{type} ".center(80, '=')

  puts " Memory Usage ".center(80, "=")
  puts

  puts "value.acts_like?"
  puts allocate_count { 1000.times { obj.acts_like?(type) } }

  puts "value.fast_acts_like?"
  puts allocate_count { 1000.times { obj.fast_acts_like?(type) } }

  puts
  puts " Benchmark.ips ".center(80, "=")
  puts

  Benchmark.ips do |x|
    x.report("acts_like?")      { obj.acts_like?(type) }
    x.report("fast_acts_like?") { obj.fast_acts_like?(type) }
    x.compare!
  end
end

puts
puts " dasherize ".center(80, "=")
puts

%w(
  short_string
  a_medium_underscore_string
  really_long_string_with_many_underscores_omg_underscores_
  rails
).each do |value|
  puts " #{value} ".center(80, '=')

  puts " Memory Usage ".center(80, "=")
  puts

  puts "value.dasherize"
  puts allocate_count {
    1000.times { ActiveSupport::Inflector.dasherize(value) }
  }

  puts "value.fast_dasherize"
  puts allocate_count {
    1000.times { ActiveSupport::Inflector.fast_dasherize(value) }
  }

  puts
  puts " Benchmark.ips ".center(80, "=")
  puts

  Benchmark.ips do |x|
    x.report("dasherize") do
      ActiveSupport::Inflector.dasherize(value)
    end
    x.report("fast_dasherize") do
      ActiveSupport::Inflector.fast_dasherize(value)
    end
    x.compare!
  end
end

puts
puts " zone ".center(80, "=")
puts

ActiveSupport::TimeZone::MAPPING.keys[0..9].each do |name|
  puts
  puts " #{name} ".center(80, "=")
  puts

  value = ActiveSupport::TimeWithZone.new(
    Time.utc(2000, 1, 1, 0), ActiveSupport::TimeZone[name]
  )

  puts
  puts " Memory Usage ".center(80, "=")
  puts

  puts "value.zone"
  puts allocate_count { 1000.times { value.zone } }

  puts "value.fast_zone"
  puts allocate_count { 1000.times { value.fast_zone } }

  puts
  puts " Benchmark.ips ".center(80, "=")
  puts

  Benchmark.ips do |x|
    x.report("zone")      { value.zone }
    x.report("fast_zone") { value.fast_zone }
    x.compare!
  end
end

puts
puts " strftime ".center(80, "=")
puts

%w(
  %Y%m%d %C %G-W%V-%u %Y%m%dT%H%M%S%z %Y-%jT%T%:z %H%M%S
).each do |name|
  puts
  puts " #{name} ".center(80, "=")
  puts

  value = ActiveSupport::TimeWithZone.new(
    Time.utc(2000, 1, 1, 0), ActiveSupport::TimeZone['UTC']
  )

  puts
  puts " Memory Usage ".center(80, "=")
  puts

  format = '%m\%d\%y'.freeze

  puts "value.strftime"
  puts allocate_count { 1000.times { value.strftime(format) } }

  puts "value.fast_strftime"
  puts allocate_count { 1000.times { value.fast_strftime(format) } }

  puts
  puts " Benchmark.ips ".center(80, "=")
  puts

  Benchmark.ips do |x|
    x.report("strftime")      { value.strftime(format) }
    x.report("fast_strftime") { value.fast_strftime(format) }
    x.compare!
  end
end
```