### PR TITLE
Use released `redis-namespace` instead of master version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,8 +80,7 @@ group :cable do
   gem "hiredis", require: false
   gem "redis", "~> 4.0", require: false
 
-  # For Redis 4.0 support. Unreleased 9cb81bf.
-  gem "redis-namespace", github: "resque/redis-namespace"
+  gem "redis-namespace"
 
   gem "websocket-client-simple", github: "matthewd/websocket-client-simple", branch: "close-race", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,13 +53,6 @@ GIT
       tilt (>= 1.1, < 3)
 
 GIT
-  remote: https://github.com/resque/redis-namespace.git
-  revision: 1403f511f6ae1ec9a8f330298a4cacf73fb10afc
-  specs:
-    redis-namespace (1.5.3)
-      redis (>= 3.0.4)
-
-GIT
   remote: https://github.com/robin850/sdoc.git
   revision: 0e340352f3ab2f196c8a8743f83c2ee286e4f71c
   branch: upgrade
@@ -409,6 +402,8 @@ GEM
     rdoc (5.1.0)
     redcarpet (3.2.3)
     redis (4.0.1)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -563,7 +558,7 @@ DEPENDENCIES
   rb-inotify!
   redcarpet (~> 3.2.3)
   redis (~> 4.0)
-  redis-namespace!
+  redis-namespace
   resque
   resque-scheduler!
   rubocop (>= 0.47)


### PR DESCRIPTION
The `redis-namespace` 1.6.0 includes redis-rb 4.0 support.
