### PR TITLE
Remove redundant return statements

### DIFF
--- a/actionmailer/test/caching_test.rb
+++ b/actionmailer/test/caching_test.rb
@@ -198,7 +198,7 @@ end
 class CacheHelperOutputBufferTest < BaseCachingTest
   class MockController
     def read_fragment(name, options)
-      return false
+      false
     end
 
     def write_fragment(name, fragment, options)

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -61,7 +61,7 @@ module ActionDispatch
           return [status, headers, body]
         end
 
-        return [404, { "X-Cascade" => "pass" }, ["Not Found"]]
+        [404, { "X-Cascade" => "pass" }, ["Not Found"]]
       end
 
       def recognize(rails_req)

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -317,7 +317,7 @@ end
 class CacheHelperOutputBufferTest < ActionController::TestCase
   class MockController
     def read_fragment(name, options)
-      return false
+      false
     end
 
     def write_fragment(name, fragment, options)

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -422,7 +422,7 @@ module ActionView
         def to_s
           value = @values[@index].to_s
           @index = next_index
-          return value
+          value
         end
 
         private
@@ -446,7 +446,7 @@ module ActionView
         # uses an instance variable of ActionView::Base.
         def get_cycle(name)
           @_cycles = Hash.new unless defined?(@_cycles)
-          return @_cycles[name]
+          @_cycles[name]
         end
 
         def set_cycle(name, cycle_object)

--- a/activejob/test/support/delayed_job/delayed/backend/test.rb
+++ b/activejob/test/support/delayed_job/delayed/backend/test.rb
@@ -77,7 +77,7 @@ module Delayed
             self.locked_by = worker
           end
 
-          return true
+          true
         end
 
         def self.db_time_now

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -236,7 +236,7 @@ module ActiveRecord
         return has_attribute?(name)
       end
 
-      return true
+      true
     end
 
     # Returns +true+ if the given attribute is in the attributes hash, otherwise +false+.

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -53,7 +53,7 @@ module ActiveRecord
           unscoped.where(primary_key => object.id).update_all(updates)
         end
 
-        return true
+        true
       end
 
       # A generic "counter updater" implementation, intended primarily to be

--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -113,7 +113,7 @@ module ActiveSupport
     def append_features(base)
       if base.instance_variable_defined?(:@_dependencies)
         base.instance_variable_get(:@_dependencies) << self
-        return false
+        false
       else
         return false if base < self
         @_dependencies.each { |dep| base.include(dep) }

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -615,7 +615,7 @@ module ActiveSupport #:nodoc:
       return false if desc.is_a?(Module) && desc.anonymous?
       name = to_constant_name desc
       return false unless qualified_const_defined?(name)
-      return autoloaded_constants.include?(name)
+      autoloaded_constants.include?(name)
     end
 
     # Will the provided constant descriptor be unloaded?

--- a/activesupport/lib/active_support/duration/iso8601_parser.rb
+++ b/activesupport/lib/active_support/duration/iso8601_parser.rb
@@ -118,7 +118,7 @@ module ActiveSupport
             raise_parsing_error "(only last part can be fractional)"
           end
 
-          return true
+          true
         end
     end
   end

--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -55,7 +55,7 @@ module ActiveSupport
           write.close
           result = read.read
           Process.wait2(pid)
-          return result.unpack("m")[0]
+          result.unpack("m")[0]
         end
       end
 

--- a/activesupport/test/core_ext/module/remove_method_test.rb
+++ b/activesupport/test/core_ext/module/remove_method_test.rb
@@ -6,22 +6,22 @@ require "active_support/core_ext/module/remove_method"
 module RemoveMethodTests
   class A
     def do_something
-      return 1
+      1
     end
 
     def do_something_protected
-      return 1
+      1
     end
     protected :do_something_protected
 
     def do_something_private
-      return 1
+      1
     end
     private :do_something_private
 
     class << self
       def do_something_else
-        return 2
+        2
       end
     end
   end


### PR DESCRIPTION
### Summary
 I just removed redundant return statements like below.

**before**
```
def some_method
  return 1
end
```

**after**
```
def some_method
  1
end
```