### PR TITLE
Fix after_commit on: :create being fired twice if save is called within

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -408,6 +408,8 @@ module ActiveRecord
           destroyed: @destroyed,
           frozen?: frozen?,
         )
+        @_start_transaction_state[:new_record] = @new_record
+        @_start_transaction_state[:destroyed] = @destroyed
         @_start_transaction_state[:level] = (@_start_transaction_state[:level] || 0) + 1
       end
 

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -554,6 +554,37 @@ class TransactionEnrollmentCallbacksTest < ActiveRecord::TestCase
   end
 end
 
+class SaveFromAfterCommitBlockTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  class TopicWithSaveInCallback < ActiveRecord::Base
+    self.table_name = :topics
+    after_commit :cache_topic, on: :create
+    after_commit :call_update, on: :update
+    attr_accessor :cached, :record_updated
+
+    def call_update
+      self.record_updated = true
+    end
+
+    def cache_topic
+      unless cached
+        self.cached = true
+        self.save
+      else
+        self.cached = false
+      end
+    end
+  end
+
+  def test_after_commit_in_save
+    topic = TopicWithSaveInCallback.new
+    topic.save
+    assert_equal true, topic.cached
+    assert_equal true, topic.record_updated
+  end
+end
+
 class CallbacksOnActionAndConditionTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
 


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/31104