### PR TITLE
Make it easy to get the controller from the route

### DIFF
--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -74,6 +74,10 @@ module ActionDispatch
         @path_formatter    = @path.build_formatter
         @internal          = internal
       end
+        
+      def to_controller_class
+        "#{defaults.fetch(:controller).classify.pluralize}Controller".constantize
+      end
 
       def eager_load!
         path.eager_load!


### PR DESCRIPTION
### Summary

While the router *should* know how to get to the controller, it doesn't. This can be annoying for metaprogramming gems.

I know this is probably not the *right way to do it*, but I would love this functionality so any guidance on how rails would love to do this would be much appreciated.