### PR TITLE
FIX: `rack-test` 0.7.1 probably got yanked.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,7 +365,7 @@ GEM
       rack (>= 0.4)
     rack-protection (2.0.0)
       rack
-    rack-test (0.7.1)
+    rack-test (0.8.0)
       rack (>= 1.0, < 3)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)


### PR DESCRIPTION
```
Fetching gem metadata from https://rubygems.org/...........
Could not find rack-test-0.7.1 in any of the sources
```