### PR TITLE
Override host in before_setup on system test

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb
@@ -12,7 +12,7 @@ module ActionDispatch
         end
 
         def before_setup
-          host! DEFAULT_HOST
+          host! app_host
           super
         end
 
@@ -21,6 +21,12 @@ module ActionDispatch
           Capybara.reset_sessions!
           super
         end
+
+        private
+
+          def app_host
+            Capybara.app_host || DEFAULT_HOST
+          end
       end
     end
   end

--- a/actionpack/test/dispatch/system_testing/system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/system_test_case_test.rb
@@ -29,6 +29,14 @@ class SetDriverToSeleniumHeadlessChromeTest < DrivenBySeleniumWithHeadlessChrome
 end
 
 class SetHostTest < DrivenByRackTest
+  setup do
+    @original_host = Capybara.app_host
+  end
+
+  teardown do
+    host! @original_host
+  end
+
   test "sets default host" do
     assert_equal "http://127.0.0.1", Capybara.app_host
   end
@@ -37,6 +45,22 @@ class SetHostTest < DrivenByRackTest
     host! "http://example.com"
 
     assert_equal "http://example.com", Capybara.app_host
+  end
+end
+
+class CustomizeAppHostInBeforeSetupTest < DrivenByRackTest
+  def before_setup
+    @original_host = Capybara.app_host
+    host! "http://custom.com"
+    super
+  end
+
+  def after_teardown
+    host! @original_host
+  end
+
+  test "sets default host" do
+    assert_equal "http://custom.com", Capybara.app_host
   end
 end
 


### PR DESCRIPTION
### Summary

We don't mind whether `setup` or `before_setup` we should call `host!` in. This fix enables to override host in `before_setup`, too.

### Other Information

Sample system test is below,

```
require "application_system_test_case"

class TasksTest < ApplicationSystemTestCase
  def before_setup
    @original_app_host = Capybara.app_host
    host! "http://localhost"
    super
  end

  def after_teardown
    super
    Capybara.app_host = @original_app_host
  end

  test "visiting the index" do
    puts Capybara.app_host # before: => "http://127.0.0.1", after: => "http://localhost"
    visit tasks_url
    assert_link 'New Task'
  end
end
```
