### PR TITLE
Performance improvements for add_method_to_attributes!

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -589,7 +589,7 @@ module ActionView
         end
 
         def add_method_to_attributes!(html_options, method)
-          if method && method.to_s.downcase != "get" && html_options["rel"] !~ /nofollow/
+          if method_not_get_method?(method) && html_options["rel"] !~ /nofollow/
             if html_options["rel"].blank?
               html_options["rel"] = "nofollow"
             else
@@ -597,6 +597,19 @@ module ActionView
             end
           end
           html_options["data-method"] = method
+        end
+
+        STRINGIFIED_COMMON_METHODS = {
+          get:    "get",
+          delete: "delete",
+          patch:  "patch",
+          post:   "post",
+          put:    "put",
+        }.freeze
+
+        def method_not_get_method?(method)
+          return false unless method
+          (STRINGIFIED_COMMON_METHODS[method] || method.to_s.downcase) != "get"
         end
 
         def token_tag(token = nil, form_options: {})


### PR DESCRIPTION
Continuation of https://github.com/rails/rails/pull/30948

Add a cache to save the `method.to_s.downcase` call.

This change prevents a string allocation for each time the method is
called, with performance changes within margin of error.

```ruby
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update
                your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", github: "rails/rails"
  gem "arel", github: "rails/arel"
  gem "benchmark-ips"
end

def allocate_count
  GC.disable
  before = ObjectSpace.count_objects
  yield
  after = ObjectSpace.count_objects
  after.each { |k,v| after[k] = v - before[k] }
  after[:T_HASH] -= 1 # probe effect - we created the before hash.
  GC.enable
  result = after.reject { |k,v| v == 0 }
  GC.start
  result
end

def add_method_to_attributes!(html_options, method)
  if method && method.to_s.downcase != "get".freeze &&
      html_options["rel".freeze] !~ /nofollow/
    html_options["rel".freeze] =
      "#{html_options["rel".freeze]} nofollow".lstrip
  end
  html_options["data-method".freeze] = method
end

def fast_add_method_to_attributes!(html_options, method)
  @_method_downcase_cache ||= {}
  downcased_method = @_method_downcase_cache[method] ||=
    method.to_s.downcase
  if downcased_method && downcased_method != "get" &&
      html_options["rel"] !~ /nofollow/
    if html_options["rel"].present?
      html_options["rel"] = "#{html_options["rel"]} nofollow"
    else
      html_options["rel"] = "nofollow"
    end
  end
  html_options["data-method"] = downcased_method
end

obj = ''.freeze

[
  [{}, 'GET'],
  [{'rel' => 'hi'}, 'GET'],
  [{}, 'DEL'],
  [{'rel' => 'hi'}, 'DEL']
].each do |html_options, method|
  puts " #{html_options} , #{method}".center(60, '=')

  puts " Memory Usage ".center(60, "=")
  puts

  puts "value.add_method_to_attributes!"
  puts allocate_count {
    1000.times { add_method_to_attributes!(html_options, method) }
  }

  puts "value.fast_add_method_to_attributes!"
  puts allocate_count {
    1000.times { fast_add_method_to_attributes!(html_options, method) }
  }

  puts
  puts " Benchmark.ips ".center(60, "=")
  puts

  Benchmark.ips do |x|
    x.report("add_method_to_attributes!") do
      add_method_to_attributes!(html_options, method)
    end
    x.report("fast_add_method_to_attributes!") do
      fast_add_method_to_attributes!(html_options, method)
    end
    x.compare!
  end
end
```

```
========================= {} , GET==========================
======================= Memory Usage =======================

value.add_method_to_attributes!
{:FREE=>-997, :T_STRING=>1052}
value.fast_add_method_to_attributes!
{:FREE=>-3, :T_STRING=>1, :T_HASH=>1}

====================== Benchmark.ips =======================

Warming up --------------------------------------
add_method_to_attributes!
                       106.245k i/100ms
fast_add_method_to_attributes!
                       105.093k i/100ms
Calculating -------------------------------------
add_method_to_attributes!
                          2.517M (±14.8%) i/s -     12.324M in   5.029593s
fast_add_method_to_attributes!
                          2.441M (±15.7%) i/s -     11.876M in   5.002305s

Comparison:
add_method_to_attributes!:  2517402.3 i/s
fast_add_method_to_attributes!:  2441322.0 i/s - same-ish: difference falls within error

==================== {"rel"=>"hi"} , GET====================
======================= Memory Usage =======================

value.add_method_to_attributes!
{:FREE=>-1001, :T_STRING=>1000}
value.fast_add_method_to_attributes!
{:FREE=>-1}

====================== Benchmark.ips =======================

Warming up --------------------------------------
add_method_to_attributes!
                       122.110k i/100ms
fast_add_method_to_attributes!
                       124.142k i/100ms
Calculating -------------------------------------
add_method_to_attributes!
                          2.640M (±14.9%) i/s -     12.944M in   5.041262s
fast_add_method_to_attributes!
                          2.730M (±11.0%) i/s -     13.531M in   5.029957s

Comparison:
fast_add_method_to_attributes!:  2730043.4 i/s
add_method_to_attributes!:  2640236.3 i/s - same-ish: difference falls within error

========================= {} , DEL==========================
======================= Memory Usage =======================

value.add_method_to_attributes!
{:FREE=>-4003, :T_STRING=>2003, :T_MATCH=>999, :T_IMEMO=>1000}
value.fast_add_method_to_attributes!
{:FREE=>-3003, :T_STRING=>1002, :T_MATCH=>1000, :T_IMEMO=>1000}

====================== Benchmark.ips =======================

Warming up --------------------------------------
add_method_to_attributes!
                        38.073k i/100ms
fast_add_method_to_attributes!
                        35.313k i/100ms
Calculating -------------------------------------
add_method_to_attributes!
                        500.309k (±16.6%) i/s -      2.475M in   5.124336s
fast_add_method_to_attributes!
                        454.153k (±20.2%) i/s -      2.189M in   5.067740s

Comparison:
add_method_to_attributes!:   500309.2 i/s
fast_add_method_to_attributes!:   454152.9 i/s - same-ish: difference falls within error

==================== {"rel"=>"hi"} , DEL====================
======================= Memory Usage =======================

value.add_method_to_attributes!
{:FREE=>-4001, :T_STRING=>2001, :T_MATCH=>999, :T_IMEMO=>1000}
value.fast_add_method_to_attributes!
{:FREE=>-3001, :T_STRING=>1000, :T_MATCH=>1000, :T_IMEMO=>1000}

====================== Benchmark.ips =======================

Warming up --------------------------------------
add_method_to_attributes!
                        36.612k i/100ms
fast_add_method_to_attributes!
                        39.979k i/100ms
Calculating -------------------------------------
add_method_to_attributes!
                        461.501k (±32.8%) i/s -      1.977M in   5.066839s
fast_add_method_to_attributes!
                        517.545k (±13.4%) i/s -      2.559M in   5.048322s

Comparison:
fast_add_method_to_attributes!:   517545.4 i/s
add_method_to_attributes!:   461501.0 i/s - same-ish: difference falls within error
```

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
