### PR TITLE
Use Erubi's CaptureEnd engine.

### DIFF
--- a/actionview/lib/action_view/template/handlers/erb/erubi.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubi.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require "erubi"
+require "erubi/capture_end"
 
 module ActionView
   class Template
     module Handlers
       class ERB
-        class Erubi < ::Erubi::Engine
+        class Erubi < ::Erubi::CaptureEndEngine
           # :nodoc: all
           def initialize(input, properties = {})
             @newline_pending = 0


### PR DESCRIPTION
# Background

1. The eRuby language, as defined by `ERB` in the Ruby standard library, requires the contents of every `<%= %>` tag to be a standalone expression. As https://github.com/ruby/ruby/blob/trunk/lib/erb.rb#L294 shows, the contents are wrapped in `()` and `to_s` is called.

    This means the following is not valid in pure eRuby, because the first tag contains a `do` without a matching `end`:

    ```ruby
      <%= form_with model: @entry do |form| %>
        <%= form.text_field :tags %>
        <%= form.submit %>
      <% end %>
    ```

    Erubis and Erubi, other eRuby parsers, have the same behavior.

1. Rails extends eRuby to work around the above limitation. The template handlers under `template/handlers/erb/` use regular expressions to parse the Ruby code for `do end` or `{ }` blocks and treat them as units (https://github.com/rails/rails/blob/master/actionview/lib/action_view/template/handlers/erb/erubi.rb#L45). This is fragile (it will choke on some valid Ruby), and the complexity is undesirable.

1. Erubi, which is the default parser as of Rails 5.1, offers an alternative syntax that accomplishes the same goal in a simpler way. See https://github.com/jeremyevans/erubi#capturing.

# This patch

1. Uses Erubi's `CaptureEndGroup` engine to add support for the new syntax. No existing Rails functionality is removed or modified.



    ### Performance testing

    I used https://gist.github.com/elebow/408ff7d50a767bdfe39070b9eb39780a to render two cases 1 million times each, and used GNU time(1) to measure the elapsed time. Results are below, with this branch on the left and master on the right. Changed rows are in bold. As you can see, the capture engine is slightly slower, but I feel it's a worthwhile tradeoff for the additional capabilities and future reduction in complexity.

    #### Rendering a form with form_for
    |# capture engine                                              |   # master|
    | --- | --- |
    Command being timed: "bundle e rails runner ./benchmark.rb"   |   Command being timed: "bundle e rails runner ./benchmark.rb"
    **User time (seconds): 43.18**                                    |   **User time (seconds): 41.11**
    **System time (seconds): 0.04** |   **System time (seconds): 0.06**
    Percent of CPU this job got: 99%                              |   Percent of CPU this job got: 99%
    **Elapsed (wall clock) time (h:mm:ss or m:ss): 0:43.28**         | **Elapsed (wall clock) time (h:mm:ss or m:ss): 0:41.23**
    Average shared text size (kbytes): 0                          |   Average shared text size (kbytes): 0
    Average unshared data size (kbytes): 0                        |   Average unshared data size (kbytes): 0
    Average stack size (kbytes): 0                                |   Average stack size (kbytes): 0
    Average total size (kbytes): 0                                |   Average total size (kbytes): 0
    **Maximum resident set size (kbytes): 88684**   |  **Maximum resident set size (kbytes): 88544**
    Average resident set size (kbytes): 0                         |   Average resident set size (kbytes): 0
    Major (requiring I/O) page faults: 0                          |   Major (requiring I/O) page faults: 0
    **Minor (reclaiming a frame) page faults: 34279**  |  **Minor (reclaiming a frame) page faults: 34300**
    **Voluntary context switches: 245**  | **Voluntary context switches: 251**
    **Involuntary context switches: 171**  | **Involuntary context switches: 282**
    Swaps: 0                                                      |   Swaps: 0
    File system inputs: 0                                         |   File system inputs: 0
    **File system outputs: 8**  | **File system outputs: 320**
    Socket messages sent: 0                                       |   Socket messages sent: 0
    Socket messages received: 0                                   |   Socket messages received: 0
    Signals delivered: 0                                          |   Signals delivered: 0
    Page size (bytes): 4096                                       |   Page size (bytes): 4096
    Exit status: 0                                                |   Exit status: 0

    #### Rendering a list taken from the Rails Guide on rendering
    |# capture engine                                              |   # master|
    | --- | --- |
    Command being timed: "bundle e rails runner ./benchmark.rb"   |   Command being timed: "bundle e rails runner ./benchmark.rb"
    **User time (seconds): 42.91**                             |  **User time (seconds): 41.50**
    **System time (seconds): 0.06**                            |  **System time (seconds): 0.07**
    Percent of CPU this job got: 99%                              |   Percent of CPU this job got: 99%
    **Elapsed (wall clock) time (h:mm:ss or m:ss): 0:43.02**    | **Elapsed (wall clock) time (h:mm:ss or m:ss): 0:41.62**
    Average shared text size (kbytes): 0                          |   Average shared text size (kbytes): 0
    Average unshared data size (kbytes): 0                        |   Average unshared data size (kbytes): 0
    Average stack size (kbytes): 0                                |   Average stack size (kbytes): 0
    Average total size (kbytes): 0                                |   Average total size (kbytes): 0
    **Maximum resident set size (kbytes): 88720**   | **Maximum resident set size (kbytes): 88388**
    Average resident set size (kbytes): 0                         |   Average resident set size (kbytes): 0
    Major (requiring I/O) page faults: 0                          |   Major (requiring I/O) page faults: 0
    **Minor (reclaiming a frame) page faults: 34303**  | **Minor (reclaiming a frame) page faults: 34256**
    **Voluntary context switches: 243**  |  **Voluntary context switches: 232**
    **Involuntary context switches: 130**  |  **Involuntary context switches: 503**
    Swaps: 0                                                      |   Swaps: 0
    File system inputs: 0                                         |   File system inputs: 0
    **File system outputs: 328** | **File system outputs: 8**
    Socket messages sent: 0                                       |   Socket messages sent: 0
    Socket messages received: 0                                   |   Socket messages received: 0
    Signals delivered: 0                                          |   Signals delivered: 0
    Page size (bytes): 4096                                       |   Page size (bytes): 4096
    Exit status: 0                                                |   Exit status: 0

# Near future work

1. Update the Rails Guide "Layouts and Rendering" to recommend the new Erubi syntax. I will open that PR if this one is approved.

# Long-term future work

1. Deprecate the old syntax, and later remove support for it from Rails.
