### PR TITLE
Unify _read_attribute definition to use &block

### DIFF
--- a/activemodel/lib/active_model/attribute_set.rb
+++ b/activemodel/lib/active_model/attribute_set.rb
@@ -37,16 +37,8 @@ module ActiveModel
       attributes.each_key.select { |name| self[name].initialized? }
     end
 
-    if defined?(JRUBY_VERSION)
-      # This form is significantly faster on JRuby, and this is one of our biggest hotspots.
-      # https://github.com/jruby/jruby/pull/2562
-      def fetch_value(name, &block)
-        self[name].value(&block)
-      end
-    else
-      def fetch_value(name)
-        self[name].value { |n| yield n if block_given? }
-      end
+    def fetch_value(name, &block)
+      self[name].value(&block)
     end
 
     def write_from_database(name, value)

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -66,16 +66,8 @@ module ActiveRecord
 
       # This method exists to avoid the expensive primary_key check internally, without
       # breaking compatibility with the read_attribute API
-      if defined?(JRUBY_VERSION)
-        # This form is significantly faster on JRuby, and this is one of our biggest hotspots.
-        # https://github.com/jruby/jruby/pull/2562
-        def _read_attribute(attr_name, &block) # :nodoc:
-          @attributes.fetch_value(attr_name.to_s, &block)
-        end
-      else
-        def _read_attribute(attr_name) # :nodoc:
-          @attributes.fetch_value(attr_name.to_s) { |n| yield n if block_given? }
-        end
+      def _read_attribute(attr_name, &block) # :nodoc
+        @attributes.fetch_value(attr_name.to_s, &block)
       end
 
       alias :attribute :_read_attribute


### PR DESCRIPTION
### Summary
Thanks to ko1, passing block parameter to another method is significantly faster in Ruby 2.5.
https://bugs.ruby-lang.org/issues/14045

Thus we no longer need to keep this ugly hack. I want to introduce this change for maintainability of Rails and to encourage next version's Rails users to use Ruby 2.5.

### Other information
Prior to Ruby 2.5, declaring `&block` means it creates Proc object when the method is called, and it was very slow. But Feature#14045 allows to lazily create Proc object when `block` is used in non-`&block` form. 

So this `_read_attribute` call won't create Proc object in Ruby 2.5 and will be faster.