### PR TITLE
Allow `Range#include?` on TWZ ranges

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Allow `Range#include?` on TWZ ranges
+
+    In #11474 we prevented TWZ ranges being iterated over which matched
+    Ruby's handling of Time ranges and as a consequence `include?`
+    stopped working with both Time ranges and TWZ ranges. However in
+    ruby/ruby@b061634 support was added for `include?` to use `cover?`
+    for 'linear' objects. Since we have no way of making Ruby consider
+    TWZ instances as 'linear' we have to override `Range#include?`.
+    
+    Fixes #30799.
+    
+    *Andrew White*
+
 *   Fix acronym support in `humanize`
 
     Acronym inflections are stored with lowercase keys in the hash but

--- a/activesupport/lib/active_support/core_ext/range.rb
+++ b/activesupport/lib/active_support/core_ext/range.rb
@@ -2,5 +2,6 @@
 
 require "active_support/core_ext/range/conversions"
 require "active_support/core_ext/range/include_range"
+require "active_support/core_ext/range/include_time_with_zone"
 require "active_support/core_ext/range/overlaps"
 require "active_support/core_ext/range/each"

--- a/activesupport/lib/active_support/core_ext/range/each.rb
+++ b/activesupport/lib/active_support/core_ext/range/each.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/time_with_zone"
+
 module ActiveSupport
   module EachTimeWithZone #:nodoc:
     def each(&block)
@@ -15,7 +17,7 @@ module ActiveSupport
     private
 
       def ensure_iteration_allowed
-        raise TypeError, "can't iterate from #{first.class}" if first.is_a?(Time)
+        raise TypeError, "can't iterate from #{first.class}" if first.is_a?(TimeWithZone)
       end
   end
 end

--- a/activesupport/lib/active_support/core_ext/range/include_time_with_zone.rb
+++ b/activesupport/lib/active_support/core_ext/range/include_time_with_zone.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "active_support/time_with_zone"
+
+module ActiveSupport
+  module IncludeTimeWithZone #:nodoc:
+    # Extends the default Range#include? to support ActiveSupport::TimeWithZone.
+    #
+    #   (1.hour.ago..1.hour.from_now).include?(Time.current) # => true
+    #
+    def include?(value)
+      if first.is_a?(TimeWithZone)
+        cover?(value)
+      elsif last.is_a?(TimeWithZone)
+        cover?(value)
+      else
+        super
+      end
+    end
+  end
+end
+
+Range.prepend(ActiveSupport::IncludeTimeWithZone)

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -121,9 +121,12 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_include_on_time_with_zone
     twz = ActiveSupport::TimeWithZone.new(nil, ActiveSupport::TimeZone["Eastern Time (US & Canada)"] , Time.utc(2006, 11, 28, 10, 30))
-    assert_raises TypeError do
-      ((twz - 1.hour)..twz).include?(twz)
-    end
+    assert ((twz - 1.hour)..twz).include?(twz)
+  end
+
+  def test_case_equals_on_time_with_zone
+    twz = ActiveSupport::TimeWithZone.new(nil, ActiveSupport::TimeZone["Eastern Time (US & Canada)"] , Time.utc(2006, 11, 28, 10, 30))
+    assert ((twz - 1.hour)..twz) === twz
   end
 
   def test_date_time_with_each


### PR DESCRIPTION
In #11474 we prevented TWZ ranges being iterated over which matched Ruby's handling of Time ranges and as a consequence `include?` stopped working with both Time ranges and TWZ ranges. However in ruby/ruby@b061634 support was added for `include?` to use `cover?` for 'linear' objects. Since we have no way of making Ruby consider TWZ instances as 'linear' we have to override `Range#include?`.
