### PR TITLE
Load environment fle in db tasks

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -4,16 +4,16 @@ require "active_record"
 
 db_namespace = namespace :db do
   desc "Set the environment value for the database"
-  task "environment:set" => [:environment, :load_config] do
+  task "environment:set" => :load_config do
     ActiveRecord::InternalMetadata.create_table
     ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Migrator.current_environment
   end
 
-  task check_protected_environments: [:environment, :load_config] do
+  task check_protected_environments: :load_config do
     ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!
   end
 
-  task :load_config do
+  task load_config: :environment do
     ActiveRecord::Base.configurations       = ActiveRecord::Tasks::DatabaseTasks.database_configuration || {}
     ActiveRecord::Migrator.migrations_paths = ActiveRecord::Tasks::DatabaseTasks.migrations_paths
   end
@@ -56,7 +56,7 @@ db_namespace = namespace :db do
   end
 
   desc "Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)."
-  task migrate: [:environment, :load_config] do
+  task migrate: :load_config do
     ActiveRecord::Tasks::DatabaseTasks.migrate
     db_namespace["_dump"].invoke
   end
@@ -78,7 +78,7 @@ db_namespace = namespace :db do
 
   namespace :migrate do
     # desc  'Rollbacks the database one migration and re migrate up (options: STEP=x, VERSION=x).'
-    task redo: [:environment, :load_config] do
+    task redo: :load_config do
       raise "Empty VERSION provided" if ENV["VERSION"] && ENV["VERSION"].empty?
 
       if ENV["VERSION"]
@@ -94,7 +94,7 @@ db_namespace = namespace :db do
     task reset: ["db:drop", "db:create", "db:migrate"]
 
     # desc 'Runs the "up" for a given migration VERSION.'
-    task up: [:environment, :load_config] do
+    task up: :load_config do
       raise "VERSION is required" if !ENV["VERSION"] || ENV["VERSION"].empty?
 
       ActiveRecord::Tasks::DatabaseTasks.check_target_version
@@ -108,7 +108,7 @@ db_namespace = namespace :db do
     end
 
     # desc 'Runs the "down" for a given migration VERSION.'
-    task down: [:environment, :load_config] do
+    task down: :load_config do
       raise "VERSION is required - To go down one migration, use db:rollback" if !ENV["VERSION"] || ENV["VERSION"].empty?
 
       ActiveRecord::Tasks::DatabaseTasks.check_target_version
@@ -122,7 +122,7 @@ db_namespace = namespace :db do
     end
 
     desc "Display status of migrations"
-    task status: [:environment, :load_config] do
+    task status: :load_config do
       unless ActiveRecord::SchemaMigration.table_exists?
         abort "Schema migrations table does not exist yet."
       end
@@ -140,14 +140,14 @@ db_namespace = namespace :db do
   end
 
   desc "Rolls the schema back to the previous version (specify steps w/ STEP=n)."
-  task rollback: [:environment, :load_config] do
+  task rollback: :load_config do
     step = ENV["STEP"] ? ENV["STEP"].to_i : 1
     ActiveRecord::Migrator.rollback(ActiveRecord::Tasks::DatabaseTasks.migrations_paths, step)
     db_namespace["_dump"].invoke
   end
 
   # desc 'Pushes the schema to the next version (specify steps w/ STEP=n).'
-  task forward: [:environment, :load_config] do
+  task forward: :load_config do
     step = ENV["STEP"] ? ENV["STEP"].to_i : 1
     ActiveRecord::Migrator.forward(ActiveRecord::Tasks::DatabaseTasks.migrations_paths, step)
     db_namespace["_dump"].invoke
@@ -157,12 +157,12 @@ db_namespace = namespace :db do
   task reset: [ "db:drop", "db:setup" ]
 
   # desc "Retrieves the charset for the current environment's database"
-  task charset: [:environment, :load_config] do
+  task charset: :load_config do
     puts ActiveRecord::Tasks::DatabaseTasks.charset_current
   end
 
   # desc "Retrieves the collation for the current environment's database"
-  task collation: [:environment, :load_config] do
+  task collation: :load_config do
     begin
       puts ActiveRecord::Tasks::DatabaseTasks.collation_current
     rescue NoMethodError
@@ -171,12 +171,12 @@ db_namespace = namespace :db do
   end
 
   desc "Retrieves the current schema version number"
-  task version: [:environment, :load_config] do
+  task version: :load_config do
     puts "Current version: #{ActiveRecord::Migrator.current_version}"
   end
 
   # desc "Raises an error if there are pending migrations"
-  task abort_if_pending_migrations: [:environment, :load_config] do
+  task abort_if_pending_migrations: :load_config do
     pending_migrations = ActiveRecord::Migrator.open(ActiveRecord::Tasks::DatabaseTasks.migrations_paths).pending_migrations
 
     if pending_migrations.any?
@@ -199,7 +199,7 @@ db_namespace = namespace :db do
 
   namespace :fixtures do
     desc "Loads fixtures into the current environment's database. Load specific fixtures using FIXTURES=x,y. Load from subdirectory in test/fixtures using FIXTURES_DIR=z. Specify an alternative path (eg. spec/fixtures) using FIXTURES_PATH=spec/fixtures."
-    task load: [:environment, :load_config] do
+    task load: :load_config do
       require "active_record/fixtures"
 
       base_dir = ActiveRecord::Tasks::DatabaseTasks.fixtures_path
@@ -221,7 +221,7 @@ db_namespace = namespace :db do
     end
 
     # desc "Search for a fixture given a LABEL or ID. Specify an alternative path (eg. spec/fixtures) using FIXTURES_PATH=spec/fixtures."
-    task identify: [:environment, :load_config] do
+    task identify: :load_config do
       require "active_record/fixtures"
 
       label, id = ENV["LABEL"], ENV["ID"]
@@ -247,7 +247,7 @@ db_namespace = namespace :db do
 
   namespace :schema do
     desc "Creates a db/schema.rb file that is portable against any DB supported by Active Record"
-    task dump: [:environment, :load_config] do
+    task dump: :load_config do
       require "active_record/schema_dumper"
       filename = ENV["SCHEMA"] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "schema.rb")
       File.open(filename, "w:utf-8") do |file|
@@ -257,7 +257,7 @@ db_namespace = namespace :db do
     end
 
     desc "Loads a schema.rb file into the database"
-    task load: [:environment, :load_config, :check_protected_environments] do
+    task load: [:load_config, :check_protected_environments] do
       ActiveRecord::Tasks::DatabaseTasks.load_schema_current(:ruby, ENV["SCHEMA"])
     end
 
@@ -267,14 +267,14 @@ db_namespace = namespace :db do
 
     namespace :cache do
       desc "Creates a db/schema_cache.yml file."
-      task dump: [:environment, :load_config] do
+      task dump: :load_config do
         conn = ActiveRecord::Base.connection
         filename = File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "schema_cache.yml")
         ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(conn, filename)
       end
 
       desc "Clears a db/schema_cache.yml file."
-      task clear: [:environment, :load_config] do
+      task clear: :load_config do
         filename = File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "schema_cache.yml")
         rm_f filename, verbose: false
       end
@@ -284,7 +284,7 @@ db_namespace = namespace :db do
 
   namespace :structure do
     desc "Dumps the database structure to db/structure.sql. Specify another file with SCHEMA=db/my_structure.sql"
-    task dump: [:environment, :load_config] do
+    task dump: :load_config do
       filename = ENV["SCHEMA"] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, "structure.sql")
       current_config = ActiveRecord::Tasks::DatabaseTasks.current_config
       ActiveRecord::Tasks::DatabaseTasks.structure_dump(current_config, filename)
@@ -299,7 +299,7 @@ db_namespace = namespace :db do
     end
 
     desc "Recreates the databases from the structure.sql file"
-    task load: [:environment, :load_config, :check_protected_environments] do
+    task load: [:load_config, :check_protected_environments] do
       ActiveRecord::Tasks::DatabaseTasks.load_schema_current(:sql, ENV["SCHEMA"])
     end
 
@@ -338,12 +338,12 @@ db_namespace = namespace :db do
     end
 
     # desc "Empty the test database"
-    task purge: %w(environment load_config check_protected_environments) do
+    task purge: %w(load_config check_protected_environments) do
       ActiveRecord::Tasks::DatabaseTasks.purge ActiveRecord::Base.configurations["test"]
     end
 
     # desc 'Load the test schema'
-    task prepare: %w(environment load_config) do
+    task prepare: :load_config do
       unless ActiveRecord::Base.configurations.blank?
         db_namespace["test:load"].invoke
       end


### PR DESCRIPTION
Currently the environment is not loaded in some db tasks.
Therefore, if use encrypted secrets values in `database.yml`, `read_encrypted_secrets` will not be true, so the value can not be used correctly.

To fix this, added `environment` task to the dependent task.
Fixes #30717