### PR TITLE
[ci skip] Added example for using headless_chrome with SystemTest

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -671,6 +671,16 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 end
 ```
 
+If you want to use a headless browser, you could use Headless Chrome by adding `headless_chrome` in the `:using` argument.
+
+```ruby
+require "test_helper"
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_chrome
+end
+```
+
 If your Capybara configuration requires more setup than provided by Rails, this
 additional configuration could be added into the `application_system_test_case.rb`
 file.


### PR DESCRIPTION
In the beginning of the System Test section of the testing guide, we mention that it's possible to use a headless browser. http://edgeguides.rubyonrails.org/testing.html#system-testing

> System tests allow you to test user interactions with your application, running tests in either a real or a **headless browser**. System tests uses Capybara under the hood.

 I think it would be reasonable to give an example of using a headless browser. 
