### PR TITLE
Allow test_ignored_columns_not_included_in_SELECT column names case insensitive

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1489,7 +1489,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   test "ignored columns not included in SELECT" do
-    query = Developer.all.to_sql
+    query = Developer.all.to_sql.downcase
 
     # ignored column
     refute query.include?("first_name")


### PR DESCRIPTION
### Summary

Allow test_ignored_columns_not_included_in_SELECT column names case insensitive

i.e. Oracle database identifier is UPPERCASE, unlike other databases.

```ruby
(byebug) query = Developer.all.to_sql
"SELECT \"DEVELOPERS\".\"ID\", \"DEVELOPERS\".\"NAME\", \"DEVELOPERS\".\"SALARY\", \"DEVELOPERS\".\"FIRM_ID\", \"DEVELOPERS\".\"MENTOR_ID\", \"DEVELOPERS\".\"CREATED_AT\", \"DEVELOPERS\".\"UPDATED_AT\", \"DEVELOPERS\".\"CREATED_ON\", \"DEVELOPERS\".\"UPDATED_ON\" FROM \"DEVELOPERS\""
```

This pull request addresses the following failure when tested with Oracle enhanced adapter.

```ruby
$ ARCONN=oracle bin/test test/cases/base_test.rb:1498
Using oracle
Run options: --seed 17490

# Running:

F

Finished in 29.406294s, 0.0340 runs/s, 0.0680 assertions/s.

  1) Failure:
BasicsTest#test_ignored_columns_not_included_in_SELECT [/home/yahonda/git/rails/activerecord/test/cases/base_test.rb:1498]:
Expected false to be truthy.

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
$
```

This test has been introduced at #30980