### PR TITLE
Fix comment in `check_class_collision` [ci skip]

### DIFF
--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -221,7 +221,7 @@ module Rails
         #
         def self.check_class_collision(options = {}) # :doc:
           define_method :check_class_collision do
-            name = if respond_to?(:controller_class_name) # for ScaffoldBase
+            name = if respond_to?(:controller_class_name) # for ResourceHelpers
               controller_class_name
             else
               class_name


### PR DESCRIPTION
`ScaffoldBase` was changed to `ResourceHelpers` by 0efedf2.
