### PR TITLE
Ability to disable lazy singular associations

### DIFF
--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -3,7 +3,6 @@
 module ActiveRecord
   module Associations
     class SingularAssociation < Association #:nodoc:
-
       mattr_accessor :disable_lazy
 
       # Implements the reader method, e.g. foo.bar for Foo.has_one :bar

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -3,13 +3,25 @@
 module ActiveRecord
   module Associations
     class SingularAssociation < Association #:nodoc:
+
+      mattr_accessor :disable_lazy
+
       # Implements the reader method, e.g. foo.bar for Foo.has_one :bar
       def reader
+        if disable_lazy && !loaded?
+          raise_lazy_disabled_exception
+        end
+
         if !loaded? || stale_target?
           reload
         end
 
         target
+      end
+
+      def raise_lazy_disabled_exception
+        raise ActiveRecord::LazySingularAssociationNotAllowed,
+          "#{owner.class} tried to lazily load #{reflection.name}"
       end
 
       # Implements the writer method, e.g. foo.bar= for Foo.belongs_to :bar

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -49,6 +49,9 @@ module ActiveRecord
   class ConnectionNotEstablished < ActiveRecordError
   end
 
+  class LazySingularAssociationNotAllowed < ActiveRecordError
+  end
+
   # Raised when Active Record cannot find a record by given id or set of ids.
   class RecordNotFound < ActiveRecordError
     attr_reader :model, :primary_key, :id

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -36,6 +36,15 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_equal 1, liquids[0].molecules.length
   end
 
+  def test_allow_singular_lazy_loading_to_be_turned_off_globally
+    ActiveRecord::Associations::SingularAssociation.disable_lazy = true
+    post = Post.create(title: "Amazing Post", body: "Informative body")
+    assert_raises ActiveRecord::LazySingularAssociationNotAllowed do
+      post.author
+    end
+    ActiveRecord::Associations::SingularAssociation.disable_lazy = false
+  end
+
   def test_subselect
     author = authors :david
     favs = author.author_favorites


### PR DESCRIPTION
### Summary

It can be difficult to track down N+1 problems. Even really great tools such as Bullet have a tendency to miss lazily loaded associations. This would allow a developer to disable lazy evaluation for singular resources in certain situations.

This seems like a good solution for collections that iterate and lazy load associated records. For instance an index action on a controller might iterate a collection of records like so:

```ruby
def index
  post = Post.all
  render json: json_serialize(post)
end

private
def json_serialize(posts)
  posts.map do |post|
    {
      title: post.title,
      author: post.author # where author is an association
    }
  end
end
```

If a test only asserts on 1 post that many tools will not find the N+1. The following test with lazy turned off would immediately alert a developer to N+1 problems.

```ruby
def test_index_action
  ActiveRecord::Associations::SingularAssociation.disable_lazy = true
  Post.create(author: Author.create)
  get "/"
  ActiveRecord::Associations::SingularAssociation.disable_lazy = false
end
```