### PR TITLE
Fix autosave belongs to association raising `Can't modify frozen hash`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix raising `RuntimeError: can't modify frozen Hash` when saving
+    resource which was destroyed by one of its callbacks.
+
+    *bbonislawski*
+
 *   Fix `bin/rails db:migrate` with specified `VERSION`.
     `bin/rails db:migrate` with empty VERSION behaves as without `VERSION`.
     Check a format of `VERSION`: Allow a migration version number

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -435,7 +435,7 @@ module ActiveRecord
 
             if (autosave && record.changed_for_autosave?) || new_record? || record_changed?(reflection, record, key)
               unless reflection.through_reflection
-                record[reflection.foreign_key] = key
+                record[reflection.foreign_key] = key if record.persisted?
               end
 
               saved = record.save(validate: !autosave)
@@ -465,14 +465,14 @@ module ActiveRecord
           autosave = reflection.options[:autosave]
 
           if autosave && record.marked_for_destruction?
-            self[reflection.foreign_key] = nil
+            self[reflection.foreign_key] = nil if self.persisted?
             record.destroy
           elsif autosave != false
             saved = record.save(validate: !autosave) if record.new_record? || (autosave && record.changed_for_autosave?)
 
             if association.updated?
               association_id = record.send(reflection.options[:primary_key] || :id)
-              self[reflection.foreign_key] = association_id
+              self[reflection.foreign_key] = association_id if self.persisted?
               association.loaded!
             end
 


### PR DESCRIPTION
### Summary

When you have lots of complicated callbacks you can run into
`RuntimeError: can't modify frozen Hash` since object was destroyed
by some callback and you cannot modify its' fields anymore and
autosave tries to save new association_id.

### Other Information

I ran into problem on Rails 5.1.4 and fixed it like that. It would be nice if it was backported to older versions.