### PR TITLE
Uniqueness validation scope with polymorphic association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix a uniqueness validation case with the `:scope` option that uses a polymorphic association name.
+
+    This change addresses a particular case when a polymorphic association included into the `:scope` option
+    is assigned using foreign key and type of a new object created with
+    [ActiveRecord::Associations::Association#create](https://github.com/rails/rails/blob/925e6d561ae8847777e57f6a0bacc930d35bf05b/activerecord/lib/active_record/associations/association.rb#L181-L183) or [ActiveRecord::Associations::Association#create!](https://github.com/rails/rails/blob/925e6d561ae8847777e57f6a0bacc930d35bf05b/activerecord/lib/active_record/associations/association.rb#L185-L187).
+
+    *Sergey Alekseev*
+
 *   Fix `bin/rails db:migrate` with specified `VERSION`.
     `bin/rails db:migrate` with empty VERSION behaves as without `VERSION`.
     Check a format of `VERSION`: Allow a migration version number

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -86,15 +86,19 @@ module ActiveRecord
       end
 
       def scope_relation(record, relation)
+        scope = {}
         Array(options[:scope]).each do |scope_item|
-          scope_value = if record.class._reflect_on_association(scope_item)
-            record.association(scope_item).reader
+          attrs = []
+          if reflection = record.class._reflect_on_association(scope_item)
+            attrs << reflection.foreign_key
+            attrs << reflection.foreign_type if reflection.polymorphic?
           else
-            record._read_attribute(scope_item)
+            attrs << scope_item
           end
-          relation = relation.where(scope_item => scope_value)
+          attrs.each { |attr| scope[attr] = record._read_attribute(attr) }
         end
 
+        relation.where!(scope) unless scope.empty?
         relation
       end
 

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -8,9 +8,9 @@ require "models/guid"
 require "models/event"
 require "models/dashboard"
 require "models/uuid_item"
-require "models/author"
-require "models/person"
-require "models/essay"
+require "models/aircraft"
+require "models/car"
+require "models/wheel"
 
 class Wizard < ActiveRecord::Base
   self.abstract_class = true
@@ -181,16 +181,23 @@ class UniquenessValidationTest < ActiveRecord::TestCase
   end
 
   def test_validate_uniqueness_with_polymorphic_object_scope
-    Essay.validates_uniqueness_of(:name, scope: :writer)
+    Wheel.validates_uniqueness_of(:serial_number, scope: :wheelable)
 
-    a = Author.create(name: "Sergey")
-    p = Person.create(first_name: "Sergey")
+    a = Aircraft.create!
+    c = Car.create!
 
-    e1 = a.essays.create(name: "Essay")
-    assert e1.valid?, "Saving e1"
+    w1 = a.wheels.create(serial_number: 1)
+    assert w1.valid?, "Saving w1"
 
-    e2 = p.essays.create(name: "Essay")
-    assert e2.valid?, "Saving e2"
+    w2 = c.wheels.create(serial_number: 1)
+    assert w2.valid?, "Saving w2"
+
+    w1.wheelable = c
+    assert_not w1.valid?, "Should be invalid"
+
+    w2.wheelable_id = a.id
+    w2.wheelable_type = "Aircraft"
+    assert_not w2.valid?, "Should be invalid"
   end
 
   def test_validate_uniqueness_with_composed_attribute_scope

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -173,6 +173,11 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
     r2 = t.replies.create "title" => "r2", "content" => "hello world"
     assert !r2.valid?, "Saving r2 first time"
+
+    Topic.where(id: t.id).delete_all
+
+    r3 = Reply.create(parent_id: t.id, title: "r3", content: "hello world")
+    assert !r3.valid?, "Saving r3 first time"
   end
 
   def test_validate_uniqueness_with_polymorphic_object_scope

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -962,6 +962,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :wheels, force: true do |t|
+    t.integer :serial_number
     t.references :wheelable, polymorphic: true
   end
 


### PR DESCRIPTION
 that uses a polymorphic association name

### Summary

This change addresses a particular case when a polymorphic association included into the `:scope` option is assigned using foreign key and type of a new object created with [ActiveRecord::Associations::Association#create](https://github.com/rails/rails/blob/925e6d561ae8847777e57f6a0bacc930d35bf05b/activerecord/lib/active_record/associations/association.rb#L181-L183) or [ActiveRecord::Associations::Association#create!](https://github.com/rails/rails/blob/925e6d561ae8847777e57f6a0bacc930d35bf05b/activerecord/lib/active_record/associations/association.rb#L185-L187).

### Other Information

This is a continuation of https://github.com/rails/rails/pull/26865 and hopefully it's complete fix.  
I found this case during implementation of https://github.com/rails/rails/pull/30988, implemented a solution and after that I noticed https://github.com/rails/rails/pull/27449. I cherry-picked that commit.

While I'm more with @matthewd about https://github.com/rails/rails/pull/27449 I don't have enough time to debug and implement a more proper solution for this case. Looking for help.

### More details

While the following test works just fine without any changes to _activerecord/lib/active_record/validations/uniqueness.rb_  

```ruby
def test_validate_uniqueness_with_object_scope
  Reply.validates_uniqueness_of(:content, scope: :topic)

  t1 = Topic.create("title" => "I'm unique!")
  t2 = Topic.create("title" => "I'm unique too!")

  r1 = t1.replies.create "title" => "r1", "content" => "hello world"
  assert r1.valid?, "Saving r1"

  r2 = t2.replies.create "title" => "r2", "content" => "hello world"
  assert r2.valid?, "Saving r2 first time"

  r1.topic = t2
  assert_not r1.valid?, "Should be invalid"

  r2.parent_id = t1.id
  assert_not r2.valid?, "Should be invalid"
end
```

a similar one for the polymorphic association fails  

```ruby
def test_validate_uniqueness_with_polymorphic_object_scope
  Wheel.validates_uniqueness_of(:serial_number, scope: :wheelable)

  a = Aircraft.create!
  c = Car.create!

  w1 = a.wheels.create(serial_number: 1)
  assert w1.valid?, "Saving w1"

  w2 = c.wheels.create(serial_number: 1)
  assert w2.valid?, "Saving w2"

  w1.wheelable = c
  assert_not w1.valid?, "Should be invalid"

  w2.wheelable_id = a.id
  w2.wheelable_type = 'Aircraft'
  assert_not w2.valid?, "Should be invalid"
end
```

Specifically `assert_not w2.valid?, "Should be invalid"` fails.   

It doesn't fail if  
```ruby
w2 = c.wheels.create(serial_number: 1)
```  

is changed to  
```ruby
w2 = Wheel.create(serial_number: 1, wheelable_id: c.id, wheelable_type: 'Car')
```

There may be a problem with a non consistent value of `ActiveRecord::Associations::Association::inversed`.