### PR TITLE
Fix deprecation warnings from with_lock

### DIFF
--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -60,7 +60,7 @@ module ActiveRecord
       # the locked record.
       def lock!(lock = true)
         if persisted?
-          if changed?
+          if has_changes_to_save?
             ActiveSupport::Deprecation.warn(<<-MSG.squish)
               Locking a record with unpersisted changes is deprecated and will raise an
               exception in Rails 5.2. Use `save` to persist the changes, or `reload` to

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -13,6 +13,7 @@ require "models/bulb"
 require "models/engine"
 require "models/wheel"
 require "models/treasure"
+require "models/frog"
 
 class LockWithoutDefault < ActiveRecord::Base; end
 
@@ -507,6 +508,16 @@ unless in_memory_db?
             person.lock!
           end
           assert_equal old, person.first_name
+        end
+      end
+    end
+
+    def test_locking_in_after_save_callback
+      assert_nothing_raised do
+        frog = ::Frog.create(name: "Old Frog")
+        frog.name = "New Frog"
+        assert_not_deprecated do
+          frog.save!
         end
       end
     end

--- a/activerecord/test/models/frog.rb
+++ b/activerecord/test/models/frog.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Frog < ActiveRecord::Base
+  after_save do
+    with_lock do
+    end
+  end
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -340,6 +340,10 @@ ActiveRecord::Schema.define do
     t.string :token
   end
 
+  create_table :frogs, force: true do |t|
+    t.string :name
+  end
+
   create_table :funny_jokes, force: true do |t|
     t.string :name
   end


### PR DESCRIPTION
Currently `with_lock` checks whether the record has `changed?`, but
when called within a callback `changed?` triggers deprecation
warnings. Instead use `has_changes_to_save?`.

These deprecation warnings have been removed from master, so this
is only necessary for 5.1.

Fixes #30307