### PR TITLE
Save an allocation when using __FILE__ when manipulating backtraces in ActiveSupport::Dependencies

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -20,6 +20,8 @@ module ActiveSupport #:nodoc:
   module Dependencies #:nodoc:
     extend self
 
+    DEPENDENCIES_FILE = __FILE__.freeze #:nodoc:
+
     mattr_accessor :interlock, default: Interlock.new
 
     # :doc:
@@ -537,7 +539,7 @@ module ActiveSupport #:nodoc:
       end
 
       name_error = NameError.new("uninitialized constant #{qualified_name}", const_name)
-      name_error.set_backtrace(caller.reject { |l| l.starts_with? __FILE__ })
+      name_error.set_backtrace(caller.reject { |l| l.starts_with? DEPENDENCIES_FILE })
       raise name_error
     end
 


### PR DESCRIPTION
`__FILE__` allocates a new object each time you invoke it:

```
irb(main):006:0> __FILE__.object_id
=> 70352219333540
irb(main):007:0> __FILE__.object_id
=> 70352219319120
irb(main):008:0> __FILE__.object_id
=> 70352227685600
```

If you throw a lot of `NameError`s for whatever reason, especially deep down a stack, ActiveSupport::Dependencies ends up allocating a string for each line of the stack when invoking `__FILE__` to compare against. In some synthetic benchmarking I was doing, this string (which is
super duper fixed) was the most allocated string, only to be tossed away completely every GC. We can save an allocation by just referencing and freezing once.

I don't think that `__FILE__` can change for already loaded code, and if the class gets reloaded through whatever magic, I put my frozen constant inside it such that it should be reloaded as well, so I think it is safe to freeze.
