### PR TITLE
Add missing documentation option to number_to_currency

### DIFF
--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -100,6 +100,9 @@ module ActionView
       #   absolute value of the number.
       # * <tt>:raise</tt> - If true, raises +InvalidNumberError+ when
       #   the argument is invalid.
+      # * <tt>:strip_insignificant_zeros</tt> - If +true+ removes
+      #   insignificant zeros after the decimal separator (defaults to
+      #   +false+).
       #
       # ==== Examples
       #
@@ -117,6 +120,8 @@ module ActionView
       #   # => R$1234567890,50
       #   number_to_currency(1234567890.50, unit: "R$", separator: ",", delimiter: "", format: "%n %u")
       #   # => 1234567890,50 R$
+      #   number_to_currency(1234567890.50, strip_insignificant_zeros: true)
+      #   # => "$1,234,567,890.5"
       def number_to_currency(number, options = {})
         delegate_number_helper_method(:number_to_currency, number, options)
       end

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -85,6 +85,9 @@ module ActiveSupport
     #   number given by <tt>:format</tt>).  Accepts the same fields
     #   than <tt>:format</tt>, except <tt>%n</tt> is here the
     #   absolute value of the number.
+    # * <tt>:strip_insignificant_zeros</tt> - If +true+ removes
+    #   insignificant zeros after the decimal separator (defaults to
+    #   +false+).
     #
     # ==== Examples
     #
@@ -100,6 +103,8 @@ module ActiveSupport
     #   # => "&pound;1234567890,50"
     #   number_to_currency(1234567890.50, unit: '&pound;', separator: ',', delimiter: '', format: '%n %u')
     #   # => "1234567890,50 &pound;"
+    #   number_to_currency(1234567890.50, strip_insignificant_zeros: true)
+    #   # => "$1,234,567,890.5"
     def number_to_currency(number, options = {})
       NumberToCurrencyConverter.convert(number, options)
     end


### PR DESCRIPTION
This PR is for mentioning the `strip_insignificant_zeros` option to `#number_to_currency` methods in the API Documentation.