### PR TITLE
Resolve Minitest 6 deprecation in assert_no_changes

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -190,7 +190,12 @@ module ActiveSupport
 
         error = "#{expression.inspect} did change to #{after}"
         error = "#{message}.\n#{error}" if message
-        assert_equal before, after, error
+
+        if before.nil?
+          assert_nil after, error
+        else
+          assert_equal before, after, error
+        end
 
         retval
       end


### PR DESCRIPTION
These changes resolve a deprecation warning in `assert_no_changes` when asserting that an expression evaluates to `nil` before and after the passed block is evaluated.

The smallest demonstration of this edge case:

```ruby
assert_no_changes "nil" do
  true # noop
end
```

Under the covers, this is evaluating

```ruby
assert_equal nil, nil
```

Minitest 5 issues a deprecation warning, and Minitest 6 will fail completely.

For additional context, the motivations and implications of this change to Minitest have been discussed at length in [seattlerb/minitest#666][].

[seattlerb/minitest#666]: https://github.com/seattlerb/minitest/issues/666