### PR TITLE
Provide arguments to RecordNotFound

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -79,7 +79,13 @@ module ActiveRecord
       def find(*args)
         if options[:inverse_of] && loaded?
           args_flatten = args.flatten
-          raise RecordNotFound, "Couldn't find #{scope.klass.name} without an ID" if args_flatten.blank?
+          model = scope.klass
+
+          if args_flatten.blank?
+            error_message = "Couldn't find #{model.name} without an ID"
+            raise RecordNotFound.new(error_message, model.name, model.primary_key, args)
+          end
+
           result = find_by_scan(*args)
 
           result_size = Array(result).size

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -88,7 +88,7 @@ module ActiveRecord
       where(arg, *args).take!
     rescue ::RangeError
       raise RecordNotFound.new("Couldn't find #{@klass.name} with an out of range value",
-                               @klass.name)
+                               @klass.name, @klass.primary_key)
     end
 
     # Gives a record (or N records if a parameter is supplied) without any implied
@@ -339,7 +339,7 @@ module ActiveRecord
       if ids.nil?
         error = "Couldn't find #{name}".dup
         error << " with#{conditions}" if conditions
-        raise RecordNotFound.new(error, name)
+        raise RecordNotFound.new(error, name, key)
       elsif Array(ids).size == 1
         error = "Couldn't find #{name} with '#{key}'=#{ids}#{conditions}"
         raise RecordNotFound.new(error, name, key, ids)
@@ -347,7 +347,7 @@ module ActiveRecord
         error = "Couldn't find all #{name.pluralize} with '#{key}': ".dup
         error << "(#{ids.join(", ")})#{conditions} (found #{result_size} results, but was looking for #{expected_size})."
         error << " Couldn't find #{name.pluralize(not_found_ids.size)} with #{key.to_s.pluralize(not_found_ids.size)} #{not_found_ids.join(', ')}." if not_found_ids
-        raise RecordNotFound.new(error, name, primary_key, ids)
+        raise RecordNotFound.new(error, name, key, ids)
       end
     end
 
@@ -433,9 +433,12 @@ module ActiveRecord
 
         ids = ids.flatten.compact.uniq
 
+        model_name = @klass.name
+
         case ids.size
         when 0
-          raise RecordNotFound, "Couldn't find #{@klass.name} without an ID"
+          error_message = "Couldn't find #{model_name} without an ID"
+          raise RecordNotFound.new(error_message, model_name, primary_key)
         when 1
           result = find_one(ids.first)
           expects_array ? [ result ] : result
@@ -443,7 +446,8 @@ module ActiveRecord
           find_some(ids)
         end
       rescue ::RangeError
-        raise RecordNotFound, "Couldn't find #{@klass.name} with an out of range ID"
+        error_message = "Couldn't find #{model_name} with an out of range ID"
+        raise RecordNotFound.new(error_message, model_name, primary_key, ids)
       end
 
       def find_one(id)

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -484,7 +484,10 @@ class InverseHasManyTests < ActiveRecord::TestCase
   def test_raise_record_not_found_error_when_no_ids_are_passed
     man = Man.create!
 
-    assert_raise(ActiveRecord::RecordNotFound) { man.interests.find() }
+    exception = assert_raise(ActiveRecord::RecordNotFound) { man.interests.load.find() }
+
+    assert_equal exception.model, "Interest"
+    assert_equal exception.primary_key, "id"
   end
 
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -120,6 +120,21 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal "The Fourth Topic of the day", records[2].title
   end
 
+  def test_find_with_ids_with_no_id_passed
+    exception = assert_raises(ActiveRecord::RecordNotFound) { Topic.find }
+    assert_equal exception.model, "Topic"
+    assert_equal exception.primary_key, "id"
+  end
+
+  def test_find_with_ids_with_id_out_of_range
+    exception = assert_raises(ActiveRecord::RecordNotFound) do
+      Topic.find("9999999999999999999999999999999")
+    end
+
+    assert_equal exception.model, "Topic"
+    assert_equal exception.primary_key, "id"
+  end
+
   def test_find_passing_active_record_object_is_not_permitted
     assert_raises(ArgumentError) do
       Topic.find(Topic.last)


### PR DESCRIPTION
`ActiveRecord::RecordNotFound` has an inconsistent API, which led to quite unexpected bug where exception instances in some cases had attributes of `primary_key`, `model name` and others don't. This pr solves the issue and adds appropriate arguments to `ActiveRecord::RecordNotFound`.