### PR TITLE
Add missing requires

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/object/duplicable"
+
 module ActiveModel
   class Attribute # :nodoc:
     class << self

--- a/activemodel/test/cases/attribute_set_test.rb
+++ b/activemodel/test/cases/attribute_set_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "active_model/attribute_set"
+require "active_model/type"
 
 module ActiveModel
   class AttributeSetTest < ActiveModel::TestCase


### PR DESCRIPTION
Currently, executing the test with only `attribute_set_test.rb` results in an error.

```
./bin/test -w test/cases/attribute_set_test.rb
Run options: --seed 33470

# Running:

E

Error:
ActiveModel::AttributeSetTest#test_#map_returns_a_new_attribute_set_with_the_changes_applied:
NameError: uninitialized constant ActiveModel::AttributeSetTest::AttributeSet
Did you mean?  ActiveModel::Attributes
               ActiveModel::Attribute
    activemodel/test/cases/attribute_set_test.rb:235:in `block in <class:AttributeSetTest>'

bin/test test/cases/attribute_set_test.rb:234
```

Added a missing require to fix this.

Also, I suspect that this is the cause of failures in CI.
Ref: https://travis-ci.org/rails/rails/jobs/299994708
