### PR TITLE
Fix RDoc and Rake URL

### DIFF
--- a/actionview/RUNNING_UNIT_TESTS.rdoc
+++ b/actionview/RUNNING_UNIT_TESTS.rdoc
@@ -4,7 +4,7 @@ The easiest way to run the unit tests is through Rake. The default task runs
 the entire test suite for all classes. For more information, checkout the
 full array of rake tasks with "rake -T"
 
-Rake can be found at http://docs.seattlerb.org/rake/.
+Rake can be found at https://ruby.github.io/rake/.
 
 == Running by hand
 

--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -16,7 +16,7 @@ RDoc
 ----
 
 The [Rails API documentation](http://api.rubyonrails.org) is generated with
-[RDoc](http://docs.seattlerb.org/rdoc/). To generate it, make sure you are
+[RDoc](https://ruby.github.io/rdoc/). To generate it, make sure you are
 in the rails root directory, run `bundle install` and execute:
 
 ```bash
@@ -26,9 +26,9 @@ in the rails root directory, run `bundle install` and execute:
 Resulting HTML files can be found in the ./doc/rdoc directory.
 
 Please consult the RDoc documentation for help with the
-[markup](http://docs.seattlerb.org/rdoc/RDoc/Markup.html),
+[markup](https://ruby.github.io/rdoc/RDoc/Markup.html),
 and also take into account these [additional
-directives](http://docs.seattlerb.org/rdoc/RDoc/Parser/Ruby.html).
+directives](https://ruby.github.io/rdoc/RDoc/Parser/Ruby.html).
 
 Wording
 -------


### PR DESCRIPTION
### Summary

[RDoc URL of Seattle.rb](http://docs.seattlerb.org/rdoc/) is obsoleted, and [RDoc URL of Ruby core](https://ruby.github.io/rdoc/) is available now. So this Pull Request replaces it.

By the same token, replaces [obsoleted Rake URL of Seattle.rb](http://docs.seattlerb.org/rake/) with [new Rake URL of Ruby core](https://ruby.github.io/rake/).