### PR TITLE
fixed typo between 'bin/rails' and  'bin/rake'

### DIFF
--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -250,7 +250,7 @@ and migrating the database. First, run:
 
 ```bash
 $ cd test/dummy
-$ bin/rails db:migrate
+$ bin/rake db:migrate
 ```
 
 While you are here, change the Hickwall and Wickwall models so that they know that they are supposed to act


### PR DESCRIPTION
below command does not exists. it would be typo of "bin/rake db:migrate"

```
bin/rails db:migrate
```