### PR TITLE
Fix guides build

### DIFF
--- a/guides/bug_report_templates/action_controller_master.rb
+++ b/guides/bug_report_templates/action_controller_master.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+gem "bundler", "< 1.16"
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_job_master.rb
+++ b/guides/bug_report_templates/active_job_master.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+gem "bundler", "< 1.16"
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_record_master.rb
+++ b/guides/bug_report_templates/active_record_master.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+gem "bundler", "< 1.16"
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/active_record_migrations_master.rb
+++ b/guides/bug_report_templates/active_record_migrations_master.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+gem "bundler", "< 1.16"
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/benchmark.rb
+++ b/guides/bug_report_templates/benchmark.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+gem "bundler", "< 1.16"
+
 begin
   require "bundler/inline"
 rescue LoadError => e

--- a/guides/bug_report_templates/generic_master.rb
+++ b/guides/bug_report_templates/generic_master.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+gem "bundler", "< 1.16"
+
 begin
   require "bundler/inline"
 rescue LoadError => e


### PR DESCRIPTION
## Summary 

Specify bundler version in template files.
    
We have already specified to install `bundler` 1.15.4 in `.travis.yml`.
https://github.com/rails/rails/blob/master/.travis.yml#L31..L32
    
However, `bundler` 1.16.0 may be used in the test.
https://travis-ci.org/rails/rails/jobs/296582467#L2208
    
The test failed due to this influence.
In order to avoid this, specifying `bundler` version in bug report templates.
