### PR TITLE
fix initial count

### DIFF
--- a/activerecord/lib/active_record/associations/alias_tracker.rb
+++ b/activerecord/lib/active_record/associations/alias_tracker.rb
@@ -33,7 +33,7 @@ module ActiveRecord
           elsif join.respond_to? :left
             join.left.name == name ? 1 : 0
           elsif join.is_a?(Hash)
-            join[name]
+            join.fetch(name, 0)
           else
             # this branch is reached by two tests:
             #

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1258,6 +1258,10 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal [comments(:eager_other_comment1)], authors(:mary).unordered_comments
   end
 
+  def test_has_many_trough_with_scope_should_accept_string_and_hash_join
+    assert_equal authors(:david), Author.joins({ comments_for_first_author: :post }, "inner join posts posts_alias on authors.id = posts_alias.author_id").eager_load(:categories).take
+  end
+
   def test_has_many_through_with_scope_should_respect_table_alias
     family = Family.create!
     users = 3.times.map { User.create! }


### PR DESCRIPTION
### Summary
NoMethodError: undefined method `+' for nil:NilClass
/activesupport/lib/active_support/core_ext/enumerable.rb:39:in `inject'

introduced by
https://github.com/rails/rails/commit/c5ab6e51a7b9ee05a2d262a72c7130b9c1d1b0ce#diff-f7f4d3aa7f5b4498d75e823790062246

### Other Information
custom joins don't have 0 as a default value
aliases = Hash.new(0)