### PR TITLE
Add load hook for `ActionDispatch::SystemTestCase`

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -131,6 +131,8 @@ module ActionDispatch
     end
 
     driven_by :selenium
+
+    ActiveSupport.run_load_hooks(:action_dispatch_system_test_case, self)
   end
 
   SystemTestCase.start_application

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1501,6 +1501,7 @@ To hook into the initialization process of one of the following classes use the 
 | `ActionController::Base`          | `action_controller`                  |
 | `ActionController::TestCase`      | `action_controller_test_case`        |
 | `ActionDispatch::IntegrationTest` | `action_dispatch_integration_test`   |
+| `ActionDispatch::SystemTestCase`  | `action_dispatch_system_test_case`   |
 | `ActionMailer::Base`              | `action_mailer`                      |
 | `ActionMailer::TestCase`          | `action_mailer_test_case`            |
 | `ActionView::Base`                | `action_view`                        |


### PR DESCRIPTION
This is useful to extend `SystemTestCase`.
Also, since other test classes already have load hooks, should also be in `SystemTestCase`.

Ref: 0510208dd1ff23baa619884c0abcae4d141fae53
