### PR TITLE
Add StrictInteger type

### DIFF
--- a/activemodel/lib/active_model/type.rb
+++ b/activemodel/lib/active_model/type.rb
@@ -12,6 +12,7 @@ require "active_model/type/decimal"
 require "active_model/type/float"
 require "active_model/type/immutable_string"
 require "active_model/type/integer"
+require "active_model/type/strict_integer"
 require "active_model/type/string"
 require "active_model/type/time"
 
@@ -47,6 +48,7 @@ module ActiveModel
     register(:float, Type::Float)
     register(:immutable_string, Type::ImmutableString)
     register(:integer, Type::Integer)
+    register(:strict_integer, Type::StrictInteger)
     register(:string, Type::String)
     register(:time, Type::Time)
   end

--- a/activemodel/lib/active_model/type/strict_integer.rb
+++ b/activemodel/lib/active_model/type/strict_integer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module Type
+    class StrictInteger < Integer  # :nodoc:
+      private
+
+        def cast_value(value)
+          case value
+          when true then 1
+          when false then 0
+          when /\A[\d\.]+\Z/ then value.to_i
+          else
+            Integer(value) rescue nil
+          end
+        end
+    end
+  end
+end

--- a/activemodel/test/cases/type/strict_integer_test.rb
+++ b/activemodel/test/cases/type/strict_integer_test.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "active_support/core_ext/numeric/time"
+
+module ActiveModel
+  module Type
+    class StrictIntegerTest < ActiveModel::TestCase
+      test "simple values" do
+        type = Type::StrictInteger.new
+        assert_equal 1, type.cast("1")
+        assert_equal 1, type.cast(1)
+        assert_equal 1, type.cast(1.7)
+        assert_equal 0, type.cast(false)
+        assert_equal 1, type.cast(true)
+        assert_nil type.cast(nil)
+      end
+
+      test "random objects cast to nil" do
+        type = Type::StrictInteger.new
+        assert_nil type.cast([1, 2])
+        assert_nil type.cast(1 => 2)
+        assert_nil type.cast(1..2)
+      end
+
+      test "casting objects without to_i" do
+        type = Type::StrictInteger.new
+        assert_nil type.cast(::Object.new)
+      end
+
+      test "casting nan and infinity" do
+        type = Type::StrictInteger.new
+        assert_nil type.cast(::Float::NAN)
+        assert_nil type.cast(1.0 / 0.0)
+      end
+
+      test "casting booleans for database" do
+        type = Type::StrictInteger.new
+        assert_equal 1, type.serialize(true)
+        assert_equal 0, type.serialize(false)
+      end
+
+      test "casting duration" do
+        type = Type::StrictInteger.new
+        assert_equal 1800, type.cast(30.minutes)
+        assert_equal 7200, type.cast(2.hours)
+      end
+
+      test "changed?" do
+        type = Type::StrictInteger.new
+
+        assert type.changed?(5, 5, "5wibble")
+        assert_not type.changed?(5, 5, "5")
+        assert_not type.changed?(5, 5, "5.0")
+        assert_not type.changed?(-5, -5, "-5")
+        assert_not type.changed?(-5, -5, "-5.0")
+        assert_not type.changed?(nil, nil, nil)
+      end
+
+      test "values below int min value are out of range" do
+        assert_raises(ActiveModel::RangeError) do
+          StrictInteger.new.serialize(-2147483649)
+        end
+      end
+
+      test "values above int max value are out of range" do
+        assert_raises(ActiveModel::RangeError) do
+          StrictInteger.new.serialize(2147483648)
+        end
+      end
+
+      test "very small numbers are out of range" do
+        assert_raises(ActiveModel::RangeError) do
+          StrictInteger.new.serialize(-9999999999999999999999999999999)
+        end
+      end
+
+      test "very large numbers are out of range" do
+        assert_raises(ActiveModel::RangeError) do
+          StrictInteger.new.serialize(9999999999999999999999999999999)
+        end
+      end
+
+      test "normal numbers are in range" do
+        type = StrictInteger.new
+        assert_equal(0, type.serialize(0))
+        assert_equal(-1, type.serialize(-1))
+        assert_equal(1, type.serialize(1))
+      end
+
+      test "int max value is in range" do
+        assert_equal(2147483647, StrictInteger.new.serialize(2147483647))
+      end
+
+      test "int min value is in range" do
+        assert_equal(-2147483648, StrictInteger.new.serialize(-2147483648))
+      end
+
+      test "columns with a larger limit have larger ranges" do
+        type = StrictInteger.new(limit: 8)
+
+        assert_equal(9223372036854775807, type.serialize(9223372036854775807))
+        assert_equal(-9223372036854775808, type.serialize(-9223372036854775808))
+        assert_raises(ActiveModel::RangeError) do
+          type.serialize(-9999999999999999999999999999999)
+        end
+        assert_raises(ActiveModel::RangeError) do
+          type.serialize(9999999999999999999999999999999)
+        end
+      end
+
+      test "invalid values" do
+        type = StrictInteger.new
+
+        assert_nil type.cast("1ignore")
+        assert_nil type.cast("bad1")
+        assert_nil type.cast("bad")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

```
= String#to_i

...

This method never raises an exception when base is valid.
```

Use `Integer()` to catch invalid integer values and return nil in the error case.  The behavior of the other casting functions and this function to return `nil` in the case of invalid values.