### PR TITLE
Faster Log Subscriber Check

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -2,7 +2,8 @@
 
 module ActiveRecord
   class LogSubscriber < ActiveSupport::LogSubscriber
-    IGNORE_PAYLOAD_NAMES = ["SCHEMA", "EXPLAIN"]
+    IGNORE_PAYLOAD_NAMES      = ["SCHEMA", "EXPLAIN"]
+    IGNORE_PAYLOAD_NAMES_HASH = IGNORE_PAYLOAD_NAMES.each_with_object({}) { |key, hash| hash[key] = true }
 
     def self.runtime=(value)
       ActiveRecord::RuntimeRegistry.sql_runtime = value
@@ -23,7 +24,7 @@ module ActiveRecord
 
       payload = event.payload
 
-      return if IGNORE_PAYLOAD_NAMES.include?(payload[:name])
+      return if IGNORE_PAYLOAD_NAMES_HASH[payload[:name]]
 
       name  = "#{payload[:name]} (#{event.duration.round(1)}ms)"
       name  = "CACHE #{name}" if payload[:cached]


### PR DESCRIPTION
```ruby
IGNORE_PAYLOAD_NAMES = ["SCHEMA", "EXPLAIN"]
IGNORE_PAYLOAD_NAMES_HASH = IGNORE_PAYLOAD_NAMES.each_with_object({}) {|key, hash| hash[key] = true }

require 'benchmark/ips'

Benchmark.ips do |x|
  x.report("array") {
    IGNORE_PAYLOAD_NAMES.include?("nope")
  }
  x.report("hash") {
    IGNORE_PAYLOAD_NAMES_HASH["nope"]
  }
  x.compare!
end
```

Gives us

```
Warming up --------------------------------------
               array   268.695k i/100ms
                hash   285.232k i/100ms
Calculating -------------------------------------
               array      6.830M (± 6.0%) i/s -     34.124M in   5.014891s
                hash      7.835M (± 7.2%) i/s -     39.077M in   5.015604s

Comparison:
                hash:  7834809.2 i/s
               array:  6829993.6 i/s - 1.15x  slower
```
