### PR TITLE
improve time zone deprecation warning

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -98,11 +98,14 @@ module ActiveRecord
               still causes `String`s to be parsed as if they were in `Time.zone`,
               and `Time`s to be converted to `Time.zone`.
 
+              To silence this deprecation warning, add one of the following to your
+              initializer:
+
               To keep the old behavior, you must add the following to your initializer:
 
                   config.active_record.time_zone_aware_types = [:datetime]
 
-              To silence this deprecation warning, add the following:
+              Or, to use the new behavior, add the following:
 
                   config.active_record.time_zone_aware_types = [:datetime, :time]
             MESSAGE

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -98,14 +98,11 @@ module ActiveRecord
               still causes `String`s to be parsed as if they were in `Time.zone`,
               and `Time`s to be converted to `Time.zone`.
 
-              To silence this deprecation warning, add one of the following to your
-              initializer:
-
               To keep the old behavior, you must add the following to your initializer:
 
                   config.active_record.time_zone_aware_types = [:datetime]
 
-              Or, to use the new behavior, add the following:
+              To use the new behavior, add the following:
 
                   config.active_record.time_zone_aware_types = [:datetime, :time]
             MESSAGE


### PR DESCRIPTION
### Summary

The deprecation warning about the new time zone aware columns is Rails 5.1 is a little unclear. It suggests that adding `config.active_record.time_zone_aware_types = [:datetime, :time]` to your project will merely silence the deprecation warning, when in fact it will make your project use the new behaviour. 

### Other Information

I didn't add any information to the changelog here because one could argue that this is a documentation change... I'd be more than happy to add it though if needed. 

Thanks a bunch! :tada: :sparkles: 
