### PR TITLE
Add master key to `gitignore` on `rails new`

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -162,7 +162,9 @@ module Rails
       return if options[:pretend] || options[:dummy_app]
 
       require "rails/generators/rails/master_key/master_key_generator"
-      Rails::Generators::MasterKeyGenerator.new([], quiet: options[:quiet]).add_master_key_file_silently
+      master_key_generator = Rails::Generators::MasterKeyGenerator.new([], quiet: options[:quiet])
+      master_key_generator.add_master_key_file_silently
+      master_key_generator.ignore_master_key_file_silently
     end
 
     def credentials

--- a/railties/lib/rails/generators/rails/encryption_key_file/encryption_key_file_generator.rb
+++ b/railties/lib/rails/generators/rails/encryption_key_file/encryption_key_file_generator.rb
@@ -44,6 +44,10 @@ module Rails
         end
       end
 
+      def ignore_key_file_silently(key_path, ignore: key_ignore(key_path))
+        append_to_file ".gitignore", ignore if File.exist?(".gitignore")
+      end
+
       private
         def key_ignore(key_path)
           [ "", "/#{key_path}", "" ].join("\n")

--- a/railties/lib/rails/generators/rails/master_key/master_key_generator.rb
+++ b/railties/lib/rails/generators/rails/master_key/master_key_generator.rb
@@ -34,6 +34,10 @@ module Rails
         key_file_generator.ignore_key_file(MASTER_KEY_PATH, ignore: key_ignore)
       end
 
+      def ignore_master_key_file_silently
+        key_file_generator.ignore_key_file_silently(MASTER_KEY_PATH, ignore: key_ignore)
+      end
+
       private
         def key_file_generator
           EncryptionKeyFileGenerator.new

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -838,6 +838,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_equal 5, @sequence_step
   end
 
+  def test_gitignore
+    run_generator
+
+    assert_file ".gitignore" do |content|
+      assert_match(/config\/master\.key/, content)
+    end
+  end
+
   def test_system_tests_directory_generated
     run_generator
 


### PR DESCRIPTION
We generate master key on `rails new`.
Therefore, if do not add master key to `.gitginore` on `rails new`as well, there is a possibility that the master key will be committed accidentally.
