### PR TITLE
Make ActiveSupport::TimeZone.all independent of previous lookups

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Make `ActiveSupport::TimeZone.all` return only time zones that are in
+    `ActiveSupport::TimeZone::MAPPING`.
+
+    Fixes #7245.
+
+    *Chris LaRose*
+
 *   MemCacheStore: Support expiring counters.
 
     Pass `expires_in: [seconds]` to `#increment` and `#decrement` options

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -256,6 +256,13 @@ module ActiveSupport
         @country_zones[code] ||= load_country_zones(code)
       end
 
+      def clear() #:nodoc:
+        @lazy_zones_map = Concurrent::Map.new
+        @country_zones  = Concurrent::Map.new
+        @zones = nil
+        @zones_map = nil
+      end
+
       private
         def load_country_zones(code)
           country = TZInfo::Country.get(code)

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -269,10 +269,7 @@ module ActiveSupport
         end
 
         def zones_map
-          @zones_map ||= begin
-            MAPPING.each_key { |place| self[place] } # load all the zones
-            @lazy_zones_map
-          end
+          @zones_map ||= Hash[MAPPING.keys.map { |place| [place, self[place]] }]
         end
     end
 

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -276,7 +276,9 @@ module ActiveSupport
         end
 
         def zones_map
-          @zones_map ||= Hash[MAPPING.keys.map { |place| [place, self[place]] }]
+          @zones_map ||= MAPPING.each_with_object({}) do |(name, _), zones|
+            zones[name] = self[name]
+          end
         end
     end
 

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -8,6 +8,17 @@ require "yaml"
 class TimeZoneTest < ActiveSupport::TestCase
   include TimeZoneTestHelpers
 
+  def setup
+    ActiveSupport::TimeZone.instance_variable_set(:@lazy_zones_map, Concurrent::Map.new)
+    ActiveSupport::TimeZone.instance_variable_set(:@country_zones, Concurrent::Map.new)
+    if ActiveSupport::TimeZone.instance_variable_defined?(:@zones_map)
+      ActiveSupport::TimeZone.remove_instance_variable(:@zones_map)
+    end
+    if ActiveSupport::TimeZone.instance_variable_defined?(:@zones)
+      ActiveSupport::TimeZone.remove_instance_variable(:@zones)
+    end
+  end
+
   def test_utc_to_local
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
     assert_equal Time.utc(1999, 12, 31, 19), zone.utc_to_local(Time.utc(2000, 1)) # standard offset -0500

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -729,6 +729,12 @@ class TimeZoneTest < ActiveSupport::TestCase
     end
   end
 
+  def test_all_uninfluenced_by_time_zone_lookups_delegated_to_tzinfo
+    galapagos = ActiveSupport::TimeZone["Pacific/Galapagos"]
+    all_zones = ActiveSupport::TimeZone.all
+    assert_not_includes all_zones, galapagos
+  end
+
   def test_index
     assert_nil ActiveSupport::TimeZone["bogus"]
     assert_instance_of ActiveSupport::TimeZone, ActiveSupport::TimeZone["Central Time (US & Canada)"]

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -9,14 +9,9 @@ class TimeZoneTest < ActiveSupport::TestCase
   include TimeZoneTestHelpers
 
   def setup
-    ActiveSupport::TimeZone.instance_variable_set(:@lazy_zones_map, Concurrent::Map.new)
-    ActiveSupport::TimeZone.instance_variable_set(:@country_zones, Concurrent::Map.new)
-    if ActiveSupport::TimeZone.instance_variable_defined?(:@zones_map)
-      ActiveSupport::TimeZone.remove_instance_variable(:@zones_map)
-    end
-    if ActiveSupport::TimeZone.instance_variable_defined?(:@zones)
-      ActiveSupport::TimeZone.remove_instance_variable(:@zones)
-    end
+    # Clear memoized time zone data on TimeZone class
+    ActiveSupport.send(:remove_const, :TimeZone) if ActiveSupport.const_defined?(:TimeZone)
+    load "active_support/values/time_zone.rb"
   end
 
   def test_utc_to_local

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -8,12 +8,6 @@ require "yaml"
 class TimeZoneTest < ActiveSupport::TestCase
   include TimeZoneTestHelpers
 
-  def setup
-    # Clear memoized time zone data on TimeZone class
-    ActiveSupport.send(:remove_const, :TimeZone) if ActiveSupport.const_defined?(:TimeZone)
-    load "active_support/values/time_zone.rb"
-  end
-
   def test_utc_to_local
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
     assert_equal Time.utc(1999, 12, 31, 19), zone.utc_to_local(Time.utc(2000, 1)) # standard offset -0500
@@ -725,6 +719,7 @@ class TimeZoneTest < ActiveSupport::TestCase
   end
 
   def test_all_uninfluenced_by_time_zone_lookups_delegated_to_tzinfo
+    ActiveSupport::TimeZone.clear
     galapagos = ActiveSupport::TimeZone["Pacific/Galapagos"]
     all_zones = ActiveSupport::TimeZone.all
     assert_not_includes all_zones, galapagos


### PR DESCRIPTION
### Summary

If you call `ActiveSupport::TimeZone.all` before you look up any `ActiveSupport::TimeZone`s by name, then all calls to `ActiveSupport::TimeZone.all` for the lifetime of the program will return a collection of `ActiveSupport::TimeZone`s corresponding to the 151 "meaningful" time zone identifiers described by `ActiveSupport::TimeZone::MAPPING`.

If, however, you look up a time zone by a name that is not a key of `ActiveSupport::TimeZone::MAPPING` _before_ making a call to `ActiveSupport::TimeZone.all`, then the collection returned from all calls to that method will contain the time zone you looked up.

### Abridged Timeline

* August 2012: The issue is first described in #7245. It is proposed that the issue is not necessarily that `ActiveSupport::TimeZone.all` returns inconsistent output, but instead that `ActionView::Helpers::FormOptionsHelper#time_zone_options_for_select` should return a `<select>` element that always contained the `selected` time zone, regardless of whether or not that time zone was a member of `ActiveSupport::TimeZone.all`.
* November 2012: #8377 is opened to fix `time_zone_options_for_select`. I do not think this solution fixes the actual problem since it does not remove the dependency of `ActiveSupport::TimeZone.all` from `time_zone_options_for_select`. As long as the former returns inconsistent output, so will the latter.
* December 2012: #8660 is opened with changes very similar to the changes proposed by this PR.
* April 2013: #8660 was closed because it was thought that the issue was still in the view code.
* January 2015: #8377 is closed
* December 2015: #22651 is opened to remove the cache used for `ActiveSupport::TimeZone.all`. This has the effect that any time you call `ActiveSupport::TimeZone.all`, you get all time zones currently known (not just the ones from `ActiveSupport::TimeZone::MAPPING`). This PR is closed because it would introduce a performance regression. It's proposed to keep the cache around, but to invalidate it when we discover a new time zone.
* February 2017: #27917 is opened to invalidate some caches when new time zones are discovered. @jeremy suggests that doing this behavior is actually quite strange. The behavior that makes most sense is for `ActiveSupport::TimeZone.all` to return _only_ time zones that are in `ActiveSupport::TimeZone::MAPPING`. I think this is absolutely 100% correct.