### PR TITLE
Update incorrect backtick usage in RDoc to teletype

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -68,7 +68,7 @@ module ActionController
     # if possible, otherwise redirects to the provided default fallback
     # location.
     #
-    # The referrer information is pulled from the HTTP `Referer` (sic) header on
+    # The referrer information is pulled from the HTTP +Referer+ (sic) header on
     # the request. This is an optional header and its presence on the request is
     # subject to browser security settings and user preferences. If the request
     # is missing this header, the <tt>fallback_location</tt> will be used.
@@ -82,7 +82,7 @@ module ActionController
     #   redirect_back fallback_location: '/', allow_other_host: false
     #
     # ==== Options
-    # * <tt>:fallback_location</tt> - The default fallback location that will be used on missing `Referer` header.
+    # * <tt>:fallback_location</tt> - The default fallback location that will be used on missing +Referer+ header.
     # * <tt>:allow_other_host</tt> - Allows or disallow redirection to the host that is different to the current host
     #
     # All other options that can be passed to <tt>redirect_to</tt> are accepted as

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -216,7 +216,7 @@ module ActionController #:nodoc:
       # The actual before_action that is used to verify the CSRF token.
       # Don't override this directly. Provide your own forgery protection
       # strategy instead. If you override, you'll disable same-origin
-      # `<script>` verification.
+      # <tt><script></tt> verification.
       #
       # Lean on the protect_from_forgery declaration to mark which actions are
       # due for same-origin request verification. If protect_from_forgery is
@@ -250,7 +250,7 @@ module ActionController #:nodoc:
       private_constant :CROSS_ORIGIN_JAVASCRIPT_WARNING
       # :startdoc:
 
-      # If `verify_authenticity_token` was run (indicating that we have
+      # If +verify_authenticity_token+ was run (indicating that we have
       # forgery protection enabled for this request) then also verify that
       # we aren't serving an unauthorized cross-origin response.
       def verify_same_origin_request # :doc:
@@ -267,7 +267,7 @@ module ActionController #:nodoc:
         @marked_for_same_origin_verification = request.get?
       end
 
-      # If the `verify_authenticity_token` before_action ran, verify that
+      # If the +verify_authenticity_token+ before_action ran, verify that
       # JavaScript responses are only served to same-origin GET requests.
       def marked_for_same_origin_verification? # :doc:
         @marked_for_same_origin_verification ||= false

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -155,7 +155,7 @@ module ActionDispatch
       # Missing routes keys may be filled in from the current request's parameters
       # (e.g. +:controller+, +:action+, +:id+ and any other parameters that are
       # placed in the path). Given that the current action has been reached
-      # through `GET /users/1`:
+      # through <tt>GET /users/1</tt>:
       #
       #   url_for(only_path: true)                        # => '/users/1'
       #   url_for(only_path: true, action: 'edit')        # => '/users/1/edit'

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -737,8 +737,8 @@ module ActiveRecord
     # Used to specify an operation that is only run when migrating up
     # (for example, populating a new column with its initial values).
     #
-    # In the following example, the new column `published` will be given
-    # the value `true` for all existing records.
+    # In the following example, the new column +published+ will be given
+    # the value +true+ for all existing records.
     #
     #    class AddPublishedToPosts < ActiveRecord::Migration[5.2]
     #      def change

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -33,9 +33,9 @@ module ActiveSupport
     # * Fault tolerant. If the Redis server is unavailable, no exceptions are
     #   raised. Cache fetches are all misses and writes are dropped.
     # * Local cache. Hot in-memory primary cache within block/middleware scope.
-    # * `read_/write_multi` support for Redis mget/mset. Use Redis::Distributed
+    # * +read_multi+ and +write_multi+ support for Redis mget/mset. Use Redis::Distributed
     #   4.0.1+ for distributed mget support.
-    # * `delete_matched` support for Redis KEYS globs.
+    # * +delete_matched+ support for Redis KEYS globs.
     class RedisCacheStore < Store
       # Keys are truncated with their own SHA2 digest if they exceed 1kB
       MAX_KEY_BYTESIZE = 1024
@@ -143,12 +143,12 @@ module ActiveSupport
       #   :url   Array  -> Redis::Distributed.new([{ url: … }, { url: … }, …])
       #
       # No namespace is set by default. Provide one if the Redis cache
-      # server is shared with other apps: `namespace: 'myapp-cache'`.
+      # server is shared with other apps: <tt>namespace: 'myapp-cache'<tt>.
       #
       # Compression is enabled by default with a 1kB threshold, so cached
       # values larger than 1kB are automatically compressed. Disable by
-      # passing `cache: false` or change the threshold by passing
-      # `compress_threshold: 4.kilobytes`.
+      # passing <tt>cache: false</tt> or change the threshold by passing
+      # <tt>compress_threshold: 4.kilobytes</tt>.
       #
       # No expiry is set on cache entries by default. Redis is expected to
       # be configured with an eviction policy that automatically deletes

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -35,8 +35,8 @@ class Array
   #   people.without "Aaron", "Todd"
   #   # => ["David", "Rafael"]
   #
-  # Note: This is an optimization of `Enumerable#without` that uses `Array#-`
-  # instead of `Array#reject` for performance reasons.
+  # Note: This is an optimization of <tt>Enumerable#without</tt> that uses <tt>Array#-</tt>
+  # instead of <tt>Array#reject</tt> for performance reasons.
   def without(*elements)
     self - elements
   end

--- a/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/compatibility.rb
@@ -8,8 +8,8 @@ class DateTime
 
   silence_redefinition_of_method :to_time
 
-  # Either return an instance of `Time` with the same UTC offset
-  # as +self+ or an instance of `Time` representing the same time
+  # Either return an instance of +Time+ with the same UTC offset
+  # as +self+ or an instance of +Time+ representing the same time
   # in the the local system timezone depending on the setting of
   # on the setting of +ActiveSupport.to_time_preserves_timezone+.
   def to_time

--- a/activesupport/lib/active_support/core_ext/object/with_options.rb
+++ b/activesupport/lib/active_support/core_ext/object/with_options.rb
@@ -62,7 +62,7 @@ class Object
   #
   #   validates :content, length: { minimum: 50 }, if: -> { content.present? }
   #
-  # Hence the inherited default for `if` key is ignored.
+  # Hence the inherited default for +if+ key is ignored.
   #
   # NOTE: You cannot call class methods implicitly inside of with_options.
   # You can access these methods using the class name instead:

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -174,7 +174,7 @@ class String
   #   <%= link_to(@person.name, person_path) %>
   #   # => <a href="/person/1-donald-e-knuth">Donald E. Knuth</a>
   #
-  # To preserve the case of the characters in a string, use the `preserve_case` argument.
+  # To preserve the case of the characters in a string, use the +preserve_case+ argument.
   #
   #   class Person
   #     def to_param

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -250,7 +250,7 @@ class String
   # Marks a string as trusted safe. It will be inserted into HTML with no
   # additional escaping performed. It is your responsibility to ensure that the
   # string contains no malicious content. This method is equivalent to the
-  # `raw` helper in views. It is recommended that you use `sanitize` instead of
+  # +raw+ helper in views. It is recommended that you use +sanitize+ instead of
   # this method. It should never be called on user input.
   def html_safe
     ActiveSupport::SafeBuffer.new(self)

--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -73,12 +73,12 @@ module ActiveSupport
     #   parameterize("Donald E. Knuth") # => "donald-e-knuth"
     #   parameterize("^très|Jolie-- ")  # => "tres-jolie"
     #
-    # To use a custom separator, override the `separator` argument.
+    # To use a custom separator, override the +separator+ argument.
     #
     #  parameterize("Donald E. Knuth", separator: '_') # => "donald_e_knuth"
     #  parameterize("^très|Jolie__ ", separator: '_')  # => "tres_jolie"
     #
-    # To preserve the case of the characters in a string, use the `preserve_case` argument.
+    # To preserve the case of the characters in a string, use the +preserve_case+ argument.
     #
     #   parameterize("Donald E. Knuth", preserve_case: true) # => "Donald-E-Knuth"
     #   parameterize("^très|Jolie-- ", preserve_case: true) # => "tres-Jolie"

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -58,8 +58,8 @@ module ActiveSupport
   # === Rotating keys
   #
   # MessageEncryptor also supports rotating out old configurations by falling
-  # back to a stack of encryptors. Call `rotate` to build and add an encryptor
-  # so `decrypt_and_verify` will also try the fallback.
+  # back to a stack of encryptors. Call +rotate+ to build and add an encryptor
+  # so +decrypt_and_verify+ will also try the fallback.
   #
   # By default any rotated encryptors use the values of the primary
   # encryptor unless specified otherwise.

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -31,7 +31,7 @@ module ActiveSupport
   #
   # +MessageVerifier+ creates HMAC signatures using SHA1 hash algorithm by default.
   # If you want to use a different hash algorithm, you can change it by providing
-  # `:digest` key as an option while initializing the verifier:
+  # +:digest+ key as an option while initializing the verifier:
   #
   #   @verifier = ActiveSupport::MessageVerifier.new('s3Krit', digest: 'SHA256')
   #
@@ -78,8 +78,8 @@ module ActiveSupport
   # === Rotating keys
   #
   # MessageVerifier also supports rotating out old configurations by falling
-  # back to a stack of verifiers. Call `rotate` to build and add a verifier to
-  # so either `verified` or `verify` will also try verifying with the fallback.
+  # back to a stack of verifiers. Call +rotate+ to build and add a verifier to
+  # so either +verified+ or +verify+ will also try verifying with the fallback.
   #
   # By default any rotated verifiers use the values of the primary
   # verifier unless specified otherwise.


### PR DESCRIPTION
Some quick doc updates to fix code formatting, replacing (incorrect) Markdown/Github style backticks with proper RDoc teletype formatting.