### PR TITLE
Modify belongs_to relation to support more dependent options

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -11,7 +11,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_dependent_options
-      [:destroy, :delete]
+      [:destroy, :delete, :nullify, :restrict_with_error, :restrict_with_exception]
     end
 
     def self.define_callbacks(model, reflection)

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -11,7 +11,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_dependent_options
-      [:destroy, :delete, :nullify, :restrict_with_error, :restrict_with_exception]
+      [:destroy, :delete, :nullify]
     end
 
     def self.define_callbacks(model, reflection)

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -924,6 +924,13 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal [author_address.id], AuthorAddress.destroyed_author_address_ids
   end
 
+  def test_belongs_to_invalid_dependent_option_raises_exception
+    error = assert_raise ArgumentError do
+      Class.new(Author).belongs_to :special_author_address, dependent: :restrict_with_error
+    end
+    assert_equal error.message, "The :dependent option must be one of [:destroy, :delete, :nullify], but is :restrict_with_error"
+  end
+
   def test_attributes_are_being_set_when_initialized_from_belongs_to_association_with_where_clause
     new_firm = accounts(:signals37).build_firm(name: "Apple")
     assert_equal new_firm.name, "Apple"

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -924,13 +924,6 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal [author_address.id], AuthorAddress.destroyed_author_address_ids
   end
 
-  def test_belongs_to_invalid_dependent_option_raises_exception
-    error = assert_raise ArgumentError do
-      Class.new(Author).belongs_to :special_author_address, dependent: :nullify
-    end
-    assert_equal error.message, "The :dependent option must be one of [:destroy, :delete], but is :nullify"
-  end
-
   def test_attributes_are_being_set_when_initialized_from_belongs_to_association_with_where_clause
     new_firm = accounts(:signals37).build_firm(name: "Apple")
     assert_equal new_firm.name, "Apple"


### PR DESCRIPTION
### Summary

Modify `belongs_to` valid dependent options to support also `nullify`, `restrict_with_error` or `restrict_with_exception`. As @rafaelfranca said here #31070 the actual behaviour is something expected to avoid orphan objects. However, I have found some situations and relationships that could need nullify instead of destroy, since the models are not heavily related.

My approach now is quite simple, just enabling all kinds of dependent options always, but could be modified to just support the new ones when `optional` is set to true.

If you need more details I can attach our example.