### PR TITLE
Call Rails.ajax without beforeSend

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee
@@ -21,7 +21,7 @@ Rails.ajax = (options) ->
       options.error?(response, xhr.statusText, xhr)
     options.complete?(xhr, xhr.statusText)
 
-  unless options.beforeSend?(xhr, options)
+  if options.beforeSend? && !options.beforeSend(xhr, options)
     return false
 
   if xhr.readyState is XMLHttpRequest.OPENED

--- a/actionview/test/ujs/public/test/call-ajax.js
+++ b/actionview/test/ujs/public/test/call-ajax.js
@@ -1,0 +1,27 @@
+(function() {
+
+module('call-ajax', {
+  setup: function() {
+    $('#qunit-fixture')
+      .append($('<a />', { href: '#' }))
+  }
+})
+
+asyncTest('call ajax without "ajax:beforeSend"', 1, function() {
+
+  var link = $('#qunit-fixture a')
+  link.bindNative('click', function() {
+    Rails.ajax({
+      type: 'get',
+      url: '/',
+      success: function() {
+        ok(true, 'calling request in ajax:success')
+      }
+    })
+  })
+
+  link.triggerNative('click')
+  setTimeout(function() { start() }, 13)
+})
+
+})()

--- a/actionview/test/ujs/views/tests/index.html.erb
+++ b/actionview/test/ujs/views/tests/index.html.erb
@@ -1,6 +1,6 @@
 <% @title = "rails-ujs test" %>
 
-<%= test_to 'data-confirm', 'data-remote', 'data-disable', 'data-disable-with', 'call-remote', 'call-remote-callbacks', 'data-method', 'override', 'csrf-refresh', 'csrf-token' %>
+<%= test_to 'data-confirm', 'data-remote', 'data-disable', 'data-disable-with', 'call-remote', 'call-remote-callbacks', 'data-method', 'override', 'csrf-refresh', 'csrf-token', 'call-ajax' %>
 
 <h1 id="qunit-header"><%= @title %></h1>
 <h2 id="qunit-banner"></h2>


### PR DESCRIPTION
When we call Rails.ajax outside rails-ujs.js, we must define `beforeSend` even though it's empty function. I think Rails.ajax is not private api so it's more useful.

## before
```
    Rails.ajax({
      type: 'get',
      url: '/',
      beforeSend: function() {
        return true
      },
      success: function() {
        // do something
      }
```

## after
```
    Rails.ajax({
      type: 'get',
      url: '/',
      success: function() {
        // do something
      }
```
