### PR TITLE
Fix typoes on ActionDispatch::HTTP::FilterParameters

### DIFF
--- a/actionpack/lib/action_dispatch/http/filter_parameters.rb
+++ b/actionpack/lib/action_dispatch/http/filter_parameters.rb
@@ -9,7 +9,7 @@ module ActionDispatch
     # sub-hashes of the params hash to filter. Filtering only certain sub-keys
     # from a hash is possible by using the dot notation: 'credit_card.number'.
     # If a block is given, each key and value of the params hash and all
-    # sub-hashes is passed to it, the value or key can be replaced using
+    # sub-hashes is passed to it, where the value or the key can be replaced using
     # String#replace or similar method.
     #
     #   env["action_dispatch.parameter_filter"] = [:password]
@@ -48,7 +48,7 @@ module ActionDispatch
         @filtered_env ||= env_filter.filter(@env)
       end
 
-      # Reconstructed a path with all sensitive GET parameters replaced.
+      # Reconstructs a path with all sensitive GET parameters replaced.
       def filtered_path
         @filtered_path ||= query_string.empty? ? path : "#{path}?#{filtered_query_string}"
       end


### PR DESCRIPTION
### Summary

I have fixed 2 typoes on the comment of ActionDispatch::HTTP::FilterParameters

* Add a continuative relative pronoun and an additional definite article for more understandable document.
* Use present tense on method description.