### PR TITLE
Fix polymorphic association class load fails.

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     # = Active Record Belongs To Polymorphic Association
     class BelongsToPolymorphicAssociation < BelongsToAssociation #:nodoc:
       def klass
-        type = owner[reflection.foreign_type]
+        type = owner.read_attribute_before_type_cast(reflection.foreign_type)
         type.presence && type.constantize
       end
 
@@ -35,7 +35,7 @@ module ActiveRecord
 
         def stale_state
           foreign_key = super
-          foreign_key && [foreign_key.to_s, owner[reflection.foreign_type].to_s]
+          foreign_key && [foreign_key.to_s, owner.read_attribute_before_type_cast(reflection.foreign_type).to_s]
         end
     end
   end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -386,6 +386,21 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal Member, sponsor.association(:sponsorable).send(:klass)
   end
 
+  def test_polymorphic_association_class_with_enum
+    sponsor = SponsorWithEnum.new
+    assert_nil sponsor.association(:sponsorable).send(:klass)
+    sponsor.association(:sponsorable).reload
+    assert_nil sponsor.sponsorable
+
+    sponsor.sponsorable_type = "" # the column doesn't have to be declared NOT NULL
+    assert_nil sponsor.association(:sponsorable).send(:klass)
+    sponsor.association(:sponsorable).reload
+    assert_nil sponsor.sponsorable
+
+    sponsor.sponsorable = Member.new name: "Bert"
+    assert_equal Member, sponsor.association(:sponsorable).send(:klass)
+  end
+
   def test_with_polymorphic_and_condition
     sponsor = Sponsor.create
     member = Member.create name: "Bert"

--- a/activerecord/test/models/sponsor.rb
+++ b/activerecord/test/models/sponsor.rb
@@ -7,3 +7,8 @@ class Sponsor < ActiveRecord::Base
   belongs_to :sponsorable_with_conditions, -> { where name: "Ernie" }, polymorphic: true,
              foreign_type: "sponsorable_type", foreign_key: "sponsorable_id"
 end
+
+class SponsorWithEnum < Sponsor
+  self.table_name = :sponsors
+  enum sponsorable_type: { member: "Member" }
+end


### PR DESCRIPTION
If we use enum to the type column of polymorphic association, to access association is failed.
```ruby
require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end

  create_table :comments, force: true do |t|
    t.integer :target_id
    t.string :target_type
  end
end

class Post < ActiveRecord::Base
end

class Comment < ActiveRecord::Base
  belongs_to :target, polymorphic: true

  enum target_type: { post: "Post" }
end

class BugTest < Minitest::Test
  def test_polymorphic_association_with_enum
    post = Post.create!
    comment = Comment.new
    comment.target = post
    comment.save

    comment.reload

    assert_equal post, comment.target
  end
end
```

`NameError: wrong constant name post` occured.

Because ActiveRecord uses `[]` method to get class name of polymorphic association.
`[]` method is affected by enum.
```ruby
post = Post.create!
comment = Comment.new
comment.target = post
comment[:target_type] #=> "post"
```