### PR TITLE
Fix tld_length documentation in ActionDispatch::Cookies

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -161,7 +161,7 @@ module ActionDispatch
   #
   # * <tt>:tld_length</tt> - When using <tt>:domain => :all</tt>, this option can be used to explicitly
   #   set the TLD length when using a short (<= 3 character) domain that is being interpreted as part of a TLD.
-  #   For example, to share cookies between user1.lvh.me and user2.lvh.me, set <tt>:tld_length</tt> to 1.
+  #   For example, to share cookies between user1.lvh.me and user2.lvh.me, set <tt>:tld_length</tt> to 2.
   # * <tt>:expires</tt> - The time at which this cookie expires, as a \Time or ActiveSupport::Duration object.
   # * <tt>:secure</tt> - Whether this cookie is only transmitted to HTTPS servers.
   #   Default is +false+.


### PR DESCRIPTION
### Summary

Change recommendation for tld_length (for sharing cookies across subdomains of a 2-token TLD), to 2 instead of 1 (TLD isn't exactly the right name here, but since that's what the option is called, that's what I'm calling it).  This option actually specifies the number of tokens in the root domain across whose subdomains you want to share the cookie.  In the example given, it is 2 (`lvh` and `me`), so recommending 1 is confusing. (calling it tld_length is also confusing, but c'est la vie) :wink:

With a setting of 2, the domain for the cookie is set to: `.lvh.me` which is the desired result.