### PR TITLE
Fix unstable test test_delegate_socket_errors_to_on_error_handler

### DIFF
--- a/actioncable/test/connection/client_socket_test.rb
+++ b/actioncable/test/connection/client_socket_test.rb
@@ -67,9 +67,9 @@ class ActionCable::Connection::ClientSocketTest < ActionCable::TestCase
       env = Rack::MockRequest.env_for "/test",
         "HTTP_CONNECTION" => "upgrade", "HTTP_UPGRADE" => "websocket",
         "HTTP_HOST" => "localhost", "HTTP_ORIGIN" => "http://rubyonrails.com"
-      io = \
+      io, client_io = \
         begin
-          Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM, 0).first
+          Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM, 0)
         rescue
           StringIO.new
         end
@@ -77,6 +77,14 @@ class ActionCable::Connection::ClientSocketTest < ActionCable::TestCase
 
       Connection.new(@server, env).tap do |connection|
         connection.process
+        if client_io
+          # Make sure server returns handshake response
+          Timeout.timeout(1) do
+            loop do
+              break if client_io.readline == "\r\n"
+            end
+          end
+        end
         connection.send :handle_open
         assert connection.connected
       end


### PR DESCRIPTION
I often face the following error when running test/connection/client_socket_test.rb:

```
$ bin/test test/connection/client_socket_test.rb:38
Run options: --seed 44035

# Running:

F

Failure:
ActionCable::Connection::ClientSocketTest#test_delegate_socket_errors_to_on_error_handler
[/app/actioncable/test/connection/client_socket_test.rb:47]:
--- expected
+++ actual
@@ -1 +1 @@
-["foo"]
+["Broken pipe", "Broken pipe", "Broken pipe", "foo"]
```

It can be reproduced easily by applying the following patch:

```diff
diff --git a/actioncable/test/connection/client_socket_test.rb b/actioncable/test/connection/client_socket_test.rb
index 2051216010..6bb9f13ea7 100644
--- a/actioncable/test/connection/client_socket_test.rb
+++ b/actioncable/test/connection/client_socket_test.rb
@@ -34,7 +34,8 @@ def on_error(message)
     @server.config.allowed_request_origins = %w( http://rubyonrails.com )
   end

-  test "delegate socket errors to on_error handler" do
+  1000.times do |i|
+  test "delegate socket errors to on_error handler #{i}" do
     run_in_eventmachine do
       connection = open_connection

@@ -47,6 +48,7 @@ def on_error(message)
       assert_equal %w[ foo ], connection.errors
     end
   end
+  end

   test "closes hijacked i/o socket at shutdown" do
     run_in_eventmachine do
```

The cause is to write io from different thread at the same time.

`connection.process` sends handshake message from [StreamEventLoop's thread][] whereas
`connection.handle_open` sends welcome message from current thread.

[StreamEventLoop's thread]: https://github.com/rails/rails/blob/067fc779c4560fff4812614a2f78f9248f3e55f8/actioncable/lib/action_cable/connection/stream_event_loop.rb#L75