### PR TITLE
Prevent source line wrapping in rescue layout

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -106,6 +106,7 @@
 
     .line {
       padding-left: 10px;
+      white-space: pre;
     }
 
     .line:hover {


### PR DESCRIPTION
### Summary

Long source lines cause line wrapping in the extracted source section of the rescue handler page which can make the line numbers not match up with the source lines.

### Other Information

Here are before/after screenshots

![error-with-wrapping](https://user-images.githubusercontent.com/103968/32216801-34e0606e-bde3-11e7-8d69-c0c30c957d1c.png)
![error-without-wrapping](https://user-images.githubusercontent.com/103968/32216802-34f6162a-bde3-11e7-8eab-7d03ae1c51bd.png)

