### PR TITLE
Performance improvements for dasherize.

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -95,7 +95,11 @@ module ActionView
 
         private
           def prefix_tag_option(prefix, key, value, escape)
-            key = "#{prefix}-#{key.to_s.dasherize}"
+            if prefix == 'data' and key == :disable_with
+              key = "data-disable-with"
+            else
+              key = "#{prefix}-#{key.to_s.dasherize}"
+            end
             unless value.is_a?(String) || value.is_a?(Symbol) || value.is_a?(BigDecimal)
               value = value.to_json
             end

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -95,7 +95,7 @@ module ActionView
 
         private
           def prefix_tag_option(prefix, key, value, escape)
-            if prefix == 'data' and key == :disable_with
+            if prefix == "data" && key == :disable_with
               key = "data-disable-with"
             else
               key = "#{prefix}-#{key.to_s.dasherize}"

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -207,13 +207,7 @@ module ActiveSupport
     #
     #   dasherize('puni_puni') # => "puni-puni"
     def dasherize(underscored_word)
-      @_dasherize_cache ||= {}
-      @_dasherize_cache[underscored_word] ||=
-        if underscored_word.include?("_")
-          underscored_word.tr("_", "-")
-        else
-          underscored_word
-        end
+      underscored_word.tr("_".freeze, "-".freeze)
     end
 
     # Removes the module part from the expression in the string.

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -207,7 +207,13 @@ module ActiveSupport
     #
     #   dasherize('puni_puni') # => "puni-puni"
     def dasherize(underscored_word)
-      underscored_word.tr("_".freeze, "-".freeze)
+      @_dasherize_cache ||= {}
+      @_dasherize_cache[underscored_word] ||=
+        if underscored_word.include?("_")
+          underscored_word.tr("_", "-")
+        else
+          underscored_word
+        end
     end
 
     # Removes the module part from the expression in the string.


### PR DESCRIPTION
Continuation of https://github.com/rails/rails/pull/30948

Add a cache to save the dasherized word so that we only generate the
string once.

This change prevents a string allocation for each time the method is
called, with a speed up of ~1.3x for small strings (5-10 chars) and
~2.4x for large strings (~50 chars)

```ruby
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update
                your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", github: "rails/rails"
  gem "arel", github: "rails/arel"
  gem "benchmark-ips"
end

def allocate_count
  GC.disable
  before = ObjectSpace.count_objects
  yield
  after = ObjectSpace.count_objects
  after.each { |k,v| after[k] = v - before[k] }
  after[:T_HASH] -= 1 # probe effect - we created the before hash.
  GC.enable
  result = after.reject { |k,v| v == 0 }
  GC.start
  result
end

module ActiveSupport
  module Inflector
    extend self
    def fast_dasherize(underscored_word)
      @_dasherize_cache ||= {}
      @_dasherize_cache[underscored_word] ||=
        if underscored_word.include?('_')
          underscored_word.tr('_', '-')
        else
          underscored_word
        end
    end
  end
end

%w(
  short_string
  a_medium_underscore_string
  really_long_string_with_many_underscores_omg_underscores_
  rails
).each do |value|
  puts " #{value} ".center(60, '=')

  puts " Memory Usage ".center(60, "=")
  puts

  puts "value.dasherize"
  puts allocate_count {
    1000.times { ActiveSupport::Inflector.dasherize(value) }
  }

  puts "value.fast_dasherize"
  puts allocate_count {
    1000.times { ActiveSupport::Inflector.fast_dasherize(value) }
  }

  puts
  puts " Benchmark.ips ".center(60, "=")
  puts

  Benchmark.ips do |x|
    x.report("dasherize") do
      ActiveSupport::Inflector.dasherize(value)
    end
    x.report("fast_dasherize") do
      ActiveSupport::Inflector.fast_dasherize(value)
    end
    x.compare!
  end
end
```

```
======================= short_string =======================
======================= Memory Usage =======================

value.dasherize
{:FREE=>-988, :T_STRING=>1052, :T_IMEMO=>1}
value.fast_dasherize
{:FREE=>-8, :T_STRING=>5, :T_HASH=>1, :T_IMEMO=>1}

====================== Benchmark.ips =======================

Warming up --------------------------------------
           dasherize   148.831k i/100ms
      fast_dasherize   127.826k i/100ms
Calculating -------------------------------------
           dasherize      2.949M (±15.7%) i/s -     14.437M in   5.042609s
      fast_dasherize      3.672M (±12.6%) i/s -     18.023M in   5.005492s

Comparison:
      fast_dasherize:  3672161.3 i/s
           dasherize:  2948709.3 i/s - same-ish: difference falls within error

================ a_medium_underscore_string ================
======================= Memory Usage =======================

value.dasherize
{:FREE=>-1001, :T_STRING=>1000}
value.fast_dasherize
{:FREE=>-5, :T_STRING=>4}

====================== Benchmark.ips =======================

Warming up --------------------------------------
           dasherize   107.950k i/100ms
      fast_dasherize   159.392k i/100ms
Calculating -------------------------------------
           dasherize      1.676M (± 8.5%) i/s -      8.420M in   5.058826s
      fast_dasherize      3.539M (± 8.9%) i/s -     17.533M in   5.000014s

Comparison:
      fast_dasherize:  3538794.2 i/s
           dasherize:  1676062.3 i/s - 2.11x  slower

 really_long_string_with_many_underscores_omg_underscores_ =
======================= Memory Usage =======================

value.dasherize
{:FREE=>-1001, :T_STRING=>1000}
value.fast_dasherize
{:FREE=>-5, :T_STRING=>4}

====================== Benchmark.ips =======================

Warming up --------------------------------------
           dasherize    96.655k i/100ms
      fast_dasherize   148.701k i/100ms
Calculating -------------------------------------
           dasherize      1.416M (±18.7%) i/s -      6.863M in   5.048829s
      fast_dasherize      3.464M (±10.0%) i/s -     17.249M in   5.037720s

Comparison:
      fast_dasherize:  3463915.3 i/s
           dasherize:  1416219.4 i/s - 2.45x  slower

========================== rails ===========================
======================= Memory Usage =======================

value.dasherize
{:FREE=>-1001, :T_STRING=>1000}
value.fast_dasherize
{:FREE=>-3, :T_STRING=>2}

====================== Benchmark.ips =======================

Warming up --------------------------------------
           dasherize   157.250k i/100ms
      fast_dasherize   158.780k i/100ms
Calculating -------------------------------------
           dasherize      3.348M (± 7.8%) i/s -     16.669M in   5.013025s
      fast_dasherize      3.855M (±10.3%) i/s -     19.054M in   5.005788s

Comparison:
      fast_dasherize:  3855075.6 i/s
           dasherize:  3347527.7 i/s - same-ish: difference falls within error
```