### PR TITLE
Fix "warning: instance variable @defined_root not initialized"

### DIFF
--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -30,7 +30,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     ActiveSupport::LogSubscriber.log_subscribers.clear
 
     # We need to undef `root`, RenderTestCases don't want this to be defined
-    Rails.instance_eval { undef :root } if @defined_root
+    Rails.instance_eval { undef :root } if defined?(@defined_root)
   end
 
   def set_logger(logger)


### PR DESCRIPTION
Currently, the following error is shows only when run the test using `bin/test`.

```
./bin/test -w test/template/log_subscriber_test.rb
Run options: --seed 17167

# Running:

/rails/actionview/test/template/log_subscriber_test.rb:34: warning: instance variable @defined_root not initialized
```

In `AVLogSubscriberTest`, if the `Rails.root` is not defined, define the method and undef it in teardown.
https://github.com/rails/rails/blob/master/actionview/test/template/log_subscriber_test.rb#L21..L33

However, in `bin/test`, `Rails.root` is defined, which results in referring to uninitialized variables and warnings.