### PR TITLE
Fix #to_json for IO objects, fixes #26132

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   `IO#to_json` now returns the `to_s` representation, rather than
+    attempting to convert to an array. This fixes a bug where `IO#to_json`
+    would raise an `IOError` when called on an unreadable object.
+
+    Fixes #26132.
+
+    *Paul Kuruvilla*
+
 *   `Hash#slice` now falls back to Ruby 2.5+'s built-in definition if defined.
 
     *Akira Matsuda*

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -135,6 +135,12 @@ module Enumerable
   end
 end
 
+class IO
+  def as_json(options = nil) #:nodoc:
+    to_s
+  end
+end
+
 class Range
   def as_json(options = nil) #:nodoc:
     to_s

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -454,6 +454,10 @@ EXPECTED
     assert_equal '{"number":null}', NaNNumber.new.to_json
   end
 
+  def test_to_json_works_on_io_objects
+    assert_equal STDOUT.to_s.to_json, STDOUT.to_json
+  end
+
   private
 
     def object_keys(json_object)


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/26132. 

**Before**

- For unreadable IO objects, `to_json` would raise an `IOError`
- For readable IO objects, `to_json` would cause a side-effect by reading the contents of the stream.

**After**

`IO#to_json` returns the `to_s` representation for both readable and unreadable IO objects.