### PR TITLE
Remove CHANGELOG entry that was backported to Rails 5.1.3. [ci skip]

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -24,11 +24,4 @@
 
     *Marc Rendl Ignacio*
 
-*   Action Cable socket errors are now logged to the console
-
-    Previously any socket errors were ignored and this made it hard to diagnose socket issues (e.g. as discussed in #28362).
-
-    *Edward Poot*
-
-
 Please check [5-1-stable](https://github.com/rails/rails/blob/5-1-stable/actioncable/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
- Backport commit: https://github.com/rails/rails/commit/7122a2cdc3634e170129f8b6cabd1e8fbed13c3d