### PR TITLE
Provide attachment writers

### DIFF
--- a/activestorage/lib/active_storage/attached/macros.rb
+++ b/activestorage/lib/active_storage/attached/macros.rb
@@ -32,6 +32,10 @@ module ActiveStorage
         def #{name}
           @active_storage_attached_#{name} ||= ActiveStorage::Attached::One.new("#{name}", self, dependent: #{dependent == :purge_later ? ":purge_later" : "false"})
         end
+
+        def #{name}=(attachable)
+          #{name}.attach(attachable)
+        end
       CODE
 
       has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record
@@ -72,6 +76,10 @@ module ActiveStorage
       class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}
           @active_storage_attached_#{name} ||= ActiveStorage::Attached::Many.new("#{name}", self, dependent: #{dependent == :purge_later ? ":purge_later" : "false"})
+        end
+
+        def #{name}=(attachables)
+          #{name}.attach(attachables)
         end
       CODE
 

--- a/activestorage/test/models/attachments_test.rb
+++ b/activestorage/test/models/attachments_test.rb
@@ -76,6 +76,20 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     assert_equal "funky.jpg", user.avatar.filename.to_s
   end
 
+  test "build new record with attached blob" do
+    assert_no_difference -> { ActiveStorage::Attachment.count } do
+      @user = User.new(name: "Jason", avatar: { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg" })
+    end
+
+    assert @user.new_record?
+    assert @user.avatar.attached?
+    assert_equal "town.jpg", @user.avatar.filename.to_s
+
+    @user.save!
+    assert @user.reload.avatar.attached?
+    assert_equal "town.jpg", @user.avatar.filename.to_s
+  end
+
   test "access underlying associations of new blob" do
     @user.avatar.attach create_blob(filename: "funky.jpg")
     assert_equal @user, @user.avatar_attachment.record
@@ -202,6 +216,24 @@ class ActiveStorage::AttachmentsTest < ActiveSupport::TestCase
     assert user.reload.highlights.attached?
     assert_equal "town.jpg", user.highlights.first.filename.to_s
     assert_equal "country.jpg", user.highlights.second.filename.to_s
+  end
+
+  test "build new record with attached blobs" do
+    assert_no_difference -> { ActiveStorage::Attachment.count } do
+      @user = User.new(name: "Jason", highlights: [
+        { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg" },
+        { io: StringIO.new("IT"), filename: "country.jpg", content_type: "image/jpg" }])
+    end
+
+    assert @user.new_record?
+    assert @user.highlights.attached?
+    assert_equal "town.jpg", @user.highlights.first.filename.to_s
+    assert_equal "country.jpg", @user.highlights.second.filename.to_s
+
+    @user.save!
+    assert @user.reload.highlights.attached?
+    assert_equal "town.jpg", @user.highlights.first.filename.to_s
+    assert_equal "country.jpg", @user.highlights.second.filename.to_s
   end
 
   test "find attached blobs" do


### PR DESCRIPTION
Permit creating a record and attaching files in a single step.

```ruby
# Before:
User.create!(user_params.except(:avatar)).tap do |user|
  user.avatar.attach(user_params[:avatar])
end

# After:
User.create!(user_params)
```

@dhh: Since you designed the ASt API, I’d like your approval on this before I merge.

Thanks to @yhirano55 for taking a first stab at this in #30737. I’ve credited you for the commit.