### PR TITLE
Use `warn` instead of `$stderr.puts` in bin/yarn

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn
@@ -3,8 +3,8 @@ Dir.chdir(APP_ROOT) do
   begin
     exec "yarnpkg #{ARGV.join(' ')}"
   rescue Errno::ENOENT
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+    warn "Yarn executable was not detected in the system."
+    warn "Download Yarn at https://yarnpkg.com/en/docs/install"
     exit 1
   end
 end


### PR DESCRIPTION
Using `$stderr.puts` triggers the `Style/StderrPuts` [rubocop cop](https://github.com/bbatsov/rubocop/blob/a6b6786ede8cf97447d0cdb9154c4e22d78d6071/lib/rubocop/cop/style/stderr_puts.rb), they have a good reason to recommend using `warn` instead:

"This cop identifies places where `$stderr.puts` can be replaced by `warn`. The latter has the advantage of easily being disabled by, e.g. the -W0 interpreter flag, or setting $VERBOSE to nil."