### PR TITLE
Fix Capybara::Webkit::Driver#resize_window deprecation warning

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -59,7 +59,7 @@ module ActionDispatch
 
         def register_webkit(app)
           Capybara::Webkit::Driver.new(app, Capybara::Webkit::Configuration.to_hash.merge(@options)).tap do |driver|
-            driver.resize_window(*@screen_size)
+            driver.resize_window_to(*@screen_size)
           end
         end
 


### PR DESCRIPTION
  >[DEPRECATION] Capybara::Webkit::Driver#resize_window is
  deprecated. Please use Capybara::Window#resize_to instead.

https://github.com/thoughtbot/capybara-webkit/blob/d63c3c8e3ae844f0c59359532a6dcb50f4a64d0a/lib/capybara/webkit/driver.rb#L135-L139