### PR TITLE
Remove unused `MissingRequestError`

### DIFF
--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -76,7 +76,6 @@ module ActionView
       autoload :MissingTemplate
       autoload :ActionViewError
       autoload :EncodingError
-      autoload :MissingRequestError
       autoload :TemplateError
       autoload :WrongEncodingError
     end

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -10,9 +10,6 @@ module ActionView
   class EncodingError < StandardError #:nodoc:
   end
 
-  class MissingRequestError < StandardError #:nodoc:
-  end
-
   class WrongEncodingError < EncodingError #:nodoc:
     def initialize(string, encoding)
       @string, @encoding = string, encoding


### PR DESCRIPTION
`MissingRequestError` is no longer used since 1e2b0ce.
