### PR TITLE
Action Cable: run Redis tests against a default config without a password

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 
 services:
   - memcached
+  - redis-server
 
 addons:
   postgresql: "9.6"
@@ -41,7 +42,6 @@ before_script:
   # Decodes to e.g. `export VARIABLE=VALUE`
   - $(base64 --decode <<< "ZXhwb3J0IFNBVUNFX0FDQ0VTU19LRVk9YTAzNTM0M2YtZTkyMi00MGIzLWFhM2MtMDZiM2VhNjM1YzQ4")
   - $(base64 --decode <<< "ZXhwb3J0IFNBVUNFX1VTRVJOQU1FPXJ1YnlvbnJhaWxz")
-  - redis-server --bind 127.0.0.1 --port 6379 --requirepass 'password' --daemonize yes
 
 script: 'ci/travis.rb'
 

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -4,12 +4,15 @@ require "test_helper"
 require_relative "common"
 require_relative "channel_prefix"
 
+require "active_support/testing/method_call_assertions"
+require "action_cable/subscription_adapter/redis"
+
 class RedisAdapterTest < ActionCable::TestCase
   include CommonSubscriptionAdapterTest
   include ChannelPrefixTest
 
   def cable_config
-    { adapter: "redis", driver: "ruby", url: "redis://:password@127.0.0.1:6379/12" }
+    { adapter: "redis", driver: "ruby" }
   end
 end
 
@@ -23,6 +26,22 @@ class RedisAdapterTest::AlternateConfiguration < RedisAdapterTest
   def cable_config
     alt_cable_config = super.dup
     alt_cable_config.delete(:url)
-    alt_cable_config.merge(host: "127.0.0.1", port: 6379, db: 12, password: "password")
+    alt_cable_config.merge(host: "127.0.0.1", port: 6379, db: 12)
+  end
+end
+
+class RedisAdapterTest::Connector < ActiveSupport::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+
+  test "slices url, host, port, db, and password from config" do
+    config = { url: 1, host: 2, port: 3, db: 4, password: 5 }
+
+    assert_called_with ::Redis, :new, [ config ] do
+      connect config.merge(other: "unrelated", stuff: "here")
+    end
+  end
+
+  def connect(config)
+    ActionCable::SubscriptionAdapter::Redis.redis_connector.call(config)
   end
 end


### PR DESCRIPTION
Simplify our dev testing and CI story since we're also testing against Redis for the Active Support cache store.

Directly test whether db, host, password, etc are passed through as config instead of spinning up a Redis server with a password set on it.

References #31134 