### PR TITLE
Remove mention of X-Post-Data-Format header [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -12,9 +12,6 @@ module ActionDispatch
       end
 
       # The MIME type of the HTTP request, such as Mime[:xml].
-      #
-      # For backward compatibility, the post \format is extracted from the
-      # X-Post-Data-Format HTTP header if present.
       def content_mime_type
         fetch_header("action_dispatch.request.content_type") do |k|
           v = if get_header("CONTENT_TYPE") =~ /^([^,\;]*)/


### PR DESCRIPTION
Support for this header was removed when `actionpack-xml_parser` was extracted (https://github.com/rails/rails/pull/9328), and has since been dropped from the gem (https://github.com/rails/actionpack-xml_parser/pull/15).