### PR TITLE
Keep default ENGINE=Innodb for MySQL and MariaDB if :options option is provided.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -293,7 +293,11 @@ module ActiveRecord
       end
 
       def create_table(table_name, **options) #:nodoc:
-        super(table_name, options: "ENGINE=InnoDB", **options)
+        unless /ENGINE=/.match?(options[:options])
+          options.merge!(options: ["ENGINE=InnoDB", options[:options]].compact.join(" "))
+        end
+
+        super(table_name, **options)
       end
 
       def bulk_change_table(table_name, operations) #:nodoc:

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -354,7 +354,8 @@ end
 ```
 
 will append `ENGINE=BLACKHOLE` to the SQL statement used to create the table
-(when using MySQL or MariaDB, the default is `ENGINE=InnoDB`).
+(when using MySQL or MariaDB, the default is `ENGINE=InnoDB`, which will be prepended
+to the `:options` option unless it alredy contains `ENGINE=` in it).
 
 Also you can pass the `:comment` option with any description for the table
 that will be stored in database itself and can be viewed with database administration


### PR DESCRIPTION
### Summary

Solves #30947

`ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#create_table` adds `ENGINE=InnoDB` by default when `:options` option isn't provided.

Before this PR default ENGINE information was lost if some value was provided to `:options` option. This PR prepends `ENGINE=InnoDB` to  `:options` option in case no ENGINE information is provided. If `:options` option contains ENGINE information, this is kept and nothing is added.

This PR also improves **tests** to check the SQL that will be actually executed against the database server. Testing the table schema dump as before wasn't checking the proper addition of `ENGINE=InnoDB`.

This PR also improves default `ENGINE=InnoDB` description for MySQL and MariaDB at the **documentation** according to the changes mentioned above.

### Other Information

I consider it necessary to update the CHANGELOG with this information. Please confirm if you also consider it necessary and I will add the entry at the top of it.