### PR TITLE
Clean database naming ambiguity

### DIFF
--- a/railties/lib/rails/tasks/engine.rake
+++ b/railties/lib/rails/tasks/engine.rake
@@ -53,7 +53,7 @@ namespace :db do
   desc "Rolls the schema back to the previous version (specify steps w/ STEP=n)."
   app_task "rollback"
 
-  desc "Create a db/schema.rb file that can be portably used against any DB supported by Active Record"
+  desc "Create a db/schema.rb file that can be portably used against any database supported by Active Record"
   app_task "schema:dump"
 
   desc "Load a schema.rb file into the database"
@@ -62,7 +62,7 @@ namespace :db do
   desc "Load the seed data from db/seeds.rb"
   app_task "seed"
 
-  desc "Create the database, load the schema, and initialize with the seed data (use db:reset to also drop the db first)"
+  desc "Create the database, load the schema, and initialize with the seed data (use db:reset to also drop the database first)"
   app_task "setup"
 
   desc "Dump the database structure to an SQL file"


### PR DESCRIPTION
### Summary

When I was reading this file I found out that this file referred to the database in three different ways: database, DB and db. The last one caused confusion with the db namespace and the db folder. This patch removes this ambiguity by using the whole word 'database' everywhere