### PR TITLE
Execute `ConfirmationValidator` validation when `_confirmation`'s value is `false`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Execute `ConfirmationValidator` validation when `_confirmation`'s value is `false`.
+
+    *bogdanvlviv*
+
 *   Allow passing a Proc or Symbol to length validator options.
 
     *Matt Rohrer*

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -9,7 +9,7 @@ module ActiveModel
       end
 
       def validate_each(record, attribute, value)
-        if (confirmed = record.send("#{attribute}_confirmation"))
+        unless (confirmed = record.send("#{attribute}_confirmation")).nil?
           unless confirmation_value_equal?(record, attribute, value, confirmed)
             human_attribute_name = record.class.human_attribute_name(attribute)
             record.errors.add(:"#{attribute}_confirmation", :confirmation, options.except(:case_sensitive).merge!(attribute: human_attribute_name))

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -37,6 +37,19 @@ class ConfirmationValidationTest < ActiveModel::TestCase
     assert t.valid?
   end
 
+  def test_validates_confirmation_of_with_boolean_attribute
+    Topic.validates_confirmation_of(:approved)
+
+    t = Topic.new(approved: true, approved_confirmation: nil)
+    assert t.valid?
+
+    t.approved_confirmation = false
+    assert t.invalid?
+
+    t.approved_confirmation = true
+    assert t.valid?
+  end
+
   def test_validates_confirmation_of_for_ruby_class
     Person.validates_confirmation_of :karma
 


### PR DESCRIPTION
In according to our documentation `ConfirmationValidator` validation shouldn't be executed only if `_confirmation`'s value is `nil`.

https://github.com/rails/rails/blob/8a2ee3d8c6921ce34e597658e3f2b43b41423d1d/guides/source/active_record_validations.md#confirmation
https://github.com/rails/rails/blob/8a2ee3d8c6921ce34e597658e3f2b43b41423d1d/activemodel/lib/active_model/validations/confirmation.rb#L60-L62