### PR TITLE
Address incorrect number of queries executed at Oracle enhanced adapter

### DIFF
--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -110,7 +110,7 @@ module ActiveRecord
     # FIXME: this needs to be refactored so specific database can add their own
     # ignored SQL, or better yet, use a different notification for the queries
     # instead examining the SQL content.
-    oracle_ignored     = [/^select .*nextval/i, /^SAVEPOINT/, /^ROLLBACK TO/, /^\s*select .* from all_triggers/im, /^\s*select .* from all_constraints/im, /^\s*select .* from all_tab_cols/im]
+    oracle_ignored     = [/^select .*nextval/i, /^SAVEPOINT/, /^ROLLBACK TO/, /^\s*select .* from all_triggers/im, /^\s*select .* from all_constraints/im, /^\s*select .* from all_tab_cols/im, /^\s*select .* from all_sequences/im]
     mysql_ignored      = [/^SHOW FULL TABLES/i, /^SHOW FULL FIELDS/, /^SHOW CREATE TABLE /i, /^SHOW VARIABLES /, /^\s*SELECT (?:column_name|table_name)\b.*\bFROM information_schema\.(?:key_column_usage|tables)\b/im]
     postgresql_ignored = [/^\s*select\b.*\bfrom\b.*pg_namespace\b/im, /^\s*select tablename\b.*from pg_tables\b/im, /^\s*select\b.*\battname\b.*\bfrom\b.*\bpg_attribute\b/im, /^SHOW search_path/i]
     sqlite3_ignored =    [/^\s*SELECT name\b.*\bFROM sqlite_master/im, /^\s*SELECT sql\b.*\bFROM sqlite_master/im]


### PR DESCRIPTION
### Summary

This pull request addresses these 17 failures when tested with Oracle enhanced adapter.
All of these failures are due to the incorrect number of queries. Here is the first one.

```ruby
$ ARCONN=oracle bin/test test/cases/nested_attributes_test.rb:1086
Using oracle
Run options: --seed 27985

F

Finished in 0.874514s, 1.1435 runs/s, 1.1435 assertions/s.

  1) Failure:
TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations#test_circular_references_do_not_perform_unnecessary_queries [/home/yahonda/git/rails/activerecord/test/cases/nested_attributes_test.rb:1086]:
6 instead of 3 queries were executed.
Queries:
select us.sequence_name from all_sequences us where us.sequence_owner = :owner and us.sequence_name = :sequence_name
INSERT INTO "SHIPS" ("NAME", "ID") VALUES (:a1, :a2)
select us.sequence_name from all_sequences us where us.sequence_owner = :owner and us.sequence_name = :sequence_name
INSERT INTO "SHIP_PARTS" ("NAME", "SHIP_ID", "UPDATED_AT", "ID") VALUES (:a1, :a2, :a3, :a4)
select us.sequence_name from all_sequences us where us.sequence_owner = :owner and us.sequence_name = :sequence_name
INSERT INTO "TREASURES" ("LOOTER_ID", "LOOTER_TYPE", "SHIP_ID", "ID") VALUES (:a1, :a2, :a3, :a4).
Expected: 3
  Actual: 6

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

Since https://github.com/rsim/oracle-enhanced/pull/1490 Oracle enhanced adapter drops its own schema caching called OracleEnhancedAdapter.cache_columns` to use Rails scehema cache
generated by `db:schema:cache:dump`.

By this change some extra sql statements executed at ActiveRecord unit test, which can be
fixed by adding the sql statement to `oracle_ignored`.

* All 17 failures fixed by this pull request:
```ruby
ARCONN=oracle bin/test test/cases/nested_attributes_test.rb:1086
ARCONN=oracle bin/test test/cases/locking_test.rb:308
ARCONN=oracle bin/test test/cases/locking_test.rb:365
ARCONN=oracle bin/test test/cases/dirty_test.rb:351
ARCONN=oracle bin/test test/cases/dirty_test.rb:334
ARCONN=oracle bin/test test/cases/autosave_association_test.rb:192
ARCONN=oracle bin/test test/cases/associations/has_many_associations_test.rb:950
ARCONN=oracle bin/test test/cases/associations/has_many_associations_test.rb:1059
ARCONN=oracle bin/test test/cases/autosave_association_test.rb:627
ARCONN=oracle bin/test test/cases/autosave_association_test.rb:607
ARCONN=oracle bin/test test/cases/autosave_association_test.rb:617
ARCONN=oracle bin/test test/cases/autosave_association_test.rb:641
ARCONN=oracle bin/test test/cases/associations/has_many_through_associations_test.rb:546
ARCONN=oracle bin/test test/cases/associations/has_many_through_associations_test.rb:297
ARCONN=oracle bin/test test/cases/associations/has_many_through_associations_test.rb:586
ARCONN=oracle bin/test test/cases/associations/has_many_through_associations_test.rb:172
ARCONN=oracle bin/test test/cases/associations/has_many_through_associations_test.rb:269
```
