### PR TITLE
Show `RequestForgeryProtection` methods in api doc  [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -248,6 +248,7 @@ module ActionController #:nodoc:
         "If you know what you're doing, go ahead and disable forgery " \
         "protection on this action to permit cross-origin JavaScript embedding."
       private_constant :CROSS_ORIGIN_JAVASCRIPT_WARNING
+      # :startdoc:
 
       # If `verify_authenticity_token` was run (indicating that we have
       # forgery protection enabled for this request) then also verify that


### PR DESCRIPTION
Several methods of `RequestForgeryProtection` are not showed in the api doc even though `:doc:` is specified.(e.g. `form_authenticity_param`)
http://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection.html

These methods are listed in the doc of v4.1.
http://api.rubyonrails.org/v4.1/classes/ActionController/RequestForgeryProtection.html

This is due to the influence of `:nodoc:` added in #18102, methods after  `CROSS_ORIGIN_JAVASCRIPT_WARNING` not showed from the doc.
Therefore, in order to show the method like originally, added `startdoc` after `CROSS_ORIGIN_JAVASCRIPT_WARNING`.

