### PR TITLE
Suppress `FATAL:  terminating connection due to administrator command…

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -154,6 +154,7 @@ module ActiveRecord
     # To restart PostgreSQL 9.1 on OS X, installed via MacPorts, ...
     # sudo su postgres -c "pg_ctl restart -D /opt/local/var/db/postgresql91/defaultdb/ -m fast"
     def test_reconnection_after_actual_disconnection_with_verify
+      $stderr, original_stderr = File.open(File::NULL, "w"), $stderr
       original_connection_pid = @connection.query("select pg_backend_pid()")
 
       # Sanity check.
@@ -188,6 +189,7 @@ module ActiveRecord
     ensure
       # Repair all fixture connections so other tests won't break.
       @fixture_connections.each(&:verify!)
+      $stderr = original_stderr
     end
 
     def test_set_session_variable_true


### PR DESCRIPTION
### Summary

Suppress `FATAL:  terminating connection due to administrator command` stderr
at`ActiveRecord::PostgresqlConnectionTest#test_reconnection_after_actual_disconnection_with_verify`when `select pg_terminate_backend(#{original_connection_pid.first.first})` is executed.

This error does not report always and it is an expected output from PostgreSQL point of view
but it is unnecessary for this test.

This pull request suppresses this stderr by replacing it to `File::NULL` which should be
port independent.

```ruby
$ ARCONN=postgresql bin/test test/cases/adapters/postgresql/connection_test.rb --seed 30124
Using postgresql
Run options: --seed 30124

.FATAL:  terminating connection due to administrator command
.......................

Finished in 0.339261s, 70.7420 runs/s, 103.1654 assertions/s.

24 runs, 35 assertions, 0 failures, 0 errors, 0 skips
$
```
