### PR TITLE
Remove CHANGELOG entry for the change that was backported to 5-1-stable [ci skip]

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -2,11 +2,4 @@
 
     *Jeremy Daer*
 
-*   Change logging instrumentation to log errors when a job raises an exception.
-
-    Fixes #26848.
-
-    *Steven Bull*
-
-
 Please check [5-1-stable](https://github.com/rails/rails/blob/5-1-stable/activejob/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
- It was backported in
  https://github.com/rails/rails/commit/0eae8dd4b859c109919e5da0d6e74ffc6dc8a258
  and is present in Rails 5.1.3

