### PR TITLE
Ignore "gem "bundler" cannot be uninstalled because it is a default gem" error when tested with ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ bundler_args: --without test --jobs 3 --retry 3
 before_install:
   - "rm ${BUNDLE_GEMFILE}.lock"
   - "travis_retry gem update --system"
-  - "rvm @global do gem uninstall bundler --all --ignore-dependencies --executables"
+  - "rvm @global do gem uninstall bundler --all --ignore-dependencies --executables || true"
   - "travis_retry gem install bundler -v 1.15.4"
   - "[ -f /tmp/beanstalkd-1.10/Makefile ] || (curl -L https://github.com/kr/beanstalkd/archive/v1.10.tar.gz | tar xz -C /tmp)"
   - "pushd /tmp/beanstalkd-1.10 && make && (./beanstalkd &); popd"


### PR DESCRIPTION
### Summary

This pull request attempts to ignore the following error when tested with ruby-head which has bundler as a default gem.

```ruby
$ rvm @global do gem uninstall bundler --all --ignore-dependencies --executables
ERROR:  While executing gem ... (Gem::InstallError)

    gem "bundler" cannot be uninstalled because it is a default gem



The command "rvm @global do gem uninstall bundler --all --ignore-dependencies --executables" failed and exited with 1 during .
```

Refer https://travis-ci.org/rails/rails/jobs/295600391#L1801

This workaround should be removed once
https://github.com/bundler/bundler/issues/6072 is addressed.

Since Rails unit test cannot run on a forked repository, I need to open a pull request to see if it works.