### PR TITLE
CI against JRuby 9.1.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,17 +106,17 @@ matrix:
         - "GEM=ar:postgresql POSTGRES=9.2"
       addons:
         postgresql: "9.2"
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.14.0
       jdk: oraclejdk8
       env:
         - "GEM=ap"
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.14.0
       jdk: oraclejdk8
       env:
         - "GEM=am,amo,aj"
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.14.0
     - env: "GEM=ac:integration"
   fast_finish: true
 


### PR DESCRIPTION
JRuby 9.1.14.0 has been released and this version is available on Travis CI.
http://jruby.org/2017/11/08/jruby-9-1-14-0
