### PR TITLE
Workaround for ActionMailer failures by not installing mail 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -168,3 +168,6 @@ end
 gem "ibm_db" if ENV["IBM_DB"]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "wdm", ">= 0.1.0", platforms: [:mingw, :mswin, :x64_mingw, :mswin64]
+
+# Workaround not to install mail 2.7
+gem "mail", ">= 2.5.4", "< 2.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -545,6 +545,7 @@ DEPENDENCIES
   kindlerb (~> 1.2.0)
   libxml-ruby
   listen (>= 3.0.5, < 3.2)
+  mail (>= 2.5.4, < 2.7)
   mini_magick
   minitest-bisect
   mocha


### PR DESCRIPTION
### Summary

This pull request should workaround these 4 failures reported at https://travis-ci.org/rails/rails/jobs/295571582

```ruby
TestHelperMailerTest#test_encode
BaseTest#test_implicit_multipart_with_attachments_creates_nested_parts
BaseTest#test_implicit_multipart_with_attachments_and_sort_order
BaseTest#test_explicit_multipart_with_attachments_creates_nested_parts
```

This should be a workaround commit to make CI green.

cc @y-yagi 