### PR TITLE
Prevent breaking lines in guides for `pre`, `tt` and `code` tags

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -40,14 +40,6 @@ p code {
   padding: 1px 3px;
 }
 
-pre, tt, code {
- white-space: pre-wrap;       /* css-3 */
- white-space: -moz-pre-wrap !important;  /* Mozilla, since 1999 */
- white-space: -pre-wrap;      /* Opera 4-6 */
- white-space: -o-pre-wrap;    /* Opera 7 */
- word-wrap: break-word;       /* Internet Explorer 5.5+ */
-}
-
 abbr, acronym { border-bottom: 1px dotted #666; }
 address { margin: 0 0 1.5em; font-style: italic; }
 del { color:#666; }


### PR DESCRIPTION
Before:
<img src="https://user-images.githubusercontent.com/6443532/32415006-c225337c-c23a-11e7-9d2d-6c365e1b7ec7.png" height="600px"/>

After:
<img src="https://user-images.githubusercontent.com/6443532/32415045-6fea2bf2-c23b-11e7-8622-28d0931bf8a5.png" height="600px"/>