### PR TITLE
Fixed typo in test for activesupport parameterize

### DIFF
--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -197,7 +197,7 @@ class StringInflectionsTest < ActiveSupport::TestCase
   end
 
   def test_string_parameterized_underscore_preserve_case
-    StringToParameterizePreserceCaseWithUnderscore.each do |normal, slugged|
+    StringToParameterizePreserveCaseWithUnderscore.each do |normal, slugged|
       assert_equal(slugged, normal.parameterize(separator: "_", preserve_case: true))
     end
   end

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -221,7 +221,7 @@ module InflectorTestCases
     "Test with malformed utf8 \251"       => "test_with_malformed_utf8"
   }
 
-  StringToParameterizePreserceCaseWithUnderscore = {
+  StringToParameterizePreserveCaseWithUnderscore = {
     "Donald E. Knuth"                     => "Donald_E_Knuth",
     "Random text with *(bad)* characters" => "Random_text_with_bad_characters",
     "With-some-dashes"                    => "With-some-dashes",


### PR DESCRIPTION
I found a typo for `StringToParameterizePreserceCaseWithUnderscore` where ..Preserce.. should be Preserve. 