### PR TITLE
Change output log about skipping instalation of Active Storage

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -464,7 +464,7 @@ module Rails
           if bundle_install?
             rails_command "active_storage:install", capture: options[:quiet]
           else
-            log("Active Storage installation was skipped. Please run 'bin/rails active_storage:install' to install Active Storage files.")
+            log("Active Storage installation was skipped. Please run `bin/rails active_storage:install` to install Active Storage files.")
           end
         end
       end


### PR DESCRIPTION
Using of "`" is preferable over "'" to express console command in output log