### PR TITLE
Do not run active storage install when bundle install is skipped

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -461,7 +461,11 @@ module Rails
 
       def run_active_storage
         unless skip_active_storage?
-          rails_command "active_storage:install", capture: options[:quiet]
+          if bundle_install?
+            rails_command "active_storage:install", capture: options[:quiet]
+          else
+            log("Active Storage installation was skipped. Please run 'bin/rails active_storage:install' to install Active Storage files.")
+          end
         end
       end
 

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -16,8 +16,6 @@ module ApplicationTests
 
     def test_bin_setup
       Dir.chdir(app_path) do
-        FileUtils.rm_rf("db/migrate")
-
         app_file "db/schema.rb", <<-RUBY
           ActiveRecord::Schema.define(version: 20140423102712) do
             create_table(:articles) {}
@@ -39,8 +37,6 @@ module ApplicationTests
 
     def test_bin_setup_output
       Dir.chdir(app_path) do
-        FileUtils.rm_rf("db/migrate")
-
         app_file "db/schema.rb", ""
 
         output = `bin/setup 2>&1`

--- a/railties/test/application/rackup_test.rb
+++ b/railties/test/application/rackup_test.rb
@@ -26,7 +26,6 @@ module ApplicationTests
 
     test "config.ru can be racked up" do
       Dir.chdir app_path do
-        FileUtils.rm_rf("db/migrate")
         @app = rackup
         assert_welcome get("/")
       end

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -287,8 +287,6 @@ module ApplicationTests
           ENV.delete "RAILS_ENV"
           ENV.delete "RACK_ENV"
 
-          Dir.chdir(app_path) { FileUtils.rm_rf("db/migrate") }
-
           app_file "db/schema.rb", <<-RUBY
             ActiveRecord::Schema.define(version: "1") do
               create_table :users do |t|
@@ -310,8 +308,6 @@ module ApplicationTests
       end
 
       test "db:setup sets ar_internal_metadata" do
-        Dir.chdir(app_path) { FileUtils.rm_rf("db/migrate") }
-
         app_file "db/schema.rb", ""
         rails "db:setup"
 

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -11,7 +11,6 @@ module ApplicationTests
     def setup
       build_app
       create_schema
-      remove_migrations
     end
 
     def teardown
@@ -726,10 +725,6 @@ module ApplicationTests
 
       def create_schema
         app_file "db/schema.rb", ""
-      end
-
-      def remove_migrations
-        Dir.chdir(app_path) { FileUtils.rm_rf("db/migrate") }
       end
 
       def create_test_file(path = :unit, name = "test", pass: true)

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -8,7 +8,6 @@ module ApplicationTests
 
     def setup
       build_app
-      remove_migrations
     end
 
     def teardown
@@ -321,10 +320,6 @@ Expected: ["id", "name"]
     end
 
     private
-      def remove_migrations
-        Dir.chdir(app_path) { FileUtils.rm_rf("db/migrate") }
-      end
-
       def assert_unsuccessful_run(name, message)
         result = run_test_file(name)
         assert_not_equal 0, $?.to_i

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -68,7 +68,6 @@ DEFAULT_APP_FILES = %w(
   config/spring.rb
   config/storage.yml
   db
-  db/migrate
   db/seeds.rb
   lib
   lib/tasks
@@ -302,6 +301,21 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_active_storage_mini_magick_gem
     run_generator
     assert_file "Gemfile", /^# gem 'mini_magick'/
+  end
+
+  def test_active_storage_install
+    command_check = -> command, _ do
+      @binstub_called ||= 0
+      case command
+      when "active_storage:install"
+        @binstub_called += 1
+        assert_equal 1, @binstub_called, "active_storage:install expected to be called once, but was called #{@install_called} times."
+      end
+    end
+
+    generator.stub :rails_command, command_check do
+      quietly { generator.invoke_all }
+    end
   end
 
   def test_app_update_does_not_generate_active_storage_contents_when_skip_active_storage_is_given

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -222,7 +222,6 @@ module SharedGeneratorTests
     end
 
     assert_file "#{application_path}/config/storage.yml"
-    assert_directory "#{application_path}/db/migrate"
     assert_directory "#{application_path}/storage"
     assert_directory "#{application_path}/tmp/storage"
 

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -90,6 +90,8 @@ module RailtiesTest
       boot_rails
 
       Dir.chdir(app_path) do
+        # Install Active Storage migration file first so as not to affect test.
+        `bundle exec rake active_storage:install`
         output = `bundle exec rake bukkits:install:migrations`
 
         ["CreateUsers", "AddLastNameToUsers", "CreateSessions"].each do |migration_name|
@@ -175,6 +177,8 @@ module RailtiesTest
       boot_rails
 
       Dir.chdir(app_path) do
+        # Install Active Storage migration file first so as not to affect test.
+        `bundle exec rake active_storage:install`
         output = `bundle exec rake railties:install:migrations`.split("\n")
 
         assert_match(/Copied migration \d+_create_users\.core_engine\.rb from core_engine/, output.first)


### PR DESCRIPTION
In order to execute the `rails` command, need to run bundle install in advance.
Therefore, if skipped bundle install, `rails` command may fail and should not do it.