### PR TITLE
No difference between JRuby and CRuby at test_read_attributes_before_…

### DIFF
--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -200,12 +200,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   if current_adapter?(:Mysql2Adapter)
     test "read attributes_before_type_cast on a boolean" do
       bool = Boolean.create!("value" => false)
-      if RUBY_PLATFORM.include?("java")
-        # JRuby will return the value before typecast as string.
-        assert_equal "0", bool.reload.attributes_before_type_cast["value"]
-      else
-        assert_equal 0, bool.reload.attributes_before_type_cast["value"]
-      end
+      assert_equal 0, bool.reload.attributes_before_type_cast["value"]
     end
   end
 


### PR DESCRIPTION
### Summary

[ActiveRecord JDBC Adapter](https://github.com/jruby/activerecord-jdbc-adapter) is actively developed and it supports Rails 5.1 now. This pull request addresses one of the failures when running
ActiveRecord unit tests with ActiveRecord JDBC Adapter.

As of right now, ActiveRecord JDBC Adapter supports Rails 5.1, not master branch
then this test only can run on `5-1-stable` branch. But I have opened this pull request to `master` branch
since this type cast should be going to work in the future versions of `ActiveRecord JDBC Adapter`.

### Steps to reproduce:
```ruby
$ cd rails/activerecord
$ git checkout 5-1-stable
$ bundle install
$ ARCONN=jdbcmysql bin/test test/cases/attribute_methods_test.rb:203
```
### Actual result without this pull request:
```ruby
$ ARCONN=jdbcmysql bin/test test/cases/attribute_methods_test.rb:203
Using jdbcmysql
Run options: --seed 8874

F

Finished in 0.709120s, 1.4102 runs/s, 1.4102 assertions/s.

  1) Failure:
AttributeMethodsTest#test_read_attributes_before_type_cast_on_a_boolean [/home/yahonda/git/rails/activerecord/test/cases/attribute_methods_test.rb:203]:
Expected: "0"
  Actual: 0

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

This is kind of reverting 230f78875999ed566cbfc54c3b824420ea082f4b

cc @enebo @kares @rdubya