### PR TITLE
Bump RuboCop to 0.51.0

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,7 @@
 engines:
   rubocop:
     enabled: true
-    channel: rubocop-0-50
+    channel: rubocop-0-51
 
 ratings:
   paths:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,7 +415,7 @@ GEM
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
     retriable (3.1.1)
-    rubocop (0.50.0)
+    rubocop (0.51.0)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -248,7 +248,7 @@ module ActionController
       def decode_credentials(header)
         ActiveSupport::HashWithIndifferentAccess[header.to_s.gsub(/^Digest\s+/, "").split(",").map do |pair|
           key, value = pair.split("=", 2)
-          [key.strip, value.to_s.gsub(/^"|"$/, "").delete('\'')]
+          [key.strip, value.to_s.gsub(/^"|"$/, "").delete("'")]
         end]
       end
 

--- a/activesupport/test/core_ext/load_error_test.rb
+++ b/activesupport/test/core_ext/load_error_test.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/load_error"
 
 class TestLoadError < ActiveSupport::TestCase
   def test_with_require
-    assert_raise(LoadError) { require 'no_this_file_don\'t_exist' }
+    assert_raise(LoadError) { require "no_this_file_don't_exist" }
   end
   def test_with_load
     assert_raise(LoadError) { load "nor_does_this_one" }


### PR DESCRIPTION
## Summary

RuboCop 0.51.0 was released.
https://github.com/bbatsov/rubocop/releases/tag/v0.51.0

And rubocop-0-51 channel is available in Code Climate.
https://github.com/codeclimate/codeclimate-rubocop/issues/109

This PR will bump RuboCop to 0.51.0 and fixes the following new offenses.

```console
% bundle exec rubocop
Inspecting 2358 files

(snip)

Offenses:

actionpack/lib/action_controller/metal/http_authentication.rb:251:59: C:
Prefer double-quoted strings unless you need single quotes to avoid
extra backslashes for escaping.
          [key.strip, value.to_s.gsub(/^"|"$/, "").delete('\'')]
                                                          ^^^^
activesupport/test/core_ext/load_error_test.rb:8:39: C: Prefer
double-quoted strings unless you need single quotes to avoid extra
backslashes for escaping.
    assert_raise(LoadError) { require 'no_this_file_don\'t_exist' }
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^

2358 files inspected, 2 offenses detected
```
