### PR TITLE
Fix french spelling mistake

### DIFF
--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -71,23 +71,23 @@ module ActiveSupport
     # a 'pretty' URL.
     #
     #   parameterize("Donald E. Knuth") # => "donald-e-knuth"
-    #   parameterize("^trés|Jolie-- ")  # => "tres-jolie"
+    #   parameterize("^très|Jolie-- ")  # => "tres-jolie"
     #
     # To use a custom separator, override the `separator` argument.
     #
     #  parameterize("Donald E. Knuth", separator: '_') # => "donald_e_knuth"
-    #  parameterize("^trés|Jolie__ ", separator: '_')  # => "tres_jolie"
+    #  parameterize("^très|Jolie__ ", separator: '_')  # => "tres_jolie"
     #
     # To preserve the case of the characters in a string, use the `preserve_case` argument.
     #
     #   parameterize("Donald E. Knuth", preserve_case: true) # => "Donald-E-Knuth"
-    #   parameterize("^trés|Jolie-- ", preserve_case: true) # => "tres-Jolie"
+    #   parameterize("^très|Jolie-- ", preserve_case: true) # => "tres-Jolie"
     #
     # It preserves dashes and underscores unless they are used as separators:
     #
-    #  parameterize("^trés|Jolie__ ")                 # => "tres-jolie__"
-    #  parameterize("^trés|Jolie-- ", separator: "_") # => "tres_jolie--"
-    #  parameterize("^trés_Jolie-- ", separator: ".") # => "tres_jolie--"
+    #  parameterize("^très|Jolie__ ")                 # => "tres-jolie__"
+    #  parameterize("^très|Jolie-- ", separator: "_") # => "tres_jolie--"
+    #  parameterize("^très_Jolie-- ", separator: ".") # => "tres_jolie--"
     #
     def parameterize(string, separator: "-", preserve_case: false)
       # Replace accented chars with their ASCII equivalents.


### PR DESCRIPTION
### Summary

Minor fix in comment
In french, we don't write 'Trés' but 'Très'

### Other Information

https://fr.wiktionary.org/wiki/tr%C3%A8s
