### PR TITLE
Add Proc#as_json method

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Added `Proc#as_json` to allow procs to be passed to json encoder
+
+        person = {email: 'bogdan@example.com', cms_data: -> { fetch_data_from_cms  }}
+        person.to_json # => {"email": "bogdan@example.com", "cms_data": {...}}
+
+    Supposed to be used when data is generated lazily due to heavy operations
+
 *   `IO#to_json` now returns the `to_s` representation, rather than
     attempting to convert to an array. This fixes a bug where `IO#to_json`
     would raise an `IOError` when called on an unreadable object.

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -225,3 +225,9 @@ class Exception
     to_s
   end
 end
+
+class Proc #:nodoc:
+  def as_json(options = nil)
+    call.as_json(options)
+  end
+end

--- a/activesupport/test/json/encoding_test_cases.rb
+++ b/activesupport/test/json/encoding_test_cases.rb
@@ -94,5 +94,6 @@ module JSONTest
     StandardTimeTests     = [[ Time.utc(2005, 2, 1, 15, 15, 10), %("2005-02-01T15:15:10.000Z") ]]
     StandardDateTimeTests = [[ DateTime.civil(2005, 2, 1, 15, 15, 10), %("2005-02-01T15:15:10.000+00:00") ]]
     StandardStringTests   = [[ "this is the <string>", %("this is the <string>")]]
+    ProcTests = [[proc { :symbol }, %("symbol")]]
   end
 end


### PR DESCRIPTION
Added `Proc#as_json` to allow procs to be passed to json encoder

``` ruby
person = {email: 'bogdan@example.com', cms_data: -> { fetch_data_from_cms  }}
person.to_json # => {"email": "bogdan@example.com", "cms_data": {...}}
```

Supposed to be used when data is generated lazily due to heavy operations.

It is required when same structures are used to be converted to JSON and in other places that allow the lazy data evaluation (in my case Liquid Templates).


