### PR TITLE
Add support for multiple encodings in String.blank?

### DIFF
--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -16,8 +16,8 @@ class BlankTest < ActiveSupport::TestCase
     end
   end
 
-  BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", [], {} ]
-  NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now ]
+  BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", [], {}, " ".encode("UTF-16LE")]
+  NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now , "my value".encode("UTF-16LE")]
 
   def test_blank
     BLANK.each { |v| assert_equal true, v.blank?,  "#{v.inspect} should be blank" }


### PR DESCRIPTION
Motivation:
  - When strings are encoded with `.encode("UTF-16LE")` `.blank?` throws
  an `Encoding::CompatibilityError` exception.
  - We tested multiple implementation to see what the fastest
  implementation was, rescueing the execption seems to be the fastest
  option we could find.

Related Issues:
  - #28953

Changes:
  - Add a rescue to catch the exception.
  - Added a `Concurrent::Map` to store a cache of encoded regex objects
  for requested encoding types.
  - Use the new `Concurrent::Map` cache to return the correct regex for
  the string being checked.

cc @matthewd for review.