### PR TITLE
5_1_release_notes include more removals [ci skip]

### DIFF
--- a/guides/source/5_1_release_notes.md
+++ b/guides/source/5_1_release_notes.md
@@ -350,6 +350,10 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 *   Removed deprecated methods related to controller filters.
     ([Commit](https://github.com/rails/rails/commit/d7be30e8babf5e37a891522869e7b0191b79b757))
+    
+*   Removed deprecated support to `:text` and `:nothing` in `render`.
+    ([Commit](https://github.com/rails/rails/commit/79a5ea9eadb4d43b62afacedc0706cbe88c54496), 
+    [Commit](https://github.com/rails/rails/commit/57e1c99a280bdc1b324936a690350320a1cd8111))
 
 ### Deprecations
 


### PR DESCRIPTION
Updated 5_1_release_notes.md to include support to :text and :nothing in render