### PR TITLE
Move touch method from Skipping Callbacks section to Running Callback…

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -213,6 +213,7 @@ The following methods trigger callbacks:
 * `save!`
 * `save(validate: false)`
 * `toggle!`
+* `touch`
 * `update_attribute`
 * `update`
 * `update!`
@@ -245,7 +246,6 @@ Just as with validations, it is also possible to skip callbacks by using the fol
 * `increment`
 * `increment_counter`
 * `toggle`
-* `touch`
 * `update_column`
 * `update_columns`
 * `update_all`


### PR DESCRIPTION
…s section [ci skip]

### Summary

On calling `touch` method `after_touch`, `after_commit` and `after_rollback` callbacks are executed.
Example provided in the [gist](https://gist.github.com/avneetmalhotra/4e2bc4fdcb0270202a2eef614cbc1440
)
So moving the method from Skipping callbacks section to Running callbacks section in Rails Guides.