### PR TITLE
Make AR::Base#association to accept reflection object

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -226,8 +226,9 @@ module ActiveRecord
       Preloader.eager_load!
     end
 
-    # Returns the association instance for the given name, instantiating it if it doesn't already exist
+    # Returns the association instance for the given name or reflection, instantiating it if it doesn't already exist
     def association(name) #:nodoc:
+      name = name.name if name.is_a?(ActiveRecord::Reflection::AbstractReflection)
       association = association_instance_get(name)
 
       if association.nil?

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -99,7 +99,7 @@ module ActiveRecord
       # Set the inverse association, if possible
       def set_inverse_instance(record)
         if invertible_for?(record)
-          inverse = record.association(inverse_reflection_for(record).name)
+          inverse = record.association(inverse_reflection_for(record))
           inverse.target = owner
           inverse.inversed = true
         end
@@ -109,7 +109,7 @@ module ActiveRecord
       # Remove the inverse association, if possible
       def remove_inverse_instance(record)
         if invertible_for?(record)
-          inverse = record.association(inverse_reflection_for(record).name)
+          inverse = record.association(inverse_reflection_for(record))
           inverse.target = nil
           inverse.inversed = false
         end

--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -133,8 +133,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.add_destroy_callbacks(model, reflection)
-      name = reflection.name
-      model.before_destroy lambda { |o| o.association(name).handle_dependency }
+      model.before_destroy lambda { |o| o.association(reflection).handle_dependency }
     end
   end
 end

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -474,7 +474,7 @@ module ActiveRecord
 
         def include_in_memory?(record)
           if reflection.is_a?(ActiveRecord::Reflection::ThroughReflection)
-            assoc = owner.association(reflection.through_reflection.name)
+            assoc = owner.association(reflection.through_reflection)
             assoc.reader.any? { |source|
               target_reflection = source.send(reflection.source_reflection.name)
               target_reflection.respond_to?(:include?) ? target_reflection.include?(record) : target_reflection == record

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -52,7 +52,7 @@ module ActiveRecord
       private
 
         def through_association
-          @through_association ||= owner.association(through_reflection.name)
+          @through_association ||= owner.association(through_reflection)
         end
 
         # The through record (built with build_record) is temporarily cached

--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -16,7 +16,7 @@ module ActiveRecord
         def create_through_record(record)
           ensure_not_nested
 
-          through_proxy  = owner.association(through_reflection.name)
+          through_proxy  = owner.association(through_reflection)
           through_record = through_proxy.load_target
 
           if through_record && !record

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -234,10 +234,10 @@ module ActiveRecord
 
           parent.children.each do |node|
             if node.reflection.collection?
-              other = ar_parent.association(node.reflection.name)
+              other = ar_parent.association(node.reflection)
               other.loaded!
             elsif ar_parent.association_cached?(node.reflection.name)
-              model = ar_parent.association(node.reflection.name).target
+              model = ar_parent.association(node.reflection).target
               construct(model, node, row, rs, seen, model_cache, aliases)
               next
             end
@@ -245,7 +245,7 @@ module ActiveRecord
             key = aliases.column_alias(node, node.primary_key)
             id = row[key]
             if id.nil?
-              nil_association = ar_parent.association(node.reflection.name)
+              nil_association = ar_parent.association(node.reflection)
               nil_association.loaded!
               next
             end
@@ -269,7 +269,7 @@ module ActiveRecord
         end
 
         def construct_model(record, node, row, model_cache, id, aliases)
-          other = record.association(node.reflection.name)
+          other = record.association(node.reflection)
 
           model = model_cache[node][id] ||=
             node.instantiate(row, aliases.column_aliases(node)) do |m|

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -166,7 +166,7 @@ module ActiveRecord
           def run(preloader); end
 
           def preloaded_records
-            owners.flat_map { |owner| owner.association(reflection.name).target }
+            owners.flat_map { |owner| owner.association(reflection).target }
           end
 
           protected
@@ -177,7 +177,7 @@ module ActiveRecord
         # and attach it to a relation. The class returned implements a `run` method
         # that accepts a preloader.
         def preloader_for(reflection, owners)
-          if owners.first.association(reflection.name).loaded?
+          if owners.first.association(reflection).loaded?
             return AlreadyLoaded
           end
           reflection.check_preloadable!

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -18,7 +18,7 @@ module ActiveRecord
         def run(preloader)
           records = load_records do |record|
             owner = owners_by_key[convert_key(record[association_key_name])]
-            association = owner.association(reflection.name)
+            association = owner.association(reflection)
             association.set_inverse_instance(record)
           end
 
@@ -42,7 +42,7 @@ module ActiveRecord
           end
 
           def associate_records_to_owner(owner, records)
-            association = owner.association(reflection.name)
+            association = owner.association(reflection)
             if reflection.collection?
               association.loaded!
               association.target.concat(records)

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     class Preloader
       class ThroughAssociation < Association # :nodoc:
         def run(preloader)
-          already_loaded     = owners.first.association(through_reflection.name).loaded?
+          already_loaded     = owners.first.association(through_reflection).loaded?
           through_scope      = through_scope()
           reflection_scope   = target_reflection_scope
           through_preloaders = preloader.preload(owners, through_reflection.name, through_scope)
@@ -14,7 +14,7 @@ module ActiveRecord
           @preloaded_records = preloaders.flat_map(&:preloaded_records)
 
           owners.each do |owner|
-            through_records = Array(owner.association(through_reflection.name).target)
+            through_records = Array(owner.association(through_reflection).target)
             if already_loaded
               if source_type = reflection.options[:source_type]
                 through_records = through_records.select do |record|
@@ -22,10 +22,10 @@ module ActiveRecord
                 end
               end
             else
-              owner.association(through_reflection.name).reset if through_scope
+              owner.association(through_reflection).reset if through_scope
             end
             result = through_records.flat_map do |record|
-              association = record.association(source_reflection.name)
+              association = record.association(source_reflection)
               target = association.target
               association.reset if preload_scope
               target

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -206,8 +206,8 @@ module ActiveRecord
       end
 
       def each_counter_cached_associations
-        _reflections.each do |name, reflection|
-          yield association(name.to_sym) if reflection.belongs_to? && reflection.counter_cache_column
+        _reflections.each do |_, reflection|
+          yield association(reflection) if reflection.belongs_to? && reflection.counter_cache_column
         end
       end
   end

--- a/activerecord/lib/active_record/touch_later.rb
+++ b/activerecord/lib/active_record/touch_later.rb
@@ -26,8 +26,8 @@ module ActiveRecord
 
       # touch the parents as we are not calling the after_save callbacks
       self.class.reflect_on_all_associations(:belongs_to).each do |r|
-        if touch = r.options[:touch]
-          ActiveRecord::Associations::Builder::BelongsTo.touch_record(self, changes_to_save, r.foreign_key, r.name, touch, :touch_later)
+        if r.options[:touch]
+          ActiveRecord::Associations::Builder::BelongsTo.touch_record(self, changes_to_save, r, :touch_later)
         end
       end
     end


### PR DESCRIPTION
It removes the necessaty to always convert reflection into name
when calling a method internally.

I found it annoying to call `association(reflection.name)` all the time intead of `association(reflection)`.