### PR TITLE
PostgreSQL boolean is called `boolean`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -440,7 +440,7 @@ module ActiveRecord
           m.alias_type "char", "varchar"
           m.alias_type "name", "varchar"
           m.alias_type "bpchar", "varchar"
-          m.register_type "bool", Type::Boolean.new
+          m.register_type "boolean", Type::Boolean.new
           register_class_with_limit m, "bit", OID::Bit
           register_class_with_limit m, "varbit", OID::BitVarying
           m.alias_type "timestamptz", "timestamp"


### PR DESCRIPTION
In PostgreSQL the type `bool` does not exist; it is called `boolean`. I don't know why it (partially works), but it causes a Ruby `false` value to be stored as `NULL` instead of `FALSE`. That causes an error if the column is `NOT NULL`.
