### PR TITLE
Fix `tzinfo-data` warning.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -163,5 +163,9 @@ end
 
 # A gem necessary for Active Record tests with IBM DB.
 gem "ibm_db" if ENV["IBM_DB"]
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-gem "wdm", ">= 0.1.0", platforms: [:mingw, :mswin, :x64_mingw, :mswin64]
+
+platforms :ruby, :mingw, :mswin, :x64_mingw, :jruby do
+  # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+  gem "tzinfo-data"
+  gem "wdm", ">= 0.1.0"
+end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -72,5 +72,8 @@ group :development do
 end
 <% end -%>
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+platforms :ruby, :mingw, :mswin, :x64_mingw, :jruby do
+  # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+  gem "tzinfo-data"
+  gem "wdm", ">= 0.1.0"
+end


### PR DESCRIPTION
### Summary

This PR fixes the noisy `tzinfo-data` warning.

On **master**:
```
➜  rails git:(master) railties/exe/rails new ~/tmp/blah-api --api -T
      create  
      create  README.md
      create  Rakefile
      create  .ruby-version
...
         run  bundle install
The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/.
Could not find gem 'rails (~> 5.2.0.alpha)' in any of the gem sources listed in your Gemfile.
         run  bundle exec spring binstub --all
Could not find gem 'rails (~> 5.2.0.alpha)' in any of the gem sources listed in your Gemfile.
Run `bundle install` to install missing gems.
       rails  active_storage:install
Could not find gem 'rails (~> 5.2.0.alpha)' in any of the gem sources listed in your Gemfile.
Run `bundle install` to install missing gems.
```

On **fix/tzinfo-data_warning**:
```
➜  rails git:(master) g co fix/tzinfo-data_warning 
Switched to branch 'fix/tzinfo-data_warning'
➜  rails git:(fix/tzinfo-data_warning) railties/exe/rails new ~/tmp/bar-api --api -T
      create  
      create  README.md
      create  Rakefile
      create  .ruby-version
...
         run  bundle install
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/.
Could not find gem 'rails (~> 5.2.0.alpha)' in any of the gem sources listed in your Gemfile.
         run  bundle exec spring binstub --all
Could not find gem 'rails (~> 5.2.0.alpha)' in any of the gem sources listed in your Gemfile.
Run `bundle install` to install missing gems.
       rails  active_storage:install
Could not find gem 'rails (~> 5.2.0.alpha)' in any of the gem sources listed in your Gemfile.
Run `bundle install` to install missing gems.
➜  rails git:(fix/tzinfo-data_warning) 
```

Re #27830

### Other Information

Quoting bundler/bundler#5345:

> fixes the problem since Bundler.local_platform can now be "ruby" on Windows