### PR TITLE
Use plain assert in assert_changes to avoid MT6 refutes

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -159,7 +159,7 @@ module ActiveSupport
         if to == UNTRACKED
           error = "#{expression.inspect} didn't change"
           error = "#{message}.\n#{error}" if message
-          assert_not_equal before, after, error
+          assert before != after, error
         else
           error = "#{expression.inspect} didn't change to #{to}"
           error = "#{message}.\n#{error}" if message
@@ -190,12 +190,7 @@ module ActiveSupport
 
         error = "#{expression.inspect} did change to #{after}"
         error = "#{message}.\n#{error}" if message
-
-        if before.nil?
-          assert_nil after, error
-        else
-          assert_equal before, after, error
-        end
+        assert before == after, error
 
         retval
       end

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -179,6 +179,7 @@ class AssertDifferenceTest < ActiveSupport::TestCase
   end
 
   def test_assert_changes_works_with_any_object
+    # Silences: instance variable @new_object not initialized.
     retval = silence_warnings do
       assert_changes :@new_object, from: nil, to: 42 do
         @new_object = 42
@@ -201,7 +202,7 @@ class AssertDifferenceTest < ActiveSupport::TestCase
   def test_assert_changes_with_to_and_case_operator
     token = nil
 
-    assert_changes -> { token },  to: /\w{32}/ do
+    assert_changes -> { token }, to: /\w{32}/ do
       token = SecureRandom.hex
     end
   end
@@ -236,7 +237,7 @@ class AssertDifferenceTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal "@object.num should not change.\n\"@object.num\" did change to 1.\nExpected: 0\n  Actual: 1", error.message
+    assert_equal "@object.num should not change.\n\"@object.num\" did change to 1", error.message
   end
 end
 


### PR DESCRIPTION
Seeing the previously issued PRs about it, we can avoid the `nil`
comparisons that can happen in `assert_changes` by using plain `assert`
calls.

This is to avoid a deprecation warning about comparing `nil` values in
`assert_equal` for Minitest 5 and a crash in Minitest 6.

You can see the preparations done in [`assert_equal`][ae]. You can also
see that [`assert`][a] does not care about `nil`s.

[ae]: https://github.com/seattlerb/minitest/blob/ca6a71ca901016db09a5ad466b4adea4b52a504a/lib/minitest/assertions.rb#L159-L188
[a]: https://github.com/seattlerb/minitest/blob/ca6a71ca901016db09a5ad466b4adea4b52a504a/lib/minitest/assertions.rb#L131-L142