### PR TITLE
Remove redundant passing --skip-active-storage in test cases

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -423,7 +423,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_config_jdbcmysql_database
-    run_generator([destination_root, "-d", "jdbcmysql", "--skip-active-storage"])
+    run_generator([destination_root, "-d", "jdbcmysql"])
     assert_file "config/database.yml", /mysql/
     assert_gem "activerecord-jdbcmysql-adapter"
   end
@@ -441,7 +441,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_config_jdbc_database
-    run_generator([destination_root, "-d", "jdbc", "--skip-active-storage"])
+    run_generator([destination_root, "-d", "jdbc"])
     assert_file "config/database.yml", /jdbc/
     assert_file "config/database.yml", /mssql/
     assert_gem "activerecord-jdbc-adapter"

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -230,7 +230,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_ensure_that_tests_work
-    run_generator [destination_root, "--skip-active-storage"]
+    run_generator
     FileUtils.cd destination_root
     quietly { system "bundle install" }
     assert_match(/1 runs, 1 assertions, 0 failures, 0 errors/, `bin/test 2>&1`)

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -7,7 +7,7 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
 
   def setup
     @destination_root = Dir.mktmpdir("bukkits")
-    Dir.chdir(@destination_root) { `bundle exec rails plugin new bukkits --skip-bundle --skip-active-storage` }
+    Dir.chdir(@destination_root) { `bundle exec rails plugin new bukkits --skip-bundle` }
     plugin_file "test/dummy/db/schema.rb", ""
   end
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -63,7 +63,7 @@ module SharedGeneratorTests
   end
 
   def test_shebang_is_added_to_rails_file
-    run_generator [destination_root, "--ruby", "foo/bar/baz", "--full", "--skip-active-storage"]
+    run_generator [destination_root, "--ruby", "foo/bar/baz", "--full"]
     assert_file "bin/rails", /#!foo\/bar\/baz/
   end
 

--- a/railties/test/generators/test_runner_in_engine_test.rb
+++ b/railties/test/generators/test_runner_in_engine_test.rb
@@ -7,7 +7,7 @@ class TestRunnerInEngineTest < ActiveSupport::TestCase
 
   def setup
     @destination_root = Dir.mktmpdir("bukkits")
-    Dir.chdir(@destination_root) { `bundle exec rails plugin new bukkits --full --skip-bundle --skip-active-storage` }
+    Dir.chdir(@destination_root) { `bundle exec rails plugin new bukkits --full --skip-bundle` }
     plugin_file "test/dummy/db/schema.rb", ""
   end
 


### PR DESCRIPTION
These were added in #30101, after #31084 it became redundant.

/cc @y-yagi 