### PR TITLE
Remove bundler 1.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ bundler_args: --without test --jobs 3 --retry 3
 before_install:
   - "rm ${BUNDLE_GEMFILE}.lock"
   - "travis_retry gem update --system"
+  - "gem uninstall bundler -v 1.16.0"
   - "travis_retry gem install bundler -v 1.15.4"
   - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
   - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"


### PR DESCRIPTION
Since 1.16.0 is installed by default, it seems that the newer one will be used even if specify an older version.
Ref: https://travis-ci.org/rails/rails/jobs/295553738#L1718

Follow up of #31023