### PR TITLE
Sort mailer previews alphabetically

### DIFF
--- a/actionmailer/lib/action_mailer/preview.rb
+++ b/actionmailer/lib/action_mailer/preview.rb
@@ -104,7 +104,7 @@ module ActionMailer
       private
         def load_previews
           if preview_path
-            Dir["#{preview_path}/**/*_preview.rb"].each { |file| require_dependency file }
+            Dir["#{preview_path}/**/*_preview.rb"].sort.each { |file| require_dependency file }
           end
         end
 


### PR DESCRIPTION
### Summary

This fixes an issue where the index page of mailer previews was not sorted in any meaningful way. It appears as though the methods underneath each mailer are sorted alphabetically but the mailers themselves are not.

Now all the mailers will be ordered alphabetically along with their methods which is more predictable and expected.

### Other Information

Here's a screenshot from my preview index as-is, where you can see the mailers are not in any obvious order.

![image](https://user-images.githubusercontent.com/1100408/32754561-4b157ab6-c925-11e7-95c9-1945e21a2066.png)

