### PR TITLE
Validate a field only if that field has changed

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -110,6 +110,8 @@ module ActiveRecord
 
       mattr_accessor :belongs_to_required_by_default, instance_accessor: false
 
+      mattr_accessor :validate_only_if_changed_by_default, instance_accessor: false
+
       class_attribute :default_connection_handler, instance_writer: false
 
       def self.connection_handler

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -22,6 +22,7 @@ module ActiveRecord
 
         relation = build_relation(finder_class, attribute, value)
         if record.persisted?
+          return if record.respond_to?("#{attribute}_changed?") && !record.send("#{attribute}_changed?")
           if finder_class.primary_key
             relation = relation.where.not(finder_class.primary_key => record.id_in_database || record.id)
           else

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -554,4 +554,16 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
     assert_equal(["has already been taken"], item2.errors[:id])
   end
+
+  def test_validate_uniqueness_queries
+    w1 = IneptWizard.new(name: "Name", city: "City")
+    assert_queries(2) { w1.valid? }
+
+    assert w1.save, "Should save w1"
+
+    assert_no_queries { w1.valid? }
+
+    w1.name = "Name1"
+    assert_queries(1) { w1.valid? }
+  end
 end

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -559,6 +559,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
   end
 
   def test_validate_uniqueness_queries
+    Topic.validate_only_if_changed_by_default = true
     w1 = IneptWizard.new(name: "Name", city: "City")
     assert_queries(2) { w1.valid? }
 
@@ -568,9 +569,11 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
     w1.name = "Name1"
     assert_queries(1) { w1.valid? }
+    Topic.validate_only_if_changed_by_default = false
   end
 
   def test_validate_uniqueness_with_alias_attribute_queries
+    Topic.validate_only_if_changed_by_default = true
     Topic.validates_uniqueness_of(:heading)
 
     t1 = Topic.create(heading: "I'm unique!")
@@ -586,9 +589,11 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     t2.heading = "I'm unique!"
     assert_not t2.valid?, "Liar!"
     assert_queries(1) { t2.valid? }
+    Topic.validate_only_if_changed_by_default = false
   end
 
   def test_validate_uniqueness_with_scope_queries
+    Reply.validate_only_if_changed_by_default = true
     Reply.validates_uniqueness_of(:content, scope: "parent_id")
 
     t1 = Topic.create("title" => "I'm unique!")
@@ -610,9 +615,11 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     r2.parent_id = t1.id
     assert_not r2.valid?, "Should be invalid"
     assert_queries(1) { r2.valid? }
+    Reply.validate_only_if_changed_by_default = false
   end
 
   def test_validate_uniqueness_with_polymorphic_object_scope_queries
+    Wheel.validate_only_if_changed_by_default = true
     Wheel.validates_uniqueness_of(:serial_number, scope: :wheelable)
 
     a1 = Aircraft.create!
@@ -647,5 +654,6 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     w2.wheelable = c2
     assert w2.valid?, "Should be valid"
     assert_queries(1) { w2.valid? }
+    Wheel.validate_only_if_changed_by_default = false
   end
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -961,6 +961,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :wheels, force: true do |t|
+    t.integer :serial_number
     t.references :wheelable, polymorphic: true
   end
 


### PR DESCRIPTION
### Summary

This commit is a proof of concept for running validations on a field only if that field has changed.
First of all targeting those validations that require a database query to perform. E.g. association presence and uniqueness validations.

In my view it makes sense to allow users to choose between the default "always-validate" behaviour and this kind of the "validate-changed" behaviour. An option and a config option similar to [`belongs_to`](https://github.com/rails/rails/pull/18937) would be nice to have. E.g. `always: true` and `validate_only_if_changed_by_default = true`.

There is an obvious speed improvement, especially for large tables.
A downside is a rare case when you need to validate a field even if there is no change (any common examples?).

Thoughts?

### Other Information

This addresses problems like @schneems had with [codetriage](https://github.com/codetriage/codetriage/pull/573#issue-239516618) and which is described in his blog post named [How I Reduced my DB Server Load by 80%](https://schneems.com/2017/07/18/how-i-reduced-my-db-server-load-by-80/).