### PR TITLE
Add missing requires

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/object/duplicable"
+require "active_model/type"
 
 module ActiveModel
   class Attribute # :nodoc:


### PR DESCRIPTION
Currently, executing the test with only `attribute_test.rb` results in an error.

```
./bin/test -w test/cases/attribute_test.rb
Run options: --seed 41205

# Running:

....E

Error:
ActiveModel::AttributeTest#test_attributes_do_not_equal_attributes_with_different_types:
NameError: uninitialized constant ActiveModel::AttributeTest::Type
    /home/yaginuma/program/rails/master_y_yagi/rails/activemodel/test/cases/attribute_test.rb:159:in `block in <class:AttributeTest>'

bin/test test/cases/attribute_test.rb:158
```

Added a missing require to fix this.