### PR TITLE
Remove mention about Evented Redis [ci skip]

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -668,8 +668,8 @@ authentication. You can see one way of doing that with Devise in this [article](
 ## Dependencies
 
 Action Cable provides a subscription adapter interface to process its
-pubsub internals. By default, asynchronous, inline, PostgreSQL, evented
-Redis, and non-evented Redis adapters are included. The default adapter
+pubsub internals. By default, asynchronous, inline, PostgreSQL, and Redis
+adapters are included. The default adapter
 in new Rails applications is the asynchronous (`async`) adapter.
 
 The Ruby side of things is built on top of [websocket-driver](https://github.com/faye/websocket-driver-ruby),


### PR DESCRIPTION
Evented Redis adapter was removed in 48766e32d31651606b9f68a16015ad05c3b0de2c.
