### PR TITLE
Move `extensions` to `PostgreSQL::SchemaDumper`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -5,6 +5,18 @@ module ActiveRecord
     module PostgreSQL
       class SchemaDumper < ConnectionAdapters::SchemaDumper # :nodoc:
         private
+
+          def extensions(stream)
+            extensions = @connection.extensions
+            if extensions.any?
+              stream.puts "  # These are extensions that must be enabled in order to support this database"
+              extensions.sort.each do |extension|
+                stream.puts "  enable_extension #{extension.inspect}"
+              end
+              stream.puts
+            end
+          end
+
           def prepare_column_options(column)
             spec = super
             spec[:array] = "true" if column.array?

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -82,16 +82,8 @@ HEADER
         stream.puts "end"
       end
 
+      # extensions are only supported by PostgreSQL
       def extensions(stream)
-        return unless @connection.supports_extensions?
-        extensions = @connection.extensions
-        if extensions.any?
-          stream.puts "  # These are extensions that must be enabled in order to support this database"
-          extensions.sort.each do |extension|
-            stream.puts "  enable_extension #{extension.inspect}"
-          end
-          stream.puts
-        end
       end
 
       def tables(stream)


### PR DESCRIPTION
### Summary

Since #30337, every database adapter has its own `SchemaDumper`.
`extensions` are only supported by PostgreSQL database and postgresql database adapter.
