### PR TITLE
Explicitly pass window handle to `resize_window_to`

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -59,7 +59,7 @@ module ActionDispatch
 
         def register_webkit(app)
           Capybara::Webkit::Driver.new(app, Capybara::Webkit::Configuration.to_hash.merge(@options)).tap do |driver|
-            driver.resize_window_to(*@screen_size)
+            driver.resize_window_to(driver.current_window_handle, *@screen_size)
           end
         end
 


### PR DESCRIPTION
Unlike `resize_window`, `resize_window_to` has three arguments.
https://github.com/thoughtbot/capybara-webkit/blob/d63c3c8e3ae844f0c59359532a6dcb50f4a64d0a/lib/capybara/webkit/driver.rb#L135-L143

Therefore, if pass only width and height just like `resize_window`, `ArgumentError`will be raised.
To prevent this, explicitly pass window handler.

Follow up of #31046

r? @eileencodes 