### PR TITLE
Improve AR connection fork safety

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -366,6 +366,19 @@ module ActiveRecord
         reset_transaction
       end
 
+      # Immediately forget this connection ever existed. Unlike disconnect!,
+      # this will not communicate with the server.
+      #
+      # After calling this method, the behavior of all other methods becomes
+      # undefined. This is called internally just before a forked process gets
+      # rid of a connection that belonged to its parent.
+      def discard!
+        # This should be overridden by concrete adapters.
+        #
+        # Prevent @connection's finalizer from touching the socket, or
+        # otherwise communicating with its server, when it is collected.
+      end
+
       # Reset the state of this connection, directing the DBMS to clear
       # transactions and other connection-related server-side state. Usually a
       # database-dependent operation.

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -105,6 +105,11 @@ module ActiveRecord
         @connection.close
       end
 
+      def discard! # :nodoc:
+        @connection.automatic_close = false
+        @connection = nil
+      end
+
       private
 
         def connect

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -273,6 +273,11 @@ module ActiveRecord
         end
       end
 
+      def discard! # :nodoc:
+        @connection.socket_io.reopen(IO::NULL)
+        @connection = nil
+      end
+
       def native_database_types #:nodoc:
         NATIVE_DATABASE_TYPES
       end


### PR DESCRIPTION
Use whatever adapter-provided means we have available to ensure forked children don't send quit/shutdown/goodbye messages to the server on connections that belonged to their parent.

* mysql2 provides a method specifically for this purpose: https://github.com/brianmario/mysql2/pull/684
* pg is not quite so helpful, but it does expose a `socket_io`, which is close enough.
* I *think* sqlite3 is immune to this problem just because there is no server to confuse.

---

I believe this should eliminate the need for [advice like this](https://github.com/rails/rails/blob/c39ed435eb578c79867552c66da7eeb035fa58ad/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt#L35-L53), along with much of what's currently described in #29807.