### PR TITLE
Now the reaper can handle inactive connections

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -561,11 +561,11 @@ module ActiveRecord
           @connections.select(&:stale?).each(&:steal!)
         end
 
-        bad_connections = synchronize do
+        exited_connections = synchronize do
           @connections.select(&:exited?).each(&:steal!)
         end
 
-        return if bad_connections.empty? && exited_connections.empty?
+        return if stale_connections.empty? && exited_connections.empty?
 
         stale_connections.each do |connection|
           if connection.active?
@@ -576,7 +576,7 @@ module ActiveRecord
           end
         end
 
-        bad_connections.each do |connection|
+        exited_connections.each do |connection|
           checkout connection
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -440,6 +440,26 @@ module ActiveRecord
         index.using.nil?
       end
 
+      def stale?
+        in_use? && dead?
+      end
+
+      def exited?
+        in_use? && inactive?
+      end
+
+      def dead?
+        !alive?
+      end
+
+      def inactive?
+        !active?
+      end
+
+      def alive?
+        owner.alive?
+      end
+
       private
         def type_map
           @type_map ||= Type::TypeMap.new.tap do |mapping|


### PR DESCRIPTION
### Summary

Sometimes services (like pgpool) will kill client connections (client = application -> pgpool) due to timeouts. These connections, from active record's perspective are "busy", but are actually gone!

The current reaper doesn't know how to deal with these inactive connections, which leaves an application open to connection starvation.

This pull request does two things:

  - Gives connections a more helpful set of functions to determine their state
  - Makes the reaper better understand the types of requests to reap