### PR TITLE
Generate the correct path in nested scaffold generator

### DIFF
--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -158,26 +158,26 @@ module Rails
 
         def model_resource_name(prefix: "") # :doc:
           resource_name = "#{prefix}#{singular_table_name}"
-          if controller_class_path.empty?
-            resource_name
-          else
+          if options[:model_name]
             "[#{controller_class_path.map { |name| ":" + name }.join(", ")}, #{resource_name}]"
+          else
+            resource_name
           end
         end
 
         def singular_route_name # :doc:
-          if controller_class_path.empty?
-            singular_table_name
-          else
+          if options[:model_name]
             "#{controller_class_path.join('_')}_#{singular_table_name}"
+          else
+            singular_table_name
           end
         end
 
         def plural_route_name # :doc:
-          if controller_class_path.empty?
-            plural_table_name
-          else
+          if options[:model_name]
             "#{controller_class_path.join('_')}_#{plural_table_name}"
+          else
+            plural_table_name
           end
         end
 

--- a/railties/test/generators/named_base_test.rb
+++ b/railties/test/generators/named_base_test.rb
@@ -33,6 +33,17 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, "foos",       :plural_name
     assert_name g, "admin.foo",  :i18n_scope
     assert_name g, "admin_foos", :table_name
+    assert_name g, "admin/foos", :controller_name
+    assert_name g, %w(admin),     :controller_class_path
+    assert_name g, "Admin::Foos", :controller_class_name
+    assert_name g, "admin/foos",  :controller_file_path
+    assert_name g, "foos",        :controller_file_name
+    assert_name g, "admin.foos",  :controller_i18n_scope
+    assert_name g, "admin_foo",  :singular_route_name
+    assert_name g, "admin_foos", :plural_route_name
+    assert_name g, "@admin_foo", :redirect_resource_name
+    assert_name g, "admin_foo",  :model_resource_name
+    assert_name g, "admin_foos", :index_helper
   end
 
   def test_named_generator_attributes_as_ruby
@@ -47,6 +58,17 @@ class NamedBaseTest < Rails::Generators::TestCase
     assert_name g, "foos",       :plural_name
     assert_name g, "admin.foo",  :i18n_scope
     assert_name g, "admin_foos", :table_name
+    assert_name g, "Admin::Foos", :controller_name
+    assert_name g, %w(admin),     :controller_class_path
+    assert_name g, "Admin::Foos", :controller_class_name
+    assert_name g, "admin/foos",  :controller_file_path
+    assert_name g, "foos",        :controller_file_name
+    assert_name g, "admin.foos",  :controller_i18n_scope
+    assert_name g, "admin_foo",  :singular_route_name
+    assert_name g, "admin_foos", :plural_route_name
+    assert_name g, "@admin_foo", :redirect_resource_name
+    assert_name g, "admin_foo",  :model_resource_name
+    assert_name g, "admin_foos", :index_helper
   end
 
   def test_named_generator_attributes_without_pluralized

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -282,7 +282,14 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
                 /class Admin::RolesTest < ApplicationSystemTestCase/
 
     # Views
-    %w(index edit new show _form).each do |view|
+    assert_file "app/views/admin/roles/index.html.erb" do |content|
+      assert_match("'Show', admin_role", content)
+      assert_match("'Edit', edit_admin_role_path(admin_role)", content)
+      assert_match("'Destroy', admin_role", content)
+      assert_match("'New Admin Role', new_admin_role_path", content)
+    end
+
+    %w(edit new show _form).each do |view|
       assert_file "app/views/admin/roles/#{view}.html.erb"
     end
     assert_no_file "app/views/layouts/admin/roles.html.erb"


### PR DESCRIPTION
Currently, namespaced scaffold generator will generate an incorrect path and the generated file will not work properly.

```
$ ./bin/rails g scaffold admin/user
$ ./bin/rails db:migrate
$  ./bin/rails t test/controllers
# Running:

E

Error:
Admin::UsersControllerTest#test_should_create_admin_user:
NameError: undefined local variable or method `admin_admin_users_url' for #<Admin::UsersControllerTest:0x000055a59f25ff68>
Did you mean?  admin_users
    test/controllers/admin/users_controller_test.rb:20:in `block (2 levels) in <class:UsersControllerTest>'
    test/controllers/admin/users_controller_test.rb:19:in `block in <class:UsersControllerTest>'

bin/rails test test/controllers/admin/users_controller_test.rb:18
```

This is because combine `controller_class_path` and `singular_table_name` to generate route.
https://github.com/rails/rails/blob/360698aa245b45349d1d1b12e1afb34759515e69/railties/lib/rails/generators/named_base.rb#L172

Normally, if using namspaced generator, table name already contains namespace. Therefore, adding `controller_class_path` adds extra namespace.
Since it is special only when explicitly specifying `model-name`, it is modified to change the value only when `model-name`is specified.

Follow up of #30729
