### PR TITLE
specify minimum capybara version for system tests

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+gem "capybara", "~> 2.13"
+
 require "capybara/dsl"
 require "capybara/minitest"
 require "action_controller"


### PR DESCRIPTION
Resolves #30952

Upgraded rails applications may have a Gemfile without a new enough capybara to run system tests.  Setting a version here gives the user a more direct error message than they get otherwise.  
