### PR TITLE
Record timezone in use when writing an attribute

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Record timezone in use when writing an attribute
+
+    With the switch to casting on read rather than on write any
+    attributes that are set inside of a `Time.use_zone` block don't
+    reflect that timezone. Fix by recording the timezone in effect
+    when the attribute is set and then using that timezone when type
+    casting the attribute for reading.
+
+    Fixes #28877.
+
+    *Andrew White*
+
 *   Execute `ConfirmationValidator` validation when `_confirmation`'s value is `false`.
 
     *bogdanvlviv*

--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -9,8 +9,8 @@ module ActiveModel
         FromDatabase.new(name, value, type)
       end
 
-      def from_user(name, value, type, original_attribute = nil)
-        FromUser.new(name, value, type, original_attribute)
+      def from_user(name, value, type, original_attribute = nil, time_zone = nil)
+        FromUser.new(name, value, type, original_attribute, time_zone)
       end
 
       def with_cast_value(name, value, type)
@@ -26,15 +26,16 @@ module ActiveModel
       end
     end
 
-    attr_reader :name, :value_before_type_cast, :type
+    attr_reader :name, :value_before_type_cast, :type, :time_zone
 
     # This method should not be called directly.
     # Use #from_database or #from_user
-    def initialize(name, value_before_type_cast, type, original_attribute = nil)
+    def initialize(name, value_before_type_cast, type, original_attribute = nil, time_zone = nil)
       @name = name
       @value_before_type_cast = value_before_type_cast
       @type = type
       @original_attribute = original_attribute
+      @time_zone = time_zone
     end
 
     def value
@@ -69,7 +70,7 @@ module ActiveModel
 
     def with_value_from_user(value)
       type.assert_valid_value(value)
-      self.class.from_user(name, value, type, original_attribute || self)
+      self.class.from_user(name, value, type, original_attribute || self, Time.zone)
     end
 
     def with_value_from_database(value)
@@ -172,7 +173,7 @@ module ActiveModel
 
       class FromUser < Attribute # :nodoc:
         def type_cast(value)
-          type.cast(value)
+          Time.use_zone(time_zone) { type.cast(value) }
         end
 
         def came_from_user?

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -741,6 +741,25 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     end
   end
 
+  test "setting a time zone-aware time in one time zone and then reading in another" do
+    in_time_zone "Pacific Time (US & Canada)" do
+      record = @target.new
+      time   = Time.utc(2017, 11, 11, 0, 0, 0)
+      zone   = ActiveSupport::TimeZone["Sydney"]
+
+      Time.use_zone(zone) { record.written_on = "2017-11-11 11:00:00" }
+
+      assert_equal time, record.written_on
+      assert_equal zone, record.written_on.time_zone
+
+      record.save
+      record.reload
+
+      assert_equal time, record.written_on
+      assert_equal Time.zone, record.written_on.time_zone
+    end
+  end
+
   test "removing time zone-aware types" do
     with_time_zone_aware_types(:datetime) do
       in_time_zone "Pacific Time (US & Canada)" do


### PR DESCRIPTION
With the switch to casting on read rather than on write any attributes that are set inside of a `Time.use_zone` block don't reflect that timezone. Fix by recording the timezone in effect when the attribute is set and then using that timezone when type casting the attribute for reading.

Fixes #28877.