### PR TITLE
[WIP] warning duplicated HashWithIndifferentAccess

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -68,6 +68,9 @@ module ActiveSupport
         super()
         update(constructor)
 
+        # TODO: we need silence option...but how to ne should set?
+        warning_duplicate_keys(constructor)
+
         hash = constructor.to_hash
         self.default = hash.default if hash.default
         self.default_proc = hash.default_proc if hash.default_proc
@@ -363,6 +366,20 @@ module ActiveSupport
           target.default_proc = default_proc.dup
         else
           target.default = default
+        end
+      end
+
+      def warning_duplicate_keys(original)
+        original.to_hash.keys.each do |k|
+          # if string key and symbol key exist, show warning
+          # (if symbol key exist, check there is string key we don't need other direction check)
+          next unless k.kind_of?(Symbol)
+
+          converted_key = convert_key(k)
+          next unless original.has_key?(converted_key)
+
+          # TODO: call more good warning method
+          puts "warning: key :#{k} and '#{converted_key}' is duplicated and overwritten"
         end
       end
   end


### PR DESCRIPTION
### Summary
The ruby allow different value between string key and symbol key.

```ruby
{x: 21, 'x'=>42}
=> {:x=>21, "x"=>42}
```

But, when we convert this hash to HashWithIndifferentAccess, we lost one side value.

```ruby
ActiveSupport::HashWithIndifferentAccess.new({x: 21, 'x'=>42})
=> {"x"=>42}
```

So, sometimes we get trouble... 😢 

When we create duplicate key's hash, ruby warning message.
```ruby
irb(main):010:0> {x: 21, 'x':42}
(irb):10: warning: key :x is duplicated and overwritten on line 10
=> {:x=>42}
```

So I think we need warning message when HashWithIndifferentAccess overwritten a key.

```
ActiveSupport::HashWithIndifferentAccess.new({x: 21, 'x'=>42})
warning: key :x and 'x' is duplicated and overwritten
=> {"x"=>42}
```

### Other Information
This problem is't big problem so the user can disable this checking.
For example, the user enable this option in development and disable in production. 

Sorry, this changes isn't completed. (I wrote TODO comment)
I don't know how to switch this checking and how to show warning message from active_support.
So please give me advise.