### PR TITLE
`supports_extensions?` return always true since PostgreSQL 9.1

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -337,18 +337,12 @@ module ActiveRecord
       end
 
       def extension_enabled?(name)
-        if supports_extensions?
-          res = exec_query("SELECT EXISTS(SELECT * FROM pg_available_extensions WHERE name = '#{name}' AND installed_version IS NOT NULL) as enabled", "SCHEMA")
-          res.cast_values.first
-        end
+        res = exec_query("SELECT EXISTS(SELECT * FROM pg_available_extensions WHERE name = '#{name}' AND installed_version IS NOT NULL) as enabled", "SCHEMA")
+        res.cast_values.first
       end
 
       def extensions
-        if supports_extensions?
-          exec_query("SELECT extname FROM pg_extension", "SCHEMA").cast_values
-        else
-          super
-        end
+        exec_query("SELECT extname FROM pg_extension", "SCHEMA").cast_values
       end
 
       # Returns the configured supported identifier length supported by PostgreSQL

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -3,78 +3,76 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-if ActiveRecord::Base.connection.supports_extensions?
-  class PostgresqlCitextTest < ActiveRecord::PostgreSQLTestCase
-    include SchemaDumpingHelper
-    class Citext < ActiveRecord::Base
-      self.table_name = "citexts"
+class PostgresqlCitextTest < ActiveRecord::PostgreSQLTestCase
+  include SchemaDumpingHelper
+  class Citext < ActiveRecord::Base
+    self.table_name = "citexts"
+  end
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+
+    enable_extension!("citext", @connection)
+
+    @connection.create_table("citexts") do |t|
+      t.citext "cival"
     end
+  end
 
-    def setup
-      @connection = ActiveRecord::Base.connection
+  teardown do
+    @connection.drop_table "citexts", if_exists: true
+    disable_extension!("citext", @connection)
+  end
 
-      enable_extension!("citext", @connection)
+  def test_citext_enabled
+    assert @connection.extension_enabled?("citext")
+  end
 
-      @connection.create_table("citexts") do |t|
-        t.citext "cival"
+  def test_column
+    column = Citext.columns_hash["cival"]
+    assert_equal :citext, column.type
+    assert_equal "citext", column.sql_type
+    assert_not column.array?
+
+    type = Citext.type_for_attribute("cival")
+    assert_not type.binary?
+  end
+
+  def test_change_table_supports_json
+    @connection.transaction do
+      @connection.change_table("citexts") do |t|
+        t.citext "username"
       end
-    end
-
-    teardown do
-      @connection.drop_table "citexts", if_exists: true
-      disable_extension!("citext", @connection)
-    end
-
-    def test_citext_enabled
-      assert @connection.extension_enabled?("citext")
-    end
-
-    def test_column
-      column = Citext.columns_hash["cival"]
-      assert_equal :citext, column.type
-      assert_equal "citext", column.sql_type
-      assert_not column.array?
-
-      type = Citext.type_for_attribute("cival")
-      assert_not type.binary?
-    end
-
-    def test_change_table_supports_json
-      @connection.transaction do
-        @connection.change_table("citexts") do |t|
-          t.citext "username"
-        end
-        Citext.reset_column_information
-        column = Citext.columns_hash["username"]
-        assert_equal :citext, column.type
-
-        raise ActiveRecord::Rollback # reset the schema change
-      end
-    ensure
       Citext.reset_column_information
+      column = Citext.columns_hash["username"]
+      assert_equal :citext, column.type
+
+      raise ActiveRecord::Rollback # reset the schema change
     end
+  ensure
+    Citext.reset_column_information
+  end
 
-    def test_write
-      x = Citext.new(cival: "Some CI Text")
-      x.save!
-      citext = Citext.first
-      assert_equal "Some CI Text", citext.cival
+  def test_write
+    x = Citext.new(cival: "Some CI Text")
+    x.save!
+    citext = Citext.first
+    assert_equal "Some CI Text", citext.cival
 
-      citext.cival = "Some NEW CI Text"
-      citext.save!
+    citext.cival = "Some NEW CI Text"
+    citext.save!
 
-      assert_equal "Some NEW CI Text", citext.reload.cival
-    end
+    assert_equal "Some NEW CI Text", citext.reload.cival
+  end
 
-    def test_select_case_insensitive
-      @connection.execute "insert into citexts (cival) values('Cased Text')"
-      x = Citext.where(cival: "cased text").first
-      assert_equal "Cased Text", x.cival
-    end
+  def test_select_case_insensitive
+    @connection.execute "insert into citexts (cival) values('Cased Text')"
+    x = Citext.where(cival: "cased text").first
+    assert_equal "Cased Text", x.cival
+  end
 
-    def test_schema_dump_with_shorthand
-      output = dump_table_schema("citexts")
-      assert_match %r[t\.citext "cival"], output
-    end
+  def test_schema_dump_with_shorthand
+    output = dump_table_schema("citexts")
+    assert_match %r[t\.citext "cival"], output
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
@@ -22,10 +22,6 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
 
     @connection = ActiveRecord::Base.connection
 
-    unless @connection.supports_extensions?
-      return skip("no extension support")
-    end
-
     @old_schema_migration_table_name = ActiveRecord::SchemaMigration.table_name
     @old_table_name_prefix = ActiveRecord::Base.table_name_prefix
     @old_table_name_suffix = ActiveRecord::Base.table_name_suffix

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -3,378 +3,376 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-if ActiveRecord::Base.connection.supports_extensions?
-  class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
-    include SchemaDumpingHelper
-    class Hstore < ActiveRecord::Base
-      self.table_name = "hstores"
-
-      store_accessor :settings, :language, :timezone
-    end
-
-    class FakeParameters
-      def to_unsafe_h
-        { "hi" => "hi" }
-      end
-    end
-
-    def setup
-      @connection = ActiveRecord::Base.connection
-
-      enable_extension!("hstore", @connection)
-
-      @connection.transaction do
-        @connection.create_table("hstores") do |t|
-          t.hstore "tags", default: ""
-          t.hstore "payload", array: true
-          t.hstore "settings"
-        end
-      end
-      Hstore.reset_column_information
-      @column = Hstore.columns_hash["tags"]
-      @type = Hstore.type_for_attribute("tags")
-    end
-
-    teardown do
-      @connection.drop_table "hstores", if_exists: true
-      disable_extension!("hstore", @connection)
-    end
-
-    def test_hstore_included_in_extensions
-      assert @connection.respond_to?(:extensions), "connection should have a list of extensions"
-      assert_includes @connection.extensions, "hstore", "extension list should include hstore"
-    end
-
-    def test_disable_enable_hstore
-      assert @connection.extension_enabled?("hstore")
-      @connection.disable_extension "hstore"
-      assert_not @connection.extension_enabled?("hstore")
-      @connection.enable_extension "hstore"
-      assert @connection.extension_enabled?("hstore")
-    ensure
-      # Restore column(s) dropped by `drop extension hstore cascade;`
-      load_schema
-    end
-
-    def test_column
-      assert_equal :hstore, @column.type
-      assert_equal "hstore", @column.sql_type
-      assert_not @column.array?
-
-      assert_not @type.binary?
-    end
-
-    def test_default
-      @connection.add_column "hstores", "permissions", :hstore, default: '"users"=>"read", "articles"=>"write"'
-      Hstore.reset_column_information
-
-      assert_equal({ "users" => "read", "articles" => "write" }, Hstore.column_defaults["permissions"])
-      assert_equal({ "users" => "read", "articles" => "write" }, Hstore.new.permissions)
-    ensure
-      Hstore.reset_column_information
-    end
-
-    def test_change_table_supports_hstore
-      @connection.transaction do
-        @connection.change_table("hstores") do |t|
-          t.hstore "users", default: ""
-        end
-        Hstore.reset_column_information
-        column = Hstore.columns_hash["users"]
-        assert_equal :hstore, column.type
-
-        raise ActiveRecord::Rollback # reset the schema change
-      end
-    ensure
-      Hstore.reset_column_information
-    end
-
-    def test_hstore_migration
-      hstore_migration = Class.new(ActiveRecord::Migration::Current) do
-        def change
-          change_table("hstores") do |t|
-            t.hstore :keys
-          end
-        end
-      end
-
-      hstore_migration.new.suppress_messages do
-        hstore_migration.migrate(:up)
-        assert_includes @connection.columns(:hstores).map(&:name), "keys"
-        hstore_migration.migrate(:down)
-        assert_not_includes @connection.columns(:hstores).map(&:name), "keys"
-      end
-    end
-
-    def test_cast_value_on_write
-      x = Hstore.new tags: { "bool" => true, "number" => 5 }
-      assert_equal({ "bool" => true, "number" => 5 }, x.tags_before_type_cast)
-      assert_equal({ "bool" => "true", "number" => "5" }, x.tags)
-      x.save
-      assert_equal({ "bool" => "true", "number" => "5" }, x.reload.tags)
-    end
-
-    def test_type_cast_hstore
-      assert_equal({ "1" => "2" }, @type.deserialize("\"1\"=>\"2\""))
-      assert_equal({}, @type.deserialize(""))
-      assert_equal({ "key" => nil }, @type.deserialize("key => NULL"))
-      assert_equal({ "c" => "}", '"a"' => 'b "a b' }, @type.deserialize(%q(c=>"}", "\"a\""=>"b \"a b")))
-    end
-
-    def test_with_store_accessors
-      x = Hstore.new(language: "fr", timezone: "GMT")
-      assert_equal "fr", x.language
-      assert_equal "GMT", x.timezone
-
-      x.save!
-      x = Hstore.first
-      assert_equal "fr", x.language
-      assert_equal "GMT", x.timezone
-
-      x.language = "de"
-      x.save!
-
-      x = Hstore.first
-      assert_equal "de", x.language
-      assert_equal "GMT", x.timezone
-    end
-
-    def test_duplication_with_store_accessors
-      x = Hstore.new(language: "fr", timezone: "GMT")
-      assert_equal "fr", x.language
-      assert_equal "GMT", x.timezone
-
-      y = x.dup
-      assert_equal "fr", y.language
-      assert_equal "GMT", y.timezone
-    end
-
-    def test_yaml_round_trip_with_store_accessors
-      x = Hstore.new(language: "fr", timezone: "GMT")
-      assert_equal "fr", x.language
-      assert_equal "GMT", x.timezone
-
-      y = YAML.load(YAML.dump(x))
-      assert_equal "fr", y.language
-      assert_equal "GMT", y.timezone
-    end
-
-    def test_changes_in_place
-      hstore = Hstore.create!(settings: { "one" => "two" })
-      hstore.settings["three"] = "four"
-      hstore.save!
-      hstore.reload
-
-      assert_equal "four", hstore.settings["three"]
-      assert_not hstore.changed?
-    end
-
-    def test_dirty_from_user_equal
-      settings = { "alongkey" => "anything", "key" => "value" }
-      hstore = Hstore.create!(settings: settings)
-
-      hstore.settings = { "key" => "value", "alongkey" => "anything" }
-      assert_equal settings, hstore.settings
-      refute hstore.changed?
-    end
-
-    def test_hstore_dirty_from_database_equal
-      settings = { "alongkey" => "anything", "key" => "value" }
-      hstore = Hstore.create!(settings: settings)
-      hstore.reload
-
-      assert_equal settings, hstore.settings
-      hstore.settings = settings
-      refute hstore.changed?
-    end
-
-    def test_gen1
-      assert_equal('" "=>""', @type.serialize(" " => ""))
-    end
-
-    def test_gen2
-      assert_equal('","=>""', @type.serialize("," => ""))
-    end
-
-    def test_gen3
-      assert_equal('"="=>""', @type.serialize("=" => ""))
-    end
-
-    def test_gen4
-      assert_equal('">"=>""', @type.serialize(">" => ""))
-    end
-
-    def test_parse1
-      assert_equal({ "a" => nil, "b" => nil, "c" => "NuLl", "null" => "c" }, @type.deserialize('a=>null,b=>NuLl,c=>"NuLl",null=>c'))
-    end
-
-    def test_parse2
-      assert_equal({ " " => " " },  @type.deserialize("\\ =>\\ "))
-    end
-
-    def test_parse3
-      assert_equal({ "=" => ">" },  @type.deserialize("==>>"))
-    end
-
-    def test_parse4
-      assert_equal({ "=a" => "q=w" },   @type.deserialize('\=a=>q=w'))
-    end
-
-    def test_parse5
-      assert_equal({ "=a" => "q=w" },   @type.deserialize('"=a"=>q\=w'))
-    end
-
-    def test_parse6
-      assert_equal({ "\"a" => "q>w" },  @type.deserialize('"\"a"=>q>w'))
-    end
-
-    def test_parse7
-      assert_equal({ "\"a" => "q\"w" }, @type.deserialize('\"a=>q"w'))
-    end
-
-    def test_rewrite
-      @connection.execute "insert into hstores (tags) VALUES ('1=>2')"
-      x = Hstore.first
-      x.tags = { '"a\'' => "b" }
-      assert x.save!
-    end
-
-    def test_select
-      @connection.execute "insert into hstores (tags) VALUES ('1=>2')"
-      x = Hstore.first
-      assert_equal({ "1" => "2" }, x.tags)
-    end
-
-    def test_array_cycle
-      assert_array_cycle([{ "AA" => "BB", "CC" => "DD" }, { "AA" => nil }])
-    end
-
-    def test_array_strings_with_quotes
-      assert_array_cycle([{ "this has" => 'some "s that need to be escaped"' }])
-    end
-
-    def test_array_strings_with_commas
-      assert_array_cycle([{ "this,has" => "many,values" }])
-    end
-
-    def test_array_strings_with_array_delimiters
-      assert_array_cycle(["{" => "}"])
-    end
-
-    def test_array_strings_with_null_strings
-      assert_array_cycle([{ "NULL" => "NULL" }])
-    end
-
-    def test_contains_nils
-      assert_array_cycle([{ "NULL" => nil }])
-    end
-
-    def test_select_multikey
-      @connection.execute "insert into hstores (tags) VALUES ('1=>2,2=>3')"
-      x = Hstore.first
-      assert_equal({ "1" => "2", "2" => "3" }, x.tags)
-    end
-
-    def test_create
-      assert_cycle("a" => "b", "1" => "2")
-    end
-
-    def test_nil
-      assert_cycle("a" => nil)
-    end
-
-    def test_quotes
-      assert_cycle("a" => 'b"ar', '1"foo' => "2")
-    end
-
-    def test_whitespace
-      assert_cycle("a b" => "b ar", '1"foo' => "2")
-    end
-
-    def test_backslash
-      assert_cycle('a\\b' => 'b\\ar', '1"foo' => "2")
-    end
-
-    def test_comma
-      assert_cycle("a, b" => "bar", '1"foo' => "2")
-    end
-
-    def test_arrow
-      assert_cycle("a=>b" => "bar", '1"foo' => "2")
-    end
-
-    def test_quoting_special_characters
-      assert_cycle("ca" => "cà", "ac" => "àc")
-    end
-
-    def test_multiline
-      assert_cycle("a\nb" => "c\nd")
-    end
-
-    class TagCollection
-      def initialize(hash); @hash = hash end
-      def to_hash; @hash end
-      def self.load(hash); new(hash) end
-      def self.dump(object); object.to_hash end
-    end
-
-    class HstoreWithSerialize < Hstore
-      serialize :tags, TagCollection
-    end
-
-    def test_hstore_with_serialized_attributes
-      HstoreWithSerialize.create! tags: TagCollection.new("one" => "two")
-      record = HstoreWithSerialize.first
-      assert_instance_of TagCollection, record.tags
-      assert_equal({ "one" => "two" }, record.tags.to_hash)
-      record.tags = TagCollection.new("three" => "four")
-      record.save!
-      assert_equal({ "three" => "four" }, HstoreWithSerialize.first.tags.to_hash)
-    end
-
-    def test_clone_hstore_with_serialized_attributes
-      HstoreWithSerialize.create! tags: TagCollection.new("one" => "two")
-      record = HstoreWithSerialize.first
-      dupe = record.dup
-      assert_equal({ "one" => "two" }, dupe.tags.to_hash)
-    end
-
-    def test_schema_dump_with_shorthand
-      output = dump_table_schema("hstores")
-      assert_match %r[t\.hstore "tags",\s+default: {}], output
-    end
-
-    def test_supports_to_unsafe_h_values
-      assert_equal("\"hi\"=>\"hi\"", @type.serialize(FakeParameters.new))
-    end
-
-    private
-      def assert_array_cycle(array)
-        # test creation
-        x = Hstore.create!(payload: array)
-        x.reload
-        assert_equal(array, x.payload)
-
-        # test updating
-        x = Hstore.create!(payload: [])
-        x.payload = array
-        x.save!
-        x.reload
-        assert_equal(array, x.payload)
-      end
-
-      def assert_cycle(hash)
-        # test creation
-        x = Hstore.create!(tags: hash)
-        x.reload
-        assert_equal(hash, x.tags)
-
-        # test updating
-        x = Hstore.create!(tags: {})
-        x.tags = hash
-        x.save!
-        x.reload
-        assert_equal(hash, x.tags)
-      end
+class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
+  include SchemaDumpingHelper
+  class Hstore < ActiveRecord::Base
+    self.table_name = "hstores"
+
+    store_accessor :settings, :language, :timezone
   end
+
+  class FakeParameters
+    def to_unsafe_h
+      { "hi" => "hi" }
+    end
+  end
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+
+    enable_extension!("hstore", @connection)
+
+    @connection.transaction do
+      @connection.create_table("hstores") do |t|
+        t.hstore "tags", default: ""
+        t.hstore "payload", array: true
+        t.hstore "settings"
+      end
+    end
+    Hstore.reset_column_information
+    @column = Hstore.columns_hash["tags"]
+    @type = Hstore.type_for_attribute("tags")
+  end
+
+  teardown do
+    @connection.drop_table "hstores", if_exists: true
+    disable_extension!("hstore", @connection)
+  end
+
+  def test_hstore_included_in_extensions
+    assert @connection.respond_to?(:extensions), "connection should have a list of extensions"
+    assert_includes @connection.extensions, "hstore", "extension list should include hstore"
+  end
+
+  def test_disable_enable_hstore
+    assert @connection.extension_enabled?("hstore")
+    @connection.disable_extension "hstore"
+    assert_not @connection.extension_enabled?("hstore")
+    @connection.enable_extension "hstore"
+    assert @connection.extension_enabled?("hstore")
+  ensure
+    # Restore column(s) dropped by `drop extension hstore cascade;`
+    load_schema
+  end
+
+  def test_column
+    assert_equal :hstore, @column.type
+    assert_equal "hstore", @column.sql_type
+    assert_not @column.array?
+
+    assert_not @type.binary?
+  end
+
+  def test_default
+    @connection.add_column "hstores", "permissions", :hstore, default: '"users"=>"read", "articles"=>"write"'
+    Hstore.reset_column_information
+
+    assert_equal({ "users" => "read", "articles" => "write" }, Hstore.column_defaults["permissions"])
+    assert_equal({ "users" => "read", "articles" => "write" }, Hstore.new.permissions)
+  ensure
+    Hstore.reset_column_information
+  end
+
+  def test_change_table_supports_hstore
+    @connection.transaction do
+      @connection.change_table("hstores") do |t|
+        t.hstore "users", default: ""
+      end
+      Hstore.reset_column_information
+      column = Hstore.columns_hash["users"]
+      assert_equal :hstore, column.type
+
+      raise ActiveRecord::Rollback # reset the schema change
+    end
+  ensure
+    Hstore.reset_column_information
+  end
+
+  def test_hstore_migration
+    hstore_migration = Class.new(ActiveRecord::Migration::Current) do
+      def change
+        change_table("hstores") do |t|
+          t.hstore :keys
+        end
+      end
+    end
+
+    hstore_migration.new.suppress_messages do
+      hstore_migration.migrate(:up)
+      assert_includes @connection.columns(:hstores).map(&:name), "keys"
+      hstore_migration.migrate(:down)
+      assert_not_includes @connection.columns(:hstores).map(&:name), "keys"
+    end
+  end
+
+  def test_cast_value_on_write
+    x = Hstore.new tags: { "bool" => true, "number" => 5 }
+    assert_equal({ "bool" => true, "number" => 5 }, x.tags_before_type_cast)
+    assert_equal({ "bool" => "true", "number" => "5" }, x.tags)
+    x.save
+    assert_equal({ "bool" => "true", "number" => "5" }, x.reload.tags)
+  end
+
+  def test_type_cast_hstore
+    assert_equal({ "1" => "2" }, @type.deserialize("\"1\"=>\"2\""))
+    assert_equal({}, @type.deserialize(""))
+    assert_equal({ "key" => nil }, @type.deserialize("key => NULL"))
+    assert_equal({ "c" => "}", '"a"' => 'b "a b' }, @type.deserialize(%q(c=>"}", "\"a\""=>"b \"a b")))
+  end
+
+  def test_with_store_accessors
+    x = Hstore.new(language: "fr", timezone: "GMT")
+    assert_equal "fr", x.language
+    assert_equal "GMT", x.timezone
+
+    x.save!
+    x = Hstore.first
+    assert_equal "fr", x.language
+    assert_equal "GMT", x.timezone
+
+    x.language = "de"
+    x.save!
+
+    x = Hstore.first
+    assert_equal "de", x.language
+    assert_equal "GMT", x.timezone
+  end
+
+  def test_duplication_with_store_accessors
+    x = Hstore.new(language: "fr", timezone: "GMT")
+    assert_equal "fr", x.language
+    assert_equal "GMT", x.timezone
+
+    y = x.dup
+    assert_equal "fr", y.language
+    assert_equal "GMT", y.timezone
+  end
+
+  def test_yaml_round_trip_with_store_accessors
+    x = Hstore.new(language: "fr", timezone: "GMT")
+    assert_equal "fr", x.language
+    assert_equal "GMT", x.timezone
+
+    y = YAML.load(YAML.dump(x))
+    assert_equal "fr", y.language
+    assert_equal "GMT", y.timezone
+  end
+
+  def test_changes_in_place
+    hstore = Hstore.create!(settings: { "one" => "two" })
+    hstore.settings["three"] = "four"
+    hstore.save!
+    hstore.reload
+
+    assert_equal "four", hstore.settings["three"]
+    assert_not hstore.changed?
+  end
+
+  def test_dirty_from_user_equal
+    settings = { "alongkey" => "anything", "key" => "value" }
+    hstore = Hstore.create!(settings: settings)
+
+    hstore.settings = { "key" => "value", "alongkey" => "anything" }
+    assert_equal settings, hstore.settings
+    refute hstore.changed?
+  end
+
+  def test_hstore_dirty_from_database_equal
+    settings = { "alongkey" => "anything", "key" => "value" }
+    hstore = Hstore.create!(settings: settings)
+    hstore.reload
+
+    assert_equal settings, hstore.settings
+    hstore.settings = settings
+    refute hstore.changed?
+  end
+
+  def test_gen1
+    assert_equal('" "=>""', @type.serialize(" " => ""))
+  end
+
+  def test_gen2
+    assert_equal('","=>""', @type.serialize("," => ""))
+  end
+
+  def test_gen3
+    assert_equal('"="=>""', @type.serialize("=" => ""))
+  end
+
+  def test_gen4
+    assert_equal('">"=>""', @type.serialize(">" => ""))
+  end
+
+  def test_parse1
+    assert_equal({ "a" => nil, "b" => nil, "c" => "NuLl", "null" => "c" }, @type.deserialize('a=>null,b=>NuLl,c=>"NuLl",null=>c'))
+  end
+
+  def test_parse2
+    assert_equal({ " " => " " },  @type.deserialize("\\ =>\\ "))
+  end
+
+  def test_parse3
+    assert_equal({ "=" => ">" },  @type.deserialize("==>>"))
+  end
+
+  def test_parse4
+    assert_equal({ "=a" => "q=w" },   @type.deserialize('\=a=>q=w'))
+  end
+
+  def test_parse5
+    assert_equal({ "=a" => "q=w" },   @type.deserialize('"=a"=>q\=w'))
+  end
+
+  def test_parse6
+    assert_equal({ "\"a" => "q>w" },  @type.deserialize('"\"a"=>q>w'))
+  end
+
+  def test_parse7
+    assert_equal({ "\"a" => "q\"w" }, @type.deserialize('\"a=>q"w'))
+  end
+
+  def test_rewrite
+    @connection.execute "insert into hstores (tags) VALUES ('1=>2')"
+    x = Hstore.first
+    x.tags = { '"a\'' => "b" }
+    assert x.save!
+  end
+
+  def test_select
+    @connection.execute "insert into hstores (tags) VALUES ('1=>2')"
+    x = Hstore.first
+    assert_equal({ "1" => "2" }, x.tags)
+  end
+
+  def test_array_cycle
+    assert_array_cycle([{ "AA" => "BB", "CC" => "DD" }, { "AA" => nil }])
+  end
+
+  def test_array_strings_with_quotes
+    assert_array_cycle([{ "this has" => 'some "s that need to be escaped"' }])
+  end
+
+  def test_array_strings_with_commas
+    assert_array_cycle([{ "this,has" => "many,values" }])
+  end
+
+  def test_array_strings_with_array_delimiters
+    assert_array_cycle(["{" => "}"])
+  end
+
+  def test_array_strings_with_null_strings
+    assert_array_cycle([{ "NULL" => "NULL" }])
+  end
+
+  def test_contains_nils
+    assert_array_cycle([{ "NULL" => nil }])
+  end
+
+  def test_select_multikey
+    @connection.execute "insert into hstores (tags) VALUES ('1=>2,2=>3')"
+    x = Hstore.first
+    assert_equal({ "1" => "2", "2" => "3" }, x.tags)
+  end
+
+  def test_create
+    assert_cycle("a" => "b", "1" => "2")
+  end
+
+  def test_nil
+    assert_cycle("a" => nil)
+  end
+
+  def test_quotes
+    assert_cycle("a" => 'b"ar', '1"foo' => "2")
+  end
+
+  def test_whitespace
+    assert_cycle("a b" => "b ar", '1"foo' => "2")
+  end
+
+  def test_backslash
+    assert_cycle('a\\b' => 'b\\ar', '1"foo' => "2")
+  end
+
+  def test_comma
+    assert_cycle("a, b" => "bar", '1"foo' => "2")
+  end
+
+  def test_arrow
+    assert_cycle("a=>b" => "bar", '1"foo' => "2")
+  end
+
+  def test_quoting_special_characters
+    assert_cycle("ca" => "cà", "ac" => "àc")
+  end
+
+  def test_multiline
+    assert_cycle("a\nb" => "c\nd")
+  end
+
+  class TagCollection
+    def initialize(hash); @hash = hash end
+    def to_hash; @hash end
+    def self.load(hash); new(hash) end
+    def self.dump(object); object.to_hash end
+  end
+
+  class HstoreWithSerialize < Hstore
+    serialize :tags, TagCollection
+  end
+
+  def test_hstore_with_serialized_attributes
+    HstoreWithSerialize.create! tags: TagCollection.new("one" => "two")
+    record = HstoreWithSerialize.first
+    assert_instance_of TagCollection, record.tags
+    assert_equal({ "one" => "two" }, record.tags.to_hash)
+    record.tags = TagCollection.new("three" => "four")
+    record.save!
+    assert_equal({ "three" => "four" }, HstoreWithSerialize.first.tags.to_hash)
+  end
+
+  def test_clone_hstore_with_serialized_attributes
+    HstoreWithSerialize.create! tags: TagCollection.new("one" => "two")
+    record = HstoreWithSerialize.first
+    dupe = record.dup
+    assert_equal({ "one" => "two" }, dupe.tags.to_hash)
+  end
+
+  def test_schema_dump_with_shorthand
+    output = dump_table_schema("hstores")
+    assert_match %r[t\.hstore "tags",\s+default: {}], output
+  end
+
+  def test_supports_to_unsafe_h_values
+    assert_equal("\"hi\"=>\"hi\"", @type.serialize(FakeParameters.new))
+  end
+
+  private
+    def assert_array_cycle(array)
+      # test creation
+      x = Hstore.create!(payload: array)
+      x.reload
+      assert_equal(array, x.payload)
+
+      # test updating
+      x = Hstore.create!(payload: [])
+      x.payload = array
+      x.save!
+      x.reload
+      assert_equal(array, x.payload)
+    end
+
+    def assert_cycle(hash)
+      # test creation
+      x = Hstore.create!(tags: hash)
+      x.reload
+      assert_equal(hash, x.tags)
+
+      # test updating
+      x = Hstore.create!(tags: {})
+      x.tags = hash
+      x.save!
+      x.reload
+      assert_equal(hash, x.tags)
+    end
 end

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -222,68 +222,66 @@ class PostgresqlUUIDGenerationTest < ActiveRecord::PostgreSQLTestCase
     connection.execute "DROP FUNCTION IF EXISTS my_uuid_generator();"
   end
 
-  if ActiveRecord::Base.connection.supports_extensions?
-    def test_id_is_uuid
-      assert_equal :uuid, UUID.columns_hash["id"].type
-      assert UUID.primary_key
-    end
+  def test_id_is_uuid
+    assert_equal :uuid, UUID.columns_hash["id"].type
+    assert UUID.primary_key
+  end
 
-    def test_id_has_a_default
-      u = UUID.create
-      assert_not_nil u.id
-    end
+  def test_id_has_a_default
+    u = UUID.create
+    assert_not_nil u.id
+  end
 
-    def test_auto_create_uuid
-      u = UUID.create
-      u.reload
-      assert_not_nil u.other_uuid
-    end
+  def test_auto_create_uuid
+    u = UUID.create
+    u.reload
+    assert_not_nil u.other_uuid
+  end
 
-    def test_pk_and_sequence_for_uuid_primary_key
-      pk, seq = connection.pk_and_sequence_for("pg_uuids")
-      assert_equal "id", pk
-      assert_nil seq
-    end
+  def test_pk_and_sequence_for_uuid_primary_key
+    pk, seq = connection.pk_and_sequence_for("pg_uuids")
+    assert_equal "id", pk
+    assert_nil seq
+  end
 
-    def test_schema_dumper_for_uuid_primary_key
-      schema = dump_table_schema "pg_uuids"
-      assert_match(/\bcreate_table "pg_uuids", id: :uuid, default: -> { "uuid_generate_v1\(\)" }/, schema)
-      assert_match(/t\.uuid "other_uuid", default: -> { "uuid_generate_v4\(\)" }/, schema)
-    end
+  def test_schema_dumper_for_uuid_primary_key
+    schema = dump_table_schema "pg_uuids"
+    assert_match(/\bcreate_table "pg_uuids", id: :uuid, default: -> { "uuid_generate_v1\(\)" }/, schema)
+    assert_match(/t\.uuid "other_uuid", default: -> { "uuid_generate_v4\(\)" }/, schema)
+  end
 
-    def test_schema_dumper_for_uuid_primary_key_with_custom_default
-      schema = dump_table_schema "pg_uuids_2"
-      assert_match(/\bcreate_table "pg_uuids_2", id: :uuid, default: -> { "my_uuid_generator\(\)" }/, schema)
-      assert_match(/t\.uuid "other_uuid_2", default: -> { "my_uuid_generator\(\)" }/, schema)
-    end
+  def test_schema_dumper_for_uuid_primary_key_with_custom_default
+    schema = dump_table_schema "pg_uuids_2"
+    assert_match(/\bcreate_table "pg_uuids_2", id: :uuid, default: -> { "my_uuid_generator\(\)" }/, schema)
+    assert_match(/t\.uuid "other_uuid_2", default: -> { "my_uuid_generator\(\)" }/, schema)
+  end
 
-    def test_schema_dumper_for_uuid_primary_key_default
-      schema = dump_table_schema "pg_uuids_3"
-      if connection.supports_pgcrypto_uuid?
-        assert_match(/\bcreate_table "pg_uuids_3", id: :uuid, default: -> { "gen_random_uuid\(\)" }/, schema)
-      else
-        assert_match(/\bcreate_table "pg_uuids_3", id: :uuid, default: -> { "uuid_generate_v4\(\)" }/, schema)
+  def test_schema_dumper_for_uuid_primary_key_default
+    schema = dump_table_schema "pg_uuids_3"
+    if connection.supports_pgcrypto_uuid?
+      assert_match(/\bcreate_table "pg_uuids_3", id: :uuid, default: -> { "gen_random_uuid\(\)" }/, schema)
+    else
+      assert_match(/\bcreate_table "pg_uuids_3", id: :uuid, default: -> { "uuid_generate_v4\(\)" }/, schema)
+    end
+  end
+
+  def test_schema_dumper_for_uuid_primary_key_default_in_legacy_migration
+    @verbose_was = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+
+    migration = Class.new(ActiveRecord::Migration[5.0]) do
+      def version; 101 end
+      def migrate(x)
+        create_table("pg_uuids_4", id: :uuid)
       end
-    end
+    end.new
+    ActiveRecord::Migrator.new(:up, [migration]).migrate
 
-    def test_schema_dumper_for_uuid_primary_key_default_in_legacy_migration
-      @verbose_was = ActiveRecord::Migration.verbose
-      ActiveRecord::Migration.verbose = false
-
-      migration = Class.new(ActiveRecord::Migration[5.0]) do
-        def version; 101 end
-        def migrate(x)
-          create_table("pg_uuids_4", id: :uuid)
-        end
-      end.new
-      ActiveRecord::Migrator.new(:up, [migration]).migrate
-
-      schema = dump_table_schema "pg_uuids_4"
-      assert_match(/\bcreate_table "pg_uuids_4", id: :uuid, default: -> { "uuid_generate_v4\(\)" }/, schema)
-    ensure
-      drop_table "pg_uuids_4"
-      ActiveRecord::Migration.verbose = @verbose_was
-    end
+    schema = dump_table_schema "pg_uuids_4"
+    assert_match(/\bcreate_table "pg_uuids_4", id: :uuid, default: -> { "uuid_generate_v4\(\)" }/, schema)
+  ensure
+    drop_table "pg_uuids_4"
+    ActiveRecord::Migration.verbose = @verbose_was
   end
 end
 
@@ -302,38 +300,36 @@ class PostgresqlUUIDTestNilDefault < ActiveRecord::PostgreSQLTestCase
     drop_table "pg_uuids"
   end
 
-  if ActiveRecord::Base.connection.supports_extensions?
-    def test_id_allows_default_override_via_nil
-      col_desc = connection.execute("SELECT pg_get_expr(d.adbin, d.adrelid) as default
-                                    FROM pg_attribute a
-                                    LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
-                                    WHERE a.attname='id' AND a.attrelid = 'pg_uuids'::regclass").first
-      assert_nil col_desc["default"]
-    end
+  def test_id_allows_default_override_via_nil
+    col_desc = connection.execute("SELECT pg_get_expr(d.adbin, d.adrelid) as default
+                                  FROM pg_attribute a
+                                  LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+                                  WHERE a.attname='id' AND a.attrelid = 'pg_uuids'::regclass").first
+    assert_nil col_desc["default"]
+  end
 
-    def test_schema_dumper_for_uuid_primary_key_with_default_override_via_nil
-      schema = dump_table_schema "pg_uuids"
-      assert_match(/\bcreate_table "pg_uuids", id: :uuid, default: nil/, schema)
-    end
+  def test_schema_dumper_for_uuid_primary_key_with_default_override_via_nil
+    schema = dump_table_schema "pg_uuids"
+    assert_match(/\bcreate_table "pg_uuids", id: :uuid, default: nil/, schema)
+  end
 
-    def test_schema_dumper_for_uuid_primary_key_with_default_nil_in_legacy_migration
-      @verbose_was = ActiveRecord::Migration.verbose
-      ActiveRecord::Migration.verbose = false
+  def test_schema_dumper_for_uuid_primary_key_with_default_nil_in_legacy_migration
+    @verbose_was = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
 
-      migration = Class.new(ActiveRecord::Migration[5.0]) do
-        def version; 101 end
-        def migrate(x)
-          create_table("pg_uuids_4", id: :uuid, default: nil)
-        end
-      end.new
-      ActiveRecord::Migrator.new(:up, [migration]).migrate
+    migration = Class.new(ActiveRecord::Migration[5.0]) do
+      def version; 101 end
+      def migrate(x)
+        create_table("pg_uuids_4", id: :uuid, default: nil)
+      end
+    end.new
+    ActiveRecord::Migrator.new(:up, [migration]).migrate
 
-      schema = dump_table_schema "pg_uuids_4"
-      assert_match(/\bcreate_table "pg_uuids_4", id: :uuid, default: nil/, schema)
-    ensure
-      drop_table "pg_uuids_4"
-      ActiveRecord::Migration.verbose = @verbose_was
-    end
+    schema = dump_table_schema "pg_uuids_4"
+    assert_match(/\bcreate_table "pg_uuids_4", id: :uuid, default: nil/, schema)
+  ensure
+    drop_table "pg_uuids_4"
+    ActiveRecord::Migration.verbose = @verbose_was
   end
 end
 
@@ -367,23 +363,21 @@ class PostgresqlUUIDTestInverseOf < ActiveRecord::PostgreSQLTestCase
     drop_table "pg_uuid_posts"
   end
 
-  if ActiveRecord::Base.connection.supports_extensions?
-    def test_collection_association_with_uuid
-      post    = UuidPost.create!
-      comment = post.uuid_comments.create!
-      assert post.uuid_comments.find(comment.id)
-    end
+  def test_collection_association_with_uuid
+    post    = UuidPost.create!
+    comment = post.uuid_comments.create!
+    assert post.uuid_comments.find(comment.id)
+  end
 
-    def test_find_with_uuid
-      UuidPost.create!
-      assert_raise ActiveRecord::RecordNotFound do
-        UuidPost.find(123456)
-      end
+  def test_find_with_uuid
+    UuidPost.create!
+    assert_raise ActiveRecord::RecordNotFound do
+      UuidPost.find(123456)
     end
+  end
 
-    def test_find_by_with_uuid
-      UuidPost.create!
-      assert_nil UuidPost.find_by(id: 789)
-    end
+  def test_find_by_with_uuid
+    UuidPost.create!
+    assert_nil UuidPost.find_by(id: 789)
   end
 end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -294,34 +294,32 @@ class SchemaDumperTest < ActiveRecord::TestCase
       assert_match %r{t\.oid\s+"obj_id"$}, output
     end
 
-    if ActiveRecord::Base.connection.supports_extensions?
-      def test_schema_dump_includes_extensions
-        connection = ActiveRecord::Base.connection
+    def test_schema_dump_includes_extensions
+      connection = ActiveRecord::Base.connection
 
-        connection.stubs(:extensions).returns(["hstore"])
-        output = perform_schema_dump
-        assert_match "# These are extensions that must be enabled", output
-        assert_match %r{enable_extension "hstore"}, output
+      connection.stubs(:extensions).returns(["hstore"])
+      output = perform_schema_dump
+      assert_match "# These are extensions that must be enabled", output
+      assert_match %r{enable_extension "hstore"}, output
 
-        connection.stubs(:extensions).returns([])
-        output = perform_schema_dump
-        assert_no_match "# These are extensions that must be enabled", output
-        assert_no_match %r{enable_extension}, output
-      end
+      connection.stubs(:extensions).returns([])
+      output = perform_schema_dump
+      assert_no_match "# These are extensions that must be enabled", output
+      assert_no_match %r{enable_extension}, output
+    end
 
-      def test_schema_dump_includes_extensions_in_alphabetic_order
-        connection = ActiveRecord::Base.connection
+    def test_schema_dump_includes_extensions_in_alphabetic_order
+      connection = ActiveRecord::Base.connection
 
-        connection.stubs(:extensions).returns(["hstore", "uuid-ossp", "xml2"])
-        output = perform_schema_dump
-        enabled_extensions = output.scan(%r{enable_extension "(.+)"}).flatten
-        assert_equal ["hstore", "uuid-ossp", "xml2"], enabled_extensions
+      connection.stubs(:extensions).returns(["hstore", "uuid-ossp", "xml2"])
+      output = perform_schema_dump
+      enabled_extensions = output.scan(%r{enable_extension "(.+)"}).flatten
+      assert_equal ["hstore", "uuid-ossp", "xml2"], enabled_extensions
 
-        connection.stubs(:extensions).returns(["uuid-ossp", "xml2", "hstore"])
-        output = perform_schema_dump
-        enabled_extensions = output.scan(%r{enable_extension "(.+)"}).flatten
-        assert_equal ["hstore", "uuid-ossp", "xml2"], enabled_extensions
-      end
+      connection.stubs(:extensions).returns(["uuid-ossp", "xml2", "hstore"])
+      output = perform_schema_dump
+      enabled_extensions = output.scan(%r{enable_extension "(.+)"}).flatten
+      assert_equal ["hstore", "uuid-ossp", "xml2"], enabled_extensions
     end
   end
 


### PR DESCRIPTION
### Summary

since the minimum version of PostgreSQL currently Rails supports is 9.1,
there is no need to handle if `supports_extensions?`

Refer https://www.postgresql.org/docs/9.1/static/sql-createextension.html
"CREATE EXTENSION"

