### PR TITLE
Remove `supports_disable_referential_integrity?`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -4,26 +4,21 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module ReferentialIntegrity # :nodoc:
-        def supports_disable_referential_integrity? # :nodoc:
-          true
-        end
-
         def disable_referential_integrity # :nodoc:
-          if supports_disable_referential_integrity?
-            original_exception = nil
+          original_exception = nil
 
-            begin
-              transaction(requires_new: true) do
-                execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
-              end
-            rescue ActiveRecord::ActiveRecordError => e
-              original_exception = e
+          begin
+            transaction(requires_new: true) do
+              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
             end
+          rescue ActiveRecord::ActiveRecordError => e
+            original_exception = e
+          end
 
-            begin
-              yield
-            rescue ActiveRecord::InvalidForeignKey => e
-              warn <<-WARNING
+          begin
+            yield
+          rescue ActiveRecord::InvalidForeignKey => e
+            warn <<-WARNING
 WARNING: Rails was not able to disable referential integrity.
 
 This is most likely caused due to missing permissions.
@@ -32,17 +27,14 @@ Rails needs superuser privileges to disable referential integrity.
     cause: #{original_exception.try(:message)}
 
               WARNING
-              raise e
-            end
+            raise e
+          end
 
-            begin
-              transaction(requires_new: true) do
-                execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
-              end
-            rescue ActiveRecord::ActiveRecordError
+          begin
+            transaction(requires_new: true) do
+              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
             end
-          else
-            yield
+          rescue ActiveRecord::ActiveRecordError
           end
         end
       end


### PR DESCRIPTION
### Summary

`supports_disable_referential_integrity?` used to handle
if PostgreSQL database supports
`ALTER TABLE <table name> DISABLE/ENABLE TRIGGER` statements.
Refer https://github.com/rails/rails/commit/9a947af0e79cfb8692eb7e5ae94c1b8c40756f49

These statements have been documented since 8.1.

https://www.postgresql.org/docs/8.1/static/sql-altertable.html
> DISABLE/ENABLE TRIGGER

Now Rails supports PostgreSQL 9.1 or higher only.
No need to handle `supports_disable_referential_integrity?` anymore.
Also, this method does not exist in any other adapters including AbstractAdapter.

