### PR TITLE
Make sidekiq and resque integration tests work in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,21 +73,25 @@ matrix:
       env: "GEM=aj:integration"
       services:
         - memcached
+        - redis-server
         - rabbitmq
     - rvm: 2.3.5
       env: "GEM=aj:integration"
       services:
         - memcached
+        - redis-server
         - rabbitmq
     - rvm: 2.4.2
       env: "GEM=aj:integration"
       services:
         - memcached
+        - redis-server
         - rabbitmq
     - rvm: ruby-head
       env: "GEM=aj:integration"
       services:
         - memcached
+        - redis-server
         - rabbitmq
     - rvm: 2.3.5
       env:

--- a/activejob/test/support/integration/adapters/resque.rb
+++ b/activejob/test/support/integration/adapters/resque.rb
@@ -7,7 +7,8 @@ module ResqueJobsManager
     Resque.logger = Rails.logger
     unless can_run?
       puts "Cannot run integration tests for resque. To be able to run integration tests for resque you need to install and start redis.\n"
-      exit
+      status = ENV["CI"] ? false : true
+      exit status
     end
   end
 

--- a/activejob/test/support/integration/adapters/resque.rb
+++ b/activejob/test/support/integration/adapters/resque.rb
@@ -3,7 +3,7 @@
 module ResqueJobsManager
   def setup
     ActiveJob::Base.queue_adapter = :resque
-    Resque.redis = Redis::Namespace.new "active_jobs_int_test", redis: Redis.new(url: "redis://:password@127.0.0.1:6379/12", thread_safe: true)
+    Resque.redis = Redis::Namespace.new "active_jobs_int_test", redis: Redis.new(url: "redis://127.0.0.1:6379/12", thread_safe: true)
     Resque.logger = Rails.logger
     unless can_run?
       puts "Cannot run integration tests for resque. To be able to run integration tests for resque you need to install and start redis.\n"

--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -5,14 +5,6 @@ require "sidekiq/api"
 require "sidekiq/testing"
 Sidekiq::Testing.disable!
 
-Sidekiq.configure_server do |config|
-  config.redis = { url: "redis://:password@127.0.0.1:6379/12" }
-end
-
-Sidekiq.configure_client do |config|
-  config.redis = { url: "redis://:password@127.0.0.1:6379/12" }
-end
-
 module SidekiqJobsManager
   def setup
     ActiveJob::Base.queue_adapter = :sidekiq

--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -18,7 +18,8 @@ module SidekiqJobsManager
     ActiveJob::Base.queue_adapter = :sidekiq
     unless can_run?
       puts "Cannot run integration tests for sidekiq. To be able to run integration tests for sidekiq you need to install and start redis.\n"
-      exit
+      status = ENV["CI"] ? false : true
+      exit status
     end
   end
 


### PR DESCRIPTION
Since 8f2490b, the integration test of sidekiq and resque is not working
in CI.
https://travis-ci.org/rails/rails/jobs/301276197#L2055
https://travis-ci.org/rails/rails/jobs/301276197#L2061

Because 8f2490b removed password from `redis-server`. So must also remove passwords from these tests.
Together, return non zero code so as to notice it immediately when it could not connect to redis.