### PR TITLE
Fix names of http authentication modules in api only guides

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -414,8 +414,10 @@ Some common modules you might want to add:
 
 - `AbstractController::Translation`: Support for the `l` and `t` localization
   and translation methods.
-- `ActionController::HttpAuthentication::Basic` (or `Digest` or `Token`): Support
-  for basic, digest or token HTTP authentication.
+- Support for basic, digest or token HTTP authentication:
+  * `ActionController::HttpAuthentication::Basic::ControllerMethods`,
+  * `ActionController::HttpAuthentication::Digest::ControllerMethods`,
+  * `ActionController::HttpAuthentication::Token::ControllerMethods`
 - `ActionView::Layouts`: Support for layouts when rendering.
 - `ActionController::MimeResponds`: Support for `respond_to`.
 - `ActionController::Cookies`: Support for `cookies`, which includes


### PR DESCRIPTION
### Summary
Hello,
[Rails guide about api only mode](http://edgeguides.rubyonrails.org/api_app.html#adding-other-modules) states that if you want to add support for basic\token\digest auth you need to include `ActionController::HttpAuthentication::Basic` (or Digest or Token) modules.

But in fact you need to include: `ActionController::HttpAuthentication::#{name}::ControllerMethods`.
https://github.com/rails/rails/blob/b383b346600d5325a211376837bc83b7ae472f46/actionpack/lib/action_controller/base.rb#L229-L231

This PR fixes the names of needed modules to be included in the guide.

