### PR TITLE
Change `VENDOR_PATH` to `APP_ROOT` in `bin/yarn`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn
@@ -1,5 +1,5 @@
-VENDOR_PATH = File.expand_path('..', __dir__)
-Dir.chdir(VENDOR_PATH) do
+APP_ROOT = File.expand_path('..', __dir__)
+Dir.chdir(APP_ROOT) do
   begin
     exec "yarnpkg #{ARGV.join(' ')}"
   rescue Errno::ENOENT


### PR DESCRIPTION
This variable was initially used to hold the vendor directory.
https://github.com/rails/rails/commit/3dac36b

Therefore, the variable name `VENDOR_PATH` was appropriate. However, `package.json` is now placed in the root of the project.
https://github.com/rails/rails/commit/8e9e943

Therefore, like other bin scripts, I think the variable name `APP_ROOT`
is appropriate.
https://github.com/rails/rails/blob/2c845f6b03ddf2aa233b00385d24d769a4a34fa6/railties/lib/rails/generators/rails/app/templates/bin/setup.tt#L5
https://github.com/rails/rails/blob/2c845f6b03ddf2aa233b00385d24d769a4a34fa6/railties/lib/rails/generators/rails/app/templates/bin/update.tt#L5
