### PR TITLE
Cache: Enable compression by default for values > 1kB

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -36,6 +36,18 @@
 
     *Jeremy Daer*
 
+*   Cache: Enable compression by default for values > 1kB.
+
+    Compression has long been available, but opt-in and at a 16kB threshold.
+    It wasn't enabled by default due to CPU cost. Today it's cheap and typical
+    cache data is eminently compressible, such as HTML or JSON fragments.
+    Compression dramatically reduces Memcached/Redis mem usage, which means
+    the same cache servers can store more data, which means higher hit rates.
+
+    To disable compression, pass `compress: false` to the initializer.
+
+    *Jeremy Daer*
+
 *   Allow `Range#include?` on TWZ ranges
 
     In #11474 we prevented TWZ ranges being iterated over which matched

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -154,12 +154,11 @@ module ActiveSupport
     #   cache.namespace = -> { @last_mod_time }  # Set the namespace to a variable
     #   @last_mod_time = Time.now  # Invalidate the entire cache by changing namespace
     #
-    # Caches can also store values in a compressed format to save space and
-    # reduce time spent sending data. Since there is overhead, values must be
-    # large enough to warrant compression. To turn on compression either pass
-    # <tt>compress: true</tt> in the initializer or as an option to +fetch+
-    # or +write+. To specify the threshold at which to compress values, set the
-    # <tt>:compress_threshold</tt> option. The default threshold is 16K.
+    # Cached data larger than 1kB are compressed by default. To turn off
+    # compression, pass <tt>compress: false</tt> to the initializer or to
+    # individual +fetch+ or +write+ method calls. The 1kB compression
+    # threshold is configurable with the <tt>:compress_threshold</tt> option,
+    # specified in bytes.
     class Store
       cattr_accessor :logger, instance_writer: true
 
@@ -218,8 +217,7 @@ module ActiveSupport
       # ask whether you should force a cache write. Otherwise, it's clearer to
       # just call <tt>Cache#write</tt>.
       #
-      # Setting <tt>:compress</tt> will store a large cache entry set by the call
-      # in a compressed format.
+      # Setting <tt>compress: false</tt> disables compression of the cache entry.
       #
       # Setting <tt>:expires_in</tt> will set an expiration time on the cache.
       # All caches support auto-expiring content after a specified number of
@@ -664,7 +662,7 @@ module ActiveSupport
     class Entry # :nodoc:
       attr_reader :version
 
-      DEFAULT_COMPRESS_LIMIT = 16.kilobytes
+      DEFAULT_COMPRESS_LIMIT = 1.kilobyte
 
       # Creates a new cache entry for the specified value. Options supported are
       # +:compress+, +:compress_threshold+, and +:expires_in+.
@@ -739,8 +737,8 @@ module ActiveSupport
 
       private
         def should_compress?(value, options)
-          if value && options[:compress]
-            compress_threshold = options[:compress_threshold] || DEFAULT_COMPRESS_LIMIT
+          if value && options.fetch(:compress, true)
+            compress_threshold = options.fetch(:compress_threshold, DEFAULT_COMPRESS_LIMIT)
             serialized_value_size = (value.is_a?(String) ? value : Marshal.dump(value)).bytesize
 
             return true if serialized_value_size >= compress_threshold

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -146,6 +146,16 @@ module CacheStoreBehavior
     assert_nil @cache.read("foo")
   end
 
+  def test_read_and_write_uncompressed_small_data
+    @cache.write("foo", "bar", compress: false)
+    assert_equal "bar", @cache.read("foo")
+  end
+
+  def test_read_and_write_uncompressed_nil
+    @cache.write("foo", nil, compress: false)
+    assert_nil @cache.read("foo")
+  end
+
   def test_cache_key
     obj = Object.new
     def obj.cache_key

--- a/activesupport/test/cache/cache_entry_test.rb
+++ b/activesupport/test/cache/cache_entry_test.rb
@@ -14,16 +14,23 @@ class CacheEntryTest < ActiveSupport::TestCase
     end
   end
 
-  def test_compress_values
+  def test_compressed_values
     value = "value" * 100
     entry = ActiveSupport::Cache::Entry.new(value, compress: true, compress_threshold: 1)
     assert_equal value, entry.value
     assert(value.bytesize > entry.size, "value is compressed")
   end
 
-  def test_non_compress_values
+  def test_compressed_by_default
     value = "value" * 100
-    entry = ActiveSupport::Cache::Entry.new(value)
+    entry = ActiveSupport::Cache::Entry.new(value, compress_threshold: 1)
+    assert_equal value, entry.value
+    assert(value.bytesize > entry.size, "value is compressed")
+  end
+
+  def test_uncompressed_values
+    value = "value" * 100
+    entry = ActiveSupport::Cache::Entry.new(value, compress: false)
     assert_equal value, entry.value
     assert_equal value.bytesize, entry.size
   end

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -366,9 +366,9 @@ There are some common options used by all cache implementations. These can be pa
 
 * `:namespace` - This option can be used to create a namespace within the cache store. It is especially useful if your application shares a cache with other applications.
 
-* `:compress` - This option can be used to indicate that compression should be used in the cache. This can be useful for transferring large cache entries over a slow network.
+* `:compress` - Enabled by default. Compresses cache entries so more data can be stored in the same memory footprint, leading to fewer cache evictions and higher hit rates.
 
-* `:compress_threshold` - This option is used in conjunction with the `:compress` option to indicate a threshold under which cache entries should not be compressed. This defaults to 16 kilobytes.
+* `:compress_threshold` - Defaults to 1kB. Cache entries larger than this threshold, specified in bytes, are compressed.
 
 * `:expires_in` - This option sets an expiration time in seconds for the cache entry when it will be automatically removed from the cache.
 


### PR DESCRIPTION
Compression has long been available, but opt-in and at a 16kB threshold.
It wasn't enabled by default due to CPU cost. Today it's cheap and
typical cache data is eminently compressible, such as HTML or JSON
fragments.

Compression dramatically reduces Memcached/Redis mem usage, which means
the same cache servers can store more data, which means higher hit
rates.

To disable compression, pass `compress: false` to the initializer.