### PR TITLE
Space between { and | missing.

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -92,7 +92,7 @@ task default: :test
     ]
 
     def generate_test_dummy(force = false)
-      opts = (options.dup || {}).keep_if { |k, | PASSTHROUGH_OPTIONS.map(&:to_s).include?(k) }
+      opts = (options.dup || {}).keep_if { |k, _| PASSTHROUGH_OPTIONS.map(&:to_s).include?(k) }
       opts[:force] = force
       opts[:skip_bundle] = true
       opts[:skip_listen] = true

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -92,7 +92,7 @@ task default: :test
     ]
 
     def generate_test_dummy(force = false)
-      opts = (options.dup || {}).keep_if {|k, | PASSTHROUGH_OPTIONS.map(&:to_s).include?(k) }
+      opts = (options.dup || {}).keep_if { |k, | PASSTHROUGH_OPTIONS.map(&:to_s).include?(k) }
       opts[:force] = force
       opts[:skip_bundle] = true
       opts[:skip_listen] = true


### PR DESCRIPTION
Improve code style recommendation following Rubocop as described in https://codeclimate.com/github/rails/rails/issues