### PR TITLE
fix bug on added? method

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -322,9 +322,13 @@ module ActiveModel
     #  person.errors.added? :name, :too_long                                # => false
     #  person.errors.added? :name, "is too long"                            # => false
     def added?(attribute, message = :invalid, options = {})
-      message = message.call if message.respond_to?(:call)
-      message = normalize_message(attribute, message, options)
-      self[attribute].include? message
+      if message.is_a? Symbol
+        self.details[attribute].map { |e| e[:error] }.include? message
+      else
+        message = message.call if message.respond_to?(:call)
+        message = normalize_message(attribute, message, options)
+        self[attribute].include? message
+      end
     end
 
     # Returns all the full error messages in an array.

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -223,6 +223,13 @@ class ErrorsTest < ActiveModel::TestCase
     assert !person.errors.added?(:name)
   end
 
+  test "added? returns false when checking for an error by symbol and a different error with same message is present" do
+    I18n.backend.store_translations("en", errors: { attributes: { name: { wrong: "is wrong", used: "is wrong" } } })
+    person = Person.new
+    person.errors.add(:name, :wrong)
+    assert !person.errors.added?(:name, :used)
+  end
+
   test "size calculates the number of error messages" do
     person = Person.new
     person.errors.add(:name, "cannot be blank")


### PR DESCRIPTION
### Summary

This Pull Requests fixes an issue with the `added?` method of `ActiveModel::Errors`.
When looking for an error by symbol, the method is returning true even if the error is not present. This happens because another error, with a different symbol, but same message, is present.