### PR TITLE
allow setting custom headers for action dispatch force ssl redirects

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add ability to configure custom headers in `ActionDispatch::SSL` redirects
+
+    *Lachlan Sylvester*
+
 *   Changed the system tests to set Puma as default server only when the
     user haven't specified manually another server.
 
@@ -38,7 +42,6 @@
 ## Rails 5.2.0.beta2 (November 28, 2017) ##
 
 *   No changes.
-
 
 ## Rails 5.2.0.beta1 (November 27, 2017) ##
 

--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -15,6 +15,10 @@ module ActionDispatch
   #
   #      config.ssl_options = { redirect: { exclude: -> request { request.path =~ /healthcheck/ } } }
   #
+  #    Custom headers can be added to the redirect responses with +headers+:
+  #
+  #      config.ssl_options = { redirect: { headers: {"Vary" => "X-Forwarded-Proto"} } }
+  #
   # 2. <b>Secure cookies</b>: Sets the +secure+ flag on cookies to tell browsers they
   #    must not be sent along with +http://+ requests. Enabled by default. Set
   #    +config.ssl_options+ with <tt>secure_cookies: false</tt> to disable this feature.
@@ -123,8 +127,8 @@ module ActionDispatch
 
       def redirect_to_https(request)
         [ @redirect.fetch(:status, redirection_status(request)),
-          { "Content-Type" => "text/html",
-            "Location" => https_location_for(request) },
+          @redirect.fetch(:headers, {}).reverse_merge("Content-Type" => "text/html",
+            "Location" => https_location_for(request)),
           @redirect.fetch(:body, []) ]
       end
 

--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -21,7 +21,7 @@ class RedirectSSLTest < SSLTest
   end
 
   def assert_redirected(redirect: {}, from: "http://a/b?c=d", to: from.sub("http", "https"))
-    redirect = { status: 301, body: [] }.merge(redirect)
+    redirect = { status: 301, body: [], headers: {} }.merge(redirect)
 
     self.app = build_app ssl_options: { redirect: redirect }
 
@@ -29,6 +29,7 @@ class RedirectSSLTest < SSLTest
     assert_response redirect[:status] || 301
     assert_redirected_to to
     assert_equal redirect[:body].join, @response.body
+    assert_equal response.headers.slice(*redirect[:headers].keys), redirect[:headers]
   end
 
   def assert_post_redirected(redirect: {}, from: "http://a/b?c=d",
@@ -94,6 +95,10 @@ class RedirectSSLTest < SSLTest
 
   test "no redirect with redirect set to false" do
     assert_not_redirected "http://example.org", redirect: false
+  end
+
+  test "custom header on redirect" do
+    assert_redirected from: "http://example.org/", redirect: { headers: { "Vary" => "X-Forwared-Proto" } }
   end
 end
 


### PR DESCRIPTION
### Summary

This adds the ability to configure custom headers to the redirect responses from  ActionDispatch::SSL middleware.

Rails is using headers like 'X-Forwarded-Proto' to determine if the request is made over https, but it doesn't include this is the Vary response, which can result in a HTTP cache in between the TLS termination and the application serving cached redirect responses to users trying to access the site on HTTPS.

The headers that would be required (if any) would depend on the server setup, which is why this is just adding ability to configure the headers, and not changing the default ones.




