### PR TITLE
Save index order :desc to schema.rb (sqlite). Fixes #30902

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fixed a bug where column orders for an index weren't written to
+    db/schema.rb when using the sqlite adapter.
+
+    Fixes #30902.
+
+    *Paul Kuruvilla*
+
 *   Remove deprecated method `#sanitize_conditions`.
 
     *Rafael Mendonça França*

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -186,7 +186,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
         assert_equal 't.index ["firm_id", "type", "rating"], name: "company_index", length: { type: 10 }', index_definition
       end
     else
-      assert_equal 't.index ["firm_id", "type", "rating"], name: "company_index"', index_definition
+      assert_equal 't.index ["firm_id", "type", "rating"], name: "company_index", order: { rating: :desc }', index_definition
     end
   end
 


### PR DESCRIPTION
### Summary

Fixes #30902. 

Although the sqlite adapter supports index sort orders, they weren't being written to db/schema.rb.

This uses [`index_xinfo`](https://sqlite.org/pragma.html#pragma_index_xinfo) instead of [`index_info`](https://sqlite.org/pragma.html#pragma_index_info) (which was used previously), as the latter doesn't contain information about the sort order. 