### PR TITLE
Do not show credentials in generators help

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -218,6 +218,7 @@ module Rails
         rails.delete("app")
         rails.delete("plugin")
         rails.delete("encrypted_secrets")
+        rails.delete("credentials")
 
         hidden_namespaces.each { |n| groups.delete(n.to_s) }
 

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -188,10 +188,11 @@ module ApplicationTests
       Rails::Command.send(:remove_const, "APP_PATH")
     end
 
-    test "help does not show hidden namespaces" do
+    test "help does not show hidden namespaces and hidden commands" do
       FileUtils.cd(rails_root) do
         output = rails("generate", "--help")
         assert_no_match "active_record:migration", output
+        assert_no_match "credentials", output
 
         output = rails("destroy", "--help")
         assert_no_match "active_record:migration", output


### PR DESCRIPTION
Since credentials generator is executed via the credentials command and does not need to be executed directly, so it is not necessary to show it in help.

